### PR TITLE
Feat/health check endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+### Added
+-  New RPC endpoint with path `v2/health` to determine whether or not a node is healthy 
+   (aka, whether it is caught up with its bootstrap peers). 
+
+### Changed
+
+### Fixed
+
 ## [2.0.11.2.0]
 
 ### Added

--- a/docs/rpc-endpoints.md
+++ b/docs/rpc-endpoints.md
@@ -344,3 +344,11 @@ object of the following form:
 Determine whether a given trait is implemented within the specified contract (either explicitly or implicitly).
 
 See OpenAPI [spec](./rpc/openapi.yaml) for details.
+
+### GET /v2/health
+
+Determine whether a node is healthy. The notion of health used for this 
+endpoint is whether or not the block height of a node is greater than or 
+equal to the max block height of its initial peers. 
+
+See OpenAPI [spec](./rpc/openapi.yaml) for details.

--- a/docs/rpc/api/core-node/get-health.example.json
+++ b/docs/rpc/api/core-node/get-health.example.json
@@ -1,4 +1,4 @@
 {
-  "is_healthy": false,
+  "matches_peers": false,
   "percent_of_blocks_synced": 33
 }

--- a/docs/rpc/api/core-node/get-health.example.json
+++ b/docs/rpc/api/core-node/get-health.example.json
@@ -1,4 +1,4 @@
 {
-  "matches_peers": false,
-  "percent_of_blocks_synced": 33
+  "matches_peers": true,
+  "percent_of_blocks_synced": 100
 }

--- a/docs/rpc/api/core-node/get-health.example.json
+++ b/docs/rpc/api/core-node/get-health.example.json
@@ -1,0 +1,4 @@
+{
+  "is_healthy": false,
+  "percent_of_blocks_synced": 33
+}

--- a/docs/rpc/api/core-node/get-health.schema.json
+++ b/docs/rpc/api/core-node/get-health.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GET request for node health",
+  "title": "GetHealthResponse",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["is_healthy", "percent_of_blocks_synced"],
+  "properties": {
+    "is_healthy": {
+      "type": "boolean"
+    },
+    "percent_of_blocks_synced": {
+      "type": "integer"
+    }
+  }
+}

--- a/docs/rpc/api/core-node/get-health.schema.json
+++ b/docs/rpc/api/core-node/get-health.schema.json
@@ -4,9 +4,9 @@
   "title": "GetHealthResponse",
   "type": "object",
   "additionalProperties": false,
