### PR TITLE
Tests: fix the expected default xenon version

### DIFF
--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -65,7 +65,7 @@ fn neon_integration_test_conf() -> (Config, StacksAddress) {
     let magic_bytes = Config::from_config_file(ConfigFile::xenon())
         .burnchain
         .magic_bytes;
-    assert_eq!(magic_bytes.as_bytes(), &['X' as u8, '4' as u8]);
+    assert_eq!(magic_bytes.as_bytes(), &['X' as u8, '5' as u8]);
     conf.burnchain.magic_bytes = magic_bytes;
     conf.burnchain.poll_time_secs = 1;
     conf.node.pox_sync_sample_secs = 0;


### PR DESCRIPTION
We bumped the default xenon version, but the test that checks for this didn't have it's check bumped.