### PR TITLE
Set FIRST_BLOCK_TESTNET

### DIFF
--- a/src/burnchains/bitcoin/indexer.rs
+++ b/src/burnchains/bitcoin/indexer.rs
@@ -63,7 +63,7 @@ pub const BITCOIN_REGTEST_NAME: &'static str = "regtest";
 
 // TODO: change MANINET once we have a target block
 pub const FIRST_BLOCK_MAINNET: u64 = 373601;
-pub const FIRST_BLOCK_TESTNET: u64 = 0;
+pub const FIRST_BLOCK_TESTNET: u64 = 300;
 pub const FIRST_BLOCK_REGTEST: u64 = 0;
 
 // batch size for searching for a reorg 


### PR DESCRIPTION
The `pox` contract is using the following formula for determining the pox-reward-cycle-id:

```
(define-private (burn-height-to-reward-cycle (height uint)) 
    (/ (- height (var-get first-burnchain-block-height)) (var-get pox-reward-cycle-length)))
```

When booting, we're publishing the pox contract and configuring it with:

```
(define-public (set-burnchain-parameters (first-burn-height uint) (prepare-cycle-length uint) (reward-cycle-length uint) (rejection-fraction uint))
``` 

`first-burn-height` is relying on `FIRST_BLOCK_TESTNET` set to 0.

This means that for the pox contract, the first Stacks block is being mined in middle of reward-cycle-id =(300 / 120) = 2.

Related, we're also using this constant:

```
pub const FIRST_BURNCHAIN_BLOCK_HASH_TESTNET : BurnchainHeaderHash = BurnchainHeaderHash([1u8; 32]);
```
Shouldn't it be an issue?