### PR TITLE
Feat: Peg-in wire formats for sBTC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -417,6 +417,8 @@ dependencies = [
  "rand_chacha 0.2.2",
  "regex",
  "ripemd",
+ "rstest",
+ "rstest_reuse",
  "rusqlite",
  "secp256k1",
  "serde",
@@ -574,11 +576,14 @@ dependencies = [
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "regex",
+ "rstest",
+ "rstest_reuse",
  "rusqlite",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_stacker",
+ "sha2-asm 0.5.5",
  "slog",
  "stacks-common",
  "time 0.2.27",
@@ -624,16 +629,6 @@ dependencies = [
  "sha2 0.9.9",
  "time 0.2.27",
  "version_check",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1039,21 +1034,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1462,16 +1442,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "bytes",
+ "http",
  "hyper",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1770,7 +1750,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1801,24 +1781,6 @@ dependencies = [
  "safemem",
  "tempfile",
  "twoway",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1929,51 +1891,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "overload"
@@ -2092,7 +2009,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2364,26 +2281,27 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-pemfile 1.0.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2532,6 +2450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,16 +2483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
-dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2632,29 +2549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2838,7 +2732,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
- "sha2-asm",
+ "sha2-asm 0.6.2",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c2f225be6502f2134e6bbb35bb5e2957e41ffa0495ed08bce2e2b4ca885da4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3345,17 +3248,18 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
+name = "tokio-rustls"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -3699,7 +3603,7 @@ dependencies = [
  "multipart",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile",
+ "rustls-pemfile 0.2.1",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -3888,30 +3792,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3922,21 +3813,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3946,21 +3825,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3973,12 +3840,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -137,6 +137,8 @@ pub fn run_analysis(
                 TypeChecker2_05::run_pass(&epoch, &mut contract_analysis, db)
             }
             StacksEpochId::Epoch21 => TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db),
+            // No type checking behavior is changed in Epoch 3.0 so we may reuse the 2.1 type checker
+            StacksEpochId::Epoch30 => TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db),
             StacksEpochId::Epoch10 => unreachable!("Epoch 1.0 is not a valid epoch for analysis"),
         }?;
         TraitChecker::run_pass(&epoch, &mut contract_analysis, db)?;

--- a/clarity/src/vm/analysis/type_checker/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/mod.rs
@@ -51,6 +51,8 @@ impl FunctionType {
                 self.check_args_2_05(accounting, args)
             }
             StacksEpochId::Epoch21 => self.check_args_2_1(accounting, args, clarity_version),
+            // No change in argument checking in Epoch 3
+            StacksEpochId::Epoch30 => self.check_args_2_1(accounting, args, clarity_version),
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),
         }
     }
@@ -67,6 +69,10 @@ impl FunctionType {
                 self.check_args_by_allowing_trait_cast_2_05(db, func_args)
             }
             StacksEpochId::Epoch21 => {
+                self.check_args_by_allowing_trait_cast_2_1(db, clarity_version, func_args)
+            }
+            StacksEpochId::Epoch30 => {
+                // No change in trait casting behavior in Epoch 3
                 self.check_args_by_allowing_trait_cast_2_1(db, clarity_version, func_args)
             }
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -700,6 +700,8 @@ impl LimitedCostTracker {
             StacksEpochId::Epoch20 => COSTS_1_NAME.to_string(),
             StacksEpochId::Epoch2_05 => COSTS_2_NAME.to_string(),
             StacksEpochId::Epoch21 => COSTS_3_NAME.to_string(),
+            // No costs are changed in Epoch 3.0
+            StacksEpochId::Epoch30 => COSTS_3_NAME.to_string(),
         }
     }
 }

--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -54,8 +54,10 @@ macro_rules! switch_on_global_epoch {
                 }
                 StacksEpochId::Epoch20 => $Epoch2Version(args, env, context),
                 StacksEpochId::Epoch2_05 => $Epoch205Version(args, env, context),
-                // Note: We reuse 2.05 for 2.1.
+                // No native functions are changed in Epoch 2.1 and 3.0, hence
+                // we may reuse the 2.05 version of all native functions.
                 StacksEpochId::Epoch21 => $Epoch205Version(args, env, context),
+                StacksEpochId::Epoch30 => $Epoch205Version(args, env, context),
             }
         }
     };

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -457,7 +457,7 @@ impl TypeSignature {
     pub fn admits_type(&self, epoch: &StacksEpochId, other: &TypeSignature) -> Result<bool> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => self.admits_type_v2_0(other),
-            StacksEpochId::Epoch21 => self.admits_type_v2_1(other),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => self.admits_type_v2_1(other),
             StacksEpochId::Epoch10 => unreachable!("epoch 1.0 not supported"),
         }
     }
@@ -928,7 +928,7 @@ impl TypeSignature {
     ) -> Result<TypeSignature> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => Self::least_supertype_v2_0(a, b),
-            StacksEpochId::Epoch21 => Self::least_supertype_v2_1(a, b),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => Self::least_supertype_v2_1(a, b),
             StacksEpochId::Epoch10 => unreachable!("Clarity 1.0 is not supported"),
         }
     }

--- a/clarity/src/vm/version.rs
+++ b/clarity/src/vm/version.rs
@@ -31,6 +31,7 @@ impl ClarityVersion {
             StacksEpochId::Epoch20 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch2_05 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch21 => ClarityVersion::Clarity2,
+            StacksEpochId::Epoch30 => ClarityVersion::Clarity2,
         }
     }
 }

