### PR TITLE
chore: Replace code that `cargo fmt` always wants to fix

### DIFF
--- a/src/vm/ast/definition_sorter/mod.rs
+++ b/src/vm/ast/definition_sorter/mod.rs
@@ -211,9 +211,10 @@ impl<'a> DefinitionSorter {
                                     return Ok(());
                                 }
                             }
-                            // NOTE: can use ClarityVersion::latest() here only as long as NO NEW FUNCTIONS are special cased
-                            // in the definition sorter.
-                        } else if let Some(native_function) =
+                        } else if
+                        // NOTE: can use ClarityVersion::latest() here only as long as NO NEW FUNCTIONS are special cased
+                        // in the definition sorter.
+                        let Some(native_function) =
                             NativeFunctions::lookup_by_name_at_version(
                                 function_name,
                                 &ClarityVersion::latest(),

--- a/src/vm/ast/definition_sorter/mod.rs
+++ b/src/vm/ast/definition_sorter/mod.rs
@@ -211,13 +211,14 @@ impl<'a> DefinitionSorter {
                                     return Ok(());
                                 }
                             }
-                        } else if let Some(native_function) =
                             // NOTE: can use ClarityVersion::latest() here only as long as NO NEW FUNCTIONS are special cased
-                        //        in the definition sorter.
+                            // in the definition sorter.
+                        } else if let Some(native_function) =
                             NativeFunctions::lookup_by_name_at_version(
-                            function_name,
-                            &ClarityVersion::latest(),
-                        ) {
+                                function_name,
+                                &ClarityVersion::latest(),
+                            )
+                        {
                             match native_function {
                                 NativeFunctions::ContractCall => {
                                     // Args: [contract-name, function-name, ...]: ignore contract-name, function-name, handle rest

--- a/src/vm/ast/definition_sorter/mod.rs
+++ b/src/vm/ast/definition_sorter/mod.rs
@@ -212,7 +212,7 @@ impl<'a> DefinitionSorter {
                                 }
                             }
                         } else if
-                        // NOTE: can use ClarityVersion::latest() here only as long as NO NEW FUNCTIONS are special cased
+                        // NOTE: We can use ClarityVersion::latest() here only as long as NO NEW FUNCTIONS are special cased
                         // in the definition sorter.
                         let Some(native_function) =
                             NativeFunctions::lookup_by_name_at_version(

--- a/src/vm/ast/definition_sorter/mod.rs
+++ b/src/vm/ast/definition_sorter/mod.rs
@@ -213,12 +213,11 @@ impl<'a> DefinitionSorter {
                             }
                         } else if let Some(native_function) =
                             // NOTE: can use ClarityVersion::latest() here only as long as NO NEW FUNCTIONS are special cased
-                            //        in the definition sorter.
+                        //        in the definition sorter.
                             NativeFunctions::lookup_by_name_at_version(
-                                    function_name,
-                                    &ClarityVersion::latest(),
-                                )
-                        {
+                            function_name,
+                            &ClarityVersion::latest(),
+                        ) {
                             match native_function {
                                 NativeFunctions::ContractCall => {
                                     // Args: [contract-name, function-name, ...]: ignore contract-name, function-name, handle rest


### PR DESCRIPTION
# Description
This change moves a comment so that `cargo fmt` will think the file is well-formatted.

# Motivation
With `cargo --version` at `cargo 1.52.0 (69767412a 2021-04-21)`, my `cargo fmt` wants to format this file *every time* I run it. It seems this is because there is a comment inside an "else if" block and inside of an assignment.

# Testing
Should have no effect.