### PR TITLE
[Do-not-merge] [Stacks v1 → v2 Upgrade] Perform export step on block interval

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3412,7 +3412,8 @@ def run_blockstackd():
 
                # have old state.  keep it around for later inspection
                target_dir = os.path.join( working_dir, 'crash.{}'.format(time.time()))
-               os.makedirs(target_dir)
+               if not os.path.exists( target_dir ):
+                   os.makedirs(target_dir)
                for sp in state_paths:
                    if os.path.exists(sp):
                       target = os.path.join( target_dir, os.path.basename(sp) )

--- a/blockstack/lib/config.py
+++ b/blockstack/lib/config.py
@@ -53,6 +53,7 @@ SAVE_REJECTED_ENV_VAR = 'BLOCKSTACK_DB_SAVE_REJECTED'
 
 V2_MIGRATION_EXPORT_ENV_VAR = 'V2_MIGRATION_EXPORT'
 V2_MIGRATION_EXPORT_TEST_INTERVAL_ENV_VAR = 'V2_MIGRATION_EXPORT_TEST_INTERVAL'
+V2_MIGRATION_EXPORT_DIR_ENV_VAR = 'V2_MIGRATION_EXPORT_DIR'
 
 # namespace version bits
 NAMESPACE_VERSION_PAY_TO_BURN = 0x1     # in epoch 4, this means "burn either bitcoin or stacks"
@@ -1812,7 +1813,7 @@ def default_blockstack_opts( working_dir, config_file=None ):
    or from sane defaults.
    """
 
-   global RPC_SERVER_IP, RPC_SERVER_PORT, BACKUP_FREQUENCY_ENV_VAR, BACKUP_MAX_AGE_ENV_VAR, SAVE_REJECTED_ENV_VAR, V2_MIGRATION_EXPORT_ENV_VAR, V2_MIGRATION_EXPORT_TEST_INTERVAL_ENV_VAR
+   global RPC_SERVER_IP, RPC_SERVER_PORT, BACKUP_FREQUENCY_ENV_VAR, BACKUP_MAX_AGE_ENV_VAR, SAVE_REJECTED_ENV_VAR, V2_MIGRATION_EXPORT_ENV_VAR, V2_MIGRATION_EXPORT_TEST_INTERVAL_ENV_VAR, V2_MIGRATION_EXPORT_DIR
 
    from .util import url_to_host_port
    from .scripts import is_name_valid
@@ -1830,12 +1831,14 @@ def default_blockstack_opts( working_dir, config_file=None ):
    save_rejected = False        # save rejected transactions?
    v2_migration_export = False
    v2_migration_export_test_interval = 0
+   v2_migration_export_dir = False
 
    backup_frequency_environ = False
    backup_max_age_environ = False
    save_rejected_environ = False
    v2_migration_export_environ = False
    v2_migration_export_test_interval_environ = False
+   v2_migration_export_dir_environ = False
 
    try:
        backup_frequency = int(os.environ.get(BACKUP_FREQUENCY_ENV_VAR, None))
@@ -1866,6 +1869,13 @@ def default_blockstack_opts( working_dir, config_file=None ):
    try:
        v2_migration_export_test_interval = int(os.environ.get(V2_MIGRATION_EXPORT_TEST_INTERVAL_ENV_VAR, None))
        v2_migration_export_test_interval_environ = True
+   except:
+       pass
+
+   try:
+       if os.environ.has_key(V2_MIGRATION_EXPORT_DIR_ENV_VAR):
+           v2_migration_export_dir = os.environ.get(V2_MIGRATION_EXPORT_DIR_ENV_VAR, False)
+           v2_migration_export_dir_environ = True
    except:
        pass
 
@@ -1970,6 +1980,9 @@ def default_blockstack_opts( working_dir, config_file=None ):
       if parser.has_option('blockstack', 'v2_migration_export_test_interval') and not v2_migration_export_test_interval_environ:
           v2_migration_export_test_interval = int(parser.get('blockstack', 'v2_migration_export_test_interval'))
 
+      if parser.has_option('blockstack', 'v2_migration_export_dir') and not v2_migration_export_dir_environ:
+          v2_migration_export_dir = parser.get('blockstack', 'v2_migration_export_dir')
+
    if os.environ.get(ATLAS_SEEDS_ENV_VAR, False):
        atlas_seed_peers = os.environ[ATLAS_SEEDS_ENV_VAR]
        check_hostport_list(atlas_seed_peers)
@@ -2044,6 +2057,7 @@ def default_blockstack_opts( working_dir, config_file=None ):
        'save_rejected': save_rejected,
        'v2_migration_export': v2_migration_export,
        'v2_migration_export_test_interval': v2_migration_export_test_interval,
+       'v2_migration_export_dir': v2_migration_export_dir,
        'enabled': run_indexer
    }
 

--- a/blockstack/lib/config.py
+++ b/blockstack/lib/config.py
@@ -52,6 +52,7 @@ BACKUP_MAX_AGE_ENV_VAR = 'BLOCKSTACK_DB_MAX_AGE'
 SAVE_REJECTED_ENV_VAR = 'BLOCKSTACK_DB_SAVE_REJECTED'
 
 V2_MIGRATION_EXPORT_ENV_VAR = 'V2_MIGRATION_EXPORT'
+V2_MIGRATION_EXPORT_TEST_INTERVAL_ENV_VAR = 'V2_MIGRATION_EXPORT_TEST_INTERVAL'
 
 # namespace version bits
 NAMESPACE_VERSION_PAY_TO_BURN = 0x1     # in epoch 4, this means "burn either bitcoin or stacks"
@@ -1811,7 +1812,7 @@ def default_blockstack_opts( working_dir, config_file=None ):
    or from sane defaults.
    """
 
