### PR TITLE
[PoX] Introducing ChainsCoordinator (stubbed version)

### DIFF
--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -11,19 +11,19 @@ use chainstate::stacks::db::{StacksHeaderInfo as HeaderInfo};
 use chainstate::stacks::events::{StacksTransactionReceipt as TransactionReceipt};
 
 #[derive(Debug, Clone)]
-struct PoxIdentifier;
+struct PoxId;
 
 #[derive(Debug, Clone)]
-pub struct SortitionIdentifier (
+pub struct SortitionId (
     BurnchainHeaderHash,
-    PoxIdentifier
+    PoxId
 );
 
 #[derive(Debug, Clone)]
-pub struct BlockIdentifier {
+pub struct StacksBlockId {
     burnchain_header_hash: BurnchainHeaderHash,
     header_hash: HeaderHash,
-    pox_identifier: PoxIdentifier,
+    pox_identifier: PoxId,
 }
 
 struct ChainStateDB;
@@ -34,12 +34,12 @@ impl ChainStateDB {
     }
 
     #[allow(unused_variables)]
-    pub fn is_block_processed(&self, block_id: &BlockIdentifier) -> Result<bool, ()> {
+    pub fn is_block_processed(&self, block_id: &StacksBlockId) -> Result<bool, ()> {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
-    pub fn process_blocks(&mut self, burnchain_blocks_db: &mut BurnchainBlocksDB, pox_identifier: PoxIdentifier) -> Result<Vec<(Option<(HeaderInfo, Vec<TransactionReceipt>)>, Option<TransactionPayload>)>, ()> {
+    pub fn process_blocks(&mut self, burnchain_blocks_db: &mut BurnchainBlocksDB, pox_identifier: PoxId) -> Result<Vec<(Option<(HeaderInfo, Vec<TransactionReceipt>)>, Option<TransactionPayload>)>, ()> {
         unimplemented!()
     }
 }
@@ -69,7 +69,7 @@ impl BlocksDB {
     }
 
     #[allow(unused_variables)]
-    pub fn get_blocks_ready_to_process(&self, sortition_id: &SortitionIdentifier, sortition_db: &SortitionDB) -> Option<Vec<Block>> {
+    pub fn get_blocks_ready_to_process(&self, sortition_id: &SortitionId, sortition_db: &SortitionDB) -> Option<Vec<Block>> {
         // This method will be calling sortition_db::latest_stacks_blocks_processed
         unimplemented!()
     }
@@ -83,23 +83,23 @@ impl PoxDB {
     }
 
     #[allow(unused_variables)]
-    pub fn get_canonical_pox_id(&self, burnchain_header_hash: &BurnchainHeaderHash) -> PoxIdentifier {
+    pub fn get_canonical_pox_id(&self, burnchain_header_hash: &BurnchainHeaderHash) -> PoxId {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
-    pub fn get_ordered_missing_anchors(&self, upper_bound: &BlockIdentifier) -> Vec<BlockIdentifier> {
+    pub fn get_ordered_missing_anchors(&self, upper_bound: &StacksBlockId) -> Vec<StacksBlockId> {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
     // Note: we'd be temporary using an associated function instead of method, because this call is writing. 
-    pub fn process_anchor(block: &BlockIdentifier, chain_state: &ChainStateDB) -> Result<(), ()> {
+    pub fn process_anchor(block: &StacksBlockId, chain_state: &ChainStateDB) -> Result<(), ()> {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
-    pub fn get_reward_set_start_for(&self, block: &BlockIdentifier) -> &BurnchainHeaderHash {
+    pub fn get_reward_set_start_for(&self, block: &StacksBlockId) -> &BurnchainHeaderHash {
         unimplemented!()
     }
 }
@@ -112,27 +112,27 @@ impl SortitionDB {
     }
   
     #[allow(unused_variables)]
-    pub fn get_sortition_id(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxIdentifier) -> Result<SortitionIdentifier, ()> {
+    pub fn get_sortition_id(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxId) -> Result<SortitionId, ()> {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
-    pub fn is_sortition_processed(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxIdentifier) -> Result<bool, ()> {
+    pub fn is_sortition_processed(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxId) -> Result<bool, ()> {
         unimplemented!()
     }
     
     #[allow(unused_variables)]
-    pub fn evaluate_sortition(burnchain_block: &BurnchainBlock, pox_id: &PoxIdentifier, pox_db: &PoxDB) -> Result<SortitionIdentifier, ()> {
+    pub fn evaluate_sortition(burnchain_block: &BurnchainBlock, pox_id: &PoxId, pox_db: &PoxDB) -> Result<SortitionId, ()> {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
-    pub fn is_stacks_block_in_sortition_set(sortition_id: &SortitionIdentifier, block_to_check: &HeaderHash) -> Result<bool, ()> {
+    pub fn is_stacks_block_in_sortition_set(sortition_id: &SortitionId, block_to_check: &HeaderHash) -> Result<bool, ()> {
         unimplemented!()
     }
  
     #[allow(unused_variables)]
-    pub fn latest_stacks_blocks_processed(sortition_id: &SortitionIdentifier) -> Result<u64, ()> {
+    pub fn latest_stacks_blocks_processed(sortition_id: &SortitionId) -> Result<u64, ()> {
         unimplemented!()
     }
 }
@@ -140,7 +140,7 @@ impl SortitionDB {
 struct ChainsCoordinator {
     canonical_burnchain_chain_tip: Option<BurnchainBlock>,
     canonical_chain_tip: Option<Block>,
-    canonical_pox_id: Option<PoxIdentifier>,
+    canonical_pox_id: Option<PoxId>,
     blocks_db: BlocksDB,
     burnchain_blocks_db: BurnchainBlocksDB,
     chain_state_db: ChainStateDB,
@@ -232,7 +232,7 @@ impl ChainsCoordinator {
     pub fn handle_new_block(&mut self) -> Result<(), ()> {
         // Rebuild sortition id
         let sortition_id = match (&self.canonical_pox_id, &self.canonical_burnchain_chain_tip) {
-            (Some(pox_id), Some(burnchain_block)) => SortitionIdentifier(burnchain_block.burn_header_hash.clone(), pox_id.clone()),
+            (Some(pox_id), Some(burnchain_block)) => SortitionId(burnchain_block.burn_header_hash.clone(), pox_id.clone()),
             (_, _) => {
                 // We received our first BlockDiscovered event before even receiving a BurnchainBlockDiscovered event
                 return Err(())
@@ -258,7 +258,7 @@ impl ChainsCoordinator {
         Ok(())
     }
 
-    fn process_new_pox_anchor(&mut self, block_id: &BlockIdentifier) -> Result<(), ()> {
+    fn process_new_pox_anchor(&mut self, block_id: &StacksBlockId) -> Result<(), ()> {
         // Ensure that the chain of anchored blocks (up to block_id) has been processed  
         let ordered_missing_anchored_blocks = self.pox_db.get_ordered_missing_anchors(block_id);
         for block_id in ordered_missing_anchored_blocks.iter() {
@@ -291,7 +291,7 @@ impl ChainsCoordinator {
         unimplemented!()
     }
 
-    fn discover_new_pox_anchor(&mut self, block_id: &BlockIdentifier) -> Result<(), ()> {
+    fn discover_new_pox_anchor(&mut self, block_id: &StacksBlockId) -> Result<(), ()> {
         PoxDB::process_anchor(block_id, &self.chain_state_db)
     }
 }

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -1,0 +1,312 @@
+use std::thread;
+use std::sync::{mpsc, Arc, Mutex};
+use std::process;
+
+use burnchains::BurnchainHeaderHash;
+use chainstate::burn::{BlockHeaderHash, BlockSnapshot as BurnchainBlock};
+use chainstate::stacks::StacksBlock;
+
+#[derive(Debug, Clone)]
+struct PoxIdentifier;
+
+#[derive(Debug, Clone)]
+pub struct SortitionIdentifier (
+    BurnchainHeaderHash,
+    PoxIdentifier
+);
+
+#[derive(Debug, Clone)]
+pub struct StacksBlockIdentifier {
+    burnchain_header_hash: BurnchainHeaderHash,
+    header_hash: BlockHeaderHash,
+    pox_identifier: PoxIdentifier,
+}
+
+struct ChainStateDB;
+impl ChainStateDB {
+
+    pub fn stubbed() -> ChainStateDB {
+        ChainStateDB {}
+    }
+
+    pub fn is_block_processed(&self, block_id: &StacksBlockIdentifier) -> Result<bool, ()> {
+        unimplemented!()
+    }
+}
+
+struct BurnchainDB;
+impl BurnchainDB {
+
+    pub fn stubbed() -> BurnchainDB {
+        BurnchainDB {}
+    }
+
+    pub fn get_canonical_chain_tip(&self) -> BurnchainBlock {
+        unimplemented!()
+    }
+
+    pub fn get_burnchain_block(&self, burnchain_header_hash: &BurnchainHeaderHash) -> Result<BurnchainBlock, ()> {
+        unimplemented!()
+    }
+}
+
+struct BlocksDB;
+impl BlocksDB {
+
+    pub fn stubbed() -> BlocksDB {
+        BlocksDB {}
+    }
+
+    pub fn get_blocks_ready_to_process(&self, sortition_id: &SortitionIdentifier, sortition_db: &SortitionDB) -> Option<Vec<StacksBlock>> {
+        unimplemented!()
+    }
+}
+
+struct PoxDB;
+impl PoxDB {
+
+    pub fn stubbed() -> PoxDB {
+        PoxDB {}
+    }
+
+    pub fn get_canonical_pox_id(&self, burnchain_header_hash: &BurnchainHeaderHash) -> PoxIdentifier {
+        unimplemented!()
+    }
+
+    pub fn get_ordered_missing_anchors(&self) -> Vec<StacksBlockIdentifier> {
+        unimplemented!()
+    }
+
+    pub fn process_anchor(block: &StacksBlockIdentifier, chain_state: &ChainStateDB) -> Result<(), ()> {
+        unimplemented!()
+    }
+
+    pub fn get_reward_set_start_for(&self, block: &StacksBlockIdentifier) -> u64 {
+        unimplemented!()
+    }
+}
+
+struct SortitionDB;
+impl SortitionDB {
+
+    pub fn stubbed() -> SortitionDB {
+        SortitionDB {}
+    }
+  
+    pub fn get_sortition_id(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxIdentifier) -> Result<SortitionIdentifier, ()> {
+        unimplemented!()
+    }
+
+    pub fn is_sortition_processed(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxIdentifier) -> Result<bool, ()> {
+        unimplemented!()
+    }
+    
+    pub fn evaluate_sortition(burnchain_block: &BurnchainBlock, pox_id: &PoxIdentifier, pox_db: &PoxDB) -> Result<SortitionIdentifier, ()> {
+        unimplemented!()
+    }
+
+    pub fn is_stacks_block_in_sortition_set(sortition_id: &SortitionIdentifier, block_to_check: &BlockHeaderHash) -> Result<bool, ()> {
+        unimplemented!()
+    }
+ 
+    pub fn latest_stacks_blocks_processed(sortition_id: &SortitionIdentifier) -> Result<u64, ()> {
+        unimplemented!()
+    }
+}
+
+struct ChainsCoordinator {
+    canonical_burnchain_chain_tip: Option<BurnchainBlock>,
+    canonical_chain_tip: Option<StacksBlock>,
+    canonical_pox_id: Option<PoxIdentifier>,
+    blocks_db: BlocksDB,
+    burnchain_db: BurnchainDB,
+    chain_state_db: ChainStateDB,
+    pox_db: PoxDB, 
+    sortition_db: SortitionDB,
+}
+
+impl ChainsCoordinator {
+
+    pub fn new() -> ChainsCoordinator {
+        
+        let blocks_db = BlocksDB::stubbed();
+        let burnchain_db = BurnchainDB::stubbed();
+        let chain_state_db = ChainStateDB::stubbed();
+        let pox_db = PoxDB::stubbed(); 
+        let sortition_db = SortitionDB::stubbed();
+            
+        ChainsCoordinator {
+            canonical_burnchain_chain_tip: None,
+            canonical_chain_tip: None,
+            canonical_pox_id: None,
+            blocks_db,
+            burnchain_db,
+            chain_state_db,
+            pox_db, 
+            sortition_db
+        }
+    }
+
+    pub fn handle_new_burnchain_block(&mut self) {
+        // Retrieve canonical burnchain chain tip from the BurnchainDB
+        let canonical_burnchain_tip = self.burnchain_db.get_canonical_chain_tip();
+        
+        // Early return: this block has already been processed
+        match self.canonical_burnchain_chain_tip {
+            Some(ref current) if current.burn_header_hash == canonical_burnchain_tip.burn_header_hash => return,
+            _ => {}
+        }
+
+        // Retrieve canonical pox id (<=> reward cycle id)
+        let pox_id = self.pox_db.get_canonical_pox_id(&canonical_burnchain_tip.burn_header_hash);
+
+        // Retrieve all the direct ancestors of this block with an unprocessed sortition 
+        let mut parent_bhh = canonical_burnchain_tip.burn_header_hash.clone();
+        let mut sortitions_to_process = vec![canonical_burnchain_tip];
+
+        while match self.sortition_db.is_sortition_processed(&parent_bhh, &pox_id) {
+            Ok(ref is_processed)  => !is_processed,
+            _ => false
+        } {
+            if let Ok(block) = self.burnchain_db.get_burnchain_block(&parent_bhh) {
+                parent_bhh = block.parent_burn_header_hash.clone();
+                sortitions_to_process.push(block);
+            } else {
+                break;
+            }
+        }
+
+        for unprocessed_block in sortitions_to_process.drain(..) {
+            let sortition_id = match SortitionDB::evaluate_sortition(&unprocessed_block, &pox_id, &self.pox_db) {
+                Ok(sortition_id) => sortition_id,
+                Err(e) => {
+                    error!("ChainsCoordinator: unable to retrieve sortition");
+                    continue
+                }
+            };
+
+            while let Some(blocks_ready_to_process) = self.blocks_db.get_blocks_ready_to_process(&sortition_id, &self.sortition_db) {
+                // todo(ludo): I think I'm supposed to use `SortitionDB::latest_stacks_blocks_processed`
+                for block in blocks_ready_to_process {
+                    match self.process_block(&block) {
+                        Some(is_pox_anchor) if is_pox_anchor == true => {
+                            self.process_new_pox_anchor();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_new_block(&mut self) {
+        // Rebuild sortition id
+        let sortition_id = match (&self.canonical_pox_id, &self.canonical_burnchain_chain_tip) {
+            (Some(pox_id), Some(burnchain_block)) => SortitionIdentifier(burnchain_block.burn_header_hash.clone(), pox_id.clone()),
+            (_, _) => {
+                // todo(ludo): handle this case
+                return;
+            }
+        };
+
+        while let Some(blocks_ready_to_process) = self.blocks_db.get_blocks_ready_to_process(&sortition_id, &self.sortition_db) {
+            // todo(ludo): I think I'm supposed to use `SortitionDB::latest_stacks_blocks_processed`
+            for block in blocks_ready_to_process {
+                match self.process_block(&block) {
+                    Some(is_pox_anchor) if is_pox_anchor == true => {
+                        self.process_new_pox_anchor();
+                    }
+                    _ => {}
+                }
+                self.canonical_chain_tip = Some(block);
+            }
+        }
+    }
+
+    fn process_new_pox_anchor(&mut self) {
+        let ordered_missing_anchored_blocks = self.pox_db.get_ordered_missing_anchors();
+        for block_id in ordered_missing_anchored_blocks.iter() {
+            match self.chain_state_db.is_block_processed(&block_id) {
+                Ok(is_processed) if is_processed == true => {
+                    PoxDB::process_anchor(&block_id, &self.chain_state_db);
+                    // self.canonical_burn_header = self.pox_db.get_reward_set_start_for(&block_id);
+                    // todo(ludo): adapt the following lines.
+                    // self.canon_burn_header = self.pox_db.get_reward_set_start_for(block) 
+                    // todo(ludo): block_id is a construct based on the pox_id, why do we need to fetch it from the DB?
+                    self.canonical_pox_id = Some(self.pox_db.get_canonical_pox_id(&block_id.burnchain_header_hash));
+                    self.canonical_chain_tip = None;
+                    // start processing from the beginning of the new PoX reward set
+                    return self.handle_new_burnchain_block()    
+                },
+                _ => {}
+            }
+        }
+        self.discover_new_pox_anchor();
+    }
+
+    fn process_block(&self, block: &StacksBlock) -> Option<bool> {
+        unimplemented!()
+    }
+
+    fn discover_new_pox_anchor(&mut self) {
+        unimplemented!()
+    }
+}
+
+pub enum ChainsEvent {
+    BlockDiscovered,
+    BurnchainBlockDiscovered,
+}
+
+pub struct ChainsEventsObserver {
+    event_tx: Option<mpsc::Sender<ChainsEvent>>,
+}
+
+impl ChainsEventsObserver {
+
+    pub fn new() -> ChainsEventsObserver {
+        ChainsEventsObserver {
+            event_tx: None
+        }
+    }
+
+    pub fn spawn_chains_coordinator(&mut self) -> mpsc::Sender<ChainsEvent> {
+        if let Some(ref event_tx) = self.event_tx {
+            error!("ChainsCoordinator is already processing chains events");
+            return event_tx.clone();
+        }
+
+        let (event_tx, event_rx) = mpsc::channel();
+        self.event_tx = Some(event_tx.clone());
+
+        thread::spawn(move || {
+            let mut chains_coordinator = ChainsCoordinator::new();
+            loop {
+                if let Ok(event) = event_rx.recv() {
+                    match event {
+                        ChainsEvent::BlockDiscovered => chains_coordinator.handle_new_block(),
+                        ChainsEvent::BurnchainBlockDiscovered => chains_coordinator.handle_new_burnchain_block(),
+                    }                
+                } else {
+                    error!("ChainsEventsObserver stopped receiving events");
+                    break;
+                }
+            }
+        });
+        event_tx
+    }
+}
+
+fn main() {
+    let mut chains_events_observer = ChainsEventsObserver::new();
+    let chains_event_tx = chains_events_observer.spawn_chains_coordinator();
+
+    // We can now, from any thread, notify the coordinator to update the different DBs, with the following events, 
+    // and be sure that the processing of these events will happen sequentially on the same thread.
+    chains_event_tx
+        .send(ChainsEvent::BlockDiscovered)
+        .expect("Unable to transmit ChainsEvent::BlockDiscovered");
+    chains_event_tx
+        .send(ChainsEvent::BurnchainBlockDiscovered)
+        .expect("Unable to transmit ChainsEvent::BurnchainBlockDiscovered");;
+}

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -33,10 +33,12 @@ impl ChainStateDB {
         ChainStateDB {}
     }
 
+    #[allow(unused_variables)]
     pub fn is_block_processed(&self, block_id: &StacksBlockIdentifier) -> Result<bool, ()> {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
     pub fn process_blocks(&mut self, burnchain_db: &mut BurnchainDB, pox_identifier: PoxIdentifier) -> Result<Vec<(Option<(StacksHeaderInfo, Vec<StacksTransactionReceipt>)>, Option<TransactionPayload>)>, ()> {
         unimplemented!()
     }
@@ -53,6 +55,7 @@ impl BurnchainDB {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
     pub fn get_burnchain_block(&self, burnchain_header_hash: &BurnchainHeaderHash) -> Result<BurnchainBlock, ()> {
         unimplemented!()
     }
@@ -65,6 +68,7 @@ impl BlocksDB {
         BlocksDB {}
     }
 
+    #[allow(unused_variables)]
     pub fn get_blocks_ready_to_process(&self, sortition_id: &SortitionIdentifier, sortition_db: &SortitionDB) -> Option<Vec<StacksBlock>> {
         // This method will be calling sortition_db::latest_stacks_blocks_processed
         unimplemented!()
@@ -78,19 +82,23 @@ impl PoxDB {
         PoxDB {}
     }
 
+    #[allow(unused_variables)]
     pub fn get_canonical_pox_id(&self, burnchain_header_hash: &BurnchainHeaderHash) -> PoxIdentifier {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
     pub fn get_ordered_missing_anchors(&self, upper_bound: &StacksBlockIdentifier) -> Vec<StacksBlockIdentifier> {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
     // Note: we'd be temporary using an associated function instead of method, because this call is writing. 
     pub fn process_anchor(block: &StacksBlockIdentifier, chain_state: &ChainStateDB) -> Result<(), ()> {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
     pub fn get_reward_set_start_for(&self, block: &StacksBlockIdentifier) -> &BurnchainHeaderHash {
         unimplemented!()
     }
@@ -103,22 +111,27 @@ impl SortitionDB {
         SortitionDB {}
     }
   
+    #[allow(unused_variables)]
     pub fn get_sortition_id(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxIdentifier) -> Result<SortitionIdentifier, ()> {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
     pub fn is_sortition_processed(&self, burnchain_header_hash: &BurnchainHeaderHash, pox_id: &PoxIdentifier) -> Result<bool, ()> {
         unimplemented!()
     }
     
+    #[allow(unused_variables)]
     pub fn evaluate_sortition(burnchain_block: &BurnchainBlock, pox_id: &PoxIdentifier, pox_db: &PoxDB) -> Result<SortitionIdentifier, ()> {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
     pub fn is_stacks_block_in_sortition_set(sortition_id: &SortitionIdentifier, block_to_check: &BlockHeaderHash) -> Result<bool, ()> {
         unimplemented!()
     }
  
+    #[allow(unused_variables)]
     pub fn latest_stacks_blocks_processed(sortition_id: &SortitionIdentifier) -> Result<u64, ()> {
         unimplemented!()
     }
@@ -273,12 +286,13 @@ impl ChainsCoordinator {
         self.discover_new_pox_anchor(block_id)
     }
 
+    #[allow(unused_variables)]
     fn process_block(&self, block: &StacksBlock) -> Result<bool, ()> {
         unimplemented!()
     }
 
     fn discover_new_pox_anchor(&mut self, block_id: &StacksBlockIdentifier) -> Result<(), ()> {
-        PoxDB::process_anchor(block_id, self.chain_state_db)
+        PoxDB::process_anchor(block_id, &self.chain_state_db)
     }
 }
 
@@ -324,10 +338,12 @@ impl ChainsEventsRouter {
                             (chains_coordinator.handle_new_burnchain_block(), tx, ChainsEventCallback::BurnchainBlockProcessed),
                     };
                     match result {
-                        Ok(res) => {
+                        Ok(_) => {
                             info!("ChainsCoordinator: successfully processed event");
                             if let Some(tx) = tx {
-                                tx.send(event_callback);
+                                if let Err(e) = tx.send(event_callback) {
+                                    error!("ChainsCoordinator: unable to send the event callback - {}", e);
+                                }
                             }
                         },
                         Err(e) => error!("ChainsCoordinator: failed processing event {:?}", e),
@@ -358,7 +374,7 @@ fn main() {
     chains_event_tx
         .send(ChainsEvent::BurnchainBlockDiscovered(Some(event_callback_tx)))
         .expect("Unable to transmit ChainsEvent::BurnchainBlockDiscovered");
-    if let Ok(event) = event_callback_rx.recv() {
+    if let Ok(_) = event_callback_rx.recv() {
         println!("Event processed!")
     }
 }

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -1,5 +1,7 @@
+use std::collections::VecDeque;
 use std::thread;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{self, Sender};
 use std::process;
 
 use burnchains::BurnchainHeaderHash;
@@ -30,6 +32,10 @@ impl ChainStateDB {
     }
 
     pub fn is_block_processed(&self, block_id: &StacksBlockIdentifier) -> Result<bool, ()> {
+        unimplemented!()
+    }
+
+    pub fn process_blocks(&mut self, burnchain_db: &mut BurnchainDB, max_blocks: usize) -> Result<Vec<(Option<(StacksHeaderInfo, Vec<StacksTransactionReceipt>)>, Option<TransactionPayload>)>, Error> {
         unimplemented!()
     }
 }
@@ -81,7 +87,7 @@ impl PoxDB {
         unimplemented!()
     }
 
-    pub fn get_reward_set_start_for(&self, block: &StacksBlockIdentifier) -> u64 {
+    pub fn get_reward_set_start_for(&self, block: &StacksBlockIdentifier) -> &BurnchainHeaderHash {
         unimplemented!()
     }
 }
@@ -147,31 +153,33 @@ impl ChainsCoordinator {
         }
     }
 
-    pub fn handle_new_burnchain_block(&mut self) {
+    pub fn handle_new_burnchain_block(&mut self) -> Result<(), ()> {
         // Retrieve canonical burnchain chain tip from the BurnchainDB
         let canonical_burnchain_tip = self.burnchain_db.get_canonical_chain_tip();
         
         // Early return: this block has already been processed
         match self.canonical_burnchain_chain_tip {
-            Some(ref current) if current.burn_header_hash == canonical_burnchain_tip.burn_header_hash => return,
-            _ => {}
-        }
+            Some(ref current) if current.burn_header_hash == canonical_burnchain_tip.burn_header_hash => Err(()),
+            _ => Ok(())
+        }?;
 
         // Retrieve canonical pox id (<=> reward cycle id)
         let pox_id = self.pox_db.get_canonical_pox_id(&canonical_burnchain_tip.burn_header_hash);
 
         // Retrieve all the direct ancestors of this block with an unprocessed sortition 
-        let mut parent_bhh = canonical_burnchain_tip.burn_header_hash.clone();
-        let mut sortitions_to_process = vec![canonical_burnchain_tip];
+        let mut cursor = canonical_burnchain_tip.burn_header_hash.clone();
+        let mut sortitions_to_process = VecDeque::new();
 
-        while match self.sortition_db.is_sortition_processed(&parent_bhh, &pox_id) {
-            Ok(ref is_processed)  => !is_processed,
+        while match self.sortition_db.is_sortition_processed(&cursor, &pox_id) {
+            Ok(ref is_processed)  => !is_processed, // We halt the ancestry research as soon as we find a processed parent
             _ => false
         } {
-            if let Ok(block) = self.burnchain_db.get_burnchain_block(&parent_bhh) {
-                parent_bhh = block.parent_burn_header_hash.clone();
-                sortitions_to_process.push(block);
+            if let Ok(block) = self.burnchain_db.get_burnchain_block(&cursor) {
+                let parent = block.parent_burn_header_hash.clone();
+                sortitions_to_process.push_front(block);
+                cursor = parent;
             } else {
+                info!("ChainsCoordinator: could not retrieve block {}", cursor);
                 break;
             }
         }
@@ -180,8 +188,8 @@ impl ChainsCoordinator {
             let sortition_id = match SortitionDB::evaluate_sortition(&unprocessed_block, &pox_id, &self.pox_db) {
                 Ok(sortition_id) => sortition_id,
                 Err(e) => {
-                    error!("ChainsCoordinator: unable to retrieve sortition");
-                    continue
+                    error!("ChainsCoordinator: unable to retrieve sortition {:?}", e);
+                    break
                 }
             };
 
@@ -189,124 +197,160 @@ impl ChainsCoordinator {
                 // todo(ludo): I think I'm supposed to use `SortitionDB::latest_stacks_blocks_processed`
                 for block in blocks_ready_to_process {
                     match self.process_block(&block) {
-                        Some(is_pox_anchor) if is_pox_anchor == true => {
-                            self.process_new_pox_anchor();
+                        Ok(is_pox_anchor) => {
+                            if is_pox_anchor == true {
+                                self.process_new_pox_anchor()?;
+                            }
+                            Ok(())
                         }
-                        _ => {}
-                    }
+                        Err(err) => Err(err)
+                    }?;
                 }
             }
         }
+
+        Ok(())
     }
 
-    pub fn handle_new_block(&mut self) {
+    pub fn handle_new_block(&mut self) -> Result<(), ()> {
         // Rebuild sortition id
         let sortition_id = match (&self.canonical_pox_id, &self.canonical_burnchain_chain_tip) {
-            (Some(pox_id), Some(burnchain_block)) => SortitionIdentifier(burnchain_block.burn_header_hash.clone(), pox_id.clone()),
+            (Some(pox_id), Some(burnchain_block)) => Ok(SortitionIdentifier(burnchain_block.burn_header_hash.clone(), pox_id.clone())),
             (_, _) => {
-                // todo(ludo): handle this case
-                return;
+                // We received a BlockDiscovered event before receiving a BurnchainBlockDiscovered event
+                Err(())
             }
-        };
+        }?;
 
         while let Some(blocks_ready_to_process) = self.blocks_db.get_blocks_ready_to_process(&sortition_id, &self.sortition_db) {
             // todo(ludo): I think I'm supposed to use `SortitionDB::latest_stacks_blocks_processed`
             for block in blocks_ready_to_process {
                 match self.process_block(&block) {
-                    Some(is_pox_anchor) if is_pox_anchor == true => {
-                        self.process_new_pox_anchor();
+                    Ok(is_pox_anchor) if is_pox_anchor == true => {
+                        self.process_new_pox_anchor()?;
                     }
                     _ => {}
                 }
                 self.canonical_chain_tip = Some(block);
             }
         }
+
+        Ok(())
     }
 
-    fn process_new_pox_anchor(&mut self) {
+    fn process_new_pox_anchor(&mut self) -> Result<(), ()> {
         let ordered_missing_anchored_blocks = self.pox_db.get_ordered_missing_anchors();
         for block_id in ordered_missing_anchored_blocks.iter() {
             match self.chain_state_db.is_block_processed(&block_id) {
-                Ok(is_processed) if is_processed == true => {
-                    PoxDB::process_anchor(&block_id, &self.chain_state_db);
-                    // self.canonical_burn_header = self.pox_db.get_reward_set_start_for(&block_id);
-                    // todo(ludo): adapt the following lines.
-                    // self.canon_burn_header = self.pox_db.get_reward_set_start_for(block) 
-                    // todo(ludo): block_id is a construct based on the pox_id, why do we need to fetch it from the DB?
-                    self.canonical_pox_id = Some(self.pox_db.get_canonical_pox_id(&block_id.burnchain_header_hash));
-                    self.canonical_chain_tip = None;
-                    // start processing from the beginning of the new PoX reward set
-                    return self.handle_new_burnchain_block()    
+                Ok(is_processed) => {
+                    if is_processed {
+                        PoxDB::process_anchor(&block_id, &self.chain_state_db)?;
+                        let canonical_bhh = self.pox_db.get_reward_set_start_for(&block_id);
+                        // Retrieve the corresponding block
+                        let canonical_block = self.burnchain_db.get_burnchain_block(canonical_bhh)?;
+                        self.canonical_burnchain_chain_tip = Some(canonical_block); 
+                        self.canonical_pox_id = Some(self.pox_db.get_canonical_pox_id(&block_id.burnchain_header_hash));
+                        self.canonical_chain_tip = None;
+                        // Start processing from the beginning of the new PoX reward set
+                        self.handle_new_burnchain_block()?;    
+                    }
+                    Ok(())
                 },
-                _ => {}
-            }
+                Err(e) => {
+                    error!("ChainsCoordinator: unable to retrieve processed block {:?}", block_id);
+                    Err(e)
+                }
+            }?;
         }
-        self.discover_new_pox_anchor();
+        self.discover_new_pox_anchor()
     }
 
-    fn process_block(&self, block: &StacksBlock) -> Option<bool> {
+    fn process_block(&self, block: &StacksBlock) -> Result<bool, ()> {
         unimplemented!()
     }
 
-    fn discover_new_pox_anchor(&mut self) {
+    fn discover_new_pox_anchor(&mut self) -> Result<(), ()> {
         unimplemented!()
     }
 }
 
 pub enum ChainsEvent {
-    BlockDiscovered,
-    BurnchainBlockDiscovered,
+    BlockDiscovered(Option<Sender<ChainsEventCallback>>),
+    BurnchainBlockDiscovered(Option<Sender<ChainsEventCallback>>),
 }
 
-pub struct ChainsEventsObserver {
-    event_tx: Option<mpsc::Sender<ChainsEvent>>,
+pub enum ChainsEventCallback {
+    BlockProcessed,
+    BurnchainBlockProcessed,
 }
 
-impl ChainsEventsObserver {
+pub struct ChainsEventsRouter {
+    events_tx: Option<mpsc::Sender<ChainsEvent>>,
+}
 
-    pub fn new() -> ChainsEventsObserver {
-        ChainsEventsObserver {
-            event_tx: None
+impl ChainsEventsRouter {
+
+    pub fn new() -> ChainsEventsRouter {
+        ChainsEventsRouter {
+            events_tx: None,
         }
     }
 
     pub fn spawn_chains_coordinator(&mut self) -> mpsc::Sender<ChainsEvent> {
-        if let Some(ref event_tx) = self.event_tx {
+        if let Some(ref events_tx) = self.events_tx {
             error!("ChainsCoordinator is already processing chains events");
-            return event_tx.clone();
+            return events_tx.clone();
         }
 
-        let (event_tx, event_rx) = mpsc::channel();
-        self.event_tx = Some(event_tx.clone());
+        let (events_tx, events_rx) = mpsc::channel();
+        self.events_tx = Some(events_tx.clone());
 
         thread::spawn(move || {
             let mut chains_coordinator = ChainsCoordinator::new();
             loop {
-                if let Ok(event) = event_rx.recv() {
-                    match event {
-                        ChainsEvent::BlockDiscovered => chains_coordinator.handle_new_block(),
-                        ChainsEvent::BurnchainBlockDiscovered => chains_coordinator.handle_new_burnchain_block(),
-                    }                
+                if let Ok(event) = events_rx.recv() {
+                    let (result, tx, event_callback) = match event {
+                        ChainsEvent::BlockDiscovered(tx) => 
+                            (chains_coordinator.handle_new_block(), tx, ChainsEventCallback::BlockProcessed),
+                        ChainsEvent::BurnchainBlockDiscovered(tx) => 
+                            (chains_coordinator.handle_new_burnchain_block(), tx, ChainsEventCallback::BurnchainBlockProcessed),
+                    };
+                    match result {
+                        Ok(res) => {
+                            info!("ChainsCoordinator: successfully processed event");
+                            if let Some(tx) = tx {
+                                tx.send(event_callback);
+                            }
+                        },
+                        Err(e) => error!("ChainsCoordinator: failed processing event {:?}", e),
+                    };
                 } else {
                     error!("ChainsEventsObserver stopped receiving events");
                     break;
                 }
             }
         });
-        event_tx
+        events_tx
     }
 }
 
 fn main() {
-    let mut chains_events_observer = ChainsEventsObserver::new();
-    let chains_event_tx = chains_events_observer.spawn_chains_coordinator();
+    let mut chains_events_router = ChainsEventsRouter::new();
+    let chains_event_tx = chains_events_router.spawn_chains_coordinator();
 
     // We can now, from any thread, notify the coordinator to update the different DBs, with the following events, 
     // and be sure that the processing of these events will happen sequentially on the same thread.
     chains_event_tx
-        .send(ChainsEvent::BlockDiscovered)
+        .send(ChainsEvent::BlockDiscovered(None))
         .expect("Unable to transmit ChainsEvent::BlockDiscovered");
+
+    // Since events processing is mono-threaded, we can, as an option, provide a callback transmitter
+    // in case we need to make a given job blocking
+    let (event_callback_tx, event_callback_rx) = mpsc::channel();
     chains_event_tx
-        .send(ChainsEvent::BurnchainBlockDiscovered)
-        .expect("Unable to transmit ChainsEvent::BurnchainBlockDiscovered");;
+        .send(ChainsEvent::BurnchainBlockDiscovered(Some(event_callback_tx)))
+        .expect("Unable to transmit ChainsEvent::BurnchainBlockDiscovered");
+    if let Ok(event) = event_callback_rx.recv() {
+        println!("Event processed!")
+    }
 }

--- a/src/chainstate/mod.rs
+++ b/src/chainstate/mod.rs
@@ -28,4 +28,4 @@ pub trait ChainstateDB {
 // needs to come _after_ the macro def above, since they both use this macro
 pub mod burn;
 pub mod stacks;
-
+pub mod coordinator;

--- a/src/vm/analysis/type_checker/tests/contracts.rs
+++ b/src/vm/analysis/type_checker/tests/contracts.rs
@@ -142,7 +142,7 @@ fn test_names_tokens_contracts_interface() {
 
     let contract_analysis = mem_type_check(INTERFACE_TEST_CONTRACT).unwrap().1;
     let test_contract_json_str = build_contract_interface(&contract_analysis).serialize();
-    let test_contract_json = serde_json::from_str(&test_contract_json_str).unwrap();
+    let test_contract_json: serde_json::Value = serde_json::from_str(&test_contract_json_str).unwrap();
 
     let test_contract_json_expected = serde_json::from_str(r#"{
         "functions": [

--- a/src/vm/analysis/type_checker/tests/contracts.rs
+++ b/src/vm/analysis/type_checker/tests/contracts.rs
@@ -144,7 +144,7 @@ fn test_names_tokens_contracts_interface() {
     let test_contract_json_str = build_contract_interface(&contract_analysis).serialize();
     let test_contract_json: serde_json::Value = serde_json::from_str(&test_contract_json_str).unwrap();
 
-    let test_contract_json_expected = serde_json::from_str(r#"{
+    let test_contract_json_expected: serde_json::Value = serde_json::from_str(r#"{
         "functions": [
             { "name": "f00",
                 "access": "private",

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -21,8 +21,7 @@ use stacks::chainstate::burn::operations::{
 };
 use stacks::core::mempool::MemPoolDB;
 use stacks::net::{
-    p2p::PeerNetwork, Error as NetError, db::PeerDB, PeerAddress,
-    NetworkResult, rpc::RPCHandlerArgs
+    p2p::PeerNetwork, Error as NetError, db::PeerDB, PeerAddress, rpc::RPCHandlerArgs
 };
 
 use stacks::util::vrf::VRFPublicKey;


### PR DESCRIPTION
This PR is introducing the ChainsCoordinator - the structure in charge of updating the chains states and consensus for each new Block / BurnchainBlock.
The code compiles, and correspond more or less to the version prototyped in Python introduced a few weeks ago by @kantai, and includes a few "fixes" that have been discussed over our calls.

Having a closer look at how we're naming things, I think we could increase overall consistency.
In this new module, I'm importing / aliasing a few structs, and paid attention to make the naming consistent.
If we're all onboard with doing a pass on name consistency, I'd be happy to follow up with a PR (or open an issue), focused on renaming some of our core structs.
