### PR TITLE
Exclude codecov error from CI test pass/fail status

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -101,7 +101,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           TEST_NAME: ${{ matrix.test-name }}
         run: docker build -o coverage-output --build-arg test_name=${{ matrix.test-name }} -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
@@ -131,7 +131,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           TEST_NAME: ${{ matrix.test-name }}
         run: docker build -o coverage-output --build-arg test_name=${{ matrix.test-name }} -f ./.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests .
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   atlas-test:
     if: ${{ true }}
     runs-on: ubuntu-latest
@@ -135,4 +135,4 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true
   atlas-test:
     if: ${{ true }}
     runs-on: ubuntu-latest
@@ -135,4 +135,4 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: large_genesis
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   # Run unit tests with code coverage
   unit-tests:
@@ -52,7 +52,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: unit_tests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   open-api-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: large_genesis
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   # Run unit tests with code coverage
   unit-tests:
@@ -52,7 +52,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: unit_tests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   open-api-validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
More than 50% of the failing tests in github pull requests are from the codecov step that happens after cargo test. This patch sets a `codecov-actiion@v2` config setting `fail_ci_if_error` to `false` so that the CI test results reflect the result of the cargo test. 

The codecov upload error reports `POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}` Yet it is inconsistent - the same test for the same PR will have its codecov step work on some CI runs, and fail on others.