### PR TITLE
add more test coverage for epoch 2.4

### DIFF
--- a/clarity/src/vm/test_util/mod.rs
+++ b/clarity/src/vm/test_util/mod.rs
@@ -39,6 +39,21 @@ pub const TEST_BURN_STATE_DB_21: UnitTestBurnStateDB = UnitTestBurnStateDB {
     ast_rules: ASTRules::PrecheckSize,
 };
 
+pub fn generate_test_burn_state_db(epoch_id: StacksEpochId) -> UnitTestBurnStateDB {
+    match epoch_id {
+        StacksEpochId::Epoch20 => UnitTestBurnStateDB {
+            epoch_id,
+            ast_rules: ASTRules::Typical,
+        },
+        StacksEpochId::Epoch2_05  | StacksEpochId::Epoch21 | StacksEpochId::Epoch22 |
+        StacksEpochId::Epoch23 | StacksEpochId::Epoch24 => UnitTestBurnStateDB {
+            epoch_id,
+            ast_rules: ASTRules::PrecheckSize
+        },
+        _ => panic!("Epoch {} not covered", &epoch_id),
+    }
+}
+
 pub fn execute(s: &str) -> Value {
     vm_execute(s).unwrap().unwrap()
 }

--- a/clarity/src/vm/tests/traits.rs
+++ b/clarity/src/vm/tests/traits.rs
@@ -41,7 +41,17 @@ use crate::vm::ContractContext;
 #[case(ClarityVersion::Clarity2, StacksEpochId::Epoch22)]
 #[case(ClarityVersion::Clarity1, StacksEpochId::Epoch23)]
 #[case(ClarityVersion::Clarity2, StacksEpochId::Epoch23)]
+#[case(ClarityVersion::Clarity1, StacksEpochId::Epoch24)]
+#[case(ClarityVersion::Clarity2, StacksEpochId::Epoch24)]
 fn test_epoch_clarity_versions(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId) {}
