### PR TITLE
feat: set impossible lock_transfer_block_id

### DIFF
--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -1433,10 +1433,6 @@ class BlockstackdRPC(BoundedThreadingMixIn, SimpleXMLRPCServer):
             'vtxindex': account_state['vtxindex'],
             'txid': account_state['txid'],
         }
-        # if block height is after the migration export threshold, return a lock height that will force the wallet to error when sending a tx
-        if result['block_id'] >= virtualchain_hooks.IMPORT_HEIGHT:
-            print log.warning('[v2-upgrade] Forcing lock_transfer_block_id to 9999999 to prevent wallet txs')
-            result['lock_transfer_block_id'] = 9999999
         return result
 
 
@@ -1456,10 +1452,16 @@ class BlockstackdRPC(BoundedThreadingMixIn, SimpleXMLRPCServer):
 
         db = get_db_state(self.working_dir)
         account = db.get_account(address, token_type)
+        last_block = db.lastblock
         db.close()
 
         if account is None:
             return {'error': 'No such account', 'http_status': 404}
+
+        # if block height is after the migration export threshold, return a lock height that will force the wallet to error when sending a tx
+        if last_block >= virtualchain_hooks.IMPORT_HEIGHT:
+            print log.warning('[v2-upgrade] Forcing lock_transfer_block_id to 9999999 to prevent wallet txs')
+            account['lock_transfer_block_id'] = 9999999
 
         state = self.export_account_state(account)
         return self.success_response({'account': state})

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -1423,7 +1423,7 @@ class BlockstackdRPC(BoundedThreadingMixIn, SimpleXMLRPCServer):
         """
         Make an account state presentable to external consumers
         """
-        return {
+        result = {
             'address': account_state['address'],
             'type': account_state['type'],
             'credit_value': '{}'.format(account_state['credit_value']),
@@ -1433,6 +1433,11 @@ class BlockstackdRPC(BoundedThreadingMixIn, SimpleXMLRPCServer):
             'vtxindex': account_state['vtxindex'],
             'txid': account_state['txid'],
         }
+        # if block height is after the migration export threshold, return a lock height that will force the wallet to error when sending a tx
+        if result['block_id'] >= 665750:
+            print log.warning('[v2-upgrade] Forcing lock_transfer_block_id to 9999999 to prevent wallet txs')
+            result['lock_transfer_block_id'] = 9999999
+        return result
 
 
     def rpc_get_account_record(self, address, token_type, **con_info):

--- a/blockstack/blockstackd.py
+++ b/blockstack/blockstackd.py
@@ -1434,7 +1434,7 @@ class BlockstackdRPC(BoundedThreadingMixIn, SimpleXMLRPCServer):
             'txid': account_state['txid'],
         }
         # if block height is after the migration export threshold, return a lock height that will force the wallet to error when sending a tx
-        if result['block_id'] >= 665750:
+        if result['block_id'] >= virtualchain_hooks.IMPORT_HEIGHT:
             print log.warning('[v2-upgrade] Forcing lock_transfer_block_id to 9999999 to prevent wallet txs')
             result['lock_transfer_block_id'] = 9999999
         return result


### PR DESCRIPTION
@yknl 
> For the wallet issue that I mentioned during stand up, one way we can disable outgoing transactions from the wallet when we enter the freeze is to return a `lock_transfer_block_id` greater than the current block from the account status API endpoint on core:
https://core.blockstack.org/v1/accounts/1JSwmo6g8zgpKPMVRcrJBeH2oqJE8N9rax/STACKS/status
> 
> example return with `lock_transfer_block_id` set to 9999999:
   ```
address: "1JSwmo6g8zgpKPMVRcrJBeH2oqJE8N9rax"
block_id: 663762
credit_value: "1591022"
debit_value: "1270011"
lock_transfer_block_id: 9999999
txid: "e1d2702b865e180133690dd3dc022085168bf680f943853c53968572ed0a8d6c"
type: "STACKS"
vtxindex: 2263
   ```