### PR TITLE
Feat/handlers for locked struct

### DIFF
--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -770,6 +770,11 @@ impl<'a> ClarityDatabase<'a> {
         self.burn_state_db.get_v1_unlock_height()
     }
 
+    /// Return the height for PoX 3 activation from the burn state db
+    pub fn get_pox_3_activation_height(&self) -> u32 {
+        self.burn_state_db.get_pox_3_activation_height()
+    }
+
     /// Return the height for PoX v2 -> v3 auto unlocks
     ///   from the burn state db
     pub fn get_v2_unlock_height(&mut self) -> u32 {

--- a/clarity/src/vm/database/structures.rs
+++ b/clarity/src/vm/database/structures.rs
@@ -599,7 +599,7 @@ impl<'db, 'conn> STXBalanceSnapshot<'db, 'conn> {
             .balance
             .get_total_balance()
             .checked_sub(amount_to_lock)
-            .expect("STX underflow");
+            .expect("FATAL: account locks more STX than balance possessed");
 
         self.balance = STXBalance::LockedPoxThree {
             amount_unlocked: new_amount_unlocked,

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -392,6 +392,127 @@ impl StacksChainState {
             .expect("FATAL: failed to set account nonce")
     }
 
+    /////////////////////// PoX-3 /////////////////////////////////
+
+    /// Lock up STX for PoX for a time.  Does NOT touch the account nonce.
+    pub fn pox_lock_v3(
+        db: &mut ClarityDatabase,
+        principal: &PrincipalData,
+        lock_amount: u128,
+        unlock_burn_height: u64,
+    ) -> Result<(), Error> {
+        assert!(unlock_burn_height > 0);
+        assert!(lock_amount > 0);
+
+        let mut snapshot = db.get_stx_balance_snapshot(principal);
+
+        if snapshot.has_locked_tokens() {
+            return Err(Error::PoxAlreadyLocked);
+        }
+        if !snapshot.can_transfer(lock_amount) {
+            return Err(Error::PoxInsufficientBalance);
+        }
+        snapshot.lock_tokens_v3(lock_amount, unlock_burn_height);
+
+        debug!(
+            "PoX v3 lock applied";
+            "pox_locked_ustx" => snapshot.balance().amount_locked(),
+            "available_ustx" => snapshot.balance().amount_unlocked(),
+            "unlock_burn_height" => unlock_burn_height,
+            "account" => %principal,
+        );
+
+        snapshot.save();
+        Ok(())
+    }
+
+    /// Extend a STX lock up for PoX for a time.  Does NOT touch the account nonce.
+    /// Returns Ok(lock_amount) when successful
+    ///
+    /// # Errors
+    /// - Returns Error::PoxExtendNotLocked if this function was called on an account
+    ///     which isn't locked. This *should* have been checked by the PoX v3 contract,
+    ///     so this should surface in a panic.
+    pub fn pox_lock_extend_v3(
+        db: &mut ClarityDatabase,
+        principal: &PrincipalData,
+        unlock_burn_height: u64,
+    ) -> Result<u128, Error> {
+        assert!(unlock_burn_height > 0);
+
+        let mut snapshot = db.get_stx_balance_snapshot(principal);
+
+        if !snapshot.has_locked_tokens() {
+            return Err(Error::PoxExtendNotLocked);
+        }
+
+        snapshot.extend_lock_v3(unlock_burn_height);
+
+        let amount_locked = snapshot.balance().amount_locked();
+
+        debug!(
+            "PoX v3 lock applied";
+            "pox_locked_ustx" => amount_locked,
+            "available_ustx" => snapshot.balance().amount_unlocked(),
+            "unlock_burn_height" => unlock_burn_height,
+            "account" => %principal,
+        );
+
+        snapshot.save();
+        Ok(amount_locked)
+    }
+
+    /// Increase a STX lock up for PoX-3.  Does NOT touch the account nonce.
+    /// Returns Ok( account snapshot ) when successful
+    ///
+    /// # Errors
+    /// - Returns Error::PoxExtendNotLocked if this function was called on an account
+    ///     which isn't locked. This *should* have been checked by the PoX v3 contract,
+    ///     so this should surface in a panic.
+    pub fn pox_lock_increase_v3(
+        db: &mut ClarityDatabase,
+        principal: &PrincipalData,
+        new_total_locked: u128,
+    ) -> Result<STXBalance, Error> {
+        assert!(new_total_locked > 0);
+
+        let mut snapshot = db.get_stx_balance_snapshot(principal);
+
+        if !snapshot.has_locked_tokens() {
+            return Err(Error::PoxExtendNotLocked);
+        }
+
+        let bal = snapshot.canonical_balance_repr();
+        let total_amount = bal
+            .amount_unlocked()
+            .checked_add(bal.amount_locked())
+            .expect("STX balance overflowed u128");
+        if total_amount < new_total_locked {
+            return Err(Error::PoxInsufficientBalance);
+        }
+
+        if bal.amount_locked() > new_total_locked {
+            return Err(Error::PoxInvalidIncrease);
+        }
+
+        snapshot.increase_lock_v3(new_total_locked);
+
+        let out_balance = snapshot.canonical_balance_repr();
+
+        debug!(
+            "PoX v3 lock increased";
+            "pox_locked_ustx" => out_balance.amount_locked(),
+            "available_ustx" => out_balance.amount_unlocked(),
+            "unlock_burn_height" => out_balance.unlock_height(),
+            "account" => %principal,
+        );
+
+        snapshot.save();
+        Ok(out_balance)
+    }
+
+    /////////////////////// PoX-2 /////////////////////////////////
+
     /// Increase a STX lock up for PoX.  Does NOT touch the account nonce.
     /// Returns Ok( account snapshot ) when successful
     ///
@@ -512,6 +633,8 @@ impl StacksChainState {
         snapshot.save();
         Ok(())
     }
+
+    /////////////////////// PoX (first version) /////////////////////////////////
 
     /// Lock up STX for PoX for a time.  Does NOT touch the account nonce.
     pub fn pox_lock_v1(

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -1160,7 +1160,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                 tx_conn.epoch = StacksEpochId::Epoch24;
             });
 
-             /////////////////// .pox-3 ////////////////////////
+            /////////////////// .pox-3 ////////////////////////
             let mainnet = self.mainnet;
             let first_block_height = self.burn_state_db.get_burn_start_height();
             let pox_prepare_length = self.burn_state_db.get_pox_prepare_length();

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -1265,12 +1265,6 @@ pub fn handle_contract_call_special_cases(
             result,
         );
     } else if *contract_id == boot_code_id(POX_3_NAME, global_context.mainnet) {
-        if global_context.database.get_current_burnchain_block_height()
-            < global_context.database.get_pox_3_activation_height()
-        {
-            warn!("PoX-3 contract invoked before PoX-3 activation height");
-            return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None));
-        }
         return handle_pox_v3_api_contract_call(
             global_context,
             sender,

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -21,8 +21,7 @@ use clarity::vm::{ast, eval_all};
 use std::cmp;
 use std::convert::{TryFrom, TryInto};
 
-use crate::chainstate::stacks::boot::POX_1_NAME;
-use crate::chainstate::stacks::boot::POX_2_NAME;
+use crate::chainstate::stacks::boot::{POX_1_NAME, POX_2_NAME, POX_3_NAME};
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::Error as ChainstateError;
 use crate::chainstate::stacks::StacksMicroblockHeader;
@@ -149,7 +148,7 @@ fn parse_pox_extend_result(result: &Value) -> std::result::Result<(PrincipalData
     }
 }
 