+
+#[template]
+#[rstest]
+#[case(StacksEpochId::Epoch21)]
+#[case(StacksEpochId::Epoch22)]
+#[case(StacksEpochId::Epoch23)]
+#[case(StacksEpochId::Epoch24)]
+fn test_epoch_only_clarity_2(#[case] epoch: StacksEpochId) {}
 
 #[apply(test_epoch_clarity_versions)]
 fn test_trait_basics(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId) {
@@ -74,8 +84,8 @@ fn test_trait_basics(#[case] version: ClarityVersion, #[case] epoch: StacksEpoch
     }
 }
 
-#[test]
-fn test_clarity2() {
+#[apply(test_epoch_only_clarity_2)]
+fn test_clarity2(#[case] epoch: StacksEpochId) {
     let to_test = [
         test_pass_principal_literal_to_trait,
         test_pass_trait_to_subtrait,
@@ -90,7 +100,7 @@ fn test_clarity2() {
         test_let3_trait,
     ];
     for test in to_test.iter() {
-        with_memory_environment(test, StacksEpochId::latest(), false);
+        with_memory_environment(test, epoch, false);
     }
 }
 

--- a/src/clarity_vm/tests/ast.rs
+++ b/src/clarity_vm/tests/ast.rs
@@ -19,6 +19,12 @@ use rstest_reuse::{self, *};
 #[case(ClarityVersion::Clarity1, StacksEpochId::Epoch2_05)]
 #[case(ClarityVersion::Clarity1, StacksEpochId::Epoch21)]
 #[case(ClarityVersion::Clarity2, StacksEpochId::Epoch21)]
+#[case(ClarityVersion::Clarity1, StacksEpochId::Epoch22)]
+#[case(ClarityVersion::Clarity2, StacksEpochId::Epoch22)]
+#[case(ClarityVersion::Clarity1, StacksEpochId::Epoch23)]
+#[case(ClarityVersion::Clarity2, StacksEpochId::Epoch23)]
+#[case(ClarityVersion::Clarity1, StacksEpochId::Epoch24)]
+#[case(ClarityVersion::Clarity2, StacksEpochId::Epoch24)]
 fn test_edge_counting_runtime_template(
     #[case] version: ClarityVersion,
     #[case] epoch: StacksEpochId,

--- a/src/clarity_vm/tests/large_contract.rs
+++ b/src/clarity_vm/tests/large_contract.rs
@@ -61,6 +61,12 @@ use crate::util_lib::boot::boot_code_id;
 #[case(ClarityVersion::Clarity1, StacksEpochId::Epoch2_05)]
 #[case(ClarityVersion::Clarity1, StacksEpochId::Epoch21)]
 #[case(ClarityVersion::Clarity2, StacksEpochId::Epoch21)]
+#[case(ClarityVersion::Clarity1, StacksEpochId::Epoch22)]
+#[case(ClarityVersion::Clarity2, StacksEpochId::Epoch22)]
+#[case(ClarityVersion::Clarity1, StacksEpochId::Epoch23)]
+#[case(ClarityVersion::Clarity2, StacksEpochId::Epoch23)]
+#[case(ClarityVersion::Clarity1, StacksEpochId::Epoch24)]
+#[case(ClarityVersion::Clarity2, StacksEpochId::Epoch24)]
 fn clarity_version_template(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId) {}
 
 fn test_block_headers(n: u8) -> StacksBlockId {
@@ -116,12 +122,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion, #[case] epoch: Stac
             .unwrap(),
     );
     let contract_identifier = QualifiedContractIdentifier::local("tokens").unwrap();
-    let burn_db = match epoch {
-        StacksEpochId::Epoch20 => &TEST_BURN_STATE_DB,
-        StacksEpochId::Epoch2_05 => &TEST_BURN_STATE_DB_205,
-        StacksEpochId::Epoch21 => &TEST_BURN_STATE_DB_21,
-        _ => panic!("Epoch {} not covered", &epoch),
-    };
+    let burn_db = &generate_test_burn_state_db(epoch);
 
     let mut gb = clarity.begin_test_genesis_block(
         &StacksBlockId::sentinel(),
@@ -137,45 +138,49 @@ fn test_simple_token_system(#[case] version: ClarityVersion, #[case] epoch: Stac
         })
         .unwrap();
 
-        if epoch == StacksEpochId::Epoch2_05 {
-            let (ast, _analysis) = tx
-                .analyze_smart_contract(
+        match epoch {
+            StacksEpochId::Epoch2_05 => {
+                let (ast, _analysis) = tx
+                    .analyze_smart_contract(
+                        &boot_code_id("costs-2", false),
+                        ClarityVersion::Clarity1,
+                        BOOT_CODE_COSTS_2,
+                        ASTRules::PrecheckSize,
+                    )
+                    .unwrap();
+                tx.initialize_smart_contract(
                     &boot_code_id("costs-2", false),
                     ClarityVersion::Clarity1,
+                    &ast,
                     BOOT_CODE_COSTS_2,
-                    ASTRules::PrecheckSize,
+                    None,
+                    |_, _| false,
                 )
-                .unwrap();
-            tx.initialize_smart_contract(
-                &boot_code_id("costs-2", false),
-                ClarityVersion::Clarity1,
-                &ast,
-                BOOT_CODE_COSTS_2,
-                None,
-                |_, _| false,
-            )
-            .unwrap();
-        }
-
-        if epoch == StacksEpochId::Epoch21 {
-            let (ast, _analysis) = tx
-                .analyze_smart_contract(
+                    .unwrap();
+            }
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 |
+            StacksEpochId::Epoch23 | StacksEpochId::Epoch24 => {
+                let (ast, _analysis) = tx
+                    .analyze_smart_contract(
+                        &boot_code_id("costs-3", false),
+                        ClarityVersion::Clarity2,
+                        BOOT_CODE_COSTS_3,
+                        ASTRules::PrecheckSize,
+                    )
+                    .unwrap();
+                tx.initialize_smart_contract(
                     &boot_code_id("costs-3", false),
                     ClarityVersion::Clarity2,
+                    &ast,
                     BOOT_CODE_COSTS_3,
-                    ASTRules::PrecheckSize,
+                    None,
+                    |_, _| false,
                 )
-                .unwrap();
-            tx.initialize_smart_contract(
-                &boot_code_id("costs-3", false),
-                ClarityVersion::Clarity2,
-                &ast,
-                BOOT_CODE_COSTS_3,
-                None,
-                |_, _| false,
-            )
-            .unwrap();
+                    .unwrap();
+            }
+            _ => panic!("Epoch {} not covered.", &epoch),
         }
+
     });
 
     gb.commit_block();
@@ -674,12 +679,7 @@ pub fn rollback_log_memory_test(
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let EXPLODE_N = 100;
-    let burn_db = match epoch_id {
-        StacksEpochId::Epoch20 => &TEST_BURN_STATE_DB,
-        StacksEpochId::Epoch2_05 => &TEST_BURN_STATE_DB_205,
-        StacksEpochId::Epoch21 => &TEST_BURN_STATE_DB_21,
-        _ => panic!("Epoch {} not covered", &epoch_id),
-    };
+    let burn_db = &generate_test_burn_state_db(epoch_id);
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
     clarity_instance
@@ -748,12 +748,7 @@ pub fn let_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_id
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let EXPLODE_N = 100;
-    let burn_db = match epoch_id {
-        StacksEpochId::Epoch20 => &TEST_BURN_STATE_DB,
-        StacksEpochId::Epoch2_05 => &TEST_BURN_STATE_DB_205,
-        StacksEpochId::Epoch21 => &TEST_BURN_STATE_DB_21,
-        _ => panic!("Epoch {} not covered", &epoch_id),
-    };
+    let burn_db = &generate_test_burn_state_db(epoch_id);
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -833,12 +828,7 @@ pub fn argument_memory_test(
     let EXPLODE_N = 100;
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
-    let burn_db = match epoch_id {
-        StacksEpochId::Epoch20 => &TEST_BURN_STATE_DB,
-        StacksEpochId::Epoch2_05 => &TEST_BURN_STATE_DB_205,
-        StacksEpochId::Epoch21 => &TEST_BURN_STATE_DB_21,
-        _ => panic!("Epoch {} not covered", &epoch_id),
-    };
+    let burn_db = &generate_test_burn_state_db(epoch_id);
 
     clarity_instance
         .begin_test_genesis_block(
@@ -912,12 +902,7 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let COUNT_PER_FUNC = 10;
     let FUNCS = 10;
-    let burn_db = match epoch_id {
-        StacksEpochId::Epoch20 => &TEST_BURN_STATE_DB,
-        StacksEpochId::Epoch2_05 => &TEST_BURN_STATE_DB_205,
-        StacksEpochId::Epoch21 => &TEST_BURN_STATE_DB_21,
-        _ => panic!("Epoch {} not covered", &epoch_id),
-    };
+    let burn_db = &generate_test_burn_state_db(epoch_id);
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -1037,12 +1022,7 @@ pub fn ccall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let COUNT_PER_CONTRACT = 20;
     let CONTRACTS = 5;
-    let burn_db = match epoch_id {
-        StacksEpochId::Epoch20 => &TEST_BURN_STATE_DB,
-        StacksEpochId::Epoch2_05 => &TEST_BURN_STATE_DB_205,
-        StacksEpochId::Epoch21 => &TEST_BURN_STATE_DB_21,
-        _ => panic!("Epoch {} not covered", &epoch_id),
-    };
+    let burn_db = &generate_test_burn_state_db(epoch_id);
 
     clarity_instance
         .begin_test_genesis_block(


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
Ensures that epoch 2.4 case is added to various places in Clarity VM tests as well as in trait testing module. 