-   global RPC_SERVER_IP, RPC_SERVER_PORT, BACKUP_FREQUENCY_ENV_VAR, BACKUP_MAX_AGE_ENV_VAR, SAVE_REJECTED_ENV_VAR, V2_MIGRATION_EXPORT_ENV_VAR
+   global RPC_SERVER_IP, RPC_SERVER_PORT, BACKUP_FREQUENCY_ENV_VAR, BACKUP_MAX_AGE_ENV_VAR, SAVE_REJECTED_ENV_VAR, V2_MIGRATION_EXPORT_ENV_VAR, V2_MIGRATION_EXPORT_TEST_INTERVAL_ENV_VAR
 
    from .util import url_to_host_port
    from .scripts import is_name_valid
@@ -1828,11 +1829,13 @@ def default_blockstack_opts( working_dir, config_file=None ):
    backup_max_age = 10008       # about 1 week
    save_rejected = False        # save rejected transactions?
    v2_migration_export = False
+   v2_migration_export_test_interval = 0
 
    backup_frequency_environ = False
    backup_max_age_environ = False
    save_rejected_environ = False
    v2_migration_export_environ = False
+   v2_migration_export_test_interval_environ = False
 
    try:
        backup_frequency = int(os.environ.get(BACKUP_FREQUENCY_ENV_VAR, None))
@@ -1857,6 +1860,12 @@ def default_blockstack_opts( working_dir, config_file=None ):
        v2_migration_export_value = int(os.environ.get(V2_MIGRATION_EXPORT_ENV_VAR, None))
        v2_migration_export = v2_migration_export_value != 0
        v2_migration_export_environ = True
+   except:
+       pass
+
+   try:
+       v2_migration_export_test_interval = int(os.environ.get(V2_MIGRATION_EXPORT_TEST_INTERVAL_ENV_VAR, None))
+       v2_migration_export_test_interval_environ = True
    except:
        pass
 
@@ -1958,6 +1967,9 @@ def default_blockstack_opts( working_dir, config_file=None ):
           else:
               v2_migration_export = False
 
+      if parser.has_option('blockstack', 'v2_migration_export_test_interval') and not v2_migration_export_test_interval_environ:
+          v2_migration_export_test_interval = int(parser.get('blockstack', 'v2_migration_export_test_interval'))
+
    if os.environ.get(ATLAS_SEEDS_ENV_VAR, False):
        atlas_seed_peers = os.environ[ATLAS_SEEDS_ENV_VAR]
        check_hostport_list(atlas_seed_peers)
@@ -2031,6 +2043,7 @@ def default_blockstack_opts( working_dir, config_file=None ):
        'subdomaindb_path': subdomaindb_path,
        'save_rejected': save_rejected,
        'v2_migration_export': v2_migration_export,
+       'v2_migration_export_test_interval': v2_migration_export_test_interval,
        'enabled': run_indexer
    }
 

--- a/blockstack/lib/nameset/db.py
+++ b/blockstack/lib/nameset/db.py
@@ -1057,8 +1057,8 @@ def namedb_get_v2_import_block_reached(con):
 
 def namedb_set_v2_import_block_reached(con, block_id):
     existing_block = namedb_get_v2_import_block_reached(con)
-    if existing_block is not None and existing_block != block_id:
-        raise Exception('v2_upgrade_import_block has already been set')
+    if existing_block is not None:
+        raise Exception('v2_upgrade_import_block has already been set to {}'.format(existing_block))
     namedb_query_execute(con, 'UPDATE v2_upgrade_signal SET import_block_id = ? WHERE id = 1', (block_id,))
 
 def namedb_open( path ):

