### PR TITLE
Epoch 3.0

### DIFF
--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -133,7 +133,7 @@ pub fn run_analysis(
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 TypeChecker2_05::run_pass(&epoch, &mut contract_analysis, db)
             }
-            StacksEpochId::Epoch21 => TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db),
             StacksEpochId::Epoch10 => unreachable!("Epoch 1.0 is not a valid epoch for analysis"),
         }?;
         TraitChecker::run_pass(&epoch, &mut contract_analysis, db)?;

--- a/clarity/src/vm/analysis/type_checker/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/mod.rs
@@ -49,7 +49,7 @@ impl FunctionType {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 self.check_args_2_05(accounting, args)
             }
-            StacksEpochId::Epoch21 => self.check_args_2_1(accounting, args, clarity_version),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => self.check_args_2_1(accounting, args, clarity_version),
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),
         }
     }
@@ -65,7 +65,7 @@ impl FunctionType {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 self.check_args_by_allowing_trait_cast_2_05(db, func_args)
             }
-            StacksEpochId::Epoch21 => {
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => {
                 self.check_args_by_allowing_trait_cast_2_1(db, clarity_version, func_args)
             }
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -50,6 +50,7 @@ pub const CLARITY_MEMORY_LIMIT: u64 = 100 * 1000 * 1000;
 pub const COSTS_1_NAME: &'static str = "costs";
 pub const COSTS_2_NAME: &'static str = "costs-2";
 pub const COSTS_3_NAME: &'static str = "costs-3";
+pub const COSTS_4_NAME: &'static str = "costs-4";
 
 lazy_static! {
     static ref COST_TUPLE_TYPE_SIGNATURE: TypeSignature = TypeSignature::TupleType(
@@ -701,6 +702,7 @@ impl LimitedCostTracker {
             StacksEpochId::Epoch20 => COSTS_1_NAME.to_string(),
             StacksEpochId::Epoch2_05 => COSTS_2_NAME.to_string(),
             StacksEpochId::Epoch21 => COSTS_3_NAME.to_string(),
+            StacksEpochId::Epoch30 => COSTS_4_NAME.to_string()
         }
     }
 }

--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -53,8 +53,8 @@ macro_rules! switch_on_global_epoch {
                 }
                 StacksEpochId::Epoch20 => $Epoch2Version(args, env, context),
                 StacksEpochId::Epoch2_05 => $Epoch205Version(args, env, context),
-                // Note: We reuse 2.05 for 2.1.
-                StacksEpochId::Epoch21 => $Epoch205Version(args, env, context),
+                // Note: We reuse 2.05 for 2.1 and 3.0.
+                StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => $Epoch205Version(args, env, context),
             }
         }
     };

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -531,7 +531,7 @@ impl TypeSignature {
     pub fn admits_type(&self, epoch: &StacksEpochId, other: &TypeSignature) -> Result<bool> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => self.admits_type_v2_0(&other),
-            StacksEpochId::Epoch21 => self.admits_type_v2_1(other),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => self.admits_type_v2_1(other),
             StacksEpochId::Epoch10 => unreachable!("epoch 1.0 not supported"),
         }
     }
@@ -1047,7 +1047,7 @@ impl TypeSignature {
     ) -> Result<TypeSignature> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => Self::least_supertype_v2_0(a, b),
-            StacksEpochId::Epoch21 => Self::least_supertype_v2_1(a, b),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => Self::least_supertype_v2_1(a, b),
             StacksEpochId::Epoch10 => unreachable!("Clarity 1.0 is not supported"),
         }
     }

--- a/clarity/src/vm/version.rs
+++ b/clarity/src/vm/version.rs
@@ -33,6 +33,7 @@ impl ClarityVersion {
             StacksEpochId::Epoch20 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch2_05 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch21 => ClarityVersion::Clarity2,
+            StacksEpochId::Epoch30 => ClarityVersion::Clarity2,
         }
     }
 }

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -3004,6 +3004,8 @@ impl SortitionDB {
             }
             StacksEpochId::Epoch2_05 => version == "2" || version == "3" || version == "4",
             StacksEpochId::Epoch21 => version == "5",
+            // I'm assuming 3.0 will have a new database version?
+            StacksEpochId::Epoch30 => todo!()
         }
     }
 
