### PR TITLE
feat: Fuzzing for FeeRate Estimates

### DIFF
--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -1,8 +1,8 @@
 use vm::costs::ExecutionCost;
 
-use chainstate::stacks::db::StacksEpochReceipt;
 use super::FeeRateEstimate;
 use super::{EstimatorError, FeeEstimator};
+use chainstate::stacks::db::StacksEpochReceipt;
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;
 use rand::thread_rng;

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -1,0 +1,57 @@
+use std::cmp;
+use std::convert::TryFrom;
+use std::{iter::FromIterator, path::Path};
+
+use rusqlite::Transaction as SqlTransaction;
+use rusqlite::{
+    types::{FromSql, FromSqlError},
+    Connection, Error as SqliteError, OptionalExtension, ToSql,
+};
+use serde_json::Value as JsonValue;
+
+use chainstate::stacks::TransactionPayload;
+use util::db::sqlite_open;
+use util::db::tx_begin_immediate_sqlite;
+use util::db::u64_to_sql;
+
+use vm::costs::ExecutionCost;
+
+use chainstate::stacks::db::StacksEpochReceipt;
+use chainstate::stacks::events::TransactionOrigin;
+
+use crate::util::db::sql_pragma;
+use crate::util::db::table_exists;
+
+use super::metrics::CostMetric;
+use super::FeeRateEstimate;
+use super::{EstimatorError, FeeEstimator};
+
+pub struct FeeRateFuzzer {
+    underlying: FeeEstimator,
+}
+
+fn fuzz_esimate(input:&FeeRateEstimate) -> FeeRateEstimate {
+    input.clone()
+}
+
+impl FeeEstimator for FeeRateFuzzer {
+    /// Just passes the information straight to `underlying`.
+    fn notify_block(
+        &mut self,
+        receipt: &StacksEpochReceipt,
+        block_limit: &ExecutionCost,
+    ) -> Result<(), EstimatorError> {
+        self.underlying.notify_block(receipt, block_limit)
+    }
+
+    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
+        match self.underlying.get_rate_estimates() {
+            Ok(underlying_estimate) => {
+                Ok(fuzz_esimate(&underlying_estimate))
+            }
+            Err(e) => {
+                Err(e)
+            }
+        }
+    }
+}

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -35,7 +35,7 @@ fn fuzz_esimate(input: &FeeRateEstimate) -> FeeRateEstimate {
 }
 
 impl FeeRateFuzzer {
-    fn new(underlying: Box<dyn FeeEstimator>) -> FeeRateFuzzer {
+    pub fn new(underlying: Box<dyn FeeEstimator>) -> FeeRateFuzzer {
         Self { underlying }
     }
 }

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -26,6 +26,8 @@ pub struct FeeRateFuzzer {
 }
 
 impl FeeRateFuzzer {
+    /// Constructor for production. It uses `thread_rng()` as the random number generator,
+    /// to get truly pseudo-random numbers.
     pub fn new(underlying: Box<dyn FeeEstimator>, uniform_bound: f64) -> Box<FeeRateFuzzer> {
         let rng_creator = Box::new(|| {
             let r: Box<dyn RngCore> = Box::new(thread_rng());
@@ -37,6 +39,9 @@ impl FeeRateFuzzer {
             uniform_bound,
         })
     }
+
+    /// Constructor meant for test. The user can pass in a contrived random number generator
+    /// factory function, so that the test is repeatable.
     pub fn new_custom_creator(
         underlying: Box<dyn FeeEstimator>,
         rng_creator: Box<dyn Fn() -> Box<dyn RngCore>>,

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -1,31 +1,8 @@
-use std::cmp;
-use std::convert::TryFrom;
-use std::{iter::FromIterator, path::Path};
-
-use rusqlite::Transaction as SqlTransaction;
-use rusqlite::{
-    types::{FromSql, FromSqlError},
-    Connection, Error as SqliteError, OptionalExtension, ToSql,
-};
-use serde_json::Value as JsonValue;
-
-use chainstate::stacks::TransactionPayload;
-use util::db::sqlite_open;
-use util::db::tx_begin_immediate_sqlite;
-use util::db::u64_to_sql;
-
 use vm::costs::ExecutionCost;
 
 use chainstate::stacks::db::StacksEpochReceipt;
-use chainstate::stacks::events::TransactionOrigin;
-
-use crate::util::db::sql_pragma;
-use crate::util::db::table_exists;
-
-use super::metrics::CostMetric;
 use super::FeeRateEstimate;
 use super::{EstimatorError, FeeEstimator};
-
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;
 use rand::thread_rng;

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -27,11 +27,17 @@ use super::FeeRateEstimate;
 use super::{EstimatorError, FeeEstimator};
 
 pub struct FeeRateFuzzer {
-    underlying: FeeEstimator,
+    underlying: Box<dyn FeeEstimator>,
 }
 
-fn fuzz_esimate(input:&FeeRateEstimate) -> FeeRateEstimate {
+fn fuzz_esimate(input: &FeeRateEstimate) -> FeeRateEstimate {
     input.clone()
+}
+
+impl FeeRateFuzzer {
+    fn new(underlying: Box<dyn FeeEstimator>) -> FeeRateFuzzer {
+        Self { underlying }
+    }
 }
 
 impl FeeEstimator for FeeRateFuzzer {
@@ -46,12 +52,8 @@ impl FeeEstimator for FeeRateFuzzer {
 
     fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
         match self.underlying.get_rate_estimates() {
-            Ok(underlying_estimate) => {
-                Ok(fuzz_esimate(&underlying_estimate))
-            }
-            Err(e) => {
-                Err(e)
-            }
+            Ok(underlying_estimate) => Ok(fuzz_esimate(&underlying_estimate)),
+            Err(e) => Err(e),
         }
     }
 }

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -26,67 +26,79 @@ use super::metrics::CostMetric;
 use super::FeeRateEstimate;
 use super::{EstimatorError, FeeEstimator};
 
+use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;
 use rand::thread_rng;
 use rand::RngCore;
 use rand::SeedableRng;
 
+/// The FeeRateFuzzer wraps an underlying FeeEstimator. It passes `notify_block` calls to the
+/// underlying estimator. On `get_rate_estimates` calls, it adds a random fuzz to the result coming
+/// back from the underlying estimator.
 pub struct FeeRateFuzzer {
     /// We will apply a random "fuzz" on top of the estimates given by this.
     underlying: Box<dyn FeeEstimator>,
     /// Creator function for a new random generator. For prod, use `thread_rng`. For test,
     /// pass in a contrived generator.
     rng_creator: Box<dyn Fn() -> Box<dyn RngCore>>,
+    /// The bound used for the uniform random fuzz.
+    uniform_bound: f64,
 }
 
 impl FeeRateFuzzer {
-    pub fn new(underlying: Box<dyn FeeEstimator>) -> Box<FeeRateFuzzer> {
+    pub fn new(underlying: Box<dyn FeeEstimator>, uniform_bound: f64) -> Box<FeeRateFuzzer> {
         let rng_creator = Box::new(|| {
             let r: Box<dyn RngCore> = Box::new(thread_rng());
             r
-            //            thread_rng()
         });
         Box::new(Self {
             underlying,
             rng_creator,
+            uniform_bound,
         })
     }
     pub fn new_custom_creator(
         underlying: Box<dyn FeeEstimator>,
         rng_creator: Box<dyn Fn() -> Box<dyn RngCore>>,
+        uniform_bound: f64,
     ) -> Box<FeeRateFuzzer> {
         Box::new(Self {
             underlying,
             rng_creator,
+            uniform_bound,
         })
     }
 
-    //fn fuzz_esimate(&self, input: &FeeRateEstimate) -> FeeRateEstimate {
-    //        let _rng: Box<dyn RngCore> = match self.seed {
-    //            Some(seed) => {
-    //                let rng: StdRng = SeedableRng::from_seed(seed);
-    //                Box::new(rng)
-    //            }
-    //            None => Box::new(thread_rng()),
-    //        };
-    //    input.clone()
-    //}
+    /// Add a uniform fuzz to input.
+    ///
+    /// Note: We use "uniform" instead of "normal" distribution to avoid importing a new crate
+    /// just for this.
+    fn fuzz_estimate(&self, input: &FeeRateEstimate) -> FeeRateEstimate {
+        let mut rng: Box<dyn RngCore> = (self.rng_creator)();
+        let normal = Uniform::new(-self.uniform_bound, self.uniform_bound);
+        FeeRateEstimate {
+            high: input.high + normal.sample(&mut rng),
+            middle: input.middle + normal.sample(&mut rng),
+            low: input.low + normal.sample(&mut rng),
+        }
+    }
 }
-//
-//impl FeeEstimator for FeeRateFuzzer {
-//    /// Just passes the information straight to `underlying`.
-//    fn notify_block(
-//        &mut self,
-//        receipt: &StacksEpochReceipt,
-//        block_limit: &ExecutionCost,
-//    ) -> Result<(), EstimatorError> {
-//        self.underlying.notify_block(receipt, block_limit)
-//    }
-//
-//    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
-//        match self.underlying.get_rate_estimates() {
-//            Ok(underlying_estimate) => Ok(fuzz_esimate(&underlying_estimate)),
-//            Err(e) => Err(e),
-//        }
-//    }
-//}
+
+impl FeeEstimator for FeeRateFuzzer {
+    /// Just passes the information straight to `underlying`.
+    fn notify_block(
+        &mut self,
+        receipt: &StacksEpochReceipt,
+        block_limit: &ExecutionCost,
+    ) -> Result<(), EstimatorError> {
+        self.underlying.notify_block(receipt, block_limit)
+    }
+
+    /// Call underlying estimator and add some fuzz.
+    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
+        match self.underlying.get_rate_estimates() {
+            Ok(underlying_estimate) => Ok(self.fuzz_estimate(&underlying_estimate)),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -11,7 +11,7 @@ use rand::SeedableRng;
 
 /// The FeeRateFuzzer wraps an underlying FeeEstimator. It passes `notify_block` calls to the
 /// underlying estimator. On `get_rate_estimates` calls, it adds a random fuzz to the result coming
-/// back from the underlying estimator.
+/// back from the underlying estimator. The fuzz applied is as a random fraction of the base value.
 ///
 /// Note: We currently use "uniform" random noise instead of "normal" distributed noise to avoid
 /// importing a new crate just for this.

--- a/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/fee_rate_fuzzer.rs
@@ -12,6 +12,9 @@ use rand::SeedableRng;
 /// The FeeRateFuzzer wraps an underlying FeeEstimator. It passes `notify_block` calls to the
 /// underlying estimator. On `get_rate_estimates` calls, it adds a random fuzz to the result coming
 /// back from the underlying estimator.
+///
+/// Note: We currently use "uniform" random noise instead of "normal" distributed noise to avoid
+/// importing a new crate just for this.
 pub struct FeeRateFuzzer {
     /// We will apply a random "fuzz" on top of the estimates given by this.
     underlying: Box<dyn FeeEstimator>,
@@ -47,9 +50,6 @@ impl FeeRateFuzzer {
     }
 
     /// Add a uniform fuzz to input.
-    ///
-    /// Note: We use "uniform" instead of "normal" distribution to avoid importing a new crate
-    /// just for this.
     fn fuzz_estimate(&self, input: &FeeRateEstimate) -> FeeRateEstimate {
         let mut rng: Box<dyn RngCore> = (self.rng_creator)();
         let normal = Uniform::new(-self.uniform_bound, self.uniform_bound);

--- a/src/cost_estimates/mod.rs
+++ b/src/cost_estimates/mod.rs
@@ -14,6 +14,7 @@ use burnchains::Txid;
 use chainstate::stacks::db::StacksEpochReceipt;
 
 pub mod fee_scalar;
+pub mod fee_rate_fuzzer;
 pub mod metrics;
 pub mod pessimistic;
 

--- a/src/cost_estimates/mod.rs
+++ b/src/cost_estimates/mod.rs
@@ -13,8 +13,8 @@ use vm::costs::ExecutionCost;
 use burnchains::Txid;
 use chainstate::stacks::db::StacksEpochReceipt;
 
-pub mod fee_scalar;
 pub mod fee_rate_fuzzer;
+pub mod fee_scalar;
 pub mod metrics;
 pub mod pessimistic;
 

--- a/src/cost_estimates/tests/common.rs
+++ b/src/cost_estimates/tests/common.rs
@@ -1,0 +1,50 @@
+use vm::costs::ExecutionCost;
+use chainstate::stacks::db::{StacksEpochReceipt, StacksHeaderInfo};
+use chainstate::stacks::events::StacksTransactionReceipt;
+use types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockHeader, StacksWorkScore};
+use types::proof::TrieHash;
+use util::hash::{to_hex, Hash160, Sha512Trunc256Sum};
+use util::vrf::VRFProof;
+use chainstate::burn::ConsensusHash;
+
+use crate::chainstate::stacks::{
+    CoinbasePayload, StacksTransaction, TokenTransferMemo, TransactionAuth,
+    TransactionContractCall, TransactionPayload, TransactionSpendingCondition, TransactionVersion,
+};
+use crate::core::StacksEpochId;
+
+/// Make a block receipt from `tx_receipts` with some dummy values filled for test.
+pub fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksEpochReceipt {
+    StacksEpochReceipt {
+        header: StacksHeaderInfo {
+            anchored_header: StacksBlockHeader {
+                version: 1,
+                total_work: StacksWorkScore { burn: 1, work: 1 },
+                proof: VRFProof::empty(),
+                parent_block: BlockHeaderHash([0; 32]),
+                parent_microblock: BlockHeaderHash([0; 32]),
+                parent_microblock_sequence: 0,
+                tx_merkle_root: Sha512Trunc256Sum([0; 32]),
+                state_index_root: TrieHash([0; 32]),
+                microblock_pubkey_hash: Hash160([0; 20]),
+            },
+            microblock_tail: None,
+            block_height: 1,
+            index_root: TrieHash([0; 32]),
+            consensus_hash: ConsensusHash([2; 20]),
+            burn_header_hash: BurnchainHeaderHash([1; 32]),
+            burn_header_height: 2,
+            burn_header_timestamp: 2,
+            anchored_block_size: 1,
+        },
+        tx_receipts,
+        matured_rewards: vec![],
+        matured_rewards_info: None,
+        parent_microblocks_cost: ExecutionCost::zero(),
+        anchored_block_cost: ExecutionCost::zero(),
+        parent_burn_block_hash: BurnchainHeaderHash([0; 32]),
+        parent_burn_block_height: 1,
+        parent_burn_block_timestamp: 1,
+        evaluated_epoch: StacksEpochId::Epoch20,
+    }
+}

--- a/src/cost_estimates/tests/common.rs
+++ b/src/cost_estimates/tests/common.rs
@@ -1,11 +1,11 @@
-use vm::costs::ExecutionCost;
+use chainstate::burn::ConsensusHash;
 use chainstate::stacks::db::{StacksEpochReceipt, StacksHeaderInfo};
 use chainstate::stacks::events::StacksTransactionReceipt;
 use types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockHeader, StacksWorkScore};
 use types::proof::TrieHash;
 use util::hash::{to_hex, Hash160, Sha512Trunc256Sum};
 use util::vrf::VRFProof;
-use chainstate::burn::ConsensusHash;
+use vm::costs::ExecutionCost;
 
 use crate::chainstate::stacks::{
     CoinbasePayload, StacksTransaction, TokenTransferMemo, TransactionAuth,

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -26,6 +26,7 @@ use crate::cost_estimates::FeeRateEstimate;
 use crate::types::chainstate::StacksAddress;
 use crate::vm::types::{PrincipalData, StandardPrincipalData};
 use crate::vm::Value;
+use cost_estimates::fee_rate_fuzzer::FeeRateFuzzer;
 
 struct MockFeeEstimator {
     pub receipts: Vec<StacksEpochReceipt>,
@@ -54,4 +55,9 @@ impl FeeEstimator for MockFeeEstimator {
 }
 
 #[test]
-fn test_empty_fee_estimator() {}
+fn test_empty_fee_estimator() {
+    let mock_estimator = MockFeeEstimator {
+        receipts: vec![],
+    };
+    let _fuzzed_estimator = FeeRateFuzzer::new(Box::new(mock_estimator));
+}

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -28,34 +28,34 @@ use crate::vm::types::{PrincipalData, StandardPrincipalData};
 use crate::vm::Value;
 use cost_estimates::fee_rate_fuzzer::FeeRateFuzzer;
 
-struct MockFeeEstimator {
-    pub receipts: Vec<StacksEpochReceipt>,
-}
-
-/// 1) on `notify_block` Inputs are recorded, and not passed anywhere.
-/// 2) on `get_rate_estimates`, a constant `FeeRateEstimate` is returned.
-impl FeeEstimator for MockFeeEstimator {
-    /// Just passes the information straight to `underlying`.
-    fn notify_block(
-        &mut self,
-        receipt: &StacksEpochReceipt,
-        block_limit: &ExecutionCost,
-    ) -> Result<(), EstimatorError> {
-        self.receipts.push(receipt.clone());
-        Ok(())
-    }
-
-    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
-        Ok(FeeRateEstimate {
-            high: 95f64,
-            middle: 50f64,
-            low: 5f64,
-        })
-    }
-}
-
-#[test]
-fn test_empty_fee_estimator() {
-    let mock_estimator = MockFeeEstimator { receipts: vec![] };
-    let _fuzzed_estimator = FeeRateFuzzer::new(Box::new(mock_estimator), Some([0u8; 32]));
-}
+//struct MockFeeEstimator {
+//    pub receipts: Vec<StacksEpochReceipt>,
+//}
+//
+///// 1) on `notify_block` Inputs are recorded, and not passed anywhere.
+///// 2) on `get_rate_estimates`, a constant `FeeRateEstimate` is returned.
+//impl FeeEstimator for MockFeeEstimator {
+//    /// Just passes the information straight to `underlying`.
+//    fn notify_block(
+//        &mut self,
+//        receipt: &StacksEpochReceipt,
+//        block_limit: &ExecutionCost,
+//    ) -> Result<(), EstimatorError> {
+//        self.receipts.push(receipt.clone());
+//        Ok(())
+//    }
+//
+//    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
+//        Ok(FeeRateEstimate {
+//            high: 95f64,
+//            middle: 50f64,
+//            low: 5f64,
+//        })
+//    }
+//}
+//
+//#[test]
+//fn test_empty_fee_estimator() {
+//    let mock_estimator = MockFeeEstimator { receipts: vec![] };
+//    let _fuzzed_estimator = FeeRateFuzzer::new(Box::new(mock_estimator), Some([0u8; 32]));
+//}

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -62,9 +62,9 @@ fn test_fuzzing_seed1() {
             .get_rate_estimates()
             .expect("Estimate should exist."),
         FeeRateEstimate {
-            high: 95.01268903765265f64,
-            middle: 49.93182838353776f64,
-            low: 4.921037454936614f64
+            high: 96.20545857700169f64,
+            middle: 50.63445188263247f64,
+            low: 5.0634451882632465f64
         }
     );
 }
@@ -86,9 +86,9 @@ fn test_fuzzing_seed2() {
             .get_rate_estimates()
             .expect("Estimate should exist."),
         FeeRateEstimate {
-            high: 95.05348553928201f64,
-            middle: 50.031434211372954f64,
-            low: 5.043648532116769f64
+            high: 100.08112623179122f64,
+            middle: 52.67427696410064f64,
+            low: 5.267427696410064f64
         }
     );
 }
@@ -145,9 +145,9 @@ fn test_notify_pass_through() {
             .get_rate_estimates()
             .expect("Estimate should exist."),
         FeeRateEstimate {
-            high: 2.053485539282013f64,
-            middle: 2.0314342113729524f64,
-            low: 2.0436485321167686f64
+            high: 2.1069710785640257f64,
+            middle: 2.1069710785640257f64,
+            low: 2.1069710785640257f64
         },
     );
 }

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -22,6 +22,8 @@ use rand::thread_rng;
 use rand::RngCore;
 use rand::SeedableRng;
 
+use cost_estimates::tests::common::make_block_receipt;
+
 struct ConstantFeeEstimator {}
 
 /// Returns a constant fee rate estimate.
@@ -91,41 +93,6 @@ fn test_fuzzing_seed2() {
             low: 5.043648532116769f64
         }
     );
-}
-
-fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksEpochReceipt {
-    StacksEpochReceipt {
-        header: StacksHeaderInfo {
-            anchored_header: StacksBlockHeader {
-                version: 1,
-                total_work: StacksWorkScore { burn: 1, work: 1 },
-                proof: VRFProof::empty(),
-                parent_block: BlockHeaderHash([0; 32]),
-                parent_microblock: BlockHeaderHash([0; 32]),
-                parent_microblock_sequence: 0,
-                tx_merkle_root: Sha512Trunc256Sum([0; 32]),
-                state_index_root: TrieHash([0; 32]),
-                microblock_pubkey_hash: Hash160([0; 20]),
-            },
-            microblock_tail: None,
-            block_height: 1,
-            index_root: TrieHash([0; 32]),
-            consensus_hash: ConsensusHash([2; 20]),
-            burn_header_hash: BurnchainHeaderHash([1; 32]),
-            burn_header_height: 2,
-            burn_header_timestamp: 2,
-            anchored_block_size: 1,
-        },
-        tx_receipts,
-        matured_rewards: vec![],
-        matured_rewards_info: None,
-        parent_microblocks_cost: ExecutionCost::zero(),
-        anchored_block_cost: ExecutionCost::zero(),
-        parent_burn_block_hash: BurnchainHeaderHash([0; 32]),
-        parent_burn_block_height: 1,
-        parent_burn_block_timestamp: 1,
-        evaluated_epoch: StacksEpochId::Epoch20,
-    }
 }
 
 struct CountingFeeEstimator {

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -27,35 +27,46 @@ use crate::types::chainstate::StacksAddress;
 use crate::vm::types::{PrincipalData, StandardPrincipalData};
 use crate::vm::Value;
 use cost_estimates::fee_rate_fuzzer::FeeRateFuzzer;
+use rand::rngs::StdRng;
+use rand::thread_rng;
+use rand::RngCore;
+use rand::SeedableRng;
 
-//struct MockFeeEstimator {
-//    pub receipts: Vec<StacksEpochReceipt>,
-//}
-//
-///// 1) on `notify_block` Inputs are recorded, and not passed anywhere.
-///// 2) on `get_rate_estimates`, a constant `FeeRateEstimate` is returned.
-//impl FeeEstimator for MockFeeEstimator {
-//    /// Just passes the information straight to `underlying`.
-//    fn notify_block(
-//        &mut self,
-//        receipt: &StacksEpochReceipt,
-//        block_limit: &ExecutionCost,
-//    ) -> Result<(), EstimatorError> {
-//        self.receipts.push(receipt.clone());
-//        Ok(())
-//    }
-//
-//    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
-//        Ok(FeeRateEstimate {
-//            high: 95f64,
-//            middle: 50f64,
-//            low: 5f64,
-//        })
-//    }
-//}
-//
-//#[test]
-//fn test_empty_fee_estimator() {
-//    let mock_estimator = MockFeeEstimator { receipts: vec![] };
-//    let _fuzzed_estimator = FeeRateFuzzer::new(Box::new(mock_estimator), Some([0u8; 32]));
-//}
+struct MockFeeEstimator {
+    pub receipts: Vec<StacksEpochReceipt>,
+}
+
+/// 1) on `notify_block` Inputs are recorded, and not passed anywhere.
+/// 2) on `get_rate_estimates`, a constant `FeeRateEstimate` is returned.
+impl FeeEstimator for MockFeeEstimator {
+    /// Just passes the information straight to `underlying`.
+    fn notify_block(
+        &mut self,
+        receipt: &StacksEpochReceipt,
+        block_limit: &ExecutionCost,
+    ) -> Result<(), EstimatorError> {
+        self.receipts.push(receipt.clone());
+        Ok(())
+    }
+
+    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
+        Ok(FeeRateEstimate {
+            high: 95f64,
+            middle: 50f64,
+            low: 5f64,
+        })
+    }
+}
+
+#[test]
+fn test_empty_fee_estimator() {
+    let mock_estimator = MockFeeEstimator { receipts: vec![] };
+    let rng_creator = Box::new(|| {
+        let seed = [0u8; 32];
+        let rng: StdRng = SeedableRng::from_seed(seed);
+        let r: Box<dyn RngCore> = Box::new(rng);
+        r
+    });
+    let _fuzzed_estimator =
+        FeeRateFuzzer::new_custom_creator(Box::new(mock_estimator), rng_creator, 0.1);
+}

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -2,13 +2,13 @@ use cost_estimates::metrics::CostMetric;
 use cost_estimates::{EstimatorError, FeeEstimator};
 use vm::costs::ExecutionCost;
 
+use chainstate::burn::ConsensusHash;
 use chainstate::stacks::db::{StacksEpochReceipt, StacksHeaderInfo};
 use chainstate::stacks::events::StacksTransactionReceipt;
 use types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockHeader, StacksWorkScore};
 use types::proof::TrieHash;
 use util::hash::{to_hex, Hash160, Sha512Trunc256Sum};
 use util::vrf::VRFProof;
-use chainstate::burn::ConsensusHash;
 
 use crate::chainstate::stacks::{
     CoinbasePayload, StacksTransaction, TokenTransferMemo, TransactionAuth,

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -32,20 +32,15 @@ use rand::thread_rng;
 use rand::RngCore;
 use rand::SeedableRng;
 
-struct MockFeeEstimator {
-    pub receipts: Vec<StacksEpochReceipt>,
-}
+struct ConstantFeeEstimator {}
 
-/// 1) on `notify_block` Inputs are recorded, and not passed anywhere.
-/// 2) on `get_rate_estimates`, a constant `FeeRateEstimate` is returned.
-impl FeeEstimator for MockFeeEstimator {
-    /// Just passes the information straight to `underlying`.
+/// Returns a constant fee rate estimate.
+impl FeeEstimator for ConstantFeeEstimator {
     fn notify_block(
         &mut self,
         receipt: &StacksEpochReceipt,
         block_limit: &ExecutionCost,
     ) -> Result<(), EstimatorError> {
-        self.receipts.push(receipt.clone());
         Ok(())
     }
 
@@ -61,7 +56,7 @@ impl FeeEstimator for MockFeeEstimator {
 /// Test the fuzzer using a fixed random seed.
 #[test]
 fn test_fuzzing_seed1() {
-    let mock_estimator = MockFeeEstimator { receipts: vec![] };
+    let mock_estimator = ConstantFeeEstimator {};
     let rng_creator = Box::new(|| {
         let seed = [0u8; 32];
         let rng: StdRng = SeedableRng::from_seed(seed);
@@ -86,7 +81,7 @@ fn test_fuzzing_seed1() {
 /// Test the fuzzer using a fixed random seed. Uses a different seed than test_fuzzing_seed1.
 #[test]
 fn test_fuzzing_seed2() {
-    let mock_estimator = MockFeeEstimator { receipts: vec![] };
+    let mock_estimator = ConstantFeeEstimator {};
     let rng_creator = Box::new(|| {
         let seed = [1u8; 32];
         let rng: StdRng = SeedableRng::from_seed(seed);
@@ -105,5 +100,100 @@ fn test_fuzzing_seed2() {
             middle: 50.031434211372954f64,
             low: 5.043648532116769f64
         }
+    );
+}
+
+fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksEpochReceipt {
+    StacksEpochReceipt {
+        header: StacksHeaderInfo {
+            anchored_header: StacksBlockHeader {
+                version: 1,
+                total_work: StacksWorkScore { burn: 1, work: 1 },
+                proof: VRFProof::empty(),
+                parent_block: BlockHeaderHash([0; 32]),
+                parent_microblock: BlockHeaderHash([0; 32]),
+                parent_microblock_sequence: 0,
+                tx_merkle_root: Sha512Trunc256Sum([0; 32]),
+                state_index_root: TrieHash([0; 32]),
+                microblock_pubkey_hash: Hash160([0; 20]),
+            },
+            microblock_tail: None,
+            block_height: 1,
+            index_root: TrieHash([0; 32]),
+            consensus_hash: ConsensusHash([2; 20]),
+            burn_header_hash: BurnchainHeaderHash([1; 32]),
+            burn_header_height: 2,
+            burn_header_timestamp: 2,
+            anchored_block_size: 1,
+        },
+        tx_receipts,
+        matured_rewards: vec![],
+        matured_rewards_info: None,
+        parent_microblocks_cost: ExecutionCost::zero(),
+        anchored_block_cost: ExecutionCost::zero(),
+        parent_burn_block_hash: BurnchainHeaderHash([0; 32]),
+        parent_burn_block_height: 1,
+        parent_burn_block_timestamp: 1,
+        evaluated_epoch: StacksEpochId::Epoch20,
+    }
+}
+
+struct CountingFeeEstimator {
+    counter: u64,
+}
+
+/// This class "counts" the number of times `notify_block` has been called, and returns this as the
+/// estimate.
+impl FeeEstimator for CountingFeeEstimator {
+    fn notify_block(
+        &mut self,
+        receipt: &StacksEpochReceipt,
+        block_limit: &ExecutionCost,
+    ) -> Result<(), EstimatorError> {
+        self.counter += 1;
+        Ok(())
+    }
+
+    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
+        Ok(FeeRateEstimate {
+            high: self.counter as f64,
+            middle: self.counter as f64,
+            low: self.counter as f64,
+        })
+    }
+}
+
+/// Tests that the receipt is passed through in `notify_block`.
+#[test]
+fn test_notify_pass_through() {
+    let mock_estimator = CountingFeeEstimator { counter: 0 };
+    let rng_creator = Box::new(|| {
+        let seed = [1u8; 32];
+        let rng: StdRng = SeedableRng::from_seed(seed);
+        let r: Box<dyn RngCore> = Box::new(rng);
+        r
+    });
+    let mut fuzzed_estimator =
+        FeeRateFuzzer::new_custom_creator(Box::new(mock_estimator), rng_creator, 0.1);
+
+    let receipt = make_block_receipt(vec![]);
+    fuzzed_estimator
+        .notify_block(&receipt, &ExecutionCost::max_value())
+        .expect("notify_block should succeed here.");
+    fuzzed_estimator
+        .notify_block(&receipt, &ExecutionCost::max_value())
+        .expect("notify_block should succeed here.");
+
+    // We've called `notify_block` twice, so the values returned are 2f, with some noise from the
+    // fuzzer.
+    assert_eq!(
+        fuzzed_estimator
+            .get_rate_estimates()
+            .expect("Estimate should exist."),
+        FeeRateEstimate {
+            high: 2.053485539282013f64,
+            middle: 2.0314342113729524f64,
+            low: 2.0436485321167686f64
+        },
     );
 }

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -58,8 +58,9 @@ impl FeeEstimator for MockFeeEstimator {
     }
 }
 
+/// Test the fuzzer using a fixed random seed.
 #[test]
-fn test_empty_fee_estimator() {
+fn test_fuzzing_seed1() {
     let mock_estimator = MockFeeEstimator { receipts: vec![] };
     let rng_creator = Box::new(|| {
         let seed = [0u8; 32];
@@ -67,6 +68,42 @@ fn test_empty_fee_estimator() {
         let r: Box<dyn RngCore> = Box::new(rng);
         r
     });
-    let _fuzzed_estimator =
+    let fuzzed_estimator =
         FeeRateFuzzer::new_custom_creator(Box::new(mock_estimator), rng_creator, 0.1);
+
+    assert_eq!(
+        fuzzed_estimator
+            .get_rate_estimates()
+            .expect("Estimate should exist."),
+        FeeRateEstimate {
+            high: 95.01268903765265f64,
+            middle: 49.93182838353776f64,
+            low: 4.921037454936614f64
+        }
+    );
+}
+
+/// Test the fuzzer using a fixed random seed. Uses a different seed than test_fuzzing_seed1.
+#[test]
+fn test_fuzzing_seed2() {
+    let mock_estimator = MockFeeEstimator { receipts: vec![] };
+    let rng_creator = Box::new(|| {
+        let seed = [1u8; 32];
+        let rng: StdRng = SeedableRng::from_seed(seed);
+        let r: Box<dyn RngCore> = Box::new(rng);
+        r
+    });
+    let fuzzed_estimator =
+        FeeRateFuzzer::new_custom_creator(Box::new(mock_estimator), rng_creator, 0.1);
+
+    assert_eq!(
+        fuzzed_estimator
+            .get_rate_estimates()
+            .expect("Estimate should exist."),
+        FeeRateEstimate {
+            high: 95.05348553928201f64,
+            middle: 50.031434211372954f64,
+            low: 5.043648532116769f64
+        }
+    );
 }

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -55,8 +55,7 @@ fn test_fuzzing_seed1() {
         let r: Box<dyn RngCore> = Box::new(rng);
         r
     });
-    let fuzzed_estimator =
-        FeeRateFuzzer::new_custom_creator(Box::new(mock_estimator), rng_creator, 0.1);
+    let fuzzed_estimator = FeeRateFuzzer::new_custom_creator(mock_estimator, rng_creator, 0.1);
 
     assert_eq!(
         fuzzed_estimator
@@ -80,8 +79,7 @@ fn test_fuzzing_seed2() {
         let r: Box<dyn RngCore> = Box::new(rng);
         r
     });
-    let fuzzed_estimator =
-        FeeRateFuzzer::new_custom_creator(Box::new(mock_estimator), rng_creator, 0.1);
+    let fuzzed_estimator = FeeRateFuzzer::new_custom_creator(mock_estimator, rng_creator, 0.1);
 
     assert_eq!(
         fuzzed_estimator
@@ -130,8 +128,7 @@ fn test_notify_pass_through() {
         let r: Box<dyn RngCore> = Box::new(rng);
         r
     });
-    let mut fuzzed_estimator =
-        FeeRateFuzzer::new_custom_creator(Box::new(mock_estimator), rng_creator, 0.1);
+    let mut fuzzed_estimator = FeeRateFuzzer::new_custom_creator(mock_estimator, rng_creator, 0.1);
 
     let receipt = make_block_receipt(vec![]);
     fuzzed_estimator

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -1,31 +1,21 @@
-use std::{env, path::PathBuf};
-use time::Instant;
-
-use rand::seq::SliceRandom;
-use rand::Rng;
-
 use cost_estimates::metrics::CostMetric;
 use cost_estimates::{EstimatorError, FeeEstimator};
 use vm::costs::ExecutionCost;
 
-use chainstate::burn::ConsensusHash;
 use chainstate::stacks::db::{StacksEpochReceipt, StacksHeaderInfo};
 use chainstate::stacks::events::StacksTransactionReceipt;
 use types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockHeader, StacksWorkScore};
 use types::proof::TrieHash;
 use util::hash::{to_hex, Hash160, Sha512Trunc256Sum};
 use util::vrf::VRFProof;
+use chainstate::burn::ConsensusHash;
 
 use crate::chainstate::stacks::{
     CoinbasePayload, StacksTransaction, TokenTransferMemo, TransactionAuth,
     TransactionContractCall, TransactionPayload, TransactionSpendingCondition, TransactionVersion,
 };
 use crate::core::StacksEpochId;
-use crate::cost_estimates::fee_scalar::ScalarFeeRateEstimator;
 use crate::cost_estimates::FeeRateEstimate;
-use crate::types::chainstate::StacksAddress;
-use crate::vm::types::{PrincipalData, StandardPrincipalData};
-use crate::vm::Value;
 use cost_estimates::fee_rate_fuzzer::FeeRateFuzzer;
 use rand::rngs::StdRng;
 use rand::thread_rng;

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -1,0 +1,57 @@
+use std::{env, path::PathBuf};
+use time::Instant;
+
+use rand::seq::SliceRandom;
+use rand::Rng;
+
+use cost_estimates::metrics::CostMetric;
+use cost_estimates::{EstimatorError, FeeEstimator};
+use vm::costs::ExecutionCost;
+
+use chainstate::burn::ConsensusHash;
+use chainstate::stacks::db::{StacksEpochReceipt, StacksHeaderInfo};
+use chainstate::stacks::events::StacksTransactionReceipt;
+use types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockHeader, StacksWorkScore};
+use types::proof::TrieHash;
+use util::hash::{to_hex, Hash160, Sha512Trunc256Sum};
+use util::vrf::VRFProof;
+
+use crate::chainstate::stacks::{
+    CoinbasePayload, StacksTransaction, TokenTransferMemo, TransactionAuth,
+    TransactionContractCall, TransactionPayload, TransactionSpendingCondition, TransactionVersion,
+};
+use crate::core::StacksEpochId;
+use crate::cost_estimates::fee_scalar::ScalarFeeRateEstimator;
+use crate::cost_estimates::FeeRateEstimate;
+use crate::types::chainstate::StacksAddress;
+use crate::vm::types::{PrincipalData, StandardPrincipalData};
+use crate::vm::Value;
+
+struct MockFeeEstimator {
+    pub receipts: Vec<StacksEpochReceipt>,
+}
+
+/// 1) on `notify_block` Inputs are recorded, and not passed anywhere.
+/// 2) on `get_rate_estimates`, a constant `FeeRateEstimate` is returned.
+impl FeeEstimator for MockFeeEstimator {
+    /// Just passes the information straight to `underlying`.
+    fn notify_block(
+        &mut self,
+        receipt: &StacksEpochReceipt,
+        block_limit: &ExecutionCost,
+    ) -> Result<(), EstimatorError> {
+        self.receipts.push(receipt.clone());
+        Ok(())
+    }
+
+    fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
+        Ok(FeeRateEstimate {
+            high: 95f64,
+            middle: 50f64,
+            low: 5f64,
+        })
+    }
+}
+
+#[test]
+fn test_empty_fee_estimator() {}

--- a/src/cost_estimates/tests/fee_rate_fuzzer.rs
+++ b/src/cost_estimates/tests/fee_rate_fuzzer.rs
@@ -56,8 +56,6 @@ impl FeeEstimator for MockFeeEstimator {
 
 #[test]
 fn test_empty_fee_estimator() {
-    let mock_estimator = MockFeeEstimator {
-        receipts: vec![],
-    };
-    let _fuzzed_estimator = FeeRateFuzzer::new(Box::new(mock_estimator));
+    let mock_estimator = MockFeeEstimator { receipts: vec![] };
+    let _fuzzed_estimator = FeeRateFuzzer::new(Box::new(mock_estimator), Some([0u8; 32]));
 }

--- a/src/cost_estimates/tests/fee_scalar.rs
+++ b/src/cost_estimates/tests/fee_scalar.rs
@@ -27,6 +27,8 @@ use crate::types::chainstate::StacksAddress;
 use crate::vm::types::{PrincipalData, StandardPrincipalData};
 use crate::vm::Value;
 
+use cost_estimates::tests::common::make_block_receipt;
+
 fn instantiate_test_db<CM: CostMetric>(m: CM) -> ScalarFeeRateEstimator<CM> {
     let mut path = env::temp_dir();
     let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
@@ -69,41 +71,6 @@ fn test_empty_fee_estimator() {
             .expect_err("Empty rate estimator should error."),
         EstimatorError::NoEstimateAvailable
     );
-}
-
-fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksEpochReceipt {
-    StacksEpochReceipt {
-        header: StacksHeaderInfo {
-            anchored_header: StacksBlockHeader {
-                version: 1,
-                total_work: StacksWorkScore { burn: 1, work: 1 },
-                proof: VRFProof::empty(),
-                parent_block: BlockHeaderHash([0; 32]),
-                parent_microblock: BlockHeaderHash([0; 32]),
-                parent_microblock_sequence: 0,
-                tx_merkle_root: Sha512Trunc256Sum([0; 32]),
-                state_index_root: TrieHash([0; 32]),
-                microblock_pubkey_hash: Hash160([0; 20]),
-            },
-            microblock_tail: None,
-            block_height: 1,
-            index_root: TrieHash([0; 32]),
-            consensus_hash: ConsensusHash([2; 20]),
-            burn_header_hash: BurnchainHeaderHash([1; 32]),
-            burn_header_height: 2,
-            burn_header_timestamp: 2,
-            anchored_block_size: 1,
-        },
-        tx_receipts,
-        matured_rewards: vec![],
-        matured_rewards_info: None,
-        parent_microblocks_cost: ExecutionCost::zero(),
-        anchored_block_cost: ExecutionCost::zero(),
-        parent_burn_block_hash: BurnchainHeaderHash([0; 32]),
-        parent_burn_block_height: 1,
-        parent_burn_block_timestamp: 1,
-        evaluated_epoch: StacksEpochId::Epoch20,
-    }
 }
 
 fn make_dummy_coinbase_tx() -> StacksTransaction {

--- a/src/cost_estimates/tests/mod.rs
+++ b/src/cost_estimates/tests/mod.rs
@@ -1,5 +1,6 @@
 use cost_estimates::FeeRateEstimate;
 
+pub mod common;
 pub mod cost_estimators;
 pub mod fee_rate_fuzzer;
 pub mod fee_scalar;

--- a/src/cost_estimates/tests/mod.rs
+++ b/src/cost_estimates/tests/mod.rs
@@ -1,6 +1,7 @@
 use cost_estimates::FeeRateEstimate;
 
 pub mod cost_estimators;
+pub mod fee_rate_fuzzer;
 pub mod fee_scalar;
 pub mod metrics;
 


### PR DESCRIPTION
Addresses #2954

We are implementing the four points in https://github.com/blockstack/stacks-blockchain/issues/2954#issuecomment-983017453

#2966 addresses the first three points.

Here, we address:
4. We should address fee changes in the face of congestion using a strategy of **"fuzzing"** the estimated fee rate: when queried, nodes will add some random noise to the estimated fee rate. In periods of congestion, clients that used the higher fee would be included in the next block, pushing the fee estimate for the next block up.


This is tested just by the new unit tests.