-/// Parse the returned value from PoX2 `stack-increase` function
+/// Parse the returned value from PoX2 or PoX3 `stack-increase` function
 ///  into a format more readily digestible in rust.
 /// Panics if the supplied value doesn't match the expected tuple structure
 fn parse_pox_increase(result: &Value) -> std::result::Result<(PrincipalData, u128), i128> {
@@ -565,10 +564,10 @@ fn create_event_info_data_code(function_name: &str, args: &[Value]) -> String {
     }
 }
 
-/// Synthesize an events data tuple to return on the successful execution of a pox-2 stacking
+/// Synthesize an events data tuple to return on the successful execution of a pox-2 or pox-3 stacking
 /// function.  It runs a series of Clarity queries against the PoX contract's data space (including
 /// calling PoX functions).
-fn synthesize_pox_2_event_info(
+fn synthesize_pox_2_or_3_event_info(
     global_context: &mut GlobalContext,
     contract_id: &QualifiedContractIdentifier,
     sender_opt: Option<&PrincipalData>,
@@ -608,7 +607,7 @@ fn synthesize_pox_2_event_info(
         let pox_2_contract = global_context
             .database
             .get_contract(contract_id)
-            .expect("FATAL: could not load PoX-2 contract metadata");
+            .expect("FATAL: could not load PoX contract metadata");
 
         let event_info = global_context
             .special_cc_handler_execute_read_only(
@@ -657,12 +656,12 @@ fn synthesize_pox_2_event_info(
                 },
             )
             .map_err(|e: ChainstateError| {
-                error!("Failed to synthesize PoX-2 event: {:?}", &e);
+                error!("Failed to synthesize PoX event: {:?}", &e);
                 e
             })?;
 
         test_debug!(
-            "Synthesized PoX-2 event info for '{}''s call to '{}': {:?}",
+            "Synthesized PoX event info for '{}''s call to '{}': {:?}",
             sender,
             function_name,
             &event_info
@@ -674,7 +673,7 @@ fn synthesize_pox_2_event_info(
 }
 
 /// Handle responses from stack-stx and delegate-stack-stx -- functions that *lock up* STX
-fn handle_stack_lockup(
+fn handle_stack_lockup_pox_v2(
     global_context: &mut GlobalContext,
     function_name: &str,
     value: &Value,
@@ -735,7 +734,7 @@ fn handle_stack_lockup(
 
 /// Handle responses from stack-extend and delegate-stack-extend -- functions that *extend
 /// already-locked* STX.
-fn handle_stack_lockup_extension(
+fn handle_stack_lockup_extension_pox_v2(
     global_context: &mut GlobalContext,
     function_name: &str,
     value: &Value,
@@ -795,9 +794,9 @@ fn handle_stack_lockup_extension(
     }
 }
 
-/// Handle resposnes from stack-increase and delegate-stack-increase -- functions that *increase
+/// Handle responses from stack-increase and delegate-stack-increase -- functions that *increase
 /// already-locked* STX amounts.
-fn handle_stack_lockup_increase(
+fn handle_stack_lockup_increase_pox_v2(
     global_context: &mut GlobalContext,
     function_name: &str,
     value: &Value,
@@ -871,7 +870,7 @@ fn handle_pox_v2_api_contract_call(
             // for some reason.
             // Failure to synthesize an event due to a bug is *NOT* an excuse to crash the whole
             // network!  Event capture is not consensus-critical.
-            let event_info_opt = match synthesize_pox_2_event_info(
+            let event_info_opt = match synthesize_pox_2_or_3_event_info(
                 global_context,
                 contract_id,
                 sender_opt,
@@ -903,11 +902,265 @@ fn handle_pox_v2_api_contract_call(
 
     // Execute function specific logic to complete the lock-up
     let lock_event_opt = if function_name == "stack-stx" || function_name == "delegate-stack-stx" {
-        handle_stack_lockup(global_context, function_name, value)?
+        handle_stack_lockup_pox_v2(global_context, function_name, value)?
     } else if function_name == "stack-extend" || function_name == "delegate-stack-extend" {
-        handle_stack_lockup_extension(global_context, function_name, value)?
+        handle_stack_lockup_extension_pox_v2(global_context, function_name, value)?
     } else if function_name == "stack-increase" || function_name == "delegate-stack-increase" {
-        handle_stack_lockup_increase(global_context, function_name, value)?
+        handle_stack_lockup_increase_pox_v2(global_context, function_name, value)?
+    } else {
+        None
+    };
+
+    // append the lockup event, so it looks as if the print event happened before the lock-up
+    if let Some(batch) = global_context.event_batches.last_mut() {
+        if let Some(print_event) = print_event_opt {
+            batch.events.push(print_event);
+        }
+        if let Some(lock_event) = lock_event_opt {
+            batch.events.push(lock_event);
+        }
+    }
+
+    Ok(())
+}
+
+/////////////// PoX-3 //////////////////////////////////////////
+
+/// Handle responses from stack-stx and delegate-stack-stx in pox-3 -- functions that *lock up* STX
+fn handle_stack_lockup_pox_v3(
+    global_context: &mut GlobalContext,
+    function_name: &str,
+    value: &Value,
+) -> Result<Option<StacksTransactionEvent>> {
+    debug!(
+        "Handle special-case contract-call to {:?} {} (which returned {:?})",
+        boot_code_id(POX_3_NAME, global_context.mainnet),
+        function_name,
+        value
+    );
+    // applying a pox lock at this point is equivalent to evaluating a transfer
+    runtime_cost(
+        ClarityCostFunction::StxTransfer,
+        &mut global_context.cost_track,
+        1,
+    )?;
+
+    match parse_pox_stacking_result(value) {
+        Ok((stacker, locked_amount, unlock_height)) => {
+            match StacksChainState::pox_lock_v3(
+                &mut global_context.database,
+                &stacker,
+                locked_amount,
+                unlock_height as u64,
+            ) {
+                Ok(_) => {
+                    let event = StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(
+                        STXLockEventData {
+                            locked_amount,
+                            unlock_height,
+                            locked_address: stacker,
+                            contract_identifier: boot_code_id(POX_3_NAME, global_context.mainnet),
+                        },
+                    ));
+                    return Ok(Some(event));
+                }
+                Err(ChainstateError::DefunctPoxContract) => {
+                    return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None));
+                }
+                Err(ChainstateError::PoxAlreadyLocked) => {
+                    // the caller tried to lock tokens into multiple pox contracts
+                    return Err(Error::Runtime(RuntimeErrorType::PoxAlreadyLocked, None));
+                }
+                Err(e) => {
+                    panic!(
+                        "FATAL: failed to lock {} from {} until {}: '{:?}'",
+                        locked_amount, stacker, unlock_height, &e
+                    );
+                }
+            }
+        }
+        Err(_) => {
+            // nothing to do -- the function failed
+            return Ok(None);
+        }
+    }
+}
+
+/// Handle responses from stack-extend and delegate-stack-extend in pox-3 -- functions that *extend
+/// already-locked* STX.
+fn handle_stack_lockup_extension_pox_v3(
+    global_context: &mut GlobalContext,
+    function_name: &str,
+    value: &Value,
+) -> Result<Option<StacksTransactionEvent>> {
+    // in this branch case, the PoX-3 contract has stored the extension information
+    //  and performed the extension checks. Now, the VM needs to update the account locks
+    //  (because the locks cannot be applied directly from the Clarity code itself)
+    // applying a pox lock at this point is equivalent to evaluating a transfer
+    debug!(
+        "Handle special-case contract-call to {:?} {} (which returned {:?})",
+        boot_code_id("pox-3", global_context.mainnet),
+        function_name,
+        value
+    );
+
+    runtime_cost(
+        ClarityCostFunction::StxTransfer,
+        &mut global_context.cost_track,
+        1,
+    )?;
+
+    if let Ok((stacker, unlock_height)) = parse_pox_extend_result(value) {
+        match StacksChainState::pox_lock_extend_v3(
+            &mut global_context.database,
+            &stacker,
+            unlock_height as u64,
+        ) {
+            Ok(locked_amount) => {
+                let event = StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(
+                    STXLockEventData {
+                        locked_amount,
+                        unlock_height,
+                        locked_address: stacker,
+                        contract_identifier: boot_code_id("pox-3", global_context.mainnet),
+                    },
+                ));
+                return Ok(Some(event));
+            }
+            Err(ChainstateError::DefunctPoxContract) => {
+                return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None))
+            }
+            Err(e) => {
+                // Error results *other* than a DefunctPoxContract panic, because
+                //  those errors should have been caught by the PoX contract before
+                //  getting to this code path.
+                panic!(
+                    "FATAL: failed to extend lock from {} until {}: '{:?}'",
+                    stacker, unlock_height, &e
+                );
+            }
+        }
+    } else {
+        // The stack-extend function returned an error: we do not need to apply a lock
+        //  in this case, and can just return and let the normal VM codepath surface the
+        //  error response type.
+        return Ok(None);
+    }
+}
+
+/// Handle responses from stack-increase and delegate-stack-increase in PoX-3 -- functions
+/// that *increase already-locked* STX amounts.
+fn handle_stack_lockup_increase_pox_v3(
+    global_context: &mut GlobalContext,
+    function_name: &str,
+    value: &Value,
+) -> Result<Option<StacksTransactionEvent>> {
+    // in this branch case, the PoX-3 contract has stored the increase information
+    //  and performed the increase checks. Now, the VM needs to update the account locks
+    //  (because the locks cannot be applied directly from the Clarity code itself)
+    // applying a pox lock at this point is equivalent to evaluating a transfer
+    debug!(
+        "Handle special-case contract-call";
+        "contract" => ?boot_code_id("pox-3", global_context.mainnet),
+        "function" => function_name,
+        "return-value" => %value,
+    );
+
+    runtime_cost(
+        ClarityCostFunction::StxTransfer,
+        &mut global_context.cost_track,
+        1,
+    )?;
+
+    if let Ok((stacker, total_locked)) = parse_pox_increase(value) {
+        match StacksChainState::pox_lock_increase_v3(
+            &mut global_context.database,
+            &stacker,
+            total_locked,
+        ) {
+            Ok(new_balance) => {
+                let event = StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(
+                    STXLockEventData {
+                        locked_amount: new_balance.amount_locked(),
+                        unlock_height: new_balance.unlock_height(),
+                        locked_address: stacker,
+                        contract_identifier: boot_code_id("pox-3", global_context.mainnet),
+                    },
+                ));
+
+                return Ok(Some(event));
+            }
+            Err(ChainstateError::DefunctPoxContract) => {
+                return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None))
+            }
+            Err(e) => {
+                // Error results *other* than a DefunctPoxContract panic, because
+                //  those errors should have been caught by the PoX contract before
+                //  getting to this code path.
+                panic!(
+                    "FATAL: failed to increase lock from {}: '{:?}'",
+                    stacker, &e
+                );
+            }
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+/// Handle special cases when calling into the PoX-3 API contract
+fn handle_pox_v3_api_contract_call(
+    global_context: &mut GlobalContext,
+    sender_opt: Option<&PrincipalData>,
+    contract_id: &QualifiedContractIdentifier,
+    function_name: &str,
+    args: &[Value],
+    value: &Value,
+) -> Result<()> {
+    // Generate a synthetic print event for all functions that alter stacking state
+    let print_event_opt = if let Value::Response(response) = value {
+        if response.committed {
+            // method succeeded.  Synthesize event info, but default to no event report if we fail
+            // for some reason.
+            // Failure to synthesize an event due to a bug is *NOT* an excuse to crash the whole
+            // network!  Event capture is not consensus-critical.
+            let event_info_opt = match synthesize_pox_2_or_3_event_info(
+                global_context,
+                contract_id,
+                sender_opt,
+                function_name,
+                args,
+            ) {
+                Ok(Some(event_info)) => Some(event_info),
+                Ok(None) => None,
+                Err(e) => {
+                    error!("Failed to synthesize PoX-3 event info: {:?}", &e);
+                    None
+                }
+            };
+            if let Some(event_info) = event_info_opt {
+                let event_response =
+                    Value::okay(event_info).expect("FATAL: failed to construct (ok event-info)");
+                let tx_event =
+                    Environment::construct_print_transaction_event(contract_id, &event_response);
+                Some(tx_event)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Execute function specific logic to complete the lock-up
+    let lock_event_opt = if function_name == "stack-stx" || function_name == "delegate-stack-stx" {
+        handle_stack_lockup_pox_v3(global_context, function_name, value)?
+    } else if function_name == "stack-extend" || function_name == "delegate-stack-extend" {
+        handle_stack_lockup_extension_pox_v3(global_context, function_name, value)?
+    } else if function_name == "stack-increase" || function_name == "delegate-stack-increase" {
+        handle_stack_lockup_increase_pox_v3(global_context, function_name, value)?
     } else {
         None
     };
@@ -1003,6 +1256,18 @@ pub fn handle_contract_call_special_cases(
             return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None));
         }
 
+        return handle_pox_v2_api_contract_call(
+            global_context,
+            sender,
+            contract_id,
+            function_name,
+            args,
+            result,
+        );
+    } else if *contract_id == boot_code_id(POX_3_NAME, global_context.mainnet)
+        && global_context.database.get_pox_3_activation_height()
+            >= global_context.database.get_current_burnchain_block_height()
+    {
         return handle_pox_v2_api_contract_call(
             global_context,
             sender,

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -1264,10 +1264,13 @@ pub fn handle_contract_call_special_cases(
             args,
             result,
         );
-    } else if *contract_id == boot_code_id(POX_3_NAME, global_context.mainnet)
-        && global_context.database.get_pox_3_activation_height()
-            >= global_context.database.get_current_burnchain_block_height()
-    {
+    } else if *contract_id == boot_code_id(POX_3_NAME, global_context.mainnet) {
+        if global_context.database.get_current_burnchain_block_height()
+            < global_context.database.get_pox_3_activation_height()
+        {
+            warn!("PoX-3 contract invoked before PoX-3 activation height");
+            return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None));
+        }
         return handle_pox_v3_api_contract_call(
             global_context,
             sender,

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -48,7 +48,7 @@ use stacks_common::util::hash::Hash160;
 use crate::vm::costs::runtime_cost;
 
 /// Parse the returned value from PoX `stack-stx` and `delegate-stack-stx` functions
-///  from pox-2.clar into a format more readily digestible in rust.
+///  from pox-2.clar or pox-3.clar into a format more readily digestible in rust.
 /// Panics if the supplied value doesn't match the expected tuple structure
 fn parse_pox_stacking_result(
     result: &Value,
@@ -119,7 +119,7 @@ fn parse_pox_stacking_result_v1(
     }
 }
 
-/// Parse the returned value from PoX2 `stack-extend` and `delegate-stack-extend` functions
+/// Parse the returned value from PoX2 or PoX3 `stack-extend` and `delegate-stack-extend` functions
 ///  into a format more readily digestible in rust.
 /// Panics if the supplied value doesn't match the expected tuple structure
 fn parse_pox_extend_result(result: &Value) -> std::result::Result<(PrincipalData, u64), i128> {
@@ -1022,7 +1022,7 @@ fn handle_stack_lockup_extension_pox_v3(
                         locked_amount,
                         unlock_height,
                         locked_address: stacker,
-                        contract_identifier: boot_code_id("pox-3", global_context.mainnet),
+                        contract_identifier: boot_code_id(POX_3_NAME, global_context.mainnet),
                     },
                 ));
                 return Ok(Some(event));
@@ -1084,7 +1084,7 @@ fn handle_stack_lockup_increase_pox_v3(
                         locked_amount: new_balance.amount_locked(),
                         unlock_height: new_balance.unlock_height(),
                         locked_address: stacker,
-                        contract_identifier: boot_code_id("pox-3", global_context.mainnet),
+                        contract_identifier: boot_code_id(POX_3_NAME, global_context.mainnet),
                     },
                 ));
 
@@ -1268,7 +1268,7 @@ pub fn handle_contract_call_special_cases(
         && global_context.database.get_pox_3_activation_height()
             >= global_context.database.get_current_burnchain_block_height()
     {
-        return handle_pox_v2_api_contract_call(
+        return handle_pox_v3_api_contract_call(
             global_context,
             sender,
             contract_id,


### PR DESCRIPTION
### Description
Add handler functions in clarity_vm::special that carry out locks/extends/increases initiated in pox-3 by altering LockedPoxThree.

### Applicable issues
- fixes #3696

### Additional info (benefits, drawbacks, caveats)
- The function `handle_stack_lockup_extension_pox_v3` calls `pox_lock_extend_v3`, and the return matches on*`Err(ChainstateError::DefunctPoxContract)` . Looking at the code, it is impossible for that error to be returned. The handler function only makes write calls if the PoX contract is active. I copied the behavior that was there for v2 (perhaps this is a redundant safety check), but not sure if I need to leave it in. 

- I want to verify that this is the correct boolean condition to “gate” calling the pox-3 handler function:
`else if contract_id == boot_code_id(POX_3_NAME, global_context.mainnet)    && global_context.database.get_pox_3_activation_height()        >= global_context.database.get_current_burnchain_block_height()`
