### PR TITLE
Refactor cost calculation to accept multiple size inputs

### DIFF
--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -81,7 +81,7 @@ impl CostTracker for TypeChecker<'_, '_> {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: u64,
+        input: Vec<u64>,
     ) -> Result<ExecutionCost, CostErrors> {
         self.cost_track.compute_cost(cost_function, input)
     }

--- a/src/vm/analysis/type_checker/mod.rs
+++ b/src/vm/analysis/type_checker/mod.rs
@@ -81,7 +81,7 @@ impl CostTracker for TypeChecker<'_, '_> {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: Vec<u64>,
+        input: &[u64],
     ) -> Result<ExecutionCost, CostErrors> {
         self.cost_track.compute_cost(cost_function, input)
     }

--- a/src/vm/callables.rs
+++ b/src/vm/callables.rs
@@ -21,7 +21,7 @@ use std::iter::FromIterator;
 
 use chainstate::stacks::events::StacksTransactionEvent;
 
-use vm::costs::{cost_functions, runtime_cost, SimpleCostSpecification};
+use vm::costs::{cost_functions, runtime_cost};
 
 use vm::analysis::errors::CheckErrors;
 use vm::contexts::ContractContext;

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -638,7 +638,7 @@ impl CostTracker for Environment<'_, '_> {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: u64,
+        input: Vec<u64>,
     ) -> std::result::Result<ExecutionCost, CostErrors> {
         self.global_context
             .cost_track
@@ -672,7 +672,7 @@ impl CostTracker for GlobalContext<'_> {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: u64,
+        input: Vec<u64>,
     ) -> std::result::Result<ExecutionCost, CostErrors> {
         self.cost_track.compute_cost(cost_function, input)
     }

