### PR TITLE
feat: `blockstack-cli addresses` outputs hexademical public key

### DIFF
--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -138,9 +138,9 @@ secret key, the corresponding public key, and the corresponding P2PKH Stacks add
 
 const ADDRESSES_USAGE: &str = "blockstack-cli (options) addresses [secret-key-hex]
 
-The addresses command calculates both the Bitcoin and Stacks addresses from a secret key.
-If successful, this command outputs both the Bitcoin and Stacks addresses to stdout, formatted
-as JSON, and exits with code 0.";
+The addresses command calculates both the Bitcoin address, Stacks addresses, and hexadecimal public
+key from a secret key.  If successful, this command outputs both the Bitcoin and Stacks addresses
+to stdout, formatted as JSON, and exits with code 0.";
 
 const DECODE_TRANSACTION_USAGE: &str =
     "blockstack-cli (options) decode-tx [transaction-hex-or-stdin]
@@ -623,9 +623,12 @@ fn get_addresses(args: &[String], version: TransactionVersion) -> Result<String,
     Ok(format!(
         "{{
     \"STX\": \"{}\",
-    \"BTC\": \"{}\"
+    \"BTC\": \"{}\",
+    \"public-key\": \"{}\"
 }}",
-        &stx_address, &b58_address_string
+        &stx_address,
+        &b58_address_string,
+        &pk.to_hex(),
     ))
 }
 


### PR DESCRIPTION
### Description
This is motivated by the fact that, when setting up the testnet, we weren't sure which other tool to use to print the "hexadecimal form" public key for a private key, to get the right input for the field:

```
bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@testnet.blockstack.org:20444"
```

This PR changes the `blockstack-cli` tool so that `addresses` will print out this hexademical public key as well.

@deantchi told me this PR worked.

### Checklist
- [x] No testing for command line tool
- [x] No changelog
- [x] Update docs for `blockstack-cli`
