### PR TITLE
Fix: Address startup lock of #3216

### DIFF
--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -2249,7 +2249,7 @@ impl PeerNetwork {
         &mut self,
         sortdb: &SortitionDB,
         ibd: bool,
-    ) -> Result<(bool, bool, Vec<NeighborKey>, Vec<NeighborKey>), net_error> {
+    ) -> (bool, bool, Vec<NeighborKey>, Vec<NeighborKey>) {
         PeerNetwork::with_inv_state(self, |network, inv_state| {
             debug!(
                 "{:?}: Inventory state has {} block stats tracked",
@@ -2481,6 +2481,7 @@ impl PeerNetwork {
                 Ok((false, false, vec![], vec![]))
             }
         })
+        .expect("FATAL: network not connected")
     }
 
     pub fn with_inv_state<F, R>(network: &mut PeerNetwork, handler: F) -> Result<R, net_error>

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -1601,14 +1601,11 @@ impl PeerNetwork {
     }
 
     /// Process new inbound TCP connections we just accepted.
-    /// Returns the event IDs of sockets we need to register
-    fn process_new_sockets(
-        &mut self,
-        poll_state: &mut NetworkPollState,
-    ) -> Result<Vec<usize>, net_error> {
+    /// Returns the event IDs of sockets we need to register.
+    fn process_new_sockets(&mut self, poll_state: &mut NetworkPollState) -> Vec<usize> {
         if self.network.is_none() {
-            test_debug!("{:?}: network not connected", &self.local_peer);
-            return Err(net_error::NotConnected);
+            warn!("{:?}: network not connected", &self.local_peer);
+            return vec![];
         }
 
         let mut registered = vec![];
@@ -1644,7 +1641,7 @@ impl PeerNetwork {
                 }
                 None => {
                     debug!("{:?}: network not connected", &self.local_peer);
-                    return Err(net_error::NotConnected);
+                    return vec![];
                 }
             };
 
@@ -1656,7 +1653,7 @@ impl PeerNetwork {
             registered.push(event_id);
         }
 
-        Ok(registered)
+        registered
     }
 
     /// Process network traffic on a p2p conversation.
@@ -2024,7 +2021,7 @@ impl PeerNetwork {
     }
 
     /// Regenerate our session private key and re-handshake with everyone.
-    fn rekey(&mut self, old_local_peer_opt: Option<&LocalPeer>) -> () {
+    fn rekey(&mut self, old_local_peer_opt: Option<&LocalPeer>) {
         assert!(old_local_peer_opt.is_some());
         let _old_local_peer = old_local_peer_opt.unwrap();
 
@@ -2132,10 +2129,10 @@ impl PeerNetwork {
 
     /// Update the state of our neighbor walk.
     /// Return true if we finish, and true if we're throttled
-    fn do_network_neighbor_walk(&mut self, ibd: bool) -> Result<bool, net_error> {
+    fn do_network_neighbor_walk(&mut self, ibd: bool) -> bool {
         if cfg!(test) && self.connection_opts.disable_neighbor_walk {
             test_debug!("neighbor walk is disabled");
-            return Ok(true);
+            return true;
         }
 
         debug!("{:?}: walk peer graph", &self.local_peer);
@@ -2149,7 +2146,7 @@ impl PeerNetwork {
                 self.process_neighbor_walk(walk_result);
             }
         }
-        Ok(done)
+        done
     }
 
     /// Do a mempool sync. Return any transactions we might receive.
@@ -2159,12 +2156,12 @@ impl PeerNetwork {
         mempool: &MemPoolDB,
         chainstate: &mut StacksChainState,
         ibd: bool,
-    ) -> Result<Option<Vec<StacksTransaction>>, net_error> {
+    ) -> Option<Vec<StacksTransaction>> {
         if ibd {
-            return Ok(None);
+            return None;
         }
 
-        match self.do_mempool_sync(dns_client_opt, mempool, chainstate)? {
+        match self.do_mempool_sync(dns_client_opt, mempool, chainstate) {
             (true, txs_opt) => {
                 // did we run to completion?
                 if let Some(txs) = txs_opt {
@@ -2176,9 +2173,9 @@ impl PeerNetwork {
 
                     self.mempool_sync_deadline =
                         get_epoch_time_secs() + self.connection_opts.mempool_sync_interval;
-                    return Ok(Some(txs));
+                    return Some(txs);
                 } else {
-                    return Ok(None);
+                    return None;
                 }
             }
             (false, txs_opt) => {
@@ -2190,9 +2187,9 @@ impl PeerNetwork {
                         txs.len()
                     );
 
-                    return Ok(Some(txs));
+                    return Some(txs);
                 } else {
-                    return Ok(None);
+                    return None;
                 }
             }
         }
@@ -2427,9 +2424,10 @@ impl PeerNetwork {
     }
 
     /// Learn our publicly-routable IP address
-    fn do_get_public_ip(&mut self) -> Result<bool, net_error> {
+    /// return true if we're done with this state machine
+    fn do_get_public_ip(&mut self) -> bool {
         if !self.need_public_ip() {
-            return Ok(true);
+            return true;
         }
         if self.local_peer.public_ip_address.is_some()
             && self.public_ip_requested_at + self.connection_opts.public_ip_request_timeout
@@ -2441,48 +2439,34 @@ impl PeerNetwork {
                 &self.local_peer,
                 self.public_ip_requested_at + self.connection_opts.public_ip_request_timeout
             );
-            return Ok(true);
+            return true;
         }
 
         match self.do_learn_public_ip() {
             Ok(b) => {
                 if !b {
                     test_debug!("{:?}: try do_learn_public_ip again", &self.local_peer);
-                    return Ok(false);
+                    return false;
                 }
             }
             Err(e) => {
-                test_debug!(
+                warn!(
                     "{:?}: failed to learn public IP: {:?}",
-                    &self.local_peer,
-                    &e
+                    &self.local_peer, &e
                 );
                 self.public_ip_reset();
-
-                match e {
-                    net_error::NoSuchNeighbor => {
-                        // haven't connected to anyone yet
-                        return Ok(true);
-                    }
-                    _ => {
-                        return Err(e);
-                    }
-                };
+                return true;
             }
         }
-        Ok(true)
+        true
     }
 
     /// Update the state of our neighbors' block inventories.
     /// Return true if we finish
-    fn do_network_inv_sync(
-        &mut self,
-        sortdb: &SortitionDB,
-        ibd: bool,
-    ) -> Result<(bool, bool), net_error> {
+    fn do_network_inv_sync(&mut self, sortdb: &SortitionDB, ibd: bool) -> (bool, bool) {
         if cfg!(test) && self.connection_opts.disable_inv_sync {
             test_debug!("{:?}: inv sync is disabled", &self.local_peer);
-            return Ok((true, false));
+            return (true, false);
         }
 
         debug!("{:?}: network inventory sync", &self.local_peer);
@@ -2493,7 +2477,7 @@ impl PeerNetwork {
 
         // synchronize peer block inventories
         let (done, throttled, broken_neighbors, dead_neighbors) =
-            self.sync_inventories(sortdb, ibd)?;
+            self.sync_inventories(sortdb, ibd);
 
         // disconnect and ban broken peers
         for broken in broken_neighbors.into_iter() {
@@ -2505,7 +2489,7 @@ impl PeerNetwork {
             self.deregister_neighbor(&dead);
         }
 
-        Ok((done, throttled))
+        (done, throttled)
     }
 
     /// Download blocks, and add them to our network result.
@@ -2517,10 +2501,10 @@ impl PeerNetwork {
         dns_client: &mut DNSClient,
         ibd: bool,
         network_result: &mut NetworkResult,
-    ) -> Result<bool, net_error> {
+    ) -> bool {
         if self.connection_opts.disable_block_download {
             debug!("{:?}: block download is disabled", &self.local_peer);
-            return Ok(true);
+            return true;
         }
 
         if self.block_downloader.is_none() {
@@ -2543,19 +2527,20 @@ impl PeerNetwork {
                     "{:?}: no progress can be made on the block downloader -- not connected",
                     &self.local_peer
                 );
-                return Ok(true);
+                return true;
             }
             Err(net_error::Transient(s)) => {
                 // not fatal, but just skip and try again
                 info!("Transient network error while downloading blocks: {}", &s);
-                return Ok(true);
+                return true;
             }
             Err(e) => {
                 warn!(
                     "{:?}: Failed to download blocks: {:?}",
                     &self.local_peer, &e
                 );
-                return Err(e);
+                // done
+                return true;
             }
         };
 
@@ -2616,10 +2601,11 @@ impl PeerNetwork {
             self.num_downloader_passes += 1;
         }
 
-        Ok(done && at_chain_tip)
+        done && at_chain_tip
     }
 
-    /// Find the next block to push
+    /// Find the next block to push.
+    /// Mask database errors if they occur
     fn find_next_push_block(
         &mut self,
         nk: &NeighborKey,
@@ -2629,10 +2615,10 @@ impl PeerNetwork {
         chainstate: &StacksChainState,
         local_blocks_inv: &BlocksInvData,
         block_stats: &NeighborBlockStats,
-    ) -> Result<Option<(ConsensusHash, StacksBlock)>, net_error> {
+    ) -> Option<(ConsensusHash, StacksBlock)> {
         let start_block_height = self.burnchain.reward_cycle_to_block_height(reward_cycle);
         if !local_blocks_inv.has_ith_block((height - start_block_height) as u16) {
-            return Ok(None);
+            return None;
         }
         if block_stats.inv.get_block_height() >= height && !block_stats.inv.has_ith_block(height) {
             let ancestor_sn = match self.get_ancestor_sortition_snapshot(sortdb, height) {
@@ -2642,7 +2628,7 @@ impl PeerNetwork {
                         "{:?}: AntiEntropy: Failed to query ancestor block height {}: {:?}",
                         &self.local_peer, height, &e
                     );
-                    return Ok(None);
+                    return None;
                 }
             };
 
@@ -2654,14 +2640,21 @@ impl PeerNetwork {
                 &chainstate.blocks_path,
                 &ancestor_sn.consensus_hash,
                 &ancestor_sn.winning_stacks_block_hash,
-            )? {
-                Some(block) => block,
-                None => {
+            ) {
+                Ok(Some(block)) => block,
+                Ok(None) => {
                     debug!(
                         "{:?}: AntiEntropy: No such block {}",
                         &self.local_peer, &index_block_hash
                     );
-                    return Ok(None);
+                    return None;
+                }
+                Err(e) => {
+                    warn!(
+                        "{:?}: AntiEntropy: failed to load block {}: {:?}",
+                        &self.local_peer, &index_block_hash, &e
+                    );
+                    return None;
                 }
             };
 
@@ -2669,13 +2662,14 @@ impl PeerNetwork {
                 "{:?}: AntiEntropy: Peer {:?} is missing Stacks block {} from height {}, which we have",
                 &self.local_peer, nk, &index_block_hash, height
             );
-            return Ok(Some((ancestor_sn.consensus_hash, block)));
+            return Some((ancestor_sn.consensus_hash, block));
         } else {
-            return Ok(None);
+            return None;
         }
     }
 
     /// Find the next confirmed microblock stream to push.
+    /// Mask database errors
     fn find_next_push_microblocks(
         &mut self,
         nk: &NeighborKey,
@@ -2685,10 +2679,10 @@ impl PeerNetwork {
         chainstate: &StacksChainState,
         local_blocks_inv: &BlocksInvData,
         block_stats: &NeighborBlockStats,
-    ) -> Result<Option<(ConsensusHash, BlockHeaderHash, Vec<StacksMicroblock>)>, net_error> {
+    ) -> Option<(ConsensusHash, BlockHeaderHash, Vec<StacksMicroblock>)> {
         let start_block_height = self.burnchain.reward_cycle_to_block_height(reward_cycle);
         if !local_blocks_inv.has_ith_microblock_stream((height - start_block_height) as u16) {
-            return Ok(None);
+            return None;
         }
         if block_stats.inv.get_block_height() >= height
             && !block_stats.inv.has_ith_microblock_stream(height)
@@ -2700,7 +2694,7 @@ impl PeerNetwork {
                         "{:?}: AntiEntropy: Failed to query ancestor block height {}: {:?}",
                         &self.local_peer, height, &e
                     );
-                    return Ok(None);
+                    return None;
                 }
             };
 
@@ -2719,7 +2713,7 @@ impl PeerNetwork {
                         &ancestor_sn.consensus_hash,
                         &ancestor_sn.winning_stacks_block_hash,
                     );
-                    return Ok(None);
+                    return None;
                 }
                 Err(e) => {
                     debug!(
@@ -2729,7 +2723,7 @@ impl PeerNetwork {
                         &ancestor_sn.winning_stacks_block_hash,
                         &e
                     );
-                    return Ok(None);
+                    return None;
                 }
             };
 
@@ -2749,7 +2743,7 @@ impl PeerNetwork {
                         &block_info.consensus_hash,
                         &block_info.anchored_block_hash,
                     );
-                    return Ok(None);
+                    return None;
                 }
                 Err(e) => {
                     debug!("{:?}: AntiEntropy: Failed to load processed microblocks in-between {}/{} and {}/{}: {:?}",
@@ -2760,7 +2754,7 @@ impl PeerNetwork {
                            &block_info.anchored_block_hash,
                            &e
                     );
-                    return Ok(None);
+                    return None;
                 }
             };
 
@@ -2772,28 +2766,24 @@ impl PeerNetwork {
                 "{:?}: AntiEntropy: Peer {:?} is missing Stacks microblocks {} from height {}, which we have",
                 &self.local_peer, nk, &index_block_hash, height
             );
-            return Ok(Some((
+            return Some((
                 block_info.parent_consensus_hash,
                 block_info.parent_anchored_block_hash,
                 microblocks,
-            )));
+            ));
         } else {
-            return Ok(None);
+            return None;
         }
     }
 
     /// Push any blocks and microblock streams that we're holding onto out to our neighbors.
     /// Start with the most-recently-arrived data, since this node is likely to have already
     /// fetched older data via the block-downloader.
-    fn try_push_local_data(
-        &mut self,
-        sortdb: &SortitionDB,
-        chainstate: &StacksChainState,
-    ) -> Result<(), net_error> {
+    fn try_push_local_data(&mut self, sortdb: &SortitionDB, chainstate: &StacksChainState) {
         if self.antientropy_last_push_ts + self.connection_opts.antientropy_retry
             >= get_epoch_time_secs()
         {
-            return Ok(());
+            return;
         }
 
         self.antientropy_last_push_ts = get_epoch_time_secs();
@@ -2806,7 +2796,7 @@ impl PeerNetwork {
 
         if num_public_inbound > 0 && !self.connection_opts.antientropy_public {
             // we're likely not NAT'ed, and we're not supposed to push blocks to the public.
-            return Ok(());
+            return;
         }
 
         if self.relay_handles.len() as u64
@@ -2818,12 +2808,12 @@ impl PeerNetwork {
                 &self.local_peer,
                 self.relay_handles.len()
             );
-            return Ok(());
+            return;
         }
 
         if self.inv_state.is_none() {
             // nothing to do
-            return Ok(());
+            return;
         }
 
         let mut total_blocks_to_broadcast = 0;
@@ -2852,7 +2842,7 @@ impl PeerNetwork {
         self.antientropy_start_reward_cycle = reward_cycle_finish;
 
         if neighbor_keys.len() == 0 {
-            return Ok(());
+            return;
         }
 
         debug!(
@@ -2916,7 +2906,7 @@ impl PeerNetwork {
                                         chainstate,
                                         &local_blocks_inv,
                                         block_stats,
-                                    )?
+                                    )
                                 {
                                     let index_block_hash = StacksBlockHeader::make_index_block_hash(
                                         &consensus_hash,
@@ -2975,7 +2965,7 @@ impl PeerNetwork {
                                         chainstate,
                                         &local_blocks_inv,
                                         block_stats,
-                                    )?
+                                    )
                                 {
                                     let index_block_hash = StacksBlockHeader::make_index_block_hash(
                                         &parent_consensus_hash,
@@ -3033,11 +3023,12 @@ impl PeerNetwork {
                         continue;
                     }
                     Err(e) => {
+                        // should be unreachable, but why tempt fate?
                         debug!(
                             "{:?}: AntiEntropy: Failed to push blocks to {:?}: {:?}",
                             &self.local_peer, &nk, &e
                         );
-                        return Err(e);
+                        break;
                     }
                 };
 
@@ -3119,9 +3110,9 @@ impl PeerNetwork {
                         .truncate_pox_inventory(&network.burnchain, reward_cycle);
                 }
                 Ok(())
-            })?;
+            })
+            .expect("FATAL: with_inv_state() should be infallible");
         }
-        Ok(())
     }
 
     /// Extract an IP address from a UrlString if it exists
@@ -3416,13 +3407,13 @@ impl PeerNetwork {
         dns_client_opt: &mut Option<&mut DNSClient>,
         mempool: &MemPoolDB,
         chainstate: &mut StacksChainState,
-    ) -> Result<(bool, Option<Vec<StacksTransaction>>), net_error> {
+    ) -> (bool, Option<Vec<StacksTransaction>>) {
         if get_epoch_time_secs() <= self.mempool_sync_deadline {
             debug!(
                 "{:?}: Wait until {} to do a mempool sync",
                 &self.local_peer, self.mempool_sync_deadline
             );
-            return Ok((true, None));
+            return (true, None);
         }
 
         if self.mempool_sync_timeout == 0 {
@@ -3436,7 +3427,7 @@ impl PeerNetwork {
                     &self.local_peer
                 );
                 self.mempool_sync_reset();
-                return Ok((true, None));
+                return (true, None);
             }
         }
 
@@ -3451,37 +3442,49 @@ impl PeerNetwork {
             match cur_state {
                 MempoolSyncState::PickOutboundPeer => {
                     // 1. pick a random outbound conversation.
-                    if let Some(next_state) =
-                        self.mempool_sync_pick_outbound_peer(dns_client_opt, &Txid([0u8; 32]))?
-                    {
-                        // success! can advance to either resolve a URL or to send a query
-                        self.mempool_state = next_state;
-                    } else {
-                        // done
-                        self.mempool_sync_reset();
-                        return Ok((true, None));
+                    match self.mempool_sync_pick_outbound_peer(dns_client_opt, &Txid([0u8; 32])) {
+                        Ok(Some(next_state)) => {
+                            // success! can advance to either resolve a URL or to send a query
+                            self.mempool_state = next_state;
+                        }
+                        Ok(None) => {
+                            // done
+                            self.mempool_sync_reset();
+                            return (true, None);
+                        }
+                        Err(e) => {
+                            // done; need reset
+                            warn!("mempool_sync_pick_outbound_peer returned {:?}", &e);
+                            self.mempool_sync_reset();
+                            return (true, None);
+                        }
                     }
                 }
                 MempoolSyncState::ResolveURL(ref url_str, ref dns_request, ref page_id) => {
                     // 2. resolve its data URL
-                    match self.mempool_sync_resolve_data_url(
-                        url_str,
-                        dns_request,
-                        dns_client_opt,
-                    )? {
-                        (false, Some(addr)) => {
+                    match self.mempool_sync_resolve_data_url(url_str, dns_request, dns_client_opt) {
+                        Ok((false, Some(addr))) => {
                             // success! advance
                             self.mempool_state =
                                 MempoolSyncState::SendQuery(url_str.clone(), addr, page_id.clone());
                         }
-                        (false, None) => {
+                        Ok((false, None)) => {
                             // try again later
-                            return Ok((false, None));
+                            return (false, None);
                         }
-                        (true, _) => {
+                        Ok((true, _)) => {
                             // done
                             self.mempool_sync_reset();
-                            return Ok((true, None));
+                            return (true, None);
+                        }
+                        Err(e) => {
+                            // failed
+                            warn!(
+                                "mempool_sync_resolve_data_url({}) failed: {:?}",
+                                url_str, &e
+                            );
+                            self.mempool_sync_reset();
+                            return (true, None);
                         }
                     }
                 }
@@ -3497,27 +3500,33 @@ impl PeerNetwork {
                         mempool,
                         chainstate,
                         page_id.clone(),
-                    )? {
-                        (false, Some(event_id)) => {
+                    ) {
+                        Ok((false, Some(event_id))) => {
                             // success! advance
                             debug!("{:?}: Mempool sync query {} for mempool transactions at {} on event {}", &self.local_peer, url, page_id, event_id);
                             self.mempool_state =
                                 MempoolSyncState::RecvResponse(url.clone(), addr.clone(), event_id);
                         }
-                        (false, None) => {
+                        Ok((false, None)) => {
                             // try again later
-                            return Ok((false, None));
+                            return (false, None);
                         }
-                        (true, _) => {
+                        Ok((true, _)) => {
                             // done
                             self.mempool_sync_reset();
-                            return Ok((true, None));
+                            return (true, None);
+                        }
+                        Err(e) => {
+                            // done
+                            warn!("mempool_sync_send_query({}) returned {:?}", url, &e);
+                            self.mempool_sync_reset();
+                            return (true, None);
                         }
                     }
                 }
                 MempoolSyncState::RecvResponse(ref url, ref addr, ref event_id) => {
-                    match self.mempool_sync_recv_response(*event_id)? {
-                        (true, next_page_id_opt, Some(txs)) => {
+                    match self.mempool_sync_recv_response(*event_id) {
+                        Ok((true, next_page_id_opt, Some(txs))) => {
                             debug!(
                                 "{:?}: Mempool sync received {} transactions; next page is {:?}",
                                 &self.local_peer,
@@ -3542,25 +3551,31 @@ impl PeerNetwork {
                                     true
                                 }
                             };
-                            return Ok((ret, Some(txs)));
+                            return (ret, Some(txs));
                         }
-                        (true, _, None) => {
+                        Ok((true, _, None)) => {
                             // done! did not get data
                             self.mempool_sync_reset();
-                            return Ok((true, None));
+                            return (true, None);
                         }
-                        (false, _, None) => {
+                        Ok((false, _, None)) => {
                             // still receiving; try again later
-                            return Ok((false, None));
+                            return (false, None);
                         }
-                        (false, _, Some(_)) => {
+                        Ok((false, _, Some(_))) => {
                             // should never happen
                             if cfg!(test) {
                                 panic!("Reached invalid state in {:?}, aborting...", &cur_state);
                             }
                             warn!("Reached invalid state in {:?}, resetting...", &cur_state);
                             self.mempool_sync_reset();
-                            return Ok((true, None));
+                            return (true, None);
+                        }
+                        Err(e) => {
+                            // likely a network error
+                            warn!("mempool_sync_recv_response returned {:?}", &e);
+                            self.mempool_sync_reset();
+                            return (true, None);
                         }
                     }
                 }
@@ -3579,7 +3594,7 @@ impl PeerNetwork {
         download_backpressure: bool,
         ibd: bool,
         network_result: &mut NetworkResult,
-    ) -> Result<bool, net_error> {
+    ) -> bool {
         // do some Actual Work(tm)
         let mut do_prune = false;
         let mut did_cycle = false;
@@ -3605,22 +3620,15 @@ impl PeerNetwork {
                         self.work_state = PeerNetworkWorkState::BlockInvSync;
                     } else {
                         // (re)determine our public IP address
-                        match self.do_get_public_ip() {
-                            Ok(b) => {
-                                if b {
-                                    self.work_state = PeerNetworkWorkState::BlockInvSync;
-                                }
-                            }
-                            Err(e) => {
-                                info!("Failed to query public IP ({:?}) skipping", &e);
-                                self.work_state = PeerNetworkWorkState::BlockInvSync;
-                            }
+                        let done = self.do_get_public_ip();
+                        if done {
+                            self.work_state = PeerNetworkWorkState::BlockInvSync;
                         }
                     }
                 }
                 PeerNetworkWorkState::BlockInvSync => {
                     // synchronize peer block inventories
-                    let (inv_done, inv_throttled) = self.do_network_inv_sync(sortdb, ibd)?;
+                    let (inv_done, inv_throttled) = self.do_network_inv_sync(sortdb, ibd);
                     if inv_done {
                         if !download_backpressure {
                             // proceed to get blocks, if we're not backpressured
@@ -3721,13 +3729,15 @@ impl PeerNetwork {
                                 let (consensus_hash, _) =
                                     SortitionDB::get_canonical_stacks_chain_tip_hash(
                                         sortdb.conn(),
-                                    )?;
+                                    )
+                                    .expect("FATAL: failed to load canonical stacks chain tip hash from sortition DB");
 
                                 let stacks_tip_sortition_height =
                                     SortitionDB::get_block_snapshot_consensus(
                                         sortdb.conn(),
                                         &consensus_hash,
-                                    )?
+                                    )
+                                    .expect("FATAL: failed to query sortition DB")
                                     .map(|sn| sn.block_height)
                                     .unwrap_or(self.burnchain.first_block_height)
                                     .saturating_sub(self.burnchain.first_block_height);
@@ -3783,14 +3793,15 @@ impl PeerNetwork {
                     // go fetch blocks
                     match dns_client_opt {
                         Some(ref mut dns_client) => {
-                            if self.do_network_block_download(
+                            let done = self.do_network_block_download(
                                 sortdb,
                                 mempool,
                                 chainstate,
                                 *dns_client,
                                 ibd,
                                 network_result,
-                            )? {
+                            );
+                            if done {
                                 // advance work state
                                 self.work_state = PeerNetworkWorkState::AntiEntropy;
                             }
@@ -3812,15 +3823,7 @@ impl PeerNetwork {
                             &self.local_peer
                         );
                     } else {
-                        match self.try_push_local_data(sortdb, chainstate) {
-                            Ok(_) => {}
-                            Err(e) => {
-                                debug!(
-                                    "{:?}: Failed to push local data: {:?}",
-                                    &self.local_peer, &e
-                                );
-                            }
-                        };
+                        self.try_push_local_data(sortdb, chainstate);
                     }
                     self.work_state = PeerNetworkWorkState::Prune;
                 }
@@ -3848,7 +3851,7 @@ impl PeerNetwork {
             );
         }
 
-        Ok(do_prune)
+        do_prune
     }
 
     fn do_attachment_downloads(
@@ -3857,12 +3860,18 @@ impl PeerNetwork {
         chainstate: &mut StacksChainState,
         mut dns_client_opt: Option<&mut DNSClient>,
         network_result: &mut NetworkResult,
-    ) -> Result<(), net_error> {
+    ) {
         if self.attachments_downloader.is_none() {
-            self.atlasdb.evict_expired_uninstantiated_attachments()?;
             self.atlasdb
-                .evict_expired_unresolved_attachment_instances()?;
-            let initial_batch = self.atlasdb.find_unresolved_attachment_instances()?;
+                .evict_expired_uninstantiated_attachments()
+                .expect("FATAL: atlasdb error: evict_expired_uninstantiated_attachments");
+            self.atlasdb
+                .evict_expired_unresolved_attachment_instances()
+                .expect("FATAL: atlasdb error: evict_expired_unresolved_attachment_instances");
+            let initial_batch = self
+                .atlasdb
+                .find_unresolved_attachment_instances()
+                .expect("FATAL: atlasdb error: find_unresolved_attachment_instances");
 
             self.init_attachments_downloader(initial_batch);
         }
@@ -3887,7 +3896,7 @@ impl PeerNetwork {
                         }
                         Ok(dead_events)
                     },
-                )?;
+                ).expect("FATAL: with_attachments_downloader() should be infallible (and it is not initialized)");
 
                 let _ = PeerNetwork::with_network_state(
                     self,
@@ -3913,7 +3922,6 @@ impl PeerNetwork {
                 );
             }
         }
-        Ok(())
     }
 
     /// Given an event ID, find the other event ID corresponding
@@ -4680,7 +4688,7 @@ impl PeerNetwork {
         unsolicited: HashMap<usize, Vec<StacksMessage>>,
         ibd: bool,
         buffer: bool,
-    ) -> Result<HashMap<NeighborKey, Vec<StacksMessage>>, net_error> {
+    ) -> HashMap<NeighborKey, Vec<StacksMessage>> {
         let mut unhandled: HashMap<NeighborKey, Vec<StacksMessage>> = HashMap::new();
         for (event_id, messages) in unsolicited.into_iter() {
             let neighbor_key = match self.peers.get(&event_id) {
@@ -4737,7 +4745,7 @@ impl PeerNetwork {
                 }
             }
         }
-        Ok(unhandled)
+        unhandled
     }
 
     /// Find unauthenticated inbound conversations
@@ -4753,10 +4761,10 @@ impl PeerNetwork {
 
     /// Find inbound conversations that have authenticated, given a list of event ids to search
     /// for.  Add them to our network pingbacks
-    fn schedule_network_pingbacks(&mut self, event_ids: Vec<usize>) -> Result<(), net_error> {
+    fn schedule_network_pingbacks(&mut self, event_ids: Vec<usize>) {
         if cfg!(test) && self.connection_opts.disable_pingbacks {
             test_debug!("{:?}: pingbacks are disabled for testing", &self.local_peer);
-            return Ok(());
+            return;
         }
 
         // clear timed-out pingbacks
@@ -4796,7 +4804,7 @@ impl PeerNetwork {
                         &addr.addrbytes,
                         addr.port,
                     )
-                    .map_err(net_error::DBError)?;
+                    .expect("FATAL: failed to read from peer database");
 
                     if neighbor_opt.is_some() {
                         debug!(
@@ -4842,7 +4850,6 @@ impl PeerNetwork {
             &self.local_peer,
             self.walk_pingbacks.len()
         );
-        Ok(())
     }
 
     /// Count up the number of inbound neighbors that have public IP addresses (i.e. that we have
@@ -4950,13 +4957,8 @@ impl PeerNetwork {
         if sn.burn_header_hash != self.burnchain_tip.burn_header_hash {
             // try processing previously-buffered messages (best-effort)
             let buffered_messages = mem::replace(&mut self.pending_messages, HashMap::new());
-            ret = self.handle_unsolicited_messages(
-                sortdb,
-                chainstate,
-                buffered_messages,
-                ibd,
-                false,
-            )?;
+            ret =
+                self.handle_unsolicited_messages(sortdb, chainstate, buffered_messages, ibd, false);
         }
 
         // update cached stacks chain view for /v2/info
@@ -4980,14 +4982,14 @@ impl PeerNetwork {
         download_backpressure: bool,
         ibd: bool,
         mut poll_state: NetworkPollState,
-    ) -> Result<(), net_error> {
+    ) {
         if self.network.is_none() {
-            test_debug!("{:?}: network not connected", &self.local_peer);
-            return Err(net_error::NotConnected);
+            warn!("{:?}: network not connected", &self.local_peer);
+            return;
         }
 
         // set up new inbound conversations
-        self.process_new_sockets(&mut poll_state)?;
+        self.process_new_sockets(&mut poll_state);
 
         // set up sockets that have finished connecting
         self.process_connecting_sockets(&mut poll_state);
@@ -5006,11 +5008,11 @@ impl PeerNetwork {
             self.deregister_peer(error_event);
         }
         let unhandled_messages =
-            self.handle_unsolicited_messages(sortdb, chainstate, unsolicited_messages, ibd, true)?;
+            self.handle_unsolicited_messages(sortdb, chainstate, unsolicited_messages, ibd, true);
         network_result.consume_unsolicited(unhandled_messages);
 
         // schedule now-authenticated inbound convos for pingback
-        self.schedule_network_pingbacks(unauthenticated_inbounds)?;
+        self.schedule_network_pingbacks(unauthenticated_inbounds);
 
         // do some Actual Work(tm)
         // do this _after_ processing new sockets, so the act of opening a socket doesn't trample
@@ -5023,35 +5025,36 @@ impl PeerNetwork {
             download_backpressure,
             ibd,
             network_result,
-        )?;
+        );
         if do_prune {
             // prune back our connections if it's been a while
             // (only do this if we're done with all other tasks).
             // Also, process banned peers.
-            let mut dead_events = self.process_bans()?;
-            for dead in dead_events.drain(..) {
-                debug!(
-                    "{:?}: Banned connection on event {}",
-                    &self.local_peer, dead
-                );
-                self.deregister_peer(dead);
+            if let Ok(mut dead_events) = self.process_bans() {
+                for dead in dead_events.drain(..) {
+                    debug!(
+                        "{:?}: Banned connection on event {}",
+                        &self.local_peer, dead
+                    );
+                    self.deregister_peer(dead);
+                }
             }
             self.prune_connections();
         }
 
         // In parallel, do a neighbor walk
-        self.do_network_neighbor_walk(ibd)?;
+        self.do_network_neighbor_walk(ibd);
 
         // In parallel, do a mempool sync.
         // Remember any txs we get, so we can feed them to the relayer thread.
         if let Some(mut txs) =
-            self.do_network_mempool_sync(&mut dns_client_opt, mempool, chainstate, ibd)?
+            self.do_network_mempool_sync(&mut dns_client_opt, mempool, chainstate, ibd)
         {
             network_result.synced_transactions.append(&mut txs);
         }
 
         // download attachments
-        self.do_attachment_downloads(mempool, chainstate, dns_client_opt, network_result)?;
+        self.do_attachment_downloads(mempool, chainstate, dns_client_opt, network_result);
 
         // remove timed-out requests from other threads
         for (_, convo) in self.peers.iter_mut() {
@@ -5077,10 +5080,15 @@ impl PeerNetwork {
         // is our key about to expire?  do we need to re-key?
         // NOTE: must come last since it invalidates local_peer
         if self.local_peer.private_key_expire < self.chain_view.burn_block_height + 1 {
-            self.peerdb.rekey(
-                self.local_peer.private_key_expire + self.connection_opts.private_key_lifetime,
-            )?;
-            let new_local_peer = self.load_local_peer()?;
+            self.peerdb
+                .rekey(
+                    self.local_peer.private_key_expire + self.connection_opts.private_key_lifetime,
+                )
+                .expect("FATAL: failed to rekey peer DB");
+
+            let new_local_peer = self
+                .load_local_peer()
+                .expect("FATAL: failed to load local peer from peer DB");
             let old_local_peer = self.local_peer.clone();
             self.local_peer = new_local_peer;
             self.rekey(Some(&old_local_peer));
@@ -5111,8 +5119,6 @@ impl PeerNetwork {
                 }
             }
         }
-
-        Ok(())
     }
 
     /// Store a single transaction
@@ -5229,6 +5235,9 @@ impl PeerNetwork {
     /// -- runs the p2p and http peer main loop
     /// Returns the table of unhandled network messages to be acted upon, keyed by the neighbors
     /// that sent them (i.e. keyed by their event IDs)
+    ///
+    /// This method can only fail if the internal network object (self.network) is not
+    /// instantiated.
     pub fn run(
         &mut self,
         sortdb: &SortitionDB,
@@ -5267,32 +5276,31 @@ impl PeerNetwork {
         );
 
         // update local-peer state
-        self.refresh_local_peer()?;
+        self.refresh_local_peer()
+            .expect("FATAL: failed to read local peer from the peer DB");
 
         // update burnchain view, before handling any HTTP connections
-        let unsolicited_buffered_messages = self.refresh_burnchain_view(sortdb, chainstate, ibd)?;
+        let unsolicited_buffered_messages = self
+            .refresh_burnchain_view(sortdb, chainstate, ibd)
+            .expect("FATAL: failed to refresh burnchain view");
+
         network_result.consume_unsolicited(unsolicited_buffered_messages);
 
         // update PoX view, before handling any HTTP connections
-        self.refresh_sortition_view(sortdb)?;
+        self.refresh_sortition_view(sortdb)
+            .expect("FATAL: failed to refresh sortition view from sortition DB");
 
         // This operation needs to be performed before any early return:
         // Events are being parsed and dispatched here once and we want to
         // enqueue them.
-        match PeerNetwork::with_attachments_downloader(self, |network, attachments_downloader| {
-            let mut known_attachments = attachments_downloader.enqueue_new_attachments(
-                attachment_requests,
-                &mut network.atlasdb,
-                false,
-            )?;
+        PeerNetwork::with_attachments_downloader(self, |network, attachments_downloader| {
+            let mut known_attachments = attachments_downloader
+                .enqueue_new_attachments(attachment_requests, &mut network.atlasdb, false)
+                .expect("FATAL: failed to store new attachments to the atlas DB");
             network_result.attachments.append(&mut known_attachments);
             Ok(())
-        }) {
-            Ok(_) => {}
-            Err(e) => {
-                warn!("Atlas: updating attachment inventory failed: {}", e);
-            }
-        }
+        })
+        .expect("FATAL: with_attachments_downloader should be infallable (not connected)");
 
         PeerNetwork::with_network_state(self, |ref mut network, ref mut network_state| {
             let http_stacks_msgs = PeerNetwork::with_http(network, |ref mut net, ref mut http| {
@@ -5305,10 +5313,11 @@ impl PeerNetwork {
                     http_poll_state,
                     handler_args,
                 )
-            })?;
+            });
             network_result.consume_http_uploads(http_stacks_msgs);
             Ok(())
-        })?;
+        })
+        .expect("FATAL: with_network_state should be infallable (not connected)");
 
         self.dispatch_network(
             &mut network_result,
@@ -5319,7 +5328,7 @@ impl PeerNetwork {
             download_backpressure,
             ibd,
             p2p_poll_state,
-        )?;
+        );
 
         debug!("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< End Network Dispatch <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
         Ok(network_result)
@@ -5485,7 +5494,7 @@ mod test {
 
                     let mut p2p_poll_state = poll_states.remove(&p2p.p2p_network_handle).unwrap();
 
-                    p2p.process_new_sockets(&mut p2p_poll_state).unwrap();
+                    p2p.process_new_sockets(&mut p2p_poll_state);
                     p2p.process_connecting_sockets(&mut p2p_poll_state);
                     total_disconnected += p2p.disconnect_unresponsive();
 
@@ -5562,7 +5571,7 @@ mod test {
 
                     let mut p2p_poll_state = poll_states.remove(&p2p.p2p_network_handle).unwrap();
 
-                    p2p.process_new_sockets(&mut p2p_poll_state).unwrap();
+                    p2p.process_new_sockets(&mut p2p_poll_state);
                     p2p.process_connecting_sockets(&mut p2p_poll_state);
 
                     thread::sleep(time::Duration::from_millis(1000));
@@ -5656,7 +5665,7 @@ mod test {
 
                     let mut p2p_poll_state = poll_state.remove(&p2p.p2p_network_handle).unwrap();
 
-                    p2p.process_new_sockets(&mut p2p_poll_state).unwrap();
+                    p2p.process_new_sockets(&mut p2p_poll_state);
                     p2p.process_connecting_sockets(&mut p2p_poll_state);
 
                     let mut banned = p2p.process_bans().unwrap();

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -375,7 +375,7 @@ impl HttpPeer {
         mempool: &MemPoolDB,
         chainstate: &mut StacksChainState,
         poll_state: &mut NetworkPollState,
-    ) -> Result<Vec<usize>, net_error> {
+    ) -> Vec<usize> {
         let mut registered = vec![];
 
         for (hint_event_id, client_sock) in poll_state.new.drain() {
@@ -420,7 +420,7 @@ impl HttpPeer {
             registered.push(event_id);
         }
 
-        Ok(registered)
+        registered
     }
 
     /// Process network traffic on a HTTP conversation.
@@ -680,9 +680,9 @@ impl HttpPeer {
         mempool: &mut MemPoolDB,
         mut poll_state: NetworkPollState,
         handler_args: &RPCHandlerArgs,
-    ) -> Result<Vec<StacksMessageType>, net_error> {
+    ) -> Vec<StacksMessageType> {
         // set up new inbound conversations
-        self.process_new_sockets(network_state, mempool, chainstate, &mut poll_state)?;
+        self.process_new_sockets(network_state, mempool, chainstate, &mut poll_state);
 
         // set up connected sockets
         self.process_connecting_sockets(network_state, mempool, chainstate, &mut poll_state);
@@ -716,7 +716,7 @@ impl HttpPeer {
         // clear out slow or non-responsive peers
         self.disconnect_unresponsive(network_state);
 
-        Ok(stacks_msgs)
+        stacks_msgs
     }
 }
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -774,10 +774,9 @@ fn spawn_peer(
                         }
                     }
                     Err(e) => {
-                        error!("P2P: Failed to process network dispatch: {:?}", &e);
-                        if config.is_node_event_driven() {
-                            panic!();
-                        }
+                        // this is only reachable if the network is not instantiated correctly --
+                        // i.e. you didn't connect it
+                        panic!("P2P: Failed to process network dispatch: {:?}", &e);
                     }
                 };
 

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -550,7 +550,7 @@ impl RunLoop {
 
         // Wait for some sortitions!
         let mut burnchain_tip = burnchain
-            .wait_for_sortitions(Some(burnchain_config.first_block_height))
+            .wait_for_sortitions(Some(burnchain_config.first_block_height + 1))
             .expect("Unable to get burnchain tip");
 
         // Boot up the p2p network and relayer, and figure out how many sortitions we have so far

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -550,7 +550,7 @@ impl RunLoop {
 
         // Wait for some sortitions!
         let mut burnchain_tip = burnchain
-            .wait_for_sortitions(None)
+            .wait_for_sortitions(Some(burnchain_config.first_block_height))
             .expect("Unable to get burnchain tip");
 
         // Boot up the p2p network and relayer, and figure out how many sortitions we have so far


### PR DESCRIPTION
### Description

This tries to fix the startup locking scenario of #3216 by reducing the amount of synchronization required before starting the p2p thread: rather than requiring the "sortition db" to reach the burnchain tip, this just makes sure that the sortition db reaches the first block height.

### Applicable issues
- fixes #3216

