### PR TITLE
DRAFT: Epoch 2.2, address PoX stack-increase issue (SIP-022)

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -98,6 +98,7 @@ jobs:
           - tests::epoch_21::test_v1_unlock_height_with_current_stackers
           - tests::epoch_21::test_v1_unlock_height_with_delay_and_current_stackers
           - tests::epoch_21::trait_invocation_cross_epoch
+          - tests::epoch_22::pox_2_stack_increase_epoch22_fix
           - tests::neon_integrations::bad_microblock_pubkey
     steps:
       - uses: actions/checkout@v2

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -137,7 +137,9 @@ pub fn run_analysis(
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 TypeChecker2_05::run_pass(&epoch, &mut contract_analysis, db)
             }
-            StacksEpochId::Epoch21 => TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
+                TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db)
+            }
             StacksEpochId::Epoch10 => unreachable!("Epoch 1.0 is not a valid epoch for analysis"),
         }?;
         TraitChecker::run_pass(&epoch, &mut contract_analysis, db)?;

--- a/clarity/src/vm/analysis/type_checker/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/mod.rs
@@ -50,7 +50,9 @@ impl FunctionType {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 self.check_args_2_05(accounting, args)
             }
-            StacksEpochId::Epoch21 => self.check_args_2_1(accounting, args, clarity_version),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
+                self.check_args_2_1(accounting, args, clarity_version)
+            }
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),
         }
     }
@@ -66,7 +68,7 @@ impl FunctionType {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 self.check_args_by_allowing_trait_cast_2_05(db, func_args)
             }
-            StacksEpochId::Epoch21 => {
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                 self.check_args_by_allowing_trait_cast_2_1(db, clarity_version, func_args)
             }
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -699,7 +699,7 @@ impl LimitedCostTracker {
             }
             StacksEpochId::Epoch20 => COSTS_1_NAME.to_string(),
             StacksEpochId::Epoch2_05 => COSTS_2_NAME.to_string(),
-            StacksEpochId::Epoch21 => COSTS_3_NAME.to_string(),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => COSTS_3_NAME.to_string(),
         }
     }
 }

--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -56,6 +56,8 @@ macro_rules! switch_on_global_epoch {
                 StacksEpochId::Epoch2_05 => $Epoch205Version(args, env, context),
                 // Note: We reuse 2.05 for 2.1.
                 StacksEpochId::Epoch21 => $Epoch205Version(args, env, context),
+                // Note: We reuse 2.05 for 2.2.
+                StacksEpochId::Epoch22 => $Epoch205Version(args, env, context),
             }
         }
     };

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -529,7 +529,7 @@ impl TypeSignature {
     pub fn admits_type(&self, epoch: &StacksEpochId, other: &TypeSignature) -> Result<bool> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => self.admits_type_v2_0(&other),
-            StacksEpochId::Epoch21 => self.admits_type_v2_1(other),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => self.admits_type_v2_1(other),
             StacksEpochId::Epoch10 => unreachable!("epoch 1.0 not supported"),
         }
     }
@@ -1045,7 +1045,7 @@ impl TypeSignature {
     ) -> Result<TypeSignature> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => Self::least_supertype_v2_0(a, b),
-            StacksEpochId::Epoch21 => Self::least_supertype_v2_1(a, b),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => Self::least_supertype_v2_1(a, b),
             StacksEpochId::Epoch10 => unreachable!("Clarity 1.0 is not supported"),
         }
     }

--- a/clarity/src/vm/version.rs
+++ b/clarity/src/vm/version.rs
@@ -31,6 +31,7 @@ impl ClarityVersion {
             StacksEpochId::Epoch20 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch2_05 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch21 => ClarityVersion::Clarity2,
+            StacksEpochId::Epoch22 => ClarityVersion::Clarity2,
         }
     }
 }

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -458,6 +458,16 @@ impl PoxConstants {
         first_block_height + reward_cycle * (self.reward_cycle_length as u64) + 1
     }
 
+    pub fn static_reward_cycle_to_block_height(
+        reward_cycle_length: u64,
+        first_block_height: u64,
+        reward_cycle: u64,
+    ) -> u64 {
+        // NOTE: the `+ 1` is because the height of the first block of a reward cycle is mod 1, not
+        // mod 0.
+        first_block_height + reward_cycle * reward_cycle_length + 1
+    }
+
     pub fn block_height_to_reward_cycle(
         &self,
         first_block_height: u64,

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2847,6 +2847,7 @@ impl SortitionDB {
             }
             StacksEpochId::Epoch2_05 => version == "2" || version == "3" || version == "4",
             StacksEpochId::Epoch21 => version == "3" || version == "4",
+            StacksEpochId::Epoch22 => version == "4",
         }
     }
 

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -501,7 +501,7 @@ impl FromRow<StacksEpoch> for StacksEpoch {
     }
 }
 
-pub const SORTITION_DB_VERSION: &'static str = "4";
+pub const SORTITION_DB_VERSION: &'static str = "5";
 
 const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
     r#"
@@ -701,6 +701,9 @@ const SORTITION_DB_SCHEMA_4: &'static [&'static str] = &[
         block_height INTEGER NOT NULL
     );"#,
 ];
