### PR TITLE
PR-3446: Fix block_limit_hit_integration_test

### DIFF
--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -4866,20 +4866,20 @@ fn block_limit_hit_integration_test() {
     assert_eq!(res.nonce, 1);
 
     let mined_block_events = test_observer::get_blocks();
-    assert!(mined_block_events.len() >= 2);
+    assert!(mined_block_events.len() == 5);
 
-    let tx_third_block = mined_block_events[2]
+    let tx_third_block = mined_block_events[3]
         .get("transactions")
         .unwrap()
         .as_array()
         .unwrap();
-    assert_eq!(tx_third_block.len(), 4); // genesis block + 3 blocks
+    assert_eq!(tx_third_block.len(), 3); // genesis block (missing) + 3 blocks
     let txid_1_exp = tx_third_block[1].get("txid").unwrap().as_str().unwrap();
     let txid_4_exp = tx_third_block[2].get("txid").unwrap().as_str().unwrap();
     assert_eq!(format!("0x{}", txid_1), txid_1_exp);
     assert_eq!(format!("0x{}", txid_4), txid_4_exp);
 
-    let tx_fourth_block = mined_block_events[3]
+    let tx_fourth_block = mined_block_events[4]
         .get("transactions")
         .unwrap()
         .as_array()


### PR DESCRIPTION
It appears the genesis block is not mined, as expected:

https://github.com/stacks-network/stacks-blockchain/commit/a86930a2a76a3f288afde2787d016f3d879a9da5#diff-e782414dee532a3fcdf6a65f99f5d6455c8773d7511827ed3011082d0440976bR4801