### PR TITLE
Make eval_all function public

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -236,7 +236,7 @@ pub fn is_reserved(name: &str) -> bool {
 /* This function evaluates a list of expressions, sharing a global context.
  * It returns the final evaluated result.
  */
-fn eval_all(
+pub fn eval_all(
     expressions: &[SymbolicExpression],
     contract_context: &mut ContractContext,
     global_context: &mut GlobalContext,


### PR DESCRIPTION
Small PR making the `vm`'s `eval_all` function public.

This will be useful for the benchmarking work @pavitthrap and I are currently working on, and for projects like the Clarity repl.