### PR TITLE
Add doc guide

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,30 @@ This project and everyone participating in it is governed by this [Code of Condu
 - Any major changes should be added to the [CHANGELOG](CHANGELOG.md).
 - Mention any required documentation changes in the description of your pull request.
 - If adding an RPC endpoint, add an entry for the new endpoint to the OpenAPI spec `./docs/rpc/openapi.yaml`.
+- If your code adds or modifies any major features (struct, trait, test, module, etc.), each should be 
+  documented according to the [Rust style guide](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html) 
+
+### Documentation Style 
+We will try to follow the [Rust style guide](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html). 
+Here's a contrived example of code following the guide: 
+```rust
+/// Returns 0 if the input is less than or equal to 5, and panics otherwise.
+/// 
+/// # Panics 
+/// The function panics if the input is greater than 5.
+pub fn example(i: int) -> int {
+    if i > 5 {
+        panic!("Panicking")
+    } else {
+        0
+    }
+}
+```
+
+Overview of documentation rules
+- Use markdown to format comments. 
+- Start with a high-level description of the function, adding more sentences with details if necessary. 
+- For some functions, you might want to add a markdown section for panics or for examples.
 
 ### Each file should include relevant unit tests
 


### PR DESCRIPTION
I added preliminary documentation guidelines to `CONTRIBUTORS.md`. Since rust comes with a tool called rustdoc, I am proposing we write our docs in a style that complies with it (for example, formatting comments with markdown). Here's what I propose we follow (thanks @diwakergupta for linking me to this): https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html 

I also added a section for overarching "documentation rules", so feel free to propose modifications/ more rules. 

I also wanted to collect people's thoughts on adding doc coverage to the release process. The nightly build of rustdoc has a flag `--show-coverage`, which calculates the percent of items with documentation. I'm thinking we could list the percent coverage in `CHANGELOG.md` when we do releases. 

Overall, feel free to chime in with any opinions here! 
