### PR TITLE
Reduce test flakiness in CI

### DIFF
--- a/testnet/stacks-node/src/tests/epoch_22.rs
+++ b/testnet/stacks-node/src/tests/epoch_22.rs
@@ -809,6 +809,7 @@ fn pox_2_unlock_all() {
     // *now* advance to 2.1
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
     info!("Test passed processing 2.1");
 
@@ -845,6 +846,7 @@ fn pox_2_unlock_all() {
     );
 
     info!("Submit 2.1 stacking tx to {:?}", &http_origin);
+    sleep_ms(5_000);
     submit_tx(&http_origin, &tx);
 
     let tx = make_contract_call(

--- a/testnet/stacks-node/src/tests/epoch_23.rs
+++ b/testnet/stacks-node/src/tests/epoch_23.rs
@@ -20,6 +20,7 @@ use std::thread;
 use stacks::burnchains::Burnchain;
 use stacks::core::STACKS_EPOCH_MAX;
 use stacks::vm::types::QualifiedContractIdentifier;
+use stacks::util::sleep_ms;
 
 use crate::config::EventKeyType;
 use crate::config::EventObserverConfig;
@@ -436,6 +437,8 @@ fn trait_invocation_behavior() {
     // stacks node to mine the stacks block which will be included in
     // epoch_2_3 - 1, so these are the last transactions processed pre-2.3.
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    // this sleep is placed here to reduce test flakiness
+    sleep_ms(10_000);
 
     let tx_3 = make_contract_call(
         &spender_sk,

--- a/testnet/stacks-node/src/tests/epoch_23.rs
+++ b/testnet/stacks-node/src/tests/epoch_23.rs
@@ -19,8 +19,8 @@ use std::thread;
 
 use stacks::burnchains::Burnchain;
 use stacks::core::STACKS_EPOCH_MAX;
-use stacks::vm::types::QualifiedContractIdentifier;
 use stacks::util::sleep_ms;
+use stacks::vm::types::QualifiedContractIdentifier;
 
 use crate::config::EventKeyType;
 use crate::config::EventObserverConfig;

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -9667,7 +9667,7 @@ fn test_problematic_microblocks_are_not_mined() {
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
             let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             if let TransactionPayload::SmartContract(..) = &parsed.payload {
-                assert!(parsed.txid() != tx_high_txid);
+                assert_ne!(parsed.txid(), tx_high_txid);
             }
         }
     }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -9634,8 +9634,13 @@ fn test_problematic_microblocks_are_not_mined() {
         let (mut new_files, cur_files_new) = find_new_files(bad_blocks_dir, &cur_files_old);
         all_new_files.append(&mut new_files);
         cur_files = cur_files_new;
+
+        // give the microblock miner a chance
+        sleep_ms(5_000);
     }
 
+    // sleep a little longer before checking tip info; this should help with test flakiness
+    sleep_ms(10_000);
     let tip_info = get_chain_info(&conf);
 
     // all microblocks were processed

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -2046,8 +2046,6 @@ fn bitcoind_resubmission_test() {
 
         let (consensus_hash, stacks_block) = get_tip_anchored_block(&conf);
 
-        //        let tip_hash = StacksBlockId::new(&consensus_hash, &stacks_block.header.block_hash());
-
         let ublock_privk =
             find_microblock_privkey(&conf, &stacks_block.header.microblock_pubkey_hash, 1024)
                 .unwrap();
@@ -10042,6 +10040,8 @@ fn test_problematic_microblocks_are_not_relayed_or_stored() {
         sleep_ms(5_000);
     }
 
+    // sleep a little longer before checking tip info; this should help with test flakiness
+    sleep_ms(10_000);
     let tip_info = get_chain_info(&conf);
 
     // all microblocks were processed


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
I'm attempting to lower the flakiness by adding some sleep statements in the following three tests:
- test_problematic_microblocks_are_not_relayed_or_stored
- epoch_23::trait_invocation_behavior
- epoch_22: pox_2_unlock_all