### PR TITLE
feat: export block height changes for names and namespaces

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3733,8 +3733,8 @@ def run_blockstackd():
         for namespace_str in namespaces_entries:
             namespace_info = db.get_namespace(namespace_str)
             namespace = {}
-            namespace['ready_block'] = namespace_info['ready_block']
-            namespace['reveal_block'] = namespace_info['reveal_block']
+            namespace['ready_block'] = namespace_info['ready_block'] - block
+            namespace['reveal_block'] = namespace_info['reveal_block'] - block
             namespace['namespace_id'] = namespace_info['namespace_id']
             namespace['address'] = b58ToC32(str(namespace_info['address']))
             namespace['buckets'] = ';'.join(str(x) for x in namespace_info['buckets'])
@@ -3757,7 +3757,7 @@ def run_blockstackd():
         name_zonefiles_txt_output_path = os.path.join(output_dir, 'name_zonefiles.txt')
         name_zonefiles_txt_hash_output_path = name_zonefiles_txt_output_path + '.sha256'
         chainstate_f.write('-----BEGIN NAMES-----\n')
-        chainstate_f.write('name,address,registered_at,expire_block,zonefile_hash\n')
+        chainstate_f.write('name,address,registered_at,expire_block,renewal_deadline,zonefile_hash\n')
         name_zonefiles = open(name_zonefiles_txt_output_path, 'w')
         for name_str in name_entries:
             name_info = load_name_info(db, name_str, block)
@@ -3768,8 +3768,16 @@ def run_blockstackd():
             name = {}
             name['name'] = name_info['name']
             name['address'] = b58ToC32(str(name_info['address']))
+
             name['expire_block'] = name_info['expire_block']
-            name['registered_at'] = max(name_info['first_registered'], name_info['last_renewed'])
+            if name['expire_block'] != -1: # for special flag `-1` do not subtract the block height
+                name['expire_block'] = name['expire_block'] - block
+
+            name['renewal_deadline'] = name_info['renewal_deadline']
+            if name['renewal_deadline'] != -1: # for special flag `-1` do not subtract the block height
+                name['renewal_deadline'] = name['renewal_deadline'] - block
+
+            name['registered_at'] = max(name_info['first_registered'], name_info['last_renewed']) - block
 
             has_zonefile_hash = 'value_hash' in name_info and name_info['value_hash'] is not None
             if has_zonefile_hash:
@@ -3781,8 +3789,8 @@ def run_blockstackd():
                 # print 'missing zonefile for {}'.format(name)
                 name_zonefiles.write(name_info['value_hash'] + '\n')
                 name_zonefiles.write(name_info['zonefile'].replace('\n', '\\n') + '\n')
