### PR TITLE
Feature/drop stale clients

### DIFF
--- a/blockstack/lib/config.py
+++ b/blockstack/lib/config.py
@@ -213,10 +213,15 @@ if os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"):
     MAX_RPC_LEN = int(os.environ.get("BLOCKSTACK_TEST_MAX_RPC_LEN"))
     print("Overriding MAX_RPC_LEN to {}".format(MAX_RPC_LEN))
 
-MAX_RPC_THREADS = 1000      # typical rlimit for the number of open file descriptors, minus a buffer
+MAX_RPC_THREADS = 100      # typical rlimit for the number of open file descriptors, minus a buffer
 if os.environ.get('BLOCKSTACK_RPC_MAX_THREADS'):
     MAX_RPC_THREADS = int(os.environ.get('BLOCKSTACK_RPC_MAX_THREADS'))
     print('Overriding MAX_RPC_THREADS to {}'.format(MAX_RPC_THREADS))
+
+QUEUE_LIFETIME = 8
+if os.environ.get("BLOCKSTACK_RPC_QUEUE_LIFETIME"):
+    QUEUE_LIFETIME = int(os.environ.get("BLOCKSTACK_RPC_QUEUE_LIFETIME"))
+    print('Overriding QUEUE_LIFETIME to {}'.format(QUEUE_LIFETIME))
 
 if BLOCKSTACK_TEST:
     RPC_MAX_INDEXING_DELAY = 5

--- a/blockstack/lib/subdomains.py
+++ b/blockstack/lib/subdomains.py
@@ -1074,7 +1074,7 @@ class SubdomainDB(object):
         else:
             accepted_filter = ''
 
-        get_cmd = "SELECT COUNT(DISTINCT fully_qualified_subdomain) as count FROM {} {};".format(
+        get_cmd = "SELECT COUNT(rowid) as count FROM {} {};".format(
             self.subdomain_table, accepted_filter)
 
         cursor = cur


### PR DESCRIPTION
This PR modifies the link between the JSON-RPC endpoint and the p2p endpoint so that the former will pass in the timestamp at which the request _began_ to the latter.  This way, when the p2p endpoint gets around to fulfilling the JSON-RPC request, it can tell whether or not the connection has been opened but not acknowledged for too long, and preemptively close it.  The timeout can be set with the envar `BLOCKSTACK_RPC_QUEUE_LIFETIME`.

This PR also changes the subdomains-count query to use the `rowid` of the subdomains table, since the maximum `rowid` ought to be equal to the number of subdomains (we never delete them; we only insert or update them).  Latency is reduced from 10s to 0.4s.

## How to test

1.  Spin up a copy of this node software
2.  Set `BLOCKSTACK_RPC_QUEUE_LIFETIME=8` for 8 seconds (or whatever)
3.  Run this script to blast it with RPC requests (tweak to your liking)
```bash
#!/bin/sh

for i in $(seq 1 1000); do
   (
       REQ=$(($RANDOM % 4))
       # REQ=0
       if [ $REQ -eq 0 ]; then  
           curl -D - --connect-timeout 10 -m 10 -s "http://localhost:36270/v1/names/judecn.id" | grep '200 OK' >/dev/null;
       elif [ $REQ -eq 1 ]; then
           curl -D - --connect-timeout 10 -m 10 -s "http://localhost:36270/v1/blockchains/bitcoin/subdomains_count" | grep '200 OK' >/dev/null;
       elif [ $REQ -eq 2 ]; then
           curl -D - --connect-timeout 10 -m 10 -s "http://localhost:36270/v1/zonefiles/45f9814834ac0d884ad78f697d59576323642a9b" | grep '200 OK' >/dev/null;
       elif [ $REQ -eq 3 ]; then 
           curl -D - --connect-timeout 10 -m 10 -s "http://localhost:36270/v1/names/jude.statism.id" | grep '200 OK' >/dev/null;
       fi
       RC=$?;
       if [ $RC -ne 0 ]; then 
          echo "Failed request $i ($REQ)";
       else
          echo "Succeeded request $i ($REQ)";
       fi
   ) &
done

wait
```

If you look at the debug output, you should only see a few broken-pipe errors (i.e. those which began just before the timeout, but completed after the timeout).