### PR TITLE
3717 add length prefixing to contract names in peg in requests

### DIFF
--- a/src/chainstate/burn/operations/peg_in.rs
+++ b/src/chainstate/burn/operations/peg_in.rs
@@ -190,6 +190,8 @@ impl From<ClarityRuntimeError> for ParseError {
 
 #[cfg(test)]
 mod tests {
+    use rand::{distributions::Alphanumeric, Rng};
+
     use super::*;
     use crate::chainstate::burn::operations::test;
 
@@ -206,6 +208,7 @@ mod tests {
         let addr_bytes = test::random_bytes(&mut rng);
         let stx_address = StacksAddress::new(1, addr_bytes.into());
         data.extend_from_slice(&addr_bytes);
+        data.push(0); // Contract name not provided, so size is 0
 
         let tx = test::burnchain_transaction(data, Some(output2), opcode);
         let header = test::burnchain_block_header();
@@ -231,7 +234,7 @@ mod tests {
         let addr_bytes = test::random_bytes(&mut rng);
         let stx_address = StacksAddress::new(1, addr_bytes.into());
         data.extend_from_slice(&addr_bytes);
-        data.extend_from_slice(&[0; 40]); // Padding contract name
+        data.push(0); // Contract name not provided, so size is 0
         data.extend_from_slice(&memo);
 
         let tx = test::burnchain_transaction(data, Some(output2), opcode);
@@ -260,8 +263,8 @@ mod tests {
         let addr_bytes = test::random_bytes(&mut rng);
         let stx_address = StacksAddress::new(1, addr_bytes.into());
         data.extend_from_slice(&addr_bytes);
+        data.push(contract_name.len() as u8);
         data.extend_from_slice(contract_name.as_bytes());
-        data.extend_from_slice(&[0; 11]); // Padding contract name
         data.extend_from_slice(&memo);
 
         let tx = test::burnchain_transaction(data, Some(output2), opcode);
@@ -293,8 +296,8 @@ mod tests {
         let addr_bytes = test::random_bytes(&mut rng);
         let stx_address = StacksAddress::new(1, addr_bytes.into());
         data.extend_from_slice(&addr_bytes);
+        data.push(contract_name.len() as u8);
         data.extend_from_slice(contract_name.as_bytes());
-        data.extend_from_slice(&[0; 4]); // Padding contract name
         data.extend_from_slice(&memo);
 
         let tx = test::burnchain_transaction(data, Some(output2), opcode);
@@ -322,7 +325,7 @@ mod tests {
         let mut data = vec![1];
         let addr_bytes: [u8; 20] = test::random_bytes(&mut rng);
         data.extend_from_slice(&addr_bytes);
-        data.extend_from_slice(&[0; 40]); // Padding contract name
+        data.push(0); // Contract name not provided, so size is 0
         data.extend_from_slice(&memo);
 
         let tx = test::burnchain_transaction(data, Some(output2), opcode);
@@ -351,8 +354,8 @@ mod tests {
         let mut data = vec![1];
         let addr_bytes: [u8; 20] = test::random_bytes(&mut rng);
         data.extend_from_slice(&addr_bytes);
+        data.push(invalid_utf8_byte_sequence.len() as u8);
         data.extend_from_slice(&invalid_utf8_byte_sequence);
-        data.extend_from_slice(&[0; 40]); // Padding contract name
         data.extend_from_slice(&memo);
 
         let tx = test::burnchain_transaction(data, Some(output2), opcode);
@@ -376,7 +379,7 @@ mod tests {
         let mut data = vec![1];
         let addr_bytes: [u8; 20] = test::random_bytes(&mut rng);
         data.extend_from_slice(&addr_bytes);
-        data.extend_from_slice(&[0; 40]); // Padding contract name
+        data.push(0); // Contract name not provided, so size is 0
         data.extend_from_slice(&memo);
 
         let tx = test::burnchain_transaction(data, None, opcode);
@@ -425,7 +428,7 @@ mod tests {
         let addr_bytes = test::random_bytes(&mut rng);
         let stx_address = StacksAddress::new(1, addr_bytes.into());
         data.extend_from_slice(&addr_bytes);
-        data.extend_from_slice(&[0; 40]); // Padding contract name
+        data.push(0); // Contract name not provided, so size is 0
         data.extend_from_slice(&memo);
 
         let create_op = move |amount| {


### PR DESCRIPTION
### Description
Changes the way we store the contract name in the peg in wire format.

#### Before
Contract name is a 40 byte slice that needs to be zero padded.

#### After
Contract name is prefixed by a size byte and it doesn't need to be zero padded — thus saving space. Contract name is not specified if size is `0`.

### Applicable issues
- Closes https://github.com/stacks-network/stacks-blockchain/issues/3717

### Additional info (benefits, drawbacks, caveats)
- Original issue in core-eng https://github.com/Trust-Machines/core-eng/issues/342

### Checklist
- [x] Test coverage for new or modified code paths
- ~~[ ] Changelog is updated~~
- ~~[ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)~~

@netrome can you offer any guidance on 2 outstanding bullet points? I'm not sure if they're relevant at all. Also, I want to be extra considerate in asking for reviews. Do you know else could be the right person to review this?