### PR TITLE
Ability to reuse SPV headers from previous run

### DIFF
--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -149,6 +149,7 @@ fn main() {
         || conf.burnchain.mode == "krypton"
         || conf.burnchain.mode == "mainnet"
     {
+        conf.clean_working_dir();
         let mut run_loop = neon::RunLoop::new(conf);
         run_loop.start(num_round, None);
     } else {


### PR DESCRIPTION
Trying to optimize the feedback look when working with Mainnet / Testnet.
With this patch, when setting a `working_dir` in the `[node]` node of a config, the stacks node will archive the previous chainstate with a timestamp, and just restore the `spv-headers.dat` file.
At some point, this piece of code will go away and the node will just be able to boot from its working_dir, but this patch sounds like a quick win today.

If we are fine with this approach, I'll clean that patch.