### PR TITLE
Feat/add stacks height to preamble

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -165,7 +165,7 @@ pub const MAX_PAYLOAD_LEN: u32 = 1 + 16 * 1024 * 1024;
 pub const MAX_MESSAGE_LEN: u32 =
     MAX_PAYLOAD_LEN + (PREAMBLE_ENCODED_SIZE + MAX_RELAYERS_LEN * RELAY_DATA_ENCODED_SIZE);
 
-/// P2P preamble length (addands correspond to fields above)
+/// P2P preamble length (addands correspond to fields in `Preamble`)
 pub const PREAMBLE_ENCODED_SIZE: u32 = 4
     + 4
     + 4
@@ -173,6 +173,7 @@ pub const PREAMBLE_ENCODED_SIZE: u32 = 4
     + BURNCHAIN_HEADER_HASH_ENCODED_SIZE
     + 8
     + BURNCHAIN_HEADER_HASH_ENCODED_SIZE
+    + 8
     + 4
     + MESSAGE_SIGNATURE_ENCODED_SIZE
     + 4;

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -96,6 +96,7 @@ impl Preamble {
         burn_block_hash: &BurnchainHeaderHash,
         stable_block_height: u64,
         stable_burn_block_hash: &BurnchainHeaderHash,
+        canonical_stacks_tip_height: u64,
         payload_len: u32,
     ) -> Preamble {
         Preamble {
@@ -106,6 +107,7 @@ impl Preamble {
             burn_block_hash: burn_block_hash.clone(),
             burn_stable_block_height: stable_block_height,
             burn_stable_block_hash: stable_burn_block_hash.clone(),
+            canonical_stacks_tip_height: canonical_stacks_tip_height,
             additional_data: 0,
             signature: MessageSignature::empty(),
             payload_len: payload_len,
@@ -189,6 +191,7 @@ impl StacksMessageCodec for Preamble {
         write_next(fd, &self.burn_block_hash)?;
         write_next(fd, &self.burn_stable_block_height)?;
         write_next(fd, &self.burn_stable_block_hash)?;
+        write_next(fd, &self.canonical_stacks_tip_height)?;
         write_next(fd, &self.additional_data)?;
         write_next(fd, &self.signature)?;
         write_next(fd, &self.payload_len)?;
@@ -203,6 +206,7 @@ impl StacksMessageCodec for Preamble {
         let burn_block_hash: BurnchainHeaderHash = read_next(fd)?;
         let burn_stable_block_height: u64 = read_next(fd)?;
         let burn_stable_block_hash: BurnchainHeaderHash = read_next(fd)?;
+        let canonical_stacks_tip_height: u64 = read_next(fd)?;
         let additional_data: u32 = read_next(fd)?;
         let signature: MessageSignature = read_next(fd)?;
         let payload_len: u32 = read_next(fd)?;
@@ -244,6 +248,7 @@ impl StacksMessageCodec for Preamble {
             burn_block_hash,
             burn_stable_block_height,
             burn_stable_block_hash,
+            canonical_stacks_tip_height,
             additional_data,
             signature,
             payload_len,
@@ -1071,6 +1076,7 @@ impl StacksMessage {
         burn_header_hash: &BurnchainHeaderHash,
         stable_block_height: u64,
         stable_burn_header_hash: &BurnchainHeaderHash,
+        canonical_stacks_tip_height: u64,
         message: StacksMessageType,
     ) -> StacksMessage {
         let preamble = Preamble::new(
@@ -1080,6 +1086,7 @@ impl StacksMessage {
             burn_header_hash,
             stable_block_height,
             stable_burn_header_hash,
+            canonical_stacks_tip_height,
             0,
         );
         StacksMessage {
@@ -1094,6 +1101,7 @@ impl StacksMessage {
         peer_version: u32,
         network_id: u32,
         chain_view: &BurnchainView,
+        canonical_stacks_tip_height: u64,
         message: StacksMessageType,
     ) -> StacksMessage {
         StacksMessage::new(
@@ -1103,6 +1111,7 @@ impl StacksMessage {
             &chain_view.burn_block_hash,
             chain_view.burn_stable_block_height,
             &chain_view.burn_stable_block_hash,
+            canonical_stacks_tip_height,
             message,
         )
     }
@@ -1491,6 +1500,7 @@ pub mod test {
             burn_block_hash: BurnchainHeaderHash([0x11; 32]),
             burn_stable_block_height: 0x00001111,
             burn_stable_block_hash: BurnchainHeaderHash([0x22; 32]),
+            canonical_stacks_tip_height: 0x00001122,
             additional_data: 0x33333333,
             signature: MessageSignature::from_raw(&vec![0x44; 65]),
             payload_len: 0x000007ff,
@@ -1507,7 +1517,8 @@ pub mod test {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x11, // stable_burn_block_hash
             0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
             0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
-            0x22, 0x22, 0x22, 0x22, // additional_data
+            0x22, 0x22, 0x22, 0x22, // canonical_stacks_tip_height
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, // additional_data
             0x33, 0x33, 0x33, 0x33, // signature
             0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
             0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
@@ -2120,6 +2131,7 @@ pub mod test {
                 burn_block_hash: BurnchainHeaderHash([0x11; 32]),
                 burn_stable_block_height: 0x00001111,
                 burn_stable_block_hash: BurnchainHeaderHash([0x22; 32]),
+                canonical_stacks_tip_height: 0,
                 additional_data: 0x33333333,
                 signature: MessageSignature::from_raw(&vec![0x44; 65]),
                 payload_len: (relayers_bytes.len() + payload_bytes.len()) as u32,
@@ -2173,6 +2185,7 @@ pub mod test {
             &BurnchainHeaderHash([0x11; 32]),
             12339,
             &BurnchainHeaderHash([0x22; 32]),
+            122,
             StacksMessageType::Ping(PingData { nonce: 0x01020304 }),
         );
 

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -1741,6 +1741,7 @@ mod test {
             &BurnchainHeaderHash([0x11; 32]),
             12339,
             &BurnchainHeaderHash([0x22; 32]),
+            122,
             StacksMessageType::Ping(PingData { nonce: nonce }),
         );
         let privkey = Secp256k1PrivateKey::new();
@@ -1786,6 +1787,7 @@ mod test {
             &BurnchainHeaderHash([0x11; 32]),
             12339,
             &BurnchainHeaderHash([0x22; 32]),
+            122,
             StacksMessageType::Ping(PingData { nonce: 0x01020304 }),
         );
 
@@ -1953,6 +1955,7 @@ mod test {
                 &BurnchainHeaderHash([0x11; 32]),
                 12339 + i,
                 &BurnchainHeaderHash([0x22; 32]),
+                122,
                 StacksMessageType::Ping(PingData { nonce: 0x01020304 }),
             );
 
@@ -2052,6 +2055,7 @@ mod test {
                     &BurnchainHeaderHash([0x11; 32]),
                     12339 + i,
                     &BurnchainHeaderHash([0x22; 32]),
+                    122,
                     StacksMessageType::Ping(PingData {
                         nonce: (0x01020304 + i) as u32,
                     }),
@@ -2166,6 +2170,7 @@ mod test {
                 &BurnchainHeaderHash([0x11; 32]),
                 12339 + i,
                 &BurnchainHeaderHash([0x22; 32]),
+                122,
                 StacksMessageType::Ping(PingData {
                     nonce: (0x01020304 + i) as u32,
                 }),

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -2177,7 +2177,7 @@ impl PeerNetwork {
             .as_mut()
             .expect("Unreachable: inv state not initialized");
 
-        let (new_tip_sort_id, new_pox_id, reloaded) = {
+        let (new_tip_sort_id, new_pox_id, new_canonical_stacks_tip_height, reloaded) = {
             if self.burnchain_tip.sortition_id != self.tip_sort_id {
                 // reloaded burnchain tip disagrees with our last-considered sortition tip
                 let ic = sortdb.index_conn();
@@ -2186,10 +2186,16 @@ impl PeerNetwork {
                 (
                     self.burnchain_tip.sortition_id.clone(),
                     sortdb_reader.get_pox_id()?,
+                    self.burnchain_tip.canonical_stacks_tip_height,
                     true,
                 )
             } else {
-                (self.tip_sort_id.clone(), self.pox_id.clone(), false)
+                (
+                    self.tip_sort_id.clone(),
+                    self.pox_id.clone(),
+                    self.canonical_stacks_tip_height.clone(),
+                    false,
+                )
             }
         };
 
@@ -2223,6 +2229,7 @@ impl PeerNetwork {
 
             self.tip_sort_id = new_tip_sort_id;
             self.pox_id = new_pox_id;
+            self.canonical_stacks_tip_height = new_canonical_stacks_tip_height;
         }
 
         debug!(

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -673,6 +673,7 @@ pub struct Preamble {
     pub burn_block_hash: BurnchainHeaderHash, // hash of the last-seen burn block
     pub burn_stable_block_height: u64, // latest stable block height (e.g. chain tip minus 7)
     pub burn_stable_block_hash: BurnchainHeaderHash, // latest stable burnchain header hash.
+    pub canonical_stacks_tip_height: u64, // chain tip height of the Stacks blockchain
     pub additional_data: u32, // RESERVED; pointer to additional data (should be all 0's if not used)
     pub signature: MessageSignature, // signature from the peer that sent this
     pub payload_len: u32,     // length of the following payload, including relayers vector

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -3486,9 +3486,14 @@ impl PeerNetwork {
                     Err(net_error::NotFoundError) => {
                         // is this remote node simply ahead of us?
                         if let Some(convo) = self.peers.get(&event_id) {
-                            if self.chain_view.burn_block_height < convo.burnchain_tip_height {
-                                debug!("{:?}: Unrecognized consensus hash {}; it is possible that {} is ahead of us", &self.local_peer, consensus_hash, outbound_neighbor_key);
-                                return Err(net_error::NotFoundError);
+                            match convo.burnchain_tip_height {
+                                Some(burnchain_tip_height) => {
+                                    if self.chain_view.burn_block_height < burnchain_tip_height {
+                                        debug!("{:?}: Unrecognized consensus hash {}; it is possible that {} is ahead of us", & self.local_peer, consensus_hash, outbound_neighbor_key);
+                                        return Err(net_error::NotFoundError);
+                                    }
+                                }
+                                None => {}
                             }
                         }
                         // not ahead of us -- it's a bad consensus hash

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -2167,6 +2167,7 @@ mod test {
                 .sign_relay_message(
                     &peer.network.local_peer,
                     &peer.network.chain_view,
+                    peer.network.canonical_stacks_tip_height,
                     relay_hints,
                     msg,
                 )


### PR DESCRIPTION
In order to implement the health check endpoint of a node (#2768), the node must have knowledge of its peer's stacks block height. By comparing the height of the tip of the stacks blockchain with that of its startup peers, a node can determine if it is "caught up" with the rest of the network, and is thus "healthy". 

In this PR, I added the canonical stacks tip height to the Preamble, which is sent along with every stacks message sent between peers. The node stores this received information in the `ConversationP2P` object for each peer it is in contact with. 

## Testing 
I updated relevant tests, did not add any new tests. 