### PR TITLE
fix: adjust price parameters for version 1 namespaces

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3754,6 +3754,9 @@ def run_blockstackd():
             namespace['lifetime'] = 0 if namespace_info['lifetime'] == NAMESPACE_LIFE_INFINITE else namespace_info['lifetime']
             if namespace_id in namespace_patches:
                 namespace.update(namespace_patches[namespace_id])
+            elif namespace_info['version'] == 1:
+                # update namespace version 1 params to adjust for btc to stx prices
+                namespace['coeff'] = namespace['coeff'] * MICROSTACKS_PER_SATOSHI_NUM / MICROSTACKS_PER_SATOSHI_DEN
             chainstate_f.write('{},{},{},{},{},{},{},{}\n'.format(
                 namespace['namespace_id'], namespace['address'],
                 namespace['buckets'], namespace['base'], namespace['coeff'], namespace['nonalpha_discount'], 

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3755,7 +3755,7 @@ def run_blockstackd():
             if namespace_id in namespace_patches:
                 namespace.update(namespace_patches[namespace_id])
             # adjust price coeff for version 1 (and version 2 that are more than a year old)
-            elif namespace_info['version'] == 1 or namespace_info['ready_block'] < 611400:
+            elif namespace_info['version'] == 1 or (namespace_info['version'] == 2 and namespace_info['ready_block'] < 611400):
                 # update namespace version 1 params to adjust for btc to stx prices
                 namespace['coeff'] = int(math.floor(namespace['coeff'] * (650 / 15.)))
             chainstate_f.write('{},{},{},{},{},{},{},{}\n'.format(

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -3754,9 +3754,10 @@ def run_blockstackd():
             namespace['lifetime'] = 0 if namespace_info['lifetime'] == NAMESPACE_LIFE_INFINITE else namespace_info['lifetime']
             if namespace_id in namespace_patches:
                 namespace.update(namespace_patches[namespace_id])
-            elif namespace_info['version'] == 1:
+            # adjust price coeff for version 1 (and version 2 that are more than a year old)
+            elif namespace_info['version'] == 1 or namespace_info['ready_block'] < 611400:
                 # update namespace version 1 params to adjust for btc to stx prices
-                namespace['coeff'] = namespace['coeff'] * MICROSTACKS_PER_SATOSHI_NUM / MICROSTACKS_PER_SATOSHI_DEN
+                namespace['coeff'] = int(math.floor(namespace['coeff'] * (650 / 15.)))
             chainstate_f.write('{},{},{},{},{},{},{},{}\n'.format(
                 namespace['namespace_id'], namespace['address'],
                 namespace['buckets'], namespace['base'], namespace['coeff'], namespace['nonalpha_discount'], 


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain/issues/2303

The namespace prices are now:
```csv
namespace_id,address,buckets,base,coeff,nonalpha_discount,no_vowel_discount,lifetime
app,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,10833,4,4,0
blockstack,SP355AMV5R2A5C7VQCF4YPPAS05W93HTB68574W7S,7;6;5;4;3;2;1;1;1;1;1;1;1;1;1;1,4,10833,4,4,0
btc,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1,1000,200,1,1,262800
graphite,SP3X2W6GTGVVG9RW78F1MT7M9AQFS2HWV2JETXPG2,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,10833,4,4,52595
helloworld,SP3TJ4WRTXW0YFWF1TWKWCG7E6Z6MZDTWAVB6SW5V,15;14;13;12;11;10;9;8;7;6;5;4;3;2;1;0,2,173,2,5,0
id,SP364R1Y0XYC8PYXEK0PE3V752RAJB2GNWF28WP90,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,10833,4,4,52595
miner,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0,1,0,1,1,0
mining,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,10833,4,4,0
podcast,SPHYHD2ZJ11HWRDKVZ160QX7FD7PCVNT2N9CT2H6,1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1,40,10833,1,1,0
stacking,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,10833,4,4,0
stacks,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,10833,4,4,0
stx,SP24TC3Y58XKHZ7GX0N69X50BFYD9ECSR8PGAE3H6,6;5;4;3;2;1;0;0;0;0;0;0;0;0;0;0,4,10833,4,4,0
```

Tested these params against `bns.clar` for `matt.id`. The name price function returns `6,933,120` microSTX.