+
+const SORTITION_DB_SCHEMA_5: &'static [&'static str] = &[r#"
+     DELETE FROM epochs;"#];
 
 // update this to add new indexes
 const LAST_SORTITION_DB_INDEX: &'static str = "index_delegate_stx_burn_header_hash";
@@ -2834,7 +2837,9 @@ impl SortitionDB {
     }
 
     /// Get the schema version of a sortition DB, given the path to it.
-    /// Returns the version string, if it exists
+    /// Returns the version string, if it exists.
+    ///
+    /// Does **not** migrate the database (like `open()` or `connect()` would)
     pub fn get_db_version_from_path(path: &str) -> Result<Option<String>, db_error> {
         if fs::metadata(path).is_err() {
             return Err(db_error::NoDBError);
@@ -2864,11 +2869,17 @@ impl SortitionDB {
         match epoch {
             StacksEpochId::Epoch10 => true,
             StacksEpochId::Epoch20 => {
-                version == "1" || version == "2" || version == "3" || version == "4"
+                version == "1"
+                    || version == "2"
+                    || version == "3"
+                    || version == "4"
+                    || version == "5"
             }
-            StacksEpochId::Epoch2_05 => version == "2" || version == "3" || version == "4",
-            StacksEpochId::Epoch21 => version == "3" || version == "4",
-            StacksEpochId::Epoch22 => version == "4",
+            StacksEpochId::Epoch2_05 => {
+                version == "2" || version == "3" || version == "4" || version == "5"
+            }
+            StacksEpochId::Epoch21 => version == "3" || version == "4" || version == "5",
+            StacksEpochId::Epoch22 => version == "3" || version == "4" || version == "5",
         }
     }
 
@@ -2937,6 +2948,21 @@ impl SortitionDB {
         Ok(())
     }
 
+    fn apply_schema_5(tx: &DBTx, epochs: &[StacksEpoch]) -> Result<(), db_error> {
+        for sql_exec in SORTITION_DB_SCHEMA_5 {
+            tx.execute_batch(sql_exec)?;
+        }
+
+        SortitionDB::validate_and_insert_epochs(&tx, epochs)?;
+
+        tx.execute(
+            "INSERT OR REPLACE INTO db_config (version) VALUES (?1)",
+            &["5"],
+        )?;
+
+        Ok(())
+    }
+
     fn check_schema_version_or_error(&mut self) -> Result<(), db_error> {
         match SortitionDB::get_schema_version(self.conn()) {
             Ok(Some(version)) => {
@@ -2974,6 +3000,10 @@ impl SortitionDB {
                     } else if version == "3" {
                         let tx = self.tx_begin()?;
                         SortitionDB::apply_schema_4(&tx.deref())?;
+                        tx.commit()?;
+                    } else if version == "4" {
+                        let tx = self.tx_begin()?;
+                        SortitionDB::apply_schema_5(&tx.deref(), epochs)?;
                         tx.commit()?;
                     } else if version == expected_version {
                         return Ok(());

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -38,6 +38,7 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::index::storage::TrieFileStorage;
 use crate::chainstate::stacks::{StacksPrivateKey, StacksPublicKey};
 use crate::codec::{write_next, Error as codec_error, StacksMessageCodec};
+use crate::core::STACKS_EPOCH_2_2_MARKER;
 use crate::core::{StacksEpoch, StacksEpochId};
 use crate::core::{STACKS_EPOCH_2_05_MARKER, STACKS_EPOCH_2_1_MARKER};
 use crate::net::Error as net_error;
@@ -753,6 +754,7 @@ impl LeaderBlockCommitOp {
             }
             StacksEpochId::Epoch2_05 => self.check_epoch_commit_marker(STACKS_EPOCH_2_05_MARKER),
             StacksEpochId::Epoch21 => self.check_epoch_commit_marker(STACKS_EPOCH_2_1_MARKER),
+            StacksEpochId::Epoch22 => self.check_epoch_commit_marker(STACKS_EPOCH_2_2_MARKER),
         }
     }
 
@@ -767,7 +769,7 @@ impl LeaderBlockCommitOp {
     ) -> Result<SortitionId, op_error> {
         let tx_tip = tx.context.chain_tip.clone();
         let intended_sortition = match epoch_id {
-            StacksEpochId::Epoch21 => {
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                 // correct behavior -- uses *sortition height* to find the intended sortition ID
                 let sortition_height = self
                     .block_height

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -2987,7 +2987,7 @@ impl<
                                     return Ok(Some(pox_anchor));
                                 }
                             }
-                            StacksEpochId::Epoch21 => {
+                            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                                 // 2.1 behavior: the anchor block must also be the
                                 // heaviest-confirmed anchor block by BTC weight, and the highest
                                 // such anchor block if there are multiple contenders.

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4886,21 +4886,41 @@ impl StacksChainState {
                             receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
                             applied = true;
                         }
+                        StacksEpochId::Epoch22 => {
+                            receipts.push(clarity_tx.block.initialize_epoch_2_05()?);
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_2()?);
+                            applied = true;
+                        }
                         _ => {
                             panic!("Bad Stacks epoch transition; parent_epoch = {}, current_epoch = {}", &stacks_parent_epoch, &sortition_epoch.epoch_id);
                         }
                     },
-                    StacksEpochId::Epoch2_05 => {
+                    StacksEpochId::Epoch2_05 => match sortition_epoch.epoch_id {
+                        StacksEpochId::Epoch21 => {
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                            applied = true;
+                        }
+                        StacksEpochId::Epoch22 => {
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_2()?);
+                            applied = true;
+                        }
+                        _ => {
+                            panic!("Bad Stacks epoch transition; parent_epoch = {}, current_epoch = {}", &stacks_parent_epoch, &sortition_epoch.epoch_id);
+                        }
+                    },
+                    StacksEpochId::Epoch21 => {
                         assert_eq!(
                             sortition_epoch.epoch_id,
-                            StacksEpochId::Epoch21,
-                            "Should only transition from Epoch2_05 to Epoch21"
+                            StacksEpochId::Epoch22,
+                            "Should only transition from Epoch21 to Epoch22"
                         );
-                        receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                        receipts.append(&mut clarity_tx.block.initialize_epoch_2_2()?);
                         applied = true;
                     }
-                    StacksEpochId::Epoch21 => {
-                        panic!("No defined transition from Epoch21 forward")
+                    StacksEpochId::Epoch22 => {
+                        panic!("No defined transition from Epoch22 forward")
                     }
                 }
             }
@@ -5487,7 +5507,7 @@ impl StacksChainState {
                 // The DelegateStx bitcoin wire format does not exist before Epoch 2.1.
                 Ok((stack_ops, transfer_ops, vec![]))
             }
-            StacksEpochId::Epoch21 => {
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                 StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
                     chainstate_tx,
                     parent_index_hash,

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -223,7 +223,7 @@ impl DBConfig {
                 self.version == "2" || self.version == "3" || self.version == "4"
             }
             StacksEpochId::Epoch21 => self.version == "3" || self.version == "4",
-            StacksEpochId::Epoch22 => self.version == "4",
+            StacksEpochId::Epoch22 => self.version == "3" || self.version == "4",
         }
     }
 }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -223,6 +223,7 @@ impl DBConfig {
                 self.version == "2" || self.version == "3" || self.version == "4"
             }
             StacksEpochId::Epoch21 => self.version == "3" || self.version == "4",
+            StacksEpochId::Epoch22 => self.version == "4",
         }
     }
 }

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -8347,6 +8347,7 @@ pub mod test {
                     StacksEpochId::Epoch20 => self.get_stacks_epoch(0),
                     StacksEpochId::Epoch2_05 => self.get_stacks_epoch(1),
                     StacksEpochId::Epoch21 => self.get_stacks_epoch(2),
+                    StacksEpochId::Epoch22 => self.get_stacks_epoch(3),
                 }
             }
             fn get_pox_payout_addrs(

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -913,8 +913,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
             self.as_transaction(|clarity_tx| {
                 clarity_tx
                     .with_clarity_db(|db| {
-                        // TODO: add epoch 2.2
-                        db.set_clarity_epoch_version(StacksEpochId::Epoch21);
+                        db.set_clarity_epoch_version(StacksEpochId::Epoch22);
                         Ok(())
                     })
                     .unwrap();

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -906,7 +906,21 @@ fn handle_pox_v2_api_contract_call(
         handle_stack_lockup(global_context, function_name, value)?
     } else if function_name == "stack-extend" || function_name == "delegate-stack-extend" {
         handle_stack_lockup_extension(global_context, function_name, value)?
-    } else if function_name == "stack-increase" || function_name == "delegate-stack-increase" {
+    } else if function_name == "stack-increase" {
+        match global_context.epoch_id {
+            // For epochs 1.0 - 2.1, stack increase is okay
+            StacksEpochId::Epoch10
+            | StacksEpochId::Epoch20
+            | StacksEpochId::Epoch2_05
+            | StacksEpochId::Epoch21 => {
+                handle_stack_lockup_increase(global_context, function_name, value)?
+            }
+            // For epoch 2.2, runtime abort
+            StacksEpochId::Epoch22 => {
+                return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None))
+            }
+        }
+    } else if function_name == "delegate-stack-increase" {
         handle_stack_lockup_increase(global_context, function_name, value)?
     } else {
         None

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -326,6 +326,10 @@ pub static STACKS_EPOCH_2_05_MARKER: u8 = 0x05;
 /// *or greater*.
 pub static STACKS_EPOCH_2_1_MARKER: u8 = 0x06;
 
+/// Stacks 2.2 epoch marker.  All block-commits in 2.2 must have a memo bitfield with this value
+/// *or greater*.
+pub static STACKS_EPOCH_2_2_MARKER: u8 = 0x07;
+
 #[test]
 fn test_ord_for_stacks_epoch() {
     let epochs = STACKS_EPOCHS_MAINNET.clone();
@@ -390,6 +394,8 @@ pub trait StacksEpochExtension {
     fn unit_test_pre_2_05(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
     #[cfg(test)]
     fn unit_test_2_1(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
+    #[cfg(test)]
+    fn unit_test_2_2(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
     #[cfg(test)]
     fn unit_test_2_1_only(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
     fn all(
@@ -554,6 +560,70 @@ impl StacksEpochExtension for StacksEpoch {
     }
 
     #[cfg(test)]
+    fn unit_test_2_2(first_burnchain_height: u64) -> Vec<StacksEpoch> {
+        info!(
+            "StacksEpoch unit_test first_burn_height = {}",
+            first_burnchain_height
+        );
+
+        vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: first_burnchain_height,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: first_burnchain_height,
+                end_height: first_burnchain_height + 4,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: first_burnchain_height + 4,
+                end_height: first_burnchain_height + 8,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: first_burnchain_height + 8,
+                end_height: first_burnchain_height + 12,
+                block_limit: ExecutionCost {
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch22,
+                start_height: first_burnchain_height + 12,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+        ]
+    }
+
+    #[cfg(test)]
     fn unit_test_2_1_only(first_burnchain_height: u64) -> Vec<StacksEpoch> {
         info!(
             "StacksEpoch unit_test first_burn_height = {}",
@@ -612,6 +682,7 @@ impl StacksEpochExtension for StacksEpoch {
             }
             StacksEpochId::Epoch2_05 => StacksEpoch::unit_test_2_05(first_burnchain_height),
             StacksEpochId::Epoch21 => StacksEpoch::unit_test_2_1(first_burnchain_height),
+            StacksEpochId::Epoch22 => StacksEpoch::unit_test_2_2(first_burnchain_height),
         }
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -50,13 +50,14 @@ pub use stacks_common::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, STACKS_EPOCH
 // fourth byte == highest epoch supported by this node
 // - 0x05 for 2.05
 // - 0x06 for 2.1
-pub const PEER_VERSION_MAINNET: u32 = 0x18000006;
-pub const PEER_VERSION_TESTNET: u32 = 0xfacade06;
+pub const PEER_VERSION_MAINNET: u32 = 0x18000007;
+pub const PEER_VERSION_TESTNET: u32 = 0xfacade07;
 
 pub const PEER_VERSION_EPOCH_1_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_05: u8 = 0x05;
 pub const PEER_VERSION_EPOCH_2_1: u8 = 0x06;
+pub const PEER_VERSION_EPOCH_2_2: u8 = 0x07;
 
 // network identifiers
 pub const NETWORK_ID_MAINNET: u32 = 0x17000000;
@@ -105,6 +106,7 @@ pub const BITCOIN_MAINNET_FIRST_BLOCK_HASH: &str =
 pub const BITCOIN_MAINNET_INITIAL_REWARD_START_BLOCK: u64 = 651389;
 pub const BITCOIN_MAINNET_STACKS_2_05_BURN_HEIGHT: u64 = 713_000;
 pub const BITCOIN_MAINNET_STACKS_21_BURN_HEIGHT: u64 = 781_551;
+pub const BITCOIN_MAINNET_STACKS_22_BURN_HEIGHT: u64 = 787_700;
 
 pub const BITCOIN_TESTNET_FIRST_BLOCK_HEIGHT: u64 = 2000000;
 pub const BITCOIN_TESTNET_FIRST_BLOCK_TIMESTAMP: u32 = 1622691840;
@@ -220,7 +222,7 @@ pub fn check_fault_injection(fault_name: &str) -> bool {
 }
 
 lazy_static! {
-    pub static ref STACKS_EPOCHS_MAINNET: [StacksEpoch; 4] = [
+    pub static ref STACKS_EPOCHS_MAINNET: [StacksEpoch; 5] = [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -245,9 +247,16 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch21,
             start_height: BITCOIN_MAINNET_STACKS_21_BURN_HEIGHT,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: BITCOIN_MAINNET_STACKS_22_BURN_HEIGHT,
             block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_1
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch22,
+            start_height: BITCOIN_MAINNET_STACKS_22_BURN_HEIGHT,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_2
         },
     ];
 }
@@ -339,9 +348,18 @@ fn test_ord_for_stacks_epoch() {
     assert_eq!(epochs[0].cmp(&epochs[0]), Ordering::Equal);
     assert_eq!(epochs[1].cmp(&epochs[1]), Ordering::Equal);
     assert_eq!(epochs[2].cmp(&epochs[2]), Ordering::Equal);
+    assert_eq!(epochs[3].cmp(&epochs[3]), Ordering::Equal);
+    assert_eq!(epochs[4].cmp(&epochs[4]), Ordering::Equal);
     assert_eq!(epochs[2].cmp(&epochs[0]), Ordering::Greater);
     assert_eq!(epochs[2].cmp(&epochs[1]), Ordering::Greater);
     assert_eq!(epochs[1].cmp(&epochs[0]), Ordering::Greater);
+    assert_eq!(epochs[3].cmp(&epochs[0]), Ordering::Greater);
+    assert_eq!(epochs[3].cmp(&epochs[1]), Ordering::Greater);
+    assert_eq!(epochs[3].cmp(&epochs[2]), Ordering::Greater);
+    assert_eq!(epochs[4].cmp(&epochs[0]), Ordering::Greater);
+    assert_eq!(epochs[4].cmp(&epochs[1]), Ordering::Greater);
+    assert_eq!(epochs[4].cmp(&epochs[2]), Ordering::Greater);
+    assert_eq!(epochs[4].cmp(&epochs[3]), Ordering::Greater);
 }
 
 #[test]

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -230,6 +230,8 @@ impl PessimisticEstimator {
                     StacksEpochId::Epoch20 => "",
                     StacksEpochId::Epoch2_05 => ":2.05",
                     StacksEpochId::Epoch21 => ":2.1",
+                    // reuse cost estimates in Epoch22
+                    StacksEpochId::Epoch22 => ":2.1",
                 };
                 format!(
                     "cc{}:{}:{}.{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,10 +219,12 @@ fn main() {
                 LimitedCostTracker::Free,
                 |env| {
                     Ok(StacksChainState::correct_reward_set(
-                        &burnchain,
                         tip_height,
                         env,
                         chainstate.mainnet,
+                        burnchain.first_block_height,
+                        burnchain.pox_constants.reward_cycle_length as u64,
+                        burnchain.pox_constants.v1_unlock_height as u64,
                     )
                     .unwrap())
                 },

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -72,11 +72,12 @@ pub enum StacksEpochId {
     Epoch20 = 0x02000,
     Epoch2_05 = 0x02005,
     Epoch21 = 0x0200a,
+    Epoch22 = 0x0200f,
 }
 
 impl StacksEpochId {
     pub fn latest() -> StacksEpochId {
-        StacksEpochId::Epoch21
+        StacksEpochId::Epoch22
     }
 }
 
@@ -87,6 +88,7 @@ impl std::fmt::Display for StacksEpochId {
             StacksEpochId::Epoch20 => write!(f, "2.0"),
             StacksEpochId::Epoch2_05 => write!(f, "2.05"),
             StacksEpochId::Epoch21 => write!(f, "2.1"),
+            StacksEpochId::Epoch22 => write!(f, "2.2"),
         }
     }
 }
@@ -100,6 +102,7 @@ impl TryFrom<u32> for StacksEpochId {
             x if x == StacksEpochId::Epoch20 as u32 => Ok(StacksEpochId::Epoch20),
             x if x == StacksEpochId::Epoch2_05 as u32 => Ok(StacksEpochId::Epoch2_05),
             x if x == StacksEpochId::Epoch21 as u32 => Ok(StacksEpochId::Epoch21),
+            x if x == StacksEpochId::Epoch22 as u32 => Ok(StacksEpochId::Epoch22),
             _ => Err("Invalid epoch"),
         }
     }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -178,6 +178,7 @@ use stacks::codec::StacksMessageCodec;
 use stacks::core::mempool::MemPoolDB;
 use stacks::core::FIRST_BURNCHAIN_CONSENSUS_HASH;
 use stacks::core::STACKS_EPOCH_2_1_MARKER;
+use stacks::core::STACKS_EPOCH_2_2_MARKER;
 use stacks::cost_estimates::metrics::CostMetric;
 use stacks::cost_estimates::metrics::UnitMetric;
 use stacks::cost_estimates::UnitEstimator;
@@ -1326,7 +1327,7 @@ impl BlockMinerThread {
             apparent_sender: sender,
             key_block_ptr: key.block_height as u32,
             key_vtxindex: key.op_vtxindex as u16,
-            memo: vec![STACKS_EPOCH_2_1_MARKER],
+            memo: vec![STACKS_EPOCH_2_2_MARKER],
             new_seed: vrf_seed,
             parent_block_ptr,
             parent_vtxindex,

--- a/testnet/stacks-node/src/tests/epoch_22.rs
+++ b/testnet/stacks-node/src/tests/epoch_22.rs
@@ -1,0 +1,569 @@
+use std::collections::HashMap;
+use std::env;
+use std::thread;
+
+use stacks::burnchains::Burnchain;
+use stacks::chainstate::stacks::address::PoxAddress;
+use stacks::chainstate::stacks::db::StacksChainState;
+use stacks::core::PEER_VERSION_EPOCH_2_2;
+use stacks::core::STACKS_EPOCH_MAX;
+use stacks::types::chainstate::StacksAddress;
+
+use crate::config::EventKeyType;
+use crate::config::EventObserverConfig;
+use crate::config::InitialBalance;
+use crate::neon;
+use crate::tests::bitcoin_regtest::BitcoinCoreController;
+use crate::tests::neon_integrations::*;
+use crate::tests::*;
+use crate::BitcoinRegtestController;
+use crate::BurnchainController;
+use stacks::core;
+
+use crate::stacks_common::types::Address;
+use crate::stacks_common::util::hash::bytes_to_hex;
+use stacks::burnchains::PoxConstants;
+
+use stacks_common::util::hash::Hash160;
+use stacks_common::util::secp256k1::Secp256k1PublicKey;
+
+use stacks::clarity_cli::vm_execute as execute;
+
+use clarity::vm::types::PrincipalData;
+use clarity::vm::ClarityVersion;
+
+use stacks::util::sleep_ms;
+
+use stacks::util_lib::boot::boot_code_id;
+use stacks_common::types::chainstate::StacksBlockId;
+
+#[test]
+#[ignore]
+/// Verify that it is acceptable to launch PoX-2 at the end of a reward cycle, and set v1 unlock
+/// height to be at the start of the subsequent reward cycle.
+///
+/// Verify that PoX-1 stackers continue to receive PoX payouts after v1 unlock height, and that
+/// PoX-2 stackers only begin receiving rewards at the start of the reward cycle following the one
+/// that contains v1 unlock height.
+///
+/// Verify that both of the above work even if miners do not mine in the same block as the PoX-2
+/// start height or v1 unlock height (e.g. suppose there's a delay).
+///
+/// Verify the (buggy) stacks-increase behavior in PoX-2, and then verify that Epoch-2.2
+///  *fixes* that behavior after it activates.
+///
+/// Verification works using expected number of slots for burn and various PoX addresses.
+///
+fn pox_2_stack_increase_epoch22_fix() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let reward_cycle_len = 10;
+    let prepare_phase_len = 3;
+    let epoch_2_05 = 215;
+    let epoch_2_1 = 230;
+    let v1_unlock_height = 231;
+    let epoch_2_2 = 255; // two blocks before next prepare phase.
+
+    let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
+    let increase_by = 1_000_0000 * (core::MICROSTACKS_PER_STACKS as u64);
+
+    let spender_sk = StacksPrivateKey::new();
+    let spender_addr: PrincipalData = to_addr(&spender_sk).into();
+
+    let spender_2_sk = StacksPrivateKey::new();
+    let spender_2_addr: PrincipalData = to_addr(&spender_2_sk).into();
+
+    let spender_3_sk = StacksPrivateKey::new();
+    let spender_3_addr: PrincipalData = to_addr(&spender_3_sk).into();
+
+    let mut initial_balances = vec![];
+
+    initial_balances.push(InitialBalance {
+        address: spender_addr.clone(),
+        amount: stacked + increase_by + 100_000,
+    });
+
+    initial_balances.push(InitialBalance {
+        address: spender_2_addr.clone(),
+        amount: stacked + 100_000,
+    });
+
+    // create a third initial balance so that there's more liquid ustx than the stacked amount bug.
+    //  otherwise, it surfaces the DoS vector.
+    initial_balances.push(InitialBalance {
+        address: spender_3_addr.clone(),
+        amount: stacked + 100_000,
+    });
+
+    let pox_pubkey_1 = Secp256k1PublicKey::from_hex(
+        "02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede",
+    )
+    .unwrap();
+    let pox_pubkey_hash_1 = bytes_to_hex(
+        &Hash160::from_node_public_key(&pox_pubkey_1)
+            .to_bytes()
+            .to_vec(),
+    );
+
+    let pox_pubkey_2 = Secp256k1PublicKey::from_hex(
+        "03cd91307e16c10428dd0120d0a4d37f14d4e0097b3b2ea1651d7bd0fb109cd44b",
+    )
+    .unwrap();
+    let pox_pubkey_hash_2 = bytes_to_hex(
+        &Hash160::from_node_public_key(&pox_pubkey_2)
+            .to_bytes()
+            .to_vec(),
+    );
+
+    let pox_pubkey_3 = Secp256k1PublicKey::from_hex(
+        "0317782e663c77fb02ebf46a3720f41a70f5678ad185974a456d35848e275fe56b",
+    )
+    .unwrap();
+    let pox_pubkey_hash_3 = bytes_to_hex(
+        &Hash160::from_node_public_key(&pox_pubkey_3)
+            .to_bytes()
+            .to_vec(),
+    );
+
+    let (mut conf, _) = neon_integration_test_conf();
+
+    // we'll manually post a forked stream to the node
+    conf.node.mine_microblocks = false;
+    conf.burnchain.max_rbf = 1000000;
+    conf.node.wait_time_for_microblocks = 0;
+    conf.node.microblock_frequency = 1_000;
+    conf.miner.first_attempt_time_ms = 2_000;
+    conf.miner.subsequent_attempt_time_ms = 5_000;
+    conf.node.wait_time_for_blocks = 1_000;
+    conf.miner.wait_for_block_download = false;
+
+    conf.miner.min_tx_fee = 1;
+    conf.miner.first_attempt_time_ms = i64::max_value() as u64;
+    conf.miner.subsequent_attempt_time_ms = i64::max_value() as u64;
+
+    test_observer::spawn();
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+    conf.initial_balances.append(&mut initial_balances);
+
+    let mut epochs = core::STACKS_EPOCHS_REGTEST.to_vec();
+    epochs[1].end_height = epoch_2_05;
+    epochs[2].start_height = epoch_2_05;
+    epochs[2].end_height = epoch_2_1;
+    epochs[3].start_height = epoch_2_1;
+    epochs[3].end_height = epoch_2_2;
+    epochs.push(StacksEpoch {
+        epoch_id: StacksEpochId::Epoch22,
+        start_height: epoch_2_2,
+        end_height: STACKS_EPOCH_MAX,
+        block_limit: epochs[3].block_limit.clone(),
+        network_epoch: PEER_VERSION_EPOCH_2_2,
+    });
+    conf.burnchain.epochs = Some(epochs);
+
+    let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    let pox_constants = PoxConstants::new(
+        reward_cycle_len,
+        prepare_phase_len,
+        4 * prepare_phase_len / 5,
+        5,
+        15,
+        u64::max_value() - 2,
+        u64::max_value() - 1,
+        v1_unlock_height as u32,
+    );
+    burnchain_config.pox_constants = pox_constants.clone();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
+    );
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let runloop_burnchain = burnchain_config.clone();
+
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(Some(runloop_burnchain), 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // push us to block 205
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // stack right away
+    let sort_height = channel.get_sortitions_processed();
+    let pox_addr_tuple_1 = execute(
+        &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash_1,),
+        ClarityVersion::Clarity2,
+    )
+    .unwrap()
+    .unwrap();
+
+    let pox_addr_tuple_3 = execute(
+        &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash_3,),
+        ClarityVersion::Clarity2,
+    )
+    .unwrap()
+    .unwrap();
+
+    let tx = make_contract_call(
+        &spender_sk,
+        0,
+        3000,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox",
+        "stack-stx",
+        &[
+            Value::UInt(stacked.into()),
+            pox_addr_tuple_1.clone(),
+            Value::UInt(sort_height as u128),
+            Value::UInt(12),
+        ],
+    );
+
+    info!("Submit 2.05 stacking tx to {:?}", &http_origin);
+    submit_tx(&http_origin, &tx);
+
+    // wait until just before epoch 2.1
+    loop {
+        let tip_info = get_chain_info(&conf);
+        if tip_info.burn_block_height >= epoch_2_1 - 2 {
+            break;
+        }
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    // skip a couple sortitions
+    btc_regtest_controller.bootstrap_chain(4);
+    sleep_ms(5000);
+
+    let sort_height = channel.get_sortitions_processed();
+    assert!(sort_height > epoch_2_1);
+    assert!(sort_height > v1_unlock_height);
+
+    // *now* advance to 2.1
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    info!("Test passed processing 2.1");
+
+    let sort_height = channel.get_sortitions_processed();
+    let pox_addr_tuple_2 = execute(
+        &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash_2,),
+        ClarityVersion::Clarity2,
+    )
+    .unwrap()
+    .unwrap();
+    let tx = make_contract_call(
+        &spender_sk,
+        1,
+        3000,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox-2",
+        "stack-stx",
+        &[
+            Value::UInt(stacked.into()),
+            pox_addr_tuple_2.clone(),
+            Value::UInt(sort_height as u128),
+            Value::UInt(12),
+        ],
+    );
+
+    info!("Submit 2.1 stacking tx to {:?}", &http_origin);
+    submit_tx(&http_origin, &tx);
+
+    let tx = make_contract_call(
+        &spender_2_sk,
+        0,
+        3000,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox-2",
+        "stack-stx",
+        &[
+            Value::UInt(stacked.into()),
+            pox_addr_tuple_3.clone(),
+            Value::UInt(sort_height as u128),
+            Value::UInt(10),
+        ],
+    );
+
+    info!("Submit 2.1 stacking tx to {:?}", &http_origin);
+    submit_tx(&http_origin, &tx);
+
+    // that it can mine _at all_ is a success criterion
+    let mut last_block_height = get_chain_info(&conf).burn_block_height;
+    for _i in 0..5 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        let tip_info = get_chain_info(&conf);
+        if tip_info.burn_block_height > last_block_height {
+            last_block_height = tip_info.burn_block_height;
+        } else {
+            panic!("FATAL: failed to mine");
+        }
+    }
+
+    // invoke stack-increase
+    let tx = make_contract_call(
+        &spender_sk,
+        2,
+        3000,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox-2",
+        "stack-increase",
+        &[Value::UInt(increase_by.into())],
+    );
+
+    info!("Submit 2.1 stack-increase tx to {:?}", &http_origin);
+    submit_tx(&http_origin, &tx);
+
+    for _i in 0..15 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        let tip_info = get_chain_info(&conf);
+        if tip_info.burn_block_height > last_block_height {
+            last_block_height = tip_info.burn_block_height;
+        } else {
+            panic!("FATAL: failed to mine");
+        }
+    }
+
+    info!("Mining two more blocks");
+
+    // finish the cycle after the 2.2 transition,
+    //  and mine two more cycles
+    for _i in 0..25 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        let tip_info = get_chain_info(&conf);
+        if tip_info.burn_block_height > last_block_height {
+            last_block_height = tip_info.burn_block_height;
+        } else {
+            panic!("FATAL: failed to mine");
+        }
+    }
+
+    let tip_info = get_chain_info(&conf);
+    let tip = StacksBlockId::new(&tip_info.stacks_tip_consensus_hash, &tip_info.stacks_tip);
+
+    let (mut chainstate, _) = StacksChainState::open(
+        false,
+        conf.burnchain.chain_id,
+        &conf.get_chainstate_path_str(),
+        None,
+    )
+    .unwrap();
+    let sortdb = btc_regtest_controller.sortdb_mut();
+
+    let mut reward_cycle_pox_addrs = HashMap::new();
+
+    info!("Last tip height = {}", tip_info.burn_block_height);
+
+    for height in 211..tip_info.burn_block_height {
+        let reward_cycle = pox_constants
+            .block_height_to_reward_cycle(burnchain_config.first_block_height, height)
+            .unwrap();
+
+        if !reward_cycle_pox_addrs.contains_key(&reward_cycle) {
+            reward_cycle_pox_addrs.insert(reward_cycle, HashMap::new());
+        }
+
+        let iconn = sortdb.index_conn();
+        let pox_addrs = chainstate
+            .clarity_eval_read_only(
+                &iconn,
+                &tip,
+                &boot_code_id("pox-2", false),
+                &format!("(get-burn-block-info? pox-addrs u{})", height),
+            )
+            .expect_optional()
+            .unwrap()
+            .expect_tuple()
+            .get_owned("addrs")
+            .unwrap()
+            .expect_list();
+
+        debug!("Test burnchain height {}", height);
+        if !burnchain_config.is_in_prepare_phase(height) {
+            if pox_addrs.len() > 0 {
+                assert_eq!(pox_addrs.len(), 2);
+                let pox_addr_0 = PoxAddress::try_from_pox_tuple(false, &pox_addrs[0]).unwrap();
+                let pox_addr_1 = PoxAddress::try_from_pox_tuple(false, &pox_addrs[1]).unwrap();
+
+                if let Some(pox_slot_count) = reward_cycle_pox_addrs
+                    .get_mut(&reward_cycle)
+                    .unwrap()
+                    .get_mut(&pox_addr_0)
+                {
+                    *pox_slot_count += 1;
+                } else {
+                    reward_cycle_pox_addrs
+                        .get_mut(&reward_cycle)
+                        .unwrap()
+                        .insert(pox_addr_0, 1);
+                }
+
+                if let Some(pox_slot_count) = reward_cycle_pox_addrs
+                    .get_mut(&reward_cycle)
+                    .unwrap()
+                    .get_mut(&pox_addr_1)
+                {
+                    *pox_slot_count += 1;
+                } else {
+                    reward_cycle_pox_addrs
+                        .get_mut(&reward_cycle)
+                        .unwrap()
+                        .insert(pox_addr_1, 1);
+                }
+            }
+
+            // let mut have_expected_payout = false;
+            // if height < epoch_2_1 + (reward_cycle_len as u64) {
+            //         for addr_tuple in pox_addrs {
+            //             // can either pay to pox tuple 1, or burn
+            //             assert_ne!(addr_tuple, pox_addr_tuple_2);
+            //             if addr_tuple == pox_addr_tuple_1 {
+            //                 have_expected_payout = true;
+            //             }
+            //         }
+            //     }
+            // } else {
+            //     if pox_addrs.len() > 0 {
+            //         assert_eq!(pox_addrs.len(), 2);
+            //         for addr_tuple in pox_addrs {
+            //             // can either pay to pox tuple 2, or burn
+            //             assert_ne!(addr_tuple, pox_addr_tuple_1);
+            //             if addr_tuple == pox_addr_tuple_2 {
+            //                 have_expected_payout = true;
+            //             }
+            //         }
+            //     }
+            // }
+            // assert!(have_expected_payout);
+        }
+    }
+
+    let reward_cycle_min = *reward_cycle_pox_addrs.keys().min().unwrap();
+    let reward_cycle_max = *reward_cycle_pox_addrs.keys().max().unwrap();
+
+    let pox_addr_1 = PoxAddress::Standard(
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()),
+        Some(AddressHashMode::SerializeP2PKH),
+    );
+    let pox_addr_2 = PoxAddress::Standard(
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()),
+        Some(AddressHashMode::SerializeP2PKH),
+    );
+    let pox_addr_3 = PoxAddress::Standard(
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()),
+        Some(AddressHashMode::SerializeP2PKH),
+    );
+    let burn_pox_addr = PoxAddress::Standard(
+        StacksAddress::new(
+            26,
+            Hash160::from_hex("0000000000000000000000000000000000000000").unwrap(),
+        ),
+        Some(AddressHashMode::SerializeP2PKH),
+    );
+
+    let expected_slots = HashMap::from([
+        (
+            21u64,
+            HashMap::from([(pox_addr_1.clone(), 13u64), (burn_pox_addr.clone(), 1)]),
+        ),
+        (
+            22u64,
+            HashMap::from([(pox_addr_1.clone(), 13u64), (burn_pox_addr.clone(), 1)]),
+        ),
+        (
+            23u64,
+            HashMap::from([(pox_addr_1.clone(), 13u64), (burn_pox_addr.clone(), 1)]),
+        ),
+        // cycle 24 is the first 2.1, it should have pox_2 and pox_3 with equal
+        //  slots (because increase hasn't gone into effect yet) and 2 burn slots
+        (
+            24,
+            HashMap::from([
+                (pox_addr_2.clone(), 6u64),
+                (pox_addr_3.clone(), 6),
+                (burn_pox_addr.clone(), 2),
+            ]),
+        ),
+        // stack-increase has been invoked, and so the reward set is skewed.
+        //  pox_addr_2 should get the majority of slots (~ 67%)
+        (
+            25,
+            HashMap::from([
+                (pox_addr_2.clone(), 9u64),
+                (pox_addr_3.clone(), 4),
+                (burn_pox_addr.clone(), 1),
+            ]),
+        ),
+        // Epoch 2.2 has started, so the reward set should be fixed.
+        //  pox_addr_2 should get 1 extra slot, because stack-increase
+        //  did increase their stacked amount
+        (
+            26,
+            HashMap::from([
+                (pox_addr_2.clone(), 7u64),
+                (pox_addr_3.clone(), 6),
+                (burn_pox_addr.clone(), 1),
+            ]),
+        ),
+        (
+            27,
+            HashMap::from([
+                (pox_addr_2.clone(), 7u64),
+                (pox_addr_3.clone(), 6),
+                (burn_pox_addr.clone(), 1),
+            ]),
+        ),
+    ]);
+
+    for reward_cycle in reward_cycle_min..(reward_cycle_max + 1) {
+        let cycle_counts = &reward_cycle_pox_addrs[&reward_cycle];
+        assert_eq!(cycle_counts.len(), expected_slots[&reward_cycle].len(), "The number of expected PoX addresses in reward cycle {} is mismatched with the actual count.", reward_cycle);
+        for (pox_addr, slots) in cycle_counts.iter() {
+            assert_eq!(
+                *slots,
+                expected_slots[&reward_cycle][&pox_addr],
+                "The number of expected slots for PoX address {} in reward cycle {} is mismatched with the actual count.",
+                &pox_addr,
+                reward_cycle,
+            );
+            info!("PoX payment received"; "cycle" => reward_cycle, "pox_addr" => %pox_addr, "slots" => slots);
+        }
+    }
+
+    test_observer::clear();
+    channel.stop_chains_coordinator();
+}

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -42,6 +42,7 @@ mod atlas;
 mod bitcoin_regtest;
 mod epoch_205;
 mod epoch_21;