-  "required": ["is_healthy", "percent_of_blocks_synced"],
+  "required": ["matches_peers", "percent_of_blocks_synced"],
   "properties": {
-    "is_healthy": {
+    "matches_peers": {
       "type": "boolean"
     },
     "percent_of_blocks_synced": {

--- a/docs/rpc/openapi.yaml
+++ b/docs/rpc/openapi.yaml
@@ -395,4 +395,14 @@ paths:
               schema:
                 $ref: ./api/core-node/get-health.schema.json
               example:
-                $ref: ./api/core-node/get-info.example.json
+                $ref: ./api/core-node/get-health.example.json
+        512:
+          description: Node is unhealthy, query to get health succeeded
+          content:
+            application/json:
+              schema:
+                $ref: ./api/core-node/get-health.schema.json
+              example:
+                $ref: ./api/core-node/get-health.example.json
+        513:
+          description: Failed to query for health

--- a/docs/rpc/openapi.yaml
+++ b/docs/rpc/openapi.yaml
@@ -379,3 +379,20 @@ paths:
         schema:
           type: string
         description: The Stacks chain tip to query from
+
+  /v2/health:
+    get:
+      summary: Get health of node
+      description: Get boolean determining whether a node is synced up with its boostrap nodes, and what percent the sync is at.
+      tags:
+        - Info
+      operationId: get_health
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: ./api/core-node/get-health.schema.json
+              example:
+                $ref: ./api/core-node/get-info.example.json

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -89,21 +89,21 @@ use crate::codec::{
 use crate::types::chainstate::{BlockHeaderHash, StacksAddress, StacksBlockId};
 
 lazy_static! {
-    static ref PATH_GET_INFO: Regex = Regex::new(r#"^/v2/info$"#).unwrap();
-    static ref PATH_GET_POX_INFO: Regex = Regex::new(r#"^/v2/pox$"#).unwrap();
-    static ref PATH_GET_NEIGHBORS: Regex = Regex::new(r#"^/v2/neighbors$"#).unwrap();
-    static ref PATH_GET_BLOCK: Regex = Regex::new(r#"^/v2/blocks/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_GET_MICROBLOCKS_INDEXED: Regex =
+    static ref PATH_GETINFO: Regex = Regex::new(r#"^/v2/info$"#).unwrap();
+    static ref PATH_GETPOXINFO: Regex = Regex::new(r#"^/v2/pox$"#).unwrap();
+    static ref PATH_GETNEIGHBORS: Regex = Regex::new(r#"^/v2/neighbors$"#).unwrap();
+    static ref PATH_GETBLOCK: Regex = Regex::new(r#"^/v2/blocks/([0-9a-f]{64})$"#).unwrap();
+    static ref PATH_GETMICROBLOCKS_INDEXED: Regex =
         Regex::new(r#"^/v2/microblocks/([0-9a-f]{64})$"#).unwrap();
     static ref PATH_GET_MICROBLOCKS_CONFIRMED: Regex =
         Regex::new(r#"^/v2/microblocks/confirmed/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_GET_MICROBLOCKS_UNCONFIRMED: Regex =
+    static ref PATH_GETMICROBLOCKS_UNCONFIRMED: Regex =
         Regex::new(r#"^/v2/microblocks/unconfirmed/([0-9a-f]{64})/([0-9]{1,5})$"#).unwrap();
-    static ref PATH_GET_TRANSACTION_UNCONFIRMED: Regex =
+    static ref PATH_GETTRANSACTION_UNCONFIRMED: Regex =
         Regex::new(r#"^/v2/transactions/unconfirmed/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_POST_TRANSACTION: Regex = Regex::new(r#"^/v2/transactions$"#).unwrap();
-    static ref PATH_POST_BLOCK: Regex = Regex::new(r#"^/v2/blocks/upload/([0-9a-f]{40})$"#).unwrap();
-    static ref PATH_POST_MICROBLOCK: Regex = Regex::new(r#"^/v2/microblocks$"#).unwrap();
+    static ref PATH_POSTTRANSACTION: Regex = Regex::new(r#"^/v2/transactions$"#).unwrap();
+    static ref PATH_POSTBLOCK: Regex = Regex::new(r#"^/v2/blocks/upload/([0-9a-f]{40})$"#).unwrap();
+    static ref PATH_POSTMICROBLOCK: Regex = Regex::new(r#"^/v2/microblocks$"#).unwrap();
     static ref PATH_GET_ACCOUNT: Regex = Regex::new(&format!(
         "^/v2/accounts/(?P<principal>{})$",
         *PRINCIPAL_DATA_REGEX
@@ -1448,48 +1448,44 @@ impl HttpRequestType {
                 &mut R,
             ) -> Result<HttpRequestType, net_error>,
         )] = &[
-            ("GET", &PATH_GET_INFO, &HttpRequestType::parse_get_info),
+            ("GET", &PATH_GETINFO, &HttpRequestType::parse_getinfo),
+            ("GET", &PATH_GETPOXINFO, &HttpRequestType::parse_getpoxinfo),
             (
                 "GET",
-                &PATH_GET_POX_INFO,
-                &HttpRequestType::parse_get_pox_info,
+                &PATH_GETNEIGHBORS,
+                &HttpRequestType::parse_getneighbors,
             ),
+            ("GET", &PATH_GETBLOCK, &HttpRequestType::parse_getblock),
             (
                 "GET",
-                &PATH_GET_NEIGHBORS,
-                &HttpRequestType::parse_get_neighbors,
-            ),
-            ("GET", &PATH_GET_BLOCK, &HttpRequestType::parse_get_block),
-            (
-                "GET",
-                &PATH_GET_MICROBLOCKS_INDEXED,
-                &HttpRequestType::parse_get_microblocks_indexed,
+                &PATH_GETMICROBLOCKS_INDEXED,
+                &HttpRequestType::parse_getmicroblocks_indexed,
             ),
             (
                 "GET",
                 &PATH_GET_MICROBLOCKS_CONFIRMED,
-                &HttpRequestType::parse_get_microblocks_confirmed,
+                &HttpRequestType::parse_getmicroblocks_confirmed,
             ),
             (
                 "GET",
-                &PATH_GET_MICROBLOCKS_UNCONFIRMED,
-                &HttpRequestType::parse_get_microblocks_unconfirmed,
+                &PATH_GETMICROBLOCKS_UNCONFIRMED,
+                &HttpRequestType::parse_getmicroblocks_unconfirmed,
             ),
             (
                 "GET",
-                &PATH_GET_TRANSACTION_UNCONFIRMED,
-                &HttpRequestType::parse_get_transaction_unconfirmed,
+                &PATH_GETTRANSACTION_UNCONFIRMED,
+                &HttpRequestType::parse_gettransaction_unconfirmed,
             ),
             (
                 "POST",
-                &PATH_POST_TRANSACTION,
-                &HttpRequestType::parse_post_transaction,
+                &PATH_POSTTRANSACTION,
+                &HttpRequestType::parse_posttransaction,
             ),
-            ("POST", &PATH_POST_BLOCK, &HttpRequestType::parse_post_block),
+            ("POST", &PATH_POSTBLOCK, &HttpRequestType::parse_postblock),
             (
                 "POST",
-                &PATH_POST_MICROBLOCK,
-                &HttpRequestType::parse_post_microblock,
+                &PATH_POSTMICROBLOCK,
+                &HttpRequestType::parse_postmicroblock,
             ),
             (
                 "GET",
@@ -1590,7 +1586,7 @@ impl HttpRequestType {
         )))
     }
 
-    fn parse_get_info<R: Read>(
+    fn parse_getinfo<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -1607,7 +1603,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_get_pox_info<R: Read>(
+    fn parse_getpoxinfo<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -1628,7 +1624,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_get_neighbors<R: Read>(
+    fn parse_getneighbors<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -1927,7 +1923,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_get_block<R: Read>(
+    fn parse_getblock<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -1956,7 +1952,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_get_microblocks_indexed<R: Read>(
+    fn parse_getmicroblocks_indexed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -1987,7 +1983,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_get_microblocks_confirmed<R: Read>(
+    fn parse_getmicroblocks_confirmed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -2017,7 +2013,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_get_microblocks_unconfirmed<R: Read>(
+    fn parse_getmicroblocks_unconfirmed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -2060,7 +2056,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_get_transaction_unconfirmed<R: Read>(
+    fn parse_gettransaction_unconfirmed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         regex: &Captures,
@@ -2113,7 +2109,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_post_transaction<R: Read>(
+    fn parse_posttransaction<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -2215,7 +2211,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_post_block<R: Read>(
+    fn parse_postblock<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         regex: &Captures,
@@ -2273,7 +2269,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_post_microblock<R: Read>(
+    fn parse_postmicroblock<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -3050,13 +3046,13 @@ impl HttpResponseType {
                 Option<usize>,
             ) -> Result<HttpResponseType, net_error>,
         )] = &[
-            (&PATH_GET_INFO, &HttpResponseType::parse_peerinfo),
-            (&PATH_GET_POX_INFO, &HttpResponseType::parse_poxinfo),
-            (&PATH_GET_NEIGHBORS, &HttpResponseType::parse_neighbors),
-            (&PATH_GET_BLOCK, &HttpResponseType::parse_block),
+            (&PATH_GETINFO, &HttpResponseType::parse_peerinfo),
+            (&PATH_GETPOXINFO, &HttpResponseType::parse_poxinfo),
+            (&PATH_GETNEIGHBORS, &HttpResponseType::parse_neighbors),
+            (&PATH_GETBLOCK, &HttpResponseType::parse_block),
             (&PATH_GET_MAP_ENTRY, &HttpResponseType::parse_get_map_entry),
             (
-                &PATH_GET_MICROBLOCKS_INDEXED,
+                &PATH_GETMICROBLOCKS_INDEXED,
                 &HttpResponseType::parse_microblocks,
             ),
             (
@@ -3064,20 +3060,20 @@ impl HttpResponseType {
                 &HttpResponseType::parse_microblocks,
             ),
             (
-                &PATH_GET_MICROBLOCKS_UNCONFIRMED,
+                &PATH_GETMICROBLOCKS_UNCONFIRMED,
                 &HttpResponseType::parse_microblocks_unconfirmed,
             ),
             (
-                &PATH_GET_TRANSACTION_UNCONFIRMED,
+                &PATH_GETTRANSACTION_UNCONFIRMED,
                 &HttpResponseType::parse_transaction_unconfirmed,
             ),
-            (&PATH_POST_TRANSACTION, &HttpResponseType::parse_txid),
+            (&PATH_POSTTRANSACTION, &HttpResponseType::parse_txid),
             (
-                &PATH_POST_BLOCK,
+                &PATH_POSTBLOCK,
                 &HttpResponseType::parse_stacks_block_accepted,
             ),
             (
-                &PATH_POST_MICROBLOCK,
+                &PATH_POSTMICROBLOCK,
                 &HttpResponseType::parse_microblock_hash,
             ),
             (&PATH_GET_ACCOUNT, &HttpResponseType::parse_get_account),

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -95,7 +95,7 @@ lazy_static! {
     static ref PATH_GETBLOCK: Regex = Regex::new(r#"^/v2/blocks/([0-9a-f]{64})$"#).unwrap();
     static ref PATH_GETMICROBLOCKS_INDEXED: Regex =
         Regex::new(r#"^/v2/microblocks/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_GET_MICROBLOCKS_CONFIRMED: Regex =
+    static ref PATH_GETMICROBLOCKS_CONFIRMED: Regex =
         Regex::new(r#"^/v2/microblocks/confirmed/([0-9a-f]{64})$"#).unwrap();
     static ref PATH_GETMICROBLOCKS_UNCONFIRMED: Regex =
         Regex::new(r#"^/v2/microblocks/unconfirmed/([0-9a-f]{64})/([0-9]{1,5})$"#).unwrap();
@@ -1463,7 +1463,7 @@ impl HttpRequestType {
             ),
             (
                 "GET",
-                &PATH_GET_MICROBLOCKS_CONFIRMED,
+                &PATH_GETMICROBLOCKS_CONFIRMED,
                 &HttpRequestType::parse_getmicroblocks_confirmed,
             ),
             (
@@ -3056,7 +3056,7 @@ impl HttpResponseType {
                 &HttpResponseType::parse_microblocks,
             ),
             (
-                &PATH_GET_MICROBLOCKS_CONFIRMED,
+                &PATH_GETMICROBLOCKS_CONFIRMED,
                 &HttpResponseType::parse_microblocks,
             ),
             (

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -89,21 +89,21 @@ use crate::codec::{
 use crate::types::chainstate::{BlockHeaderHash, StacksAddress, StacksBlockId};
 
 lazy_static! {
-    static ref PATH_GETINFO: Regex = Regex::new(r#"^/v2/info$"#).unwrap();
-    static ref PATH_GETPOXINFO: Regex = Regex::new(r#"^/v2/pox$"#).unwrap();
-    static ref PATH_GETNEIGHBORS: Regex = Regex::new(r#"^/v2/neighbors$"#).unwrap();
-    static ref PATH_GETBLOCK: Regex = Regex::new(r#"^/v2/blocks/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_GETMICROBLOCKS_INDEXED: Regex =
+    static ref PATH_GET_INFO: Regex = Regex::new(r#"^/v2/info$"#).unwrap();
+    static ref PATH_GET_POX_INFO: Regex = Regex::new(r#"^/v2/pox$"#).unwrap();
+    static ref PATH_GET_NEIGHBORS: Regex = Regex::new(r#"^/v2/neighbors$"#).unwrap();
+    static ref PATH_GET_BLOCK: Regex = Regex::new(r#"^/v2/blocks/([0-9a-f]{64})$"#).unwrap();
+    static ref PATH_GET_MICROBLOCKS_INDEXED: Regex =
         Regex::new(r#"^/v2/microblocks/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_GETMICROBLOCKS_CONFIRMED: Regex =
+    static ref PATH_GET_MICROBLOCKS_CONFIRMED: Regex =
         Regex::new(r#"^/v2/microblocks/confirmed/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_GETMICROBLOCKS_UNCONFIRMED: Regex =
+    static ref PATH_GET_MICROBLOCKS_UNCONFIRMED: Regex =
         Regex::new(r#"^/v2/microblocks/unconfirmed/([0-9a-f]{64})/([0-9]{1,5})$"#).unwrap();
-    static ref PATH_GETTRANSACTION_UNCONFIRMED: Regex =
+    static ref PATH_GET_TRANSACTION_UNCONFIRMED: Regex =
         Regex::new(r#"^/v2/transactions/unconfirmed/([0-9a-f]{64})$"#).unwrap();
-    static ref PATH_POSTTRANSACTION: Regex = Regex::new(r#"^/v2/transactions$"#).unwrap();
-    static ref PATH_POSTBLOCK: Regex = Regex::new(r#"^/v2/blocks/upload/([0-9a-f]{40})$"#).unwrap();
-    static ref PATH_POSTMICROBLOCK: Regex = Regex::new(r#"^/v2/microblocks$"#).unwrap();
+    static ref PATH_POST_TRANSACTION: Regex = Regex::new(r#"^/v2/transactions$"#).unwrap();
+    static ref PATH_POST_BLOCK: Regex = Regex::new(r#"^/v2/blocks/upload/([0-9a-f]{40})$"#).unwrap();
+    static ref PATH_POST_MICROBLOCK: Regex = Regex::new(r#"^/v2/microblocks$"#).unwrap();
     static ref PATH_GET_ACCOUNT: Regex = Regex::new(&format!(
         "^/v2/accounts/(?P<principal>{})$",
         *PRINCIPAL_DATA_REGEX
@@ -139,6 +139,7 @@ lazy_static! {
     static ref PATH_GET_ATTACHMENT: Regex =
         Regex::new(r#"^/v2/attachments/([0-9a-f]{40})$"#).unwrap();
     static ref PATH_OPTIONS_WILDCARD: Regex = Regex::new("^/v2/.{0,4096}$").unwrap();
+    static ref PATH_GET_HEALTH: Regex = Regex::new(r#"^/v2/health$"#).unwrap();
 }
 
 /// HTTP headers that we really care about
@@ -1447,44 +1448,48 @@ impl HttpRequestType {
                 &mut R,
             ) -> Result<HttpRequestType, net_error>,
         )] = &[
-            ("GET", &PATH_GETINFO, &HttpRequestType::parse_getinfo),
-            ("GET", &PATH_GETPOXINFO, &HttpRequestType::parse_getpoxinfo),
+            ("GET", &PATH_GET_INFO, &HttpRequestType::parse_get_info),
             (
                 "GET",
-                &PATH_GETNEIGHBORS,
-                &HttpRequestType::parse_getneighbors,
-            ),
-            ("GET", &PATH_GETBLOCK, &HttpRequestType::parse_getblock),
-            (
-                "GET",
-                &PATH_GETMICROBLOCKS_INDEXED,
-                &HttpRequestType::parse_getmicroblocks_indexed,
+                &PATH_GET_POX_INFO,
+                &HttpRequestType::parse_get_pox_info,
             ),
             (
                 "GET",
-                &PATH_GETMICROBLOCKS_CONFIRMED,
-                &HttpRequestType::parse_getmicroblocks_confirmed,
+                &PATH_GET_NEIGHBORS,
+                &HttpRequestType::parse_get_neighbors,
+            ),
+            ("GET", &PATH_GET_BLOCK, &HttpRequestType::parse_get_block),
+            (
+                "GET",
+                &PATH_GET_MICROBLOCKS_INDEXED,
+                &HttpRequestType::parse_get_microblocks_indexed,
             ),
             (
                 "GET",
-                &PATH_GETMICROBLOCKS_UNCONFIRMED,
-                &HttpRequestType::parse_getmicroblocks_unconfirmed,
+                &PATH_GET_MICROBLOCKS_CONFIRMED,
+                &HttpRequestType::parse_get_microblocks_confirmed,
             ),
             (
                 "GET",
-                &PATH_GETTRANSACTION_UNCONFIRMED,
-                &HttpRequestType::parse_gettransaction_unconfirmed,
+                &PATH_GET_MICROBLOCKS_UNCONFIRMED,
+                &HttpRequestType::parse_get_microblocks_unconfirmed,
+            ),
+            (
+                "GET",
+                &PATH_GET_TRANSACTION_UNCONFIRMED,
+                &HttpRequestType::parse_get_transaction_unconfirmed,
             ),
             (
                 "POST",
-                &PATH_POSTTRANSACTION,
-                &HttpRequestType::parse_posttransaction,
+                &PATH_POST_TRANSACTION,
+                &HttpRequestType::parse_post_transaction,
             ),
-            ("POST", &PATH_POSTBLOCK, &HttpRequestType::parse_postblock),
+            ("POST", &PATH_POST_BLOCK, &HttpRequestType::parse_post_block),
             (
                 "POST",
-                &PATH_POSTMICROBLOCK,
-                &HttpRequestType::parse_postmicroblock,
+                &PATH_POST_MICROBLOCK,
+                &HttpRequestType::parse_post_microblock,
             ),
             (
                 "GET",
@@ -1536,6 +1541,7 @@ impl HttpRequestType {
                 &PATH_GET_ATTACHMENTS_INV,
                 &HttpRequestType::parse_get_attachments_inv,
             ),
+            ("GET", &PATH_GET_HEALTH, &HttpRequestType::parse_get_health),
         ];
 
         // use url::Url to parse path and query string
@@ -1584,7 +1590,7 @@ impl HttpRequestType {
         )))
     }
 
-    fn parse_getinfo<R: Read>(
+    fn parse_get_info<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -1601,7 +1607,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_getpoxinfo<R: Read>(
+    fn parse_get_pox_info<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -1622,7 +1628,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_getneighbors<R: Read>(
+    fn parse_get_neighbors<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -1921,7 +1927,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_getblock<R: Read>(
+    fn parse_get_block<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -1950,7 +1956,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_getmicroblocks_indexed<R: Read>(
+    fn parse_get_microblocks_indexed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -1981,7 +1987,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_getmicroblocks_confirmed<R: Read>(
+    fn parse_get_microblocks_confirmed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -2011,7 +2017,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_getmicroblocks_unconfirmed<R: Read>(
+    fn parse_get_microblocks_unconfirmed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         captures: &Captures,
@@ -2054,7 +2060,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_gettransaction_unconfirmed<R: Read>(
+    fn parse_get_transaction_unconfirmed<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         regex: &Captures,
@@ -2090,7 +2096,24 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_posttransaction<R: Read>(
+    fn parse_get_health<R: Read>(
+        _protocol: &mut StacksHttp,
+        preamble: &HttpRequestPreamble,
+        _regex: &Captures,
+        _query: Option<&str>,
+        _fd: &mut R,
+    ) -> Result<HttpRequestType, net_error> {
+        if preamble.get_content_length() != 0 {
+            return Err(net_error::DeserializeError(
+                "Invalid Http request: expected 0-length body for GetInfo".to_string(),
+            ));
+        }
+        Ok(HttpRequestType::GetHealth(
+            HttpRequestMetadata::from_preamble(preamble),
+        ))
+    }
+
+    fn parse_post_transaction<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -2192,7 +2215,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_postblock<R: Read>(
+    fn parse_post_block<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         regex: &Captures,
@@ -2250,7 +2273,7 @@ impl HttpRequestType {
         ))
     }
 
-    fn parse_postmicroblock<R: Read>(
+    fn parse_post_microblock<R: Read>(
         _protocol: &mut StacksHttp,
         preamble: &HttpRequestPreamble,
         _regex: &Captures,
@@ -2431,6 +2454,7 @@ impl HttpRequestType {
             HttpRequestType::OptionsPreflight(ref md, ..) => md,
             HttpRequestType::GetAttachmentsInv(ref md, ..) => md,
             HttpRequestType::GetAttachment(ref md, ..) => md,
+            HttpRequestType::GetHealth(ref md) => md,
             HttpRequestType::ClientError(ref md, ..) => md,
         }
     }
@@ -2458,6 +2482,7 @@ impl HttpRequestType {
             HttpRequestType::OptionsPreflight(ref mut md, ..) => md,
             HttpRequestType::GetAttachmentsInv(ref mut md, ..) => md,
             HttpRequestType::GetAttachment(ref mut md, ..) => md,
+            HttpRequestType::GetHealth(ref mut md) => md,
             HttpRequestType::ClientError(ref mut md, ..) => md,
         }
     }
@@ -2591,6 +2616,7 @@ impl HttpRequestType {
             HttpRequestType::GetAttachment(_, content_hash) => {
                 format!("/v2/attachments/{}", to_hex(&content_hash.0[..]))
             }
+            HttpRequestType::GetHealth(_md) => "/v2/health".to_string(),
             HttpRequestType::ClientError(_md, e) => match e {
                 ClientError::NotFound(path) => path.to_string(),
                 _ => "error path unknown".into(),
@@ -2626,6 +2652,7 @@ impl HttpRequestType {
             HttpRequestType::GetAttachmentsInv(..) => "/v2/attachments/inv",
             HttpRequestType::GetAttachment(..) => "/v2/attachments/:hash",
             HttpRequestType::GetIsTraitImplemented(..) => "/v2/traits/:principal/:contract_name",
+            HttpRequestType::GetHealth(..) => "/v2/health",
             HttpRequestType::OptionsPreflight(..) | HttpRequestType::ClientError(..) => "/",
         }
     }
@@ -3023,34 +3050,34 @@ impl HttpResponseType {
                 Option<usize>,
             ) -> Result<HttpResponseType, net_error>,
         )] = &[
-            (&PATH_GETINFO, &HttpResponseType::parse_peerinfo),
-            (&PATH_GETPOXINFO, &HttpResponseType::parse_poxinfo),
-            (&PATH_GETNEIGHBORS, &HttpResponseType::parse_neighbors),
-            (&PATH_GETBLOCK, &HttpResponseType::parse_block),
+            (&PATH_GET_INFO, &HttpResponseType::parse_peerinfo),
+            (&PATH_GET_POX_INFO, &HttpResponseType::parse_poxinfo),
+            (&PATH_GET_NEIGHBORS, &HttpResponseType::parse_neighbors),
+            (&PATH_GET_BLOCK, &HttpResponseType::parse_block),
             (&PATH_GET_MAP_ENTRY, &HttpResponseType::parse_get_map_entry),
             (
-                &PATH_GETMICROBLOCKS_INDEXED,
+                &PATH_GET_MICROBLOCKS_INDEXED,
                 &HttpResponseType::parse_microblocks,
             ),
             (
-                &PATH_GETMICROBLOCKS_CONFIRMED,
+                &PATH_GET_MICROBLOCKS_CONFIRMED,
                 &HttpResponseType::parse_microblocks,
             ),
             (
-                &PATH_GETMICROBLOCKS_UNCONFIRMED,
+                &PATH_GET_MICROBLOCKS_UNCONFIRMED,
                 &HttpResponseType::parse_microblocks_unconfirmed,
             ),
             (
-                &PATH_GETTRANSACTION_UNCONFIRMED,
+                &PATH_GET_TRANSACTION_UNCONFIRMED,
                 &HttpResponseType::parse_transaction_unconfirmed,
             ),
-            (&PATH_POSTTRANSACTION, &HttpResponseType::parse_txid),
+            (&PATH_POST_TRANSACTION, &HttpResponseType::parse_txid),
             (
-                &PATH_POSTBLOCK,
+                &PATH_POST_BLOCK,
                 &HttpResponseType::parse_stacks_block_accepted,
             ),
             (
-                &PATH_POSTMICROBLOCK,
+                &PATH_POST_MICROBLOCK,
                 &HttpResponseType::parse_microblock_hash,
             ),
             (&PATH_GET_ACCOUNT, &HttpResponseType::parse_get_account),
@@ -3078,6 +3105,7 @@ impl HttpResponseType {
                 &PATH_GET_ATTACHMENTS_INV,
                 &HttpResponseType::parse_get_attachments_inv,
             ),
+            (&PATH_GET_HEALTH, &HttpResponseType::parse_get_health),
         ];
 
         // use url::Url to parse path and query string
@@ -3408,6 +3436,20 @@ impl HttpResponseType {
         ))
     }
 
+    fn parse_get_health<R: Read>(
+        _protocol: &mut StacksHttp,
+        request_version: HttpVersion,
+        preamble: &HttpResponsePreamble,
+        fd: &mut R,
+        len_hint: Option<usize>,
+    ) -> Result<HttpResponseType, net_error> {
+        let res = HttpResponseType::parse_json(preamble, fd, len_hint, MAX_MESSAGE_LEN as u64)?;
+        Ok(HttpResponseType::GetHealth(
+            HttpResponseMetadata::from_preamble(request_version, preamble),
+            res,
+        ))
+    }
+
     fn parse_stacks_block_accepted<R: Read>(
         _protocol: &mut StacksHttp,
         request_version: HttpVersion,
@@ -3504,6 +3546,7 @@ impl HttpResponseType {
             HttpResponseType::GetAttachment(ref md, _) => md,
             HttpResponseType::GetAttachmentsInv(ref md, _) => md,
             HttpResponseType::OptionsPreflight(ref md) => md,
+            HttpResponseType::GetHealth(ref md, _) => md,
             // errors
             HttpResponseType::BadRequestJSON(ref md, _) => md,
             HttpResponseType::BadRequest(ref md, _) => md,
@@ -3735,6 +3778,10 @@ impl HttpResponseType {
                 )?;
                 HttpResponseType::send_text(protocol, md, fd, "".as_bytes())?;
             }
+            HttpResponseType::GetHealth(ref md, ref data) => {
+                HttpResponsePreamble::ok_JSON_from_md(fd, md)?;
+                HttpResponseType::send_json(protocol, md, fd, data)?;
+            }
             HttpResponseType::BadRequestJSON(ref md, ref data) => {
                 HttpResponsePreamble::new_serialized(
                     fd,
@@ -3838,6 +3885,7 @@ impl MessageSequence for StacksHttpMessage {
                 HttpRequestType::GetAttachment(..) => "HTTP(GetAttachment)",
                 HttpRequestType::GetAttachmentsInv(..) => "HTTP(GetAttachmentsInv)",
                 HttpRequestType::OptionsPreflight(..) => "HTTP(OptionsPreflight)",
+                HttpRequestType::GetHealth(_) => "HTTP(GetHealth)",
                 HttpRequestType::ClientError(..) => "HTTP(ClientError)",
             },
             StacksHttpMessage::Response(ref res) => match res {
@@ -3862,6 +3910,7 @@ impl MessageSequence for StacksHttpMessage {
                 HttpResponseType::MicroblockHash(_, _) => "HTTP(MicroblockHash)",
                 HttpResponseType::UnconfirmedTransaction(_, _) => "HTTP(UnconfirmedTransaction)",
                 HttpResponseType::OptionsPreflight(_) => "HTTP(OptionsPreflight)",
+                HttpResponseType::GetHealth(..) => "HTTP(GetHealth)",
                 HttpResponseType::BadRequestJSON(..) | HttpResponseType::BadRequest(..) => {
                     "HTTP(400)"
                 }

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -2868,7 +2868,7 @@ impl HttpResponseType {
             && preamble.content_type != HttpContentType::JSON
         {
             return Err(net_error::DeserializeError(
-                "Invalid error response: expected text/plain or json".to_string(),
+                "Invalid error response: expected text/plain or application/json".to_string(),
             ));
         }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1381,6 +1381,8 @@ pub enum HttpResponseType {
     // peer-given error responses
     BadRequest(HttpResponseMetadata, String),
     BadRequestJSON(HttpResponseMetadata, serde_json::Value),
+    GetHealthError(HttpResponseMetadata, serde_json::Value),
+    GetHealthQueryError(HttpResponseMetadata, String),
     Unauthorized(HttpResponseMetadata, String),
     PaymentRequired(HttpResponseMetadata, String),
     Forbidden(HttpResponseMetadata, String),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1115,7 +1115,7 @@ pub struct GetAttachmentResponse {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GetHealthResponse {
-    pub is_healthy: bool,
+    pub matches_peers: bool,
     pub percent_of_blocks_synced: u8,
 }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1113,6 +1113,12 @@ pub struct GetAttachmentResponse {
     pub attachment: Attachment,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GetHealthResponse {
+    pub is_healthy: bool,
+    pub percent_of_blocks_synced: u8,
+}
+
 impl Serialize for GetAttachmentResponse {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         let hex_encoded = to_hex(&self.attachment.content[..]);
@@ -1275,6 +1281,7 @@ pub enum HttpRequestType {
         TraitIdentifier,
         Option<StacksBlockId>,
     ),
+    GetHealth(HttpRequestMetadata),
     /// catch-all for any errors we should surface from parsing
     ClientError(HttpRequestMetadata, ClientError),
 }
@@ -1370,6 +1377,7 @@ pub enum HttpResponseType {
     GetAttachment(HttpResponseMetadata, GetAttachmentResponse),
     GetAttachmentsInv(HttpResponseMetadata, GetAttachmentsInvResponse),
     OptionsPreflight(HttpResponseMetadata),
+    GetHealth(HttpResponseMetadata, GetHealthResponse),
     // peer-given error responses
     BadRequest(HttpResponseMetadata, String),
     BadRequestJSON(HttpResponseMetadata, serde_json::Value),

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -1580,8 +1580,7 @@ impl ConversationHttp {
             } else {
                 let data = GetHealthResponse {
                     matches_peers: false,
-                    percent_of_blocks_synced: ((block_height as f32 / max_height as f32) * (100.0))
-                        as u8,
+                    percent_of_blocks_synced: (block_height * 100 / max_height) as u8,
                 };
                 HttpResponseType::GetHealthError(response_metadata.clone(), json!(data))
             }

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -1570,7 +1570,7 @@ impl ConversationHttp {
                 return response.send(http, fd).map(|_| ());
             }
 
-            let data = if block_height >= max_height {
+            let data = if block_height >= (max_height - 1) {
                 GetHealthResponse {
                     is_healthy: true,
                     percent_of_blocks_synced: 100,

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -52,6 +52,7 @@ use mio::net as mio_net;
 use util::get_epoch_time_secs;
 
 use core::mempool::*;
+use net::inv::NeighborBlockStats;
 
 #[derive(Debug)]
 pub struct HttpPeer {


### PR DESCRIPTION
## Description
Fixes #1229 

The get health endpoint first gets a list of all valid initial peers of the node. It then gets the max height amongst those nodes. If the block height of the node is greater than or equal to that max height, the health check endpoint returns `true` for the field `is_healthy`, and `false` otherwise. The endpoint also returns the fraction `(block height of node/ max height of initial peers)` as a percentage. 

In addition to the rpc endpoint, I updated some function and variable names in `http.rs` for consistency (because there is a discrepancy between newly added rpc calls and older ones). I switched older methods to use pure snake case in naming (so `get_poxinfo` would now be `get_pox_info`). Let me know if this change is unwanted, I can switch it back. If it is wanted, I will make a similar change in `rpc.rs` as well. 

### To think about: 
- It's possible a node isn't keeping track of the block stats for any of its initial peers - might need to consider fallback scenario (where we consider the block heights of any node we are currently keeping the stats of)


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Are documentation updates required?
Added docs to existing rpc documentation. 

## Testing information
Added typical RPC test for this. Mocked out block stats for the peer server. 

Need to test this on a live node.
