### PR TITLE
Migration: change export block duration from 500 to 300

### DIFF
--- a/blockstack/lib/nameset/virtualchain_hooks.py
+++ b/blockstack/lib/nameset/virtualchain_hooks.py
@@ -580,7 +580,7 @@ def db_save( block_height, consensus_hash, ops_hash, accepted_ops, virtualchain_
         # threshold of required ID registrations
         v2_upgrade_signal_required_registrations = 20
         # number of blocks to wait after signal threshold is reached until block import and chainstate dump 
-        v2_upgrade_signal_import_threshold = 500
+        v2_upgrade_signal_import_threshold = 300
         if BLOCKSTACK_TEST:
             v2_upgrade_signal_import_threshold = 10
 


### PR DESCRIPTION
At some point we decided to change the migration export waiting period from 500 blocks to 300 blocks, but never made the change. Here it is.

Ref: https://github.com/blockstackpbc/devops/issues/549#issuecomment-755407063