+mod epoch_22;
 mod integrations;
 mod mempool;
 pub mod neon_integrations;


### PR DESCRIPTION
### Description

This PR addresses the PoX stack-increase issue (SIP-022) by introducing a new 2.2 epoch. The changes are:

* At the epoch transition, all future reward cycles are checked such that each solo stacker's locked amount exactly matches the reward set data for the stacker.
* If there is a mismatch, the database is updated to match the locked amount.
* After database updates, the check is performed again, asserting no further mismatches.
* `pox-2.stacks-increase` runtime aborts in Epoch 2.2
* PoX anchor blocks in Epoch 2.2 reward cycles must also have been in Epoch 2.2

This PR is a draft as it still *needs* test coverage:

#### Unit test to ensure that the epoch transition catches and correctly fixes PoX reward sets
         
* @kantai: authored `pox_2_tests::epoch_2_2_stack_increase` which checks a simple case of two stackers, where one invokes stacks increase.

#### Unit test to ensure that the epoch transition correctly fixes _all_ PoX reward sets which could be used after the transition (i.e., if the PoX anchor block selected is exactly EPOCH_2_2 transition height)

* @kantai: `pox_2_tests::epoch_2_2_stack_increase` checks reward cycles at exactly the transition height, which means if that block was chosen as the anchor, the reward cycle data would correspond to the checked data in that method.

