### PR TITLE
Feat/cap discount mining

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -72,6 +72,9 @@ jobs:
           - tests::epoch_205::test_cost_limit_switch_version205
           - tests::epoch_205::test_exact_block_costs
           - tests::epoch_205::bigger_microblock_streams_in_2_05
+          - tests::epoch_21::transition_fixes_utxo_chaining
+          - tests::epoch_21::transition_adds_burn_block_height
+          - tests::epoch_21::transition_caps_discount_mining_upside
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -20,6 +20,7 @@
 use crate::burnchains::{
     Burnchain, BurnchainBlockHeader, BurnchainStateTransition, Error as BurnchainError,
 };
+use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::burn::db::sortdb::{InitialMiningBonus, SortitionHandleTx};
 use crate::chainstate::burn::operations::{
     leader_block_commit::{MissedBlockCommit, RewardSetInfo},

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -128,7 +128,7 @@ impl<'a> SortitionHandleTx<'a> {
             .fold(Some(0u64), |acc, op| {
                 if let Some(acc) = acc {
                     let bf = match op {
-                        BlockstackOperationType::LeaderBlockCommit(ref op) => op.burn_fee,
+                        BlockstackOperationType::LeaderBlockCommit(ref op) => op.total_spend(),
                         BlockstackOperationType::UserBurnSupport(ref op) => op.burn_fee,
                         _ => 0,
                     };
@@ -425,6 +425,7 @@ mod tests {
 
             commit_outs: vec![],
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -5135,7 +5135,6 @@ pub mod tests {
             sn.parent_sortition_id = sn_parent.sortition_id.clone();
             sn.burn_header_hash = next_hash;
             sn.block_height += 1;
-            sn.num_sortitions += 1;
             sn.consensus_hash = ConsensusHash([0x23; 20]);
 
             let index_root = tx

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1979,7 +1979,11 @@ impl<'a> SortitionHandleConn<'a> {
     ///     * ch, bhh identify the Stacks block that is the anchor block
     ///     * confs is the number of confirmations
     ///     * burns is the list of burns spent by the anchor block's descendants (only winning
-    ///     commits' burns are considered).
+    ///     commits' burns are considered).  Note that the *total burn* -- PoX cutoff burn +
+    ///     send-to-burn-address burn -- are considered, *even before* Stacks 2.1.  This is fine,
+    ///     because this information is derived to calculate the next reward cycle's PoX cutoff,
+    ///     and this isn't used by the sortition logic or block-commit logic until the proper time
+    ///     anyway.
     ///
     /// Returns Ok(Err(confs)) if an anchor block was not chosen -- i.e. confs < F*w
     /// Returns Err(..) if we could not calculate this result for some reason.

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -3546,6 +3546,9 @@ impl SortitionDB {
         conn: &Connection,
         block_snapshot: &BlockSnapshot,
     ) -> Result<u64, db_error> {
+        let cur_epoch = SortitionDB::get_stacks_epoch(conn, block_snapshot.block_height)?
+            .expect("FATAL: no epoch defined for snapshot");
+
         let user_burns = SortitionDB::get_user_burns_by_block(conn, &block_snapshot.sortition_id)?;
         let block_commits =
             SortitionDB::get_block_commits_by_block(conn, &block_snapshot.sortition_id)?;
@@ -3558,7 +3561,7 @@ impl SortitionDB {
         }
         for i in 0..block_commits.len() {
             burn_total = burn_total
-                .checked_add(block_commits[i].total_spend())
+                .checked_add(block_commits[i].sortition_spend(cur_epoch.epoch_id))
                 .expect("Way too many tokens burned");
         }
         Ok(burn_total)

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -85,6 +85,7 @@ impl LeaderBlockCommitOp {
             parent_vtxindex: 0,
             memo: vec![0x00],
             burn_fee: burn_fee,
+            destroyed: 0,
             input: input.clone(),
             block_header_hash: block_header_hash.clone(),
             commit_outs: vec![],
@@ -117,6 +118,7 @@ impl LeaderBlockCommitOp {
             parent_vtxindex: parent.vtxindex as u16,
             memo: vec![],
             burn_fee: burn_fee,
+            destroyed: 0,
             input: input.clone(),
             block_header_hash: block_header_hash.clone(),
             commit_outs: vec![],
@@ -290,14 +292,14 @@ impl LeaderBlockCommitOp {
             return Err(op_error::ParseError);
         }
 
-        let (commit_outs, burn_fee) = if burnchain.is_in_prepare_phase(block_height) {
+        let (commit_outs, burn_fee, destroyed) = if burnchain.is_in_prepare_phase(block_height) {
             // check if we're in a prepare phase
             // should be only one burn output
             if !outputs[0].address.is_burn() {
                 return Err(op_error::BlockCommitBadOutputs);
             }
             let BurnchainRecipient { address, amount } = outputs.remove(0);
-            (vec![address], amount)
+            (vec![address], amount, 0)
         } else {
             let mut commit_outs = vec![];
             let mut pox_fee = None;
@@ -335,7 +337,7 @@ impl LeaderBlockCommitOp {
                 return Err(op_error::ParseError);
             }
 
-            (commit_outs, burn_fee)
+            (commit_outs, burn_fee, tx.get_burn_amount())
         };
 
         let input = tx
@@ -359,6 +361,7 @@ impl LeaderBlockCommitOp {
 
             commit_outs,
             burn_fee,
+            destroyed,
             input,
             apparent_sender,
 
@@ -388,6 +391,33 @@ impl LeaderBlockCommitOp {
 
     pub fn is_first_block(&self) -> bool {
         self.parent_block_ptr == 0 && self.parent_vtxindex == 0
+    }
+
+    /// Method to get the total number of burnchain tokens destroyed, so we make *absolutely
+    /// certain* to count both the `destroyed` and `burn_fee` quantities.
+    pub fn total_spend(&self) -> u64 {
+        self.burn_fee
+            .checked_add(self.destroyed)
+            .expect("FATAL: too many tokens spent")
+    }
+
+    /// Epoch-specific measurement of token spend.  In epochs prior to 2.1, we only count the
+    /// burn_fee.  In epochs 2.1 and later, we count the total spend
+    pub fn sortition_spend(&self, epoch_id: StacksEpochId) -> u64 {
+        match epoch_id {
+            // in epoch 2.1 and later, we count both the PoX spend and the amount destroyed via
+            // the OP_RETURN.  Before that, we only counted the burn fee.
+            StacksEpochId::Epoch21 => self.total_spend(),
+            _ => self.burn_fee,
+        }
+    }
+
+    /// Convert the burn_fee and destroyed members to strings for storing in a DB
+    pub fn encode_spends_for_db(&self) -> (String, String) {
+        (
+            format!("{}", &self.burn_fee),
+            format!("{}", &self.destroyed),
+        )
     }
 }
 
@@ -476,7 +506,7 @@ impl LeaderBlockCommitOp {
     ) -> Result<(), op_error> {
         let parent_block_height = self.parent_block_ptr as u64;
 
-        /////////////////////////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////e/////////////////////////////////
         // This tx must have the expected commit or burn outputs:
         //    * if there is a known anchor block for the current reward cycle, and this
         //       block commit descends from that block, and this block commit is not in the
@@ -522,8 +552,10 @@ impl LeaderBlockCommitOp {
                     }
                 } else {
                     let expect_pox_descendant = if self.all_outputs_burn() {
+                        // reward-phase with PoB (does not descend from anchor block)
                         false
                     } else {
+                        // reward-phase with PoX (must descend from anchor block)
                         let mut check_recipients: Vec<_> = reward_set_info
                             .recipients
                             .iter()
@@ -560,6 +592,7 @@ impl LeaderBlockCommitOp {
                                 return Err(op_error::BlockCommitBadOutputs);
                             }
                         }
+
                         true
                     };
 
@@ -568,6 +601,7 @@ impl LeaderBlockCommitOp {
                             error!("Failed to check whether parent (height={}) is descendent of anchor block={}: {}",
                                    parent_block_height, &reward_set_info.anchor_block, e);
                             op_error::BlockCommitAnchorCheck})?;
+
                     if descended_from_anchor != expect_pox_descendant {
                         if descended_from_anchor {
                             warn!("Invalid block commit: descended from PoX anchor, but used burn outputs");
@@ -576,6 +610,40 @@ impl LeaderBlockCommitOp {
                             );
                         }
                         return Err(op_error::BlockCommitBadOutputs);
+                    }
+
+                    if descended_from_anchor {
+                        // if this is a PoX anchor block descendant, and we're in Stacks 2.1 or later,
+                        // then we need to verify that the total PoX payout does not exceed the PoX
+                        // cutoff for this reward cycle.  Any additional expenditure must be destroyed.
+                        let epoch =
+                            SortitionDB::get_stacks_epoch(tx, self.block_height)?.expect(&format!(
+                                "FATAL: impossible block height: no epoch defined for {}",
+                                self.block_height
+                            ));
+                        match epoch.epoch_id {
+                            StacksEpochId::Epoch21 => {
+                                let pox_cutoff = tx.get_pox_cutoff()?.expect(
+                                    "FATAL: In PoX in Epoch 2.1 but do not have a known PoX cutoff",
+                                );
+
+                                if self.burn_fee > pox_cutoff {
+                                    warn!("Invalid block commit: PoX cutoff is {}, but sent {} to PoX addresses", pox_cutoff, self.burn_fee);
+                                    return Err(op_error::BlockCommitPoxOverpay);
+                                }
+
+                                if self.total_spend() > self.burn_fee {
+                                    // must have sent `pox_cutoff` tokens
+                                    if self.burn_fee != pox_cutoff {
+                                        warn!("Invalid block commit: total spend exceeds PoX cutoff ({}) but PoX payout ({}) was incomplete", pox_cutoff, self.burn_fee);
+                                        return Err(op_error::BlockCommitPoxUnderpay);
+                                    }
+                                }
+                            }
+                            _ => {
+                                // noop
+                            }
+                        }
                     }
                 }
             }
@@ -617,7 +685,7 @@ impl LeaderBlockCommitOp {
         let tx_tip = tx.context.chain_tip.clone();
 
         /////////////////////////////////////////////////////////////////////////////////////
-        // There must be a burn
+        // There must be a burn/spend
         /////////////////////////////////////////////////////////////////////////////////////
 
         let apparent_sender_address = self
@@ -869,6 +937,9 @@ mod tests {
 
     use crate::types::chainstate::StacksAddress;
     use crate::types::chainstate::{BlockHeaderHash, SortitionId, VRFSeed};
+
+    use crate::chainstate::coordinator::PoxAnchorBlockStatus;
+    use crate::chainstate::coordinator::RewardCycleInfo;
 
     use super::*;
 
@@ -1253,6 +1324,7 @@ mod tests {
                     ],
 
                     burn_fee: 24690,
+                    destroyed: 0,
                     input: (Txid([0x11; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![
@@ -1384,6 +1456,10 @@ mod tests {
             "0000000000000000000000000000000000000000000000000000000000001260",
         )
         .unwrap();
+        let block_127_hash = BurnchainHeaderHash::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000001270",
+        )
+        .unwrap();
 
         let block_header_hashes = [
             block_122_hash.clone(),
@@ -1391,10 +1467,13 @@ mod tests {
             block_124_hash.clone(),
             block_125_hash.clone(), // prepare phase
             block_126_hash.clone(), // prepare phase
+            block_127_hash.clone(),
         ];
 
+        let pox_consts = PoxConstants::new(5, 2, 2, 25, 5, u32::max_value());
+
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, u32::max_value()),
+            pox_constants: pox_consts.clone(),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),
@@ -1406,6 +1485,35 @@ mod tests {
             initial_reward_start_block: first_block_height,
             first_block_timestamp: 0,
             first_block_hash: first_burn_hash.clone(),
+        };
+
+        let leader_key_0 = LeaderKeyRegisterOp {
+            consensus_hash: ConsensusHash::from_bytes(
+                &hex_bytes("1111111111111111111111111111111111111111").unwrap(),
+            )
+            .unwrap(),
+            public_key: VRFPublicKey::from_bytes(
+                &hex_bytes("cc66b0e89e4bdd79d5d4926a260af06036fcebd9f518892a242d418cb5562347")
+                    .unwrap(),
+            )
+            .unwrap(),
+            memo: vec![01, 02, 03, 04, 05],
+            address: StacksAddress::from_bitcoin_address(
+                &BitcoinAddress::from_scriptpubkey(
+                    BitcoinNetworkType::Testnet,
+                    &hex_bytes("76a914306231b2782b5f80d944bf69f9d46a1453a0a0eb88ac").unwrap(),
+                )
+                .unwrap(),
+            ),
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("f3b73257538366cbf11d9b23d69fc9710a015d73ab79ddc2582682c4b5dfb4e9")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 2,
+            block_height: 122,
+            burn_header_hash: block_122_hash.clone(),
         };
 
         let leader_key_1 = LeaderKeyRegisterOp {
@@ -1466,10 +1574,94 @@ mod tests {
             burn_header_hash: block_124_hash.clone(),
         };
 
+        // consumes leader_key_0; will be the anchor block
+        let block_commit_0 = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("1111111111111111111111111111111111111111111111111111111111111111")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("4444444444444444444444444444444444444444444444444444444444444444")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: 0,
+            parent_vtxindex: 0,
+            key_block_ptr: 122,
+            key_vtxindex: 2,
+            memo: vec![0x80],
+            commit_outs: vec![],
+
+            burn_fee: 12345,
+            destroyed: 0,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("70b9a33eff6b30954caac52b862dc5bafc5f7108d3509e7bb9180d79f6bea160")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 444,
+            block_height: 124,
+            burn_parent_modulus: (123 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_123_hash.clone(),
+        };
+
+        // consumes leader_key_0, but is not the anchor block
+        let block_commit_0_not_anchor = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("1111111111111111111111111111111111111111111111111111111111111112")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("4444444444444444444444444444444444444444444444444444444444444445")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: 0,
+            parent_vtxindex: 0,
+            key_block_ptr: 122,
+            key_vtxindex: 2,
+            memo: vec![0x80],
+            commit_outs: vec![],
+
+            burn_fee: 12345,
+            destroyed: 0,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("80b9a33eff6b30954caac52b862dc5bafc5f7108d3509e7bb9180d79f6bea160")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 200,
+            block_height: 123,
+            burn_parent_modulus: (122 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_123_hash.clone(),
+        };
+
         // consumes leader_key_1
         let block_commit_1 = LeaderBlockCommitOp {
             block_header_hash: BlockHeaderHash::from_bytes(
-                &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
+                &hex_bytes("2222222222222222222222222222222222222222222222222222222222222221")
                     .unwrap(),
             )
             .unwrap(),
@@ -1486,6 +1678,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(
@@ -1507,6 +1700,274 @@ mod tests {
             burn_header_hash: block_125_hash.clone(),
         };
 
+        // consumes leader_key_1
+        let block_commit_1_not_anchor = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("2222222222222222222222222222222222222222222222222222222222222211")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("3333333333333333333333333333333333333333333333333333333333333322")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: block_commit_0_not_anchor.block_height.try_into().unwrap(),
+            parent_vtxindex: block_commit_0_not_anchor.vtxindex.try_into().unwrap(),
+            key_block_ptr: 124,
+            key_vtxindex: 456,
+            memo: vec![0x80],
+            commit_outs: vec![],
+
+            burn_fee: 12345,
+            destroyed: 0,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27ce")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 444,
+            block_height: 126,
+            burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_126_hash.clone(),
+        };
+
+        // consumes leader_key_1 but in second reward cycle
+        let block_commit_2 = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("4444444444444444444444444444444444444444444444444444444444444444")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("5555555555555555555555555555555555555555555555555555555555555555")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: block_commit_0.block_height.try_into().unwrap(),
+            parent_vtxindex: block_commit_0.vtxindex.try_into().unwrap(),
+            key_block_ptr: 124,
+            key_vtxindex: 456,
+            memo: vec![0x80],
+            commit_outs: vec![
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+            ],
+
+            burn_fee: 10_000, // maximum PoX payout allowed in this cycle
+            destroyed: 0,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d0")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 444,
+            block_height: 127,
+            burn_parent_modulus: (126 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_127_hash.clone(),
+        };
+
+        // consumes leader_key_1 but in second reward cycle
+        let block_commit_2_destroyed = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("5555555555555555555555555555555555555555555555555555555555555555")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("6666666666666666666666666666666666666666666666666666666666666666")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: block_commit_0.block_height.try_into().unwrap(),
+            parent_vtxindex: block_commit_0.vtxindex.try_into().unwrap(),
+            key_block_ptr: 124,
+            key_vtxindex: 456,
+            memo: vec![0x80],
+            commit_outs: vec![
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+            ],
+
+            burn_fee: 10_000, // maximum PoX payout allowed in this cycle
+            destroyed: 5_000, // total_spend() should be 15_000
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d1")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 445,
+            block_height: 127,
+            burn_parent_modulus: (126 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_127_hash.clone(),
+        };
+
+        // consumes leader_key_1 but in second reward cycle.
+        // This is valid because it does PoB during PoX -- there's nothing to overpay or overspend.
+        let block_commit_2_pob_destroyed = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("6666666666666666666666666666666666666666666666666666666666666666")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("7777777777777777777777777777777777777777777777777777777777777777")
+                    .unwrap(),
+            )
+            .unwrap(),
+            // does not descend from anchor block
+            parent_block_ptr: block_commit_1_not_anchor.block_height.try_into().unwrap(),
+            parent_vtxindex: block_commit_1_not_anchor.vtxindex.try_into().unwrap(),
+            key_block_ptr: 124,
+            key_vtxindex: 456,
+            memo: vec![0x80],
+            commit_outs: vec![],
+
+            burn_fee: 15_000, // exceeds maximum PoX payout allowed in this cycle, but is PoB
+            destroyed: 0,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d2")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 445,
+            block_height: 127,
+            burn_parent_modulus: (126 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_127_hash.clone(),
+        };
+
+        // consumes leader_key_1 but in second reward cycle
+        // this is invalid because it overpays PoX outputs
+        let block_commit_2_pox_not_destroyed = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("7777777777777777777777777777777777777777777777777777777777777777")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("8888888888888888888888888888888888888888888888888888888888888888")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: block_commit_0.block_height.try_into().unwrap(),
+            parent_vtxindex: block_commit_0.block_height.try_into().unwrap(),
+            key_block_ptr: 124,
+            key_vtxindex: 456,
+            memo: vec![0x80],
+            commit_outs: vec![
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+            ],
+
+            burn_fee: 15_000, // exceeds maximum PoX payout allowed in this cycle, so will fail
+            destroyed: 0,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d3")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 445,
+            block_height: 127,
+            burn_parent_modulus: (126 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_127_hash.clone(),
+        };
+
+        // consumes leader_key_1 but in second reward cycle
+        // this is invalid because it underpays PoX outputs
+        let block_commit_2_pox_underpaid = LeaderBlockCommitOp {
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("8888888888888888888888888888888888888888888888888888888888888888")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("9999999999999999999999999999999999999999999999999999999999999999")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: block_commit_0.block_height.try_into().unwrap(),
+            parent_vtxindex: block_commit_0.block_height.try_into().unwrap(),
+            key_block_ptr: 124,
+            key_vtxindex: 456,
+            memo: vec![0x80],
+            commit_outs: vec![
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+                StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6").unwrap(),
+            ],
+
+            burn_fee: 9_999, // does not meet maximum PoX output
+            destroyed: 1,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27d4")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 445,
+            block_height: 127,
+            burn_parent_modulus: (126 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_127_hash.clone(),
+        };
+
         let mut db = SortitionDB::connect_test_with_epochs(
             first_block_height,
             &first_burn_hash,
@@ -1515,11 +1976,16 @@ mod tests {
         .unwrap();
         let block_ops = vec![
             // 122
-            vec![],
+            vec![BlockstackOperationType::LeaderKeyRegister(
+                leader_key_0.clone(),
+            )],
             // 123
-            vec![],
+            vec![BlockstackOperationType::LeaderBlockCommit(
+                block_commit_0_not_anchor.clone(),
+            )],
             // 124
             vec![
+                BlockstackOperationType::LeaderBlockCommit(block_commit_0.clone()),
                 BlockstackOperationType::LeaderKeyRegister(leader_key_1.clone()),
                 BlockstackOperationType::LeaderKeyRegister(leader_key_2.clone()),
             ],
@@ -1528,12 +1994,42 @@ mod tests {
                 block_commit_1.clone(),
             )],
             // 126
-            vec![],
+            vec![BlockstackOperationType::LeaderBlockCommit(
+                block_commit_1_not_anchor.clone(),
+            )],
+            // 127
+            vec![BlockstackOperationType::LeaderBlockCommit(
+                block_commit_2.clone(),
+            )],
         ];
 
+        let mut test_reward_set_info = None;
         let tip_index_root = {
             let mut prev_snapshot = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();
             for i in 0..block_header_hashes.len() {
+                let (sortition, winning_block_txid, winning_stacks_block_hash, num_sortitions) = {
+                    let mut sortition = false;
+                    let mut winning_block_txid = Txid([0x00; 32]);
+                    let mut winning_stacks_block_hash = BlockHeaderHash([0x00; 32]);
+                    let mut num_sortitions = prev_snapshot.num_sortitions;
+                    for j in 0..block_ops[i].len() {
+                        if let BlockstackOperationType::LeaderBlockCommit(ref op) = block_ops[i][j]
+                        {
+                            sortition = true;
+                            winning_block_txid = op.txid.clone();
+                            winning_stacks_block_hash = op.block_header_hash.clone();
+                            num_sortitions += 1;
+                            break;
+                        }
+                    }
+                    (
+                        sortition,
+                        winning_block_txid,
+                        winning_stacks_block_hash,
+                        num_sortitions,
+                    )
+                };
+
                 let mut snapshot_row = BlockSnapshot {
                     accumulated_coinbase_ustx: 0,
                     pox_valid: true,
@@ -1572,18 +2068,13 @@ mod tests {
                     ])
                     .unwrap(),
                     total_burn: i as u64,
-                    sortition: true,
-                    sortition_hash: SortitionHash::initial(),
-                    winning_block_txid: Txid::from_hex(
-                        "0000000000000000000000000000000000000000000000000000000000000000",
-                    )
-                    .unwrap(),
-                    winning_stacks_block_hash: BlockHeaderHash::from_hex(
-                        "0000000000000000000000000000000000000000000000000000000000000000",
-                    )
-                    .unwrap(),
+                    sortition: sortition,
+                    sortition_hash: SortitionHash(Sha512Trunc256Sum::from_data(&i.to_be_bytes()).0),
+                    winning_block_txid: winning_block_txid,
+                    winning_stacks_block_hash: winning_stacks_block_hash,
+                    // overwritten
                     index_root: TrieHash::from_empty_data(),
-                    num_sortitions: (i + 1) as u64,
+                    num_sortitions: num_sortitions,
                     stacks_block_accepted: false,
                     stacks_block_height: 0,
                     arrival_index: 0,
@@ -1591,16 +2082,64 @@ mod tests {
                     canonical_stacks_tip_hash: BlockHeaderHash([0u8; 32]),
                     canonical_stacks_tip_consensus_hash: ConsensusHash([0u8; 20]),
                 };
+                test_debug!(
+                    "Sortition ID of height {} is {}, parent is {}",
+                    snapshot_row.block_height,
+                    &snapshot_row.sortition_id,
+                    &snapshot_row.parent_sortition_id
+                );
                 let mut tx =
                     SortitionHandleTx::begin(&mut db, &prev_snapshot.sortition_id).unwrap();
+
+                let (reward_cycle_info, reward_set_info) = if i == block_header_hashes.len() - 1 {
+                    // this is the first snapshot in the second reward phase, so add PoX data
+                    let mock_reward_addresses =
+                        vec![
+                            StacksAddress::from_string("STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6")
+                                .unwrap();
+                            ((pox_consts.reward_cycle_length - pox_consts.prepare_length) * 2)
+                                as usize
+                        ];
+                    (
+                        Some(RewardCycleInfo {
+                            anchor_status: PoxAnchorBlockStatus::SelectedAndKnown(
+                                block_commit_0.block_header_hash.clone(),
+                                mock_reward_addresses,
+                            ),
+                            pox_cutoff: 10_000,
+                        }),
+                        Some(RewardSetInfo {
+                            anchor_block: block_commit_0.block_header_hash.clone(),
+                            recipients: vec![
+                                (
+                                    StacksAddress::from_string(
+                                        "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
+                                    )
+                                    .unwrap(),
+                                    0,
+                                ),
+                                (
+                                    StacksAddress::from_string(
+                                        "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
+                                    )
+                                    .unwrap(),
+                                    1,
+                                ),
+                            ],
+                        }),
+                    )
+                } else {
+                    (None, None)
+                };
+
                 let next_index_root = tx
                     .append_chain_tip_snapshot(
                         &prev_snapshot,
                         &snapshot_row,
                         &block_ops[i],
                         &vec![],
-                        None,
-                        None,
+                        reward_cycle_info,
+                        reward_set_info.as_ref(),
                         None,
                     )
                     .unwrap();
@@ -1609,6 +2148,9 @@ mod tests {
                 tx.commit().unwrap();
 
                 prev_snapshot = snapshot_row;
+                if test_reward_set_info.is_none() {
+                    test_reward_set_info = reward_set_info;
+                }
             }
 
             prev_snapshot.index_root.clone()
@@ -1640,6 +2182,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -1689,6 +2232,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -1738,6 +2282,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -1787,6 +2332,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -1848,6 +2394,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -1884,6 +2431,22 @@ mod tests {
                     intended_sortition: SortitionId(first_burn_hash.0.clone()),
                 })),
             },
+            CheckFixture {
+                op: block_commit_2_destroyed,
+                res: Ok(()),
+            },
+            CheckFixture {
+                op: block_commit_2_pob_destroyed,
+                res: Ok(()),
+            },
+            CheckFixture {
+                op: block_commit_2_pox_not_destroyed,
+                res: Err(op_error::BlockCommitPoxOverpay),
+            },
+            CheckFixture {
+                op: block_commit_2_pox_underpaid,
+                res: Err(op_error::BlockCommitPoxUnderpay),
+            },
         ];
 
         for (ix, fixture) in fixtures.iter().enumerate() {
@@ -1902,7 +2465,18 @@ mod tests {
             .unwrap();
             assert_eq!(
                 format!("{:?}", &fixture.res),
-                format!("{:?}", &fixture.op.check(&burnchain, &mut ic, None))
+                format!(
+                    "{:?}",
+                    &fixture.op.check(
+                        &burnchain,
+                        &mut ic,
+                        if fixture.op.block_height >= 127 {
+                            test_reward_set_info.as_ref()
+                        } else {
+                            None
+                        }
+                    )
+                )
             );
         }
     }
@@ -2037,6 +2611,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(
@@ -2188,6 +2763,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2237,6 +2813,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2286,6 +2863,7 @@ mod tests {
                     memo: vec![0x80],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2335,6 +2913,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2384,6 +2963,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2433,6 +3013,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 0,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2482,6 +3063,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2531,6 +3113,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2580,6 +3163,7 @@ mod tests {
                     commit_outs: vec![],
 
                     burn_fee: 12345,
+                    destroyed: 0,
                     input: (Txid([0; 32]), 0),
                     apparent_sender: BurnchainSigner {
                         public_keys: vec![StacksPublicKey::from_hex(
@@ -2720,6 +3304,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(
@@ -2748,6 +3333,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(
@@ -2776,6 +3362,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(
@@ -2804,6 +3391,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(
@@ -2832,6 +3420,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -74,6 +74,8 @@ pub enum Error {
     BlockCommitAnchorCheck,
     BlockCommitBadModulus,
     BlockCommitBadEpoch,
+    BlockCommitPoxOverpay,
+    BlockCommitPoxUnderpay,
     MissedBlockCommit(MissedBlockCommit),
 
     // all the things that can go wrong with leader key register
@@ -119,6 +121,12 @@ impl fmt::Display for Error {
             }
             Error::BlockCommitBadEpoch => {
                 write!(f, "Block commit has an invalid epoch")
+            }
+            Error::BlockCommitPoxOverpay => {
+                write!(f, "Block commit overpaid PoX addresses")
+            }
+            Error::BlockCommitPoxUnderpay => {
+                write!(f, "Block commit did not pay the full PoX amount")
             }
             Error::MissedBlockCommit(_) => write!(
                 f,
@@ -218,6 +226,8 @@ pub struct LeaderBlockCommitOp {
 
     /// how many burn tokens (e.g. satoshis) were committed to produce this block
     pub burn_fee: u64,
+    /// number of burnchain tokens destroyed.
+    pub destroyed: u64,
     /// the input transaction, used in mining commitment smoothing
     pub input: (Txid, u32),
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -510,6 +510,7 @@ fn make_genesis_block_with_recipients(
     let commit_op = LeaderBlockCommitOp {
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
+        destroyed: 0,
         input: (Txid([0; 32]), 0),
         apparent_sender: BurnchainSigner {
             num_sigs: 1,
@@ -691,6 +692,7 @@ fn make_stacks_block_with_input(
     let commit_op = LeaderBlockCommitOp {
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
+        destroyed: 0,
         input,
         apparent_sender: BurnchainSigner {
             num_sigs: 1,

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1330,6 +1330,7 @@ mod test {
             commit_outs: vec![],
 
             burn_fee: 12345,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner {
                 public_keys: vec![StacksPublicKey::from_hex(

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -1866,7 +1866,7 @@ pub mod test {
                     if let BlockstackOperationType::LeaderBlockCommit(ref opdata) = &op {
                         eprintln!("prepare phase {}: {:?}", burn_height, opdata);
                         assert!(opdata.all_outputs_burn());
-                        assert!(opdata.burn_fee > 0);
+                        assert!(opdata.total_spend() > 0);
 
                         if tenure_id > 1 && cur_reward_cycle > lockup_reward_cycle {
                             prepared = true;
@@ -1886,7 +1886,7 @@ pub mod test {
                             assert!(opdata.all_outputs_burn());
                         }
 
-                        assert!(opdata.burn_fee > 0);
+                        assert!(opdata.total_spend() > 0);
                     }
                 }
             }

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -3789,7 +3789,14 @@ impl StacksChainState {
             SortitionDB::get_block_burn_amount(db_handle, &penultimate_sortition_snapshot)
                 .expect("FATAL: have block commit but no total burns in its sortition");
 
-        Ok(Some((block_commit.burn_fee, sortition_burns)))
+        let epoch =
+            SortitionDB::get_stacks_epoch(db_handle, penultimate_sortition_snapshot.block_height)?
+                .expect("FATAL: do not have epoch at penultimate sortition");
+
+        Ok(Some((
+            block_commit.sortition_spend(epoch.epoch_id),
+            sortition_burns,
+        )))
     }
 
     /// Pre-process and store an anchored block to staging, queuing it up for

--- a/src/main.rs
+++ b/src/main.rs
@@ -753,7 +753,7 @@ check if the associated microblocks can be downloaded
                 .get_block_commit_by_txid(&winner_txid)
                 .unwrap()
                 .unwrap();
-            reward_phase_payouts.push(block_commit.burn_fee);
+            reward_phase_payouts.push(block_commit.total_spend());
             cur_height += 1;
         }
 

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -192,6 +192,7 @@ impl BurnchainController for MocknetController {
                         key_vtxindex: payload.key_vtxindex,
                         memo: payload.memo,
                         burn_fee: payload.burn_fee,
+                        destroyed: 0,
                         apparent_sender: payload.apparent_sender,
                         input: payload.input,
                         commit_outs: payload.commit_outs,

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -1057,6 +1057,7 @@ impl Node {
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
             block_header_hash,
             burn_fee,
+            destroyed: 0,
             input: (Txid([0; 32]), 0),
             apparent_sender: self.keychain.get_burnchain_signer(),
             key_block_ptr: key.block_height as u32,

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -603,6 +603,7 @@ fn transition_empty_blocks() {
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
                 block_header_hash: BlockHeaderHash([0xff; 32]),
                 burn_fee: burn_fee_cap,
+                destroyed: 0,
                 input: (Txid([0; 32]), 0),
                 apparent_sender: keychain.get_burnchain_signer(),
                 key_block_ptr,

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1841,7 +1841,7 @@ fn microblock_integration_test() {
     // this microblock should correspond to `second_microblock`
     let microblock = microblock_events.pop().unwrap();
     let transactions = microblock.get("transactions").unwrap().as_array().unwrap();
-    assert_eq!(transactions.len(), 1);
+    assert!(transactions.len() >= 1);
     let tx_sequence = transactions[0]
         .get("microblock_sequence")
         .unwrap()
@@ -1883,7 +1883,7 @@ fn microblock_integration_test() {
     // this microblock should correspond to the first microblock that was posted
     let microblock = microblock_events.pop().unwrap();
     let transactions = microblock.get("transactions").unwrap().as_array().unwrap();
-    assert_eq!(transactions.len(), 1);
+    assert!(transactions.len() >= 1);
     let tx_sequence = transactions[0]
         .get("microblock_sequence")
         .unwrap()

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -753,7 +753,7 @@ pub fn get_account<F: std::fmt::Display>(http_origin: &str, account: &F) -> Acco
     }
 }
 
-fn get_pox_info(http_origin: &str) -> RPCPoxInfoData {
+pub fn get_pox_info(http_origin: &str) -> RPCPoxInfoData {
     let client = reqwest::blocking::Client::new();
     let path = format!("{}/v2/pox", http_origin);
     client


### PR DESCRIPTION
This PR addresses #3095 (and #2613) by capping the amount of BTC a PoX output can pay.  If a miner wants to spend more BTC than this amount, then they must _burn_ it via the `OP_RETURN` output.  This puts an upper bound on how much of a discount a miner who stacks can expect to receive.

The _PoX cutoff_ is calculated on a reward cycle basis within the prepare phase.  Specifically, the code examines the sequence of BTC burns _B_ by the _winning_ block-commits in the prepare phase, and sets the cutoff _C = 4 * min(mean(B), median(B))_.  If a miner wants to spend _S > C_ BTC, they must burn _S - C_ BTC.  In addition, if the miner spends _S <= C_ BTC, they _must_ spend it by sending it to PoX outputs (i.e. they may not burn it).  This only applies to reward cycles with PoX; nothing changes for PoB reward cycles, or for miners who want to mine off of a fork that does not descend from the anchor block.

The rationale for this cutoff calculation is as follows.  Consider a miner who wants to mine at a steep discount of their choosing by stacking STX and spending an unbound amount of BTC when their reward addresses come up for payment.  The cutoff calculation is designed so that the only way a miner can unilaterally choose their discount is by executing a 51% attack on the blockchain during the prepare-phase.  To set a target cutoff _C_, the miner must both ensure that the _majority_ of winning block-commits spend at least _0.25C_ BTC (i.e. they must win at least 51 blocks to guarantee this), and must ensure that the average winning block-commit spends at least _0.25C_ BTC (i.e. they have to burn enough BTC, no matter their win rate, to push the average up).  The 4x multiplier was chosen by examining the cutoff value for all of the system's reward cycles to date: in all but one reward cycle (the 3rd one in the system, when there was a large fluctuation in mining payouts), this cutoff is always higher than the network's PoX outputs.

When working on this PR, I noticed that the now-obsolete `sunset_burn` field was not being used to calculate the sortition weight of a block-commit when calculating the burn distribution.  This was likely a bug, but one that we didn't ever see in the wild because the required sunset burn has been 0.  Nevertheless, this PR (1) makes it so that the total sortition weight of a block-commit includes both the payment to PoX outputs and the burnt amount, and (2) gates this calculation so that it only applies in 2.1.  Prior to this, a block-commit that burns BTC via its OP_RETURN will be treated as if it did not do any burn at all -- i.e. the burn won't improve the block-commit's chances of winning, which is in-line with how 2.05 behaves today.

The PoX cutoff itself is stored in the sortition DB as part of its MARF, so each reward cycle has a distinct PoX cutoff value.  This value is not queried except in epoch 2.1, so it should be safe to migrate the existing chainstate to this node's new chainstate as long as its done before 2.1 activates.  To accommodate this, there's a special rule for the PoX cutoff in the event that 2.1 activates _in the middle of_ a reward cycle:  in this partially-2.1 reward cycle, the cutoff is `u64::MAX` (i.e. there's no cutoff).  The cutoff is only calculated and used in the first full 2.1 reward cycle.

As for testing, I've add the following coverage:

* The block-commit validation tests use a mocked PoX reward cycle in order to verify that a block-commit must burn the right amount of BTC if it overpays, and verifies that the block-commit cannot underpay PoX outputs by burning if it does not meet the cutoff.

* The sortition-processing validation tests verify that the epoch gating for calculating a block-commit's sortition weight applies, and that a block-commit's `destroyed` BTC gets applied only in epoch 2.1.

* The sortition DB testing covers the new PoX cutoff calculation logic, as well as the cutoff storage and retrieval

* There is a neon integration test that verifies that a miner that overpays BTC in PoX cannot win sortitions

EDIT: For clarity, this PR does _not_ make it so that a discount-miner can receive a maximum 4x discount, or anything like that. What it does is it makes it so that a discount-miner must maintain multiple independent UTXO chains (i.e. run multiple separate miner nodes) in order to avoid burning BTC.  This raises the cost of attempting to discount-mine.

Today, a discount-miner would need to spend their target BTC for the 3 blocks prior to the block in which they intend to receive a discount.  This is because the sortition weight of a miner is the minimum of the last BTC spend they made, and the median spend they made in the last 6 blocks (as tracked by the miner's UTXO chain).  With this PR, the amount of BTC the miner would be allowed to recover _per UTXO chain_ is capped by a function of the BTC burnt in the last prepare phase.  So in order to receive more BTC back than this threshold _C_, the discount-miner would be required to run multiple UTXO-chains.  If the miner wanted to spend _k * C_ BTC, they would need to maintain _k_ UTXO chains, and pay _k_ times more BTC transaction fees (whereas today, they only need to pay the fees for a single UTXO chain).