-            chainstate_f.write('{},{},{},{},{}\n'.format(
-                name['name'], name['address'], name['registered_at'], name['expire_block'], name['zonefile_hash']
+            chainstate_f.write('{},{},{},{},{},{}\n'.format(
+                name['name'], name['address'], name['registered_at'], name['expire_block'], name['renewal_deadline'], name['zonefile_hash']
             ))
         name_zonefiles.flush()
         name_zonefiles.close()

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3773,7 +3773,7 @@ def run_blockstackd():
             if name['expire_block'] != -1: # for special flag `-1` do not subtract the block height
                 name['expire_block'] = name['expire_block'] - block
 
-            name['registered_at'] = max(name_info['first_registered'], name_info['last_renewed']) - block
+            name['registered_at'] = 0
 
             has_zonefile_hash = 'value_hash' in name_info and name_info['value_hash'] is not None
             if has_zonefile_hash:

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3729,12 +3729,10 @@ def run_blockstackd():
         namespaces_entries = db.get_all_namespace_ids()
         namespaces_entries.sort()
         chainstate_f.write('-----BEGIN NAMESPACES-----\n')
-        chainstate_f.write('namespace_id,address,reveal_block,ready_block,buckets,base,coeff,nonalpha_discount,no_vowel_discount,lifetime\n')
+        chainstate_f.write('namespace_id,address,buckets,base,coeff,nonalpha_discount,no_vowel_discount,lifetime\n')
         for namespace_str in namespaces_entries:
             namespace_info = db.get_namespace(namespace_str)
             namespace = {}
-            namespace['ready_block'] = namespace_info['ready_block'] - block
-            namespace['reveal_block'] = namespace_info['reveal_block'] - block
             namespace['namespace_id'] = namespace_info['namespace_id']
             namespace['address'] = b58ToC32(str(namespace_info['address']))
             namespace['buckets'] = ';'.join(str(x) for x in namespace_info['buckets'])
@@ -3743,8 +3741,8 @@ def run_blockstackd():
             namespace['nonalpha_discount'] = namespace_info['nonalpha_discount']
             namespace['no_vowel_discount'] = namespace_info['no_vowel_discount']
             namespace['lifetime'] = 0 if namespace_info['lifetime'] == NAMESPACE_LIFE_INFINITE else namespace_info['lifetime']
-            chainstate_f.write('{},{},{},{},{},{},{},{},{},{}\n'.format(
-                namespace['namespace_id'], namespace['address'], namespace['reveal_block'], namespace['ready_block'],
+            chainstate_f.write('{},{},{},{},{},{},{},{}\n'.format(
+                namespace['namespace_id'], namespace['address'],
                 namespace['buckets'], namespace['base'], namespace['coeff'], namespace['nonalpha_discount'], 
                 namespace['no_vowel_discount'], namespace['lifetime']
             ))

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3755,7 +3755,7 @@ def run_blockstackd():
         name_zonefiles_txt_output_path = os.path.join(output_dir, 'name_zonefiles.txt')
         name_zonefiles_txt_hash_output_path = name_zonefiles_txt_output_path + '.sha256'
         chainstate_f.write('-----BEGIN NAMES-----\n')
-        chainstate_f.write('name,address,registered_at,expire_block,zonefile_hash\n')
+        chainstate_f.write('name,address,zonefile_hash\n')
         name_zonefiles = open(name_zonefiles_txt_output_path, 'w')
         for name_str in name_entries:
             name_info = load_name_info(db, name_str, block)
@@ -3767,12 +3767,6 @@ def run_blockstackd():
             name['name'] = name_info['name']
             name['address'] = b58ToC32(str(name_info['address']))
 
-            name['expire_block'] = name_info['expire_block']
-            if name['expire_block'] != -1: # for special flag `-1` do not subtract the block height
-                name['expire_block'] = name['expire_block'] - block
-
-            name['registered_at'] = 0
-
             has_zonefile_hash = 'value_hash' in name_info and name_info['value_hash'] is not None
             if has_zonefile_hash:
                 name['zonefile_hash'] = name_info['value_hash']
@@ -3783,8 +3777,8 @@ def run_blockstackd():
                 # print 'missing zonefile for {}'.format(name)
                 name_zonefiles.write(name_info['value_hash'] + '\n')
                 name_zonefiles.write(name_info['zonefile'].replace('\n', '\\n') + '\n')
-            chainstate_f.write('{},{},{},{},{}\n'.format(
-                name['name'], name['address'], name['registered_at'], name['expire_block'], name['zonefile_hash']
+            chainstate_f.write('{},{},{}\n'.format(
+                name['name'], name['address'], name['zonefile_hash']
             ))
         name_zonefiles.flush()
         name_zonefiles.close()

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3757,7 +3757,7 @@ def run_blockstackd():
         name_zonefiles_txt_output_path = os.path.join(output_dir, 'name_zonefiles.txt')
         name_zonefiles_txt_hash_output_path = name_zonefiles_txt_output_path + '.sha256'
         chainstate_f.write('-----BEGIN NAMES-----\n')
-        chainstate_f.write('name,address,registered_at,expire_block,renewal_deadline,zonefile_hash\n')
+        chainstate_f.write('name,address,registered_at,expire_block,zonefile_hash\n')
         name_zonefiles = open(name_zonefiles_txt_output_path, 'w')
         for name_str in name_entries:
             name_info = load_name_info(db, name_str, block)
@@ -3773,10 +3773,6 @@ def run_blockstackd():
             if name['expire_block'] != -1: # for special flag `-1` do not subtract the block height
                 name['expire_block'] = name['expire_block'] - block
 
-            name['renewal_deadline'] = name_info['renewal_deadline']
-            if name['renewal_deadline'] != -1: # for special flag `-1` do not subtract the block height
-                name['renewal_deadline'] = name['renewal_deadline'] - block
-
             name['registered_at'] = max(name_info['first_registered'], name_info['last_renewed']) - block
 
             has_zonefile_hash = 'value_hash' in name_info and name_info['value_hash'] is not None
@@ -3789,8 +3785,8 @@ def run_blockstackd():
                 # print 'missing zonefile for {}'.format(name)
                 name_zonefiles.write(name_info['value_hash'] + '\n')
                 name_zonefiles.write(name_info['zonefile'].replace('\n', '\\n') + '\n')
-            chainstate_f.write('{},{},{},{},{},{}\n'.format(
-                name['name'], name['address'], name['registered_at'], name['expire_block'], name['renewal_deadline'], name['zonefile_hash']
+            chainstate_f.write('{},{},{},{},{}\n'.format(
+                name['name'], name['address'], name['registered_at'], name['expire_block'], name['zonefile_hash']
             ))
         name_zonefiles.flush()
         name_zonefiles.close()


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain/issues/2274

> Stacks 2.0 BNS import needs the exported BNS data block heights to be deltas rather than an arbitrary Stacks 1.0 block height. This is already done for the lockup schedule block heights.

* We decided to reset name registrations to block 0 to avoid the negative integer issue. The `first_registered` column is now removed. The `expired_at` column is also removed as it's not used in the import process.
* We also decided to remove the `reveal_block` and `ready_block` from the `namespaces` table as these will always be negative.
* The rust import code will need some minor tweaks to work with a new `chainstate.txt` after this PR.

Snapshot of latest `chainstate.txt`: https://mega.nz/file/MNsQSQLb#P6Jpatjun-fhREzELK3YJHsTTOYrU13gzDZAndWRwgs

Here's a sample of the new output data:
```csv
-----BEGIN NAMESPACES-----
namespace_id,address,buckets,base,coeff,nonalpha_discount,no_vowel_discount,lifetime
app,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,250,4,4,0
blockstack,SP355AMV5R2A5C7VQCF4YPPAS05W93HTB68574W7S,7;6;5;4;3;2;1;1;1;1;1;1;1;1;1;1,4,250,4,4,0
btc,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,3;3;3;3;3;3;3;3;3;3;3;3;3;3;3;3,10,2,1,1,262800
graphite,SP3X2W6GTGVVG9RW78F1MT7M9AQFS2HWV2JETXPG2,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,250,4,4,52595
helloworld,SP3TJ4WRTXW0YFWF1TWKWCG7E6Z6MZDTWAVB6SW5V,15;14;13;12;11;10;9;8;7;6;5;4;3;2;1;0,2,4,2,5,0
id,SP364R1Y0XYC8PYXEK0PE3V752RAJB2GNWF28WP90,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,250,4,4,52595
miner,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0,1,0,1,1,0
mining,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,250,4,4,0
podcast,SPHYHD2ZJ11HWRDKVZ160QX7FD7PCVNT2N9CT2H6,1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1,40,250,1,1,0
stacking,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,250,4,4,0
stacks,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,250,4,4,0
stx,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,250,4,4,0
-----END NAMESPACES-----
-----BEGIN NAMES-----
name,address,zonefile_hash
jude.blockstack,SP1JHJ56H4JTP1FR3TEWC4RS8D5T2VV53N9YZ2FE3,0c79ea594ac287aafe9c2a2c677d674b06066c34
0.id,SP1HPCXTGV31W5659M3WTBEFP5AN55HV4B1Q9T31F,c5f5b4197c94d4561f6332160f624d728b0da8bf
1.id,SP1FRDVA4JAZ4TC93XZC850QAY6R4MTHN10XZJ035,8961c32ad98df87af12b186c3d0be6ca22105936
10.id,SP12TFSBQFZWVVEAWJTVRW3K8V00R0S4895ABXRBR,8ae7173b9a2f96521ba077bbcbe9b56b1cf2449f
10x.id,SP3N5TVVEHGA8B6G3JXWBP476161E32654D9P9A3Y,3d0576cd134fa1ff8d54d8e2ef5da97f5cae36f2
111111111.id,SP15XBGYRVMKF1TWPXE6A3M0T2A87VYSVF9VFSZ1A,01a8c60c852b75f9c6417491ac89275fb9de774c
123.id,SP2PEZ0W4PFGYV6ZZ2DWDVNAVVTQPJ9KX8EK4VRVT,ae34427289a8865028eb2d475dafb085060d5625
12345.id,SP2TVQY1GZ81YPNMF7GEVQHB3XYQG6Q8D3YYJ7HMA,c2fe1fc7097eea0aa83662cb54f103bdcbdd1573
180.id,SP2RWN4GG3XBKZMGEW0E51FEQHNYG77DSG96F7DHS,d0757f74e5b86a31abfc7ad37a37c6296bb8a6a7
180canada.id,SP3CMWZWFE019VZ8JYVPJMYE4P4F4A2CHZ87VNWG5,df54539e135c5ebee49cac4d96724c1951258527
1glenco.id,SP2W5S34H18ECTX1292SFMR9W5R5CM82FBCVZ8RT8,5b3e2ec62deba8eab24b64cb26f475e69a75a335
21.id,SP1FRKP5DNGYH70AYEWRHM3J3Z6S1HPR85XSNFAXG,2fb73c0af99810c0431f198eae762f8d14ed29ee
4m8b.id,SP206DSBHDEJ8B3PNAFRE0GVJ3HTD2GD6CY4PVCKQ,d4cc424442defd5c7aa9231fc69e6919a6ef0d53
```