### PR TITLE
Feat/stackerdb

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -520,7 +520,8 @@ pub struct BurnchainView {
     pub burn_block_hash: BurnchainHeaderHash, // last-seen burn block hash
     pub burn_stable_block_height: u64, // latest stable block height (e.g. chain tip minus 7)
     pub burn_stable_block_hash: BurnchainHeaderHash, // latest stable burn block hash
-    pub last_burn_block_hashes: HashMap<u64, BurnchainHeaderHash>, // map all block heights from burn_block_height back to the oldest one we'll take for considering the peer a neighbor
+    pub last_burn_block_hashes: HashMap<u64, BurnchainHeaderHash>, // map all block heights from burn_block_height back to the oldest one we'll take for considering the peer a neighbor,
+    pub rc_consensus_hash: ConsensusHash, // consensus hash of the current reward cycle's start block
 }
 
 /// The burnchain block's encoded state transition:

--- a/src/main.rs
+++ b/src/main.rs
@@ -565,6 +565,7 @@ check if the associated microblocks can be downloaded
             None,
             0,
             UrlString::try_from("abc").unwrap(),
+            vec![],
         );
 
         let header_hashes = {

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -3901,7 +3901,8 @@ mod test {
 
             // received a valid HandshakeAccept from peer 2
             match reply_handshake_1.payload {
-                StacksMessageType::HandshakeAccept(ref data) => {
+                StacksMessageType::HandshakeAccept(ref data)
+                | StacksMessageType::StackerDBHandshakeAccept(ref data, ..) => {
                     assert_eq!(data.handshake.addrbytes, local_peer_2.addrbytes);
                     assert_eq!(data.handshake.port, local_peer_2.port);
                     assert_eq!(data.handshake.services, local_peer_2.services);
@@ -4242,7 +4243,8 @@ mod test {
 
             // received a valid HandshakeAccept from peer 2
             match reply_1.payload {
-                StacksMessageType::HandshakeAccept(ref data) => {
+                StacksMessageType::HandshakeAccept(ref data)
+                | StacksMessageType::StackerDBHandshakeAccept(ref data, ..) => {
                     assert_eq!(data.handshake.addrbytes, local_peer_2.addrbytes);
                     assert_eq!(data.handshake.port, local_peer_2.port);
                     assert_eq!(data.handshake.services, local_peer_2.services);

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -361,6 +361,7 @@ pub struct ConnectionOptions {
     pub max_block_push_bandwidth: u64,
     pub max_microblocks_push_bandwidth: u64,
     pub max_transaction_push_bandwidth: u64,
+    pub max_stackerdb_push_bandwidth: u64,
     pub max_sockets: usize,
     pub public_ip_address: Option<(PeerAddress, u16)>,
     pub public_ip_request_timeout: u64,
@@ -450,6 +451,7 @@ impl std::default::Default for ConnectionOptions {
             max_block_push_bandwidth: 0, // infinite upload bandwidth allowed
             max_microblocks_push_bandwidth: 0, // infinite upload bandwidth allowed
             max_transaction_push_bandwidth: 0, // infinite upload bandwidth allowed
+            max_stackerdb_push_bandwidth: 0, // infinite upload bandwidth allowed
             max_sockets: 800,            // maximum number of client sockets we'll ever register
             public_ip_address: None,     // resolve it at runtime by default
             public_ip_request_timeout: 60, // how often we can attempt to look up our public IP address

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3866,6 +3866,7 @@ mod test {
             burn_stable_block_height: 12340,
             burn_stable_block_hash: BurnchainHeaderHash([0x22; 32]),
             last_burn_block_hashes: HashMap::new(),
+            rc_consensus_hash: ConsensusHash([0x33; 20]),
         };
 
         burnchain_view.make_test_data();

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -53,9 +53,12 @@ use crate::burnchains::PublicKey;
 
 use rand::prelude::*;
 use rand::thread_rng;
+use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::*;
 use stacks_common::util::log;
+
+use clarity::vm::ContractName;
 
 #[cfg(test)]
 pub const NEIGHBOR_MINIMUM_CONTACT_INTERVAL: u64 = 0;
@@ -118,18 +121,30 @@ impl Neighbor {
     /// Update this peer in the DB.
     /// If there's no DB entry for this peer, then do nothing.
     /// Updates last-contact-time to now, since this is only called when we get back a Handshake
-    pub fn save_update<'a>(&mut self, tx: &mut DBTx<'a>) -> Result<(), net_error> {
+    pub fn save_update<'a>(
+        &mut self,
+        tx: &mut DBTx<'a>,
+        stacker_dbs: Option<&[(StacksAddress, ContractName)]>,
+    ) -> Result<(), net_error> {
         self.last_contact_time = get_epoch_time_secs();
-        PeerDB::update_peer(tx, &self).map_err(net_error::DBError)
+        PeerDB::update_peer(tx, &self).map_err(net_error::DBError)?;
+        if let Some(stacker_dbs) = stacker_dbs {
+            PeerDB::update_peer_stacker_dbs(tx, &self, stacker_dbs).map_err(net_error::DBError)?;
+        }
+        Ok(())
     }
 
     /// Save to the peer DB, inserting it if it isn't already there.
     /// Updates last-contact-time to now, since this is only called when we get back a Handshake
     /// Return true if saved.
     /// Return false if not saved -- i.e. the frontier is full and we should try evicting neighbors.
-    pub fn save<'a>(&mut self, tx: &mut DBTx<'a>) -> Result<bool, net_error> {
+    pub fn save<'a>(
+        &mut self,
+        tx: &mut DBTx<'a>,
+        stacker_dbs: Option<&[(StacksAddress, ContractName)]>,
+    ) -> Result<bool, net_error> {
         self.last_contact_time = get_epoch_time_secs();
-        PeerDB::try_insert_peer(tx, &self).map_err(net_error::DBError)
+        PeerDB::try_insert_peer(tx, &self, stacker_dbs.unwrap_or(&[])).map_err(net_error::DBError)
     }
 
     /// Attempt to load a neighbor from our peer DB, given its NeighborAddress reported by another
@@ -238,6 +253,237 @@ impl NeighborWalkResult {
         self.broken_connections.clear();
         self.replaced_neighbors.clear();
         self.do_prune = false;
+    }
+}
+
+/// A trait for representing a set of connected neighbors, for the purposes of executing some P2P
+/// algorithm.
+pub trait NeighborSet {
+    /// Add a neighbor and its event ID as connecting
+    fn add_connecting(&mut self, nk: &NeighborKey, event_id: usize);
+    /// Get a connecting neighbor's event ID
+    fn get_connecting(&self, nk: &NeighborKey) -> Option<usize>;
+    /// Remove a neighbor from connecting state
+    fn remove_connecting(&mut self, nk: &NeighborKey);
+    /// Mark a neighbor as dead (inactive, unreachable, etc.)
+    fn add_dead(&mut self, nk: &NeighborKey);
+    /// Pin a connection -- prevent it from getting pruned
+    fn pin_connection(&mut self, event_id: usize);
+    /// Unpin a connection -- allow it to get pruned
+    fn unpin_connection(&mut self, event_id: usize);
+    /// Is the connection pinned?
+    fn is_pinned(&self, event_id: usize) -> bool;
+
+    /// Send off a handshake to a remote peer.
+    /// Fails if not connected.
+    fn neighbor_handshake(
+        &mut self,
+        network: &mut PeerNetwork,
+        nk: &NeighborKey,
+    ) -> Result<ReplyHandleP2P, net_error> {
+        // send handshake.
+        let handshake_data = HandshakeData::from_local_peer(&network.local_peer);
+
+        debug!("{:?}: send Handshake to {:?}", &network.local_peer, &nk);
+        self.remove_connecting(nk);
+
+        let msg = match network.sign_for_peer(nk, StacksMessageType::Handshake(handshake_data)) {
+            Ok(msg) => msg,
+            Err(e) => {
+                info!(
+                    "{:?}: Failed to sign for peer {:?}",
+                    &network.local_peer, &nk
+                );
+                self.add_dead(nk);
+                return Err(e);
+            }
+        };
+
+        let req_res = network.send_message(nk, msg, network.connection_opts.timeout);
+
+        // we tried this neighbor
+        match req_res {
+            Ok(handle) => Ok(handle),
+            Err(e) => {
+                debug!(
+                    "{:?}: Not connected: {:?} ({:?})",
+                    &network.local_peer, nk, &e
+                );
+                self.add_dead(nk);
+                Err(net_error::PeerNotConnected)
+            }
+        }
+    }
+
+    /// Connect to a neighbor if we're not connected yet, and send it a handshake.
+    /// Returns Ok(Some(handle)) if the handshake is now sending
+    /// Returns Ok(None) if we're still connecting. The caller should try again.
+    /// Returns Err(..) if connection or sending failed for some reason.
+    fn neighbor_connect_and_handshake(
+        &mut self,
+        network: &mut PeerNetwork,
+        nk: &NeighborKey,
+    ) -> Result<Option<ReplyHandleP2P>, net_error> {
+        match network.can_register_peer(nk, true) {
+            Ok(_) => {
+                if let Some(event_id) = self.get_connecting(nk) {
+                    // is the peer network still working?
+                    if !network.is_connecting(event_id) {
+                        debug!("{:?}: Failed to connect to {:?} (event {} no longer connecting; assumed timed out)", &network.local_peer, event_id, nk);
+                        return Err(net_error::PeerNotConnected);
+                    }
+
+                    // still connecting
+                    debug!(
+                        "{:?}: still connecting to {:?} (event {})",
+                        &network.local_peer, nk, event_id
+                    );
+                    return Ok(None);
+                } else {
+                    let con_res = network.connect_peer(nk);
+                    match con_res {
+                        Ok(event_id) => {
+                            // remember this in the walk result
+                            self.add_connecting(nk, event_id);
+
+                            // force the caller to try again -- we're not registered yet
+                            debug!(
+                                "{:?}: Connecting to {:?} (event {})",
+                                &network.local_peer, &nk, event_id
+                            );
+                            return Ok(None);
+                        }
+                        Err(_e) => {
+                            debug!(
+                                "{:?}: Failed to connect to {:?}: {:?}",
+                                &network.local_peer, nk, &_e
+                            );
+                            return Err(net_error::PeerNotConnected);
+                        }
+                    }
+                }
+            }
+            Err(net_error::AlreadyConnected(_event_id, _nk)) => {
+                test_debug!(
+                    "{:?}: already connected to {:?} as event {}",
+                    &network.local_peer,
+                    &nk,
+                    _event_id
+                );
+            }
+            Err(e) => {
+                info!(
+                    "{:?}: could not connect to {:?}: {:?}",
+                    &network.local_peer, &nk, &e
+                );
+                return Err(e);
+            }
+        }
+
+        self.neighbor_handshake(network, nk)
+            .and_then(|handle| Ok(Some(handle)))
+    }
+
+    /// Connect to a remote neighbor, and get back a reply handle which we can use to wait for a
+    /// handshake response.  If the neighbor is already connected, then just send a handshake.
+    /// Return Ok(Some(handle)) if we connected.
+    /// Return Ok(None) if we're in the process of connecting, and should try again.
+    /// Return Err(..) if we fail
+    fn neighbor_session_begin(
+        &mut self,
+        network: &mut PeerNetwork,
+        neighbor_addr: &NeighborKey,
+        neighbor_pubkh: &Hash160,
+    ) -> Result<Option<ReplyHandleP2P>, net_error> {
+        match network.can_register_peer_with_pubkey(&neighbor_addr, true, &neighbor_pubkh) {
+            Ok(_) => self.neighbor_connect_and_handshake(network, &neighbor_addr),
+            Err(net_error::AlreadyConnected(event_id, handshake_nk)) => {
+                // already connected, but on a possibly-different address.
+                // If the already-connected handle is inbound,
+                // then try to connect to this address anyway in
+                // order to maximize our outbound connections we have.
+                if let Some(convo) = network.peers.get(&event_id) {
+                    if !convo.is_outbound() {
+                        debug!("{:?}: Already connected to {:?} on inbound event {} (address {:?}). Try to establish outbound connection to {:?} {:?}.",
+                               &network.local_peer, &neighbor_addr, &event_id, &handshake_nk, &neighbor_pubkh, &neighbor_addr);
+                        let res = self.neighbor_connect_and_handshake(network, &neighbor_addr)?;
+                        return Ok(res);
+                    } else {
+                        debug!(
+                            "{:?}: Already connected to {:?} on event {} (address: {:?})",
+                            &network.local_peer, &neighbor_addr, &event_id, &handshake_nk
+                        );
+                        let handle = self.neighbor_handshake(network, &handshake_nk)?;
+                        return Ok(Some(handle));
+                    }
+                } else {
+                    // should never be reachable
+                    error!(
+                        "AlreadyConnected error on event {} has no conversation",
+                        event_id
+                    );
+                    return Err(net_error::PeerNotConnected);
+                }
+            }
+            Err(e) => {
+                debug!(
+                    "{:?}: Failed to check connection to {:?}: {:?}. No handshake sent.",
+                    &network.local_peer, &neighbor_addr, &e
+                );
+                return Err(e);
+            }
+        }
+    }
+
+    /// Send a message to a connected neighbor.
+    /// Fails if the neighbor is not connected.
+    fn neighbor_send(
+        network: &mut PeerNetwork,
+        neighbor_addr: &NeighborKey,
+        msg_payload: StacksMessageType,
+    ) -> Result<ReplyHandleP2P, net_error> {
+        let msg = network.sign_for_peer(&neighbor_addr, msg_payload)?;
+        network.send_message(neighbor_addr, msg, network.connection_opts.timeout)
+    }
+
+    /// Try to receive a message from a peer handle.
+    /// On success, consume the reply handle and return the StacksMessage.
+    /// On error, either return the reply handle so we can try again, or return an error if we
+    /// encounter an irrecoverable failure.  In the event of a failure, the neighbor will be added
+    /// to the `dead` set in the neighbor set.
+    fn neighbor_try_recv(
+        &mut self,
+        network: &mut PeerNetwork,
+        req_nk: &NeighborKey,
+        mut req: ReplyHandleP2P,
+    ) -> Result<StacksMessage, Result<ReplyHandleP2P, net_error>> {
+        if let Err(e) = network.saturate_p2p_socket(req.get_event_id(), &mut req) {
+            self.add_dead(req_nk);
+            return Err(Err(e));
+        }
+
+        match req.try_send_recv() {
+            Ok(message) => {
+                return Ok(message);
+            }
+            Err(req_res) => {
+                match req_res {
+                    Ok(same_req) => {
+                        // try again
+                        return Err(Ok(same_req));
+                    }
+                    Err(e) => {
+                        // disconnected
+                        debug!(
+                            "{:?}: Failed to get reply from {:?}: {:?}",
+                            &network.local_peer, req_nk, &e
+                        );
+                        self.add_dead(req_nk);
+                        return Err(Err(e));
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -493,6 +739,94 @@ impl NeighborWalk {
         self.set_state(NeighborWalkState::HandshakeFinish);
     }
 
+    /// Handle a HandshakeAcceptData.
+    /// Update the PeerDB information from the handshake data, as well as `self.cur_neighbor`, if
+    /// this neighbor was routable.  If it's not routable (i.e. we walked to an inbound neighbor),
+    /// then do not update the DB.
+    /// Add this neighbor to our newly-calculated frontier either way.
+    /// Returns the updated `self.cur_neighbor` on success.
+    /// Returns Err(..) if we failed to validate the request or we have a DB error.
+    fn handle_handshake_accept(
+        &mut self,
+        network: &mut PeerNetwork,
+        message: &StacksMessage,
+        data: &HandshakeAcceptData,
+        db_data: Option<&StackerDBHandshakeData>,
+    ) -> Result<Neighbor, net_error> {
+        // accepted! can proceed to ask for neighbors
+        // save knowledge to the peer DB if it was outbound
+        // (NOTE: an outbound neighbor should already be in
+        // the DB, since it's cur_neighbor)
+        if self.walk_outbound {
+            // connected to a routable neighbor, so update its entry in the DB.
+            let mut tx = network.peerdb.tx_begin()?;
+            let mut neighbor_from_handshake = Neighbor::from_handshake(
+                &mut tx,
+                message.preamble.peer_version,
+                message.preamble.network_id,
+                &data.handshake,
+            )?;
+
+            // if the neighbor accidentally gave us a private IP address, then
+            // just use the one we used to contact it.  This can happen if the
+            // node is behind a load-balancer, or is doing port-forwarding,
+            // etc.
+            if neighbor_from_handshake.addr.addrbytes.is_in_private_range() {
+                debug!(
+                    "{:?}: outbound neighbor gave private IP address {:?}; assuming it meant {:?}",
+                    &self.local_peer, &neighbor_from_handshake.addr, &self.cur_neighbor.addr
+                );
+                neighbor_from_handshake.addr.addrbytes = self.cur_neighbor.addr.addrbytes.clone();
+                neighbor_from_handshake.addr.port = self.cur_neighbor.addr.port;
+            }
+
+            let res = if neighbor_from_handshake.addr != self.cur_neighbor.addr {
+                // somehow, got a handshake from someone that _isn't_ cur_neighbor
+                debug!("{:?}: got unsolicited (or bootstrapping) HandshakeAccept from outbound {:?} (expected {:?})", 
+                           &self.local_peer,
+                           &neighbor_from_handshake.addr,
+                           &self.cur_neighbor.addr);
+
+                Err(net_error::PeerNotConnected)
+            } else {
+                // this is indeed cur_neighbor
+                self.cur_neighbor
+                    .handshake_update(&mut tx, &data.handshake)?;
+                self.cur_neighbor
+                    .save_update(&mut tx, db_data.map(|x| x.smart_contracts.as_slice()))?;
+
+                debug!(
+                    "{:?}: Connected with {:?}",
+                    &self.local_peer, &self.cur_neighbor.addr
+                );
+                self.new_frontier
+                    .insert(self.cur_neighbor.addr.clone(), self.cur_neighbor.clone());
+
+                // advance state!
+                Ok(self.cur_neighbor.clone())
+            };
+            tx.commit()?;
+            self.neighbor_from_handshake = neighbor_from_handshake.addr;
+            res
+        } else {
+            // connected to an unroutable neighbor, so
+            // don't save to DB (but do update frontier)
+            let neighbor_from_handshake = Neighbor::from_handshake(
+                &network.peerdb.conn(),
+                message.preamble.peer_version,
+                message.preamble.network_id,
+                &data.handshake,
+            )?;
+            debug!(
+                "{:?}: Connected with inbound non-frontier neighbor {:?}: {:?}",
+                &self.local_peer, &self.cur_neighbor.addr, &neighbor_from_handshake.addr
+            );
+
+            self.neighbor_from_handshake = neighbor_from_handshake.addr;
+            Ok(self.cur_neighbor.clone())
+        }
+    }
+
     /// Finish handshaking with our current neighbor, thereby ensuring that it is connected
     pub fn handshake_try_finish(
         &mut self,
@@ -529,10 +863,6 @@ impl NeighborWalk {
                 } else {
                     match message.payload {
                         StacksMessageType::HandshakeAccept(ref data) => {
-                            // accepted! can proceed to ask for neighbors
-                            // save knowledge to the peer DB if it was outbound
-                            // (NOTE: an outbound neighbor should already be in
-                            // the DB, since it's cur_neighbor)
                             debug!(
                                 "{:?}: received HandshakeAccept from {} {:?}: {:?}",
                                 &self.local_peer,
@@ -548,81 +878,39 @@ impl NeighborWalk {
                                 &data.handshake
                             );
 
-                            if self.walk_outbound {
-                                // connected to a routable neighbor, so update its entry in the DB.
-                                let mut tx = network.peerdb.tx_begin()?;
-                                let mut neighbor_from_handshake = Neighbor::from_handshake(
-                                    &mut tx,
-                                    message.preamble.peer_version,
-                                    message.preamble.network_id,
-                                    &data.handshake,
-                                )?;
+                            let updated_cur_neighbor =
+                                self.handle_handshake_accept(network, &message, data, None)?;
 
-                                // if the neighbor accidentally gave us a private IP address, then
-                                // just use the one we used to contact it.  This can happen if the
-                                // node is behind a load-balancer, or is doing port-forwarding,
-                                // etc.
-                                if neighbor_from_handshake.addr.addrbytes.is_in_private_range() {
-                                    debug!("{:?}: outbound neighbor gave private IP address {:?}; assuming it meant {:?}", &self.local_peer, &neighbor_from_handshake.addr, &self.cur_neighbor.addr);
-                                    neighbor_from_handshake.addr.addrbytes =
-                                        self.cur_neighbor.addr.addrbytes.clone();
-                                    neighbor_from_handshake.addr.port = self.cur_neighbor.addr.port;
-                                }
-
-                                let res = if neighbor_from_handshake.addr != self.cur_neighbor.addr
-                                {
-                                    // somehow, got a handshake from someone that _isn't_ cur_neighbor
-                                    debug!("{:?}: got unsolicited (or bootstrapping) HandshakeAccept from outbound {:?} (expected {:?})", 
-                                               &self.local_peer,
-                                               &neighbor_from_handshake.addr,
-                                               &self.cur_neighbor.addr);
-
-                                    Err(net_error::PeerNotConnected)
+                            // proceed to ask this neighbor for its neighbors.
+                            self.set_state(NeighborWalkState::GetNeighborsBegin);
+                            Ok(Some(updated_cur_neighbor))
+                        }
+                        StacksMessageType::StackerDBHandshakeAccept(ref data, ref db_data) => {
+                            debug!(
+                                "{:?}: received StackerDBHandshakeAccept from {} {:?}: {:?}, {:?}",
+                                &self.local_peer,
+                                if self.walk_outbound {
+                                    "outbound"
                                 } else {
-                                    // this is indeed cur_neighbor
-                                    self.cur_neighbor
-                                        .handshake_update(&mut tx, &data.handshake)?;
-                                    self.cur_neighbor.save_update(&mut tx)?;
+                                    "inbound"
+                                },
+                                &message.to_neighbor_key(
+                                    &data.handshake.addrbytes,
+                                    data.handshake.port
+                                ),
+                                &data.handshake,
+                                db_data
+                            );
+                            let updated_cur_neighbor = self.handle_handshake_accept(
+                                network,
+                                &message,
+                                data,
+                                Some(db_data),
+                            )?;
 
-                                    debug!(
-                                        "{:?}: Connected with {:?}",
-                                        &self.local_peer, &self.cur_neighbor.addr
-                                    );
-                                    self.new_frontier.insert(
-                                        self.cur_neighbor.addr.clone(),
-                                        self.cur_neighbor.clone(),
-                                    );
-
-                                    // advance state!
-                                    self.set_state(NeighborWalkState::GetNeighborsBegin);
-                                    Ok(Some(self.cur_neighbor.clone()))
-                                };
-                                tx.commit()?;
-
-                                self.neighbor_from_handshake = neighbor_from_handshake.addr;
-                                res
-                            } else {
-                                // connected to an unroutable neighbor, so
-                                // don't save to DB (but do update frontier)
-                                let neighbor_from_handshake = Neighbor::from_handshake(
-                                    &network.peerdb.conn(),
-                                    message.preamble.peer_version,
-                                    message.preamble.network_id,
-                                    &data.handshake,
-                                )?;
-                                debug!(
-                                    "{:?}: Connected with inbound non-frontier neighbor {:?}: {:?}",
-                                    &self.local_peer,
-                                    &self.cur_neighbor.addr,
-                                    &neighbor_from_handshake.addr
-                                );
-
-                                self.neighbor_from_handshake = neighbor_from_handshake.addr;
-
-                                // advance state!
-                                self.set_state(NeighborWalkState::GetNeighborsBegin);
-                                Ok(Some(self.cur_neighbor.clone()))
-                            }
+                            // proceed to ask this neighbor for its neighbors.
+                            self.set_state(NeighborWalkState::GetNeighborsBegin);
+                            Ok(Some(updated_cur_neighbor))
                         }
                         StacksMessageType::HandshakeReject => {
                             // told to bugger off
@@ -904,6 +1192,7 @@ impl NeighborWalk {
         peer_version: u32,
         network_id: u32,
         handshake: &HandshakeData,
+        db_data: Option<&StackerDBHandshakeData>,
     ) -> Result<(bool, Neighbor), net_error> {
         let mut neighbor_from_handshake =
             Neighbor::from_handshake(tx, peer_version, network_id, handshake)?;
@@ -914,7 +1203,8 @@ impl NeighborWalk {
                     "{:?}: already know about {:?}",
                     &self.local_peer, &neighbor.addr
                 );
-                neighbor_from_handshake.save_update(tx)?;
+                neighbor_from_handshake
+                    .save_update(tx, db_data.map(|x| x.smart_contracts.as_slice()))?;
 
                 // seen this neighbor before
                 Ok((false, neighbor_from_handshake))
@@ -926,7 +1216,8 @@ impl NeighborWalk {
                 );
 
                 // didn't know about this neighbor yet. Try to add it.
-                let added = neighbor_from_handshake.save(tx)?;
+                let added = neighbor_from_handshake
+                    .save(tx, db_data.map(|x| x.smart_contracts.as_slice()))?;
                 if !added {
                     // no more room in the db.  See if we can add it by
                     // evicting an existing neighbor once we're done with this
@@ -960,6 +1251,45 @@ impl NeighborWalk {
                 Ok((true, neighbor_from_handshake))
             }
         }
+    }
+
+    /// Handle a handshake accept from a neighbor as part of our neighbor-handshake step
+    fn handle_neighbor_handshake_accept(
+        &mut self,
+        network: &mut PeerNetwork,
+        block_height: u64,
+        naddr: NeighborAddress,
+        message: &StacksMessage,
+        data: &HandshakeAcceptData,
+        db_data: Option<&StackerDBHandshakeData>,
+    ) -> Result<(), net_error> {
+        // NOTE: even if cur_neighbor is an inbound neighbor, the neighbors
+        // of cur_neighbor that we could handshake with are necessarily
+        // outbound connections.  So, save them all.
+        // Do we know about this peer already?
+        let mut tx = network.peerdb.tx_begin()?;
+        let (new, neighbor) = self.add_or_schedule_replace_neighbor(
+            &mut tx,
+            block_height,
+            &naddr,
+            message.preamble.peer_version,
+            message.preamble.network_id,
+            &data.handshake,
+            db_data,
+        )?;
+        if new {
+            // neighbor was new
+            self.new_frontier
+                .insert(neighbor.addr.clone(), neighbor.clone());
+        } else {
+            // frontier maintenance
+            self.frontier
+                .insert(neighbor.addr.clone(), neighbor.clone());
+        }
+
+        self.resolved_handshake_neighbors.insert(naddr, neighbor);
+        tx.commit()?;
+        Ok(())
     }
 
     /// Try to finish getting handshakes from cur_neighbors' neighbors.
@@ -1016,31 +1346,29 @@ impl NeighborWalk {
                                     &self.local_peer, &naddr
                                 );
 
-                                // NOTE: even if cur_neighbor is an inbound neighbor, the neighbors
-                                // of cur_neighbor that we could handshake with are necessarily
-                                // outbound connections.  So, save them all.
-                                // Do we know about this peer already?
-                                let mut tx = network.peerdb.tx_begin()?;
-                                let (new, neighbor) = self.add_or_schedule_replace_neighbor(
-                                    &mut tx,
+                                self.handle_neighbor_handshake_accept(
+                                    network,
                                     block_height,
-                                    &naddr,
-                                    message.preamble.peer_version,
-                                    message.preamble.network_id,
-                                    &data.handshake,
+                                    naddr,
+                                    &message,
+                                    data,
+                                    None,
                                 )?;
-                                if new {
-                                    // neighbor was new
-                                    self.new_frontier
-                                        .insert(neighbor.addr.clone(), neighbor.clone());
-                                } else {
-                                    // frontier maintenance
-                                    self.frontier
-                                        .insert(neighbor.addr.clone(), neighbor.clone());
-                                }
+                            }
+                            StacksMessageType::StackerDBHandshakeAccept(ref data, ref db_data) => {
+                                debug!(
+                                    "{:?}: Got StackerDBHandshakeAccept from {:?}",
+                                    &self.local_peer, &naddr
+                                );
 
-                                self.resolved_handshake_neighbors.insert(naddr, neighbor);
-                                tx.commit()?;
+                                self.handle_neighbor_handshake_accept(
+                                    network,
+                                    block_height,
+                                    naddr,
+                                    &message,
+                                    data,
+                                    Some(db_data),
+                                )?;
                             }
                             StacksMessageType::HandshakeReject => {
                                 // remote peer doesn't want to talk to us
@@ -1264,7 +1592,7 @@ impl NeighborWalk {
                 );
 
                 let mut tx = network.peerdb.tx_begin()?;
-                self.cur_neighbor.save_update(&mut tx)?;
+                self.cur_neighbor.save_update(&mut tx, None)?;
                 tx.commit()?;
             }
 
@@ -1481,7 +1809,8 @@ impl NeighborWalk {
                     } else {
                         // if we got back a HandshakeAccept, and it's on the same chain as us, we're good!
                         match message.payload {
-                            StacksMessageType::HandshakeAccept(ref data) => {
+                            StacksMessageType::HandshakeAccept(ref data)
+                            | StacksMessageType::StackerDBHandshakeAccept(ref data, ..) => {
                                 debug!("{:?}: received HandshakeAccept from peer {:?}; now known to be routable from us", &self.local_peer, &message.to_neighbor_key(&data.handshake.addrbytes, data.handshake.port));
 
                                 // must have the same key; otherwise don't add
@@ -1502,6 +1831,7 @@ impl NeighborWalk {
                                     message.preamble.peer_version,
                                     message.preamble.network_id,
                                     &data.handshake,
+                                    None,
                                 )?;
                                 tx.commit()?;
                             }
@@ -1562,6 +1892,43 @@ impl NeighborWalk {
         self.set_state(NeighborWalkState::ReplacedNeighborsPingFinish);
     }
 
+    /// Handle a handshake accept for a pinged neighbor.
+    /// If it was a StackerDBHandshakeAccept, then also handle the newly-announced DBs
+    fn handle_handshake_accept_from_ping(
+        &mut self,
+        network: &mut PeerNetwork,
+        message: &StacksMessage,
+        data: &HandshakeAcceptData,
+        db_data: Option<&StackerDBHandshakeData>,
+    ) -> Result<(), net_error> {
+        let mut tx = network.peerdb.tx_begin()?;
+        let mut neighbor_from_handshake = Neighbor::from_handshake(
+            &mut tx,
+            message.preamble.peer_version,
+            message.preamble.network_id,
+            &data.handshake,
+        )?;
+        neighbor_from_handshake
+            .save_update(&mut tx, db_data.map(|x| x.smart_contracts.as_slice()))?;
+        tx.commit()?;
+
+        // not going to replace
+        if self
+            .replaced_neighbors
+            .contains_key(&neighbor_from_handshake.addr)
+        {
+            test_debug!(
+                "{:?}: will NOT replace {:?}",
+                &self.local_peer,
+                &neighbor_from_handshake.addr
+            );
+            self.replaced_neighbors
+                .remove(&neighbor_from_handshake.addr);
+        }
+
+        Ok(())
+    }
+
     // try to finish pinging/handshaking all exisitng neighbors.
     // if the remote neighbor does _not_ respond to our ping, then replace it.
     // Return the list of _evicted_ neighbors.
@@ -1572,8 +1939,9 @@ impl NeighborWalk {
         assert!(self.state == NeighborWalkState::ReplacedNeighborsPingFinish);
 
         let mut new_unresolved_neighbor_pings = HashMap::new();
-
-        for (nkey, mut rh) in self.unresolved_neighbor_pings.drain() {
+        let mut unresolved_neighbor_pings =
+            std::mem::replace(&mut self.unresolved_neighbor_pings, HashMap::new());
+        for (nkey, mut rh) in unresolved_neighbor_pings.drain() {
             let rh_nkey = nkey.clone(); // used below
             if let Err(_e) = network.saturate_p2p_socket(rh.get_event_id(), &mut rh) {
                 self.result.add_dead(rh_nkey);
@@ -1595,30 +1963,28 @@ impl NeighborWalk {
                                     data.handshake.port
                                 )
                             );
-
-                            let mut tx = network.peerdb.tx_begin()?;
-                            let mut neighbor_from_handshake = Neighbor::from_handshake(
-                                &mut tx,
-                                message.preamble.peer_version,
-                                message.preamble.network_id,
-                                &data.handshake,
+                            self.handle_handshake_accept_from_ping(network, &message, data, None)?;
+                        }
+                        StacksMessageType::StackerDBHandshakeAccept(ref data, ref db_data) => {
+                            // this peer is still alive -- will not replace it
+                            // save knowledge to the peer DB (NOTE: the neighbor should already be in
+                            // the DB, since it's cur_neighbor)
+                            test_debug!(
+                                "{:?}: received StackerDBHandshakeAccept from {:?}: {:?}, {:?}",
+                                &self.local_peer,
+                                &message.to_neighbor_key(
+                                    &data.handshake.addrbytes,
+                                    data.handshake.port
+                                ),
+                                data,
+                                db_data
+                            );
+                            self.handle_handshake_accept_from_ping(
+                                network,
+                                &message,
+                                data,
+                                Some(db_data),
                             )?;
-                            neighbor_from_handshake.save_update(&mut tx)?;
-                            tx.commit()?;
-
-                            // not going to replace
-                            if self
-                                .replaced_neighbors
-                                .contains_key(&neighbor_from_handshake.addr)
-                            {
-                                test_debug!(
-                                    "{:?}: will NOT replace {:?}",
-                                    &self.local_peer,
-                                    &neighbor_from_handshake.addr
-                                );
-                                self.replaced_neighbors
-                                    .remove(&neighbor_from_handshake.addr);
-                            }
                         }
                         StacksMessageType::Nack(ref data) => {
                             // evict
@@ -1708,6 +2074,37 @@ impl NeighborWalk {
     }
 }
 
+impl NeighborSet for NeighborWalk {
+    fn add_connecting(&mut self, nk: &NeighborKey, event_id: usize) {
+        self.connecting.insert(nk.clone(), event_id);
+        self.pin_connection(event_id);
+    }
+
+    fn get_connecting(&self, nk: &NeighborKey) -> Option<usize> {
+        self.connecting.get(nk).cloned()
+    }
+
+    fn remove_connecting(&mut self, nk: &NeighborKey) {
+        self.connecting.remove(nk);
+    }
+
+    fn add_dead(&mut self, nk: &NeighborKey) {
+        self.result.dead_connections.insert(nk.clone());
+    }
+
+    fn pin_connection(&mut self, event_id: usize) {
+        self.events.insert(event_id);
+    }
+
+    fn unpin_connection(&mut self, event_id: usize) {
+        self.events.remove(&event_id);
+    }
+
+    fn is_pinned(&self, event_id: usize) -> bool {
+        self.events.contains(&event_id)
+    }
+}
+
 impl PeerNetwork {
     /// Get some initial fresh random neighbor(s) to crawl,
     /// given the number of neighbors and current burn block height
@@ -1736,112 +2133,20 @@ impl PeerNetwork {
         Ok(neighbors)
     }
 
-    /// Send off a handshake to a remote peer
     fn walk_handshake(
         &mut self,
         walk: &mut NeighborWalk,
         nk: &NeighborKey,
     ) -> Result<ReplyHandleP2P, net_error> {
-        // send handshake.
-        let handshake_data = HandshakeData::from_local_peer(&self.local_peer);
-
-        debug!("{:?}: send Handshake to {:?}", &self.local_peer, &nk);
-        walk.connecting.remove(nk);
-
-        let msg = match self.sign_for_peer(nk, StacksMessageType::Handshake(handshake_data)) {
-            Ok(msg) => msg,
-            Err(e) => {
-                info!("{:?}: Failed to sign for peer {:?}", &self.local_peer, &nk);
-                walk.result.add_dead(nk.clone());
-                return Err(e);
-            }
-        };
-
-        let req_res = self.send_message(nk, msg, self.connection_opts.timeout);
-
-        // we tried this neighbor
-        match req_res {
-            Ok(handle) => Ok(handle),
-            Err(e) => {
-                debug!("{:?}: Not connected: {:?} ({:?})", &self.local_peer, nk, &e);
-                walk.result.add_dead(nk.clone());
-                Err(net_error::PeerNotConnected)
-            }
-        }
+        walk.neighbor_handshake(self, nk)
     }
 
-    /// Connect to a remote peer and begin to handshake with it.
-    /// Returns Ok(None) if the connection is in progress.
-    /// Returns Ok(Some(handle)) if the connection succeeded and we sent the handshake
-    /// Returns Err(..) if there was a problem
     fn walk_connect_and_handshake(
         &mut self,
         walk: &mut NeighborWalk,
         nk: &NeighborKey,
     ) -> Result<Option<ReplyHandleP2P>, net_error> {
-        match self.can_register_peer(nk, true) {
-            Ok(_) => {
-                if !walk.connecting.contains_key(nk) {
-                    let con_res = self.connect_peer(nk);
-                    match con_res {
-                        Ok(event_id) => {
-                            // remember this in the walk result
-                            walk.connecting.insert(nk.clone(), event_id);
-
-                            // stop the pruner from removing this connection
-                            walk.events.insert(event_id);
-
-                            // force the caller to try again -- we're not registered yet
-                            debug!(
-                                "{:?}: Walk is connecting to {:?} (event {})",
-                                &self.local_peer, &nk, event_id
-                            );
-                            return Ok(None);
-                        }
-                        Err(_e) => {
-                            debug!(
-                                "{:?}: Failed to connect to {:?}: {:?}",
-                                &self.local_peer, nk, &_e
-                            );
-                            return Err(net_error::PeerNotConnected);
-                        }
-                    }
-                } else {
-                    let event_id = walk.connecting.get(nk).unwrap();
-
-                    // is the peer network still working?
-                    if !self.is_connecting(*event_id) {
-                        debug!("{:?}: Failed to connect to {:?} (event {} no longer connecting; assumed timed out)", &self.local_peer, *event_id, nk);
-                        return Err(net_error::PeerNotConnected);
-                    }
-
-                    // still connecting
-                    debug!(
-                        "{:?}: walk still connecting to {:?} (event {})",
-                        &self.local_peer, nk, event_id
-                    );
-                    return Ok(None);
-                }
-            }
-            Err(net_error::AlreadyConnected(_event_id, _nk)) => {
-                test_debug!(
-                    "{:?}: already connected to {:?} as event {}",
-                    &self.local_peer,
-                    &nk,
-                    _event_id
-                );
-            }
-            Err(e) => {
-                info!(
-                    "{:?}: could not connect to {:?}: {:?}",
-                    &self.local_peer, &nk, &e
-                );
-                return Err(e);
-            }
-        }
-
-        self.walk_handshake(walk, nk)
-            .and_then(|handle| Ok(Some(handle)))
+        walk.neighbor_connect_and_handshake(self, nk)
     }
 
     /// Instantiate the neighbor walk from a neighbor routable from us.
@@ -2090,7 +2395,7 @@ impl PeerNetwork {
     /// Return true/false to indicate if we connected or not.
     /// Return an error to reset the walk.
     pub fn walk_handshake_begin(&mut self) -> Result<bool, net_error> {
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             match walk.handshake_request {
                 Some(_) => {
                     // in progress already
@@ -2134,47 +2439,7 @@ impl PeerNetwork {
                     walk.clear_state();
 
                     let cur_pubkh = Hash160::from_node_public_key(&walk.cur_neighbor.public_key);
-                    let res = match network
-                        .can_register_peer_with_pubkey(&cur_addr, true, &cur_pubkh)
-                    {
-                        Ok(_) => network.walk_connect_and_handshake(walk, &cur_addr)?,
-                        Err(net_error::AlreadyConnected(event_id, handshake_nk)) => {
-                            // already connected, but on a possibly-different address.
-                            // If the already-connected handle is inbound, and we're _not_ doing an
-                            // inbound neighbor walk, try to connect to this address anyway in
-                            // order to maximize our outbound connections we have.
-                            if let Some(convo) = network.peers.get(&event_id) {
-                                if !convo.is_outbound() {
-                                    debug!("{:?}: Already connected to {:?} on inbound event {} (address {:?}). Try to establish outbound connection to {:?} {:?}.",
-                                           &network.local_peer, &cur_addr, &event_id, &handshake_nk, &cur_pubkh, &cur_addr);
-                                    network.walk_connect_and_handshake(walk, &cur_addr)?
-                                } else {
-                                    debug!(
-                                        "{:?}: Already connected to {:?} on event {} (address: {:?})",
-                                        &network.local_peer, &cur_addr, &event_id, &handshake_nk
-                                    );
-                                    network
-                                        .walk_handshake(walk, &handshake_nk)
-                                        .and_then(|handle| Ok(Some(handle)))?
-                                }
-                            } else {
-                                // should never be reachable
-                                unreachable!(
-                                    "AlreadyConnected error on event {} has no conversation",
-                                    event_id
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            debug!(
-                                "{:?}: Failed to check connection to {:?}: {:?}. No handshake sent.",
-                                &network.local_peer, &cur_addr, &e
-                            );
-                            return Ok(false);
-                        }
-                    };
-
-                    match res {
+                    match walk.neighbor_session_begin(network, &cur_addr, &cur_pubkh)? {
                         Some(handle) => {
                             debug!("{:?}: Handshake sent to {:?}", &walk.local_peer, &cur_addr);
                             walk.handshake_begin(handle);
@@ -2182,8 +2447,8 @@ impl PeerNetwork {
                         }
                         None => {
                             debug!(
-                                "{:?}: No Handshake sent (dest was {:?})",
-                                &walk.local_peer, &cur_addr
+                                "{:?}: No Handshake sent (dest was {:?}); still connecting",
+                                &walk.local_peer, &cur_addr,
                             );
                             Ok(false)
                         }
@@ -2197,7 +2462,7 @@ impl PeerNetwork {
     pub fn walk_handshake_try_finish(&mut self) -> Result<Option<Neighbor>, net_error> {
         let burn_stable_block_height = self.chain_view.burn_stable_block_height;
 
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             walk.handshake_try_finish(network, burn_stable_block_height)
         })
     }
@@ -2207,34 +2472,26 @@ impl PeerNetwork {
     /// and then stepping to one of the neighbor's neighbors.
     /// Return an error to reset the walk.
     pub fn walk_getneighbors_begin(&mut self) -> Result<(), net_error> {
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
-            match walk.getneighbors_request {
-                Some(_) => Ok(()),
-                None => {
-                    debug!(
-                        "{:?}: send GetNeighbors to {:?}",
-                        &walk.local_peer, &walk.cur_neighbor.addr
-                    );
+        PeerNetwork::with_walk_state(self, |network, walk| match walk.getneighbors_request {
+            Some(_) => Ok(()),
+            None => {
+                debug!(
+                    "{:?}: send GetNeighbors to {:?}",
+                    &walk.local_peer, &walk.cur_neighbor.addr
+                );
 
-                    let msg = network
-                        .sign_for_peer(&walk.cur_neighbor.addr, StacksMessageType::GetNeighbors)?;
-                    let req_res = network.send_message(
-                        &walk.cur_neighbor.addr,
-                        msg,
-                        network.connection_opts.timeout,
-                    );
-                    match req_res {
-                        Ok(handle) => {
-                            walk.getneighbors_begin(Some(handle));
-                            Ok(())
-                        }
-                        Err(e) => {
-                            debug!(
-                                "{:?}: Not connected: {:?} ({:?}",
-                                &walk.local_peer, &walk.cur_neighbor.addr, &e
-                            );
-                            Err(e)
-                        }
+                let addr = walk.cur_neighbor.addr.clone();
+                match NeighborWalk::neighbor_send(network, &addr, StacksMessageType::GetNeighbors) {
+                    Ok(handle) => {
+                        walk.getneighbors_begin(Some(handle));
+                        Ok(())
+                    }
+                    Err(e) => {
+                        debug!(
+                            "{:?}: Not connected: {:?} ({:?}",
+                            &walk.local_peer, &walk.cur_neighbor.addr, &e
+                        );
+                        Err(e)
                     }
                 }
             }
@@ -2247,7 +2504,7 @@ impl PeerNetwork {
     pub fn walk_getneighbors_try_finish(&mut self) -> Result<bool, net_error> {
         let burn_block_height = self.chain_view.burn_block_height;
 
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             if walk.pending_neighbor_addrs.is_none() {
                 // keep trying to finish getting neighbor addresses.  Stop trying once we get something.
                 let neighbor_addrs_opt =
@@ -2318,7 +2575,7 @@ impl PeerNetwork {
 
     /// Start handshaking with our neighbors' neighbors.
     pub fn walk_neighbor_handshakes_begin(&mut self) -> Result<bool, net_error> {
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             let my_pubkey_hash = Hash160::from_node_public_key(&Secp256k1PublicKey::from_private(
                 &walk.local_peer.private_key,
             ));
@@ -2390,64 +2647,31 @@ impl PeerNetwork {
                             continue;
                         }
 
-                        match network.can_register_peer_with_pubkey(&nk, true, &na.public_key_hash)
-                        {
-                            Ok(_) => {
-                                // not connected; try and do so
-                                test_debug!(
-                                    "{:?}: try to connect to {:?} ({:?})",
-                                    &network.local_peer,
-                                    &nk,
-                                    &na
-                                );
-
-                                match network.walk_connect_and_handshake(walk, &nk) {
-                                    Ok(Some(handle)) => {
-                                        debug!(
-                                            "{:?}: will Handshake with neighbor-of-neighbor {:?} ({})",
-                                            &network.local_peer, &nk, &na.public_key_hash
-                                        );
-                                        walk.unresolved_handshake_neighbors
-                                            .insert(na.clone(), handle);
-                                    }
-                                    Ok(None) => {
-                                        test_debug!(
-                                            "{:?}: already connecting to {:?}",
-                                            &network.local_peer,
-                                            &nk
-                                        );
-                                        pending = true;
-
-                                        // try again
-                                        continue;
-                                    }
-                                    Err(e) => {
-                                        debug!(
-                                            "{:?}: Failed to connect to {:?}: {:?}",
-                                            &network.local_peer, &nk, &e
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-                            Err(net_error::AlreadyConnected(_event_id, handshake_nk)) => {
-                                // connected already -- just proceed to send handshake
-                                match network.walk_handshake(walk, &handshake_nk) {
-                                    Ok(handle) => {
-                                        debug!("{:?}: will Handshake with neighbor-of-neighbor {:?} {:?} (connected as {:?})", &network.local_peer, &na.public_key_hash, &nk, &handshake_nk);
-                                        walk.unresolved_handshake_neighbors
-                                            .insert(na.clone(), handle);
-                                    }
-                                    Err(e) => {
-                                        info!("{:?}: failed to send Handshake to neighbor-of-neighbor {:?} ({:?}): {:?}", &network.local_peer, &handshake_nk, &nk, &e);
-                                        continue;
-                                    }
-                                }
-                            }
-                            Err(_e) => {
+                        // start a session with this neighbor
+                        match walk.neighbor_session_begin(network, &nk, &na.public_key_hash) {
+                            Ok(Some(handle)) => {
                                 debug!(
-                                    "{:?}: cannot handshake with neighbor peer {:?}: {:?}",
-                                    &network.local_peer, &nk, &_e
+                                    "{:?}: will Handshake with neighbor-of-neighbor {:?} ({})",
+                                    &network.local_peer, &nk, &na.public_key_hash
+                                );
+                                walk.unresolved_handshake_neighbors
+                                    .insert(na.clone(), handle);
+                            }
+                            Ok(None) => {
+                                test_debug!(
+                                    "{:?}: already connecting to {:?}",
+                                    &network.local_peer,
+                                    &nk
+                                );
+                                pending = true;
+
+                                // try again
+                                continue;
+                            }
+                            Err(e) => {
+                                debug!(
+                                    "{:?}: Failed to connect to {:?}: {:?}",
+                                    &network.local_peer, &nk, &e
                                 );
                                 continue;
                             }
@@ -2482,7 +2706,7 @@ impl PeerNetwork {
         let burn_block_height = self.chain_view.burn_block_height;
         let burn_stable_block_height = self.chain_view.burn_stable_block_height;
 
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             match walk.neighbor_handshakes_try_finish(
                 network,
                 burn_block_height,
@@ -2500,9 +2724,12 @@ impl PeerNetwork {
 
     /// Get our neighbors' neighbors
     pub fn walk_getneighbors_neighbors_begin(&mut self) -> Result<(), net_error> {
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             walk.unresolved_getneighbors_neighbors.clear();
-            for nk in walk.handshake_neighbor_keys.drain(..) {
+
+            let mut handshake_neighbor_keys =
+                std::mem::replace(&mut walk.handshake_neighbor_keys, vec![]);
+            for nk in handshake_neighbor_keys.drain(..) {
                 if !network.is_registered(&nk) {
                     // not connected to this neighbor -- can't ask for neighbors
                     debug!("{:?}: Not connected to {:?}", &network.local_peer, &nk);
@@ -2511,9 +2738,7 @@ impl PeerNetwork {
 
                 debug!("{:?}: send GetNeighbors to {:?}", &walk.local_peer, &nk);
 
-                let msg = network.sign_for_peer(&nk, StacksMessageType::GetNeighbors)?;
-                let rh_res = network.send_message(&nk, msg, network.connection_opts.timeout);
-                match rh_res {
+                match NeighborWalk::neighbor_send(network, &nk, StacksMessageType::GetNeighbors) {
                     Ok(rh) => {
                         walk.unresolved_getneighbors_neighbors.insert(nk, rh);
                     }
@@ -2539,7 +2764,7 @@ impl PeerNetwork {
     pub fn walk_getneighbors_neighbors_try_finish(&mut self) -> Result<bool, net_error> {
         let burn_stable_block_height = self.chain_view.burn_stable_block_height;
 
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             match walk.getneighbors_neighbors_try_finish(network, burn_stable_block_height)? {
                 None => {
                     // not done yet
@@ -2557,7 +2782,7 @@ impl PeerNetwork {
 
     /// Begin handshaking with peers that reached out to us
     pub fn walk_pingback_handshakes_begin(&mut self) -> Result<bool, net_error> {
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             let mut pending = false;
             let mut network_pingbacks = mem::replace(&mut walk.network_pingbacks, HashMap::new());
             let mut new_network_pingbacks = HashMap::new();
@@ -2580,55 +2805,29 @@ impl PeerNetwork {
                 );
 
                 // already trying to connect to this neighbor?
-                if walk.connecting.contains_key(&nk) {
+                if walk.get_connecting(&nk).is_some() {
                     continue;
                 }
 
-                match network.can_register_peer_with_pubkey(&nk, true, &naddr.public_key_hash) {
-                    Ok(_) => {
-                        // not connected yet
-                        // still have to connect
-                        pending = true;
-                        match network.walk_connect_and_handshake(walk, &nk)? {
-                            Some(handle) => {
-                                debug!(
-                                    "{:?}: Sent pingback handshake to {:?}",
-                                    &network.local_peer, &nk
-                                );
-                                walk.pending_pingback_handshakes
-                                    .insert(naddr.clone(), handle);
-                            }
-                            None => {
-                                debug!(
-                                    "{:?}: No pingback handshake sent to {:?}",
-                                    &network.local_peer, &nk
-                                );
-
-                                // try again
-                                new_network_pingbacks.insert(naddr, pingback);
-                            }
-                        }
+                // start a session with this neighbor
+                match walk.neighbor_session_begin(network, &nk, &naddr.public_key_hash) {
+                    Ok(Some(handle)) => {
+                        debug!(
+                            "{:?}: Sent pingback handshake to {:?}",
+                            &network.local_peer, &nk
+                        );
+                        walk.pending_pingback_handshakes
+                            .insert(naddr.clone(), handle);
                     }
-                    Err(net_error::AlreadyConnected(_event_id, handshake_nk)) => {
-                        // use preferred address
-                        // already connected; just send
-                        match network.walk_handshake(walk, &handshake_nk) {
-                            Ok(handle) => {
-                                debug!(
-                                    "{:?}: Sent pingback handshake to {:?}",
-                                    &network.local_peer, &handshake_nk
-                                );
-                                walk.pending_pingback_handshakes
-                                    .insert(naddr.clone(), handle);
-                            }
-                            Err(e) => {
-                                info!(
-                                    "{:?}: Failed to send pingback handshake to {:?}: {:?}",
-                                    &network.local_peer, &handshake_nk, &e
-                                );
-                                continue;
-                            }
-                        }
+                    Ok(None) => {
+                        debug!(
+                            "{:?}: No pingback handshake sent to {:?}; still connecting",
+                            &network.local_peer, &nk
+                        );
+
+                        // try again
+                        pending = true;
+                        new_network_pingbacks.insert(naddr, pingback);
                     }
                     Err(e) => {
                         debug!(
@@ -2658,7 +2857,7 @@ impl PeerNetwork {
         let burn_block_height = self.chain_view.burn_block_height;
         let burn_stable_block_height = self.chain_view.burn_stable_block_height;
 
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             walk.pingback_handshakes_try_finish(
                 network,
                 burn_block_height,
@@ -2669,22 +2868,26 @@ impl PeerNetwork {
 
     /// Begin pinging existing neighbors up for replacement
     pub fn walk_ping_existing_neighbors_begin(&mut self) -> Result<(), net_error> {
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             let mut ping_handles = HashMap::new();
 
             // proceed to ping/handshake neighbors we need to replace
-            for (nk, _) in walk.replaced_neighbors.iter() {
+            let replaced_neighbors = walk.replaced_neighbors.clone();
+            for (nk, _) in replaced_neighbors.iter() {
                 test_debug!(
                     "{:?}: send Handshake to replaceable neighbor {:?}",
                     &walk.local_peer,
                     nk
                 );
 
-                let handshake_data = HandshakeData::from_local_peer(&walk.local_peer);
-                let msg =
-                    network.sign_for_peer(nk, StacksMessageType::Handshake(handshake_data))?;
-                let req_res = network.send_message(nk, msg, network.connection_opts.timeout);
-                match req_res {
+                let nk_send = nk.clone();
+                match NeighborWalk::neighbor_send(
+                    network,
+                    &nk_send,
+                    StacksMessageType::Handshake(HandshakeData::from_local_peer(
+                        &network.local_peer,
+                    )),
+                ) {
                     Ok(handle) => {
                         ping_handles.insert((*nk).clone(), handle);
                     }
@@ -2710,7 +2913,7 @@ impl PeerNetwork {
     ) -> Result<Option<NeighborWalkResult>, net_error> {
         let burn_block_height = self.chain_view.burn_block_height;
 
-        PeerNetwork::with_walk_state(self, |ref mut network, ref mut walk| {
+        PeerNetwork::with_walk_state(self, |network, walk| {
             let replaced_opt = walk.ping_existing_neighbors_try_finish(network)?;
             match replaced_opt {
                 None => {
@@ -4807,6 +5010,24 @@ mod test {
         })
     }
 
+    fn stacker_db_id(i: usize) -> (StacksAddress, ContractName) {
+        (
+            StacksAddress {
+                version: 0x01,
+                bytes: Hash160([i as u8; 20]),
+            },
+            format!("db-{}", i).as_str().into(),
+        )
+    }
+
+    fn make_stacker_db_ids(i: usize) -> Vec<(StacksAddress, ContractName)> {
+        let mut dbs = vec![];
+        for j in 0..i {
+            dbs.push(stacker_db_id(j));
+        }
+        dbs
+    }
+
     fn setup_peer_config(
         i: usize,
         port_base: u16,
@@ -4837,6 +5058,19 @@ mod test {
 
         let j = i as u32;
         conf.burnchain.peer_version = PEER_VERSION_TESTNET | (j << 16) | (j << 8) | j; // different non-major versions for each peer
+
+        // even-number peers support stacker DBs.
+        // odd-number peers do not
+        if i % 2 == 0 {
+            conf.services = (ServiceFlags::RELAY as u16)
+                | (ServiceFlags::RPC as u16)
+                | (ServiceFlags::STACKERDB as u16);
+            conf.stacker_dbs = make_stacker_db_ids(i);
+        } else {
+            conf.services = (ServiceFlags::RELAY as u16) | (ServiceFlags::RPC as u16);
+            conf.stacker_dbs = vec![];
+        }
+
         conf
     }
 
@@ -5739,11 +5973,13 @@ mod test {
                 random_order[i] = i;
             }
             let mut rng = thread_rng();
-            let _ = &mut &random_order.shuffle(&mut rng);
+            random_order.shuffle(&mut rng);
 
+            debug!("Random order = {:?}", &random_order);
             for i in random_order.into_iter() {
                 let _ = peers[i].step();
                 let nk = peers[i].config.to_neighbor().addr;
+                debug!("Step peer {:?}", &nk);
 
                 // allowed peers are still connected
                 match initial_allowed.get(&nk) {
@@ -5785,24 +6021,33 @@ mod test {
                 }
 
                 // done?
-                finished = if use_finished_check {
-                    finished_check(&peers)
-                } else {
-                    let mut done = true;
-                    let all_neighbors =
-                        PeerDB::get_all_peers(peers[i].network.peerdb.conn()).unwrap();
-                    peer_counts += all_neighbors.len();
-                    if (all_neighbors.len() as u64) < ((PEER_COUNT - 1) as u64) {
-                        let nk = peers[i].config.to_neighbor().addr;
-                        test_debug!(
-                            "waiting for {:?} to fill up its frontier: {}",
-                            &nk,
-                            all_neighbors.len()
-                        );
-                        done = false;
-                    }
-                    done
-                };
+                finished = finished
+                    && if use_finished_check {
+                        finished_check(&peers)
+                    } else {
+                        let mut done = true;
+                        let all_neighbors =
+                            PeerDB::get_all_peers(peers[i].network.peerdb.conn()).unwrap();
+                        peer_counts += all_neighbors.len();
+
+                        if (all_neighbors.len() as u64) < ((PEER_COUNT - 1) as u64) {
+                            test_debug!(
+                                "waiting for {:?} to fill up its frontier: {} < {}",
+                                &nk,
+                                all_neighbors.len(),
+                                PEER_COUNT - 1
+                            );
+                            done = false;
+                        } else {
+                            test_debug!(
+                                "not waiting for {:?} to fill up its frontier: {} >= {}",
+                                &nk,
+                                all_neighbors.len(),
+                                PEER_COUNT - 1
+                            );
+                        }
+                        done
+                    };
             }
 
             count += 1;
@@ -5824,5 +6069,49 @@ mod test {
         test_debug!("Converged after {} calls to network.run()", count);
         dump_peers(&peers);
         dump_peer_histograms(&peers);
+
+        // each peer learns each other peer's stacker DBs
+        for (i, peer) in peers.iter().enumerate() {
+            if i % 2 != 0 {
+                continue;
+            }
+            let mut expected_dbs = PeerDB::get_local_peer(peer.network.peerdb.conn())
+                .unwrap()
+                .stacker_dbs;
+            expected_dbs.sort();
+            for (j, other_peer) in peers.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+
+                let all_neighbors =
+                    PeerDB::get_all_peers(other_peer.network.peerdb.conn()).unwrap();
+
+                if (all_neighbors.len() as u64) < ((PEER_COUNT - 1) as u64) {
+                    // this is a simulated-NAT'ed node -- it won't learn about other NAT'ed nodes'
+                    // DBs
+                    continue;
+                }
+
+                let mut other_peer_dbs = other_peer
+                    .network
+                    .peerdb
+                    .get_peer_stacker_dbs(&peer.config.to_neighbor())
+                    .unwrap();
+                other_peer_dbs.sort();
+
+                if j % 2 == 0 {
+                    test_debug!(
+                        "Compare stacker DBs of {} vs {}",
+                        &peer.config.to_neighbor(),
+                        &other_peer.config.to_neighbor()
+                    );
+                    assert_eq!(expected_dbs, other_peer_dbs);
+                } else {
+                    // this peer doesn't support Stacker DBs
+                    assert_eq!(other_peer_dbs, vec![]);
+                }
+            }
+        }
     }
 }

--- a/src/net/poll.rs
+++ b/src/net/poll.rs
@@ -343,9 +343,11 @@ impl NetworkState {
             })?;
 
         if cfg!(test) {
-            // edge-trigger torture test
-            stream.set_send_buffer_size(32).unwrap();
-            stream.set_recv_buffer_size(32).unwrap();
+            if std::env::var("STACKS_TEST_DISABLE_EDGE_TRIGGER_TEST") != Ok("1".to_string()) {
+                // edge-trigger torture test
+                stream.set_send_buffer_size(32).unwrap();
+                stream.set_recv_buffer_size(32).unwrap();
+            }
         }
 
         test_debug!("New socket connected to {:?}: {:?}", addr, &stream);

--- a/src/net/prune.rs
+++ b/src/net/prune.rs
@@ -96,21 +96,23 @@ impl PeerNetwork {
             };
         }
 
-        test_debug!(
-            "==== ORG NEIGHBOR DISTRIBUTION OF {:?} ===",
-            &self.local_peer
-        );
-        for (ref _org, ref neighbor_infos) in org_neighbor.iter() {
-            let _neighbors: Vec<NeighborKey> =
-                neighbor_infos.iter().map(|ni| ni.0.clone()).collect();
+        if cfg!(test) {
             test_debug!(
-                "Org {}: {} neighbors: {:?}",
-                _org,
-                _neighbors.len(),
-                &_neighbors
+                "==== ORG NEIGHBOR DISTRIBUTION OF {:?} ===",
+                &self.local_peer
             );
+            for (ref _org, ref neighbor_infos) in org_neighbor.iter() {
+                let _neighbors: Vec<NeighborKey> =
+                    neighbor_infos.iter().map(|ni| ni.0.clone()).collect();
+                test_debug!(
+                    "Org {}: {} neighbors: {:?}",
+                    _org,
+                    _neighbors.len(),
+                    &_neighbors
+                );
+            }
+            test_debug!("===============================================================");
         }
-        test_debug!("===============================================================");
 
         Ok(org_neighbor)
     }
@@ -179,7 +181,8 @@ impl PeerNetwork {
         unreachable!();
     }
 
-    /// If we have an overabundance of outbound connections, then remove ones from overrepresented
+    /// If we have an overabundance of outbound connections established through a neighbor walk
+    /// (but not stacker dbs), then remove ones from overrepresented
     /// organizations that are unhealthy or very-recently discovered.
     /// Returns the list of neighbor keys to remove.
     fn prune_frontier_outbound_orgs(

--- a/src/net/stackerdb/bits.rs
+++ b/src/net/stackerdb/bits.rs
@@ -1,0 +1,114 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This module contains methods for interacting with the data contained within the messages
+use crate::net::{
+    Error as net_error, StackerDBChunkData, StackerDBChunkInvData, StackerDBGetChunkData,
+    StackerDBGetChunkInvData,
+};
+
+use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
+
+use stacks_common::types::chainstate::{ConsensusHash, StacksAddress, StacksPrivateKey};
+
+use stacks_common::types::PrivateKey;
+
+use crate::net::stackerdb::ChunkMetadata;
+
+use crate::chainstate::stacks::StacksPublicKey;
+
+use stacks_common::util::secp256k1::MessageSignature;
+
+impl ChunkMetadata {
+    /// Get the digest to sign that authenticates this chunk data and metadata
+    fn sighash(&self) -> Sha512Trunc256Sum {
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&self.rc_consensus_hash.0);
+        bytes.extend_from_slice(&self.chunk_id.to_be_bytes());
+        bytes.extend_from_slice(&self.chunk_version.to_be_bytes());
+        bytes.extend_from_slice(&self.data_hash.0);
+
+        Sha512Trunc256Sum::from_data(&bytes)
+    }
+
+    /// Sign this chunk metadata, committing to rc_consensus_hash, chunk_id, chunk_version, and
+    /// data_hash.
+    pub fn sign(&mut self, privkey: &StacksPrivateKey) -> Result<(), net_error> {
+        let sigh = self.sighash();
+        let sig = privkey
+            .sign(&sigh.0)
+            .map_err(|se| net_error::SigningError(se.to_string()))?;
+
+        self.signature = sig;
+        Ok(())
+    }
+
+    /// Verify that a given principal signed this chunk metadata.
+    /// Note that the address version is ignored.
+    pub fn verify(&self, principal: &StacksAddress) -> Result<bool, net_error> {
+        let sigh = self.sighash();
+        let pubk = StacksPublicKey::recover_to_pubkey(sigh.as_bytes(), &self.signature)
+            .map_err(|ve| net_error::VerifyingError(ve.to_string()))?;
+
+        let pubkh = Hash160::from_node_public_key(&pubk);
+        Ok(pubkh == principal.bytes)
+    }
+}
+
+impl StackerDBChunkData {
+    pub fn new(chunk_id: u32, chunk_version: u32, data: Vec<u8>) -> StackerDBChunkData {
+        StackerDBChunkData {
+            chunk_id,
+            chunk_version,
+            sig: MessageSignature::empty(),
+            data,
+        }
+    }
+
+    pub fn data_hash(&self) -> Sha512Trunc256Sum {
+        Sha512Trunc256Sum::from_data(&self.data)
+    }
+
+    pub fn get_chunk_metadata(&self, rc_consensus_hash: ConsensusHash) -> ChunkMetadata {
+        ChunkMetadata {
+            rc_consensus_hash,
+            chunk_id: self.chunk_id,
+            chunk_version: self.chunk_version,
+            data_hash: self.data_hash(),
+            signature: self.sig.clone(),
+        }
+    }
+
+    pub fn sign(
+        &mut self,
+        rc_consensus_hash: ConsensusHash,
+        privk: &StacksPrivateKey,
+    ) -> Result<(), net_error> {
+        let mut md = self.get_chunk_metadata(rc_consensus_hash);
+        md.sign(privk)?;
+        self.sig = md.signature;
+        Ok(())
+    }
+
+    pub fn verify(
+        &self,
+        rc_consensus_hash: ConsensusHash,
+        addr: &StacksAddress,
+    ) -> Result<bool, net_error> {
+        let md = self.get_chunk_metadata(rc_consensus_hash);
+        md.verify(addr)
+    }
+}

--- a/src/net/stackerdb/config.rs
+++ b/src/net/stackerdb/config.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::net::stackerdb::StackerDBConfig;
+
+/// Minimum chunk size for FROST is 97 + T * 33, where T = 3000
+const MIN_CHUNK_SIZE: u64 = 97 + 3000 * 33;
+
+const CHUNK_SIZE: u64 = MIN_CHUNK_SIZE * 2;
+const WRITE_FREQ: u64 = 60;
+const MAX_WRITES: u32 = 1024;
+const NUM_NEIGHBORS: usize = 8;
+
+impl StackerDBConfig {
+    pub fn noop() -> StackerDBConfig {
+        StackerDBConfig {
+            chunk_size: u64::MAX,
+            write_freq: 0,
+            max_writes: u32::MAX,
+            hint_peers: vec![],
+            num_neighbors: NUM_NEIGHBORS,
+            num_chunks: 4096,
+        }
+    }
+
+    pub fn default_pox() -> StackerDBConfig {
+        StackerDBConfig {
+            chunk_size: CHUNK_SIZE,
+            write_freq: WRITE_FREQ,
+            max_writes: MAX_WRITES,
+            hint_peers: vec![],
+            num_neighbors: NUM_NEIGHBORS,
+            num_chunks: 4096,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn one_chunk() -> StackerDBConfig {
+        StackerDBConfig {
+            chunk_size: CHUNK_SIZE,
+            write_freq: 0,
+            max_writes: u32::MAX,
+            hint_peers: vec![],
+            num_neighbors: NUM_NEIGHBORS,
+            num_chunks: 1,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn ten_chunks() -> StackerDBConfig {
+        StackerDBConfig {
+            chunk_size: CHUNK_SIZE,
+            write_freq: 0,
+            max_writes: u32::MAX,
+            hint_peers: vec![],
+            num_neighbors: NUM_NEIGHBORS,
+            num_chunks: 10,
+        }
+    }
+}

--- a/src/net/stackerdb/db.rs
+++ b/src/net/stackerdb/db.rs
@@ -1,0 +1,602 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use crate::chainstate::stacks::address::PoxAddress;
+use crate::net::stackerdb::{
+    ChunkMetadata, StackerDB, StackerDBConfig, StackerDBTx, STACKERDB_INV_MAX,
+};
+use crate::net::Error as net_error;
+use crate::net::{
+    StackerDBChunkData, StackerDBChunkInvData, StackerDBGetChunkInvData, StackerDBHandshakeData,
+};
+
+use rusqlite::{
+    types::ToSql, Connection, OpenFlags, OptionalExtension, Row, Transaction, NO_PARAMS,
+};
+
+use crate::util_lib::db::{
+    opt_u64_to_sql, query_row, query_row_panic, query_rows, sql_pragma, sqlite_open,
+    tx_begin_immediate, tx_busy_handler, u64_to_sql, DBConn, Error as db_error, FromColumn,
+    FromRow,
+};
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::StacksAddress;
+use stacks_common::util::get_epoch_time_secs;
+use stacks_common::util::hash::Sha512Trunc256Sum;
+use stacks_common::util::secp256k1::MessageSignature;
+
+use clarity::vm::ContractName;
+
+const STACKER_DB_SCHEMA: &'static [&'static str] = &[
+    r#"
+    PRAGMA foreign_keys = ON;
+    "#,
+    r#"
+    CREATE TABLE databases(
+        -- table name
+        table_name TEXT NOT NULL,
+
+        smart_contract_addr TEXT NOT NULL,
+        smart_contract_name TEXT NOT NULL,
+        PRIMARY KEY(table_name)
+    );
+    "#,
+];
+
+const CHUNKS_DB_TABLE_BODY: &'static str = r#"
+    (
+        -- reward cycle in which this chunk exists.
+        -- this is a consensus hash of the start of a reward cycle
+        rc_consensus_hash TEXT NOT NULL,
+        -- chunk ID
+        chunk_id INTEGER NOT NULL,
+        -- lamport clock of the chunk.
+        version INTEGER NOT NULL,
+        -- hash of the data to be stored
+        data_hash TEXT NOT NULL,
+        -- secp256k1 recoverable signature from the stacker over the above columns
+        signature TEXT NOT NULL,
+
+        -- the following is NOT covered by the signature
+        -- address of the creator of this chunk
+        stacker STRING NOT NULL,
+        -- the chunk data itself
+        data BLOB NOT NULL,
+        -- UNIX timestamp when the chunk was written.
+        write_time INTEGER NOT NULL,
+        
+        PRIMARY KEY(rc_consensus_hash,chunk_id)
+    );
+    "#;
+
+const CHUNKS_DB_INDEX_BODIES: &'static [(&'static str, &'static str)] =
+    &[("chunk_versions", "(rc_consensus_hash,chunk_id,version)")];
+
+pub const NO_VERSION: i64 = 0;
+
+/// Private struct for loading the data we need to validate an incoming chunk
+pub struct ChunkValidation {
+    pub stacker: StacksAddress,
+    pub version: u32,
+    pub write_time: u64,
+}
+
+impl FromRow<ChunkMetadata> for ChunkMetadata {
+    fn from_row<'a>(row: &'a Row) -> Result<ChunkMetadata, db_error> {
+        let rc_consensus_hash: ConsensusHash =
+            ConsensusHash::from_column(row, "rc_consensus_hash")?;
+        let chunk_id: u32 = row.get_unwrap("chunk_id");
+        let chunk_version: u32 = row.get_unwrap("version");
+        let data_hash_str: String = row.get_unwrap("data_hash");
+        let data_hash =
+            Sha512Trunc256Sum::from_hex(&data_hash_str).map_err(|_| db_error::ParseError)?;
+        let message_sig_str: String = row.get_unwrap("signature");
+        let signature =
+            MessageSignature::from_hex(&message_sig_str).map_err(|_| db_error::ParseError)?;
+
+        Ok(ChunkMetadata {
+            rc_consensus_hash,
+            chunk_id,
+            chunk_version,
+            data_hash,
+            signature,
+        })
+    }
+}
+
+impl FromRow<ChunkValidation> for ChunkValidation {
+    fn from_row<'a>(row: &'a Row) -> Result<ChunkValidation, db_error> {
+        let stacker = StacksAddress::from_column(row, "stacker")?;
+        let version: u32 = row.get_unwrap("version");
+        let write_time_i64: i64 = row.get_unwrap("write_time");
+        if write_time_i64 < 0 {
+            return Err(db_error::ParseError);
+        }
+        let write_time = write_time_i64 as u64;
+
+        Ok(ChunkValidation {
+            stacker,
+            version,
+            write_time,
+        })
+    }
+}
+
+impl FromRow<StackerDBChunkData> for StackerDBChunkData {
+    fn from_row<'a>(row: &'a Row) -> Result<StackerDBChunkData, db_error> {
+        let chunk_id: u32 = row.get_unwrap("chunk_id");
+        let chunk_version: u32 = row.get_unwrap("version");
+        let data: Vec<u8> = row.get_unwrap("data");
+        let message_sig_str: String = row.get_unwrap("signature");
+        let sig = MessageSignature::from_hex(&message_sig_str).map_err(|_| db_error::ParseError)?;
+
+        Ok(StackerDBChunkData {
+            chunk_id,
+            chunk_version,
+            sig,
+            data,
+        })
+    }
+}
+
+/// Convert a smart contract name to a table name
+fn stackerdb_table(addr: (&StacksAddress, &ContractName)) -> String {
+    let normalized_name = format!("{}", &addr.1).replace("-", "_");
+
+    format!("stackerdb_{}_{}", addr.0, normalized_name)
+}
+
+/// Load up chunk metadata from the database, given the primary key.
+/// Inner method body for related methods in both the DB instance and the transaction instance.
+fn inner_get_chunk_metadata(
+    conn: &DBConn,
+    smart_contract: (&StacksAddress, &ContractName),
+    rc_consensus_hash: &ConsensusHash,
+    chunk_id: u32,
+) -> Result<Option<ChunkMetadata>, net_error> {
+    let sql = format!("SELECT chunk_id,rc_consensus_hash,version,data_hash,signature FROM {} WHERE rc_consensus_hash = ?1 AND chunk_id = ?2", stackerdb_table(smart_contract));
+    let args: &[&dyn ToSql] = &[rc_consensus_hash, &chunk_id];
+    query_row(conn, &sql, args).map_err(|e| e.into())
+}
+
+/// Load up validation information from the database, given the primary key
+/// Inner method body for related methods in both the DB instance and the transaction instance.
+fn inner_get_chunk_validation(
+    conn: &DBConn,
+    smart_contract: (&StacksAddress, &ContractName),
+    rc_consensus_hash: &ConsensusHash,
+    chunk_id: u32,
+) -> Result<Option<ChunkValidation>, net_error> {
+    let sql = format!(
+        "SELECT stacker,write_time,version FROM {} WHERE rc_consensus_hash = ?1 AND chunk_id = ?2",
+        stackerdb_table(smart_contract)
+    );
+    let args: &[&dyn ToSql] = &[rc_consensus_hash, &chunk_id];
+    query_row(conn, &sql, args).map_err(|e| e.into())
+}
+
+impl<'a> StackerDBTx<'a> {
+    pub fn commit(self) -> Result<(), net_error> {
+        self.sql_tx.commit().map_err(net_error::from)
+    }
+
+    pub fn conn(&self) -> &DBConn {
+        &self.sql_tx
+    }
+
+    /// Create a stacker DB table.
+    /// Idempotent
+    pub fn create_stackerdb(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+    ) -> Result<(), net_error> {
+        let qry = format!(
+            "CREATE TABLE IF NOT EXISTS {}{}",
+            stackerdb_table(smart_contract),
+            CHUNKS_DB_TABLE_BODY
+        );
+        let mut stmt = self.sql_tx.prepare(&qry)?;
+        stmt.execute(NO_PARAMS)?;
+
+        for (index_name, index_body) in CHUNKS_DB_INDEX_BODIES.iter() {
+            let qry = format!(
+                "CREATE INDEX IF NOT EXISTS index_{}_{} ON {}{}",
+                stackerdb_table(smart_contract),
+                index_name,
+                stackerdb_table(smart_contract),
+                index_body
+            );
+            let mut stmt = self.sql_tx.prepare(&qry)?;
+            stmt.execute(NO_PARAMS)?;
+        }
+
+        let qry = "REPLACE INTO databases (table_name,smart_contract_addr,smart_contract_name) VALUES (?1,?2,?3)";
+        let args: &[&dyn ToSql] = &[
+            &stackerdb_table(smart_contract),
+            &smart_contract.0.to_string(),
+            &smart_contract.1.as_str(),
+        ];
+        let mut stmt = self.sql_tx.prepare(&qry)?;
+        stmt.execute(args)?;
+
+        Ok(())
+    }
+
+    /// Delete a stacker DB table.
+    /// Idempotent
+    pub fn delete_stackerdb(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+    ) -> Result<(), net_error> {
+        let qry = "DELETE FROM databases WHERE table_name = ?1";
+        let mut stmt = self.sql_tx.prepare(&qry)?;
+        stmt.execute(&[&stackerdb_table(smart_contract)])?;
+
+        let qry = format!("DROP TABLE IF EXISTS {}", stackerdb_table(smart_contract));
+        let mut stmt = self.sql_tx.prepare(&qry)?;
+        stmt.execute(NO_PARAMS)?;
+
+        Ok(())
+    }
+
+    /// List all stacker DB smart contracts we have available
+    pub fn get_stackerdbs(&self) -> Result<Vec<(StacksAddress, ContractName)>, net_error> {
+        let sql =
+            "SELECT smart_contract_addr, smart_contract_name FROM databases ORDER BY table_name";
+        query_rows(&self.conn(), sql, NO_PARAMS).map_err(|e| e.into())
+    }
+
+    /// Set up a database's storage slots.
+    /// The slots must be in a deterministic order, since they are used to determine the chunk ID
+    /// (and thus the key used to authenticate them)
+    pub fn prepare_stackerdb_slots(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        slots: &[(StacksAddress, u64)],
+    ) -> Result<(), net_error> {
+        if slots.len() > (STACKERDB_INV_MAX as usize) {
+            return Err(net_error::ArrayTooLong);
+        }
+
+        let qry = format!("REPLACE INTO {} (rc_consensus_hash,stacker,chunk_id,version,write_time,data,data_hash,signature) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)", stackerdb_table(smart_contract));
+        let mut stmt = self.sql_tx.prepare(&qry)?;
+        let mut chunk_id = 0u32;
+
+        for (principal, slot_count) in slots.iter() {
+            for _ in 0..*slot_count {
+                let args: &[&dyn ToSql] = &[
+                    rc_consensus_hash,
+                    &principal.to_string(),
+                    &chunk_id,
+                    &NO_VERSION,
+                    &0,
+                    &vec![],
+                    &Sha512Trunc256Sum([0u8; 32]),
+                    &MessageSignature::empty(),
+                ];
+                stmt.execute(args)?;
+
+                chunk_id += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Clear a database's slots and its data
+    pub fn clear_stackerdb_slots(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+    ) -> Result<(), net_error> {
+        let qry = format!(
+            "DELETE FROM {} WHERE rc_consensus_hash = ?1",
+            stackerdb_table(smart_contract)
+        );
+        let mut stmt = self.sql_tx.prepare(&qry)?;
+
+        let args: &[&dyn ToSql] = &[rc_consensus_hash];
+        stmt.execute(args)?;
+        Ok(())
+    }
+
+    /// Get the chunk metadata
+    pub fn get_chunk_metadata(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        chunk_id: u32,
+    ) -> Result<Option<ChunkMetadata>, net_error> {
+        inner_get_chunk_metadata(self.conn(), smart_contract, rc_consensus_hash, chunk_id)
+    }
+
+    /// Get a chunk's validation data
+    pub fn get_chunk_validation(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        chunk_id: u32,
+    ) -> Result<Option<ChunkValidation>, net_error> {
+        inner_get_chunk_validation(self.conn(), smart_contract, rc_consensus_hash, chunk_id)
+    }
+
+    /// Insert a chunk into the DB.
+    /// It must be authenticated, and its lamport clock must be higher than the one that's already
+    /// there.  These will not be checked.
+    fn insert_chunk(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        chunk_desc: &ChunkMetadata,
+        chunk: &[u8],
+    ) -> Result<(), net_error> {
+        let sql = format!("UPDATE {} SET version = ?1, data_hash = ?2, signature = ?3, data = ?4, write_time = ?5 WHERE rc_consensus_hash = ?6 AND chunk_id = ?7", stackerdb_table(smart_contract));
+        let mut stmt = self.sql_tx.prepare(&sql)?;
+
+        let args: &[&dyn ToSql] = &[
+            &chunk_desc.chunk_version,
+            &Sha512Trunc256Sum::from_data(chunk),
+            &chunk_desc.signature,
+            &chunk,
+            &u64_to_sql(get_epoch_time_secs())?,
+            &chunk_desc.rc_consensus_hash,
+            &chunk_desc.chunk_id,
+        ];
+
+        stmt.execute(args)?;
+        Ok(())
+    }
+
+    /// Add or replace a chunk for a given reward cycle, if it is valid
+    /// Otherwise, this errors out with Error::StaleChunk
+    pub fn try_replace_chunk(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        chunk_desc: &ChunkMetadata,
+        chunk: &[u8],
+    ) -> Result<(), net_error> {
+        let chunk_validation = self
+            .get_chunk_validation(
+                smart_contract,
+                &chunk_desc.rc_consensus_hash,
+                chunk_desc.chunk_id,
+            )?
+            .ok_or(net_error::NoSuchChunk(
+                smart_contract.0.clone(),
+                chunk_desc.chunk_id,
+            ))?;
+
+        if !chunk_desc.verify(&chunk_validation.stacker)? {
+            return Err(net_error::BadChunkSigner(
+                chunk_validation.stacker,
+                chunk_desc.chunk_id,
+            ));
+        }
+        if chunk_desc.chunk_version <= chunk_validation.version {
+            return Err(net_error::StaleChunk(
+                chunk_validation.version,
+                chunk_desc.chunk_version,
+            ));
+        }
+        if chunk_desc.chunk_version > self.config.max_writes {
+            return Err(net_error::TooManyChunkWrites(
+                self.config.max_writes,
+                chunk_validation.version,
+            ));
+        }
+        if chunk_validation.write_time + self.config.write_freq >= get_epoch_time_secs() {
+            return Err(net_error::TooFrequentChunkWrites(
+                chunk_validation.write_time + self.config.write_freq,
+            ));
+        }
+        self.insert_chunk(smart_contract, chunk_desc, chunk)
+    }
+}
+
+impl StackerDB {
+    /// Instantiate the DB
+    fn instantiate(path: &str, readwrite: bool) -> Result<StackerDB, net_error> {
+        let mut create_flag = false;
+
+        let open_flags = if path != ":memory:" {
+            match fs::metadata(path) {
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::NotFound {
+                        // need to create
+                        if readwrite {
+                            create_flag = true;
+                            let ppath = Path::new(path);
+                            let pparent_path = ppath
+                                .parent()
+                                .expect(&format!("BUG: no parent of '{}'", path));
+                            fs::create_dir_all(&pparent_path).map_err(|e| db_error::IOError(e))?;
+
+                            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE
+                        } else {
+                            return Err(db_error::NoDBError.into());
+                        }
+                    } else {
+                        return Err(db_error::IOError(e).into());
+                    }
+                }
+                Ok(_md) => {
+                    // can just open
+                    if readwrite {
+                        OpenFlags::SQLITE_OPEN_READ_WRITE
+                    } else {
+                        OpenFlags::SQLITE_OPEN_READ_ONLY
+                    }
+                }
+            }
+        } else {
+            create_flag = true;
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE
+        };
+
+        let conn = sqlite_open(path, open_flags, true)?;
+        let mut db = StackerDB { conn };
+
+        if create_flag {
+            let db_tx = db.tx_begin(StackerDBConfig::noop())?;
+            for sql in STACKER_DB_SCHEMA.iter() {
+                db_tx.sql_tx.execute_batch(sql)?;
+            }
+            db_tx.commit()?;
+        }
+
+        Ok(db)
+    }
+
+    /// Connect to a stacker DB, creating it if it doesn't exist and if readwrite is true.
+    /// Readwrite is enforced by the underling sqlite connection.
+    pub fn connect(path: &str, readwrite: bool) -> Result<StackerDB, net_error> {
+        Self::instantiate(path, readwrite)
+    }
+
+    #[cfg(test)]
+    pub fn connect_memory() -> StackerDB {
+        Self::instantiate(":memory:", true).unwrap()
+    }
+
+    /// Open a transaction on the Stacker DB.
+    /// The config would be obtained from a DBSelector instance
+    pub fn tx_begin<'a>(
+        &'a mut self,
+        config: StackerDBConfig,
+    ) -> Result<StackerDBTx<'a>, net_error> {
+        let sql_tx = tx_begin_immediate(&mut self.conn)?;
+        Ok(StackerDBTx { sql_tx, config })
+    }
+
+    /// List all stacker DB smart contracts we have available
+    pub fn get_stackerdbs(&self) -> Result<Vec<(StacksAddress, ContractName)>, net_error> {
+        let sql =
+            "SELECT smart_contract_addr, smart_contract_name FROM databases ORDER BY table_name";
+        query_rows(&self.conn, sql, NO_PARAMS).map_err(|e| e.into())
+    }
+
+    /// Get the principal who signs a particular chunk in a particular stacker DB
+    pub fn get_chunk_signer(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        chunk_id: u32,
+    ) -> Result<Option<StacksAddress>, net_error> {
+        let sql = &format!(
+            "SELECT stacker FROM {} WHERE rc_consensus_hash = ?1 AND chunk_id = ?2",
+            stackerdb_table(smart_contract)
+        );
+        let args: &[&dyn ToSql] = &[rc_consensus_hash, &chunk_id];
+        query_row(&self.conn, &sql, args).map_err(|e| e.into())
+    }
+
+    /// Get the chunk metadata
+    pub fn get_chunk_metadata(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        chunk_id: u32,
+    ) -> Result<Option<ChunkMetadata>, net_error> {
+        inner_get_chunk_metadata(&self.conn, smart_contract, rc_consensus_hash, chunk_id)
+    }
+
+    /// Get a chunk's validation data
+    pub fn get_chunk_validation(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        chunk_id: u32,
+    ) -> Result<Option<ChunkValidation>, net_error> {
+        inner_get_chunk_validation(&self.conn, smart_contract, rc_consensus_hash, chunk_id)
+    }
+
+    /// Get the list of chunk ID versions for a given DB instance at a given reward cycle
+    pub fn get_chunk_versions(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+    ) -> Result<Vec<u32>, net_error> {
+        let sql = format!(
+            "SELECT version FROM {} WHERE rc_consensus_hash = ?1 ORDER BY chunk_id",
+            stackerdb_table(smart_contract)
+        );
+        let args: &[&dyn ToSql] = &[rc_consensus_hash];
+        query_rows(&self.conn, &sql, args).map_err(|e| e.into())
+    }
+
+    /// Get the list of chunk ID write timestamps for a given DB instance at a given reward cycle
+    pub fn get_chunk_write_timestamps(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+    ) -> Result<Vec<u64>, net_error> {
+        let sql = format!(
+            "SELECT write_time FROM {} WHERE rc_consensus_hash = ?1 ORDER BY chunk_id",
+            stackerdb_table(smart_contract)
+        );
+        let args: &[&dyn ToSql] = &[rc_consensus_hash];
+        query_rows(&self.conn, &sql, args).map_err(|e| e.into())
+    }
+
+    /// Get the latest chunk out of the database.
+    pub fn get_latest_chunk(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        chunk_id: u32,
+    ) -> Result<Vec<u8>, net_error> {
+        let qry = format!(
+            "SELECT data FROM {} where rc_consensus_hash = ?1 AND chunk_id = ?2",
+            stackerdb_table(smart_contract)
+        );
+        let args: &[&dyn ToSql] = &[rc_consensus_hash, &chunk_id];
+
+        let mut stmt = self
+            .conn
+            .prepare(&qry)
+            .map_err(|e| net_error::DBError(e.into()))?;
+
+        let mut rows = stmt.query(args).map_err(|e| net_error::DBError(e.into()))?;
+
+        let mut data = None;
+        while let Some(row) = rows.next().map_err(|e| net_error::DBError(e.into()))? {
+            data = Some(row.get_unwrap(0));
+            break;
+        }
+        Ok(data.unwrap_or(vec![]))
+    }
+
+    /// Get a versioned chunk out of this database.  If the version is not present, then None will
+    /// be returned.
+    pub fn get_chunk(
+        &self,
+        smart_contract: (&StacksAddress, &ContractName),
+        rc_consensus_hash: &ConsensusHash,
+        chunk_id: u32,
+        chunk_version: u32,
+    ) -> Result<Option<StackerDBChunkData>, net_error> {
+        let qry = format!("SELECT chunk_id,version,signature,data FROM {} where rc_consensus_hash = ?1 AND chunk_id = ?2 AND version = ?3", stackerdb_table(smart_contract));
+        let args: &[&dyn ToSql] = &[rc_consensus_hash, &chunk_id, &chunk_version];
+        query_row(&self.conn, &qry, args).map_err(|e| e.into())
+    }
+}

--- a/src/net/stackerdb/mod.rs
+++ b/src/net/stackerdb/mod.rs
@@ -1,0 +1,186 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod bits;
+pub mod config;
+pub mod db;
+pub mod selectors;
+pub mod sync;
+
+#[cfg(test)]
+pub mod tests;
+
+use crate::util_lib::db::{DBConn, DBTx};
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::util::hash::Sha512Trunc256Sum;
+use stacks_common::util::secp256k1::MessageSignature;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::clarity_vm::clarity::ClarityReadOnlyConnection;
+
+use crate::chainstate::stacks::boot::{RawRewardSetEntry, RewardSet};
+
+use crate::net::connection::ReplyHandleP2P;
+use crate::net::Error as net_error;
+use crate::net::Neighbor;
+use crate::net::NeighborKey;
+use crate::net::StackerDBChunkData;
+use crate::net::StackerDBChunkInvData;
+use crate::net::StackerDBGetChunkData;
+
+use clarity::vm::ContractName;
+use stacks_common::types::chainstate::StacksAddress;
+
+/// maximum chunk inventory size
+pub const STACKERDB_INV_MAX: u32 = 4096;
+
+/// Settings for the Stacker DB
+#[derive(Clone, Debug, PartialEq)]
+pub struct StackerDBConfig {
+    /// maximum chunk size
+    pub chunk_size: u64,
+    /// number of chunks in this DB
+    pub num_chunks: u64,
+    /// minimum time between writes to the same chunk.
+    pub write_freq: u64,
+    /// maximum number of times a chunk may be written to during a reward cycle.
+    pub max_writes: u32,
+    /// some initial peers that have replicas of this DB
+    pub hint_peers: Vec<NeighborKey>,
+    /// how many neighbors to connect to
+    pub num_neighbors: usize,
+}
+
+/// This is a replicated database that stores fixed-length opaque blobs of data from Stackers.  Stackers get one
+/// blob per reward slot they clinch.
+///
+/// Stackers can store whatever they like in their blobs.  In practice, this is sBTC signature
+/// generation data.
+pub struct StackerDB {
+    conn: DBConn,
+}
+
+/// A transaction against the Stacker DB
+pub struct StackerDBTx<'a> {
+    sql_tx: DBTx<'a>,
+    config: StackerDBConfig,
+}
+
+/// Chunk metadata from the DB
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChunkMetadata {
+    /// Reward cycle identifier
+    pub rc_consensus_hash: ConsensusHash,
+    /// Chunk identifier (unique for each DB instance)
+    pub chunk_id: u32,
+    /// Chunk version (a lamport clock)
+    pub chunk_version: u32,
+    /// data hash
+    pub data_hash: Sha512Trunc256Sum,
+    /// signature over the above
+    pub signature: MessageSignature,
+}
+
+/// Set of peers for a stacker DB
+pub struct StackerDBPeerSet {
+    /// which contract this is a replica for
+    pub smart_contract_name: ContractName,
+    pub smart_contract_addr: StacksAddress,
+    /// number of chunks in this DB
+    pub num_chunks: usize,
+    /// how frequently we accept chunk writes
+    pub write_freq: u64,
+    /// event handles to peers we're talking to
+    pub peers: HashSet<usize>,
+    /// peers that are in the process of connecting
+    pub connecting: HashMap<NeighborKey, usize>,
+    /// in-flight requests for the current state
+    pub requests: HashMap<NeighborKey, ReplyHandleP2P>,
+    /// in-flight requests for the next state
+    pub next_requests: HashMap<NeighborKey, ReplyHandleP2P>,
+    /// nodes that didn't reply, and can be disconnected
+    pub dead: HashSet<NeighborKey>,
+    /// What versions of each chunk does each neighbor have?
+    pub chunk_invs: HashMap<NeighborKey, StackerDBChunkInvData>,
+    /// What priority should we be fetching chunks in, and from whom?
+    pub chunk_priorities: Vec<(StackerDBGetChunkData, Vec<NeighborKey>)>,
+    /// Index into `chunk_priorities` at which to consider the next download.
+    pub next_chunk_priority: usize,
+    /// What is the expected version vector for this DB's chunks?
+    pub expected_versions: Vec<u32>,
+    /// Downloaded chunks
+    pub downloaded_chunks: HashMap<NeighborKey, Vec<StackerDBChunkData>>,
+}
+
+/// Final result of synchronizing state with a remote set of DB replicas
+pub struct StackerDBSyncResult {
+    /// which contract this is a replica for
+    pub smart_contract_name: ContractName,
+    pub smart_contract_addr: StacksAddress,
+    /// list of data to store
+    pub chunks_to_store: Vec<StackerDBChunkData>,
+    /// dead neighbors we can disconnect from
+    pub dead: HashSet<NeighborKey>,
+}
+
+/// Possible states a DB sync state-machine can be in
+pub enum StackerDBSyncState {
+    ConnectBegin(Vec<Neighbor>, StackerDBPeerSet, u64),
+    ConnectFinish(StackerDBPeerSet),
+    GetChunkInv(StackerDBPeerSet),
+    GetChunks(StackerDBPeerSet),
+    Final(StackerDBSyncResult),
+}
+
+/// Top-level state machine a stacker DB
+pub struct StackerDBSync {
+    pub smart_contract_addr: StacksAddress,
+    pub smart_contract_name: ContractName,
+    pub stacker_db: StackerDB,
+    pub total_stored: u64,
+    state: Option<StackerDBSyncState>,
+}
+
+/// Trait to implement for loading up the config for a DB, and determining DB chunk slots.
+pub trait StackerDBSelector {
+    /// Load up the configuration for this DB for this reward cycle
+    fn load_config(
+        &self,
+        clarity_conn: &ClarityReadOnlyConnection,
+        rc_reward_cycle: &ConsensusHash,
+    ) -> Result<StackerDBConfig, net_error>;
+
+    /// Given a read-only connection to the clarity DB, the consensus hash of the new reward cycle,
+    /// and the reward cycle participants, determine the list of DB chunk slots to be allocated for this DB
+    /// for this reward cycle.  The order of this list will be used to determine chunk IDs.
+    /// Entries may be duplicated.
+    fn find_slots(
+        &self,
+        clarity_conn: &ClarityReadOnlyConnection,
+        rc_reward_cycle: &ConsensusHash,
+        reward_set: &RewardSet,
+        registered_addrs: Vec<RawRewardSetEntry>,
+    ) -> Result<Vec<(StacksAddress, u64)>, net_error>;
+}
+
+/// PoX slot selector implementation
+pub struct PoxSelector {}
+
+/// Smart contract selector implementation
+pub struct SmartContractSelector {
+    pub smart_contract_addr: StacksAddress,
+    pub smart_contract_name: ContractName,
+}

--- a/src/net/stackerdb/selectors/mod.rs
+++ b/src/net/stackerdb/selectors/mod.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod pox;
+pub mod smart_contract;

--- a/src/net/stackerdb/selectors/pox.rs
+++ b/src/net/stackerdb/selectors/pox.rs
@@ -1,0 +1,52 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use crate::net::stackerdb::{PoxSelector, StackerDBConfig, StackerDBSelector};
+
+use crate::net::Error as net_error;
+
+use crate::chainstate::stacks::boot::{RawRewardSetEntry, RewardSet};
+
+use crate::clarity_vm::clarity::ClarityReadOnlyConnection;
+use clarity::vm::types::PrincipalData;
+
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::StacksAddress;
+
+impl StackerDBSelector for PoxSelector {
+    fn load_config(
+        &self,
+        _clarity_conn: &ClarityReadOnlyConnection,
+        _rc_consensus_hash: &ConsensusHash,
+    ) -> Result<StackerDBConfig, net_error> {
+        Ok(StackerDBConfig::default_pox())
+    }
+
+    /// Given a reward set, figure out the list of principals who must sign off on each
+    /// blob.
+    fn find_slots(
+        &self,
+        _clarity_conn: &ClarityReadOnlyConnection,
+        _rc_consensus_hash: &ConsensusHash,
+        _reward_set: &RewardSet,
+        mut _registered_addrs: Vec<RawRewardSetEntry>,
+    ) -> Result<Vec<(StacksAddress, u64)>, net_error> {
+        unimplemented!()
+    }
+}

--- a/src/net/stackerdb/selectors/smart_contract.rs
+++ b/src/net/stackerdb/selectors/smart_contract.rs
@@ -1,0 +1,49 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::net::stackerdb::{SmartContractSelector, StackerDBConfig, StackerDBSelector};
+
+use crate::net::Error as net_error;
+
+use crate::chainstate::stacks::boot::{RawRewardSetEntry, RewardSet};
+
+use crate::clarity_vm::clarity::ClarityReadOnlyConnection;
+
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::StacksAddress;
+
+impl StackerDBSelector for SmartContractSelector {
+    /// Load up the config from this smart contract
+    fn load_config(
+        &self,
+        _clarity_conn: &ClarityReadOnlyConnection,
+        _rc_consensus_hash: &ConsensusHash,
+    ) -> Result<StackerDBConfig, net_error> {
+        unimplemented!()
+    }
+
+    /// Given a reward set, figure out the list of principals who must sign off on each
+    /// blob.
+    fn find_slots(
+        &self,
+        _clarity_conn: &ClarityReadOnlyConnection,
+        _rc_consensus_hash: &ConsensusHash,
+        _reward_set: &RewardSet,
+        mut _registered_addrs: Vec<RawRewardSetEntry>,
+    ) -> Result<Vec<(StacksAddress, u64)>, net_error> {
+        unimplemented!()
+    }
+}

--- a/src/net/stackerdb/sync.rs
+++ b/src/net/stackerdb/sync.rs
@@ -1,0 +1,996 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::net::neighbors::NeighborSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::net::stackerdb::{
+    StackerDB, StackerDBConfig, StackerDBPeerSet, StackerDBSync, StackerDBSyncResult,
+    StackerDBSyncState,
+};
+
+use crate::net::db::PeerDB;
+
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::StacksAddress;
+use stacks_common::util::get_epoch_time_secs;
+use stacks_common::util::hash::Hash160;
+
+use clarity::vm::ContractName;
+
+use crate::net::chat::ConversationP2P;
+use crate::net::connection::ReplyHandleP2P;
+use crate::net::p2p::PeerNetwork;
+use crate::net::Error as net_error;
+use crate::net::{
+    NackData, Neighbor, NeighborKey, StackerDBChunkData, StackerDBChunkInvData,
+    StackerDBGetChunkData, StackerDBGetChunkInvData, StacksMessageType,
+};
+
+use rand::prelude::SliceRandom;
+use rand::thread_rng;
+use rand::RngCore;
+
+const MAX_CHUNKS_IN_FLIGHT: usize = 6;
+
+impl NeighborSet for StackerDBPeerSet {
+    fn add_connecting(&mut self, nk: &NeighborKey, event_id: usize) {
+        self.connecting.insert(nk.clone(), event_id);
+        self.pin_connection(event_id);
+    }
+    fn get_connecting(&self, nk: &NeighborKey) -> Option<usize> {
+        self.connecting.get(nk).copied()
+    }
+    fn remove_connecting(&mut self, nk: &NeighborKey) {
+        self.connecting.remove(nk);
+    }
+    fn add_dead(&mut self, nk: &NeighborKey) {
+        self.dead.insert(nk.clone());
+    }
+    fn pin_connection(&mut self, event_id: usize) {
+        self.peers.insert(event_id);
+    }
+    fn unpin_connection(&mut self, event_id: usize) {
+        self.peers.remove(&event_id);
+    }
+    fn is_pinned(&self, event_id: usize) -> bool {
+        self.peers.contains(&event_id)
+    }
+}
+
+impl StackerDBPeerSet {
+    pub fn new(
+        smart_contract: (StacksAddress, ContractName),
+        num_chunks: usize,
+        write_freq: u64,
+    ) -> StackerDBPeerSet {
+        StackerDBPeerSet {
+            smart_contract_name: smart_contract.1,
+            smart_contract_addr: smart_contract.0,
+            num_chunks,
+            write_freq,
+            peers: HashSet::new(),
+            connecting: HashMap::new(),
+            dead: HashSet::new(),
+            requests: HashMap::new(),
+            next_requests: HashMap::new(),
+            chunk_invs: HashMap::new(),
+            chunk_priorities: vec![],
+            next_chunk_priority: 0,
+            expected_versions: vec![],
+            downloaded_chunks: HashMap::new(),
+        }
+    }
+
+    /// Declare a neighbor dead and unpin its connection
+    pub fn add_dead_and_unpin(&mut self, nk: &NeighborKey, event_id: usize) {
+        self.add_dead(nk);
+        self.unpin_connection(event_id);
+    }
+
+    /// Advance to the next state.
+    /// Move all next_requests into requests.
+    pub fn advance(&mut self) {
+        self.requests.clear();
+        let next_requests = std::mem::replace(&mut self.next_requests, HashMap::new());
+        self.requests = next_requests;
+    }
+
+    /// Make a chunk inv request
+    pub fn make_getchunkinv(&self, rc_consensus_hash: &ConsensusHash) -> StacksMessageType {
+        StacksMessageType::StackerDBGetChunkInv(StackerDBGetChunkInvData {
+            smart_contract_addr: self.smart_contract_addr.clone(),
+            smart_contract_name: self.smart_contract_name.clone(),
+            rc_consensus_hash: rc_consensus_hash.clone(),
+        })
+    }
+
+    /// Given the downloaded set of chunk inventories, identify:
+    /// * which chunks we need to fetch, because they're newer than ours.
+    /// * what order to fetch chunks in, in rarest-first order
+    pub fn make_chunk_request_schedule(
+        &self,
+        stackerdb: &StackerDB,
+        rc_consensus_hash: &ConsensusHash,
+    ) -> Result<Vec<(StackerDBGetChunkData, Vec<NeighborKey>)>, net_error> {
+        let local_chunk_versions = stackerdb.get_chunk_versions(
+            (&self.smart_contract_addr, &self.smart_contract_name),
+            rc_consensus_hash,
+        )?;
+        let local_write_timestamps = stackerdb.get_chunk_write_timestamps(
+            (&self.smart_contract_addr, &self.smart_contract_name),
+            rc_consensus_hash,
+        )?;
+        assert_eq!(local_chunk_versions.len(), local_write_timestamps.len());
+
+        let mut need_chunks: HashMap<usize, (StackerDBGetChunkData, Vec<NeighborKey>)> =
+            HashMap::new();
+        let now = get_epoch_time_secs();
+
+        // who has data we need?
+        for (i, local_version) in local_chunk_versions.iter().enumerate() {
+            let write_ts = local_write_timestamps[i];
+            if write_ts + self.write_freq >= now {
+                test_debug!(
+                    "Chunk {} was written too freuently ({} + {} >= {}), so will not fetch chunk",
+                    local_chunk_versions[i],
+                    write_ts,
+                    self.write_freq,
+                    now
+                );
+                continue;
+            }
+
+            for (nk, chunk_inv) in self.chunk_invs.iter() {
+                assert_eq!(
+                    chunk_inv.chunk_versions.len(),
+                    local_chunk_versions.len(),
+                    "FATAL: did not validate StackerDBChunkInvData"
+                );
+
+                if *local_version >= chunk_inv.chunk_versions[i] {
+                    // remote peer has same view as local peer, or stale
+                    continue;
+                }
+
+                if let Some((ref mut request, ref mut available)) = need_chunks.get_mut(&i) {
+                    if request.chunk_version < chunk_inv.chunk_versions[i] {
+                        // this peer has a newer view
+                        available.clear();
+                        available.push(nk.clone());
+                        *request = StackerDBGetChunkData {
+                            smart_contract_addr: self.smart_contract_addr.clone(),
+                            smart_contract_name: self.smart_contract_name.clone(),
+                            rc_consensus_hash: rc_consensus_hash.clone(),
+                            chunk_id: i as u32,
+                            chunk_version: chunk_inv.chunk_versions[i],
+                        };
+                    } else if request.chunk_version == chunk_inv.chunk_versions[i] {
+                        // this peer has the same view as a prior peer.
+                        // just track how many times we see this
+                        available.push(nk.clone());
+                    } else {
+                        // this peer has an older view than the prior peer.
+                        continue;
+                    }
+                } else {
+                    // haven't seen anyone with this data yet
+                    need_chunks.insert(
+                        i,
+                        (
+                            StackerDBGetChunkData {
+                                smart_contract_addr: self.smart_contract_addr.clone(),
+                                smart_contract_name: self.smart_contract_name.clone(),
+                                rc_consensus_hash: rc_consensus_hash.clone(),
+                                chunk_id: i as u32,
+                                chunk_version: chunk_inv.chunk_versions[i],
+                            },
+                            vec![nk.clone()],
+                        ),
+                    );
+                }
+            }
+        }
+
+        // prioritize requests by rarest-chunk-first order, but choose neighbors in random order
+        let mut request_priority = BTreeMap::new();
+        for (_i, (stacker_db_getchunkdata, mut neighbors)) in need_chunks.into_iter() {
+            neighbors.shuffle(&mut thread_rng());
+            request_priority.insert(
+                (neighbors.len(), stacker_db_getchunkdata.chunk_id),
+                (stacker_db_getchunkdata, neighbors),
+            );
+        }
+
+        let mut ret = vec![];
+
+        debug!(
+            "Will request up to {} chunks from {}.{}",
+            &request_priority.len(),
+            &self.smart_contract_addr,
+            &self.smart_contract_name
+        );
+        for (_, (stacker_db_getchunkdata, neighbors)) in request_priority.into_iter() {
+            debug!(
+                "Will request chunk {}.{}/{}.{} from {:?}",
+                &stacker_db_getchunkdata.smart_contract_addr,
+                &stacker_db_getchunkdata.smart_contract_name,
+                &stacker_db_getchunkdata.chunk_id,
+                &stacker_db_getchunkdata.chunk_version,
+                &neighbors
+            );
+            ret.push((stacker_db_getchunkdata, neighbors));
+        }
+
+        Ok(ret)
+    }
+
+    /// Validate a downloaded chunk
+    pub fn validate_downloaded_chunk(
+        &self,
+        rc_consensus_hash: &ConsensusHash,
+        data: &StackerDBChunkData,
+        stacker_db: &StackerDB,
+    ) -> Result<bool, net_error> {
+        // validate -- must be a valid chunk
+        if data.chunk_id >= (self.expected_versions.len() as u32) {
+            info!(
+                "Received StackerDBChunk ID {}, which is too big ({})",
+                data.chunk_id,
+                self.expected_versions.len()
+            );
+            return Ok(false);
+        }
+
+        // validate -- must be signed by the expected author
+        let addr = match stacker_db.get_chunk_signer(
+            (&self.smart_contract_addr, &self.smart_contract_name),
+            rc_consensus_hash,
+            data.chunk_id,
+        )? {
+            Some(addr) => addr,
+            None => {
+                return Ok(false);
+            }
+        };
+
+        let chunk_metadata = data.get_chunk_metadata(rc_consensus_hash.clone());
+        if !chunk_metadata.verify(&addr)? {
+            info!(
+                "StackerDBChunk ID {} is not signed by {}",
+                data.chunk_id, &addr
+            );
+            return Ok(false);
+        }
+
+        // validate -- must be the current or newer version
+        let chunk_idx = data.chunk_id as usize;
+        if data.chunk_version < self.expected_versions[chunk_idx] {
+            info!(
+                "Received StackerDBChunk ID {} version {}, which is stale (expected {})",
+                data.chunk_id, data.chunk_version, self.expected_versions[chunk_idx]
+            );
+            return Ok(false);
+        }
+
+        // no need to validate the timestamp, because we already skipped requesting it if it was
+        // written too recently.
+
+        Ok(true)
+    }
+
+    /// Store a downloaded chunk to RAM, and update bookkeeping
+    pub fn add_downloaded_chunk(&mut self, nk: NeighborKey, data: StackerDBChunkData) {
+        let chunk_id = data.chunk_id;
+        let _chunk_version = data.chunk_version;
+
+        if let Some(data_list) = self.downloaded_chunks.get_mut(&nk) {
+            data_list.push(data);
+        } else {
+            self.downloaded_chunks.insert(nk.clone(), vec![data]);
+        }
+
+        // yes, this is a linear scan. But because the number of chunks in the DB is a small O(1)
+        // enforced by the protocol, this isn't a big deal.
+        // This loop is only expected to run once, but is in place for defensive purposes.
+        loop {
+            let mut remove_idx = None;
+            for (i, (chunk, ..)) in self.chunk_priorities.iter().enumerate() {
+                if chunk.chunk_id == chunk_id {
+                    remove_idx = Some(i);
+                    break;
+                }
+            }
+            if let Some(remove_idx) = remove_idx {
+                test_debug!(
+                    "Downloaded chunk {}.{} from {:?}",
+                    chunk_id,
+                    _chunk_version,
+                    &nk
+                );
+                self.chunk_priorities.remove(remove_idx);
+            } else {
+                break;
+            }
+        }
+        if self.chunk_priorities.len() > 0 {
+            let next_chunk_priority = self.next_chunk_priority % self.chunk_priorities.len();
+            self.next_chunk_priority = next_chunk_priority;
+        }
+    }
+
+    /// Make download requests -- keep our `requests` table full.
+    /// Returns the (number of new requests created, number of requests in flight)
+    fn send_getchunks_requests(&mut self, network: &mut PeerNetwork) -> (usize, usize) {
+        if self.chunk_priorities.len() == 0 {
+            return (0, self.requests.len());
+        }
+
+        let capacity = MAX_CHUNKS_IN_FLIGHT.saturating_sub(self.requests.len());
+        let mut cur_priority = self.next_chunk_priority % self.chunk_priorities.len();
+        let mut num_new_requests = 0;
+
+        test_debug!(
+            "{:?}: Issue up to {} StackerDBGetChunk requests",
+            &network.local_peer,
+            capacity
+        );
+        for _i in 0..capacity {
+            let chunk_request = self.chunk_priorities[cur_priority].0.clone();
+
+            let mut selected_neighbor = None;
+            for (j, nk) in self.chunk_priorities[cur_priority].1.iter().enumerate() {
+                if self.requests.get(&nk).is_some() {
+                    // already talking to this neighbor
+                    continue;
+                }
+
+                selected_neighbor = Some((j, nk.clone()));
+                break;
+            }
+
+            if let Some((idx, nk)) = selected_neighbor {
+                let handle = match Self::neighbor_send(
+                    network,
+                    &nk,
+                    StacksMessageType::StackerDBGetChunk(chunk_request.clone()),
+                ) {
+                    Ok(h) => h,
+                    Err(e) => {
+                        info!(
+                            "Failed to request chunk {} of {}.{} from {:?}: {:?}",
+                            chunk_request.chunk_id,
+                            &self.smart_contract_addr,
+                            &self.smart_contract_name,
+                            &nk,
+                            &e
+                        );
+                        continue;
+                    }
+                };
+
+                debug!(
+                    "{:?}: Send StackerDBGetChunk(db={}.{},id={},ver={}) to {}",
+                    &network.local_peer,
+                    &self.smart_contract_addr,
+                    &self.smart_contract_name,
+                    chunk_request.chunk_id,
+                    chunk_request.chunk_version,
+                    &nk
+                );
+                self.requests.insert(nk, handle);
+
+                num_new_requests += 1;
+                self.chunk_priorities[cur_priority].1.remove(idx);
+            }
+
+            cur_priority = (cur_priority + 1) % self.chunk_priorities.len();
+            if cur_priority == self.next_chunk_priority {
+                // looped around
+                break;
+            }
+        }
+        test_debug!(
+            "{:?}: Issued {} StackerDBGetChunk requests; {} in-flight",
+            &network.local_peer,
+            num_new_requests,
+            self.requests.len()
+        );
+        self.next_chunk_priority = cur_priority;
+        (num_new_requests, self.requests.len())
+    }
+
+    /// Convert ourselves into the result to store.
+    pub fn into_stacker_db_sync_result(self) -> StackerDBSyncResult {
+        let mut chunks = vec![];
+        for (_, mut data) in self.downloaded_chunks.into_iter() {
+            chunks.append(&mut data);
+        }
+        StackerDBSyncResult {
+            smart_contract_addr: self.smart_contract_addr,
+            smart_contract_name: self.smart_contract_name,
+            chunks_to_store: chunks,
+            dead: self.dead,
+        }
+    }
+}
+
+impl StackerDBSyncState {
+    /// Initialize the state machine for replicating a DB.
+    /// Finds some initial peers.
+    /// Returns NoSuchNeighbor if there aren't any known replicas.
+    pub fn new(
+        smart_contract: &(StacksAddress, ContractName),
+        num_chunks: usize,
+        write_freq: u64,
+        peerdb: &PeerDB,
+        max_neighbors: usize,
+        start_time: u64,
+    ) -> Result<StackerDBSyncState, net_error> {
+        let local_peer = PeerDB::get_local_peer(peerdb.conn())?;
+        let peers = PeerDB::find_stacker_db_replicas(
+            peerdb.conn(),
+            local_peer.network_id,
+            smart_contract,
+            max_neighbors,
+        )?;
+        if peers.len() == 0 {
+            debug!(
+                "No available peers to replicate {}.{}",
+                &smart_contract.0, &smart_contract.1
+            );
+        }
+        Ok(StackerDBSyncState::ConnectBegin(
+            peers,
+            StackerDBPeerSet::new(smart_contract.clone(), num_chunks, write_freq),
+            start_time,
+        ))
+    }
+
+    /// Ask inbound neighbors who replicate this DB for their chunks.
+    /// Returns the map of reply handles.
+    /// TODO: limit the number
+    fn send_getchunkinv_to_inbound_neighbors(
+        network: &mut PeerNetwork,
+        neighbor_set: &StackerDBPeerSet,
+    ) -> HashMap<NeighborKey, ReplyHandleP2P> {
+        let mut ret = HashMap::new();
+        let mut to_send = vec![];
+        for (_, convo) in network.peers.iter() {
+            if !ConversationP2P::supports_stackerdb(convo.peer_services) {
+                continue;
+            }
+            if convo.is_outbound() {
+                continue;
+            }
+            if !convo.replicates_stackerdb((
+                &neighbor_set.smart_contract_addr,
+                &neighbor_set.smart_contract_name,
+            )) {
+                continue;
+            }
+            let nk = convo.to_neighbor_key();
+            let chunks_req = neighbor_set.make_getchunkinv(&network.chain_view.rc_consensus_hash);
+            to_send.push((nk, chunks_req));
+        }
+
+        for (nk, chunks_req) in to_send.into_iter() {
+            match StackerDBPeerSet::neighbor_send(network, &nk, chunks_req) {
+                Ok(handle) => {
+                    ret.insert(nk, handle);
+                }
+                Err(e) => {
+                    warn!("Failed to send GetChunkInv to {:?}: {:?}", &nk, &e);
+                }
+            }
+        }
+        ret
+    }
+
+    /// Establish sessions with remote replicas.
+    /// We might not be connected to any yet.
+    fn run_connect_begin(
+        network: &mut PeerNetwork,
+        neighbors: Vec<Neighbor>,
+        mut neighbor_set: StackerDBPeerSet,
+        start_time: u64,
+    ) -> Result<StackerDBSyncState, net_error> {
+        test_debug!(
+            "{:?}: StackerDBSyncState run_connect_begin",
+            &network.local_peer
+        );
+        if get_epoch_time_secs() < start_time {
+            return Ok(StackerDBSyncState::ConnectBegin(
+                neighbors,
+                neighbor_set,
+                start_time,
+            ));
+        }
+
+        let mut retry_requests = vec![];
+        for neighbor in neighbors.into_iter() {
+            if network.can_register_peer(&neighbor.addr, true).is_ok() {
+                // neighbor is not yet connected
+                match neighbor_set.neighbor_session_begin(
+                    network,
+                    &neighbor.addr,
+                    &Hash160::from_node_public_key(&neighbor.public_key),
+                ) {
+                    Ok(Some(handle)) => {
+                        neighbor_set.next_requests.insert(neighbor.addr, handle);
+                    }
+                    Ok(None) => {
+                        retry_requests.push(neighbor);
+                    }
+                    Err(e) => {
+                        info!("Failed to connect to {:?}: {:?}", &neighbor.addr, &e);
+                        continue;
+                    }
+                }
+            } else {
+                debug!(
+                    "{:?}: already connected to {}",
+                    &network.local_peer, &neighbor.addr
+                );
+
+                // proceed to ask for a chunk inventory
+                let chunks_req =
+                    neighbor_set.make_getchunkinv(&network.chain_view.rc_consensus_hash);
+                let handle = StackerDBPeerSet::neighbor_send(network, &neighbor.addr, chunks_req)?;
+                neighbor_set.next_requests.insert(neighbor.addr, handle);
+            }
+        }
+        if retry_requests.len() == 0 {
+            // *also* ask any *existing* neighbors who have this DB for their chunk invs
+            let mut existing_neighbor_requests =
+                Self::send_getchunkinv_to_inbound_neighbors(network, &neighbor_set);
+            for (nk, rh) in existing_neighbor_requests.drain() {
+                neighbor_set.next_requests.insert(nk, rh);
+            }
+
+            // attempted all connections
+            neighbor_set.advance();
+            return Ok(StackerDBSyncState::ConnectFinish(neighbor_set));
+        } else {
+            // still must attempt more
+            return Ok(StackerDBSyncState::ConnectBegin(
+                retry_requests,
+                neighbor_set,
+                start_time,
+            ));
+        }
+    }
+
+    /// Finish establishing all connections, and if we asked for a chunk inventory, handle that as
+    /// well.
+    fn run_connect_finish(
+        network: &mut PeerNetwork,
+        mut neighbor_set: StackerDBPeerSet,
+    ) -> Result<StackerDBSyncState, net_error> {
+        debug!(
+            "{:?}: StackerDBSyncState run_connect_finish",
+            &network.local_peer
+        );
+        let mut requests = std::mem::replace(&mut neighbor_set.requests, HashMap::new());
+        let mut retry_requests = HashMap::new();
+        for (nk, rh) in requests.drain() {
+            let event_id = rh.get_event_id();
+            match neighbor_set.neighbor_try_recv(network, &nk, rh) {
+                Ok(message) => {
+                    match message.payload {
+                        StacksMessageType::StackerDBHandshakeAccept(_, db_data) => {
+                            if network.chain_view.rc_consensus_hash != db_data.rc_consensus_hash {
+                                // stale or inconsistent view. Do not proceed
+                                debug!(
+                                    "{:?}: remote peer {:?} has stale view ({} != {})",
+                                    &network.local_peer,
+                                    &nk,
+                                    &network.chain_view.rc_consensus_hash,
+                                    &db_data.rc_consensus_hash
+                                );
+                                neighbor_set.unpin_connection(event_id);
+                                continue;
+                            }
+
+                            // ask for chunk inv
+                            let chunks_req =
+                                neighbor_set.make_getchunkinv(&db_data.rc_consensus_hash);
+                            let handle = StackerDBPeerSet::neighbor_send(network, &nk, chunks_req)?;
+                            neighbor_set.next_requests.insert(nk, handle);
+                        }
+                        StacksMessageType::StackerDBChunkInv(data) => {
+                            // got a chunk inv, because this neighbor was already connected and we
+                            // didn't need to handshake.  Proceed to store if well-formed.
+                            if data.chunk_versions.len() != neighbor_set.num_chunks {
+                                info!("Received malformed StackerDBChunkInv from {:?}: expected {} chunks, got {}", &nk, neighbor_set.num_chunks, data.chunk_versions.len());
+                                continue;
+                            }
+
+                            neighbor_set.chunk_invs.insert(nk, data);
+                        }
+                        StacksMessageType::Nack(data) => {
+                            debug!(
+                                "{:?}: remote peer {:?} NACK'ed us with code {}",
+                                &network.local_peer, &nk, data.error_code
+                            );
+                            neighbor_set.unpin_connection(event_id);
+                            continue;
+                        }
+                        x => {
+                            info!("Received unexpected message {:?}", &x);
+                            neighbor_set.add_dead_and_unpin(&nk, event_id);
+                            continue;
+                        }
+                    }
+                }
+                Err(Ok(retry)) => {
+                    retry_requests.insert(nk, retry);
+                }
+                Err(Err(e)) => {
+                    info!("Failed to finish connecting to {:?}: {:?}", &nk, &e);
+                    neighbor_set.add_dead_and_unpin(&nk, event_id);
+                    continue;
+                }
+            }
+        }
+        neighbor_set.requests = retry_requests;
+
+        if neighbor_set.requests.len() == 0 {
+            // no more requests to complete. Can advance.
+            neighbor_set.advance();
+            return Ok(StackerDBSyncState::GetChunkInv(neighbor_set));
+        } else {
+            // must keep trying
+            return Ok(StackerDBSyncState::ConnectFinish(neighbor_set));
+        }
+    }
+
+    /// Finish fetching chunk invs, and when we do, schedule and kick off chunk requests.
+    fn run_getchunkinv(
+        network: &mut PeerNetwork,
+        stackerdb: &StackerDB,
+        mut neighbor_set: StackerDBPeerSet,
+    ) -> Result<StackerDBSyncState, net_error> {
+        debug!(
+            "{:?}: StackerDBSyncState run_getchunkinv",
+            &network.local_peer
+        );
+        let mut requests = std::mem::replace(&mut neighbor_set.requests, HashMap::new());
+        let mut retry_requests = HashMap::new();
+        for (nk, rh) in requests.drain() {
+            let event_id = rh.get_event_id();
+            match neighbor_set.neighbor_try_recv(network, &nk, rh) {
+                Ok(message) => {
+                    debug!(
+                        "{:?}: got {} from {:?}",
+                        &network.local_peer,
+                        &message.payload.get_message_description(),
+                        &nk
+                    );
+                    match message.payload {
+                        StacksMessageType::StackerDBChunkInv(data) => {
+                            // must be well-formed
+                            if data.chunk_versions.len() != neighbor_set.num_chunks {
+                                info!("Received malformed StackerDBChunkInv from {:?}: expected {} chunks, got {}", &nk, neighbor_set.num_chunks, data.chunk_versions.len());
+                                continue;
+                            }
+
+                            neighbor_set.chunk_invs.insert(nk, data);
+                        }
+                        StacksMessageType::Nack(data) => {
+                            debug!("{:?}: remote peer {:?} NACK'ed our StackerDBGetChunkInv with code {}", &network.local_peer, &nk, data.error_code);
+                            neighbor_set.unpin_connection(event_id);
+                            continue;
+                        }
+                        x => {
+                            info!("Received unexpected message {:?}", &x);
+                            neighbor_set.add_dead_and_unpin(&nk, event_id);
+                            continue;
+                        }
+                    }
+                }
+                Err(Ok(retry)) => {
+                    retry_requests.insert(nk, retry);
+                }
+                Err(Err(e)) => {
+                    info!(
+                        "Failed to finish getting chunk inv from {:?}: {:?}",
+                        &nk, &e
+                    );
+                    neighbor_set.add_dead_and_unpin(&nk, event_id);
+                    continue;
+                }
+            }
+        }
+        neighbor_set.requests = retry_requests;
+        if neighbor_set.requests.len() == 0 {
+            // no more requests to complete. Can advance
+            neighbor_set.advance();
+
+            // schedule downloads
+            let priorities = neighbor_set
+                .make_chunk_request_schedule(stackerdb, &network.chain_view.rc_consensus_hash)?;
+            let expected_versions = stackerdb.get_chunk_versions(
+                (
+                    &neighbor_set.smart_contract_addr,
+                    &neighbor_set.smart_contract_name,
+                ),
+                &network.chain_view.rc_consensus_hash,
+            )?;
+            neighbor_set.chunk_priorities = priorities;
+            neighbor_set.expected_versions = expected_versions;
+
+            // begin requests
+            neighbor_set.send_getchunks_requests(network);
+            return Ok(StackerDBSyncState::GetChunks(neighbor_set));
+        } else {
+            // must keep trying
+            return Ok(StackerDBSyncState::GetChunkInv(neighbor_set));
+        }
+    }
+
+    /// Go get chunks.
+    fn run_getchunks(
+        network: &mut PeerNetwork,
+        stackerdb: &StackerDB,
+        mut neighbor_set: StackerDBPeerSet,
+    ) -> Result<StackerDBSyncState, net_error> {
+        debug!(
+            "{:?}: StackerDBSyncState run_getchunks",
+            &network.local_peer
+        );
+        let mut requests = std::mem::replace(&mut neighbor_set.requests, HashMap::new());
+        let mut retry_requests = HashMap::new();
+        for (nk, rh) in requests.drain() {
+            let event_id = rh.get_event_id();
+            match neighbor_set.neighbor_try_recv(network, &nk, rh) {
+                Ok(message) => {
+                    debug!(
+                        "{:?}: got {} from {:?}",
+                        &network.local_peer,
+                        &message.payload.get_message_description(),
+                        &nk
+                    );
+                    match message.payload {
+                        StacksMessageType::StackerDBChunk(data) => {
+                            // validate
+                            if !neighbor_set.validate_downloaded_chunk(
+                                &network.chain_view.rc_consensus_hash,
+                                &data,
+                                stackerdb,
+                            )? {
+                                info!(
+                                    "Remote neighbor {:?} served an invalid chunk for ID {}",
+                                    &nk, data.chunk_id
+                                );
+                                neighbor_set.add_dead_and_unpin(&nk, event_id);
+                                continue;
+                            }
+
+                            // update bookkeeping
+                            neighbor_set.add_downloaded_chunk(nk, data);
+                        }
+                        StacksMessageType::Nack(data) => {
+                            debug!(
+                                "{:?}: remote peer {:?} NACK'ed our StackerDBGetChunk with code {}",
+                                &network.local_peer, &nk, data.error_code
+                            );
+                            neighbor_set.unpin_connection(event_id);
+                            continue;
+                        }
+                        x => {
+                            info!("Received unexpected message {:?}", &x);
+                            neighbor_set.add_dead_and_unpin(&nk, event_id);
+                            continue;
+                        }
+                    }
+                }
+                Err(Ok(retry)) => {
+                    retry_requests.insert(nk, retry);
+                }
+                Err(Err(e)) => {
+                    info!("Failed to finish getting chunk from {:?}: {:?}", &nk, &e);
+                    neighbor_set.add_dead_and_unpin(&nk, event_id);
+                    continue;
+                }
+            }
+        }
+        neighbor_set.requests = retry_requests;
+
+        // keep the pipe full
+        let (num_added, num_inflight) = neighbor_set.send_getchunks_requests(network);
+        if num_added == 0 && num_inflight == 0 {
+            // all requests terminated
+            return Ok(StackerDBSyncState::Final(
+                neighbor_set.into_stacker_db_sync_result(),
+            ));
+        } else {
+            // some requests still in-flight
+            return Ok(StackerDBSyncState::GetChunks(neighbor_set));
+        }
+    }
+
+    /// Run the state-machine
+    pub fn next_state(
+        self,
+        network: &mut PeerNetwork,
+        stackerdb: &StackerDB,
+    ) -> Result<StackerDBSyncState, net_error> {
+        match self {
+            StackerDBSyncState::ConnectBegin(neighbors, neighbor_set, start_time) => {
+                Self::run_connect_begin(network, neighbors, neighbor_set, start_time)
+            }
+            StackerDBSyncState::ConnectFinish(neighbor_set) => {
+                Self::run_connect_finish(network, neighbor_set)
+            }
+            StackerDBSyncState::GetChunkInv(neighbor_set) => {
+                Self::run_getchunkinv(network, stackerdb, neighbor_set)
+            }
+            StackerDBSyncState::GetChunks(neighbor_set) => {
+                Self::run_getchunks(network, stackerdb, neighbor_set)
+            }
+            StackerDBSyncState::Final(result) => Ok(StackerDBSyncState::Final(result)),
+        }
+    }
+
+    /// Get a ref to the neighbor set
+    pub fn neighbor_set(&self) -> Option<&StackerDBPeerSet> {
+        match self {
+            StackerDBSyncState::ConnectBegin(ref _neighbors, ref neighbor_set, _) => {
+                Some(neighbor_set)
+            }
+            StackerDBSyncState::ConnectFinish(ref neighbor_set) => Some(neighbor_set),
+            StackerDBSyncState::GetChunkInv(ref neighbor_set) => Some(neighbor_set),
+            StackerDBSyncState::GetChunks(ref neighbor_set) => Some(neighbor_set),
+            StackerDBSyncState::Final(_) => None,
+        }
+    }
+}
+
+impl StackerDBSync {
+    pub fn new(
+        peerdb: &PeerDB,
+        smart_contract: (StacksAddress, ContractName),
+        stackerdb_config: &StackerDBConfig,
+        db_path: &str,
+    ) -> Result<StackerDBSync, net_error> {
+        if stackerdb_config.num_chunks > (usize::MAX as u64) {
+            return Err(net_error::OverflowError(
+                "StackerDB num_chunks exceeds usize::MAX".to_string(),
+            ));
+        }
+        let num_neighbors = stackerdb_config.num_neighbors;
+        let num_chunks = stackerdb_config.num_chunks as usize;
+        let write_freq = stackerdb_config.write_freq;
+        let stacker_db = StackerDB::connect(db_path, true)?;
+        Ok(StackerDBSync {
+            smart_contract_addr: smart_contract.0.clone(),
+            smart_contract_name: smart_contract.1.clone(),
+            stacker_db,
+            total_stored: 0,
+            state: Some(StackerDBSyncState::new(
+                &smart_contract,
+                num_chunks,
+                write_freq,
+                peerdb,
+                num_neighbors,
+                0,
+            )?),
+        })
+    }
+
+    /// Reset the state machine
+    pub fn reset(
+        &mut self,
+        peerdb: &PeerDB,
+        stackerdb_config: &StackerDBConfig,
+    ) -> Result<(), net_error> {
+        debug!(
+            "Reset StackerDBSync({}.{})",
+            &self.smart_contract_addr, &self.smart_contract_name
+        );
+        let sc = (
+            self.smart_contract_addr.clone(),
+            self.smart_contract_name.clone(),
+        );
+        self.state = Some(StackerDBSyncState::new(
+            &sc,
+            stackerdb_config.num_chunks as usize,
+            stackerdb_config.write_freq,
+            peerdb,
+            stackerdb_config.num_neighbors,
+            stackerdb_config.write_freq + get_epoch_time_secs(),
+        )?);
+        Ok(())
+    }
+
+    /// Run one state-machine pass.
+    /// If the state machine
+    pub fn run(
+        &mut self,
+        network: &mut PeerNetwork,
+        stackerdb_config: &StackerDBConfig,
+    ) -> Result<Option<StackerDBSyncResult>, net_error> {
+        let state = self.state.take();
+        if let Some(state) = state {
+            let new_state = match state.next_state(network, &self.stacker_db) {
+                Ok(state) => state,
+                Err(e) => {
+                    info!("Failed state transition: {:?}", &e);
+                    self.reset(&network.peerdb, stackerdb_config)?;
+                    return Ok(None);
+                }
+            };
+            if let StackerDBSyncState::Final(result) = new_state {
+                self.total_stored += result.chunks_to_store.len() as u64;
+                self.reset(&network.peerdb, stackerdb_config)?;
+                Ok(Some(result))
+            } else {
+                self.state = Some(new_state);
+                Ok(None)
+            }
+        } else {
+            self.reset(&network.peerdb, stackerdb_config)?;
+            Ok(None)
+        }
+    }
+
+    /// Get a ref to the neighbor set, if we're running
+    pub fn neighbor_set(&self) -> Option<&StackerDBPeerSet> {
+        if let Some(state) = self.state.as_ref() {
+            state.neighbor_set()
+        } else {
+            None
+        }
+    }
+}
+
+impl PeerNetwork {
+    /// Run all stacker DB sync state-machines
+    pub fn run_stacker_db_sync(&mut self) -> Result<Vec<StackerDBSyncResult>, net_error> {
+        let mut results = vec![];
+        let mut stacker_db_syncs = self
+            .stacker_db_syncs
+            .take()
+            .expect("FATAL: did not replace stacker dbs");
+        let stacker_db_configs = self.stacker_db_configs.clone();
+
+        for (sc, stacker_db_sync) in stacker_db_syncs.iter_mut() {
+            if let Some(config) = stacker_db_configs.get(sc) {
+                match stacker_db_sync.run(self, config) {
+                    Ok(Some(result)) => {
+                        // clear dead nodes
+                        for dead in result.dead.iter() {
+                            self.deregister_neighbor(dead);
+                        }
+                        results.push(result);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        info!(
+                            "Failed to run StackerDB state machine for {}.{}: {:?}",
+                            &sc.0, &sc.1, &e
+                        );
+                    }
+                }
+            } else {
+                info!("No stacker DB config for {}.{}", &sc.0, &sc.1);
+            }
+        }
+        self.stacker_db_syncs = Some(stacker_db_syncs);
+        Ok(results)
+    }
+}

--- a/src/net/stackerdb/tests/bits.rs
+++ b/src/net/stackerdb/tests/bits.rs
@@ -1,0 +1,67 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fs;
+
+use crate::net::stackerdb::{ChunkMetadata, StackerDB};
+use crate::net::StackerDBChunkData;
+
+use clarity::vm::ContractName;
+use stacks_common::types::chainstate::StacksAddress;
+
+use stacks_common::util::hash::Hash160;
+use stacks_common::util::hash::Sha512Trunc256Sum;
+use stacks_common::util::secp256k1::MessageSignature;
+
+use stacks_common::address::{AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG};
+use stacks_common::types::chainstate::{ConsensusHash, StacksPrivateKey, StacksPublicKey};
+use stacks_common::types::PrivateKey;
+
+#[test]
+fn test_stackerdb_chunk_metadata_sign_verify() {
+    let pk = StacksPrivateKey::new();
+    let addr = StacksAddress::from_public_keys(
+        C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+        &AddressHashMode::SerializeP2PKH,
+        1,
+        &vec![StacksPublicKey::from_private(&pk)],
+    )
+    .unwrap();
+    let bad_addr = StacksAddress {
+        version: 0x01,
+        bytes: Hash160([0x01; 20]),
+    };
+
+    let chunk_data = StackerDBChunkData {
+        chunk_id: 0,
+        chunk_version: 1,
+        sig: MessageSignature::empty(),
+        data: vec![0x1; 128],
+    };
+
+    let mut chunk_metadata = chunk_data.get_chunk_metadata(ConsensusHash([0x01; 20]));
+    chunk_metadata.sign(&pk).unwrap();
+
+    assert!(chunk_metadata.verify(&addr).unwrap());
+
+    // fails with wrong address
+    assert!(!chunk_metadata.verify(&bad_addr).unwrap());
+
+    // fails with wrong reward cycle consensus hash
+    let mut bad_chunk_metadata = chunk_data.get_chunk_metadata(ConsensusHash([0x02; 20]));
+    bad_chunk_metadata.sign(&pk).unwrap();
+    assert!(bad_chunk_metadata.verify(&addr).unwrap());
+}

--- a/src/net/stackerdb/tests/db.rs
+++ b/src/net/stackerdb/tests/db.rs
@@ -1,0 +1,553 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fs;
+
+use crate::net::stackerdb::{db::ChunkValidation, ChunkMetadata, StackerDB, StackerDBConfig};
+
+use crate::net::Error as net_error;
+use crate::net::StackerDBChunkData;
+
+use clarity::vm::ContractName;
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::StacksAddress;
+
+use stacks_common::util::hash::Hash160;
+use stacks_common::util::hash::Sha512Trunc256Sum;
+use stacks_common::util::secp256k1::MessageSignature;
+
+use stacks_common::address::{
+    AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+};
+use stacks_common::types::chainstate::{StacksPrivateKey, StacksPublicKey};
+
+#[test]
+fn test_stackerdb_connect() {
+    let path = "/tmp/test_stackerdb_connect.sqlite";
+    if fs::metadata(path).is_ok() {
+        fs::remove_file(path).unwrap();
+    }
+
+    let _ = StackerDB::connect(path, true).unwrap();
+}
+
+#[test]
+fn test_stackerdb_create_list_delete() {
+    let path = "/tmp/test_stackerdb_create_list_delete.sqlite";
+    if fs::metadata(path).is_ok() {
+        fs::remove_file(path).unwrap();
+    }
+
+    let mut db = StackerDB::connect(path, true).unwrap();
+    let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
+
+    tx.create_stackerdb((
+        &StacksAddress {
+            version: 0x01,
+            bytes: Hash160([0x01; 20]),
+        },
+        &ContractName::try_from("db1").unwrap(),
+    ))
+    .unwrap();
+    tx.create_stackerdb((
+        &StacksAddress {
+            version: 0x02,
+            bytes: Hash160([0x02; 20]),
+        },
+        &ContractName::try_from("db2").unwrap(),
+    ))
+    .unwrap();
+    tx.create_stackerdb((
+        &StacksAddress {
+            version: 0x03,
+            bytes: Hash160([0x03; 20]),
+        },
+        &ContractName::try_from("db3").unwrap(),
+    ))
+    .unwrap();
+
+    tx.commit().unwrap();
+
+    let mut dbs = db.get_stackerdbs().unwrap();
+    dbs.sort();
+
+    assert_eq!(
+        dbs,
+        vec![
+            (
+                StacksAddress {
+                    version: 0x01,
+                    bytes: Hash160([0x01; 20])
+                },
+                ContractName::try_from("db1").unwrap()
+            ),
+            (
+                StacksAddress {
+                    version: 0x02,
+                    bytes: Hash160([0x02; 20])
+                },
+                ContractName::try_from("db2").unwrap()
+            ),
+            (
+                StacksAddress {
+                    version: 0x03,
+                    bytes: Hash160([0x03; 20])
+                },
+                ContractName::try_from("db3").unwrap()
+            ),
+        ]
+    );
+
+    // adding the same DB is idempotent
+    let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
+    tx.create_stackerdb((
+        &StacksAddress {
+            version: 0x01,
+            bytes: Hash160([0x01; 20]),
+        },
+        &ContractName::try_from("db1").unwrap(),
+    ))
+    .unwrap();
+    tx.commit().unwrap();
+
+    let mut dbs = db.get_stackerdbs().unwrap();
+    dbs.sort();
+
+    assert_eq!(
+        dbs,
+        vec![
+            (
+                StacksAddress {
+                    version: 0x01,
+                    bytes: Hash160([0x01; 20])
+                },
+                ContractName::try_from("db1").unwrap()
+            ),
+            (
+                StacksAddress {
+                    version: 0x02,
+                    bytes: Hash160([0x02; 20])
+                },
+                ContractName::try_from("db2").unwrap()
+            ),
+            (
+                StacksAddress {
+                    version: 0x03,
+                    bytes: Hash160([0x03; 20])
+                },
+                ContractName::try_from("db3").unwrap()
+            ),
+        ]
+    );
+
+    // remove a db
+    let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
+    tx.delete_stackerdb((
+        &StacksAddress {
+            version: 0x01,
+            bytes: Hash160([0x01; 20]),
+        },
+        &ContractName::try_from("db1").unwrap(),
+    ))
+    .unwrap();
+    tx.commit().unwrap();
+
+    let mut dbs = db.get_stackerdbs().unwrap();
+    dbs.sort();
+
+    assert_eq!(
+        dbs,
+        vec![
+            (
+                StacksAddress {
+                    version: 0x02,
+                    bytes: Hash160([0x02; 20])
+                },
+                ContractName::try_from("db2").unwrap()
+            ),
+            (
+                StacksAddress {
+                    version: 0x03,
+                    bytes: Hash160([0x03; 20])
+                },
+                ContractName::try_from("db3").unwrap()
+            ),
+        ]
+    );
+
+    // deletion is idempotent
+    let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
+    tx.delete_stackerdb((
+        &StacksAddress {
+            version: 0x01,
+            bytes: Hash160([0x01; 20]),
+        },
+        &ContractName::try_from("db1").unwrap(),
+    ))
+    .unwrap();
+    tx.commit().unwrap();
+
+    let mut dbs = db.get_stackerdbs().unwrap();
+    dbs.sort();
+
+    assert_eq!(
+        dbs,
+        vec![
+            (
+                StacksAddress {
+                    version: 0x02,
+                    bytes: Hash160([0x02; 20])
+                },
+                ContractName::try_from("db2").unwrap()
+            ),
+            (
+                StacksAddress {
+                    version: 0x03,
+                    bytes: Hash160([0x03; 20])
+                },
+                ContractName::try_from("db3").unwrap()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_stackerdb_prepare_clear_slots() {
+    let path = "/tmp/test_stackerdb_prepare_clear_slots.sqlite";
+    if fs::metadata(path).is_ok() {
+        fs::remove_file(path).unwrap();
+    }
+
+    let sc = (
+        StacksAddress {
+            version: 0x01,
+            bytes: Hash160([0x01; 20]),
+        },
+        ContractName::try_from("db1").unwrap(),
+    );
+
+    let mut db = StackerDB::connect(path, true).unwrap();
+    let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
+
+    tx.create_stackerdb((&sc.0, &sc.1)).unwrap();
+    tx.prepare_stackerdb_slots(
+        (&sc.0, &sc.1),
+        &ConsensusHash([0x01; 20]),
+        &vec![
+            (
+                StacksAddress {
+                    version: 0x02,
+                    bytes: Hash160([0x02; 20]),
+                },
+                2,
+            ),
+            (
+                StacksAddress {
+                    version: 0x03,
+                    bytes: Hash160([0x03; 20]),
+                },
+                3,
+            ),
+            (
+                StacksAddress {
+                    version: 0x04,
+                    bytes: Hash160([0x04; 20]),
+                },
+                4,
+            ),
+        ],
+    )
+    .unwrap();
+
+    tx.commit().unwrap();
+
+    // slots must all be inserted in the right places and quantities
+    for chunk_id in 0..(2 + 3 + 4) {
+        let chunk_metadata = db
+            .get_chunk_metadata((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), chunk_id)
+            .unwrap()
+            .unwrap();
+        let chunk_validation = db
+            .get_chunk_validation((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), chunk_id)
+            .unwrap()
+            .unwrap();
+
+        if chunk_id < 2 {
+            // belongs to 0x02
+            assert_eq!(
+                chunk_validation.stacker,
+                StacksAddress {
+                    version: 0x02,
+                    bytes: Hash160([0x02; 20])
+                }
+            );
+        } else if chunk_id >= 2 && chunk_id < 2 + 3 {
+            // belongs to 0x03
+            assert_eq!(
+                chunk_validation.stacker,
+                StacksAddress {
+                    version: 0x03,
+                    bytes: Hash160([0x03; 20])
+                }
+            );
+        } else if chunk_id >= 2 + 3 && chunk_id < 2 + 3 + 4 {
+            // belongs to 0x03
+            assert_eq!(
+                chunk_validation.stacker,
+                StacksAddress {
+                    version: 0x04,
+                    bytes: Hash160([0x04; 20])
+                }
+            );
+        } else {
+            unreachable!()
+        }
+
+        assert_eq!(chunk_metadata.rc_consensus_hash, ConsensusHash([0x01; 20]));
+        assert_eq!(chunk_metadata.chunk_id, chunk_id);
+        assert_eq!(chunk_metadata.chunk_version, 0);
+        assert_eq!(chunk_metadata.data_hash, Sha512Trunc256Sum([0x00; 32]));
+        assert_eq!(chunk_metadata.signature, MessageSignature::empty());
+
+        assert_eq!(chunk_validation.version, 0);
+        assert_eq!(chunk_validation.write_time, 0);
+    }
+
+    let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
+    tx.clear_stackerdb_slots((&sc.0, &sc.1), &ConsensusHash([0x01; 20]))
+        .unwrap();
+    tx.commit().unwrap();
+
+    // no more slots
+    for chunk_id in 0..(2 + 3 + 4) {
+        let chunk_metadata = db
+            .get_chunk_metadata((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), chunk_id)
+            .unwrap();
+        assert!(chunk_metadata.is_none());
+
+        let chunk_validation = db
+            .get_chunk_validation((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), chunk_id)
+            .unwrap();
+        assert!(chunk_validation.is_none());
+    }
+}
+
+#[test]
+fn test_stackerdb_insert_query_chunks() {
+    let path = "/tmp/test_stackerdb_insert_query_chunks.sqlite";
+    if fs::metadata(path).is_ok() {
+        fs::remove_file(path).unwrap();
+    }
+
+    let sc = (
+        StacksAddress {
+            version: 0x01,
+            bytes: Hash160([0x01; 20]),
+        },
+        ContractName::try_from("db1").unwrap(),
+    );
+
+    let mut db = StackerDB::connect(path, true).unwrap();
+
+    let mut db_config = StackerDBConfig::noop();
+    db_config.max_writes = 3;
+    db_config.write_freq = 120;
+
+    let tx = db.tx_begin(db_config.clone()).unwrap();
+
+    tx.create_stackerdb((&sc.0, &sc.1)).unwrap();
+
+    let pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let addrs: Vec<_> = pks
+        .iter()
+        .map(|pk| {
+            StacksAddress::from_public_keys(
+                C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+                &AddressHashMode::SerializeP2PKH,
+                1,
+                &vec![StacksPublicKey::from_private(&pk)],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    tx.prepare_stackerdb_slots(
+        (&sc.0, &sc.1),
+        &ConsensusHash([0x01; 20]),
+        &addrs
+            .clone()
+            .into_iter()
+            .map(|addr| (addr, 1))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    // store some data
+    for (i, pk) in pks.iter().enumerate() {
+        let mut chunk_data = StackerDBChunkData {
+            chunk_id: i as u32,
+            chunk_version: 1,
+            sig: MessageSignature::empty(),
+            data: vec![i as u8; 128],
+        };
+
+        chunk_data.sign(ConsensusHash([0x01; 20]), &pk).unwrap();
+
+        let chunk_metadata = tx
+            .get_chunk_metadata((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32)
+            .unwrap()
+            .unwrap();
+        assert_eq!(chunk_metadata.rc_consensus_hash, ConsensusHash([0x01; 20]));
+        assert_eq!(chunk_metadata.chunk_id, i as u32);
+        assert_eq!(chunk_metadata.chunk_version, 0);
+        assert_eq!(chunk_metadata.data_hash, Sha512Trunc256Sum([0x00; 32]));
+        assert_eq!(chunk_metadata.signature, MessageSignature::empty());
+
+        // should succeed
+        tx.try_replace_chunk(
+            (&sc.0, &sc.1),
+            &chunk_data.get_chunk_metadata(ConsensusHash([0x01; 20])),
+            &chunk_data.data,
+        )
+        .unwrap();
+
+        let chunk_metadata = tx
+            .get_chunk_metadata((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32)
+            .unwrap()
+            .unwrap();
+        assert_eq!(chunk_metadata.rc_consensus_hash, ConsensusHash([0x01; 20]));
+        assert_eq!(chunk_metadata.chunk_id, i as u32);
+        assert_eq!(chunk_metadata.chunk_version, chunk_data.chunk_version);
+        assert_eq!(chunk_metadata.data_hash, chunk_data.data_hash());
+        assert_eq!(chunk_metadata.signature, chunk_data.sig);
+
+        // should fail -- stale version
+        if let Err(net_error::StaleChunk(db_version, given_version)) = tx.try_replace_chunk(
+            (&sc.0, &sc.1),
+            &chunk_data.get_chunk_metadata(ConsensusHash([0x01; 20])),
+            &chunk_data.data,
+        ) {
+            assert_eq!(db_version, 1);
+            assert_eq!(given_version, 1);
+        } else {
+            panic!("Did not get StaleChunk");
+        }
+
+        // should fail -- too many writes version
+        chunk_data.chunk_version = db_config.max_writes + 1;
+        chunk_data.sign(ConsensusHash([0x01; 20]), &pk).unwrap();
+        if let Err(net_error::TooManyChunkWrites(db_max, cur_version)) = tx.try_replace_chunk(
+            (&sc.0, &sc.1),
+            &chunk_data.get_chunk_metadata(ConsensusHash([0x01; 20])),
+            &chunk_data.data,
+        ) {
+            assert_eq!(db_max, db_config.max_writes);
+            assert_eq!(cur_version, 1);
+        } else {
+            panic!("Did not get TooManyChunkWrites");
+        }
+
+        // should fail -- bad signature
+        chunk_data.chunk_version = 2;
+        if let Err(net_error::BadChunkSigner(stacker, chunk_id)) = tx.try_replace_chunk(
+            (&sc.0, &sc.1),
+            &chunk_data.get_chunk_metadata(ConsensusHash([0x01; 20])),
+            &chunk_data.data,
+        ) {
+            assert_eq!(stacker, addrs[i]);
+            assert_eq!(chunk_id, i as u32);
+        } else {
+            eprintln!(
+                "{}",
+                tx.try_replace_chunk(
+                    (&sc.0, &sc.1),
+                    &chunk_data.get_chunk_metadata(ConsensusHash([0x01; 20])),
+                    &chunk_data.data
+                )
+                .unwrap_err()
+            );
+            panic!("Did not get BadChunkSigner");
+        }
+
+        // should fail -- throttled
+        chunk_data.sign(ConsensusHash([0x01; 20]), &pk).unwrap();
+        if let Err(net_error::TooFrequentChunkWrites(..)) = tx.try_replace_chunk(
+            (&sc.0, &sc.1),
+            &chunk_data.get_chunk_metadata(ConsensusHash([0x01; 20])),
+            &chunk_data.data,
+        ) {
+            chunk_data.chunk_version -= 1;
+        } else {
+            panic!("Did not get TooFrequentChunkWrites");
+        }
+    }
+
+    tx.commit().unwrap();
+
+    // test queries against the data
+    for (i, addr) in addrs.iter().enumerate() {
+        let signer = db
+            .get_chunk_signer((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32)
+            .unwrap()
+            .unwrap();
+        assert_eq!(signer, *addr);
+
+        let chunk = db
+            .get_latest_chunk((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32)
+            .unwrap();
+        assert_eq!(chunk, vec![i as u8; 128]);
+
+        // correct version
+        let chunk = db
+            .get_chunk((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32, 1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(chunk.data, vec![i as u8; 128]);
+        assert_eq!(chunk.chunk_version, 1);
+        assert_eq!(chunk.chunk_id, i as u32);
+        assert!(chunk.verify(ConsensusHash([0x01; 20]), &addr).unwrap());
+
+        // incorrect version
+        let chunk = db
+            .get_chunk((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32, 0)
+            .unwrap();
+        assert!(chunk.is_none());
+
+        // incorrect version
+        let chunk = db
+            .get_chunk((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32, 2)
+            .unwrap();
+        assert!(chunk.is_none());
+
+        let chunk_metadata = db
+            .get_chunk_metadata((&sc.0, &sc.1), &ConsensusHash([0x01; 20]), i as u32)
+            .unwrap()
+            .unwrap();
+        assert!(chunk_metadata.verify(&addr).unwrap());
+    }
+
+    let versions = db
+        .get_chunk_versions((&sc.0, &sc.1), &ConsensusHash([0x01; 20]))
+        .unwrap();
+    assert_eq!(versions, vec![1; 10]);
+
+    let timestamps = db
+        .get_chunk_write_timestamps((&sc.0, &sc.1), &ConsensusHash([0x01; 20]))
+        .unwrap();
+    for ts in timestamps {
+        assert!(ts > 0);
+    }
+}

--- a/src/net/stackerdb/tests/mod.rs
+++ b/src/net/stackerdb/tests/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod bits;
+pub mod db;
+pub mod sync;

--- a/src/net/stackerdb/tests/sync.rs
+++ b/src/net/stackerdb/tests/sync.rs
@@ -173,6 +173,7 @@ fn load_stackerdb(peer: &TestPeer, idx: usize) -> Vec<(ChunkMetadata, Vec<u8>)> 
 #[test]
 fn test_stackerdb_replica_2_neighbors_1_chunk() {
     with_timeout(600, || {
+        std::env::set_var("STACKS_TEST_DISABLE_EDGE_TRIGGER_TEST", "1");
         let mut peer_1_config = TestPeerConfig::from_port(BASE_PORT);
         let mut peer_2_config = TestPeerConfig::from_port(BASE_PORT + 2);
 
@@ -257,6 +258,7 @@ fn test_stackerdb_replica_2_neighbors_1_chunk() {
 #[test]
 fn test_stackerdb_replica_2_neighbors_10_chunks() {
     with_timeout(600, || {
+        std::env::set_var("STACKS_TEST_DISABLE_EDGE_TRIGGER_TEST", "1");
         let mut peer_1_config = TestPeerConfig::from_port(BASE_PORT + 4);
         let mut peer_2_config = TestPeerConfig::from_port(BASE_PORT + 6);
 
@@ -350,6 +352,7 @@ fn test_stackerdb_replica_2_neighbors_10_chunks() {
 #[test]
 fn test_stackerdb_replica_10_neighbors_line_10_chunks() {
     with_timeout(600, || {
+        std::env::set_var("STACKS_TEST_DISABLE_EDGE_TRIGGER_TEST", "1");
         let num_peers: usize = 10;
         let mut peer_configs = vec![];
         let mut peer_db_idxs = vec![];
@@ -466,6 +469,7 @@ fn test_stackerdb_replica_10_neighbors_line_10_chunks() {
 #[test]
 fn test_stackerdb_10_replicas_10_neighbors_line_10_chunks() {
     with_timeout(600, || {
+        std::env::set_var("STACKS_TEST_DISABLE_EDGE_TRIGGER_TEST", "1");
         let num_peers: usize = 10;
         let num_dbs: usize = 10;
         let mut peer_configs = vec![];

--- a/src/net/stackerdb/tests/sync.rs
+++ b/src/net/stackerdb/tests/sync.rs
@@ -1,0 +1,601 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fs;
+
+use crate::net::stackerdb::{db::ChunkValidation, ChunkMetadata, StackerDB, StackerDBConfig};
+
+use crate::net::Error as net_error;
+use crate::net::StackerDBChunkData;
+
+use clarity::vm::ContractName;
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::StacksAddress;
+
+use stacks_common::util::hash::Hash160;
+use stacks_common::util::hash::Sha512Trunc256Sum;
+use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PrivateKey};
+
+use stacks_common::address::{
+    AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+};
+use stacks_common::types::chainstate::{StacksPrivateKey, StacksPublicKey};
+
+use rand::prelude::*;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use rand::Rng;
+use rand::RngCore;
+
+use crate::net::relay::Relayer;
+use crate::net::test::TestPeer;
+use crate::net::test::TestPeerConfig;
+use crate::util_lib::test::with_timeout;
+
+const BASE_PORT: u16 = 33000;
+
+/// Add a stacker DB to a node's config.
+/// Return its index into the list of configured stacker DBs (can be used as `idx` in the call to
+/// `setup_stackerdb()`
+fn add_stackerdb(config: &mut TestPeerConfig, stackerdb_config: Option<StackerDBConfig>) -> usize {
+    let name = ContractName::try_from(format!("db-{}", config.stacker_dbs.len())).unwrap();
+    let addr = StacksAddress {
+        version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+        bytes: Hash160::from_data(&config.stacker_dbs.len().to_be_bytes()),
+    };
+
+    let stackerdb_config = stackerdb_config.unwrap_or(StackerDBConfig::noop());
+
+    config.stacker_dbs.push((addr, name));
+    config.stacker_db_configs.push(Some(stackerdb_config));
+
+    config.stacker_dbs.len() - 1
+}
+
+/// Set up a stacker DB and optionally fill it with random data.
+/// `idx` refers to the `idx`th stacker DB in the node config struct.
+fn setup_stackerdb(peer: &mut TestPeer, idx: usize, fill: bool) {
+    let (addr, name) = &peer.config.stacker_dbs[idx];
+    let rc_consensus_hash = &peer.network.chain_view.rc_consensus_hash;
+
+    let noop = StackerDBConfig::noop();
+    let stackerdb_config = peer.config.stacker_db_configs[idx]
+        .as_ref()
+        .unwrap_or(&noop);
+    let num_chunks = stackerdb_config.num_chunks;
+    let chunk_size = stackerdb_config.chunk_size;
+
+    let mut k: u64 = 0;
+    let mut pks = vec![];
+    let mut slots = vec![];
+    for i in 0..num_chunks {
+        // deterministically generate private keys
+        let pk = loop {
+            let h = Sha512Trunc256Sum::from_data(&k.to_be_bytes());
+            k += 1;
+
+            if let Ok(pk) = Secp256k1PrivateKey::from_slice(&h.0) {
+                break pk;
+            }
+        };
+        let pubk = StacksPublicKey::from_private(&pk);
+        let addr = StacksAddress {
+            version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+            bytes: Hash160::from_node_public_key(&pubk),
+        };
+
+        pks.push(pk);
+        slots.push((addr, 1));
+    }
+
+    let tx = peer
+        .network
+        .stacker_db
+        .tx_begin(stackerdb_config.clone())
+        .unwrap();
+
+    tx.create_stackerdb((&addr, &name)).unwrap();
+    tx.prepare_stackerdb_slots((&addr, &name), &rc_consensus_hash, &slots)
+        .unwrap();
+
+    if fill {
+        for i in 0..num_chunks {
+            // deterministically generate chunk data
+            let mut inner_data = vec![0x00; chunk_size as usize];
+            thread_rng().fill(&mut inner_data[..]);
+
+            let mut chunk_data = StackerDBChunkData::new(i as u32, 1, inner_data);
+            chunk_data
+                .sign(rc_consensus_hash.clone(), &pks[i as usize])
+                .unwrap();
+
+            let chunk_md = chunk_data.get_chunk_metadata(rc_consensus_hash.clone());
+            tx.try_replace_chunk((&addr, &name), &chunk_md, &chunk_data.data)
+                .unwrap();
+        }
+    }
+
+    tx.commit().unwrap();
+}
+
+/// Load up the entire stacker DB, including its metadata
+fn load_stackerdb(peer: &TestPeer, idx: usize) -> Vec<(ChunkMetadata, Vec<u8>)> {
+    let num_chunks = peer.config.stacker_db_configs[idx]
+        .as_ref()
+        .unwrap_or(&StackerDBConfig::noop())
+        .num_chunks;
+    let rc_consensus_hash = &peer.network.chain_view.rc_consensus_hash;
+    let mut ret = vec![];
+    for i in 0..num_chunks {
+        let chunk_metadata = peer
+            .network
+            .stacker_db
+            .get_chunk_metadata(
+                (
+                    &peer.config.stacker_dbs[idx].0,
+                    &peer.config.stacker_dbs[idx].1,
+                ),
+                rc_consensus_hash,
+                i as u32,
+            )
+            .unwrap()
+            .unwrap();
+        let chunk = peer
+            .network
+            .stacker_db
+            .get_latest_chunk(
+                (
+                    &peer.config.stacker_dbs[idx].0,
+                    &peer.config.stacker_dbs[idx].1,
+                ),
+                rc_consensus_hash,
+                i as u32,
+            )
+            .unwrap();
+        ret.push((chunk_metadata, chunk));
+    }
+    ret
+}
+
+#[test]
+fn test_stackerdb_replica_2_neighbors_1_chunk() {
+    with_timeout(600, || {
+        let mut peer_1_config = TestPeerConfig::from_port(BASE_PORT);
+        let mut peer_2_config = TestPeerConfig::from_port(BASE_PORT + 2);
+
+        peer_1_config.allowed = -1;
+        peer_2_config.allowed = -1;
+
+        // short-lived walks...
+        peer_1_config.connection_opts.walk_max_duration = 10;
+        peer_2_config.connection_opts.walk_max_duration = 10;
+
+        // peer 1 crawls peer 2, and peer 2 crawls peer 1
+        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+
+        // set up stacker DBs for both peers
+        let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::one_chunk()));
+        let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::one_chunk()));
+
+        let mut peer_1 = TestPeer::new(peer_1_config);
+        let mut peer_2 = TestPeer::new(peer_2_config);
+
+        // peer 1 gets the DB
+        setup_stackerdb(&mut peer_1, idx_1, true);
+        setup_stackerdb(&mut peer_2, idx_2, false);
+
+        // verify that peer 1 got the data
+        let peer_1_db_chunks = load_stackerdb(&peer_1, idx_1);
+        assert_eq!(peer_1_db_chunks.len(), 1);
+        assert_eq!(peer_1_db_chunks[0].0.chunk_id, 0);
+        assert_eq!(peer_1_db_chunks[0].0.chunk_version, 1);
+        assert!(peer_1_db_chunks[0].1.len() > 0);
+
+        // verify that peer 2 did NOT get the data
+        let peer_2_db_chunks = load_stackerdb(&peer_2, idx_2);
+        assert_eq!(peer_2_db_chunks.len(), 1);
+        assert_eq!(peer_2_db_chunks[0].0.chunk_id, 0);
+        assert_eq!(peer_2_db_chunks[0].0.chunk_version, 0);
+        assert!(peer_2_db_chunks[0].1.len() == 0);
+
+        let peer_1_db_configs = peer_1.config.get_stacker_db_configs();
+        let peer_2_db_configs = peer_2.config.get_stacker_db_configs();
+
+        let mut i = 0;
+        loop {
+            // run peer network state-machines
+            let res_1 = peer_1.step();
+            let res_2 = peer_2.step();
+
+            if let Ok(res) = res_1 {
+                Relayer::process_stacker_db_chunks(
+                    &mut peer_1.network.stacker_db,
+                    &peer_1_db_configs,
+                    &peer_1.network.chain_view.rc_consensus_hash,
+                    &res.stacker_db_sync_results,
+                )
+                .unwrap();
+            }
+
+            if let Ok(res) = res_2 {
+                Relayer::process_stacker_db_chunks(
+                    &mut peer_2.network.stacker_db,
+                    &peer_2_db_configs,
+                    &peer_2.network.chain_view.rc_consensus_hash,
+                    &res.stacker_db_sync_results,
+                )
+                .unwrap();
+            }
+
+            let db1 = load_stackerdb(&peer_1, idx_1);
+            let db2 = load_stackerdb(&peer_2, idx_2);
+
+            if db1 == db2 {
+                break;
+            }
+            i += 1;
+        }
+
+        debug!("Completed stacker DB sync in {} step(s)", i);
+    })
+}
+
+#[test]
+fn test_stackerdb_replica_2_neighbors_10_chunks() {
+    with_timeout(600, || {
+        let mut peer_1_config = TestPeerConfig::from_port(BASE_PORT + 4);
+        let mut peer_2_config = TestPeerConfig::from_port(BASE_PORT + 6);
+
+        peer_1_config.allowed = -1;
+        peer_2_config.allowed = -1;
+
+        // short-lived walks...
+        peer_1_config.connection_opts.walk_max_duration = 10;
+        peer_2_config.connection_opts.walk_max_duration = 10;
+
+        // peer 1 crawls peer 2, and peer 2 crawls peer 1
+        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+
+        // set up stacker DBs for both peers
+        let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::ten_chunks()));
+        let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::ten_chunks()));
+
+        let mut peer_1 = TestPeer::new(peer_1_config);
+        let mut peer_2 = TestPeer::new(peer_2_config);
+
+        // peer 1 gets the DB
+        setup_stackerdb(&mut peer_1, idx_1, true);
+        setup_stackerdb(&mut peer_2, idx_2, false);
+
+        // verify that peer 1 got the data
+        let peer_1_db_chunks = load_stackerdb(&peer_1, idx_1);
+        assert_eq!(peer_1_db_chunks.len(), 10);
+        for i in 0..10 {
+            assert_eq!(peer_1_db_chunks[i].0.chunk_id, i as u32);
+            assert_eq!(peer_1_db_chunks[i].0.chunk_version, 1);
+            assert!(peer_1_db_chunks[i].1.len() > 0);
+        }
+
+        // verify that peer 2 did NOT get the data
+        let peer_2_db_chunks = load_stackerdb(&peer_2, idx_2);
+        assert_eq!(peer_2_db_chunks.len(), 10);
+        for i in 0..10 {
+            assert_eq!(peer_2_db_chunks[i].0.chunk_id, i as u32);
+            assert_eq!(peer_2_db_chunks[i].0.chunk_version, 0);
+            assert!(peer_2_db_chunks[i].1.len() == 0);
+        }
+
+        let peer_1_db_configs = peer_1.config.get_stacker_db_configs();
+        let peer_2_db_configs = peer_2.config.get_stacker_db_configs();
+
+        let mut i = 0;
+        loop {
+            // run peer network state-machines
+            let res_1 = peer_1.step();
+            let res_2 = peer_2.step();
+
+            if let Ok(res) = res_1 {
+                Relayer::process_stacker_db_chunks(
+                    &mut peer_1.network.stacker_db,
+                    &peer_1_db_configs,
+                    &peer_1.network.chain_view.rc_consensus_hash,
+                    &res.stacker_db_sync_results,
+                )
+                .unwrap();
+            }
+
+            if let Ok(res) = res_2 {
+                Relayer::process_stacker_db_chunks(
+                    &mut peer_2.network.stacker_db,
+                    &peer_2_db_configs,
+                    &peer_2.network.chain_view.rc_consensus_hash,
+                    &res.stacker_db_sync_results,
+                )
+                .unwrap();
+            }
+
+            let db1 = load_stackerdb(&peer_1, idx_1);
+            let db2 = load_stackerdb(&peer_2, idx_2);
+
+            if db1 == db2 {
+                break;
+            }
+            i += 1;
+        }
+
+        debug!("Completed stacker DB sync in {} step(s)", i);
+
+        // we were efficient
+        for (_, sync_state) in peer_2.network.stacker_db_syncs.as_ref().unwrap().iter() {
+            assert_eq!(sync_state.total_stored, 10);
+        }
+    })
+}
+
+#[test]
+fn test_stackerdb_replica_10_neighbors_line_10_chunks() {
+    with_timeout(600, || {
+        let num_peers: usize = 10;
+        let mut peer_configs = vec![];
+        let mut peer_db_idxs = vec![];
+        let mut peers = vec![];
+        let mut peer_db_configs = vec![];
+
+        for i in 0..num_peers {
+            let mut peer_config = TestPeerConfig::from_port(BASE_PORT + 8 + (2 * i as u16));
+
+            peer_config.allowed = -1;
+
+            // short-lived walks...
+            peer_config.connection_opts.walk_max_duration = 10;
+            let idx = add_stackerdb(&mut peer_config, Some(StackerDBConfig::ten_chunks()));
+
+            peer_configs.push(peer_config);
+            peer_db_idxs.push(idx);
+        }
+
+        // line topology: neighbor N connects to neighbors N-1 and N+1
+        for i in 1..(num_peers - 1) {
+            let n1 = peer_configs[i - 1].to_neighbor();
+            let n2 = peer_configs[i + 1].to_neighbor();
+            peer_configs[i].add_neighbor(&n1);
+            peer_configs[i].add_neighbor(&n2);
+        }
+
+        for (i, peer_config) in peer_configs.into_iter().enumerate() {
+            let mut peer = TestPeer::new(peer_config);
+
+            if i == 0 {
+                // peer 0 -- at one end of the line -- gets the initial DB
+                setup_stackerdb(&mut peer, peer_db_idxs[i], true);
+
+                // verify instantiation
+                let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i]);
+                assert_eq!(peer_db_chunks.len(), 10);
+                for j in 0..10 {
+                    assert_eq!(peer_db_chunks[j].0.chunk_id, j as u32);
+                    assert_eq!(peer_db_chunks[j].0.chunk_version, 1);
+                    assert!(peer_db_chunks[j].1.len() > 0);
+                }
+            } else {
+                // everyone else gets nothing
+                setup_stackerdb(&mut peer, peer_db_idxs[i], false);
+
+                // verify instantiation
+                let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i]);
+                assert_eq!(peer_db_chunks.len(), 10);
+                for j in 0..10 {
+                    assert_eq!(peer_db_chunks[j].0.chunk_id, j as u32);
+                    assert_eq!(peer_db_chunks[j].0.chunk_version, 0);
+                    assert!(peer_db_chunks[j].1.len() == 0);
+                }
+            }
+
+            peers.push(peer);
+        }
+
+        for (i, peer) in peers.iter().enumerate() {
+            let peer_db_config = peer.config.get_stacker_db_configs();
+            peer_db_configs.push(peer_db_config);
+        }
+        let mut step_count = 0;
+        loop {
+            // run peer network state-machines
+            for i in 0..num_peers {
+                let res = peers[i].step();
+                if let Ok(res) = res {
+                    let rc_consensus_hash = peers[i].network.chain_view.rc_consensus_hash.clone();
+                    Relayer::process_stacker_db_chunks(
+                        &mut peers[i].network.stacker_db,
+                        &peer_db_configs[i],
+                        &rc_consensus_hash,
+                        &res.stacker_db_sync_results,
+                    )
+                    .unwrap();
+                }
+            }
+
+            let mut db_state = None;
+            let mut different = false;
+            for i in 0..num_peers {
+                let db = load_stackerdb(&peers[i], peer_db_idxs[i]);
+                if let Some(cmp_db) = db_state.as_ref() {
+                    if &db != cmp_db {
+                        different = true;
+                        break;
+                    }
+                } else {
+                    db_state = Some(db);
+                }
+            }
+
+            if !different {
+                break;
+            }
+            step_count += 1;
+        }
+
+        debug!("Completed stacker DB sync in {} step(s)", step_count);
+
+        // we were efficient
+        for (i, peer) in peers.iter().enumerate() {
+            for (_, sync_state) in peer.network.stacker_db_syncs.as_ref().unwrap().iter() {
+                if i != 0 {
+                    assert_eq!(sync_state.total_stored, 10);
+                }
+            }
+        }
+    })
+}
+
+#[test]
+fn test_stackerdb_10_replicas_10_neighbors_line_10_chunks() {
+    with_timeout(600, || {
+        let num_peers: usize = 10;
+        let num_dbs: usize = 10;
+        let mut peer_configs = vec![];
+        let mut peer_db_idxs = vec![];
+        let mut peers = vec![];
+        let mut peer_db_configs = vec![];
+
+        for i in 0..num_peers {
+            let mut peer_config = TestPeerConfig::from_port(BASE_PORT + 28 + (2 * i as u16));
+
+            peer_config.allowed = -1;
+
+            // short-lived walks...
+            peer_config.connection_opts.walk_max_duration = 10;
+
+            // bigger inbox/outbox
+            peer_config.connection_opts.inbox_maxlen = 101;
+            peer_config.connection_opts.outbox_maxlen = 101;
+
+            let mut idxs = vec![];
+            for j in 0..10 {
+                let idx = add_stackerdb(&mut peer_config, Some(StackerDBConfig::ten_chunks()));
+                idxs.push(idx);
+            }
+
+            peer_configs.push(peer_config);
+            peer_db_idxs.push(idxs);
+        }
+
+        // line topology: neighbor N connects to neighbors N-1 and N+1
+        for i in 1..(num_peers - 1) {
+            let n1 = peer_configs[i - 1].to_neighbor();
+            let n2 = peer_configs[i + 1].to_neighbor();
+            peer_configs[i].add_neighbor(&n1);
+            peer_configs[i].add_neighbor(&n2);
+        }
+
+        for (i, peer_config) in peer_configs.into_iter().enumerate() {
+            let mut peer = TestPeer::new(peer_config);
+
+            if i == 0 {
+                for j in 0..peer_db_idxs[i].len() {
+                    // peer 0 -- at one end of the line -- gets the initial DBs
+                    setup_stackerdb(&mut peer, peer_db_idxs[i][j], true);
+
+                    // verify instantiation
+                    let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i][j]);
+                    assert_eq!(peer_db_chunks.len(), 10);
+                    for k in 0..10 {
+                        assert_eq!(peer_db_chunks[k].0.chunk_id, k as u32);
+                        assert_eq!(peer_db_chunks[k].0.chunk_version, 1);
+                        assert!(peer_db_chunks[k].1.len() > 0);
+                    }
+                }
+            } else {
+                for j in 0..peer_db_idxs[i].len() {
+                    // everyone else gets nothing
+                    setup_stackerdb(&mut peer, peer_db_idxs[i][j], false);
+
+                    // verify instantiation
+                    let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i][j]);
+                    assert_eq!(peer_db_chunks.len(), 10);
+                    for k in 0..10 {
+                        assert_eq!(peer_db_chunks[k].0.chunk_id, k as u32);
+                        assert_eq!(peer_db_chunks[k].0.chunk_version, 0);
+                        assert!(peer_db_chunks[k].1.len() == 0);
+                    }
+                }
+            }
+
+            peers.push(peer);
+        }
+
+        for (i, peer) in peers.iter().enumerate() {
+            let peer_db_config = peer.config.get_stacker_db_configs();
+            peer_db_configs.push(peer_db_config);
+        }
+        let mut step_count = 0;
+        loop {
+            // run peer network state-machines
+            for i in 0..num_peers {
+                let res = peers[i].step();
+                if let Ok(res) = res {
+                    let rc_consensus_hash = peers[i].network.chain_view.rc_consensus_hash.clone();
+                    Relayer::process_stacker_db_chunks(
+                        &mut peers[i].network.stacker_db,
+                        &peer_db_configs[i],
+                        &rc_consensus_hash,
+                        &res.stacker_db_sync_results,
+                    )
+                    .unwrap();
+                }
+            }
+
+            let mut different = false;
+            for k in 0..num_dbs {
+                for i in 0..num_peers {
+                    let db1 = load_stackerdb(&peers[i], peer_db_idxs[i][k]);
+                    for j in (i + 1)..num_peers {
+                        let db2 = load_stackerdb(&peers[j], peer_db_idxs[j][k]);
+                        if db1 != db2 {
+                            debug!("Different {}: {} != {}", k, i, j);
+                            different = true;
+                            break;
+                        }
+                    }
+                    if different {
+                        break;
+                    }
+                }
+                if different {
+                    break;
+                }
+            }
+
+            if !different {
+                break;
+            }
+            step_count += 1;
+        }
+
+        debug!("Completed stacker DB sync in {} step(s)", step_count);
+
+        // we were efficient
+        for (i, peer) in peers.iter().enumerate() {
+            for (_, sync_state) in peer.network.stacker_db_syncs.as_ref().unwrap().iter() {
+                if i != 0 {
+                    assert_eq!(sync_state.total_stored, 10);
+                }
+            }
+        }
+    })
+}

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -42,7 +42,9 @@ use serde_json::Error as serde_error;
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use stacks_common::types::chainstate::SortitionId;
+use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::types::chainstate::StacksBlockId;
+use stacks_common::types::Address;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::Secp256k1PrivateKey;
 use stacks_common::util::secp256k1::Secp256k1PublicKey;
@@ -184,6 +186,13 @@ impl FromRow<u64> for u64 {
     }
 }
 
+impl FromRow<u32> for u32 {
+    fn from_row<'a>(row: &'a Row) -> Result<u32, Error> {
+        let x: u32 = row.get_unwrap(0);
+        Ok(x)
+    }
+}
+
 impl FromRow<String> for String {
     fn from_row<'a>(row: &'a Row) -> Result<String, Error> {
         let x: String = row.get_unwrap(0);
@@ -263,6 +272,14 @@ impl FromColumn<Secp256k1PrivateKey> for Secp256k1PrivateKey {
         let privkey =
             Secp256k1PrivateKey::from_hex(&privkey_hex).map_err(|_e| Error::ParseError)?;
         Ok(privkey)
+    }
+}
+
+impl FromRow<StacksAddress> for StacksAddress {
+    fn from_row<'a>(row: &'a Row) -> Result<StacksAddress, Error> {
+        let addr_str: String = row.get_unwrap(0);
+        let addr = StacksAddress::from_string(&addr_str).ok_or(Error::ParseError)?;
+        Ok(addr)
     }
 }
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1203,6 +1203,12 @@ impl Config {
         path.to_str().expect("Unable to produce path").to_string()
     }
 
+    pub fn get_stacker_db_file_path(&self) -> String {
+        let mut path = self.get_chainstate_path();
+        path.set_file_name("stacker_db.sqlite");
+        path.to_str().expect("Unable to produce path").to_string()
+    }
+
     pub fn add_initial_balance(&mut self, address: String, amount: u64) {
         let new_balance = InitialBalance {
             address: PrincipalData::parse_standard_principal(&address)

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -27,6 +27,7 @@ use stacks::net::{
     db::PeerDB,
     p2p::PeerNetwork,
     rpc::RPCHandlerArgs,
+    stackerdb::StackerDB,
     Error as NetError, PeerAddress,
 };
 use stacks::types::chainstate::TrieHash;
@@ -478,7 +479,8 @@ impl Node {
         let view = {
             let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn())
                 .expect("Failed to get sortition tip");
-            SortitionDB::get_burnchain_view(&sortdb.conn(), &burnchain, &sortition_tip).unwrap()
+            SortitionDB::get_burnchain_view(&sortdb.index_conn(), &burnchain, &sortition_tip)
+                .unwrap()
         };
 
         // create a new peerdb
@@ -525,8 +527,9 @@ impl Node {
             PeerAddress::from_socketaddr(&p2p_addr),
             p2p_sock.port(),
             data_url,
-            &vec![],
+            &[],
             Some(&initial_neighbors),
+            &[],
         )
         .unwrap();
 
@@ -549,6 +552,8 @@ impl Node {
         let atlasdb =
             AtlasDB::connect(atlas_config, &self.config.get_atlas_db_file_path(), true).unwrap();
 
+        let stackerdb = StackerDB::connect(&self.config.get_stacker_db_file_path(), true).unwrap();
+
         let local_peer = match PeerDB::get_local_peer(peerdb.conn()) {
             Ok(local_peer) => local_peer,
             _ => panic!("Unable to retrieve local peer"),
@@ -560,11 +565,13 @@ impl Node {
         let p2p_net = PeerNetwork::new(
             peerdb,
             atlasdb,
+            stackerdb,
             local_peer,
             self.config.burnchain.peer_version,
             burnchain.clone(),
             view,
             self.config.connection_options.clone(),
+            vec![],
             epochs,
         );
         let _join_handle = spawn_peer(


### PR DESCRIPTION
Closing in favor of:
- https://github.com/stacks-network/stacks-blockchain/pull/3560
- https://github.com/stacks-network/stacks-blockchain/pull/3558
- https://github.com/stacks-network/stacks-blockchain/pull/3552
- https://github.com/stacks-network/stacks-blockchain/pull/3551

This PR creates a **Stacker DB** subsystem in the peer network.  A stacker DB is an ephemeral database that can be created for any existing smart contract that confirms to a simple trait interface.  Nodes opt-in to hosting replicas of the DB, and users of the smart contract get to leverage the Stacks p2p network to store app-specific state for up to one reward cycle at a time.

This PR is just a draft because the system is not complete.  This PR still needs the following:

- [ ] An RPC interface for getting chunks
- [ ] An RPC interface for storing chunks
- [ ] An update to `/v2/neighbors` to include the list of stacker DBs that the neighbor claims to replicate
- [ ] The ability to query the DB's associated smart contract for a list of principals and number of DB slots they can write to
- [ ] The ability to vacuum DBs every reward cycle
- [ ] Messages for nodes to inform their neighbors when they have new chunks, as well as the means for neighbors to react by pulling the chunks if they are newer (right now, the system is only pull-oriented).
- [ ] Integration tests for all of the above.

I'm creating this draft to (1) start running CI on it and (2) start working with @donpdonp and @xoloki to get the RPC interface and contract interface nailed down.