### PR TITLE
PoX fix: addresses being excluded

### DIFF
--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -429,10 +429,7 @@ pub mod test {
             ),
         ];
         let reward_set = StacksChainState::make_reward_set(threshold, addresses);
-        assert_eq!(
-            reward_set.len(),
-            4
-        );
+        assert_eq!(reward_set.len(), 4);
     }
 
     #[test]


### PR DESCRIPTION
This PR is aiming at fixing something that looks like a bug to me, but the unit test associated to the function is a bit confusing, so I could be missing a nuance in SIP007.

In its current state, the `make_reward_set` function is excluding all the addresses that are not stacking at least the threshold being specified. I think this threshold should only be used for repeating the addresses who ended up stacking more than threshold, but also including all the others, knowing that the min-requirement is being checked by the `pox` contract, synchronously when users are stacking.

EDIT: after spending more time on the code, I think I understand that this is actually a feature and it is working as intended. 