### PR TITLE
Xenon adjustments

### DIFF
--- a/src/burnchains/bitcoin/spv.rs
+++ b/src/burnchains/bitcoin/spv.rs
@@ -337,6 +337,7 @@ impl SpvClient {
             "SELECT MAX(height) FROM headers",
             NO_PARAMS,
         )? {
+            Some(max) if max == 0 => Ok(0),
             Some(max) => Ok(max + 1),
             None => Ok(0),
         }
@@ -904,7 +905,7 @@ impl BitcoinMessageHandler for SpvClient {
 
                 debug!(
                     "Request headers for blocks {} - {} in range {} - {}",
-                    block_height,
+                    block_height + 1,
                     block_height + 2000,
                     self.start_block_height,
                     end_block_height
@@ -1019,7 +1020,7 @@ mod test {
             false,
         )
         .unwrap();
-        assert_eq!(spv_client.get_headers_height().unwrap(), 1);
+        assert_eq!(spv_client.get_headers_height().unwrap(), 0);
         assert_eq!(
             spv_client.read_block_header(0).unwrap().unwrap(),
             genesis_regtest_header

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -559,27 +559,6 @@ impl ChainStateBootData {
             post_flight_callback,
         }
     }
-
-    /// The callback post_flight_callback is invoked after initial balances are inserted, and after boot contracts are initialized
-    /// This method is used for inserting a callback before any other callback previously setup.
-    pub fn prepend_post_flight_callback(
-        &mut self,
-        new_callback: Box<dyn FnOnce(&mut ClarityTx) -> ()>,
-    ) {
-        match self.post_flight_callback.take() {
-            Some(initial_callback) => {
-                self.post_flight_callback = Some(Box::new(|clarity_tx| {
-                    new_callback(clarity_tx);
-                    initial_callback(clarity_tx);
-                }));
-            }
-            None => {
-                self.post_flight_callback = Some(Box::new(|clarity_tx| {
-                    new_callback(clarity_tx);
-                }));
-            }
-        }
-    }
 }
 
 impl StacksChainState {

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -7,8 +7,12 @@ use stacks::burnchains::bitcoin::address::BitcoinAddressType;
 use stacks::burnchains::{Address, Burnchain};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::coordinator::comm::{CoordinatorChannels, CoordinatorReceivers};
-use stacks::chainstate::coordinator::{ChainsCoordinator, CoordinatorCommunication};
-use stacks::chainstate::stacks::db::ChainStateBootData;
+use stacks::chainstate::coordinator::{
+    BlockEventDispatcher, ChainsCoordinator, CoordinatorCommunication,
+};
+use stacks::chainstate::stacks::boot::STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR;
+use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
+use stacks::vm::types::{PrincipalData, QualifiedContractIdentifier, Value};
 use std::cmp;
 use std::thread;
 
@@ -122,7 +126,9 @@ impl RunLoop {
             false
         };
 
-        let mut target_burnchain_block_height = 1;
+        let burnchain_config = burnchain.get_burnchain();
+        let mut target_burnchain_block_height = burnchain_config.first_block_height;
+
         match burnchain.start(Some(target_burnchain_block_height)) {
             Ok(_) => {}
             Err(e) => {
@@ -149,44 +155,65 @@ impl RunLoop {
 
         let mut coordinator_dispatcher = event_dispatcher.clone();
 
-        let (network, _) = self.config.burnchain.get_bitcoin_network();
-
-        let burnchain_config = match burnchain_opt {
-            Some(burnchain_config) => burnchain_config.clone(),
-            None => match Burnchain::new(
-                &self.config.get_burn_db_path(),
-                &self.config.burnchain.chain,
-                &network,
-            ) {
-                Ok(burnchain) => burnchain,
-                Err(e) => {
-                    error!("Failed to instantiate burnchain: {}", e);
-                    panic!()
-                }
-            },
-        };
         let chainstate_path = self.config.get_chainstate_path();
         let coordinator_burnchain_config = burnchain_config.clone();
 
-        thread::spawn(move || {
-            let mut boot_data =
-                ChainStateBootData::new(&coordinator_burnchain_config, initial_balances, None);
+        let first_block_height = burnchain_config.first_block_height as u128;
+        let pox_prepare_length = burnchain_config.pox_constants.prepare_length as u128;
+        let pox_reward_cycle_length = burnchain_config.pox_constants.reward_cycle_length as u128;
+        let pox_rejection_fraction = burnchain_config.pox_constants.pox_rejection_fraction as u128;
 
+        let boot_block = Box::new(move |clarity_tx: &mut ClarityTx| {
+            let contract = QualifiedContractIdentifier::parse(&format!(
+                "{}.pox",
+                STACKS_BOOT_CODE_CONTRACT_ADDRESS_STR
+            ))
+            .expect("Failed to construct boot code contract address");
+            let sender = PrincipalData::from(contract.clone());
+            let params = vec![
+                Value::UInt(first_block_height),
+                Value::UInt(pox_prepare_length),
+                Value::UInt(pox_reward_cycle_length),
+                Value::UInt(pox_rejection_fraction),
+            ];
+
+            clarity_tx.connection().as_transaction(|conn| {
+                conn.run_contract_call(
+                    &sender,
+                    &contract,
+                    "set-burnchain-parameters",
+                    &params,
+                    |_, _| false,
+                )
+                .expect("Failed to set burnchain parameters in PoX contract");
+            });
+        });
+        let mut boot_data = ChainStateBootData::new(
+            &coordinator_burnchain_config,
+            initial_balances,
+            Some(boot_block),
+        );
+
+        let (chain_state_db, receipts) = StacksChainState::open_and_exec(
+            mainnet,
+            chainid,
+            &chainstate_path,
+            Some(&mut boot_data),
+            block_limit,
+        )
+        .unwrap();
+        coordinator_dispatcher.dispatch_boot_receipts(receipts);
+
+        thread::spawn(move || {
             ChainsCoordinator::run(
-                &chainstate_path,
+                chain_state_db,
                 coordinator_burnchain_config,
-                mainnet,
-                chainid,
-                block_limit,
                 &mut coordinator_dispatcher,
                 coordinator_receivers,
-                &mut boot_data,
             );
         });
 
         let mut burnchain_tip = burnchain.wait_for_sortitions(None);
-
-        let mut block_height = burnchain_tip.block_snapshot.block_height;
 
         let chainstate_path = self.config.get_chainstate_path();
         let mut pox_watchdog = PoxSyncWatchdog::new(
@@ -236,10 +263,12 @@ impl RunLoop {
             });
         }
 
-        let mut burnchain_height = 1;
+        let mut block_height = burnchain_tip.block_snapshot.block_height;
+
+        let mut burnchain_height = block_height;
 
         // prepare to fetch the first reward cycle!
-        target_burnchain_block_height = pox_constants.reward_cycle_length as u64;
+        target_burnchain_block_height = burnchain_height + pox_constants.reward_cycle_length as u64;
 
         loop {
             // wait for the p2p state-machine to do at least one pass


### PR DESCRIPTION
This PR is fixing an off by one error, previously patched in the previous Xenon PR, mistakenly discarded during one of the multiple rebase / conflict resolution sessions.

It's also addressing a race condition that I've been experiencing during my tests, where the main StacksChainState in charge of building the genesis block, is being initialized after the one initialized in the PoxSyncWatchdog.
By doing so, it's also addressing https://github.com/blockstack/stacks-blockchain/issues/2066.