### PR TITLE
ci: cherry-pick from Ci/next costs coverage (#2934)

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -6,7 +6,7 @@ ENV BITCOIND_TEST 1
 RUN cargo build && \
     cargo test -- --test-threads 1 --ignored "$test_name"
 
-RUN grcov . --binary-path ../../target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
-    ./codecov
+    ./codecov --name "$test_name"

--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -18,4 +18,4 @@ RUN cargo build && \
 RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
     curl -Os https://uploader.codecov.io/latest/linux/codecov && \
     chmod +x codecov && \
-    ./codecov
+    ./codecov --name "unit_tests"

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -13,7 +13,8 @@ RUN rustup override set nightly && \
 ENV RUSTFLAGS="-Zinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
-RUN cargo build
+RUN cargo test --no-run && \
+    cargo build
 
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -4,12 +4,25 @@ WORKDIR /src
 
 COPY . .
 
-RUN cargo test --no-run --workspace
-
 RUN cd / && wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
+RUN rustup override set nightly && \
+    rustup component add llvm-tools-preview && \
+    cargo install grcov
+
+ENV RUSTFLAGS="-Zinstrument-coverage" \
+    LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
+
+RUN cargo test --no-run --workspace && \
+    cargo build --workspace
+
 ENV BITCOIND_TEST 1
 RUN cd testnet/stacks-node && cargo test --release --features prod-genesis-chainstate -- --test-threads 1 --ignored neon_integrations::bitcoind_integration_test
+
+RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info && \
+    curl -Os https://uploader.codecov.io/latest/linux/codecov && \
+    chmod +x codecov && \
+    ./codecov --name "large_genesis"

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Single full genesis integration test
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
+        # Remove .dockerignore file so codecov has access to git info
+        run: |
+          rm .dockerignore
+          docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.large-genesis .
 
   # Run unit tests with code coverage
   unit-tests:


### PR DESCRIPTION
## Description

Cherry-picking updates on code-coverage from #2934 to develop.
These updates add coverage for the large genesis test, and fix the pathing to the source code when generating coverage for stacks-node integration tests.

## Does this introduce a breaking change?
No
