### PR TITLE
More possible corruption fixes to the MARF

### DIFF
--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -1317,9 +1317,7 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
 
             debug!("Flush: identifier of {} is {}", flush_options, block_id);
 
-            if self.unconfirmed {
-                self.cur_block_id = Some(block_id);
-            }
+            self.cur_block_id = None;
         }
 
         Ok(())
@@ -1353,6 +1351,8 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
                     .expect("Corruption: Failed to drop the extended trie");
             }
             self.last_extended = None;
+            self.cur_block_id = None;
+            self.cur_block = TrieFileStorage::block_sentinel();
         }
     }
 
@@ -1367,6 +1367,8 @@ impl <T: MarfTrieId> TrieFileStorage <T> {
             tx.commit()
                 .expect("Corruption: Failed to drop the extended trie");
             self.last_extended = None;
+            self.cur_block_id = None;
+            self.cur_block = TrieFileStorage::block_sentinel();
         }
     }
 


### PR DESCRIPTION
This is still shooting blind, but I want to run this by CircleCI at least to see what happens if we forcibly invalidate `cur_block` and `cur_block_id` when we drop extending tries.