@@ -9999,7 +10001,11 @@ pub mod tests {
         let mut db = SortitionDB::connect_test_with_epochs(
             first_block_height,
             &first_block_header.block_hash,
-            StacksEpoch::all(0, 0, 0),
+            StacksEpoch::all(
+                0, 
+                0, 
+                0, 
+                0),
         )
         .unwrap();
 

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -43,7 +43,7 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::index::storage::TrieFileStorage;
 use crate::chainstate::stacks::{StacksPrivateKey, StacksPublicKey};
 use crate::codec::{write_next, Error as codec_error, StacksMessageCodec};
-use crate::core::{StacksEpoch, StacksEpochId};
+use crate::core::{StacksEpoch, StacksEpochId, STACKS_EPOCH_3_0_MARKER};
 use crate::core::{STACKS_EPOCH_2_05_MARKER, STACKS_EPOCH_2_1_MARKER};
 use crate::net::Error as net_error;
 use crate::types::chainstate::TrieHash;
@@ -754,7 +754,7 @@ impl LeaderBlockCommitOp {
             }
             StacksEpochId::Epoch2_05 => self.check_epoch_commit_marker(STACKS_EPOCH_2_05_MARKER),
             StacksEpochId::Epoch21 => self.check_epoch_commit_marker(STACKS_EPOCH_2_1_MARKER),
-            StacksEpochId::Epoch30 => todo!()
+            StacksEpochId::Epoch30 => self.check_epoch_commit_marker(STACKS_EPOCH_3_0_MARKER)
         }
     }
 

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -754,6 +754,7 @@ impl LeaderBlockCommitOp {
             }
             StacksEpochId::Epoch2_05 => self.check_epoch_commit_marker(STACKS_EPOCH_2_05_MARKER),
             StacksEpochId::Epoch21 => self.check_epoch_commit_marker(STACKS_EPOCH_2_1_MARKER),
+            StacksEpochId::Epoch30 => todo!()
         }
     }
 
@@ -768,6 +769,9 @@ impl LeaderBlockCommitOp {
     ) -> Result<SortitionId, op_error> {
         let tx_tip = tx.context.chain_tip.clone();
         let intended_sortition = match epoch_id {
+            StacksEpochId::Epoch30 => {
+                todo!()
+            }
             StacksEpochId::Epoch21 => {
                 // correct behavior -- uses *sortition height* to find the intended sortition ID
                 let sortition_height = self
@@ -1868,7 +1872,11 @@ mod tests {
         let mut db = SortitionDB::connect_test_with_epochs(
             first_block_height,
             &first_burn_hash,
-            StacksEpoch::all(0, 0, first_block_height),
+            StacksEpoch::all(
+                0, 
+                0, 
+                first_block_height, 
+                first_block_height + 100),
         )
         .unwrap();
         let block_ops = vec![

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -2108,8 +2108,6 @@ impl<
         &mut self,
         already_processed_burn_blocks: &mut HashSet<BurnchainHeaderHash>,
     ) -> Result<Option<BlockHeaderHash>, Error> {
-        debug!("Handle new burnchain block");
-
         let last_2_05_rc = self.sortition_db.get_last_epoch_2_05_reward_cycle()?;
 
         // first, see if the canonical affirmation map has changed.  If so, this will wind back the
@@ -2124,6 +2122,7 @@ impl<
                 )),
             None => SortitionDB::get_canonical_burn_chain_tip(&self.sortition_db.conn())?,
         };
+
         let cur_epoch = SortitionDB::get_stacks_epoch(
             self.sortition_db.conn(),
             before_canonical_snapshot.block_height,

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -2992,7 +2992,8 @@ impl<
                                 {
                                     return Ok(Some(pox_anchor));
                                 }
-                            }
+                            },
+                            StacksEpochId::Epoch30 => todo!()
                         }
                     }
                 }

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -302,6 +302,7 @@ pub fn setup_states_with_epochs(
     let mut others = vec![];
 
     for path in paths.iter() {
+        trace!("Processing path '{}'", path);
         let burnchain = get_burnchain(path, pox_consts.clone());
         let epochs = epochs_opt.clone().unwrap_or(StacksEpoch::unit_test(
             stacks_epoch_id,
@@ -1644,7 +1645,7 @@ fn late_block_commits_2_1() {
             0, 
             0, 
             0, 
-            0)),
+            10_000)),
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf));
@@ -4623,6 +4624,7 @@ fn test_epoch_verify_active_pox_contract() {
     ];
 
     let first_block_ht = burnchain_conf.first_block_height;
+
     setup_states_with_epochs(
         &[path],
         &vrf_keys,
@@ -4639,8 +4641,8 @@ fn test_epoch_verify_active_pox_contract() {
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf.clone()));
-
-    coord.handle_new_burnchain_block().unwrap();
+    
+    coord.handle_new_burnchain_block().unwrap(); // here
 
     let sort_db = get_sortition_db(path, pox_consts.clone());
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -281,7 +281,11 @@ pub fn setup_states_2_1(
         pox_consts,
         initial_balances,
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 0)),
+        Some(StacksEpoch::all(
+            0, 
+            0, 
+            0, 
+            0)),
     )
 }
 
