### PR TITLE
Allow specifying endpoint in event observer config and env var

### DIFF
--- a/src/testnet/helium/config.rs
+++ b/src/testnet/helium/config.rs
@@ -113,7 +113,7 @@ impl Config {
             None => vec![]
         };
 
-        let events_observers = match config_file.events_observer {
+        let mut events_observers = match config_file.events_observer {
             Some(raw_observers) => {
                 let mut observers = vec![];
                 for observer in raw_observers {
@@ -129,6 +129,17 @@ impl Config {
                 observers
             }
             None => vec![]
+        };
+
+        // check for observer config in env vars
+        match std::env::var("STACKS_EVENT_OBSERVER") {
+            Ok(val) => {
+                events_observers.push(EventObserverConfig {
+                    endpoint: val,
+                    events_keys: vec![EventKeyType::AnyEvent],
+                })
+            },
+            _ => ()
         };
 
         let connection_options = match config_file.connection_options {

--- a/src/testnet/helium/config.rs
+++ b/src/testnet/helium/config.rs
@@ -122,8 +122,7 @@ impl Config {
                         .collect();
 
                     observers.push(EventObserverConfig {
-                        address: observer.address,
-                        port: observer.port,
+                        endpoint: observer.endpoint,
                         events_keys
                     });
                 }
@@ -326,15 +325,13 @@ pub struct MempoolConfig {
 
 #[derive(Clone, Deserialize)]
 pub struct EventObserverConfigFile {
-    pub port: u16,
-    pub address: String,
+    pub endpoint: String,
     pub events_keys: Vec<String>,
 }
 
 #[derive(Clone, Default)]
 pub struct EventObserverConfig {
-    pub port: u16,
-    pub address: String,
+    pub endpoint: String,
     pub events_keys: Vec<EventKeyType>,
 }
 

--- a/src/testnet/helium/event_dispatcher.rs
+++ b/src/testnet/helium/event_dispatcher.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::thread::spawn;
-use std::net::{SocketAddr};
+use std::net::{SocketAddr, ToSocketAddrs};
 use mio::tcp::TcpStream;
 use serde_json::json;
 use serde::Serialize;
@@ -18,20 +18,16 @@ use super::config::{EventObserverConfig, EventKeyType};
 
 #[derive(Debug)]
 struct EventObserver {
-    sock_addr: SocketAddr
+    endpoint: String
 }
 
 impl EventObserver {
 
-    pub fn new(address: &str, port: u16) -> EventObserver {
-        let sock_addr = SocketAddr::new(address.parse().unwrap(), port);
-        EventObserver { sock_addr }
-    }
-
     pub fn send(&mut self, filtered_events: Vec<&(Txid, &StacksTransactionEvent)>, chain_tip: &StacksBlock, chain_tip_info: &StacksHeaderInfo, receipts: &Vec<StacksTransactionReceipt>) {
-        // Initiate a tcp socket
-        let stream = TcpStream::connect(&self.sock_addr).unwrap();
-        
+        // Initiate a tcp socket, first using std::net TCP connect for smart DNS resolution
+        let std_stream = std::net::TcpStream::connect(&self.endpoint).unwrap();
+        // Then wrap as mio TCP stream
+        let stream = TcpStream::from_stream(std_stream).unwrap();
         // Serialize events to JSON
         let serialized_events: Vec<serde_json::Value> = filtered_events.iter().map(|(txid, event)|
             event.json_serialize(txid)
@@ -181,8 +177,9 @@ impl EventDispatcher {
     }
 
     pub fn register_observer(&mut self, conf: &EventObserverConfig) {
-        let event_observer = EventObserver::new(&conf.address, conf.port);
-        
+        // let event_observer = EventObserver::new(&conf.address, conf.port);
+        let event_observer = EventObserver { endpoint: conf.endpoint.clone() };
+
         let observer_index = self.registered_observers.len() as u16;
 
         for event_key_type in conf.events_keys.iter() {

--- a/src/testnet/helium/event_dispatcher.rs
+++ b/src/testnet/helium/event_dispatcher.rs
@@ -26,6 +26,8 @@ impl EventObserver {
     pub fn send(&mut self, filtered_events: Vec<&(Txid, &StacksTransactionEvent)>, chain_tip: &StacksBlock, chain_tip_info: &StacksHeaderInfo, receipts: &Vec<StacksTransactionReceipt>) {
         // Initiate a tcp socket, first using std::net TCP connect for smart DNS resolution
         let std_stream = std::net::TcpStream::connect(&self.endpoint).unwrap();
+        info!("Connected to event observer at: {}", std_stream.peer_addr().unwrap());
+
         // Then wrap as mio TCP stream
         let stream = TcpStream::from_stream(std_stream).unwrap();
         // Serialize events to JSON
@@ -178,6 +180,7 @@ impl EventDispatcher {
 
     pub fn register_observer(&mut self, conf: &EventObserverConfig) {
         // let event_observer = EventObserver::new(&conf.address, conf.port);
+        info!("Registering event observer at: {}", conf.endpoint);
         let event_observer = EventObserver { endpoint: conf.endpoint.clone() };
 
         let observer_index = self.registered_observers.len() as u16;

--- a/src/testnet/helium/node.rs
+++ b/src/testnet/helium/node.rs
@@ -1,4 +1,5 @@
 use super::{Keychain, MemPool, MemPoolFS, Config, LeaderTenure, BurnchainState, EventDispatcher};
+use super::config::{EventObserverConfig, EventKeyType};
 
 use std::collections::HashMap;
 use std::sync::mpsc::{channel, Sender, Receiver};
@@ -135,6 +136,17 @@ impl Node {
         let mem_pool = MemPoolFS::new(&config.mempool.path);
 
         let mut event_dispatcher = EventDispatcher::new();
+
+        // check for observer config in env vars
+        match std::env::var("STACKS_EVENT_OBSERVER") {
+            Ok(val) => {
+                event_dispatcher.register_observer(&EventObserverConfig {
+                    endpoint: val,
+                    events_keys: vec![EventKeyType::AnyEvent],
+                });
+            },
+            _ => ()
+        }
 
         for observer in &config.events_observers {
             event_dispatcher.register_observer(observer);

--- a/src/testnet/helium/node.rs
+++ b/src/testnet/helium/node.rs
@@ -137,17 +137,6 @@ impl Node {
 
         let mut event_dispatcher = EventDispatcher::new();
 
-        // check for observer config in env vars
-        match std::env::var("STACKS_EVENT_OBSERVER") {
-            Ok(val) => {
-                event_dispatcher.register_observer(&EventObserverConfig {
-                    endpoint: val,
-                    events_keys: vec![EventKeyType::AnyEvent],
-                });
-            },
-            _ => ()
-        }
-
         for observer in &config.events_observers {
             event_dispatcher.register_observer(observer);
         }


### PR DESCRIPTION
PR enables two features:
* Allows an event observer to be specified through an environmental variable in addition to the config toml file
* Allows an event observer hostname to be specified and resolved, rather than only a static IP address

Both of these are useful for various service deployment configurations that are often cumbersome when limited to static IPs and config files.