### PR TITLE
[Stacks v1 → v2 Upgrade] Export name, namespaces, subdomains and zonefiles

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3621,7 +3621,12 @@ def run_blockstackd():
         subdomain_db_path = os.path.abspath(os.path.join(working_dir, 'subdomains.db'))
         subdomain_csv_path = os.path.join(output_dir, 'subdomains.csv')
         subdomain_csv_hash_path = subdomain_csv_path + '.sha256'
-        subdomain_query_str = 'SELECT zonefile_hash, fully_qualified_subdomain, owner from subdomain_records ORDER BY owner, fully_qualified_subdomain;'
+        subdomain_query_str = """
+            SELECT zonefile_hash, parent_zonefile_hash, fully_qualified_subdomain, owner, block_height, parent_zonefile_index, zonefile_offset, resolver
+            FROM subdomain_records
+            WHERE accepted = 1 AND missing = ''
+            GROUP BY fully_qualified_subdomain
+            ORDER BY block_height DESC, zonefile_hash;"""
         cmd = 'sqlite3 {} -cmd ".headers on" -cmd ".mode csv" -cmd ".output {}" "{}"'.format(
             pipes.quote(subdomain_db_path), 
             pipes.quote(subdomain_csv_path), 

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3572,10 +3572,6 @@ def run_blockstackd():
            print 'fast_sync failed'
            sys.exit(1)
 
-        # treat this as a recovery
-        print_status("Running setup recovery...")
-        setup_recovery(working_dir)
-
         block = int(args.block_height)
         # allow consensus_hash to be provided as a string or within a file
         consensus_hash = args.consensus_hash

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3729,8 +3729,15 @@ def run_blockstackd():
         for namespace_str in namespaces_entries:
             namespace_info = db.get_namespace(namespace_str)
             namespace = {}
+            namespace['ready_block'] = namespace_info['ready_block']
+            namespace['reveal_block'] = namespace_info['reveal_block']
             namespace['namespace_id'] = namespace_info['namespace_id']
             namespace['address'] = b58ToC32(str(namespace_info['address']))
+            namespace['buckets'] = ';'.join(str(x) for x in namespace_info['buckets'])
+            namespace['base'] = namespace_info['base']
+            namespace['coeff'] = namespace_info['coeff']
+            namespace['nonalpha_discount'] = namespace_info['nonalpha_discount']
+            namespace['no_vowel_discount'] = namespace_info['no_vowel_discount']
             namespaces.append(namespace)
 
         print_status("Querying names...")

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3644,11 +3644,11 @@ def run_blockstackd():
             print_status('Could not find "awk" utility on system path')
             sys.exit(1)
         # Watch out, the following awk code is so fast you might miss it if you blink.
-        # Reduce 10GB disk space of zonefiles into a 300MB txt file.
+        # Reduce 10GB disk space of zonefiles into a 400MB txt file.
         awk_export_cmd = """awk -F, 'BEGIN {OFS=","} NR>1 {
             save_rs = RS
             RS = "^$"
-            file_path = "%s/" substr($1,0,2) "/" substr($1,2,2) "/" $1 ".txt"
+            file_path = "%s/" substr($1,0,2) "/" substr($1,3,2) "/" $1 ".txt"
             getline zonefile < file_path
             gsub(/\\n/,"/n",zonefile)
             close(file_path)

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3561,6 +3561,14 @@ def run_blockstackd():
 
     elif args.action == 'export_migration_json':
 
+        import hashlib
+        def sha256(file_path):
+            hash_sha256 = hashlib.sha256()
+            with open(file_path, "rb") as f:
+                for chunk in iter(lambda: f.read(4096), b""):
+                    hash_sha256.update(chunk)
+            return hash_sha256.hexdigest()
+
         def print_status(msg):
             print "[{}] {}".format(int(round(time.time())), msg)
 
@@ -3626,14 +3634,11 @@ def run_blockstackd():
             sys.exit(1)
 
         print_status("Writing subdomains csv file hash...")
-        from hashlib import sha256
-        with open(subdomain_csv_path, 'rb') as f:
-            file_bytes = f.read()
-            file_hash = sha256(file_bytes).hexdigest()
-            print_status("Subdomain csv data sha256 hash: {}".format(file_hash))
-            with open(subdomain_csv_hash_path, 'w') as hash_out:
-                hash_out.write(file_hash)
-                hash_out.flush()
+        file_hash = sha256(subdomain_csv_path)
+        print_status("Subdomain csv data sha256 hash: {}".format(file_hash))
+        with open(subdomain_csv_hash_path, 'w') as hash_out:
+            hash_out.write(file_hash)
+            hash_out.flush()
 
         print_status("Aggregating subdomain zonefiles...")
         # Reduce 10GB disk space of zonefiles into a 400MB txt file.
@@ -3706,14 +3711,11 @@ def run_blockstackd():
 
         # out sha256 hash of aggregated subdomain subdomain_zonefiles.txt
         print_status("Writing json file hash for aggregated subdomain zonefiles...")
-        from hashlib import sha256
-        with open(subdomain_zonefile_txt_path, 'rb') as f:
-            file_bytes = f.read()
-            json_hash = sha256(file_bytes).hexdigest()
-            print_status("Aggregated subdomain zonefiles sha256 hash: {}".format(json_hash))
-            with open(subdomain_zonefile_hash_txt_path, 'w') as hash_out:
-                hash_out.write(json_hash)
-                hash_out.flush()
+        json_hash = sha256(subdomain_zonefile_txt_path)
+        print_status("Aggregated subdomain zonefiles sha256 hash: {}".format(json_hash))
+        with open(subdomain_zonefile_hash_txt_path, 'w') as hash_out:
+            hash_out.write(json_hash)
+            hash_out.flush()
 
         print_status("Querying namespace IDs...")
         namespaces_entries = db.get_all_namespace_ids()
@@ -3788,14 +3790,11 @@ def run_blockstackd():
 
         # also output the sha256 hash
         print_status("Writing json file hash...")
-        from hashlib import sha256
-        with open(json_output_path, 'rb') as f:
-            file_bytes = f.read()
-            json_hash = sha256(file_bytes).hexdigest()
-            print_status("Migration json data sha256 hash: {}".format(json_hash))
-            with open(json_hash_output_path, 'w') as hash_out:
-                hash_out.write(json_hash)
-                hash_out.flush()
+        json_hash = sha256(json_output_path)
+        print_status("Migration json data sha256 hash: {}".format(json_hash))
+        with open(json_hash_output_path, 'w') as hash_out:
+            hash_out.write(json_hash)
+            hash_out.flush()
         
         # compress into tar.gz
         print_status("Compressing export data into archive file...")

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3738,6 +3738,7 @@ def run_blockstackd():
             namespace['coeff'] = namespace_info['coeff']
             namespace['nonalpha_discount'] = namespace_info['nonalpha_discount']
             namespace['no_vowel_discount'] = namespace_info['no_vowel_discount']
+            namespace['lifetime'] = 0 if namespace_info['lifetime'] == NAMESPACE_LIFE_INFINITE else namespace_info['lifetime']
             namespaces.append(namespace)
 
         print_status("Querying names...")

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3746,10 +3746,15 @@ def run_blockstackd():
         names = []
         for name_str in name_entries:
             name_info = load_name_info(db, name_str, block)
+            if name_info['revoked']:
+                continue
+            if name_info['expired']:
+                continue
             name = {}
             name['name'] = name_info['name']
             name['address'] = b58ToC32(str(name_info['address']))
             name['expire_block'] = name_info['expire_block']
+            name['registered_at'] = max(name_info['first_registered'], name_info['last_renewed'])
             if 'zonefile' not in name_info or name_info['zonefile'] is None:
                 # print 'missing zonefile for {}'.format(name)
                 name['zonefile'] = ""

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3790,7 +3790,7 @@ def run_blockstackd():
         json_output_path = os.path.join(output_dir, 'chainstate.json')
         json_hash_output_path = json_output_path + '.sha256'
         with open(json_output_path, 'w') as json_out:
-            json.dump(json_data, json_out, separators=(',', ':'), check_circular=False, ensure_ascii=False)
+            json.dump(json_data, json_out, separators=(',', ':'), check_circular=False)
             json_out.flush()
 
         # also output the sha256 hash


### PR DESCRIPTION
Adds namespaces and on-chain names to the exported JSON. 

Export two new files:
* `subdomains.csv`: a dump the `subdomains.db` sqlite file. Currently 420MB. Sample output:
```csv
zonefile_hash,parent_zonefile_hash,fully_qualified_subdomain,owner,block_height,parent_zonefile_index,zonefile_offset,resolver
0038e66cb945dc0aa36643b4e0328f886ee9bf4f,b49dab6c53962e79d65fee61253a3c833dd53e0b,zuricorbin-twitter.id.blockstack,1MdP2PhNmuHjXXrWdggpBBaiprHbHi4atg,653715,125154,45,https://registrar.blockstack.org
007d172f2f11f51a636132ffae70a4940ccff962,b49dab6c53962e79d65fee61253a3c833dd53e0b,callmejustmerd-twitter.id.blockstack,1MDE9fbZSee7abrFF2i45Frx7EEQB9emTN,653715,125154,81,https://registrar.blockstack.org
01512a1ac45a97bd41ad7e47b1b7083b905871c5,b49dab6c53962e79d65fee61253a3c833dd53e0b,4brash-twitter.id.blockstack,123xYRdgRTQAfZu8bP2FLQzsc7DuPnywwN,653715,125154,117,https://registrar.blockstack.org
0412fca826dc3f7ee999e80d4b76ca3a603232fe,b49dab6c53962e79d65fee61253a3c833dd53e0b,orcngny-twitter.id.blockstack,19M1BnhKp5rqKq1WFsyd2gjM2qiKks2d4C,653715,125154,50,https://registrar.blockstack.org
073f747ae42ffe9da47b21e0e003b8813708e936,b49dab6c53962e79d65fee61253a3c833dd53e0b,atatat666-twitter.id.blockstack,1CNmVESKb4G8qn4uWNUSw8ymQyKqZbJRME,653715,125154,83,https://registrar.blockstack.org
075b60670330716ad3dfb80cb8f145151fce5e4a,b49dab6c53962e79d65fee61253a3c833dd53e0b,mabling-twitter.id.blockstack,1PECnt8V7pX5raP33SHDKogGGX4HZQUW1h,653715,125154,37,https://registrar.blockstack.org
```
* `subdomain_zonefiles.txt`: all subdomain zonefiles. Currently 400MB. Format is zonefile_hash string followed by new-line escaped zonefile content, repeated. Sample output:
```
0038e66cb945dc0aa36643b4e0328f886ee9bf4f
$ORIGIN zuricorbin-twitter \n$TTL 3600\n_https._tcp URI 10 1 'https://gaia.blockstack.org/hub/1MdP2PhNmuHjXXrWdggpBBaiprHbHi4atg/profile.json'
007d172f2f11f51a636132ffae70a4940ccff962
$ORIGIN callmejustmerd-twitter \n$TTL 3600\n_https._tcp URI 10 1 'https://gaia.blockstack.org/hub/1MDE9fbZSee7abrFF2i45Frx7EEQB9emTN/profile.json'
01512a1ac45a97bd41ad7e47b1b7083b905871c5
$ORIGIN 4brash-twitter \n$TTL 3600\n_https._tcp URI 10 1 'https://gaia.blockstack.org/hub/123xYRdgRTQAfZu8bP2FLQzsc7DuPnywwN/profile.json'
0412fca826dc3f7ee999e80d4b76ca3a603232fe
$ORIGIN orcngny-twitter \n$TTL 3600\n_https._tcp URI 10 1 'https://gaia.blockstack.org/hub/19M1BnhKp5rqKq1WFsyd2gjM2qiKks2d4C/profile.json'
073f747ae42ffe9da47b21e0e003b8813708e936
$ORIGIN atatat666-twitter \n$TTL 3600\n_https._tcp URI 10 1 'https://gaia.blockstack.org/hub/1CNmVESKb4G8qn4uWNUSw8ymQyKqZbJRME/profile.json'
075b60670330716ad3dfb80cb8f145151fce5e4a
$ORIGIN mabling-twitter \n$TTL 3600\n_https._tcp URI 10 1 'https://gaia.blockstack.org/hub/1PECnt8V7pX5raP33SHDKogGGX4HZQUW1h/profile.json'
```

Sha256 hashes of all three files are also included.

The final exported tar.gz file is ~300MB, and the process takes around 15 to 30 minutes to complete (depending on which utilities are available on PATH).

Ingest implementation note: the `subdomains.csv` and `subdomain_zonefiles.txt` are both too large to read into memory at once, however, they are both ordered by the `zonefile_hash`. This allows each of the files to be stream read in tandem with minimal memory usage. 

```
matt$ time python bin/blockstack-core export_migration_json ./snapshot-test-data.tar.gz 653759 17e4af7e088cbd043625843b642e2b2d /tmp/migration-output --working_dir /tmp/blockstack-migration-test
[1604063229] Importing fast-sync dump snapshot-test-data.tar.gz into /tmp/blockstack-migration-test
[1604063811] Running setup recovery...
[1604063811] Exporting subdomain metadata to csv...
[1604063822] Writing subdomains csv file hash...
[1604063822] Subdomain csv data sha256 hash: 67f27ade9d94583ae3324ad37b934911268a22a8c2f625920b50a62b478b2123
[1604063822] Exporting subdomain zonefiles...
[1604063903] Querying namespace IDs...
[1604063903] Querying names...
[1604063907] Querying account addresses...
[1604063908] Querying account balances...
[1604063930] Querying account vesting addresses...
[1604063931] Writing on-chain migration data to json...
[1604063936] Writing json file hash...
[1604063936] Migration json data sha256 hash: 93835ea4acb8ef376e502a2b0092402cb3860619356e88f6019dc0de3a19a759
[1604063936] Compressing export data into archive file...
[1604063989] Files exported to /tmp/migration-output.tar.gz
Migration data export complete

real	31m50.588s
user	4m14.248s
sys	14m8.112s
```

----

### Reviewer notes:
* File formats are picked based on optimal file size and portability (e.g. easy for Rust to import).
* Several operations are shell'd out to system utilities for performance purposes. For example `sqlite3` binary is used to stream subdomain metadata into a csv file. Either `awk` or `dotnet` are used to consolidate millions of zonefiles into a single txt file. 

Exported file sample: https://mega.nz/file/ERdmlZBb#ghlwCwEk5AY3JqJkFAtdLGe_Jnb6HthccBe9H249W_M
At block height 653759