### PR TITLE
pox endpoint changed to use current stacks height

### DIFF
--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -423,6 +423,7 @@ impl RPCPoxInfoData {
                 net_error::ChainstateError("Burn block height overflowed i64".into())
             })?;
 
+        let cur_block_pox_contract = pox_consts.active_pox_contract(burnchain_tip.block_height);
         let cur_cycle_pox_contract =
             pox_consts.active_pox_contract(burnchain.reward_cycle_to_block_height(reward_cycle_id));
         let next_cycle_pox_contract = pox_consts
@@ -475,7 +476,7 @@ impl RPCPoxInfoData {
         let cur_cycle_pox_active = sortdb.is_pox_active(burnchain, &burnchain_tip)?;
 
         Ok(RPCPoxInfoData {
-            contract_id: boot_code_id(cur_cycle_pox_contract, chainstate.mainnet).to_string(),
+            contract_id: boot_code_id(cur_block_pox_contract, chainstate.mainnet).to_string(),
             pox_activation_threshold_ustx,
             first_burnchain_block_height,
             current_burnchain_block_height: burnchain_tip.block_height,


### PR DESCRIPTION
Description

change /v2/pox report for active contract_id to use the current stacks block height instead of the next reward cycle block height to more accurately reflect when POX-2 becomes the default contract. POX-2 becomes the default at v1_unlock_height+1.
Applicable issues

    fixes 

    https://github.com/stacks-network/stacks-blockchain/issues/3422

Additional info (benefits, drawbacks, caveats)
Checklist

    [X ] Test coverage for new or modified code paths
    Changelog is updated
    Required documentation changes (e.g., docs/rpc/openapi.yaml and rpc-endpoints.md for v2 endpoints, event-dispatcher.md for new events)
    New clarity functions have corresponding PR in clarity-benchmarking repo
    New integration test(s) added to bitcoin-tests.yml