### PR TITLE
Chore: update default read_count

### DIFF
--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -436,7 +436,7 @@ impl std::default::Default for ConnectionOptions {
                 write_length: 0,
                 write_count: 0,
                 read_length: 100000,
-                read_count: 30,
+                read_count: 64,
                 runtime: 1_000_000_000,
             },
             maximum_call_argument_size: 20 * BOUND_VALUE_SERIALIZATION_HEX,


### PR DESCRIPTION
In this PR, we're fine tuning the default value used for controlling how many times a readonly RPC contract-call can hit storage.
With the previous default value, sophisticated contracts like Arkadiko would end up being unusable by default.