--- a/src/blockstack_cli.rs
+++ b/src/blockstack_cli.rs
@@ -284,7 +284,7 @@ fn make_contract_call(
     function_args: Vec<Value>,
 ) -> Result<TransactionContractCall, CliError> {
     let address =
-        StacksAddress::from_string(&contract_address).ok_or("Failed to parse contract address")?;
+        StacksAddress::from_str(&contract_address).ok_or("Failed to parse contract address")?;
     let contract_name = ContractName::try_from(contract_name)?;
     let function_name = ClarityName::try_from(function_name)?;
 

--- a/src/burnchains/bitcoin/address.rs
+++ b/src/burnchains/bitcoin/address.rs
@@ -620,7 +620,7 @@ impl Address for LegacyBitcoinAddress {
         self.bytes.as_bytes().to_vec()
     }
 
-    fn from_string(s: &str) -> Option<LegacyBitcoinAddress> {
+    fn from_str(s: &str) -> Option<LegacyBitcoinAddress> {
         match LegacyBitcoinAddress::from_b58(s) {
             Ok(a) => Some(a),
             Err(_e) => None,
@@ -637,7 +637,7 @@ impl Address for SegwitBitcoinAddress {
         self.bytes()
     }
 
-    fn from_string(s: &str) -> Option<SegwitBitcoinAddress> {
+    fn from_str(s: &str) -> Option<SegwitBitcoinAddress> {
         SegwitBitcoinAddress::from_bech32(s)
     }
 
@@ -681,11 +681,11 @@ impl Address for BitcoinAddress {
         }
     }
 
-    fn from_string(s: &str) -> Option<BitcoinAddress> {
-        if let Some(addr) = LegacyBitcoinAddress::from_string(s) {
+    fn from_str(s: &str) -> Option<BitcoinAddress> {
+        if let Some(addr) = LegacyBitcoinAddress::from_str(s) {
             Some(addr.into())
         } else {
-            SegwitBitcoinAddress::from_string(s).map(|addr| addr.into())
+            SegwitBitcoinAddress::from_str(s).map(|addr| addr.into())
         }
     }
 
@@ -901,7 +901,7 @@ mod tests {
 
         for fixture in fixtures.iter() {
             test_debug!("Test '{}'", &fixture.addr);
-            let addr_opt = BitcoinAddress::from_string(&fixture.addr);
+            let addr_opt = BitcoinAddress::from_str(&fixture.addr);
             match (addr_opt, fixture.result.as_ref()) {
                 (Some(addr), Some(res)) => assert_eq!(addr, *res),
                 (None, None) => {}

--- a/src/burnchains/bitcoin/blocks.rs
+++ b/src/burnchains/bitcoin/blocks.rs
@@ -981,11 +981,11 @@ mod tests {
                     outputs: vec![
                         BitcoinTxOutput {
                             units: 5500,
-                            address: BitcoinAddress::from_string("bc1qsgynkc4rdxfg9kfxnqd76an9aquye2j4kdnk7c").unwrap(),
+                            address: BitcoinAddress::from_str("bc1qsgynkc4rdxfg9kfxnqd76an9aquye2j4kdnk7c").unwrap(),
                         },
                         BitcoinTxOutput {
                             units: 4999444000,
-                            address: BitcoinAddress::from_string("1BaqZJqwt2dcdxt6oa3mwSK4DiEyfXCgnZ").unwrap(),
+                            address: BitcoinAddress::from_str("1BaqZJqwt2dcdxt6oa3mwSK4DiEyfXCgnZ").unwrap(),
                         },
                     ],
                 }),

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -151,7 +151,7 @@ impl BurnchainStateTransition {
                     accepted_ops.push(block_ops[i].clone());
                 }
                 BlockstackOperationType::PegIn(_) => {
-                    todo!(); //TODO(sbtc): Implement
+                    accepted_ops.push(block_ops[i].clone());
                 }
                 BlockstackOperationType::LeaderBlockCommit(ref op) => {
                     // we don't yet know which block commits are going to be accepted until we have

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -195,40 +195,38 @@ pub enum BurnchainTransaction {
 
 impl BurnchainTransaction {
     pub fn txid(&self) -> Txid {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc.txid.clone(),
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => btc.txid.clone(),
         }
     }
 
     pub fn vtxindex(&self) -> u32 {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc.vtxindex,
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => btc.vtxindex,
         }
     }
 
     pub fn opcode(&self) -> u8 {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc.opcode,
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => btc.opcode,
         }
     }
 
-    pub fn data(&self) -> Vec<u8> {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc.data.clone(),
+    pub fn data(&self) -> &[u8] {
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => &btc.data,
         }
     }
 
     pub fn num_signers(&self) -> usize {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc.inputs.len(),
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => btc.inputs.len(),
         }
     }
 
     pub fn get_input_tx_ref(&self, input: usize) -> Option<&(Txid, u32)> {
         match self {
-            BurnchainTransaction::Bitcoin(ref btc) => {
-                btc.inputs.get(input).map(|txin| txin.tx_ref())
-            }
+            BurnchainTransaction::Bitcoin(btc) => btc.inputs.get(input).map(|txin| txin.tx_ref()),
         }
     }
 
@@ -236,8 +234,8 @@ impl BurnchainTransaction {
     /// A `None` value at slot `i` means "there is a recipient at slot `i`, but we don't know how
     /// to decode it`.
     pub fn get_recipients(&self) -> Vec<Option<BurnchainRecipient>> {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => btc
                 .outputs
                 .iter()
                 .map(|ref o| BurnchainRecipient::try_from_bitcoin_output(o))
@@ -246,14 +244,14 @@ impl BurnchainTransaction {
     }
 
     pub fn num_recipients(&self) -> usize {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc.outputs.len(),
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => btc.outputs.len(),
         }
     }
 
     pub fn get_burn_amount(&self) -> u64 {
-        match *self {
-            BurnchainTransaction::Bitcoin(ref btc) => btc.data_amt,
+        match self {
+            BurnchainTransaction::Bitcoin(btc) => btc.data_amt,
         }
     }
 }

--- a/src/chainstate/burn/db/mod.rs
+++ b/src/chainstate/burn/db/mod.rs
@@ -69,7 +69,7 @@ impl FromColumn<VRFPublicKey> for VRFPublicKey {
 impl FromColumn<StacksAddress> for StacksAddress {
     fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<Self, db_error> {
         let address_str: String = row.get_unwrap(column_name);
-        match Self::from_string(&address_str) {
+        match Self::from_str(&address_str) {
             Some(a) => Ok(a),
             None => Err(db_error::ParseError),
         }
@@ -89,7 +89,7 @@ impl FromColumn<PoxAddress> for PoxAddress {
 impl FromColumn<BitcoinAddress> for BitcoinAddress {
     fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<Self, db_error> {
         let address_str: String = row.get_unwrap(column_name);
-        match Self::from_string(&address_str) {
+        match Self::from_str(&address_str) {
             Some(a) => Ok(a),
             None => Err(db_error::ParseError),
         }

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -106,6 +106,14 @@ impl<'a> SortitionHandleTx<'a> {
                 );
                 BurnchainError::OpError(e)
             }),
+
+            BlockstackOperationType::PegIn(ref op) => op.check().map_err(|e| {
+                warn!(
+                    "REJECTED({}) delegate stx op {} at {},{}: {:?}",
+                    op.block_height, &op.txid, op.block_height, op.vtxindex, &e
+                );
+                BurnchainError::OpError(e)
+            }),
         }
     }
 

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2843,10 +2843,7 @@ impl SortitionDB {
             }
             StacksEpochId::Epoch2_05 => version == "2" || version == "3" || version == "4",
             StacksEpochId::Epoch21 => version == "3" || version == "4",
-            StacksEpochId::Epoch30 => version == "5", // TODO(sbtc): Introduce DB version 5
-                                                      //              In epoch 3 we need to keep
-                                                      //              track for sBTC ops, which
-                                                      //              is not supported in versions <= 4
+            StacksEpochId::Epoch30 => version == "5",
         }
     }
 
@@ -6263,8 +6260,6 @@ pub mod tests {
             BurnchainHeaderHash([0x01; 32]),
             &vec![BlockstackOperationType::PegIn(peg_in.clone())],
         );
-
-        // TODO(sbtc): Cont...
 
         let res_peg_ins = SortitionDB::get_peg_in_ops(db.conn(), &burn_header_hash)
             .expect("Failed to get peg-in ops from sortition DB");

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -6239,7 +6239,9 @@ pub mod tests {
         )
         .unwrap();
 
-        let mut db = SortitionDB::connect_test(block_height, &first_burn_hash).unwrap();
+        let epochs = StacksEpoch::unit_test(StacksEpochId::Epoch30, block_height);
+        let mut db =
+            SortitionDB::connect_test_with_epochs(block_height, &first_burn_hash, epochs).unwrap();
 
         let snapshot = test_append_snapshot(
             &mut db,
@@ -9521,7 +9523,7 @@ pub mod tests {
         let mut db = SortitionDB::connect_test_with_epochs(
             first_block_height,
             &first_block_header.block_hash,
-            StacksEpoch::all(0, 0, 0),
+            StacksEpoch::all(0, 0, 0, 0),
         )
         .unwrap();
 

--- a/src/chainstate/burn/mod.rs
+++ b/src/chainstate/burn/mod.rs
@@ -75,6 +75,7 @@ pub enum Opcodes {
     PreStx = 'p' as u8,
     TransferStx = '$' as u8,
     DelegateStx = '#' as u8,
+    PegIn = '<' as u8,
 }
 
 // a burnchain block snapshot

--- a/src/chainstate/burn/operations/delegate_stx.rs
+++ b/src/chainstate/burn/operations/delegate_stx.rs
@@ -31,7 +31,7 @@ impl DelegateStxOp {
         )
     }
 
-    fn parse_data(data: &Vec<u8>) -> Option<ParsedData> {
+    fn parse_data(data: &[u8]) -> Option<ParsedData> {
         /*
             Wire format:
 
@@ -150,7 +150,7 @@ impl DelegateStxOp {
             return Err(op_error::InvalidInput);
         };
 
-        let data = DelegateStxOp::parse_data(&tx.data()).ok_or_else(|| {
+        let data = DelegateStxOp::parse_data(tx.data()).ok_or_else(|| {
             warn!("Invalid tx data");
             op_error::ParseError
         })?;

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1872,7 +1872,7 @@ mod tests {
         let mut db = SortitionDB::connect_test_with_epochs(
             first_block_height,
             &first_burn_hash,
-            StacksEpoch::all(0, 0, first_block_height),
+            StacksEpoch::all(0, 0, first_block_height, u64::MAX),
         )
         .unwrap();
         let block_ops = vec![

--- a/src/chainstate/burn/operations/leader_key_register.rs
+++ b/src/chainstate/burn/operations/leader_key_register.rs
@@ -77,7 +77,7 @@ impl LeaderKeyRegisterOp {
         Some(LeaderKeyRegisterOp::new(&prover_pubk))
     }
 
-    fn parse_data(data: &Vec<u8>) -> Option<ParsedData> {
+    fn parse_data(data: &[u8]) -> Option<ParsedData> {
         /*
             Wire format:
 
@@ -149,7 +149,7 @@ impl LeaderKeyRegisterOp {
             return Err(op_error::InvalidInput);
         }
 
-        let data = match LeaderKeyRegisterOp::parse_data(&tx.data()) {
+        let data = match LeaderKeyRegisterOp::parse_data(tx.data()) {
             Some(data) => data,
             None => {
                 test_debug!("Invalid tx data");

--- a/src/chainstate/burn/operations/peg_in.rs
+++ b/src/chainstate/burn/operations/peg_in.rs
@@ -61,6 +61,7 @@ impl PegInOp {
     }
 
     pub fn check(&self) -> Result<(), OpError> {
+        // TODO(sbtc): Check peg wallet address
         if self.amount == 0 {
             warn!("Invalid PegInOp: Peg amount must be positive");
             return Err(OpError::PegInAmountMustBePositive);

--- a/src/chainstate/burn/operations/peg_in.rs
+++ b/src/chainstate/burn/operations/peg_in.rs
@@ -1,0 +1,161 @@
+use crate::burnchains::BurnchainBlockHeader;
+use crate::burnchains::BurnchainTransaction;
+use crate::chainstate::burn::Opcodes;
+use crate::types::chainstate::StacksAddress;
+use crate::types::Address;
+
+use crate::chainstate::burn::operations::Error as OpError;
+use crate::chainstate::burn::operations::PegInOp;
+
+impl PegInOp {
+    // TODO(sbtc): Write tests
+    pub fn from_tx(
+        block_header: &BurnchainBlockHeader,
+        tx: &BurnchainTransaction,
+    ) -> Result<Self, OpError> {
+        if tx.opcode() != Opcodes::PegIn as u8 {
+            warn!("Invalid tx: invalid opcode {}", tx.opcode());
+            return Err(OpError::InvalidInput);
+        }
+
+        let (amount, peg_wallet_address) = if let Some(Some(recepient)) = tx.get_recipients().get(1)
+        {
+            (recepient.amount, recepient.address.clone())
+        } else {
+            warn!("Invalid tx: Output 2 not provided");
+            return Err(OpError::InvalidInput);
+        };
+
+        let address = Self::parse_data(tx.data())?;
+
+        let txid = tx.txid();
+        let vtxindex = tx.vtxindex();
+        let block_height = block_header.block_height;
+        let burn_header_hash = block_header.block_hash;
+
+        Ok(Self {
+            address,
+            peg_wallet_address,
+            amount,
+            txid,
+            vtxindex,
+            block_height,
+            burn_header_hash,
+        })
+    }
+
+    fn parse_data(data: &[u8]) -> Result<StacksAddress, ParseError> {
+        /*
+            Wire format:
+
+            0      2  3                                          80
+            |------|--|------------------------------------------|
+             magic  op       c32-encoded Stacks address
+
+             Note that `data` is missing the first 3 bytes -- the magic and op must
+             be stripped before this method is called. At the time of writing,
+             this is done in `burnchains::bitcoin::blocks::BitcoinBlockParser::parse_data`.
+
+             The c32-encoded Stacks address may be padded with trailing ascii whitespace
+        */
+        StacksAddress::from_str(std::str::from_utf8(data)?.trim()).ok_or(ParseError::AddressParsing)
+    }
+
+    pub fn check(&self) -> Result<(), OpError> {
+        if self.amount == 0 {
+            warn!("Invalid PegInOp: Peg amount must be positive");
+            return Err(OpError::PegInAmountMustBePositive);
+        }
+
+        Ok(())
+    }
+}
+
+enum ParseError {
+    Utf8(std::str::Utf8Error),
+    AddressParsing,
+}
+
+impl From<std::str::Utf8Error> for ParseError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Utf8(err)
+    }
+}
+
+impl From<ParseError> for OpError {
+    fn from(_: ParseError) -> Self {
+        Self::ParseError
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clarity::util::hash::Hash160;
+
+    use crate::burnchains::{
+        bitcoin::{
+            address::{
+                BitcoinAddress, LegacyBitcoinAddress, LegacyBitcoinAddressType,
+                SegwitBitcoinAddress,
+            },
+            BitcoinInputType, BitcoinNetworkType, BitcoinTransaction, BitcoinTxInputStructured,
+            BitcoinTxOutput,
+        },
+        Txid,
+    };
+
+    use super::*;
+
+    fn test_parse_peg_in_should_succeed_given_a_conforming_transaction() {
+        let tx = bitcoin_transaction(vec![0; 80], 10, [0; 32]);
+        let header = burnchain_block_header();
+    }
+
+    fn burnchain_block_header() -> BurnchainBlockHeader {
+        BurnchainBlockHeader {
+            block_height: 0,
+            block_hash: [0; 32].into(),
+            parent_block_hash: [0; 32].into(),
+            num_txs: 0,
+            timestamp: 0,
+        }
+    }
+
+    fn bitcoin_transaction(
+        data: Vec<u8>,
+        amount: u64,
+        peg_in_wallet_address: [u8; 32],
+    ) -> BitcoinTransaction {
+        BitcoinTransaction {
+            txid: Txid([0; 32]),
+            vtxindex: 0,
+            opcode: Opcodes::PreStx as u8,
+            data,
+            data_amt: 0,
+            inputs: vec![BitcoinTxInputStructured {
+                keys: vec![],
+                num_required: 0,
+                in_type: BitcoinInputType::Standard,
+                tx_ref: (Txid([0; 32]), 0),
+            }
+            .into()],
+            outputs: vec![
+                BitcoinTxOutput {
+                    units: 10,
+                    address: BitcoinAddress::Legacy(LegacyBitcoinAddress {
+                        addrtype: LegacyBitcoinAddressType::PublicKeyHash,
+                        network_id: BitcoinNetworkType::Mainnet,
+                        bytes: Hash160([1; 20]),
+                    }),
+                },
+                BitcoinTxOutput {
+                    units: amount,
+                    address: BitcoinAddress::Segwit(SegwitBitcoinAddress::P2TR(
+                        true,
+                        peg_in_wallet_address,
+                    )),
+                },
+            ],
+        }
+    }
+}

--- a/src/chainstate/burn/operations/stack_stx.rs
+++ b/src/chainstate/burn/operations/stack_stx.rs
@@ -172,7 +172,7 @@ impl StackStxOp {
         }
     }
 
-    fn parse_data(data: &Vec<u8>) -> Option<ParsedData> {
+    fn parse_data(data: &[u8]) -> Option<ParsedData> {
         /*
             Wire format:
             0      2  3                             19        20
@@ -275,7 +275,7 @@ impl StackStxOp {
             return Err(op_error::InvalidInput);
         };
 
-        let data = StackStxOp::parse_data(&tx.data()).ok_or_else(|| {
+        let data = StackStxOp::parse_data(tx.data()).ok_or_else(|| {
             warn!("Invalid tx data");
             op_error::ParseError
         })?;

--- a/src/chainstate/burn/operations/transfer_stx.rs
+++ b/src/chainstate/burn/operations/transfer_stx.rs
@@ -69,7 +69,7 @@ impl TransferStxOp {
         }
     }
 
-    fn parse_data(data: &Vec<u8>) -> Option<ParsedData> {
+    fn parse_data(data: &[u8]) -> Option<ParsedData> {
         /*
             Wire format:
             0      2  3                             19        80
@@ -175,7 +175,7 @@ impl TransferStxOp {
             return Err(op_error::InvalidInput);
         };
 
-        let data = TransferStxOp::parse_data(&tx.data()).ok_or_else(|| {
+        let data = TransferStxOp::parse_data(tx.data()).ok_or_else(|| {
             warn!("Invalid tx data");
             op_error::ParseError
         })?;

--- a/src/chainstate/burn/operations/user_burn_support.rs
+++ b/src/chainstate/burn/operations/user_burn_support.rs
@@ -53,7 +53,7 @@ struct ParsedData {
 }
 
 impl UserBurnSupportOp {
-    fn parse_data(data: &Vec<u8>) -> Option<ParsedData> {
+    fn parse_data(data: &[u8]) -> Option<ParsedData> {
         /*
             Wire format:
 
@@ -146,7 +146,7 @@ impl UserBurnSupportOp {
 
         let burn_fee = output_0.amount;
 
-        let data = match UserBurnSupportOp::parse_data(&tx.data()) {
+        let data = match UserBurnSupportOp::parse_data(tx.data()) {
             None => {
                 test_debug!("Invalid tx data");
                 return Err(op_error::ParseError);
@@ -356,7 +356,7 @@ mod tests {
                 txstr: "01000000011111111111111111111111111111111111111111111111111111111111111111000000006a47304402204c51707ac34b6dcbfc518ba40c5fc4ef737bf69cc21a9f8a8e6f621f511f78e002200caca0f102d5df509c045c4fe229d957aa7ef833dc8103dc2fe4db15a22bab9e012102d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d000000000030000000000000000536a4c5069645f2222222222222222222222222222222222222222a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a3333333333333333333333333333333333333333010203040539300000000000001976a914000000000000000000000000000000000000000088aca05b0000000000001976a9140be3e286a15ea85882761618e366586b5574100d88ac00000000".to_string(),
                 opstr: "69645f2222222222222222222222222222222222222222a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a33333333333333333333333333333333333333330102030405".to_string(),
                 result: Some(UserBurnSupportOp {
-                    address: StacksAddress::from_legacy_bitcoin_address(&BitcoinAddress::from_string(&"mgbpit8FvkVJ9kuXY8QSM5P7eibnhcEMBk".to_string()).unwrap().expect_legacy()),
+                    address: StacksAddress::from_legacy_bitcoin_address(&BitcoinAddress::from_str(&"mgbpit8FvkVJ9kuXY8QSM5P7eibnhcEMBk".to_string()).unwrap().expect_legacy()),
                     consensus_hash: ConsensusHash::from_bytes(&hex_bytes("2222222222222222222222222222222222222200").unwrap()).unwrap(),
                     public_key: VRFPublicKey::from_bytes(&hex_bytes("22a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c").unwrap()).unwrap(),
                     block_header_hash_160: Hash160::from_bytes(&hex_bytes("7a33333333333333333333333333333333333333").unwrap()).unwrap(),

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -2742,7 +2742,7 @@ impl<
                     // Was this block sufficiently confirmed by the prepare phase that it was a PoX
                     // anchor block?  And if we're in epoch 2.1, does it match the heaviest-confirmed
                     // block-commit in the burnchain DB, and is it affirmed by the majority of the
-                    // network?
+                    // network? TODO(sbtc): What are the additional checks we need in 3.0 here?
                     if let Some(pox_anchor) = self
                         .sortition_db
                         .is_stacks_block_pox_anchor(&block_hash, &canonical_sortition_tip)?
@@ -2793,6 +2793,9 @@ impl<
                                 {
                                     return Ok(Some(pox_anchor));
                                 }
+                            }
+                            StacksEpochId::Epoch30 => {
+                                todo!() //TODO(sbtc): What are the additional checks we need in 3.0 here?
                             }
                         }
                     }

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -281,7 +281,7 @@ pub fn setup_states_2_1(
         pox_consts,
         initial_balances,
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 0)),
+        Some(StacksEpoch::all(0, 0, 0, 0)),
     )
 }
 
@@ -959,7 +959,7 @@ fn missed_block_commits_2_05() {
         pox_consts.clone(),
         Some(initial_balances),
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 1000000)),
+        Some(StacksEpoch::all(0, 0, 1000000, u64::MAX)),
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf.clone()));
@@ -1275,7 +1275,7 @@ fn missed_block_commits_2_1() {
         pox_consts.clone(),
         Some(initial_balances),
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 0)),
+        Some(StacksEpoch::all(0, 0, 0, 0)),
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf));
@@ -1615,7 +1615,7 @@ fn late_block_commits_2_1() {
         pox_consts.clone(),
         Some(initial_balances),
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 0)),
+        Some(StacksEpoch::all(0, 0, 0, 0)),
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf));
@@ -4338,6 +4338,7 @@ fn test_epoch_verify_active_pox_contract() {
             first_block_ht,
             first_block_ht + 4,
             first_block_ht + 8,
+            u64::MAX,
         )),
     );
 
@@ -4926,7 +4927,7 @@ fn test_sortition_with_sunset_and_epoch_switch() {
         pox_consts.clone(),
         None,
         StacksEpochId::Epoch20,
-        Some(StacksEpoch::all(0, 5, epoch_switch_ht)),
+        Some(StacksEpoch::all(0, 5, epoch_switch_ht, u64::MAX)),
     );
 
     let mut coord = make_reward_set_coordinator(path, reward_set, pox_consts.clone());

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -3435,7 +3435,7 @@ fn test_delegate_stx_btc_ops() {
         let expected_winner = good_op.txid();
         let mut ops = vec![good_op];
         let reward_addr = PoxAddress::Standard(
-            StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
+            StacksAddress::from_str("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
             Some(AddressHashMode::SerializeP2PKH),
         );
         if ix == 0 {

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -924,7 +924,7 @@ pub mod test {
         let addresses = vec![
             RawRewardSetEntry {
                 reward_address: PoxAddress::Standard(
-                    StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(),
+                    StacksAddress::from_str("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(),
                     Some(AddressHashMode::SerializeP2PKH),
                 ),
                 amount_stacked: 1500,
@@ -932,7 +932,7 @@ pub mod test {
             },
             RawRewardSetEntry {
                 reward_address: PoxAddress::Standard(
-                    StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
+                    StacksAddress::from_str("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
                     Some(AddressHashMode::SerializeP2PKH),
                 ),
 
@@ -941,7 +941,7 @@ pub mod test {
             },
             RawRewardSetEntry {
                 reward_address: PoxAddress::Standard(
-                    StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(),
+                    StacksAddress::from_str("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap(),
                     Some(AddressHashMode::SerializeP2PKH),
                 ),
                 amount_stacked: 1500,
@@ -949,7 +949,7 @@ pub mod test {
             },
             RawRewardSetEntry {
                 reward_address: PoxAddress::Standard(
-                    StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
+                    StacksAddress::from_str("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap(),
                     Some(AddressHashMode::SerializeP2PKH),
                 ),
                 amount_stacked: 400,
@@ -1760,8 +1760,8 @@ pub mod test {
     #[test]
     fn test_lockups() {
         let mut peer_config = TestPeerConfig::new(function_name!(), 2000, 2001);
-        let alice = StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap();
-        let bob = StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap();
+        let alice = StacksAddress::from_str("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap();
+        let bob = StacksAddress::from_str("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap();
         peer_config.initial_lockups = vec![
             ChainstateAccountLockup::new(alice.into(), 1000, 1),
             ChainstateAccountLockup::new(bob, 1000, 1),

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -561,7 +561,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -1023,7 +1023,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -1298,7 +1298,7 @@ fn delegate_stack_increase() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -1619,7 +1619,7 @@ fn stack_increase() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -1861,7 +1861,7 @@ fn test_lock_period_invariant_extend_transition() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -2024,7 +2024,7 @@ fn test_pox_extend_transition_pox_2() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -2468,7 +2468,7 @@ fn test_delegate_extend_transition_pox_2() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -3186,7 +3186,7 @@ fn test_pox_2_getters() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -3464,7 +3464,7 @@ fn test_get_pox_addrs() {
 
     assert_eq!(burnchain.pox_constants.reward_slots(), 4);
 
-    let epochs = StacksEpoch::all(1, 2, 3);
+    let epochs = StacksEpoch::all(1, 2, 3, u64::MAX);
 
     let (mut peer, keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -3733,7 +3733,7 @@ fn test_stack_with_segwit() {
 
     assert_eq!(burnchain.pox_constants.reward_slots(), 4);
 
-    let epochs = StacksEpoch::all(1, 2, 3);
+    let epochs = StacksEpoch::all(1, 2, 3, u64::MAX);
 
     let (mut peer, all_keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -4058,7 +4058,7 @@ fn test_pox_2_delegate_stx_addr_validation() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -4237,7 +4237,7 @@ fn stack_aggregation_increase() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 
@@ -4684,7 +4684,7 @@ fn stack_in_both_pox1_and_pox2() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10, u64::MAX);
 
     let observer = TestEventObserver::new();
 

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -1254,7 +1254,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
     let common_data = PoxPrintFields {
         op_name: "handle-unlock".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
+            StacksAddress::from_str("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
                 .unwrap()
                 .to_account_principal(),
         ),
@@ -1564,7 +1564,7 @@ fn delegate_stack_increase() {
         (
             "delegator",
             Value::Principal(
-                StacksAddress::from_string("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
+                StacksAddress::from_str("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
                     .unwrap()
                     .to_account_principal(),
             ),
@@ -1573,7 +1573,7 @@ fn delegate_stack_increase() {
     let common_data = PoxPrintFields {
         op_name: "delegate-stack-increase".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST2Q1B4S2DY2Y96KYNZTVCCZZD1V9AGWCS5MFXM4C")
+            StacksAddress::from_str("ST2Q1B4S2DY2Y96KYNZTVCCZZD1V9AGWCS5MFXM4C")
                 .unwrap()
                 .to_account_principal(),
         ),
@@ -1823,7 +1823,7 @@ fn stack_increase() {
     let common_data = PoxPrintFields {
         op_name: "stack-increase".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST2Q1B4S2DY2Y96KYNZTVCCZZD1V9AGWCS5MFXM4C")
+            StacksAddress::from_str("ST2Q1B4S2DY2Y96KYNZTVCCZZD1V9AGWCS5MFXM4C")
                 .unwrap()
                 .to_account_principal(),
         ),
@@ -2396,7 +2396,7 @@ fn test_pox_extend_transition_pox_2() {
     let common_data = PoxPrintFields {
         op_name: "stack-stx".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
+            StacksAddress::from_str("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
                 .unwrap()
                 .to_account_principal(),
         ),
@@ -2416,7 +2416,7 @@ fn test_pox_extend_transition_pox_2() {
     let common_data = PoxPrintFields {
         op_name: "stack-extend".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
+            StacksAddress::from_str("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
                 .unwrap()
                 .to_account_principal(),
         ),
@@ -3080,7 +3080,7 @@ fn test_delegate_extend_transition_pox_2() {
         (
             "delegator",
             Value::Principal(
-                StacksAddress::from_string("ST9DJEQ7PRF5PZCGBJ2R53A343KW48FM6DJS5VNY")
+                StacksAddress::from_str("ST9DJEQ7PRF5PZCGBJ2R53A343KW48FM6DJS5VNY")
                     .unwrap()
                     .to_account_principal(),
             ),
@@ -3089,7 +3089,7 @@ fn test_delegate_extend_transition_pox_2() {
     let common_data = PoxPrintFields {
         op_name: "delegate-stack-stx".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
+            StacksAddress::from_str("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
                 .unwrap()
                 .to_account_principal(),
         ),
@@ -3108,7 +3108,7 @@ fn test_delegate_extend_transition_pox_2() {
         (
             "delegator",
             Value::Principal(
-                StacksAddress::from_string("ST9DJEQ7PRF5PZCGBJ2R53A343KW48FM6DJS5VNY")
+                StacksAddress::from_str("ST9DJEQ7PRF5PZCGBJ2R53A343KW48FM6DJS5VNY")
                     .unwrap()
                     .to_account_principal(),
             ),
@@ -3117,7 +3117,7 @@ fn test_delegate_extend_transition_pox_2() {
     let common_data = PoxPrintFields {
         op_name: "delegate-stack-extend".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST2Q1B4S2DY2Y96KYNZTVCCZZD1V9AGWCS5MFXM4C")
+            StacksAddress::from_str("ST2Q1B4S2DY2Y96KYNZTVCCZZD1V9AGWCS5MFXM4C")
                 .unwrap()
                 .to_account_principal(),
         ),
@@ -3137,7 +3137,7 @@ fn test_delegate_extend_transition_pox_2() {
     let common_data = PoxPrintFields {
         op_name: "stack-aggregation-commit".to_string(),
         stacker: Value::Principal(
-            StacksAddress::from_string("ST9DJEQ7PRF5PZCGBJ2R53A343KW48FM6DJS5VNY")
+            StacksAddress::from_str("ST9DJEQ7PRF5PZCGBJ2R53A343KW48FM6DJS5VNY")
                 .unwrap()
                 .to_account_principal(),
         ),

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -1368,10 +1368,10 @@ mod test {
     fn get_tip_ancestor() {
         let mut chainstate = instantiate_chainstate(false, 0x80000000, "get_tip_ancestor_test");
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+            StacksAddress::from_str(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
         let user_1 =
-            StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
+            StacksAddress::from_str(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
                 .unwrap();
         let mut miner_reward = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
         let user_reward = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
@@ -1443,10 +1443,10 @@ mod test {
         let mut chainstate =
             instantiate_chainstate(false, 0x80000000, "load_store_miner_payment_schedule");
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+            StacksAddress::from_str(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
         let user_1 =
-            StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
+            StacksAddress::from_str(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
                 .unwrap();
 
         let mut miner_reward = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
@@ -1511,7 +1511,7 @@ mod test {
             "load_store_miner_payment_schedule_pay_contract",
         );
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+            StacksAddress::from_str(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
 
         let mut miner_reward = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
@@ -1561,7 +1561,7 @@ mod test {
     #[test]
     fn miner_reward_one_miner_no_tx_fees_no_users() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+            StacksAddress::from_str(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
         let participant = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
 
@@ -1591,7 +1591,7 @@ mod test {
     #[test]
     fn miner_reward_one_miner_no_tx_fees_no_users_pay_contract() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+            StacksAddress::from_str(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
         let mut participant = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
         participant.recipient = PrincipalData::Contract(QualifiedContractIdentifier::transient());
@@ -1630,10 +1630,10 @@ mod test {
     #[test]
     fn miner_reward_one_miner_one_user_no_tx_fees() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+            StacksAddress::from_str(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
         let user_1 =
-            StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
+            StacksAddress::from_str(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
                 .unwrap();
 
         let miner = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 250, 1000);
@@ -1678,11 +1678,11 @@ mod test {
     #[test]
     fn miner_reward_tx_fees() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
+            StacksAddress::from_str(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
 
         let parent_miner_1 =
-            StacksAddress::from_string(&"SP2QDF700V0FWXVNQJJ4XFGBWE6R2Y4APTSFQNBVE".to_string())
+            StacksAddress::from_str(&"SP2QDF700V0FWXVNQJJ4XFGBWE6R2Y4APTSFQNBVE".to_string())
                 .unwrap();
 
         let participant = make_dummy_miner_payment_schedule(&miner_1, 500, 100, 105, 1000, 1000);

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4874,21 +4874,41 @@ impl StacksChainState {
                             receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
                             applied = true;
                         }
+                        StacksEpochId::Epoch30 => {
+                            receipts.push(clarity_tx.block.initialize_epoch_2_05()?);
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_3_0()?);
+                            applied = true;
+                        }
                         _ => {
                             panic!("Bad Stacks epoch transition; parent_epoch = {}, current_epoch = {}", &stacks_parent_epoch, &sortition_epoch.epoch_id);
                         }
                     },
-                    StacksEpochId::Epoch2_05 => {
+                    StacksEpochId::Epoch2_05 => match sortition_epoch.epoch_id {
+                        StacksEpochId::Epoch21 => {
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                            applied = true;
+                        }
+                        StacksEpochId::Epoch30 => {
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_3_0()?);
+                            applied = true;
+                        }
+                        _ => {
+                            panic!("Bad Stacks epoch transition; parent_epoch = {}, current_epoch = {}", &stacks_parent_epoch, &sortition_epoch.epoch_id);
+                        }
+                    },
+                    StacksEpochId::Epoch21 => {
                         assert_eq!(
                             sortition_epoch.epoch_id,
-                            StacksEpochId::Epoch21,
-                            "Should only transition from Epoch2_05 to Epoch21"
+                            StacksEpochId::Epoch30,
+                            "Should only transition to Epoch30 from Epoch21"
                         );
                         receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
                         applied = true;
                     }
-                    StacksEpochId::Epoch21 => {
-                        panic!("No defined transition from Epoch21 forward")
+                    StacksEpochId::Epoch30 => {
+                        panic!("No defined transition from Epoch30 forward")
                     }
                 }
             }
@@ -5480,6 +5500,10 @@ impl StacksChainState {
                     burn_tip_height,
                     cur_epoch.start_height,
                 )
+            }
+
+            StacksEpochId::Epoch30 => {
+                todo!() // TODO(sbtc): Extend the logic of this function to return sbtc bitcoin-ops
             }
         }
     }
@@ -11305,7 +11329,7 @@ pub mod test {
         let initial_balance = 1000000000;
         peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
         let recv_addr =
-            StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
+            StacksAddress::from_str("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
 
         let mut peer = TestPeer::new(peer_config.clone());
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -223,6 +223,7 @@ impl DBConfig {
                 self.version == "2" || self.version == "3" || self.version == "4"
             }
             StacksEpochId::Epoch21 => self.version == "3" || self.version == "4",
+            StacksEpochId::Epoch30 => self.version == "3" || self.version == "4",
         }
     }
 }
@@ -1125,7 +1126,7 @@ impl StacksChainState {
         let mut stacks_address = match LegacyBitcoinAddress::from_b58(&addr) {
             Ok(addr) => StacksAddress::from_legacy_bitcoin_address(&addr),
             // A few addresses (from legacy placeholder accounts) are already STX addresses
-            _ => match StacksAddress::from_string(addr) {
+            _ => match StacksAddress::from_str(addr) {
                 Some(addr) => addr,
                 None => panic!("Failed to parsed genesis address {}", addr),
             },

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -7802,7 +7802,7 @@ pub mod test {
                 vec![
                     Value::UInt(1000000000),
                     Value::Principal(PrincipalData::from(
-                        StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01")
+                        StacksAddress::from_str("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01")
                             .unwrap(),
                     )),
                 ],
@@ -8395,6 +8395,7 @@ pub mod test {
                     StacksEpochId::Epoch20 => self.get_stacks_epoch(0),
                     StacksEpochId::Epoch2_05 => self.get_stacks_epoch(1),
                     StacksEpochId::Epoch21 => self.get_stacks_epoch(2),
+                    StacksEpochId::Epoch30 => self.get_stacks_epoch(3),
                 }
             }
             fn get_pox_payout_addrs(

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -775,7 +775,7 @@ mod test {
             let canonical_tip = StacksBlockId::new(&consensus_hash, &stacks_block.block_hash());
 
             let recv_addr =
-                StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
+                StacksAddress::from_str("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
 
             // build 1-block microblock stream
             let microblocks = {
@@ -999,7 +999,7 @@ mod test {
             let canonical_tip = StacksBlockId::new(&consensus_hash, &stacks_block.block_hash());
 
             let recv_addr =
-                StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
+                StacksAddress::from_str("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
 
             // build microblock stream iteratively, and test balances at each additional microblock
             let sortdb = peer.sortdb.take().unwrap();
@@ -1159,7 +1159,7 @@ mod test {
         let mut last_block: Option<StacksBlock> = None;
         let mut next_nonce = 0;
         let recv_addr =
-            StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
+            StacksAddress::from_str("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
         let mut recv_balance = 0;
 
         for tenure_id in 0..num_blocks {

--- a/src/chainstate/stacks/tests/accounting.rs
+++ b/src/chainstate/stacks/tests/accounting.rs
@@ -151,7 +151,7 @@ fn test_bad_microblock_fees_pre_v210() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut block_ids = vec![];
     for tenure_id in 0..num_blocks {
@@ -472,7 +472,7 @@ fn test_bad_microblock_fees_fix_transition() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut block_ids = vec![];
     for tenure_id in 0..num_blocks {
@@ -827,7 +827,7 @@ fn test_get_block_info_v210() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
@@ -1197,7 +1197,7 @@ fn test_get_block_info_v210_no_microblocks() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
@@ -1516,7 +1516,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let contract_src = r#"(begin (print "hello world"))"#;
     let contract_name = "hello-world";

--- a/src/chainstate/stacks/tests/block_construction.rs
+++ b/src/chainstate/stacks/tests/block_construction.rs
@@ -194,7 +194,7 @@ fn test_build_anchored_blocks_stx_transfers_single() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
     let mut sender_nonce = 0;
 
     let mut last_block = None;
@@ -332,7 +332,7 @@ fn test_build_anchored_blocks_empty_with_builder_timeout() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
     let mut sender_nonce = 0;
 
     let mut last_block = None;
@@ -467,7 +467,7 @@ fn test_build_anchored_blocks_stx_transfers_multi() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
     let mut sender_nonce = 0;
 
     let mut last_block = None;
@@ -672,7 +672,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut last_block = None;
     for tenure_id in 0..num_blocks {
@@ -910,7 +910,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut last_block: Option<StacksBlock> = None;
     let mut last_block_ch: Option<ConsensusHash> = None;
@@ -1377,7 +1377,7 @@ fn test_build_anchored_blocks_skip_too_expensive() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
     let mut sender_nonce = 0;
 
     let mut last_block = None;
@@ -2473,7 +2473,7 @@ fn test_build_microblock_stream_forks() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut last_block = None;
     for tenure_id in 0..num_blocks {
@@ -2775,7 +2775,7 @@ fn test_build_microblock_stream_forks_with_descendants() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut microblock_tail_1: Option<StacksMicroblockHeader> = None;
     let mut microblock_tail_2: Option<StacksMicroblockHeader> = None;
@@ -3279,7 +3279,7 @@ fn test_contract_call_across_clarity_versions() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
@@ -3828,7 +3828,7 @@ fn test_is_tx_problematic() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut last_block = None;
     for tenure_id in 0..num_blocks {
@@ -4281,7 +4281,7 @@ fn test_fee_order_mismatch_nonce_order() {
     };
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
     let sender_nonce = 0;
 
     let mut last_block = None;
@@ -4462,7 +4462,7 @@ fn paramaterized_mempool_walk_test(
     }
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     let mut chainstate =
         instantiate_chainstate_with_balances(false, 0x80000000, &test_name, vec![]);

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -1082,6 +1082,10 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
         })
     }
 
+    pub fn initialize_epoch_3_0(&mut self) -> Result<Vec<StacksTransactionReceipt>, Error> {
+        todo!(); // TODO(sbtc): Epoch 3.0 initialization logic
+    }
+
     pub fn start_transaction_processing<'c>(&'c mut self) -> ClarityTransactionConnection<'c, 'a> {
         let store = &mut self.datastore;
         let cost_track = &mut self.cost_track;

--- a/src/clarity_vm/database/mod.rs
+++ b/src/clarity_vm/database/mod.rs
@@ -91,7 +91,7 @@ impl<'a> HeadersDB for HeadersDBConn<'a> {
     fn get_miner_address(&self, id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         get_miner_column(self.0, id_bhh, "address", |r| {
             let s: String = r.get_unwrap("address");
-            let addr = StacksAddress::from_string(&s).expect("FATAL: malformed address");
+            let addr = StacksAddress::from_str(&s).expect("FATAL: malformed address");
             addr
         })
     }
@@ -165,7 +165,7 @@ impl<'a> HeadersDB for ChainstateTx<'a> {
     fn get_miner_address(&self, id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         get_miner_column(self.deref().deref(), id_bhh, "address", |r| {
             let s: String = r.get_unwrap("address");
-            let addr = StacksAddress::from_string(&s).expect("FATAL: malformed address");
+            let addr = StacksAddress::from_str(&s).expect("FATAL: malformed address");
             addr
         })
     }
@@ -242,7 +242,7 @@ impl HeadersDB for MARF<StacksBlockId> {
     fn get_miner_address(&self, id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         get_miner_column(self.sqlite_conn(), id_bhh, "address", |r| {
             let s: String = r.get_unwrap("address");
-            let addr = StacksAddress::from_string(&s).expect("FATAL: malformed address");
+            let addr = StacksAddress::from_str(&s).expect("FATAL: malformed address");
             addr
         })
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -323,13 +323,17 @@ lazy_static! {
     ];
 }
 
-/// Stacks 2.05 epoch marker.  All block-commits in 2.05 must have a memo bitfield with this value
-/// *or greater*.
+/// Stacks epoch markers.  All block-commits in an epoch must have a
+///  memo bitfield the epochs marker value *or greater*.
 pub static STACKS_EPOCH_2_05_MARKER: u8 = 0x05;
 
 /// Stacks 2.1 epoch marker.  All block-commits in 2.1 must have a memo bitfield with this value
 /// *or greater*.
 pub static STACKS_EPOCH_2_1_MARKER: u8 = 0x06;
+
+/// Stacks 3.0 epoch marker.  All block-commits in 3.0 must have a memo bitfield with this value
+/// *or greater*.
+pub static STACKS_EPOCH_3_0_MARKER: u8 = 0x07;
 
 #[test]
 fn test_ord_for_stacks_epoch() {
@@ -617,6 +621,7 @@ impl StacksEpochExtension for StacksEpoch {
             }
             StacksEpochId::Epoch2_05 => StacksEpoch::unit_test_2_05(first_burnchain_height),
             StacksEpochId::Epoch21 => StacksEpoch::unit_test_2_1(first_burnchain_height),
+            StacksEpochId::Epoch30 => StacksEpoch::unit_test_2_1(first_burnchain_height), // TODO(sbtc): Write 3_0 function
         }
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -50,6 +50,7 @@ pub use stacks_common::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, STACKS_EPOCH
 // fourth byte == highest epoch supported by this node
 // - 0x05 for 2.05
 // - 0x06 for 2.1
+// - 0x07 for 3.0
 pub const PEER_VERSION_MAINNET: u32 = 0x18000006;
 pub const PEER_VERSION_TESTNET: u32 = 0xfacade06;
 
@@ -57,6 +58,7 @@ pub const PEER_VERSION_EPOCH_1_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_05: u8 = 0x05;
 pub const PEER_VERSION_EPOCH_2_1: u8 = 0x06;
+pub const PEER_VERSION_EPOCH_3_0: u8 = 0x07;
 
 // network identifiers
 pub const NETWORK_ID_MAINNET: u32 = 0x17000000;
@@ -401,10 +403,15 @@ pub trait StacksEpochExtension {
     fn unit_test_2_1(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
     #[cfg(test)]
     fn unit_test_2_1_only(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
+    #[cfg(test)]
+    fn unit_test_3_0(epoch_3_0_block_height: u64) -> Vec<StacksEpoch>;
+    #[cfg(test)]
+    fn unit_test_3_0_only(epoch_3_0_block_height: u64) -> Vec<StacksEpoch>;
     fn all(
         epoch_2_0_block_height: u64,
         epoch_2_05_block_height: u64,
         epoch_2_1_block_height: u64,
+        epoch_3_0_block_height: u64,
     ) -> Vec<StacksEpoch>;
     fn validate_epochs(epochs: &[StacksEpoch]) -> Vec<StacksEpoch>;
 }
@@ -614,6 +621,136 @@ impl StacksEpochExtension for StacksEpoch {
     }
 
     #[cfg(test)]
+    fn unit_test_3_0(first_burnchain_height: u64) -> Vec<StacksEpoch> {
+        info!(
+            "StacksEpoch unit_test first_burn_height = {}",
+            first_burnchain_height
+        );
+
+        vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: first_burnchain_height,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: first_burnchain_height,
+                end_height: first_burnchain_height + 4,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: first_burnchain_height + 4,
+                end_height: first_burnchain_height + 8,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: first_burnchain_height + 8,
+                end_height: first_burnchain_height + 12,
+                block_limit: ExecutionCost {
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch30,
+                start_height: first_burnchain_height + 12,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    // TODO(sbtc): Should we update these?
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_3_0,
+            },
+        ]
+    }
+
+    #[cfg(test)]
+    fn unit_test_3_0_only(first_burnchain_height: u64) -> Vec<StacksEpoch> {
+        info!(
+            "StacksEpoch unit_test first_burn_height = {}",
+            first_burnchain_height
+        );
+
+        vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: 0,
+                end_height: first_burnchain_height,
+                block_limit: ExecutionCost {
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch30,
+                start_height: first_burnchain_height,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    // TODO(sbtc): Should we update these?
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_3_0,
+            },
+        ]
+    }
+
+    #[cfg(test)]
     fn unit_test(stacks_epoch_id: StacksEpochId, first_burnchain_height: u64) -> Vec<StacksEpoch> {
         match stacks_epoch_id {
             StacksEpochId::Epoch10 | StacksEpochId::Epoch20 => {
@@ -621,7 +758,7 @@ impl StacksEpochExtension for StacksEpoch {
             }
             StacksEpochId::Epoch2_05 => StacksEpoch::unit_test_2_05(first_burnchain_height),
             StacksEpochId::Epoch21 => StacksEpoch::unit_test_2_1(first_burnchain_height),
-            StacksEpochId::Epoch30 => StacksEpoch::unit_test_2_1(first_burnchain_height), // TODO(sbtc): Write 3_0 function
+            StacksEpochId::Epoch30 => StacksEpoch::unit_test_3_0(first_burnchain_height),
         }
     }
 
@@ -629,6 +766,7 @@ impl StacksEpochExtension for StacksEpoch {
         epoch_2_0_block_height: u64,
         epoch_2_05_block_height: u64,
         epoch_2_1_block_height: u64,
+        epoch_3_0_block_height: u64,
     ) -> Vec<StacksEpoch> {
         vec![
             StacksEpoch {
@@ -655,6 +793,13 @@ impl StacksEpochExtension for StacksEpoch {
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch21,
                 start_height: epoch_2_1_block_height,
+                end_height: epoch_3_0_block_height,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch30,
+                start_height: epoch_3_0_block_height,
                 end_height: STACKS_EPOCH_MAX,
                 block_limit: ExecutionCost::max_value(),
                 network_epoch: PEER_VERSION_EPOCH_1_0,

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -230,6 +230,7 @@ impl PessimisticEstimator {
                     StacksEpochId::Epoch20 => "",
                     StacksEpochId::Epoch2_05 => ":2.05",
                     StacksEpochId::Epoch21 => ":2.1",
+                    StacksEpochId::Epoch30 => ":3.0",
                 };
                 format!(
                     "cc{}:{}:{}.{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1025,25 +1025,25 @@ simulating a miner.
         // initial argon balances -- see testnet/stacks-node/conf/testnet-follower-conf.toml
         let initial_balances = vec![
             (
-                StacksAddress::from_string("ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2")
+                StacksAddress::from_str("ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2")
                     .unwrap()
                     .to_account_principal(),
                 10000000000000000,
             ),
             (
-                StacksAddress::from_string("ST319CF5WV77KYR1H3GT0GZ7B8Q4AQPY42ETP1VPF")
+                StacksAddress::from_str("ST319CF5WV77KYR1H3GT0GZ7B8Q4AQPY42ETP1VPF")
                     .unwrap()
                     .to_account_principal(),
                 10000000000000000,
             ),
             (
-                StacksAddress::from_string("ST221Z6TDTC5E0BYR2V624Q2ST6R0Q71T78WTAX6H")
+                StacksAddress::from_str("ST221Z6TDTC5E0BYR2V624Q2ST6R0Q71T78WTAX6H")
                     .unwrap()
                     .to_account_principal(),
                 10000000000000000,
             ),
             (
-                StacksAddress::from_string("ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B")
+                StacksAddress::from_str("ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B")
                     .unwrap()
                     .to_account_principal(),
                 10000000000000000,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1053,11 +1053,7 @@ simulating a miner.
         let burnchain = Burnchain::regtest(&burnchain_db_path);
         let first_burnchain_block_height = burnchain.first_block_height;
         let first_burnchain_block_hash = burnchain.first_block_hash;
-        let epochs = StacksEpoch::all(
-            first_burnchain_block_height,
-            u64::max_value(),
-            u64::max_value(),
-        );
+        let epochs = StacksEpoch::all(first_burnchain_block_height, u64::MAX, u64::MAX, u64::MAX);
         let (mut new_sortition_db, _) = burnchain
             .connect_db(
                 true,
@@ -1142,11 +1138,7 @@ simulating a miner.
         let mut known_stacks_blocks = HashSet::new();
         let mut next_arrival = 0;
 
-        let epochs = StacksEpoch::all(
-            first_burnchain_block_height,
-            u64::max_value(),
-            u64::max_value(),
-        );
+        let epochs = StacksEpoch::all(first_burnchain_block_height, u64::MAX, u64::MAX, u64::MAX);
 
         let (p2p_new_sortition_db, _) = burnchain
             .connect_db(

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -1828,7 +1828,7 @@ impl HttpRequestType {
             )));
         }
 
-        let contract_addr = StacksAddress::from_string(&captures["address"]).ok_or_else(|| {
+        let contract_addr = StacksAddress::from_str(&captures["address"]).ok_or_else(|| {
             net_error::DeserializeError("Failed to parse contract address".into())
         })?;
         let contract_name = ContractName::try_from(captures["contract"].to_string())
@@ -1870,7 +1870,7 @@ impl HttpRequestType {
             ));
         }
 
-        let contract_addr = StacksAddress::from_string(&captures["address"]).ok_or_else(|| {
+        let contract_addr = StacksAddress::from_str(&captures["address"]).ok_or_else(|| {
             net_error::DeserializeError("Failed to parse contract address".into())
         })?;
         let contract_name = ContractName::try_from(captures["contract"].to_string())
@@ -1919,7 +1919,7 @@ impl HttpRequestType {
             ));
         }
 
-        let contract_addr = StacksAddress::from_string(&captures["address"]).ok_or_else(|| {
+        let contract_addr = StacksAddress::from_str(&captures["address"]).ok_or_else(|| {
             net_error::DeserializeError("Failed to parse contract address".into())
         })?;
         let contract_name = ContractName::try_from(captures["contract"].to_string())
@@ -1974,7 +1974,7 @@ impl HttpRequestType {
             ));
         }
 
-        let contract_addr = StacksAddress::from_string(&captures["address"]).ok_or_else(|| {
+        let contract_addr = StacksAddress::from_str(&captures["address"]).ok_or_else(|| {
             net_error::DeserializeError("Failed to parse contract address".into())
         })?;
         let contract_name = ContractName::try_from(captures["contract"].to_string())
@@ -2030,14 +2030,14 @@ impl HttpRequestType {
             ));
         }
 
-        let contract_addr = StacksAddress::from_string(&captures["address"]).ok_or_else(|| {
+        let contract_addr = StacksAddress::from_str(&captures["address"]).ok_or_else(|| {
             net_error::DeserializeError("Failed to parse contract address".into())
         })?;
         let contract_name = ContractName::try_from(captures["contract"].to_string())
             .map_err(|_e| net_error::DeserializeError("Failed to parse contract name".into()))?;
         let trait_name = ClarityName::try_from(captures["traitName"].to_string())
             .map_err(|_e| net_error::DeserializeError("Failed to parse trait name".into()))?;
-        let trait_contract_addr = StacksAddress::from_string(&captures["traitContractAddr"])
+        let trait_contract_addr = StacksAddress::from_str(&captures["traitContractAddr"])
             .ok_or_else(|| net_error::DeserializeError("Failed to parse contract address".into()))?
             .into();
         let trait_contract_name = ContractName::try_from(captures["traitContractName"].to_string())

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2185,7 +2185,8 @@ pub mod test {
                 BlockstackOperationType::TransferStx(_)
                 | BlockstackOperationType::DelegateStx(_)
                 | BlockstackOperationType::PreStx(_)
-                | BlockstackOperationType::StackStx(_) => Ok(()),
+                | BlockstackOperationType::StackStx(_)
+                | BlockstackOperationType::PegIn(_) => Ok(()),
             }
         }
 

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -4972,7 +4972,7 @@ pub mod test {
         };
 
         let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
-        let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+        let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
         let high_repeat_factor = 128 * 1024;
         let tx_high_body_start = "{ a : ".repeat(high_repeat_factor as usize);

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -5255,8 +5255,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getcontractsrc(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world".try_into().unwrap(),
                     TipRequest::UseLatestAnchoredTip,
                     false,
@@ -5303,8 +5302,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getcontractsrc(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
                     TipRequest::UseLatestAnchoredTip,
                     false,
@@ -5357,8 +5355,7 @@ mod test {
                     .unconfirmed_chain_tip
                     .clone();
                 convo_client.new_getcontractsrc(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
                     TipRequest::SpecificTip(unconfirmed_tip),
                     false,
@@ -5404,8 +5401,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getcontractsrc(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
                     TipRequest::UseLatestAnchoredTip,
                     false,
@@ -5447,7 +5443,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getaccount(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal(),
                     TipRequest::UseLatestAnchoredTip,
@@ -5495,7 +5491,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getaccount(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal(),
                     TipRequest::UseLatestAnchoredTip,
@@ -5544,7 +5540,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getaccount(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal(),
                     TipRequest::UseLatestAnchoredTip,
@@ -5596,7 +5592,7 @@ mod test {
                     .unconfirmed_chain_tip
                     .clone();
                 convo_client.new_getaccount(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal(),
                     TipRequest::SpecificTip(unconfirmed_tip),
@@ -5641,8 +5637,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getdatavar(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world".try_into().unwrap(),
                     "bar".try_into().unwrap(),
                     TipRequest::UseLatestAnchoredTip,
@@ -5695,8 +5690,7 @@ mod test {
                     .unconfirmed_chain_tip
                     .clone();
                 convo_client.new_getdatavar(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world".try_into().unwrap(),
                     "bar".try_into().unwrap(),
                     TipRequest::SpecificTip(unconfirmed_tip),
@@ -5742,8 +5736,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getdatavar(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world".try_into().unwrap(),
                     "bar-nonexistant".try_into().unwrap(),
                     TipRequest::UseLatestAnchoredTip,
@@ -5789,12 +5782,11 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 let principal =
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal();
                 convo_client.new_getmapentry(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world".try_into().unwrap(),
                     "unit-map".try_into().unwrap(),
                     Value::Tuple(
@@ -5858,12 +5850,11 @@ mod test {
                     .unconfirmed_chain_tip
                     .clone();
                 let principal =
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal();
                 convo_client.new_getmapentry(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world".try_into().unwrap(),
                     "unit-map".try_into().unwrap(),
                     Value::Tuple(
@@ -5917,12 +5908,11 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 let principal =
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal();
                 convo_client.new_getmapentry(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world".try_into().unwrap(),
                     "unit-map".try_into().unwrap(),
                     Value::Tuple(
@@ -5979,8 +5969,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getcontractabi(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
                     TipRequest::UseLatestAnchoredTip,
                 )
@@ -6031,8 +6020,7 @@ mod test {
                     .unconfirmed_chain_tip
                     .clone();
                 convo_client.new_getcontractabi(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
                     TipRequest::SpecificTip(unconfirmed_tip),
                 )
@@ -6070,8 +6058,7 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_getcontractabi(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
                     TipRequest::UseLatestAnchoredTip,
                 )
@@ -6112,10 +6099,9 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_callreadonlyfunction(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal(),
                     None,
@@ -6166,10 +6152,9 @@ mod test {
              ref mut peer_server,
              ref mut convo_server| {
                 convo_client.new_callreadonlyfunction(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal(),
                     None,
@@ -6227,10 +6212,9 @@ mod test {
                     .unconfirmed_chain_tip
                     .clone();
                 convo_client.new_callreadonlyfunction(
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
-                        .unwrap(),
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R").unwrap(),
                     "hello-world-unconfirmed".try_into().unwrap(),
-                    StacksAddress::from_string("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
+                    StacksAddress::from_str("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R")
                         .unwrap()
                         .to_account_principal(),
                     None,

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -54,7 +54,7 @@ pub trait PrivateKey: Clone + fmt::Debug + serde::Serialize + serde::de::Deseria
 
 pub trait Address: Clone + fmt::Debug + fmt::Display {
     fn to_bytes(&self) -> Vec<u8>;
-    fn from_string(from: &str) -> Option<Self>
+    fn from_str(from: &str) -> Option<Self>
     where
         Self: Sized;
     fn is_burn(&self) -> bool;
@@ -72,6 +72,7 @@ pub enum StacksEpochId {
     Epoch20 = 0x02000,
     Epoch2_05 = 0x02005,
     Epoch21 = 0x0200a,
+    Epoch30 = 0x03000,
 }
 
 impl StacksEpochId {
@@ -87,6 +88,7 @@ impl std::fmt::Display for StacksEpochId {
             StacksEpochId::Epoch20 => write!(f, "2.0"),
             StacksEpochId::Epoch2_05 => write!(f, "2.05"),
             StacksEpochId::Epoch21 => write!(f, "2.1"),
+            StacksEpochId::Epoch30 => write!(f, "3.0"),
         }
     }
 }
@@ -100,6 +102,7 @@ impl TryFrom<u32> for StacksEpochId {
             x if x == StacksEpochId::Epoch20 as u32 => Ok(StacksEpochId::Epoch20),
             x if x == StacksEpochId::Epoch2_05 as u32 => Ok(StacksEpochId::Epoch2_05),
             x if x == StacksEpochId::Epoch21 as u32 => Ok(StacksEpochId::Epoch21),
+            x if x == StacksEpochId::Epoch30 as u32 => Ok(StacksEpochId::Epoch30),
             _ => Err("Invalid epoch"),
         }
     }
@@ -202,7 +205,7 @@ impl Address for StacksAddress {
         self.bytes.as_bytes().to_vec()
     }
 
-    fn from_string(s: &str) -> Option<StacksAddress> {
+    fn from_str(s: &str) -> Option<StacksAddress> {
         let (version, bytes) = match c32_address_decode(s) {
             Ok((v, b)) => (v, b),
             Err(_) => {
@@ -217,7 +220,7 @@ impl Address for StacksAddress {
         let mut hash_bytes = [0u8; 20];
         hash_bytes.copy_from_slice(&bytes[..]);
         Some(StacksAddress {
-            version: version,
+            version,
             bytes: Hash160(hash_bytes),
         })
     }

--- a/testnet/stacks-node/src/keychain.rs
+++ b/testnet/stacks-node/src/keychain.rs
@@ -492,7 +492,7 @@ mod tests {
             let k2 = KeychainOld::default(seed.to_vec());
 
             let recv_addr =
-                StacksAddress::from_string("SP1Z4P459B2M5XC2PMM2CSCNZ6824DN5GZG2XYWFH").unwrap();
+                StacksAddress::from_str("SP1Z4P459B2M5XC2PMM2CSCNZ6824DN5GZG2XYWFH").unwrap();
 
             let mut tx_stx_transfer_1 = StacksTransaction::new(
                 TransactionVersion::Testnet,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -258,7 +258,7 @@ fn advance_to_2_1(
             // pox-2 should be initialized now
             let _ = get_contract_src(
                 &http_origin,
-                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "pox-2".to_string(),
                 true,
             )
@@ -269,7 +269,7 @@ fn advance_to_2_1(
             // pox-2 should NOT be initialized
             let e = get_contract_src(
                 &http_origin,
-                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "pox-2".to_string(),
                 true,
             )
@@ -769,7 +769,7 @@ fn transition_fixes_bitcoin_rigidity() {
             // pox-2 should be initialized now
             let _ = get_contract_src(
                 &http_origin,
-                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "pox-2".to_string(),
                 true,
             )
@@ -778,7 +778,7 @@ fn transition_fixes_bitcoin_rigidity() {
             // costs-3 should be initialized now
             let _ = get_contract_src(
                 &http_origin,
-                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "costs-3".to_string(),
                 true,
             )
@@ -789,7 +789,7 @@ fn transition_fixes_bitcoin_rigidity() {
             // pox-2 should NOT be initialized
             let e = get_contract_src(
                 &http_origin,
-                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "pox-2".to_string(),
                 true,
             )
@@ -799,7 +799,7 @@ fn transition_fixes_bitcoin_rigidity() {
             // costs-3 should NOT be initialized
             let e = get_contract_src(
                 &http_origin,
-                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "costs-3".to_string(),
                 true,
             )
@@ -1122,7 +1122,7 @@ fn transition_adds_get_pox_addr_recipients() {
             &spender_sk,
             0,
             300,
-            &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+            &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
             "pox-2",
             "stack-stx",
             &[
@@ -1162,7 +1162,7 @@ fn transition_adds_get_pox_addr_recipients() {
             &spender_sk,
             0,
             300,
-            &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+            &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
             "pox-2",
             "stack-stx",
             &[
@@ -1582,7 +1582,7 @@ fn transition_removes_pox_sunset() {
         &spender_sk,
         0,
         260,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "pox",
         "stack-stx",
         &[
@@ -1644,7 +1644,7 @@ fn transition_removes_pox_sunset() {
         &spender_sk,
         1,
         260 * 2,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "pox-2",
         "stack-stx",
         &[
@@ -4416,7 +4416,7 @@ fn test_v1_unlock_height() {
         &spender_sk,
         0,
         3000,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "pox-2",
         "stack-stx",
         &[

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -318,7 +318,7 @@ fn integration_test_get_info() {
                     &spender_sk,
                     (round - 1).into(),
                     10,
-                    &StacksAddress::from_string(ADDR_4).unwrap().into(),
+                    &StacksAddress::from_str(ADDR_4).unwrap().into(),
                     100,
                 );
                 tenure
@@ -796,7 +796,7 @@ fn integration_test_get_info() {
 
                 // tx_xfer is 180 bytes long
                 let tx_xfer = make_stacks_transfer(&spender_sk, round.into(), 200,
-                                                   &StacksAddress::from_string(ADDR_4).unwrap().into(), 123);
+                                                   &StacksAddress::from_str(ADDR_4).unwrap().into(), 123);
 
                 let res: String = client.post(&path)
                     .header("Content-Type", "application/octet-stream")
@@ -828,7 +828,7 @@ fn integration_test_get_info() {
 
                 // tx_xfer_invalid is 180 bytes long
                 let tx_xfer_invalid = make_stacks_transfer(&spender_sk, (round + 30).into(), 200,     // bad nonce
-                                                           &StacksAddress::from_string(ADDR_4).unwrap().into(), 456);
+                                                           &StacksAddress::from_str(ADDR_4).unwrap().into(), 456);
 
                 let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
 
@@ -2127,7 +2127,7 @@ fn mempool_errors() {
             let spender_sk = StacksPrivateKey::from_hex(SK_3).unwrap();
             let spender_addr = to_addr(&spender_sk);
 
-            let send_to = StacksAddress::from_string(ADDR_4).unwrap().into();
+            let send_to = StacksAddress::from_str(ADDR_4).unwrap().into();
 
             if round == 1 {
                 // let's submit an invalid transaction!

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -261,7 +261,7 @@ pub fn new_test_conf() -> Config {
         10000,
     );
 
-    conf.burnchain.epochs = Some(StacksEpoch::all(0, 0, 0));
+    conf.burnchain.epochs = Some(StacksEpoch::all(0, 0, 0, 0));
 
     let rpc_port = u16::from_be_bytes(buf[0..2].try_into().unwrap()).saturating_add(1025) - 1; // use a non-privileged port between 1024 and 65534
     let p2p_port = u16::from_be_bytes(buf[2..4].try_into().unwrap()).saturating_add(1025) - 1; // use a non-privileged port between 1024 and 65534

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1430,7 +1430,7 @@ fn lockup_integration() {
     // 3QsabRcGFfw3B9rNpEcW9rN6twjZGwNz5s,13888888889,3
     // 3QsabRcGFfw3B9rNpEcW9rN6twjZGwNz5s -> SN3Z4MMRJ29FVZB38FGYPE94N1D8ZGF55R7YWH00A
     let recipient_addr_str = "SN3Z4MMRJ29FVZB38FGYPE94N1D8ZGF55R7YWH00A";
-    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+    let recipient = StacksAddress::from_str(recipient_addr_str).unwrap();
 
     // first block will hold our VRF registration
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
@@ -2113,7 +2113,7 @@ fn microblock_fork_poison_integration_test() {
 
     info!("Test microblock");
 
-    let recipient = StacksAddress::from_string(ADDR_4).unwrap();
+    let recipient = StacksAddress::from_str(ADDR_4).unwrap();
     let unconfirmed_tx_bytes =
         make_stacks_transfer_mblock_only(&spender_sk, 0, 1000, &recipient.into(), 1000);
     let unconfirmed_tx =
@@ -2341,7 +2341,7 @@ fn microblock_integration_test() {
     assert_eq!(account.nonce, 0);
 
     // okay, let's push a transaction that is marked microblock only!
-    let recipient = StacksAddress::from_string(ADDR_4).unwrap();
+    let recipient = StacksAddress::from_str(ADDR_4).unwrap();
     let tx = make_stacks_transfer_mblock_only(&spender_sk, 0, 1000, &recipient.into(), 1000);
     submit_tx(&http_origin, &tx);
 
@@ -2371,7 +2371,7 @@ fn microblock_integration_test() {
     assert_eq!(account.nonce, 1);
 
     // push another two transactions that are marked microblock only
-    let recipient = StacksAddress::from_string(ADDR_4).unwrap();
+    let recipient = StacksAddress::from_str(ADDR_4).unwrap();
     let unconfirmed_tx_bytes =
         make_stacks_transfer_mblock_only(&spender_sk, 1, 1000, &recipient.into(), 1000);
     let unconfirmed_tx =
@@ -2777,7 +2777,7 @@ fn filter_low_fee_tx_integration_test() {
         .iter()
         .enumerate()
         .map(|(ix, spender_sk)| {
-            let recipient = StacksAddress::from_string(ADDR_4).unwrap();
+            let recipient = StacksAddress::from_str(ADDR_4).unwrap();
 
             if ix < 5 {
                 // low-fee
@@ -2874,7 +2874,7 @@ fn filter_long_runtime_tx_integration_test() {
         .iter()
         .enumerate()
         .map(|(ix, spender_sk)| {
-            let recipient = StacksAddress::from_string(ADDR_4).unwrap();
+            let recipient = StacksAddress::from_str(ADDR_4).unwrap();
             make_stacks_transfer(&spender_sk, 0, 1000 + (ix as u64), &recipient.into(), 1000)
         })
         .collect();
@@ -4153,7 +4153,7 @@ fn block_replay_integration_test() {
     assert_eq!(account.balance, 100300);
     assert_eq!(account.nonce, 0);
 
-    let recipient = StacksAddress::from_string(ADDR_4).unwrap();
+    let recipient = StacksAddress::from_str(ADDR_4).unwrap();
     let tx = make_stacks_transfer(&spender_sk, 0, 1000, &recipient.into(), 1000);
     submit_tx(&http_origin, &tx);
 
@@ -4373,7 +4373,7 @@ fn cost_voting_integration() {
         &spender_sk,
         5,
         1000,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "cost-voting",
         "confirm-miners",
         &[Value::UInt(0)],
@@ -4423,7 +4423,7 @@ fn cost_voting_integration() {
         &spender_sk,
         6,
         1000,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "cost-voting",
         "confirm-miners",
         &[Value::UInt(0)],
@@ -5620,7 +5620,7 @@ fn pox_integration_test() {
         &spender_sk,
         0,
         260,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "pox",
         "stack-stx",
         &[
@@ -5733,7 +5733,7 @@ fn pox_integration_test() {
         &spender_2_sk,
         0,
         260,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "pox",
         "stack-stx",
         &[
@@ -5756,7 +5756,7 @@ fn pox_integration_test() {
         &spender_3_sk,
         0,
         260,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "pox",
         "stack-stx",
         &[
@@ -6093,7 +6093,7 @@ fn atlas_integration_test() {
             &user_1,
             0,
             260,
-            &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+            &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
             "bns",
             "namespace-preorder",
             &[
@@ -6152,7 +6152,7 @@ fn atlas_integration_test() {
             &user_1,
             1,
             1000,
-            &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+            &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
             "bns",
             "namespace-reveal",
             &[
@@ -6214,7 +6214,7 @@ fn atlas_integration_test() {
             &user_1,
             2,
             500,
-            &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+            &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
             "bns",
             "name-import",
             &[
@@ -6409,7 +6409,7 @@ fn atlas_integration_test() {
             &user_1,
             2 + i,
             500,
-            &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+            &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
             "bns",
             "name-import",
             &[
@@ -6870,7 +6870,7 @@ fn atlas_stress_integration_test() {
         &user_1,
         0,
         1000,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "bns",
         "namespace-preorder",
         &[
@@ -6929,7 +6929,7 @@ fn atlas_stress_integration_test() {
         &user_1,
         1,
         1000,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "bns",
         "namespace-reveal",
         &[
@@ -7017,7 +7017,7 @@ fn atlas_stress_integration_test() {
                 &user_1,
                 2 + (batch_size * i + j) as u64,
                 1000,
-                &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "bns",
                 "name-import",
                 &[
@@ -7086,7 +7086,7 @@ fn atlas_stress_integration_test() {
         &user_1,
         2 + (batch_size as u64) * (batches as u64),
         1000,
-        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
         "bns",
         "namespace-ready",
         &[Value::buff_from(namespace.as_bytes().to_vec()).unwrap()],
@@ -7146,7 +7146,7 @@ fn atlas_stress_integration_test() {
                 &users[batches * batch_size + j],
                 0,
                 1000,
-                &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "bns",
                 "name-preorder",
                 &[
@@ -7205,7 +7205,7 @@ fn atlas_stress_integration_test() {
                 &users[batches * batch_size + j],
                 1,
                 1000,
-                &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "bns",
                 "name-register",
                 &[
@@ -7268,7 +7268,7 @@ fn atlas_stress_integration_test() {
                 &users[batches * batch_size + j],
                 2,
                 1000,
-                &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "bns",
                 "name-update",
                 &[
@@ -7330,7 +7330,7 @@ fn atlas_stress_integration_test() {
                 &users[batches * batch_size + j],
                 3,
                 1000,
-                &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                &StacksAddress::from_str("ST000000000000000000002AMW42H").unwrap(),
                 "bns",
                 "name-renewal",
                 &[
@@ -7793,7 +7793,7 @@ fn use_latest_tip_integration_test() {
         .unwrap();
 
     // Make microblock with two transactions.
-    let recipient = StacksAddress::from_string(ADDR_4).unwrap();
+    let recipient = StacksAddress::from_str(ADDR_4).unwrap();
     let transfer_tx =
         make_stacks_transfer_mblock_only(&spender_sk, 0, 1000, &recipient.into(), 1000);
 


### PR DESCRIPTION
Draft of what I have so far on the Peg-in wire format. This is currently blocked on verifying the peg wallet address, which requires updates to the PoX contract to provide unique public keys for stackers.

To do:
- [ ] Verification logic for peg-wallet address.
- [ ] Integration test: Write PegIn transaction to burnchain and query it from the node.

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
