### PR TITLE
experiment: Logging to show how much time is spent inside/outside of transaction processing

### DIFF
--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1041,8 +1041,8 @@ impl MemPoolDB {
         let mut remember_start_with_estimate = None;
 
         let mut last_time = Instant::now();
-        let mut total_outside_time = last_time - last_time;
-        let mut total_inside_time = last_time - last_time;
+        let mut total_outside_time = last_time - last_time;  // zero duration
+        let mut total_inside_time = last_time - last_time;  // zero duration
 
         loop {
             if start_time.elapsed().as_millis() > settings.max_walk_time_ms as u128 {

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1041,12 +1041,17 @@ impl MemPoolDB {
         let mut remember_start_with_estimate = None;
 
         let mut last_time = Instant::now();
+
+        // all time inside `todo`
         let mut total_outside_time = Duration::ZERO;
+        // all time outside of `todo`
         let mut total_inside_time = Duration::ZERO;
 
         // time for get_next_tx_to_consider
         let mut total_consider_next_time = Duration::ZERO;
+        // time spent updating nonce
         let mut total_update_nonce_time = Duration::ZERO;
+        // time spent bumping nonce
         let mut total_bump_nonce_time = Duration::ZERO;
 
         loop {


### PR DESCRIPTION
This is code for an experiment I tried to see how much time is spent 1) getting ready to process a transaction, versus 2) actually processing.

The output of running `stacks-inspect try-mine` with this change on a sample chainstate is:

```
    INFO [1658933651.933806] [src/core/mempool.rs:1143] [main] total_inside_time: 2.113118383s total_outside_time: 12.945902065s total_consider_next_time: 12.230043321s total_update_nonce_time: 610.289211ms total_bump_nonce_time: 151.940206ms
    INFO [1658933651.937111] [src/core/mempool.rs:1143] [main] total_inside_time: 0ns total_outside_time: 0ns total_consider_next_time: 3.272365ms total_update_nonce_time: 0ns total_bump_nonce_time: 0ns
```

This indicates that around `12.3s` are spent outside of processing for `2.1s` actually spent processing, suggesting a savings of 6-7x if we can pre-cache these "getting ready to process" calculations.
