### PR TITLE
feat: add `pox-3` to contract list in `/v2/pox` RPC response

### DIFF
--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -1135,7 +1135,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
 
             debug!("Epoch 2.3 initialized");
 
-            (old_cost_tracker, Ok(vec![pox_3_initialization_receipt]))
+            (old_cost_tracker, Ok(vec![]))
         })
     }
 
@@ -1160,7 +1160,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                 tx_conn.epoch = StacksEpochId::Epoch24;
             });
 
-             /////////////////// .pox-3 ////////////////////////
+            /////////////////// .pox-3 ////////////////////////
             let mainnet = self.mainnet;
             let first_block_height = self.burn_state_db.get_burn_start_height();
             let pox_prepare_length = self.burn_state_db.get_pox_prepare_length();
@@ -1273,7 +1273,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
 
             debug!("Epoch 2.4 initialized");
 
-            (old_cost_tracker, Ok(vec![]))
+            (old_cost_tracker, Ok(vec![pox_3_initialization_receipt]))
         })
     }
 

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -308,8 +308,7 @@ impl RPCPoxInfoData {
             .block_height_to_reward_cycle(burnchain.first_block_height as u64)
             .ok_or(net_error::ChainstateError(
                 "PoX-1 first reward cycle begins before first burn block height".to_string(),
-            ))?
-            + 1;
+            ))?;
 
         let pox_2_first_cycle = burnchain
             .block_height_to_reward_cycle(burnchain.pox_constants.v1_unlock_height as u64)

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -308,7 +308,8 @@ impl RPCPoxInfoData {
             .block_height_to_reward_cycle(burnchain.first_block_height as u64)
             .ok_or(net_error::ChainstateError(
                 "PoX-1 first reward cycle begins before first burn block height".to_string(),
-            ))?;
+            ))?
+            + 1;
 
         let pox_2_first_cycle = burnchain
             .block_height_to_reward_cycle(burnchain.pox_constants.v1_unlock_height as u64)

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -117,7 +117,7 @@ use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::Hash160;
 use stacks_common::util::hash::{hex_bytes, to_hex};
 
-use crate::chainstate::stacks::boot::{POX_1_NAME, POX_2_NAME};
+use crate::chainstate::stacks::boot::{POX_1_NAME, POX_2_NAME, POX_3_NAME};
 use crate::chainstate::stacks::StacksBlockHeader;
 use crate::clarity_vm::database::marf::MarfedKV;
 use stacks_common::types::chainstate::BlockHeaderHash;
@@ -316,6 +316,12 @@ impl RPCPoxInfoData {
                 "PoX-2 first reward cycle begins before first burn block height".to_string(),
             ))?
             + 1;
+
+        let pox_3_first_cycle = burnchain
+            .block_height_to_reward_cycle(burnchain.pox_constants.pox_3_activation_height as u64)
+            .ok_or(net_error::ChainstateError(
+                "PoX-3 first reward cycle begins before first burn block height".to_string(),
+            ))?;
 
         let data = chainstate
             .maybe_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {
@@ -519,6 +525,14 @@ impl RPCPoxInfoData {
                     activation_burnchain_block_height: burnchain.pox_constants.v1_unlock_height
                         as u64,
                     first_reward_cycle_id: pox_2_first_cycle,
+                },
+                RPCPoxContractVersion {
+                    contract_id: boot_code_id(POX_3_NAME, chainstate.mainnet).to_string(),
+                    activation_burnchain_block_height: burnchain
+                        .pox_constants
+                        .pox_3_activation_height
+                        as u64,
+                    first_reward_cycle_id: pox_3_first_cycle,
                 },
             ],
         })

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -321,7 +321,8 @@ impl RPCPoxInfoData {
             .block_height_to_reward_cycle(burnchain.pox_constants.pox_3_activation_height as u64)
             .ok_or(net_error::ChainstateError(
                 "PoX-3 first reward cycle begins before first burn block height".to_string(),
-            ))?;
+            ))?
+            + 1;
 
         let data = chainstate
             .maybe_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {


### PR DESCRIPTION
Adds a new `pox-3` entry to the `contract_versions` array returned by the `/v2/pox` RPC endpoint. Sample output from regtest/krypton node:

```json
{
  "contract_id": "ST000000000000000000002AMW42H.pox-2",
  "pox_activation_threshold_ustx": 600057388429055,
  "first_burnchain_block_height": 0,
  "current_burnchain_block_height": 111,
  "prepare_phase_block_length": 1,
  "reward_phase_block_length": 4,
  "reward_slots": 8,
  "rejection_fraction": 3333333333333333,
  "total_liquid_supply_ustx": 60005738842905576,
  "current_cycle": {
    "id": 22,
    "min_threshold_ustx": 1875180000000000,
    "stacked_ustx": 0,
    "is_pox_active": false
  },
  "next_cycle": {
    "id": 23,
    "min_threshold_ustx": 1875180000000000,
    "min_increment_ustx": 7500717355363,
    "stacked_ustx": 0,
    "prepare_phase_start_block_height": 114,
    "blocks_until_prepare_phase": 3,
    "reward_phase_start_block_height": 115,
    "blocks_until_reward_phase": 4,
    "ustx_until_pox_rejection": 8484139029839119000
  },
  "min_amount_ustx": 1875180000000000,
  "prepare_cycle_length": 1,
  "reward_cycle_id": 22,
  "reward_cycle_length": 5,
  "rejection_votes_left_required": 8484139029839119000,
  "next_reward_cycle_in": 4,
  "contract_versions": [
    {
      "contract_id": "ST000000000000000000002AMW42H.pox",
      "activation_burnchain_block_height": 0,
      "first_reward_cycle_id": 0
    },
    {
      "contract_id": "ST000000000000000000002AMW42H.pox-2",
      "activation_burnchain_block_height": 107,
      "first_reward_cycle_id": 22
    },
    {
      "contract_id": "ST000000000000000000002AMW42H.pox-3",
      "activation_burnchain_block_height": 3000000,
      "first_reward_cycle_id": 600000
    }
  ]
}
```

TODO: 
* [ ] Tests