### PR TITLE
Fix tuple_merge cost calculation

### DIFF
--- a/src/vm/functions/mod.rs
+++ b/src/vm/functions/mod.rs
@@ -258,11 +258,7 @@ pub fn lookup_reserved_functions(name: &str) -> Option<CallableType> {
             DeleteEntry => SpecialFunction("special_delete-entry", &database::special_delete_entry),
             TupleCons => SpecialFunction("special_tuple", &tuples::tuple_cons),
             TupleGet => SpecialFunction("special_get-tuple", &tuples::tuple_get),
-            TupleMerge => NativeFunction(
-                "native_merge-tuple",
-                NativeHandle::DoubleArg(&tuples::tuple_merge),
-                ClarityCostFunction::TupleMerge,
-            ),
+            TupleMerge => SpecialFunction("special_merge-tuple", &tuples::tuple_merge),
             Begin => NativeFunction(
                 "native_begin",
                 NativeHandle::MoreArg(&native_begin),

--- a/src/vm/functions/tuples.rs
+++ b/src/vm/functions/tuples.rs
@@ -76,7 +76,16 @@ pub fn tuple_get(
     }
 }
 
-pub fn tuple_merge(base: Value, update: Value) -> Result<Value> {
+pub fn tuple_merge(
+    args: &[SymbolicExpression],
+    env: &mut Environment,
+    context: &LocalContext,
+) -> Result<Value> {
+    check_argument_count(2, args)?;
+
+    let base = eval(&args[0], env, context)?;
+    let update = eval(&args[1], env, context)?;
+
     let initial_values = match base {
         Value::Tuple(initial_values) => Ok(initial_values),
         _ => Err(CheckErrors::ExpectedTuple(TypeSignature::type_of(&base))),
@@ -88,5 +97,8 @@ pub fn tuple_merge(base: Value, update: Value) -> Result<Value> {
     }?;
 
     let combined = TupleData::shallow_merge(initial_values, new_values)?;
+
+    runtime_cost(ClarityCostFunction::TupleMerge, env, combined.len())?;
+
     Ok(Value::Tuple(combined))
 }


### PR DESCRIPTION
Fix `tuple_merge` function so that it uses the length of the merged tuple as the `input_size` for calculating runtime cost.