#### End-to-end (bitcoin regtest) test case that applies the epoch transition and fixes the PoX reward set

* @kantai: authored `tests::epoch_22::pox_2_stack_increase_epoch22_fix` which transitions through epochs 2.1 and 2.2. It executes stack-increase in 2.1 in order to exhibit the buggy behavior, and then asserts that after 2.2 begins, the reward set distribution is corrected.

#### End-to-end test case that applies the epoch transition and demonstrates that stacks-increase always runtime aborts

* @kantai: `tests::epoch_22::pox_2_stack_increase_epoch22_fix` tests `stack-increase` in epoch 2.2 and asserts that it aborts.

#### Unit test to ensure that a SortitionDB is correctly "migrated" (the schema doesn't change, but the epochs table must be refreshed)
#### Unit (?) or E2E test case that ensures the PoX anchor block selection cannot select an Epoch 2.1 block after Epoch 2.2 activates


### Epoch 2.2 height

This PR also selects an Epoch 2.2 height: 

```rust
pub const BITCOIN_MAINNET_STACKS_22_BURN_HEIGHT: u64 = 787_700;
```

This is 50 blocks before the start of the next reward cycle's prepare phase. In order for these changes to be applied _before_ the next reward cycle, I think this is close to the latest block height.

### Open Testing Questions

Here I'm listing some potential concerns that I have some uncertainty about the best way to test. I am interested in input and help here!

#### Solo Lock == Stacked Amount Assumption 

One of the assumptions that this fix makes is: for every solo stacker, their current account lock should equal their "stacked" amount in the reward set list. This is not true when looking at *current* reward cycle: when you invoke `stack-stx`, you are immediately locked, but not added to the current cycle. The first cycle you are added to is the next cycle. 

The commit d0c281b8fce885b1abce400a8a7bc83620f86a2f addressed this specific case by changing the epoch transition behavior such that it starts corrections at the _next_ cycle (it also panics if Epoch 2.2's start height is a reward cycle boundary to avoid an off-by-one issue here).

This is the only case where this assumption breaks that is obvious to me, but I'd like some help in thinking about other ways this assumption (which becomes an assertion at the transition) could fail.