### PR TITLE
Enables hot reloading of mining configuration file

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -116,7 +116,8 @@ impl LeaderBlockCommitFees {
         config: &Config,
         config_handle: &ConfigHandle,
     ) -> LeaderBlockCommitFees {
-        let mut fees = LeaderBlockCommitFees::estimated_fees_from_payload(payload, config, config_handle);
+        let mut fees =
+            LeaderBlockCommitFees::estimated_fees_from_payload(payload, config, config_handle);
         fees.spent_in_attempts = cmp::max(1, self.spent_in_attempts);
         fees.final_size = self.final_size;
         fees.fee_rate = self.fee_rate + config_handle.get().burnchain.rbf_fee_increment;
@@ -214,7 +215,7 @@ impl BitcoinRegtestController {
         let config_handle = ConfigHandle::new(config.clone());
         Self::with_burnchain(config, config_handle, None, Some(burnchain_config), None)
     }
-    
+
     pub fn with_burnchain(
         config: Config,
         config_handle: ConfigHandle,
@@ -749,7 +750,13 @@ impl BitcoinRegtestController {
         // Serialize the payload
         let op_bytes = {
             let mut buffer = vec![];
-            let mut magic_bytes = self.config_handle.get().burnchain.magic_bytes.as_bytes().to_vec();
+            let mut magic_bytes = self
+                .config_handle
+                .get()
+                .burnchain
+                .magic_bytes
+                .as_bytes()
+                .to_vec();
             buffer.append(&mut magic_bytes);
             payload
                 .consensus_serialize(&mut buffer)
@@ -867,7 +874,8 @@ impl BitcoinRegtestController {
         } else {
             self.prepare_tx(
                 &public_key,
-                DUST_UTXO_LIMIT + max_tx_size * self.config_handle.get().burnchain.satoshis_per_byte,
+                DUST_UTXO_LIMIT
+                    + max_tx_size * self.config_handle.get().burnchain.satoshis_per_byte,
                 None,
                 None,
                 0,
@@ -931,7 +939,8 @@ impl BitcoinRegtestController {
         let public_key = signer.get_public_key();
         let max_tx_size = 280;
 
-        let output_amt = DUST_UTXO_LIMIT + max_tx_size * self.config_handle.get().burnchain.satoshis_per_byte;
+        let output_amt =
+            DUST_UTXO_LIMIT + max_tx_size * self.config_handle.get().burnchain.satoshis_per_byte;
         let (mut tx, mut utxos) = self.prepare_tx(&public_key, output_amt, None, None, 0)?;
 
         // Serialize the payload
@@ -983,7 +992,11 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let mut estimated_fees = match previous_fees {
             Some(fees) => fees.fees_from_previous_tx(&payload, &self.config, &self.config_handle),
-            None => LeaderBlockCommitFees::estimated_fees_from_payload(&payload, &self.config, &self.config_handle),
+            None => LeaderBlockCommitFees::estimated_fees_from_payload(
+                &payload,
+                &self.config,
+                &self.config_handle,
+            ),
         };
 
         let public_key = signer.get_public_key();
@@ -1125,7 +1138,9 @@ impl BitcoinRegtestController {
 
         // Stop as soon as the fee_rate is ${self.config.burnchain.max_rbf} percent higher, stop RBF
         if ongoing_op.fees.fee_rate
-            > (self.config_handle.get().burnchain.satoshis_per_byte * self.config_handle.get().burnchain.max_rbf / 100)
+            > (self.config_handle.get().burnchain.satoshis_per_byte
+                * self.config_handle.get().burnchain.max_rbf
+                / 100)
         {
             warn!(
                 "RBF'd block commits reached {}% satoshi per byte fee rate, not resubmitting",

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -58,6 +58,8 @@ use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
 
 use stacks::monitoring::{increment_btc_blocks_received_counter, increment_btc_ops_sent_counter};
 
+use crate::config::ConfigHandle;
+
 #[cfg(test)]
 use stacks::chainstate::burn::Opcodes;
 use stacks::types::chainstate::BurnchainHeaderHash;
@@ -70,6 +72,7 @@ const DUST_UTXO_LIMIT: u64 = 5500;
 
 pub struct BitcoinRegtestController {
     config: Config,
+    config_handle: ConfigHandle,
     indexer: BitcoinIndexer,
     db: Option<SortitionDB>,
     burnchain_db: Option<BurnchainDB>,
@@ -111,11 +114,12 @@ impl LeaderBlockCommitFees {
         &self,
         payload: &LeaderBlockCommitOp,
         config: &Config,
+        config_handle: &ConfigHandle,
     ) -> LeaderBlockCommitFees {
-        let mut fees = LeaderBlockCommitFees::estimated_fees_from_payload(payload, config);
+        let mut fees = LeaderBlockCommitFees::estimated_fees_from_payload(payload, config, config_handle);
         fees.spent_in_attempts = cmp::max(1, self.spent_in_attempts);
         fees.final_size = self.final_size;
-        fees.fee_rate = self.fee_rate + config.burnchain.rbf_fee_increment;
+        fees.fee_rate = self.fee_rate + config_handle.get().burnchain.rbf_fee_increment;
         fees.is_rbf_enabled = true;
         fees
     }
@@ -123,6 +127,7 @@ impl LeaderBlockCommitFees {
     pub fn estimated_fees_from_payload(
         payload: &LeaderBlockCommitOp,
         config: &Config,
+        config_handle: &ConfigHandle,
     ) -> LeaderBlockCommitFees {
         let sunset_fee = if payload.sunset_burn > 0 {
             cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT)
@@ -134,7 +139,7 @@ impl LeaderBlockCommitFees {
         let value_per_transfer = payload.burn_fee / number_of_transfers;
         let sortition_fee = value_per_transfer * number_of_transfers;
         let spent_in_attempts = 0;
-        let fee_rate = config.burnchain.satoshis_per_byte;
+        let fee_rate = config_handle.get().burnchain.satoshis_per_byte;
         let default_tx_size = config.burnchain.block_commit_tx_estimated_size;
 
         LeaderBlockCommitFees {
@@ -195,11 +200,24 @@ impl LeaderBlockCommitFees {
 
 impl BitcoinRegtestController {
     pub fn new(config: Config, coordinator_channel: Option<CoordinatorChannels>) -> Self {
-        BitcoinRegtestController::with_burnchain(config, coordinator_channel, None, None)
+        let config_handle = ConfigHandle::new(config.clone());
+        BitcoinRegtestController::with_burnchain(
+            config,
+            config_handle,
+            coordinator_channel,
+            None,
+            None,
+        )
     }
 
+    pub fn with_burnchain_test(config: Config, burnchain_config: Burnchain) -> Self {
+        let config_handle = ConfigHandle::new(config.clone());
+        Self::with_burnchain(config, config_handle, None, Some(burnchain_config), None)
+    }
+    
     pub fn with_burnchain(
         config: Config,
+        config_handle: ConfigHandle,
         coordinator_channel: Option<CoordinatorChannels>,
         burnchain_config: Option<Burnchain>,
         should_keep_running: Option<Arc<AtomicBool>>,
@@ -256,6 +274,7 @@ impl BitcoinRegtestController {
         Self {
             use_coordinator: coordinator_channel,
             config,
+            config_handle,
             indexer: burnchain_indexer,
             db: None,
             burnchain_db: None,
@@ -268,7 +287,7 @@ impl BitcoinRegtestController {
 
     /// create a dummy bitcoin regtest controller.
     ///   used just for submitting bitcoin ops.
-    pub fn new_dummy(config: Config) -> Self {
+    pub fn new_dummy(config: Config, config_handle: ConfigHandle) -> Self {
         let (network, _) = config.burnchain.get_bitcoin_network();
         let burnchain_params = BurnchainParameters::from_params(&config.burnchain.chain, &network)
             .expect("Bitcoin network unsupported");
@@ -300,6 +319,7 @@ impl BitcoinRegtestController {
         Self {
             use_coordinator: None,
             config,
+            config_handle,
             indexer: burnchain_indexer,
             db: None,
             burnchain_db: None,
@@ -312,7 +332,8 @@ impl BitcoinRegtestController {
 
     /// Creates a dummy bitcoin regtest controller, with the given ongoing block-commits
     pub fn new_ongoing_dummy(config: Config, ongoing: Option<OngoingBlockCommit>) -> Self {
-        let mut ret = Self::new_dummy(config);
+        let config_handle = ConfigHandle::new(config.clone());
+        let mut ret = Self::new_dummy(config, config_handle);
         ret.ongoing_block_commit = ongoing;
         ret
     }
@@ -719,7 +740,7 @@ impl BitcoinRegtestController {
         let public_key = signer.get_public_key();
 
         let btc_miner_fee = self.config.burnchain.leader_key_tx_estimated_size
-            * self.config.burnchain.satoshis_per_byte;
+            * self.config_handle.get().burnchain.satoshis_per_byte;
         let budget_for_outputs = DUST_UTXO_LIMIT;
         let total_required = btc_miner_fee + budget_for_outputs;
 
@@ -728,7 +749,7 @@ impl BitcoinRegtestController {
         // Serialize the payload
         let op_bytes = {
             let mut buffer = vec![];
-            let mut magic_bytes = self.config.burnchain.magic_bytes.as_bytes().to_vec();
+            let mut magic_bytes = self.config_handle.get().burnchain.magic_bytes.as_bytes().to_vec();
             buffer.append(&mut magic_bytes);
             payload
                 .consensus_serialize(&mut buffer)
@@ -751,7 +772,7 @@ impl BitcoinRegtestController {
 
         tx.output.push(identifier_output);
 
-        let fee_rate = self.config.burnchain.satoshis_per_byte;
+        let fee_rate = self.config_handle.get().burnchain.satoshis_per_byte;
 
         self.finalize_tx(
             &mut tx,
@@ -846,7 +867,7 @@ impl BitcoinRegtestController {
         } else {
             self.prepare_tx(
                 &public_key,
-                DUST_UTXO_LIMIT + max_tx_size * self.config.burnchain.satoshis_per_byte,
+                DUST_UTXO_LIMIT + max_tx_size * self.config_handle.get().burnchain.satoshis_per_byte,
                 None,
                 None,
                 0,
@@ -877,7 +898,7 @@ impl BitcoinRegtestController {
             DUST_UTXO_LIMIT,
             0,
             max_tx_size,
-            self.config.burnchain.satoshis_per_byte,
+            self.config_handle.get().burnchain.satoshis_per_byte,
             &mut utxos,
             signer,
         )?;
@@ -910,7 +931,7 @@ impl BitcoinRegtestController {
         let public_key = signer.get_public_key();
         let max_tx_size = 280;
 
-        let output_amt = DUST_UTXO_LIMIT + max_tx_size * self.config.burnchain.satoshis_per_byte;
+        let output_amt = DUST_UTXO_LIMIT + max_tx_size * self.config_handle.get().burnchain.satoshis_per_byte;
         let (mut tx, mut utxos) = self.prepare_tx(&public_key, output_amt, None, None, 0)?;
 
         // Serialize the payload
@@ -936,7 +957,7 @@ impl BitcoinRegtestController {
             output_amt,
             0,
             max_tx_size,
-            self.config.burnchain.satoshis_per_byte,
+            self.config_handle.get().burnchain.satoshis_per_byte,
             &mut utxos,
             signer,
         )?;
@@ -961,8 +982,8 @@ impl BitcoinRegtestController {
         previous_txids: &Vec<Txid>,
     ) -> Option<Transaction> {
         let mut estimated_fees = match previous_fees {
-            Some(fees) => fees.fees_from_previous_tx(&payload, &self.config),
-            None => LeaderBlockCommitFees::estimated_fees_from_payload(&payload, &self.config),
+            Some(fees) => fees.fees_from_previous_tx(&payload, &self.config, &self.config_handle),
+            None => LeaderBlockCommitFees::estimated_fees_from_payload(&payload, &self.config, &self.config_handle),
         };
 
         let public_key = signer.get_public_key();
@@ -1104,11 +1125,11 @@ impl BitcoinRegtestController {
 
         // Stop as soon as the fee_rate is ${self.config.burnchain.max_rbf} percent higher, stop RBF
         if ongoing_op.fees.fee_rate
-            > (self.config.burnchain.satoshis_per_byte * self.config.burnchain.max_rbf / 100)
+            > (self.config_handle.get().burnchain.satoshis_per_byte * self.config_handle.get().burnchain.max_rbf / 100)
         {
             warn!(
                 "RBF'd block commits reached {}% satoshi per byte fee rate, not resubmitting",
-                self.config.burnchain.max_rbf
+                self.config_handle.get().burnchain.max_rbf
             );
             self.ongoing_block_commit = Some(ongoing_op);
             return None;

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1,11 +1,11 @@
-use std::cell::{Cell, Ref, RefCell};
+use std::cell::RefCell;
 use std::convert::TryInto;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::SystemTime;
-use std::{convert, fs, thread};
+use std::{convert, fs};
 
 use rand::RngCore;
 
@@ -1571,7 +1571,7 @@ impl FeeEstimationConfig {
                     .try_into()
                     .expect("Configured fee rate window size out of bounds."),
             )
-                .expect("Error opening fee estimator");
+            .expect("Error opening fee estimator");
             Box::new(FeeRateFuzzer::new(
                 underlying_estimator,
                 self.fee_rate_fuzzer_fraction,

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -562,7 +562,7 @@ impl Config {
     pub fn from_config_file(config_file: ConfigFile) -> Result<Config, String> {
         Config::from_config_file_with_options(config_file, true)
     }
-    
+
     pub fn from_config_file_with_options(
         config_file: ConfigFile,
         verbose: bool,

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::convert::TryInto;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
@@ -491,39 +490,39 @@ impl ConfigLoader {
 
 #[derive(Clone, Debug)]
 pub struct ConfigLoaderHandle {
-    handle: std::sync::Arc<std::sync::Mutex<RefCell<ConfigLoader>>>,
+    handle: std::sync::Arc<std::sync::Mutex<ConfigLoader>>,
 }
 
 impl ConfigLoaderHandle {
     pub fn new(config_loader: ConfigLoader) -> ConfigLoaderHandle {
         ConfigLoaderHandle {
-            handle: std::sync::Arc::new(std::sync::Mutex::new(RefCell::new(config_loader))),
+            handle: std::sync::Arc::new(std::sync::Mutex::new(config_loader)),
         }
     }
 
     pub fn get(&self) -> ConfigLoader {
-        self.handle.lock().unwrap().borrow().clone()
+        self.handle.lock().unwrap().clone()
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct ConfigHandle {
-    handle: std::sync::Arc<std::sync::Mutex<RefCell<Config>>>,
+    handle: std::sync::Arc<std::sync::Mutex<Config>>,
 }
 
 impl ConfigHandle {
     pub fn new(config: Config) -> ConfigHandle {
         ConfigHandle {
-            handle: std::sync::Arc::new(std::sync::Mutex::new(RefCell::new(config))),
+            handle: std::sync::Arc::new(std::sync::Mutex::new(config)),
         }
     }
 
     pub fn replace(&self, config: &Config) {
-        self.handle.lock().unwrap().replace(config.clone());
+        *self.handle.lock().unwrap() = config.clone();
     }
 
     pub fn get(&self) -> Config {
-        self.handle.lock().unwrap().borrow().clone()
+        self.handle.lock().unwrap().clone()
     }
 }
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -843,8 +843,8 @@ impl Config {
                 .map(|balance| {
                     let address: PrincipalData =
                         PrincipalData::parse_standard_principal(&balance.address)
-                        .unwrap()
-                        .into();
+                            .unwrap()
+                            .into();
                     InitialBalance {
                         address,
                         amount: balance.amount,

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -190,7 +190,7 @@ fn main() {
     let conf = match Config::from_config_file(config_file) {
         Ok(conf) => conf,
         Err(e) => {
-            warn!("Invalid config: {}", e);
+            error!("Invalid config: {}", e);
             process::exit(1);
         }
     };

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -45,7 +45,7 @@ pub use self::run_loop::{helium, neon};
 pub use self::tenure::Tenure;
 
 use pico_args::Arguments;
-use std::{env, thread};
+use std::env;
 
 use std::convert::TryInto;
 use std::panic;

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -136,6 +136,7 @@
 ///    * Metrics about the node's behavior (e.g. number of blocks processed, etc.)
 ///
 /// This file may be refactored in the future into a full-fledged module.
+use std::borrow::Borrow;
 use std::cmp;
 use std::collections::HashMap;
 use std::collections::{HashSet, VecDeque};
@@ -143,6 +144,7 @@ use std::convert::{TryFrom, TryInto};
 use std::default::Default;
 use std::mem;
 use std::net::SocketAddr;
+use std::ops::Deref;
 use std::sync::mpsc::{Receiver, SyncSender, TrySendError};
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc, Mutex};
 use std::time::Duration;
@@ -203,6 +205,7 @@ use stacks::{burnchains::BurnchainSigner, chainstate::stacks::db::StacksHeaderIn
 
 use crate::burnchains::bitcoin_regtest_controller::BitcoinRegtestController;
 use crate::burnchains::bitcoin_regtest_controller::OngoingBlockCommit;
+use crate::config::ConfigHandle;
 use crate::run_loop::neon::Counters;
 use crate::run_loop::neon::RunLoop;
 use crate::run_loop::RegisteredKey;

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -136,7 +136,6 @@
 ///    * Metrics about the node's behavior (e.g. number of blocks processed, etc.)
 ///
 /// This file may be refactored in the future into a full-fledged module.
-use std::borrow::Borrow;
 use std::cmp;
 use std::collections::HashMap;
 use std::collections::{HashSet, VecDeque};
@@ -144,7 +143,6 @@ use std::convert::{TryFrom, TryInto};
 use std::default::Default;
 use std::mem;
 use std::net::SocketAddr;
-use std::ops::Deref;
 use std::sync::mpsc::{Receiver, SyncSender, TrySendError};
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc, Mutex};
 use std::time::Duration;

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -662,6 +662,7 @@ impl MicroblockMinerThread {
     pub fn from_relayer_thread(relayer_thread: &RelayerThread) -> Option<MicroblockMinerThread> {
         let globals = relayer_thread.globals.clone();
         let config = relayer_thread.config.clone();
+        let config_handle = ConfigHandle::new(config.clone());
         let miner_tip = match relayer_thread.miner_tip.clone() {
             Some(tip) => tip,
             None => {
@@ -744,7 +745,7 @@ impl MicroblockMinerThread {
                     relayer_thread.microblock_stream_cost.clone()
                 };
 
-                let frequency = config.node.microblock_frequency;
+                let frequency = config_handle.get().node.microblock_frequency;
                 let settings =
                     config.make_block_builder_settings(0, true, globals.get_miner_status());
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1897,7 +1897,8 @@ impl RelayerThread {
         .expect("Database failure opening mempool");
 
         let keychain = Keychain::default(config.node.seed.clone());
-        let bitcoin_controller = BitcoinRegtestController::new_dummy(config.clone());
+        let config_handle = ConfigHandle::new(config.clone());
+        let bitcoin_controller = BitcoinRegtestController::new_dummy(config.clone(), config_handle);
 
         RelayerThread {
             config: config.clone(),

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -241,13 +241,13 @@ impl RunLoop {
     }
 
     pub fn config_loader_handle(&self) -> &ConfigLoaderHandle {
-         &self.config_loader_handle
+        &self.config_loader_handle
     }
-    
+
     pub fn config_handle(&self) -> ConfigHandle {
         self.config_loader_handle.get().get_config_handle().clone()
     }
-    
+
     pub fn get_event_dispatcher(&self) -> EventDispatcher {
         self.event_dispatcher.clone()
     }

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -1,6 +1,4 @@
 use libc;
-use libc::newlocale;
-use std::cell::{Cell, RefCell};
 use std::cmp;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -27,9 +27,9 @@ use stacks::vm::types::PrincipalData;
 use stacks::vm::ContractName;
 use std::convert::TryFrom;
 
-use crate::config::{ConfigHandle, EventKeyType};
 use crate::config::EventObserverConfig;
 use crate::config::InitialBalance;
+use crate::config::{ConfigHandle, EventKeyType};
 use crate::tests::bitcoin_regtest::BitcoinCoreController;
 use crate::tests::make_contract_call;
 use crate::tests::make_contract_call_mblock_only;

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -27,7 +27,7 @@ use stacks::vm::types::PrincipalData;
 use stacks::vm::ContractName;
 use std::convert::TryFrom;
 
-use crate::config::EventKeyType;
+use crate::config::{ConfigHandle, EventKeyType};
 use crate::config::EventObserverConfig;
 use crate::config::InitialBalance;
 use crate::tests::bitcoin_regtest::BitcoinCoreController;
@@ -545,7 +545,8 @@ fn transition_empty_blocks() {
     // second block will be the first mined Stacks block
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
-    let mut bitcoin_controller = BitcoinRegtestController::new_dummy(conf.clone());
+    let config_handle = ConfigHandle::new(conf.clone());
+    let mut bitcoin_controller = BitcoinRegtestController::new_dummy(conf.clone(), config_handle);
     let burnchain = Burnchain::regtest(&conf.get_burn_db_path());
 
     // these should all succeed across the epoch boundary

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -82,7 +82,7 @@ use super::{
     make_microblock, make_stacks_transfer, make_stacks_transfer_mblock_only, to_addr, ADDR_4, SK_1,
     SK_2,
 };
-use crate::config::{ConfigHandle, FeeEstimatorName};
+use crate::config::FeeEstimatorName;
 use crate::tests::SK_3;
 use clarity::vm::ast::stack_depth_checker::AST_CALL_STACK_DEPTH_BUFFER;
 use clarity::vm::ast::ASTRules;
@@ -5189,6 +5189,7 @@ fn block_large_tx_integration_test() {
 
 #[test]
 #[ignore]
+#[allow(non_snake_case)]
 fn microblock_large_tx_integration_test_FLAKY() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
@@ -6552,7 +6553,7 @@ fn antientropy_integration_test() {
         tip_height, tip_height, target_height
     );
 
-    let mut btc_regtest_controller =
+    let btc_regtest_controller =
         BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node.clone(), burnchain_config.clone());
 
     let mut burnchain_deadline = get_epoch_time_secs() + 60;

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -5927,8 +5927,10 @@ fn atlas_integration_test() {
     let bootstrap_node_thread = thread::spawn(move || {
         let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
 
-        let mut btc_regtest_controller =
-            BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node.clone(), burnchain_config.clone());
+        let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain_test(
+            conf_bootstrap_node.clone(),
+            burnchain_config.clone(),
+        );
         let http_origin = format!("http://{}", &conf_bootstrap_node.node.rpc_bind);
 
         btc_regtest_controller.bootstrap_chain(201);
@@ -6452,8 +6454,10 @@ fn antientropy_integration_test() {
 
     let conf_bootstrap_node_clone = conf_bootstrap_node.clone();
     let bootstrap_node_thread = thread::spawn(move || {
-        let mut btc_regtest_controller =
-            BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node_clone.clone(), burnchain_config.clone());
+        let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain_test(
+            conf_bootstrap_node_clone.clone(),
+            burnchain_config.clone(),
+        );
 
         btc_regtest_controller.bootstrap_chain(201);
 
@@ -6553,8 +6557,10 @@ fn antientropy_integration_test() {
         tip_height, tip_height, target_height
     );
 
-    let btc_regtest_controller =
-        BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node.clone(), burnchain_config.clone());
+    let btc_regtest_controller = BitcoinRegtestController::with_burnchain_test(
+        conf_bootstrap_node.clone(),
+        burnchain_config.clone(),
+    );
 
     let mut burnchain_deadline = get_epoch_time_secs() + 60;
     while tip_height < (target_height - 3) as u64 {
@@ -6677,8 +6683,10 @@ fn atlas_stress_integration_test() {
 
     let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
 
-    let mut btc_regtest_controller =
-        BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node.clone(), burnchain_config.clone());
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain_test(
+        conf_bootstrap_node.clone(),
+        burnchain_config.clone(),
+    );
     let http_origin = format!("http://{}", &conf_bootstrap_node.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -9864,8 +9872,10 @@ fn test_competing_miners_build_on_same_chain(
         .map_err(|_e| ())
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller =
-        BitcoinRegtestController::with_burnchain_test(confs[0].clone(), burnchain_configs[0].clone());
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain_test(
+        confs[0].clone(),
+        burnchain_configs[0].clone(),
+    );
 
     btc_regtest_controller.bootstrap_chain(1);
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -5927,7 +5927,7 @@ fn atlas_integration_test() {
         let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
 
         let mut btc_regtest_controller =
-            BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
+            BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node.clone(), burnchain_config.clone());
         let http_origin = format!("http://{}", &conf_bootstrap_node.node.rpc_bind);
 
         btc_regtest_controller.bootstrap_chain(201);
@@ -6449,15 +6449,16 @@ fn antientropy_integration_test() {
     let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
     let target_height = 3 + (3 * burnchain_config.pox_constants.reward_cycle_length);
 
+    let conf_bootstrap_node_clone = conf_bootstrap_node.clone();
     let bootstrap_node_thread = thread::spawn(move || {
         let mut btc_regtest_controller =
-            BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
+            BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node_clone.clone(), burnchain_config.clone());
 
         btc_regtest_controller.bootstrap_chain(201);
 
         eprintln!("Chain bootstrapped...");
 
-        let mut run_loop = neon::RunLoop::new(conf_bootstrap_node.clone());
+        let mut run_loop = neon::RunLoop::new(conf_bootstrap_node_clone.clone());
         let blocks_processed = run_loop.get_blocks_processed_arc();
         let channel = run_loop.get_coordinator_channel().unwrap();
 
@@ -6552,7 +6553,7 @@ fn antientropy_integration_test() {
     );
 
     let mut btc_regtest_controller =
-        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
+        BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node.clone(), burnchain_config.clone());
 
     let mut burnchain_deadline = get_epoch_time_secs() + 60;
     while tip_height < (target_height - 3) as u64 {
@@ -6676,7 +6677,7 @@ fn atlas_stress_integration_test() {
     let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
 
     let mut btc_regtest_controller =
-        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
+        BitcoinRegtestController::with_burnchain_test(conf_bootstrap_node.clone(), burnchain_config.clone());
     let http_origin = format!("http://{}", &conf_bootstrap_node.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -9863,7 +9864,7 @@ fn test_competing_miners_build_on_same_chain(
         .expect("Failed starting bitcoind");
 
     let mut btc_regtest_controller =
-        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
+        BitcoinRegtestController::with_burnchain_test(confs[0].clone(), burnchain_configs[0].clone());
 
     btc_regtest_controller.bootstrap_chain(1);
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1133,12 +1133,7 @@ fn bad_microblock_pubkey() {
 
     let burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
 
     btc_regtest_controller.bootstrap_chain(201);
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -82,7 +82,7 @@ use super::{
     make_microblock, make_stacks_transfer, make_stacks_transfer_mblock_only, to_addr, ADDR_4, SK_1,
     SK_2,
 };
-use crate::config::FeeEstimatorName;
+use crate::config::{ConfigHandle, FeeEstimatorName};
 use crate::tests::SK_3;
 use clarity::vm::ast::stack_depth_checker::AST_CALL_STACK_DEPTH_BUFFER;
 use clarity::vm::ast::ASTRules;
@@ -1040,12 +1040,8 @@ fn deep_contract() {
 
     let burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -1229,12 +1225,8 @@ fn liquid_ustx_integration() {
 
     let burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -1350,12 +1342,8 @@ fn lockup_integration() {
 
     let burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -4192,12 +4180,8 @@ fn cost_voting_integration() {
 
     let burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -5448,12 +5432,8 @@ fn pox_integration_test() {
     );
     burnchain_config.pox_constants = pox_constants.clone();
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -5946,12 +5926,8 @@ fn atlas_integration_test() {
     let bootstrap_node_thread = thread::spawn(move || {
         let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
 
-        let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-            conf_bootstrap_node.clone(),
-            None,
-            Some(burnchain_config.clone()),
-            None,
-        );
+        let mut btc_regtest_controller =
+            BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
         let http_origin = format!("http://{}", &conf_bootstrap_node.node.rpc_bind);
 
         btc_regtest_controller.bootstrap_chain(201);
@@ -6474,12 +6450,8 @@ fn antientropy_integration_test() {
     let target_height = 3 + (3 * burnchain_config.pox_constants.reward_cycle_length);
 
     let bootstrap_node_thread = thread::spawn(move || {
-        let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-            conf_bootstrap_node.clone(),
-            None,
-            Some(burnchain_config.clone()),
-            None,
-        );
+        let mut btc_regtest_controller =
+            BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
 
         btc_regtest_controller.bootstrap_chain(201);
 
@@ -6579,12 +6551,8 @@ fn antientropy_integration_test() {
         tip_height, tip_height, target_height
     );
 
-    let btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf_follower_node.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
 
     let mut burnchain_deadline = get_epoch_time_secs() + 60;
     while tip_height < (target_height - 3) as u64 {
@@ -6707,12 +6675,8 @@ fn atlas_stress_integration_test() {
 
     let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf_bootstrap_node.clone(),
-        None,
-        Some(burnchain_config.clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
     let http_origin = format!("http://{}", &conf_bootstrap_node.node.rpc_bind);
 
     btc_regtest_controller.bootstrap_chain(201);
@@ -9898,12 +9862,8 @@ fn test_competing_miners_build_on_same_chain(
         .map_err(|_e| ())
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        confs[0].clone(),
-        None,
-        Some(burnchain_configs[0].clone()),
-        None,
-    );
+    let mut btc_regtest_controller =
+        BitcoinRegtestController::with_burnchain_test(conf.clone(), burnchain_config.clone());
 
     btc_regtest_controller.bootstrap_chain(1);
 


### PR DESCRIPTION
Enables hot reloading of mining configuration file.

Prior to every mining burnchain transaction, the config file will be reloaded if its modified time is newer and the following settings will be reloaded:

```
burnchain.burn_fee_cap
burnchain.satoshis_per_byte
burnchain.rbf_fee_increment
burnchain.max_rbf
node.microblock_frequency
node.wait_time_for_microblocks
```

The following config file items, if missing, will be read from environment variables:
```
node.seed => STACKS_NODE_SEED
burnchain.username => STACKS_BURNCHAIN_USERNAME
burnchain.password => STACKS_BURNCHAIN_PASSWORD 
```

Addresses the following issues:
- https://github.com/stacks-network/stacks-blockchain/issues/2629
- https://github.com/stacks-network/stacks-blockchain/issues/3181