### PR TITLE
WIP: add `multi-stack-stx` function to pox-2

### DIFF
--- a/src/vm/functions/special.rs
+++ b/src/vm/functions/special.rs
@@ -180,7 +180,10 @@ fn handle_pox_v2_api_contract_call(
     function_name: &str,
     value: &Value,
 ) -> Result<()> {
-    if function_name == "stack-stx" || function_name == "delegate-stack-stx" {
+    if function_name == "stack-stx"
+        || function_name == "delegate-stack-stx"
+        || function_name == "multi-stack-stx"
+    {
         debug!(
             "Handle special-case contract-call to {:?} {} (which returned {:?})",
             boot_code_id(POX_2_NAME, global_context.mainnet),


### PR DESCRIPTION
## Description

I'm working on a set of smart contracts that essentially allows a large pool of STX to be 'rented out' to multiple various other parties, so that the other party can use some amount of the pool's STX for a stacking cycle.

These funds are held by a single smart contract, so I'm trying to find a solution to allow a single principal to stack to multiple different reward addresses. After learning a lot about the underlying DB and how it interacts with the PoX contract to perform locking, I believe this solution works well in tandem with existing functionality.

Because the snapshot DB does not allow for multiple different locking periods, this new function only allows you to:

- Perform this "multi-stack" once
- Only for one cycle

The idea is that this function will work well for an initial stack, but would need further changes to support "continuous stacking" in this use case. I am more than willing to follow along with future implementations for things like `stack-increase` to support this "multi stack" use case, and to work on that implementation.

This is more of a proposal than anything - I'm hopeful that we can figure out a solution for this use case, and it doesn't have to be this solution.

I have other tests in a different repo (using clarity-cli), and I can work on translating them all into these rust tests.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Yes, which is why it's intended for the `next` branch

## Are documentation updates required?
Eventually, pox-2 contract documentation