--- a/blockstack/lib/nameset/namedb.py
+++ b/blockstack/lib/nameset/namedb.py
@@ -149,6 +149,7 @@ class BlockstackDB(virtualchain.StateEngine):
 
         self.v2_migration_export = blockstack_opts['v2_migration_export']
         self.v2_migration_export_test_interval = blockstack_opts['v2_migration_export_test_interval']
+        self.v2_migration_export_dir = blockstack_opts['v2_migration_export_dir']
 
     @classmethod
     def get_readonly_instance(cls, working_dir, expected_snapshots={}):
@@ -1167,8 +1168,15 @@ class BlockstackDB(virtualchain.StateEngine):
         if not self.v2_migration_export:
             return
 
-        export_file_path = os.path.abspath(os.path.join( self.working_dir, 'v2_migration_data.tar.gz'))
-        consensus_hash_file_path = os.path.abspath(os.path.join( self.working_dir, 'v2_migration_data.consensus_hash.txt'))
+        migration_dir = os.path.abspath(self.working_dir)
+        if self.v2_migration_export_dir:
+            migration_dir = os.path.abspath(self.v2_migration_export_dir)
+
+        if not os.path.exists(migration_dir):
+            os.makedirs(migration_dir)
+
+        export_file_path = os.path.join(migration_dir, 'v2_migration_data.tar.gz')
+        consensus_hash_file_path = os.path.join(migration_dir, 'v2_migration_data.consensus_hash.txt')
         if os.path.exists(export_file_path):
             log.warn('v2_migration_data already exists at {}'.format(export_file_path))
             return

--- a/blockstack/lib/nameset/namedb.py
+++ b/blockstack/lib/nameset/namedb.py
@@ -1181,6 +1181,8 @@ class BlockstackDB(virtualchain.StateEngine):
             log.warn('v2_migration_data already exists at {}'.format(export_file_path))
             return
 
+        open(os.path.join(migration_dir, 'exporting.lock'), 'a').close()
+
         # override backup frequency to force a backup _now_
         # note: the `make_backup` function subtracts 1 from the given block ID
         old_backup_frequency = self.backup_frequency
@@ -1193,6 +1195,7 @@ class BlockstackDB(virtualchain.StateEngine):
         if snapshot_success:
             with open(consensus_hash_file_path, 'w') as f:
                 f.write(consensus_hash)
+            open(os.path.join(migration_dir, 'exporting.complete'), 'a').close()
         else:
             raise Exception('failed to export v2 datafile')
 

--- a/blockstack/lib/nameset/namedb.py
+++ b/blockstack/lib/nameset/namedb.py
@@ -148,6 +148,7 @@ class BlockstackDB(virtualchain.StateEngine):
         self.set_backup_max_age( blockstack_opts['backup_max_age'] )
 
         self.v2_migration_export = blockstack_opts['v2_migration_export']
+        self.v2_migration_export_test_interval = blockstack_opts['v2_migration_export_test_interval']
 
     @classmethod
     def get_readonly_instance(cls, working_dir, expected_snapshots={}):
@@ -1166,10 +1167,10 @@ class BlockstackDB(virtualchain.StateEngine):
         if not self.v2_migration_export:
             return
 
-        export_file_path = os.path.join( self.working_dir, 'v2_migration_data.tar.bz2')
-        consensus_hash_file_path = os.path.join( self.working_dir, 'v2_migration_data.consensus_hash.txt')
+        export_file_path = os.path.abspath(os.path.join( self.working_dir, 'v2_migration_data.tar.gz'))
+        consensus_hash_file_path = os.path.abspath(os.path.join( self.working_dir, 'v2_migration_data.consensus_hash.txt'))
         if os.path.exists(export_file_path):
-            log.warning('v2_migration_data already exists at {}'.format(export_file_path))
+            log.warn('v2_migration_data already exists at {}'.format(export_file_path))
             return
 
         # override backup frequency to force a backup _now_


### PR DESCRIPTION
Ref https://github.com/blockstackpbc/devops/issues/478

Added a new option to trigger the migration export on a block interval (as opposed to name registration threshold). 

Instructions: set the following env vars:
`V2_MIGRATION_EXPORT=1` (enables exporting)
`V2_MIGRATION_EXPORT_TEST_INTERVAL=10` (the block interval to export at)

The file `<datadir>/v2_migration_data.consensus_hash.txt` will be written once the export is complete. 