### PR TITLE
chore(Clarity2): Replace some costs with "Unimplemented", fix build issues

### DIFF
--- a/src/vm/functions/conversions.rs
+++ b/src/vm/functions/conversions.rs
@@ -56,7 +56,7 @@ pub fn buff_to_int_generic(
                 .into());
             } else {
                 let mut transfer_buffer = [0u8; 16];
-                let mut original_slice = sequence_data.as_slice();
+                let original_slice = sequence_data.as_slice();
                 // 'conversion_fn' expects to receive a 16-byte buffer. If the input is little-endian, it should
                 // be zero-padded on the right. If the input is big-endian, it should be zero-padded on the left.
                 let offset = if direction == EndianDirection::LittleEndian {

--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -289,50 +289,22 @@ pub fn lookup_reserved_functions(name: &str, version: &ClarityVersion) -> Option
             StringToInt => NativeFunction(
                 "native_string_to_int",
                 NativeHandle::SingleArg(&conversions::native_string_to_int),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             StringToUInt => NativeFunction(
                 "native_string_to_uint",
                 NativeHandle::SingleArg(&conversions::native_string_to_uint),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             IntToAscii => NativeFunction(
                 "native_int_to_ascii",
                 NativeHandle::SingleArg(&conversions::native_int_to_ascii),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             IntToUtf8 => NativeFunction(
                 "native_int_to_utf8",
                 NativeHandle::SingleArg(&conversions::native_int_to_utf8),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
-            ),
-            StringToInt => NativeFunction(
-                "native_string_to_int",
-                NativeHandle::SingleArg(&conversions::native_string_to_int),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
-            ),
-            StringToUInt => NativeFunction(
-                "native_string_to_uint",
-                NativeHandle::SingleArg(&conversions::native_string_to_uint),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
-            ),
-            IntToAscii => NativeFunction(
-                "native_int_to_ascii",
-                NativeHandle::SingleArg(&conversions::native_int_to_ascii),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
-            ),
-            IntToUtf8 => NativeFunction(
-                "native_int_to_utf8",
-                NativeHandle::SingleArg(&conversions::native_int_to_utf8),
-                // TODO: Create a dedicated cost function for this case.
-                ClarityCostFunction::Mul,
+                ClarityCostFunction::Unimplemented,
             ),
             Fold => SpecialFunction("special_fold", &sequences::special_fold),
             Concat => SpecialFunction("special_concat", &sequences::special_concat),

--- a/src/vm/functions/principals.rs
+++ b/src/vm/functions/principals.rs
@@ -28,10 +28,13 @@ pub fn special_is_standard(
     let owner = eval(&args[0], env, context)?;
 
     let version = match owner {
-        Value::Principal(PrincipalData::Standard(StandardPrincipalData(version, bytes))) => version,
-        Value::Principal(PrincipalData::Contract(QualifiedContractIdentifier { issuer, name })) => {
-            issuer.0
+        Value::Principal(PrincipalData::Standard(StandardPrincipalData(version, _bytes))) => {
+            version
         }
+        Value::Principal(PrincipalData::Contract(QualifiedContractIdentifier {
+            issuer,
+            name: _,
+        })) => issuer.0,
         _ => return Err(CheckErrors::TypeValueError(TypeSignature::PrincipalType, owner).into()),
     };
 


### PR DESCRIPTION
## Description
We replace some "place holder" cost functions with "Unimplemented".

We also fix the following build warnings:
* four function declarations were duplicated (a result of a mistaken merge and multiple PR's being in flight at once). So, we remove the duplicates.
* unused variable warnings
* an unnecessary "mut"

## Type of Change
- [ ] Bug fix


## Does this introduce a breaking change?
No

## Testing information
Running against existing tests. Unfortunately, the change does not require changing tests.