--- a/src/vm/contexts.rs
+++ b/src/vm/contexts.rs
@@ -638,7 +638,7 @@ impl CostTracker for Environment<'_, '_> {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: Vec<u64>,
+        input: &[u64],
     ) -> std::result::Result<ExecutionCost, CostErrors> {
         self.global_context
             .cost_track
@@ -672,7 +672,7 @@ impl CostTracker for GlobalContext<'_> {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: Vec<u64>,
+        input: &[u64],
     ) -> std::result::Result<ExecutionCost, CostErrors> {
         self.cost_track.compute_cost(cost_function, input)
     }

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -527,7 +527,7 @@ fn load_cost_functions(clarity_db: &mut ClarityDatabase) -> Result<CostStateSumm
                     ) {
                         (Fixed(tf), Fixed(cf)) => {
                             if cf.args.len() != tf.args.len() {
-                                warn!("Confirmed cost proposal invalid: wrong number of arguments";
+                                warn!("Confirmed cost proposal invalid: cost-function contains the wrong number of arguments";
                                       "confirmed_proposal_id" => confirmed_proposal,
                                       "target_contract_name" => %target_contract,
                                       "target_function_name" => %target_function,
@@ -868,12 +868,7 @@ impl CostTracker for LimitedCostTracker {
         // grr, if HashMap::get didn't require Borrow, we wouldn't need this cloning.
         let lookup_key = (contract.clone(), function.clone());
         if let Some(cost_function) = self.contract_call_circuits.get(&lookup_key).cloned() {
-            let input_sizes = if input.is_empty() {
-                vec![0]
-            } else {
-                input.to_vec()
-            };
-            compute_cost(self, cost_function, input_sizes)?;
+            compute_cost(self, cost_function, input.to_vec())?;
             Ok(true)
         } else {
             Ok(false)

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -32,12 +32,15 @@ use vm::contexts::{ContractContext, Environment, GlobalContext, OwnedEnvironment
 use vm::costs::cost_functions::ClarityCostFunction;
 use vm::database::{marf::NullBackingStore, ClarityDatabase, MemoryBackingStore};
 use vm::errors::{Error, InterpreterResult};
+use vm::types::signatures::FunctionType::Fixed;
 use vm::types::Value::UInt;
-use vm::types::{PrincipalData, QualifiedContractIdentifier, TupleData, TypeSignature, NONE};
+use vm::types::{
+    FunctionArg, FunctionType, PrincipalData, QualifiedContractIdentifier, TupleData,
+    TypeSignature, NONE,
+};
 use vm::{ast, eval_all, ClarityName, SymbolicExpression, Value};
 
 use vm::types::signatures::{FunctionSignature, TupleTypeSignature};
-use vm::types::FunctionType;
 
 type Result<T> = std::result::Result<T, CostErrors>;
 
@@ -62,7 +65,7 @@ pub fn runtime_cost<T: TryInto<u64>, C: CostTracker>(
     input: T,
 ) -> Result<()> {
     let size: u64 = input.try_into().map_err(|_| CostErrors::CostOverflow)?;
-    let cost = tracker.compute_cost(cost_function, size)?;
+    let cost = tracker.compute_cost(cost_function, vec![size])?;
 
     tracker.add_cost(cost)
 }
@@ -84,7 +87,7 @@ pub fn analysis_typecheck_cost<T: CostTracker>(
     let t2_size = t2.type_size().map_err(|_| CostErrors::CostOverflow)?;
     let cost = track.compute_cost(
         ClarityCostFunction::AnalysisTypeCheck,
-        cmp::max(t1_size, t2_size) as u64,
+        vec![cmp::max(t1_size, t2_size) as u64],
     )?;
     track.add_cost(cost)
 }
@@ -103,7 +106,7 @@ pub trait CostTracker {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: u64,
+        input: Vec<u64>,
     ) -> Result<ExecutionCost>;
     fn add_cost(&mut self, cost: ExecutionCost) -> Result<()>;
     fn add_memory(&mut self, memory: u64) -> Result<()>;
@@ -125,7 +128,7 @@ impl CostTracker for () {
     fn compute_cost(
         &mut self,
         _cost_function: ClarityCostFunction,
-        _input: u64,
+        _input: Vec<u64>,
     ) -> std::result::Result<ExecutionCost, CostErrors> {
         Ok(ExecutionCost::zero())
     }
@@ -420,7 +423,9 @@ fn load_cost_functions(clarity_db: &mut ClarityDatabase) -> Result<CostStateSumm
 
         // make sure the contract is "cost contract eligible" via the
         //  arithmetic-checking analysis pass
-        let cost_func_ref = match clarity_db.load_contract_analysis(&cost_contract) {
+        let (cost_func_ref, cost_func_type) = match clarity_db
+            .load_contract_analysis(&cost_contract)
+        {
             Some(c) => {
                 if !c.is_cost_contract_eligible {
                     warn!("Confirmed cost proposal invalid: cost-function-contract uses non-arithmetic or otherwise illegal operations";
@@ -454,18 +459,32 @@ fn load_cost_functions(clarity_db: &mut ClarityDatabase) -> Result<CostStateSumm
                         );
                         continue;
                     }
-                } else {
-                    warn!("Confirmed cost proposal invalid: cost-function-name not defined";
-                          "confirmed_proposal_id" => confirmed_proposal,
-                          "contract_name" => %cost_contract,
-                          "function_name" => %cost_function,
-                    );
-                    continue;
+
+                    let maybe_cost_function_types =
+                        c.public_function_types.get(&cost_function).or_else(|| {
+                            c.read_only_function_types
+                                .get(&cost_function)
+                                .or_else(|| c.private_function_types.get(&cost_function).clone())
+                        });
+
+                    let cost_function_types = if let Some(result) = maybe_cost_function_types {
+                        result
+                    } else {
+                        warn!("Confirmed cost proposal invalid: cost-function-name not defined";
+                              "confirmed_proposal_id" => confirmed_proposal,
+                              "contract_name" => %cost_contract,
+                              "function_name" => %cost_function,
+                        );
+                        continue;
+                    };
                 }
-                ClarityCostFunctionReference {
-                    contract_id: cost_contract,
-                    function_name: cost_function.to_string(),
-                }
+                (
+                    ClarityCostFunctionReference {
+                        contract_id: cost_contract,
+                        function_name: cost_function.to_string(),
+                    },
+                    cost_function_types.clone(),
+                )
             }
             None => {
                 warn!("Confirmed cost proposal invalid: cost-function-contract is not a published contract";
@@ -491,7 +510,7 @@ fn load_cost_functions(clarity_db: &mut ClarityDatabase) -> Result<CostStateSumm
                 .cost_function_references
                 .insert(target, cost_func_ref);
         } else {
-            // refering to a user-defined function
+            // referring to a user-defined function
             match clarity_db.load_contract_analysis(&target_contract) {
                 Some(c) => {
                     if !c.read_only_function_types.contains_key(&target_function) {
@@ -501,6 +520,35 @@ fn load_cost_functions(clarity_db: &mut ClarityDatabase) -> Result<CostStateSumm
                               "target_function_name" => %target_function,
                         );
                         continue;
+                    }
+                    match (
+                        c.read_only_function_types.get(&target_function).unwrap(),
+                        &cost_func_type,
+                    ) {
+                        (Fixed(tf), Fixed(cf)) => {
+                            if cf.args.len() != tf.args.len() {
+                                warn!("Confirmed cost proposal invalid: wrong number of arguments";
+                                      "confirmed_proposal_id" => confirmed_proposal,
+                                      "target_contract_name" => %target_contract,
+                                      "target_function_name" => %target_function,
+                                );
+                                continue;
+                            }
+                            for arg in &cf.args {
+                                match &arg.signature {
+                                    TypeSignature::UIntType => {}
+                                    _ => {
+                                        warn!("Confirmed cost proposal invalid: contains non UInt argument";
+                                              "confirmed_proposal_id" => confirmed_proposal,
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            panic!("Cost and target functions should be Fixed");
+                        }
                     }
                 }
                 None => {
@@ -702,7 +750,7 @@ fn parse_cost(
 fn compute_cost(
     cost_tracker: &mut LimitedCostTracker,
     cost_function_reference: ClarityCostFunctionReference,
-    input_size: u64,
+    input_sizes: Vec<u64>,
 ) -> Result<ExecutionCost> {
     let mut null_store = NullBackingStore::new();
     let conn = null_store.as_clarity_db();
@@ -716,10 +764,16 @@ fn compute_cost(
             &cost_function_reference
         )))?;
 
-    let program = vec![
-        SymbolicExpression::atom(cost_function_reference.function_name[..].into()),
-        SymbolicExpression::atom_value(Value::UInt(input_size.into())),
-    ];
+    let mut program = vec![SymbolicExpression::atom(
+        cost_function_reference.function_name[..].into(),
+    )];
+
+    let mut args = input_sizes
+        .into_iter()
+        .map(|size| SymbolicExpression::atom_value(Value::UInt(size.into())))
+        .collect::<Vec<SymbolicExpression>>();
+
+    program.append(&mut args);
 
     let function_invocation = [SymbolicExpression::list(program.into_boxed_slice())];
 
@@ -763,7 +817,7 @@ impl CostTracker for LimitedCostTracker {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: u64,
+        input: Vec<u64>,
     ) -> std::result::Result<ExecutionCost, CostErrors> {
         if self.free {
             return Ok(ExecutionCost::zero());
@@ -814,8 +868,7 @@ impl CostTracker for LimitedCostTracker {
         // grr, if HashMap::get didn't require Borrow, we wouldn't need this cloning.
         let lookup_key = (contract.clone(), function.clone());
         if let Some(cost_function) = self.contract_call_circuits.get(&lookup_key).cloned() {
-            let input_size = input.iter().fold(0, |agg, cur| agg + cur);
-            compute_cost(self, cost_function, input_size)?;
+            compute_cost(self, cost_function, input.into())?;
             Ok(true)
         } else {
             Ok(false)
@@ -827,7 +880,7 @@ impl CostTracker for &mut LimitedCostTracker {
     fn compute_cost(
         &mut self,
         cost_function: ClarityCostFunction,
-        input: u64,
+        input: Vec<u64>,
     ) -> std::result::Result<ExecutionCost, CostErrors> {
         LimitedCostTracker::compute_cost(self, cost_function, input)
     }

--- a/src/vm/costs/mod.rs
+++ b/src/vm/costs/mod.rs
@@ -868,7 +868,12 @@ impl CostTracker for LimitedCostTracker {
         // grr, if HashMap::get didn't require Borrow, we wouldn't need this cloning.
         let lookup_key = (contract.clone(), function.clone());
         if let Some(cost_function) = self.contract_call_circuits.get(&lookup_key).cloned() {
-            compute_cost(self, cost_function, input.into())?;
+            let input_sizes = if input.is_empty() {
+                vec![0]
+            } else {
+                input.to_vec()
+            };
+            compute_cost(self, cost_function, input_sizes)?;
             Ok(true)
         } else {
             Ok(false)

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -782,13 +782,19 @@ fn test_cost_voting_integration() {
         let (_db, tracker) = owned_env.destruct().unwrap();
 
         let circuits = tracker.contract_call_circuits();
-        assert_eq!(circuits.len(), 1);
-        for (target, referenced_function) in circuits.into_iter() {
-            assert_eq!(&target.0, &intercepted);
-            assert_eq!(&target.1.to_string(), "intercepted-function");
-            assert_eq!(&referenced_function.contract_id, &cost_definer);
-            assert_eq!(&referenced_function.function_name, "cost-definition");
-        }
+        assert_eq!(circuits.len(), 2);
+
+        let circuit1 = circuits.get(&(intercepted.clone(), "intercepted-function".into()));
+        let circuit2 = circuits.get(&(intercepted.clone(), "intercepted-function2".into()));
+
+        assert!(circuit1.is_some());
+        assert!(circuit2.is_some());
+
+        assert_eq!(circuit1.unwrap().contract_id, cost_definer);
+        assert_eq!(circuit1.unwrap().function_name, "cost-definition");
+
+        assert_eq!(circuit2.unwrap().contract_id, cost_definer);
+        assert_eq!(circuit2.unwrap().function_name, "cost-definition-multi-arg");
 
         for (target, referenced_function) in tracker.cost_function_references().into_iter() {
             if target == &ClarityCostFunction::Le {

--- a/src/vm/tests/costs.rs
+++ b/src/vm/tests/costs.rs
@@ -509,7 +509,7 @@ fn test_cost_voting_integration() {
     ";
 
         let bad_cost_args_definer_src = "
-    (define-read-only (cost-definition (b uint) (b uint))
+    (define-read-only (cost-definition (a uint) (b uint))
        {
          runtime: u1, write_length: u1, write_count: u1, read_count: u1, read_length: u1
        })


### PR DESCRIPTION
Refactor the `runtime_cost` function to take a `Vec<u64>` instead of a single `u64`, thus enabling Clarity cost functions to take multiple size input args.