@@ -972,7 +976,11 @@ fn missed_block_commits_2_05() {
         pox_consts.clone(),
         Some(initial_balances),
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 1000000)),
+        Some(StacksEpoch::all(
+            0, 
+            0, 
+            1000000,
+            2000000)),
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf.clone()));
@@ -1288,7 +1296,11 @@ fn missed_block_commits_2_1() {
         pox_consts.clone(),
         Some(initial_balances),
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 0)),
+        Some(StacksEpoch::all(
+            0, 
+            0, 
+            0, 
+            0)),
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf));
@@ -1628,7 +1640,11 @@ fn late_block_commits_2_1() {
         pox_consts.clone(),
         Some(initial_balances),
         StacksEpochId::Epoch21,
-        Some(StacksEpoch::all(0, 0, 0)),
+        Some(StacksEpoch::all(
+            0, 
+            0, 
+            0, 
+            0)),
     );
 
     let mut coord = make_coordinator(path, Some(burnchain_conf));
@@ -4618,6 +4634,7 @@ fn test_epoch_verify_active_pox_contract() {
             first_block_ht,
             first_block_ht + 4,
             first_block_ht + 8,
+            first_block_ht + 16
         )),
     );
 
@@ -5206,7 +5223,11 @@ fn test_sortition_with_sunset_and_epoch_switch() {
         pox_consts.clone(),
         None,
         StacksEpochId::Epoch20,
-        Some(StacksEpoch::all(0, 5, epoch_switch_ht)),
+        Some(StacksEpoch::all(
+            0, 
+            5, 
+            epoch_switch_ht, 
+            80)),
     );
 
     let mut coord = make_reward_set_coordinator(path, reward_set, pox_consts.clone());

