### PR TITLE
draft: Change to speed up block processing by around 7x

### DIFF
--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1009,26 +1009,18 @@ impl MemPoolDB {
     ///  highest-fee-first order.  This method is interruptable -- in the `settings` struct, the
     ///  caller may choose how long to spend iterating before this method stops.
     ///
-    ///  `todo` returns an option to a `TransactionEvent` representing the outcome, or None to indicate
-    ///  that iteration through the mempool should be halted.
-    ///
-    /// `output_events` is modified in place, adding all substantive transaction events (success and error
-    /// events, but not skipped) output by `todo`.
+    ///  `todo` returns a boolean representing whether or not to keep iterating.
     pub fn iterate_candidates<F, E, C>(
         &mut self,
         clarity_tx: &mut C,
-        output_events: &mut Vec<TransactionEvent>,
         _tip_height: u64,
         settings: MemPoolWalkSettings,
+        id_list: &Vec<&str>,
         mut todo: F,
     ) -> Result<u64, E>
     where
         C: ClarityConnection,
-        F: FnMut(
-            &mut C,
-            &ConsiderTransaction,
-            &mut dyn CostEstimator,
-        ) -> Result<Option<TransactionEvent>, E>,
+        F: FnMut(&mut C, &ConsiderTransaction, &mut dyn CostEstimator) -> Result<bool, E>,
         E: From<db_error> + From<ChainstateError>,
     {
         let start_time = Instant::now();
@@ -1036,84 +1028,129 @@ impl MemPoolDB {
 
         debug!("Mempool walk for {}ms", settings.max_walk_time_ms,);
 
-        let tx_consideration_sampler = Uniform::new(0, 100);
+        // let tx_consideration_sampler = Uniform::new(0, 100);
         let mut rng = rand::thread_rng();
-        let mut remember_start_with_estimate = None;
+        // let mut remember_start_with_estimate = None;
 
-        loop {
-            if start_time.elapsed().as_millis() > settings.max_walk_time_ms as u128 {
-                debug!("Mempool iteration deadline exceeded";
-                       "deadline_ms" => settings.max_walk_time_ms);
-                break;
+        let mut last_time = Instant::now();
+        let mut total_outside_time = last_time - last_time;
+        let mut total_inside_time = last_time - last_time;
+
+        for id in id_list {
+            info!("id {}", id);
+            if id.is_empty() {
+                continue;
             }
+            let txid = Txid::from_hex(id).expect("Couldn't parse id");
+            let tx = MemPoolDB::get_tx(&self.db, &txid)
+                .unwrap()
+                .expect("No mempool tx found.");
 
-            let start_with_no_estimate = remember_start_with_estimate.unwrap_or_else(|| {
-                tx_consideration_sampler.sample(&mut rng) < settings.consider_no_estimate_tx_prob
-            });
+            let consider = ConsiderTransaction {
+                tx,
+                update_estimate: true,
+            };
 
-            match self.get_next_tx_to_consider(start_with_no_estimate)? {
-                ConsiderTransactionResult::NoTransactions => {
-                    debug!("No more transactions to consider in mempool");
-                    break;
-                }
-                ConsiderTransactionResult::UpdateNonces(addresses) => {
-                    // if we need to update the nonce for the considered transaction,
-                    //  use the last value of start_with_no_estimate on the next loop
-                    remember_start_with_estimate = Some(start_with_no_estimate);
-                    let mut last_addr = None;
-                    for address in addresses.into_iter() {
-                        debug!("Update nonce"; "address" => %address);
-                        // do not recheck nonces if the sponsor == origin
-                        if last_addr.as_ref() == Some(&address) {
-                            continue;
-                        }
-                        let min_nonce =
-                            StacksChainState::get_account(clarity_tx, &address.clone().into())
-                                .nonce;
-
-                        self.update_last_known_nonces(&address, min_nonce)?;
-                        last_addr = Some(address)
-                    }
-                }
-                ConsiderTransactionResult::Consider(consider) => {
-                    // if we actually consider the chosen transaction,
-                    //  compute a new start_with_no_estimate on the next loop
-                    remember_start_with_estimate = None;
-                    debug!("Consider mempool transaction";
+            debug!("Consider mempool transaction";
                            "txid" => %consider.tx.tx.txid(),
                            "origin_addr" => %consider.tx.metadata.origin_address,
                            "sponsor_addr" => %consider.tx.metadata.sponsor_address,
                            "accept_time" => consider.tx.metadata.accept_time,
                            "tx_fee" => consider.tx.metadata.tx_fee,
                            "size" => consider.tx.metadata.len);
-                    total_considered += 1;
+            total_considered += 1;
 
-                    // Run `todo` on the transaction.
-                    match todo(clarity_tx, &consider, self.cost_estimator.as_mut())? {
-                        Some(tx_event) => {
-                            match tx_event {
-                                TransactionEvent::Skipped(_) => {
-                                    // don't push `Skipped` events to the observer
-                                }
-                                _ => {
-                                    output_events.push(tx_event);
-                                }
-                            }
-                        }
-                        None => {
-                            debug!("Mempool iteration early exit from iterator");
-                            break;
-                        }
-                    }
+            let outside_delta = Instant::now() - last_time;
+            total_outside_time += outside_delta;
+            last_time = Instant::now();
+            let inside_result = todo(clarity_tx, &consider, self.cost_estimator.as_mut());
+            let inside_delta = Instant::now() - last_time;
+            total_inside_time += inside_delta;
+            last_time = Instant::now();
 
-                    self.bump_last_known_nonces(&consider.tx.metadata.origin_address)?;
-                    if consider.tx.tx.auth.is_sponsored() {
-                        self.bump_last_known_nonces(&consider.tx.metadata.sponsor_address)?;
-                    }
-                }
+            if !inside_result? {
+                debug!("Mempool iteration early exit from iterator");
+                break;
             }
+
+            self.bump_last_known_nonces(&consider.tx.metadata.origin_address)?;
+            if consider.tx.tx.auth.is_sponsored() {
+                self.bump_last_known_nonces(&consider.tx.metadata.sponsor_address)?;
+            }
+
+            // if start_time.elapsed().as_millis() > settings.max_walk_time_ms as u128 {
+            //     debug!("Mempool iteration deadline exceeded";
+            //            "deadline_ms" => settings.max_walk_time_ms);
+            //     break;
+            // }
+            //
+            // let start_with_no_estimate = remember_start_with_estimate.unwrap_or_else(|| {
+            //     tx_consideration_sampler.sample(&mut rng) < settings.consider_no_estimate_tx_prob
+            // });
+            //
+            // match self.get_next_tx_to_consider(start_with_no_estimate)? {
+            //     ConsiderTransactionResult::NoTransactions => {
+            //         debug!("No more transactions to consider in mempool");
+            //         break;
+            //     }
+            //     ConsiderTransactionResult::UpdateNonces(addresses) => {
+            //         // if we need to update the nonce for the considered transaction,
+            //         //  use the last value of start_with_no_estimate on the next loop
+            //         remember_start_with_estimate = Some(start_with_no_estimate);
+            //         let mut last_addr = None;
+            //         for address in addresses.into_iter() {
+            //             debug!("Update nonce"; "address" => %address);
+            //             // do not recheck nonces if the sponsor == origin
+            //             if last_addr.as_ref() == Some(&address) {
+            //                 continue;
+            //             }
+            //             let min_nonce =
+            //                 StacksChainState::get_account(clarity_tx, &address.clone().into())
+            //                     .nonce;
+            //
+            //             self.update_last_known_nonces(&address, min_nonce)?;
+            //             last_addr = Some(address)
+            //         }
+            //     }
+            //     ConsiderTransactionResult::Consider(consider) => {
+            //         // if we actually consider the chosen transaction,
+            //         //  compute a new start_with_no_estimate on the next loop
+            //         remember_start_with_estimate = None;
+            //         debug!("Consider mempool transaction";
+            //                "txid" => %consider.tx.tx.txid(),
+            //                "origin_addr" => %consider.tx.metadata.origin_address,
+            //                "sponsor_addr" => %consider.tx.metadata.sponsor_address,
+            //                "accept_time" => consider.tx.metadata.accept_time,
+            //                "tx_fee" => consider.tx.metadata.tx_fee,
+            //                "size" => consider.tx.metadata.len);
+            //         total_considered += 1;
+            //
+            //         let outside_delta = Instant::now() - last_time;
+            //         total_outside_time += outside_delta;
+            //         last_time = Instant::now();
+            //         let inside_result = todo(clarity_tx, &consider, self.cost_estimator.as_mut());
+            //         let inside_delta = Instant::now() - last_time;
+            //         total_inside_time += inside_delta;
+            //         last_time = Instant::now();
+            //
+            //         if !inside_result? {
+            //             debug!("Mempool iteration early exit from iterator");
+            //             break;
+            //         }
+            //
+            //         self.bump_last_known_nonces(&consider.tx.metadata.origin_address)?;
+            //         if consider.tx.tx.auth.is_sponsored() {
+            //             self.bump_last_known_nonces(&consider.tx.metadata.sponsor_address)?;
+            //         }
+            //     }
+            // }
         }
 
+        total_outside_time += last_time - Instant::now();
+        info!(
+            "total_inside_time: {:?} total_outside_time: {:?}",
+            &total_inside_time, &total_outside_time
+        );
         debug!(
             "Mempool iteration finished";
             "considered_txs" => total_considered,

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ use blockstack_lib::{
     util_lib::db::sqlite_open,
 };
 use std::collections::HashSet;
+use std::time::Instant;
 
 fn main() {
     let mut argv: Vec<String> = env::args().collect();
@@ -695,34 +696,34 @@ check if the associated microblocks can be downloaded
         process::exit(0);
     }
 
+    /// Note: This is running specific candidates.
     if argv[1] == "try-mine" {
-        if argv.len() < 3 {
+        if argv.len() < 4 {
             eprintln!(
-                "Usage: {} try-mine <working-dir> [min-fee [max-time]]
+                "Usage: {} try-mine <working-dir> <id-list>
 
-Given a <working-dir>, try to ''mine'' an anchored block. This invokes the miner block
-assembly, but does not attempt to broadcast a block commit. This is useful for determining
-what transactions a given chain state would include in an anchor block, or otherwise
-simulating a miner.
+<working-dir> is the directory with the chain state.
+<id-list> is mandatory in this branch and is a list of id's to try.
 ",
                 argv[0]
             );
             process::exit(1);
         }
 
+        let base_path = argv[2].clone();
+        let id_list_path = argv[3].clone();
+
+        let id_contents =
+            fs::read_to_string(id_list_path).expect("Something went wrong reading the file");
+        let id_list: Vec<&str> = id_contents.split("\n").collect();
+        info!("id_list {:?}", &id_list);
+        info!("id_contents {:?}", &id_contents);
         let start = get_epoch_time_ms();
-        let sort_db_path = format!("{}/mainnet/burnchain/sortition", &argv[2]);
-        let chain_state_path = format!("{}/mainnet/chainstate/", &argv[2]);
+        let sort_db_path = format!("{}/mainnet/burnchain/sortition", &base_path);
+        let chain_state_path = format!("{}/mainnet/chainstate/", &base_path);
 
         let mut min_fee = u64::max_value();
         let mut max_time = u64::max_value();
-
-        if argv.len() >= 4 {
-            min_fee = argv[3].parse().expect("Could not parse min_fee");
-        }
-        if argv.len() >= 5 {
-            max_time = argv[4].parse().expect("Could not parse max_time");
-        }
 
         let sort_db = SortitionDB::open(&sort_db_path, false)
             .expect(&format!("Failed to open {}", &sort_db_path));
@@ -767,570 +768,61 @@ simulating a miner.
         settings.max_miner_time_ms = max_time;
         settings.mempool_settings.min_tx_fee = min_fee;
 
-        let result = StacksBlockBuilder::build_anchored_block(
-            &chain_state,
-            &sort_db.index_conn(),
-            &mut mempool_db,
-            &parent_header,
-            chain_tip.total_burn,
-            VRFProof::empty(),
-            Hash160([0; 20]),
-            &coinbase_tx,
-            settings,
-            None,
-        );
+        {
+            let build_start = Instant::now();
+            let result = StacksBlockBuilder::build_anchored_block(
+                &chain_state,
+                &sort_db.index_conn(),
+                &mut mempool_db,
+                &parent_header,
+                chain_tip.total_burn,
+                VRFProof::empty(),
+                Hash160([0; 20]),
+                &coinbase_tx,
+                settings.clone(),
+                None,
+                &id_list,
+            );
 
-        let stop = get_epoch_time_ms();
+            let build_end = Instant::now();
+            let delta = build_end - build_start;
+            info!("build_anchored_block delta: {:?}", &delta);
+            let stop = get_epoch_time_ms();
 
-        println!(
-            "{} mined block @ height = {} off of {} ({}/{}) in {}ms. Min-fee: {}, Max-time: {}",
-            if result.is_ok() {
-                "Successfully"
-            } else {
-                "Failed to"
-            },
-            parent_header.stacks_block_height + 1,
-            StacksBlockHeader::make_index_block_hash(
-                &parent_header.consensus_hash,
-                &parent_header.anchored_header.block_hash()
-            ),
-            &parent_header.consensus_hash,
-            &parent_header.anchored_header.block_hash(),
-            stop.saturating_sub(start),
-            min_fee,
-            max_time
-        );
-
-        if let Ok((block, execution_cost, size)) = result {
-            let mut total_fees = 0;
-            for tx in block.txs.iter() {
-                total_fees += tx.get_tx_fee();
-            }
             println!(
-                "Block {}: {} uSTX, {} bytes, cost {:?}",
-                block.block_hash(),
-                total_fees,
-                size,
-                &execution_cost
-            );
-        }
-
-        process::exit(0);
-    }
-
-    if argv[1] == "decode-microblocks" {
-        if argv.len() < 3 {
-            eprintln!(
-                "Usage: {} decode-microblocks MICROBLOCK_STREAM_PATH",
-                argv[0]
-            );
-            process::exit(1);
-        }
-
-        let mblock_path = &argv[2];
-        let mblock_data = fs::read(mblock_path).expect(&format!("Failed to open {}", mblock_path));
-
-        let mut cursor = io::Cursor::new(&mblock_data);
-        let mut debug_cursor = LogReader::from_reader(&mut cursor);
-        let mblocks: Vec<StacksMicroblock> = Vec::consensus_deserialize(&mut debug_cursor)
-            .map_err(|e| {
-                eprintln!("Failed to decode microblocks: {:?}", &e);
-                eprintln!("Bytes consumed:");
-                for buf in debug_cursor.log().iter() {
-                    eprintln!("  {}", to_hex(buf));
-                }
-                process::exit(1);
-            })
-            .unwrap();
-
-        println!("{:#?}", &mblocks);
-        process::exit(0);
-    }
-
-    if argv[1] == "header-indexed-get" {
-        if argv.len() < 5 {
-            eprintln!(
-                "Usage: {} header-indexed-get STATE_DIR BLOCK_ID_HASH KEY",
-                argv[0]
-            );
-            eprintln!("       STATE_DIR is either the chain state directory OR a marf index and data db file");
-            process::exit(1);
-        }
-        let (marf_path, db_path, arg_next) = if argv.len() == 5 {
-            let headers_dir = &argv[2];
-            (
-                format!("{}/vm/index.sqlite", &headers_dir),
-                format!("{}/vm/headers.sqlite", &headers_dir),
-                3,
-            )
-        } else {
-            (argv[2].to_string(), argv[3].to_string(), 4)
-        };
-        let marf_tip = &argv[arg_next];
-        let marf_key = &argv[arg_next + 1];
-
-        if fs::metadata(&marf_path).is_err() {
-            eprintln!("No such file or directory: {}", &marf_path);
-            process::exit(1);
-        }
-
-        if fs::metadata(&db_path).is_err() {
-            eprintln!("No such file or directory: {}", &db_path);
-            process::exit(1);
-        }
-
-        let marf_bhh = StacksBlockId::from_hex(marf_tip).expect("Bad MARF block hash");
-        let marf_opts = MARFOpenOpts::default();
-        let mut marf = MARF::from_path(&marf_path, marf_opts).expect("Failed to open MARF");
-        let value_opt = marf.get(&marf_bhh, marf_key).expect("Failed to read MARF");
-
-        if let Some(value) = value_opt {
-            let conn = sqlite_open(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)
-                .expect("Failed to open DB");
-            let args: &[&dyn ToSql] = &[&value.to_hex()];
-            let res: Result<String, rusqlite::Error> = conn.query_row_and_then(
-                "SELECT value FROM __fork_storage WHERE value_hash = ?1",
-                args,
-                |row| {
-                    let s: String = row.get_unwrap(0);
-                    Ok(s)
+                "{} mined block @ height = {} off of {} ({}/{}) in {}ms. Min-fee: {}, Max-time: {}",
+                if result.is_ok() {
+                    "Successfully"
+                } else {
+                    "Failed to"
                 },
+                parent_header.stacks_block_height + 1,
+                StacksBlockHeader::make_index_block_hash(
+                    &parent_header.consensus_hash,
+                    &parent_header.anchored_header.block_hash()
+                ),
+                &parent_header.consensus_hash,
+                &parent_header.anchored_header.block_hash(),
+                stop.saturating_sub(start),
+                min_fee,
+                max_time
             );
 
-            let row = res.expect(&format!(
-                "Failed to query DB for MARF value hash {}",
-                &value
-            ));
-            println!("{}", row);
-        } else {
-            println!("(undefined)");
+            if let Ok((block, execution_cost, size)) = result {
+                let mut total_fees = 0;
+                for tx in block.txs.iter() {
+                    total_fees += tx.get_tx_fee();
+                }
+                println!(
+                    "Block {}: {} uSTX, {} bytes, cost {:?}",
+                    block.block_hash(),
+                    total_fees,
+                    size,
+                    &execution_cost
+                );
+            }
         }
 
         process::exit(0);
-    }
-
-    if argv[1] == "exec_program" {
-        if argv.len() < 3 {
-            eprintln!("Usage: {} exec_program [program-file.clar]", argv[0]);
-            process::exit(1);
-        }
-        let program: String =
-            fs::read_to_string(&argv[2]).expect(&format!("Error reading file: {}", argv[2]));
-        match clarity_cli::vm_execute(&program) {
-            Ok(Some(result)) => println!("{}", result),
-            Ok(None) => println!(""),
-            Err(error) => {
-                panic!("Program Execution Error: \n{}", error);
-            }
-        }
-        return;
-    }
-
-    if argv[1] == "marf-get" {
-        let path = &argv[2];
-        let tip = BlockHeaderHash::from_hex(&argv[3]).unwrap();
-        let consensustip = ConsensusHash::from_hex(&argv[4]).unwrap();
-        let itip = StacksBlockHeader::make_index_block_hash(&consensustip, &tip);
-        let key = &argv[5];
-
-        let marf_opts = MARFOpenOpts::default();
-        let mut marf = MARF::from_path(path, marf_opts).unwrap();
-        let res = marf.get(&itip, key).expect("MARF error.");
-        match res {
-            Some(x) => println!("{}", x),
-            None => println!("None"),
-        };
-        return;
-    }
-
-    if argv[1] == "get-ancestors" {
-        let path = &argv[2];
-        let tip = BlockHeaderHash::from_hex(&argv[3]).unwrap();
-        let burntip = BurnchainHeaderHash::from_hex(&argv[4]).unwrap();
-
-        let conn = rusqlite::Connection::open(path).unwrap();
-        let mut cur_burn = burntip.clone();
-        let mut cur_tip = tip.clone();
-        loop {
-            println!("{}, {}", cur_burn, cur_tip);
-            let (next_burn, next_tip) = match
-                conn.query_row("SELECT parent_burn_header_hash, parent_anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ? and burn_header_hash = ?",
-                               &[&cur_tip as &dyn rusqlite::types::ToSql, &cur_burn], |row| Ok((row.get_unwrap(0), row.get_unwrap(1)))) {
-                    Ok(x) => x,
-                    Err(e) => {
-                        match e {
-                            rusqlite::Error::QueryReturnedNoRows => {},
-                            e => {
-                                eprintln!("SQL Error: {}", e);
-                            },
-                        }
-                        break
-                    }
-                };
-            cur_burn = next_burn;
-            cur_tip = next_tip;
-        }
-        return;
-    }
-
-    if argv[1] == "docgen" {
-        println!(
-            "{}",
-            blockstack_lib::clarity::vm::docs::make_json_api_reference()
-        );
-        return;
-    }
-
-    if argv[1] == "docgen_boot" {
-        println!(
-            "{}",
-            blockstack_lib::chainstate::stacks::boot::docs::make_json_boot_contracts_reference()
-        );
-        return;
-    }
-
-    if argv[1] == "local" {
-        clarity_cli::invoke_command(&format!("{} {}", argv[0], argv[1]), &argv[2..]);
-        return;
-    }
-
-    if argv[1] == "process-block" {
-        let path = &argv[2];
-        let sort_path = &argv[3];
-        let (mut chainstate, _) = StacksChainState::open(false, 0x80000000, path, None).unwrap();
-        let mut sortition_db = SortitionDB::open(sort_path, true).unwrap();
-        let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(sortition_db.conn())
-            .unwrap()
-            .sortition_id;
-        let mut tx = sortition_db.tx_handle_begin(&sortition_tip).unwrap();
-        let null_event_dispatcher: Option<&DummyEventDispatcher> = None;
-        chainstate
-            .process_next_staging_block(&mut tx, null_event_dispatcher)
-            .unwrap();
-        return;
-    }
-
-    if argv[1] == "replay-chainstate" {
-        if argv.len() < 7 {
-            eprintln!("Usage: {} OLD_CHAINSTATE_PATH OLD_SORTITION_DB_PATH OLD_BURNCHAIN_DB_PATH NEW_CHAINSTATE_PATH NEW_BURNCHAIN_DB_PATH", &argv[0]);
-            process::exit(1);
-        }
-
-        let old_chainstate_path = &argv[2];
-        let old_sort_path = &argv[3];
-        let old_burnchaindb_path = &argv[4];
-
-        let new_chainstate_path = &argv[5];
-        let burnchain_db_path = &argv[6];
-
-        let (old_chainstate, _) =
-            StacksChainState::open(false, 0x80000000, old_chainstate_path, None).unwrap();
-        let old_sortition_db = SortitionDB::open(old_sort_path, true).unwrap();
-
-        // initial argon balances -- see testnet/stacks-node/conf/testnet-follower-conf.toml
-        let initial_balances = vec![
-            (
-                StacksAddress::from_string("ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2")
-                    .unwrap()
-                    .to_account_principal(),
-                10000000000000000,
-            ),
-            (
-                StacksAddress::from_string("ST319CF5WV77KYR1H3GT0GZ7B8Q4AQPY42ETP1VPF")
-                    .unwrap()
-                    .to_account_principal(),
-                10000000000000000,
-            ),
-            (
-                StacksAddress::from_string("ST221Z6TDTC5E0BYR2V624Q2ST6R0Q71T78WTAX6H")
-                    .unwrap()
-                    .to_account_principal(),
-                10000000000000000,
-            ),
-            (
-                StacksAddress::from_string("ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B")
-                    .unwrap()
-                    .to_account_principal(),
-                10000000000000000,
-            ),
-        ];
-
-        let burnchain = Burnchain::regtest(&burnchain_db_path);
-        let spv_headers_path = "/tmp/replay-chainstate".to_string();
-        let indexer_config = BitcoinIndexerConfig {
-            peer_host: "127.0.0.1".to_string(),
-            peer_port: 18444,
-            rpc_port: 18443,
-            rpc_ssl: false,
-            username: Some("blockstack".to_string()),
-            password: Some("blockstacksystem".to_string()),
-            timeout: 30,
-            spv_headers_path,
-            first_block: 0,
-            magic_bytes: BLOCKSTACK_MAGIC_MAINNET.clone(),
-            epochs: None,
-        };
-
-        let indexer = BitcoinIndexer::new(
-            indexer_config,
-            BitcoinIndexerRuntime::new(BitcoinNetworkType::Regtest),
-        );
-        let first_burnchain_block_height = burnchain.first_block_height;
-        let first_burnchain_block_hash = burnchain.first_block_hash;
-        let (mut new_sortition_db, _) = burnchain
-            .connect_db(
-                &indexer,
-                true,
-                first_burnchain_block_hash,
-                BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP.into(),
-            )
-            .unwrap();
-
-        let old_burnchaindb = BurnchainDB::connect(
-            &old_burnchaindb_path,
-            first_burnchain_block_height,
-            &first_burnchain_block_hash,
-            BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP.into(),
-            true,
-        )
-        .unwrap();
-
-        let mut boot_data = ChainStateBootData {
-            initial_balances,
-            post_flight_callback: None,
-            first_burnchain_block_hash,
-            first_burnchain_block_height: first_burnchain_block_height as u32,
-            first_burnchain_block_timestamp: 0,
-            pox_constants: PoxConstants::regtest_default(),
-            get_bulk_initial_lockups: None,
-            get_bulk_initial_balances: None,
-            get_bulk_initial_namespaces: None,
-            get_bulk_initial_names: None,
-        };
-
-        let (mut new_chainstate, _) = StacksChainState::open_and_exec(
-            false,
-            0x80000000,
-            new_chainstate_path,
-            Some(&mut boot_data),
-            None,
-        )
-        .unwrap();
-
-        let all_snapshots = old_sortition_db.get_all_snapshots().unwrap();
-        let all_stacks_blocks =
-            StacksChainState::get_all_staging_block_headers(&old_chainstate.db()).unwrap();
-
-        // order block hashes by arrival index
-        let mut stacks_blocks_arrival_indexes = vec![];
-        for snapshot in all_snapshots.iter() {
-            if !snapshot.sortition {
-                continue;
-            }
-            if snapshot.arrival_index == 0 {
-                continue;
-            }
-            let index_hash = StacksBlockHeader::make_index_block_hash(
-                &snapshot.consensus_hash,
-                &snapshot.winning_stacks_block_hash,
-            );
-            stacks_blocks_arrival_indexes.push((index_hash, snapshot.arrival_index));
-        }
-        stacks_blocks_arrival_indexes.sort_by(|ref a, ref b| a.1.partial_cmp(&b.1).unwrap());
-        let stacks_blocks_arrival_order: Vec<StacksBlockId> = stacks_blocks_arrival_indexes
-            .into_iter()
-            .map(|(h, _)| h)
-            .collect();
-
-        let mut stacks_blocks_available: HashMap<StacksBlockId, StagingBlock> = HashMap::new();
-        let num_staging_blocks = all_stacks_blocks.len();
-        for staging_block in all_stacks_blocks.into_iter() {
-            if !staging_block.orphaned {
-                let index_hash = StacksBlockHeader::make_index_block_hash(
-                    &staging_block.consensus_hash,
-                    &staging_block.anchored_block_hash,
-                );
-                eprintln!(
-                    "Will consider {}/{}",
-                    &staging_block.consensus_hash, &staging_block.anchored_block_hash
-                );
-                stacks_blocks_available.insert(index_hash, staging_block);
-            }
-        }
-
-        eprintln!(
-            "\nWill replay {} stacks epochs out of {}\n",
-            &stacks_blocks_available.len(),
-            num_staging_blocks
-        );
-
-        let mut known_stacks_blocks = HashSet::new();
-        let mut next_arrival = 0;
-
-        let (p2p_new_sortition_db, _) = burnchain
-            .connect_db(
-                &indexer,
-                true,
-                first_burnchain_block_hash,
-                BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP.into(),
-            )
-            .unwrap();
-        let (mut p2p_chainstate, _) =
-            StacksChainState::open(false, 0x80000000, new_chainstate_path, None).unwrap();
-
-        let _ = thread::spawn(move || {
-            loop {
-                // simulate the p2p refreshing itself
-                // update p2p's read-only view of the unconfirmed state
-                p2p_chainstate
-                    .refresh_unconfirmed_state(&p2p_new_sortition_db.index_conn())
-                    .expect("Failed to open unconfirmed Clarity state");
-
-                sleep_ms(100);
-            }
-        });
-
-        for old_snapshot in all_snapshots.into_iter() {
-            // replay this burnchain block
-            let BurnchainBlockData {
-                header: burn_block_header,
-                ops: blockstack_txs,
-            } = old_burnchaindb
-                .get_burnchain_block(&old_snapshot.burn_header_hash)
-                .unwrap();
-            if old_snapshot.parent_burn_header_hash == BurnchainHeaderHash::sentinel() {
-                // skip initial snapshot -- it's a placeholder
-                continue;
-            }
-
-            let (new_snapshot, ..) = {
-                let sortition_tip =
-                    SortitionDB::get_canonical_burn_chain_tip(new_sortition_db.conn()).unwrap();
-                new_sortition_db
-                    .evaluate_sortition(
-                        &burn_block_header,
-                        blockstack_txs,
-                        &burnchain,
-                        &sortition_tip.sortition_id,
-                        None,
-                        |_| {},
-                    )
-                    .unwrap()
-            };
-
-            // importantly, the burnchain linkage must all match
-            assert_eq!(old_snapshot.burn_header_hash, new_snapshot.burn_header_hash);
-            assert_eq!(
-                old_snapshot.parent_burn_header_hash,
-                new_snapshot.parent_burn_header_hash
-            );
-            assert_eq!(old_snapshot.sortition, new_snapshot.sortition);
-            assert_eq!(
-                old_snapshot.winning_stacks_block_hash,
-                new_snapshot.winning_stacks_block_hash
-            );
-            assert_eq!(old_snapshot.consensus_hash, new_snapshot.consensus_hash);
-            assert_eq!(old_snapshot.sortition_hash, new_snapshot.sortition_hash);
-            assert_eq!(old_snapshot.block_height, new_snapshot.block_height);
-            assert_eq!(old_snapshot.total_burn, new_snapshot.total_burn);
-            assert_eq!(old_snapshot.ops_hash, new_snapshot.ops_hash);
-
-            // "discover" the stacks blocks
-            if new_snapshot.sortition {
-                let mut stacks_block_id = StacksBlockHeader::make_index_block_hash(
-                    &new_snapshot.consensus_hash,
-                    &new_snapshot.winning_stacks_block_hash,
-                );
-                known_stacks_blocks.insert(stacks_block_id.clone());
-
-                if next_arrival >= stacks_blocks_arrival_order.len() {
-                    // all blocks should have been queued up
-                    continue;
-                }
-
-                if stacks_block_id == stacks_blocks_arrival_order[next_arrival] {
-                    while next_arrival < stacks_blocks_arrival_order.len()
-                        && known_stacks_blocks.contains(&stacks_block_id)
-                    {
-                        if let Some(_) = stacks_blocks_available.get(&stacks_block_id) {
-                            // load up the block
-                            let stacks_block_opt = StacksChainState::load_block(
-                                &old_chainstate.blocks_path,
-                                &new_snapshot.consensus_hash,
-                                &new_snapshot.winning_stacks_block_hash,
-                            )
-                            .unwrap();
-                            if let Some(stacks_block) = stacks_block_opt {
-                                // insert it into the new chainstate
-                                let ic = new_sortition_db.index_conn();
-                                Relayer::process_new_anchored_block(
-                                    &ic,
-                                    &mut new_chainstate,
-                                    &new_snapshot.consensus_hash,
-                                    &stacks_block,
-                                    0,
-                                )
-                                .unwrap();
-                            } else {
-                                warn!(
-                                    "No such stacks block {}/{}",
-                                    &new_snapshot.consensus_hash,
-                                    &new_snapshot.winning_stacks_block_hash
-                                );
-                            }
-                        } else {
-                            warn!(
-                                "Missing stacks block {}/{}",
-                                &new_snapshot.consensus_hash,
-                                &new_snapshot.winning_stacks_block_hash
-                            );
-                        }
-
-                        next_arrival += 1;
-                        if next_arrival >= stacks_blocks_arrival_order.len() {
-                            break;
-                        }
-                        stacks_block_id = stacks_blocks_arrival_order[next_arrival].clone();
-                    }
-                }
-
-                // TODO: also process microblocks
-                // TODO: process blocks in arrival order
-            }
-
-            // process all new blocks
-            let mut epoch_receipts = vec![];
-            loop {
-                let sortition_tip =
-                    SortitionDB::get_canonical_burn_chain_tip(new_sortition_db.conn())
-                        .unwrap()
-                        .sortition_id;
-                let sortition_tx = new_sortition_db.tx_handle_begin(&sortition_tip).unwrap();
-                let null_event_dispatcher: Option<&DummyEventDispatcher> = None;
-                let receipts = new_chainstate
-                    .process_blocks(sortition_tx, 1, null_event_dispatcher)
-                    .unwrap();
-                if receipts.len() == 0 {
-                    break;
-                }
-                for (epoch_receipt_opt, _) in receipts.into_iter() {
-                    if let Some(epoch_receipt) = epoch_receipt_opt {
-                        epoch_receipts.push(epoch_receipt);
-                    }
-                }
-            }
-        }
-
-        eprintln!(
-            "Final arrival index is {} out of {}",
-            next_arrival,
-            stacks_blocks_arrival_order.len()
-        );
-        return;
-    }
-
-    if argv.len() < 4 {
-        eprintln!("Usage: {} blockchain network working_dir", argv[0]);
-        process::exit(1);
     }
 }

--- a/testnet/stacks-node/conf/mainnet-follower-conf.toml
+++ b/testnet/stacks-node/conf/mainnet-follower-conf.toml
@@ -1,5 +1,5 @@
 [node]
-# working_dir = "/dir/to/save/chainstate"
+working_dir = "/data/spaces"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 bootstrap_node = "02da7a464ac770ae8337a343670778b93410f2f3fef6bea98dd1c3e9224459d36b@seed-0.mainnet.stacks.co:20444,02afeae522aab5f8c99a00ddf75fbcb4a641e052dd48836408d9cf437344b63516@seed-1.mainnet.stacks.co:20444,03652212ea76be0ed4cd83a25c06e57819993029a7b9999f7d63c36340b34a4e62@seed-2.mainnet.stacks.co:20444"


### PR DESCRIPTION
### Description

This PR shows how to "pre-cache" the list of transactions to try on a call to `stacks-inspect try-mine`.

We have shown that, using this change, we can get a block made 6x faster than the baseline in `develop`. With this change, we get a block made in `2.4s` instead of around `15s` in `develop`.

new:

```
DEBG [1658941143.197815] [src/chainstate/stacks/miner.rs:2163] [main] Miner: mined anchored block, block_hash: 4f5308cac19c76c0749168a1b407f638eaf3c18ea0764abf4b58cb16e9492570, height: 69059, tx_count: 71, parent_stacks_block_hash: 3e39db238c15dfb2f07d0d0c1c25a3fbd90e085d072bcb608ce5460637a9f2ca, parent_stacks_microblock: 0000000000000000000000000000000000000000000000000000000000000000, parent_stacks_microblock_seq: 0, block_size: 24964, execution_consumed: {"runtime": 39377540, "write_len": 44822, "write_cnt": 569, "read_len": 9288054, "read_cnt": 4139}, assembly_time_ms: 2438, tx_fees_microstacks: 4065566
```

baseline:

```
DEBG [1658883820.474547] [src/chainstate/stacks/miner.rs:2179] [main] Miner: mined anchored block, block_hash: 99fd3a1e5bca342db0a0279f90837062a5cac88fbabd87cd02684ce9587f4cce, height: 69059, tx_count: 71, parent_stacks_block_hash: 3e39db238c15dfb2f07d0d0c1c25a3fbd90e085d072bcb608ce5460637a9f2ca, parent_stacks_microblock: 0000000000000000000000000000000000000000000000000000000000000000, parent_stacks_microblock_seq: 0, block_size: 24964, execution_consumed: {"runtime": 39377540, "write_len": 44822, "write_cnt": 569, "read_len": 9288054, "read_cnt": 4139}, assembly_time_ms: 15742, tx_fees_microstacks: 4065566
```