### PR TITLE
Fix/increase delegation amount

### DIFF
--- a/src/chainstate/stacks/boot/pox-3.clar
+++ b/src/chainstate/stacks/boot/pox-3.clar
@@ -658,6 +658,8 @@
       ;; delegate-stack-* functions assert that
       ;; 1. users can't swim in two pools at the same time.
       ;; 2. users can't switch pools without cool down cycle.
+      ;;    Other pool admins can't increase or extend.
+      ;; 3. users can't join a pool while already directly stacking.
 
       ;; pox-addr, if given, must be valid
       (match pox-addr

--- a/src/chainstate/stacks/boot/pox_3_tests.rs
+++ b/src/chainstate/stacks/boot/pox_3_tests.rs
@@ -1829,7 +1829,7 @@ fn stack_increase() {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    // in the next tenure, PoX 2 should now exist.
+    // in the next tenure, PoX 3 should now exist.
     let tip = get_tip(peer.sortdb.as_ref());
 
     // submit an increase: this should fail, because Alice is not yet locked
@@ -2762,12 +2762,12 @@ fn delegate_extend_pox_3() {
 
     assert_eq!(
         alice_first_cycle as u64, first_v3_cycle,
-        "Alice's first cycle in PoX-2 stacking state is the next cycle, which is 8"
+        "Alice's first cycle in PoX-3 stacking state is the next cycle, which is 12"
     );
     assert_eq!(alice_lock_period, 6);
     assert_eq!(
         bob_first_cycle as u64, first_v3_cycle,
-        "Bob's first cycle in PoX-2 stacking state is the next cycle, which is 8"
+        "Bob's first cycle in PoX-3 stacking state is the next cycle, which is 12"
     );
     assert_eq!(bob_lock_period, 3);
 


### PR DESCRIPTION
### Description
In epoch 2.4, pox-3 should allow to increase the delegation amount so that users can compound rewards.

This PR
* allows users to change all delegation data (after user revoke permission)

The required assertions to prevent swimming in two pools at the same time or to change the pool without a cool down cycle are already present in pox-3.