--- a/src/chainstate/stacks/boot/costs-4.clar
+++ b/src/chainstate/stacks/boot/costs-4.clar
@@ -1,0 +1,657 @@
+
+;; TODO:
+;; PLACEHOLDER FOR THE costs-4 CONTRACT.
+;; A COPY OF costs-3 CONTRACT UNTIL THE TIME
+;; THAT costs-4 CAN BE GENERATED USING THE NEW
+;; CLARITY-WASM RUNTIME
+
+;; Helper Functions
+
+;; Return a Cost Specification with just a runtime cost
+(define-private (runtime (r uint))
+    {
+        runtime: r,
+        write_length: u0,
+        write_count: u0,
+        read_count: u0,
+        read_length: u0,
+    })
+
+;; Linear cost-assessment function
+(define-private (linear (n uint) (a uint) (b uint))
+    (+ (* a n) b))
+
+;; LogN cost-assessment function
+(define-private (logn (n uint) (a uint) (b uint))
+    (+ (* a (log2 n)) b))
+
+;; NLogN cost-assessment function
+(define-private (nlogn (n uint) (a uint) (b uint))
+    (+ (* a (* n (log2 n))) b))
+
+
+;; Cost Functions
+(define-read-only (cost_analysis_type_annotate (n uint))
+    (runtime (linear n u1 u9)))
+
+(define-read-only (cost_analysis_type_check (n uint))
+    (runtime (linear n u113 u1)))
+
+(define-read-only (cost_analysis_type_lookup (n uint))
+    (runtime (linear n u1 u4)))
+
+(define-read-only (cost_analysis_visit (n uint))
+    (runtime u1))
+
+(define-read-only (cost_analysis_iterable_func (n uint))
+    (runtime (linear n u2 u14)))
+
+(define-read-only (cost_analysis_option_cons (n uint))
+    (runtime u5))
+
+(define-read-only (cost_analysis_option_check (n uint))
+    (runtime u4))
+
+(define-read-only (cost_analysis_bind_name (n uint))
+    (runtime (linear n u1 u59)))
+
+(define-read-only (cost_analysis_list_items_check (n uint))
+    (runtime (linear n u2 u4)))
+
+(define-read-only (cost_analysis_check_tuple_get (n uint))
+    (runtime (logn n u1 u2)))
+
+(define-read-only (cost_analysis_check_tuple_merge (n uint))
+    (runtime (nlogn n u45 u49)))
+
+(define-read-only (cost_analysis_check_tuple_cons (n uint))
+    (runtime (nlogn n u3 u5)))
+
+(define-read-only (cost_analysis_tuple_items_check (n uint))
+    (runtime (linear n u1 u28)))
+
+(define-read-only (cost_analysis_check_let (n uint))
+    (runtime (linear n u1 u10)))
+
+(define-read-only (cost_analysis_lookup_function (n uint))
+    (runtime u18))
+
+(define-read-only (cost_analysis_lookup_function_types (n uint))
+    (runtime (linear n u1 u26)))
+
+(define-read-only (cost_analysis_lookup_variable_const (n uint))
+    (runtime u15))
+
+(define-read-only (cost_analysis_lookup_variable_depth (n uint))
+    (runtime (nlogn n u1 u12)))
+
+(define-read-only (cost_ast_parse (n uint))
+    (runtime (linear n u27 u81)))
+
+(define-read-only (cost_ast_cycle_detection (n uint))
+    (runtime (linear n u141 u72)))
+
+(define-read-only (cost_analysis_storage (n uint))
+    {
+        runtime: (linear n u2 u94),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_analysis_use_trait_entry (n uint))
+    {
+        runtime: (linear n u9 u698),
+        write_length: (linear n u1 u1),
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+(define-read-only (cost_analysis_fetch_contract_entry (n uint))
+    {
+        runtime: (linear n u1 u1516),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+(define-read-only (cost_analysis_get_function_entry (n uint))
+    {
+        runtime: (linear n u78 u1307),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+(define-read-only (cost_lookup_variable_depth (n uint))
+    (runtime (linear n u1 u1)))
+
+(define-read-only (cost_lookup_variable_size (n uint))
+    (runtime (linear n u2 u1)))
+
+(define-read-only (cost_lookup_function (n uint))
+    (runtime u16))
+
+(define-read-only (cost_bind_name (n uint))
+    (runtime u216))
+
+(define-read-only (cost_inner_type_check_cost (n uint))
+    (runtime (linear n u2 u5)))
+
+(define-read-only (cost_user_function_application (n uint))
+    (runtime (linear n u26 u5)))
+
+(define-read-only (cost_let (n uint))
+    (runtime (linear n u117 u178)))
+
+(define-read-only (cost_if (n uint))
+    (runtime u168))
+
+(define-read-only (cost_asserts (n uint))
+    (runtime u128))
+
+(define-read-only (cost_map (n uint))
+    (runtime (linear n u1198 u3067)))
+
+(define-read-only (cost_filter (n uint))
+    (runtime u407))
+
+(define-read-only (cost_len (n uint))
+    (runtime u429))
+
+(define-read-only (cost_element_at (n uint))
+    (runtime u498))
+
+(define-read-only (cost_index_of (n uint))
+    (runtime (linear n u1 u211)))
+
+(define-read-only (cost_fold (n uint))
+    (runtime u460))
+
+(define-read-only (cost_list_cons (n uint))
+    (runtime (linear n u14 u164)))
+
+(define-read-only (cost_type_parse_step (n uint))
+    (runtime u4))
+
+(define-read-only (cost_tuple_get (n uint))
+    (runtime (nlogn n u4 u1736)))
+
+(define-read-only (cost_tuple_merge (n uint))
+    (runtime (linear n u4 u408)))
+
+(define-read-only (cost_tuple_cons (n uint))
+    (runtime (nlogn n u10 u1876)))
+
+(define-read-only (cost_add (n uint))
+    (runtime (linear n u11 u125)))
+
+(define-read-only (cost_sub (n uint))
+    (runtime (linear n u11 u125)))
+
+(define-read-only (cost_mul (n uint))
+    (runtime (linear n u13 u125)))
+
+(define-read-only (cost_div (n uint))
+    (runtime (linear n u13 u125)))
+
+(define-read-only (cost_geq (n uint))
+    (runtime (linear n u7 u128)))
+
+(define-read-only (cost_leq (n uint))
+    (runtime (linear n u7 u128)))
+
+(define-read-only (cost_le (n uint))
+    (runtime (linear n u7 u128)))
+
+(define-read-only (cost_ge (n uint))
+    (runtime (linear n u7 u128)))
+
+(define-read-only (cost_int_cast (n uint))
+    (runtime u135))
+
+(define-read-only (cost_mod (n uint))
+    (runtime u141))
+
+(define-read-only (cost_pow (n uint))
+    (runtime u143))
+
+(define-read-only (cost_sqrti (n uint))
+    (runtime u142))
+
+(define-read-only (cost_log2 (n uint))
+    (runtime u133))
+
+(define-read-only (cost_xor (n uint))
+    (runtime (linear n u15 u129)))
+
+(define-read-only (cost_not (n uint))
+    (runtime u138))
+
+(define-read-only (cost_eq (n uint))
+    (runtime (linear n u7 u151)))
+
+(define-read-only (cost_begin (n uint))
+    (runtime u151))
+
+(define-read-only (cost_hash160 (n uint))
+    (runtime (linear n u1 u188)))
+
+(define-read-only (cost_sha256 (n uint))
+    (runtime (linear n u1 u100)))
+
+(define-read-only (cost_sha512 (n uint))
+    (runtime (linear n u1 u176)))
+
+(define-read-only (cost_sha512t256 (n uint))
+    (runtime (linear n u1 u56)))
+
+(define-read-only (cost_keccak256 (n uint))
+    (runtime (linear n u1 u127)))
+
+(define-read-only (cost_secp256k1recover (n uint))
+    (runtime u8655))
+
+(define-read-only (cost_secp256k1verify (n uint))
+    (runtime u8349))
+
+(define-read-only (cost_print (n uint))
+    (runtime (linear n u15 u1458)))
+
+(define-read-only (cost_some_cons (n uint))
+    (runtime u199))
+
+(define-read-only (cost_ok_cons (n uint))
+    (runtime u199))
+
+(define-read-only (cost_err_cons (n uint))
+    (runtime u199))
+
+(define-read-only (cost_default_to (n uint))
+    (runtime u268))
+
+(define-read-only (cost_unwrap_ret (n uint))
+    (runtime u274))
+
+(define-read-only (cost_unwrap_err_or_ret (n uint))
+    (runtime u302))
+
+(define-read-only (cost_is_okay (n uint))
+    (runtime u258))
+
+(define-read-only (cost_is_none (n uint))
+    (runtime u214))
+
+(define-read-only (cost_is_err (n uint))
+    (runtime u245))
+
+(define-read-only (cost_is_some (n uint))
+    (runtime u195))
+
+(define-read-only (cost_unwrap (n uint))
+    (runtime u252))
+
+(define-read-only (cost_unwrap_err (n uint))
+    (runtime u248))
+
+(define-read-only (cost_try_ret (n uint))
+    (runtime u240))
+
+(define-read-only (cost_match (n uint))
+    (runtime u264))
+
+(define-read-only (cost_or (n uint))
+    (runtime (linear n u3 u120)))
+
+(define-read-only (cost_and (n uint))
+    (runtime (linear n u3 u120)))
+
+(define-read-only (cost_append (n uint))
+    (runtime (linear n u73 u285)))
+
+(define-read-only (cost_concat (n uint))
+    (runtime (linear n u37 u220)))
+
+(define-read-only (cost_as_max_len (n uint))
+    (runtime u475))
+
+(define-read-only (cost_contract_call (n uint))
+    (runtime u134))
+
+(define-read-only (cost_contract_of (n uint))
+    (runtime u13400))
+
+(define-read-only (cost_principal_of (n uint))
+    (runtime u984))
+
+(define-read-only (cost_at_block (n uint))
+    {
+        runtime: u1327,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_load_contract (n uint))
+    {
+        runtime: (linear n u1 u80),
+        write_length: u0,
+        write_count: u0,
+        ;; set to 3 because of the associated metadata loads
+        read_count: u3,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_create_map (n uint))
+    {
+        runtime: (linear n u1 u1564),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_var (n uint))
+    {
+        runtime: (linear n u7 u2025),
+        write_length: (linear n u1 u1),
+        write_count: u2,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_nft (n uint))
+    {
+        runtime: (linear n u1 u1570),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_create_ft (n uint))
+    {
+        runtime: u1831,
+        write_length: u1,
+        write_count: u2,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_fetch_entry (n uint))
+    {
+        runtime: (linear n u1 u1025),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_set_entry (n uint))
+    {
+        runtime: (linear n u4 u1899),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_fetch_var (n uint))
+    {
+        runtime: (linear n u1 u468),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: (linear n u1 u1)
+    })
+
+
+(define-read-only (cost_set_var (n uint))
+    {
+        runtime: (linear n u5 u655),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u1,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_contract_storage (n uint))
+    {
+        runtime: (linear n u11 u7165),
+        write_length: (linear n u1 u1),
+        write_count: u1,
+        read_count: u0,
+        read_length: u0
+    })
+
+
+(define-read-only (cost_block_info (n uint))
+    {
+        runtime: u6321,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_stx_balance (n uint))
+    {
+        runtime: u4294,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_stx_transfer (n uint))
+    {
+        runtime: u4640,
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_mint (n uint))
+    {
+        runtime: u1479,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_transfer (n uint))
+    {
+        runtime: u549,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_balance (n uint))
+    {
+        runtime: u479,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_mint (n uint))
+    {
+        runtime: (linear n u9 u575),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_transfer (n uint))
+    {
+        runtime: (linear n u9 u572),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_nft_owner (n uint))
+    {
+        runtime: (linear n u9 u795),
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_get_supply (n uint))
+    {
+        runtime: u420,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_ft_burn (n uint))
+    {
+        runtime: u549,
+        write_length: u1,
+        write_count: u2,
+        read_count: u2,
+        read_length: u1
+    })
+
+
+(define-read-only (cost_nft_burn (n uint))
+    {
+        runtime: (linear n u9 u572),
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+
+(define-read-only (poison_microblock (n uint))
+    {
+        runtime: u17485,
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_buff_to_int_le (n uint))
+    (runtime u141))
+
+(define-read-only (cost_buff_to_uint_le (n uint))
+    (runtime u141))
+
+(define-read-only (cost_buff_to_int_be (n uint))
+    (runtime u141))
+
+(define-read-only (cost_buff_to_uint_be (n uint))
+    (runtime u141))
+
+(define-read-only (cost_is_standard (n uint))
+    (runtime u127))
+
+(define-read-only (cost_principal_destruct (n uint))
+    (runtime u314))
+
+(define-read-only (cost_principal_construct (n uint))
+    (runtime u398))
+
+(define-read-only (cost_string_to_int (n uint))
+    (runtime u168))
+
+(define-read-only (cost_string_to_uint (n uint))
+    (runtime u168))
+
+(define-read-only (cost_int_to_ascii (n uint))
+    (runtime u147))
+
+(define-read-only (cost_int_to_utf8 (n uint))
+    (runtime u181))
+
+
+(define-read-only (cost_burn_block_info (n uint))
+    {
+        runtime: u96479,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_stx_account (n uint))
+    {
+        runtime: u4654,
+        write_length: u0,
+        write_count: u0,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_slice (n uint))
+    (runtime u448))
+
+(define-read-only (cost_to_consensus_buff (n uint))
+    (runtime (linear n u1 u233)))
+
+(define-read-only (cost_from_consensus_buff (n uint))
+    (runtime (nlogn n u3 u185)))
+
+(define-read-only (cost_stx_transfer_memo (n uint))
+    {
+        runtime: u4709,
+        write_length: u1,
+        write_count: u1,
+        read_count: u1,
+        read_length: u1
+    })
+
+(define-read-only (cost_replace_at (n uint))
+    (runtime (linear n u1 u561)))
+
+(define-read-only (cost_as_contract (n uint))
+    (runtime u138))
+
+(define-read-only (cost_bitwise_and (n uint))
+    (runtime (linear n u15 u129)))
+
+(define-read-only (cost_bitwise_or (n uint))
+    (runtime (linear n u15 u129)))
+
+(define-read-only (cost_bitwise_not (n uint))
+    (runtime u147))
+
+(define-read-only (cost_bitwise_left_shift (n uint))
+    (runtime u167))
+
+(define-read-only (cost_bitwise_right_shift (n uint))
+    (runtime u167))

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -559,7 +559,11 @@ fn test_simple_pox_lockup_transition_pox_2() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -1021,7 +1025,11 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -1296,7 +1304,11 @@ fn delegate_stack_increase() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -1649,7 +1661,11 @@ fn stack_increase() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -1891,7 +1907,11 @@ fn test_lock_period_invariant_extend_transition() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -2054,7 +2074,11 @@ fn test_pox_extend_transition_pox_2() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -2498,7 +2522,11 @@ fn test_delegate_extend_transition_pox_2() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -3216,7 +3244,11 @@ fn test_pox_2_getters() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -3494,7 +3526,11 @@ fn test_get_pox_addrs() {
 
     assert_eq!(burnchain.pox_constants.reward_slots(), 4);
 
-    let epochs = StacksEpoch::all(1, 2, 3);
+    let epochs = StacksEpoch::all(
+        1, 
+        2, 
+        3,
+        4);
 
     let (mut peer, keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -3763,7 +3799,11 @@ fn test_stack_with_segwit() {
 
     assert_eq!(burnchain.pox_constants.reward_slots(), 4);
 
-    let epochs = StacksEpoch::all(1, 2, 3);
+    let epochs = StacksEpoch::all(
+        1, 
+        2, 
+        3,
+        4);
 
     let (mut peer, all_keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -4088,7 +4128,11 @@ fn test_pox_2_delegate_stx_addr_validation() {
     eprintln!("First v2 cycle = {}", first_v2_cycle);
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
@@ -4267,7 +4311,11 @@ fn stack_aggregation_increase() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 
@@ -4714,7 +4762,11 @@ fn stack_in_both_pox1_and_pox2() {
 
     eprintln!("First v2 cycle = {}", first_v2_cycle);
 
-    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+    let epochs = StacksEpoch::all(
+        0, 
+        0, 
+        EMPTY_SORTITIONS as u64 + 10,
+        EMPTY_SORTITIONS as u64 + 20);
 
     let observer = TestEventObserver::new();
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4893,7 +4893,8 @@ impl StacksChainState {
                     }
                     StacksEpochId::Epoch21 => {
                         panic!("No defined transition from Epoch21 forward")
-                    }
+                    },
+                    StacksEpochId::Epoch30 => todo!()
                 }
             }
         }
@@ -5489,6 +5490,7 @@ impl StacksChainState {
                     cur_epoch.start_height,
                 )
             }
+            StacksEpochId::Epoch30 => todo!()
         }
     }
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4891,10 +4891,9 @@ impl StacksChainState {
                         receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
                         applied = true;
                     }
-                    StacksEpochId::Epoch21 => {
+                    StacksEpochId::Epoch21 | StacksEpochId::Epoch30 => {
                         panic!("No defined transition from Epoch21 forward")
                     },
-                    StacksEpochId::Epoch30 => todo!()
                 }
             }
         }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -222,8 +222,7 @@ impl DBConfig {
                 self.version == "2" || self.version == "3" || self.version == "4"
             }
             StacksEpochId::Epoch21 => self.version == "3" || self.version == "4",
-            // TODO: I'm assuming there will be a new db version with nakamoto?
-            StacksEpochId::Epoch30 => todo!()
+            StacksEpochId::Epoch30 => self.version == "5"
         }
     }
 }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -222,6 +222,8 @@ impl DBConfig {
                 self.version == "2" || self.version == "3" || self.version == "4"
             }
             StacksEpochId::Epoch21 => self.version == "3" || self.version == "4",
+            // TODO: I'm assuming there will be a new db version with nakamoto?
+            StacksEpochId::Epoch30 => todo!()
         }
     }
 }

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -8345,6 +8345,7 @@ pub mod test {
                     StacksEpochId::Epoch20 => self.get_stacks_epoch(0),
                     StacksEpochId::Epoch2_05 => self.get_stacks_epoch(1),
                     StacksEpochId::Epoch21 => self.get_stacks_epoch(2),
+                    StacksEpochId::Epoch30 => self.get_stacks_epoch(3)
                 }
             }
             fn get_pox_payout_addrs(

--- a/src/chainstate/stacks/index/storage.rs
+++ b/src/chainstate/stacks/index/storage.rs
@@ -873,7 +873,7 @@ impl<T: MarfTrieId> TrieRAM<T> {
         for j in 0..node_data.len() {
             let next_node = &mut self.data[node_data[j] as usize].0;
             if !next_node.is_leaf() {
-                let mut ptrs = next_node.ptrs_mut();
+                let ptrs = next_node.ptrs_mut();
                 let num_children = ptrs.len();
                 for k in 0..num_children {
                     if ptrs[k].id != TrieNodeID::Empty as u8 && !is_backptr(ptrs[k].id) {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -291,7 +291,7 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref STACKS_EPOCHS_TESTNET: [StacksEpoch; 4] = [
+    pub static ref STACKS_EPOCHS_TESTNET: [StacksEpoch; 5] = [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -316,15 +316,22 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch21,
             start_height: BITCOIN_TESTNET_STACKS_21_BURN_HEIGHT,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT,
             block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_1
         },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch30,
+            start_height: BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: BLOCK_LIMIT_MAINNET_30.clone(),
+            network_epoch: PEER_VERSION_EPOCH_3_0
+        }
     ];
 }
 
 lazy_static! {
-    pub static ref STACKS_EPOCHS_REGTEST: [StacksEpoch; 4] = [
+    pub static ref STACKS_EPOCHS_REGTEST: [StacksEpoch; 5] = [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -349,10 +356,17 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch21,
             start_height: 2000,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: 3000,
             block_limit: HELIUM_BLOCK_LIMIT_20.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_1
         },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch30,
+            start_height: 3000,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: HELIUM_BLOCK_LIMIT_30.clone(),
+            network_epoch: PEER_VERSION_EPOCH_3_0
+        }
     ];
 }
 
@@ -380,6 +394,8 @@ fn test_ord_for_stacks_epoch() {
     assert_eq!(epochs[2].cmp(&epochs[0]), Ordering::Greater);
     assert_eq!(epochs[2].cmp(&epochs[1]), Ordering::Greater);
     assert_eq!(epochs[1].cmp(&epochs[0]), Ordering::Greater);
+    assert_eq!(epochs[3].cmp(&epochs[2]), Ordering::Greater);
+    assert_eq!(epochs[4].cmp(&epochs[3]), Ordering::Greater);
 }
 
 #[test]
@@ -418,6 +434,18 @@ fn test_ord_for_stacks_epoch_id() {
     );
     assert_eq!(
         StacksEpochId::Epoch20.cmp(&StacksEpochId::Epoch10),
+        Ordering::Greater
+    );
+    assert_eq!(
+        StacksEpochId::Epoch21.cmp(&StacksEpochId::Epoch2_05),
+        Ordering::Greater
+    );
+    assert_eq!(
+        StacksEpochId::Epoch21.cmp(&StacksEpochId::Epoch30),
+        Ordering::Less
+    );
+    assert_eq!(
+        StacksEpochId::Epoch30.cmp(&StacksEpochId::Epoch21),
         Ordering::Greater
     );
 }
@@ -810,21 +838,21 @@ impl StacksEpochExtension for StacksEpoch {
                 start_height: epoch_2_0_block_height,
                 end_height: epoch_2_05_block_height,
                 block_limit: ExecutionCost::max_value(),
-                network_epoch: PEER_VERSION_EPOCH_1_0,
+                network_epoch: PEER_VERSION_EPOCH_2_0,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch2_05,
                 start_height: epoch_2_05_block_height,
                 end_height: epoch_2_1_block_height,
                 block_limit: ExecutionCost::max_value(),
-                network_epoch: PEER_VERSION_EPOCH_1_0, // Shouldn't this be PEER_VERSION_EPOCH_2_05?
+                network_epoch: PEER_VERSION_EPOCH_2_05,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch21,
                 start_height: epoch_2_1_block_height,
-                end_height: STACKS_EPOCH_MAX,
+                end_height: epoch_3_0_block_height,
                 block_limit: ExecutionCost::max_value(),
-                network_epoch: PEER_VERSION_EPOCH_1_0, // Shouldn't this be PEER_VERSION_EPOCH_2_1?
+                network_epoch: PEER_VERSION_EPOCH_2_1,
             },
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch30,

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -228,6 +228,7 @@ impl PessimisticEstimator {
                     StacksEpochId::Epoch20 => "",
                     StacksEpochId::Epoch2_05 => ":2.05",
                     StacksEpochId::Epoch21 => ":2.1",
+                    StacksEpochId::Epoch30 => ":3.0",
                 };
                 format!(
                     "cc{}:{}:{}.{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1053,6 +1053,7 @@ simulating a miner.
             first_burnchain_block_height,
             u64::max_value(),
             u64::max_value(),
+            u64::max_value()
         );
         let (mut new_sortition_db, _) = burnchain
             .connect_db(
@@ -1142,6 +1143,7 @@ simulating a miner.
             first_burnchain_block_height,
             u64::max_value(),
             u64::max_value(),
+            u64::max_value()
         );
 
         let (p2p_new_sortition_db, _) = burnchain

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -387,8 +387,12 @@ where
 {
     log_sql_eqp(conn, sql_query);
     let mut stmt = conn.prepare(sql_query)?;
-    let result = stmt.query_and_then(sql_args, |row| T::from_row(row))?;
-
+    let result = stmt.query_and_then(
+        sql_args, 
+        |row| {
+            T::from_row(row) 
+        }
+    )?;
     result.collect()
 }
 

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -101,6 +101,7 @@ impl TryFrom<u32> for StacksEpochId {
             x if x == StacksEpochId::Epoch20 as u32 => Ok(StacksEpochId::Epoch20),
             x if x == StacksEpochId::Epoch2_05 as u32 => Ok(StacksEpochId::Epoch2_05),
             x if x == StacksEpochId::Epoch21 as u32 => Ok(StacksEpochId::Epoch21),
+            x if x == StacksEpochId::Epoch30 as u32 => Ok(StacksEpochId::Epoch30),
             _ => Err("Invalid epoch"),
         }
     }

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -71,6 +71,7 @@ pub enum StacksEpochId {
     Epoch20 = 0x02000,
     Epoch2_05 = 0x02005,
     Epoch21 = 0x0200a,
+    Epoch30 = 0x03000,
 }
 
 impl StacksEpochId {
@@ -86,6 +87,7 @@ impl std::fmt::Display for StacksEpochId {
             StacksEpochId::Epoch20 => write!(f, "2.0"),
             StacksEpochId::Epoch2_05 => write!(f, "2.05"),
             StacksEpochId::Epoch21 => write!(f, "2.1"),
+            StacksEpochId::Epoch30 => write!(f, "3.0"),
         }
     }
 }

--- a/stacks-common/src/util/hash.rs
+++ b/stacks-common/src/util/hash.rs
@@ -426,7 +426,7 @@ where
             row_hashes.reserve(nodes[i].len() / 2);
 
             for j in 0..(nodes[i].len() / 2) {
-                let h = MerkleTree::get_node_hash(&nodes[i][(2 * j)], &nodes[i][2 * j + 1]);
+                let h = MerkleTree::get_node_hash(&nodes[i][2 * j], &nodes[i][2 * j + 1]);
                 row_hashes.push(h);
             }
 


### PR DESCRIPTION
### Description
Figured I'd take a stab at adding the 3.0 epoch for Nakamoto since over in Clarity-WASM we're starting discussing epoch gating, and it would be beneficial if the enum variant and related were already now available in `next` for all WG's who need it.

The code compiles and, unless I missed any, all failing tests are due to `todo!()` statements which I added in match statements where it felt like the logic will be handled by @jcnelson + @kantai in their WGs?

Also added boilerplate for costs v4 (and added a placeholder `costs-4.clar` for tests) as I'm assuming there will be a new costs version given the scope of changes?