### PR TITLE
Fix Xenon crash

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1798,6 +1798,11 @@ impl<'a> SortitionHandleConn<'a> {
                     let block_commit = self.get_block_commit_by_txid(&cursor.0)?.expect(
                         "CORRUPTED: Failed to fetch block commit for known sortition winner",
                     );
+                    // is this a height=1 block?
+                    if block_commit.is_parent_genesis() {
+                        break;
+                    }
+
                     // find the parent sortition
                     let sn = SortitionDB::get_ancestor_snapshot(
                         self,


### PR DESCRIPTION
Address https://github.com/blockstack/stacks-blockchain/issues/2240.
We have reasons to think that the node crashed when trying to handle the first block post genesis.
This code path was introduced when we got rid this check of https://github.com/blockstack/stacks-blockchain/pull/2233/commits/321fb172ae50c6a4921169d43725521e536fc19d