### PR TITLE
Send Signer results over a channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,7 +1242,6 @@ dependencies = [
 [[package]]
 name = "frost-coordinator"
 version = "0.0.1"
-source = "git+https://github.com/Trust-Machines/stacks-sbtc#c17d0fbf717d488ed41186a6e9a4627f9eeeee04"
 dependencies = [
  "backoff",
  "clap 4.4.1",
@@ -1259,7 +1258,6 @@ dependencies = [
 [[package]]
 name = "frost-signer"
 version = "0.0.1"
-source = "git+https://github.com/Trust-Machines/stacks-sbtc#c17d0fbf717d488ed41186a6e9a4627f9eeeee04"
 dependencies = [
  "aes-gcm 0.10.2",
  "backoff",
@@ -4650,8 +4648,6 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9822f9052b53d23fb9535781ee904e444cb5292788ae2f08e08de27eb765b39c"
 dependencies = [
  "bs58 0.5.0",
  "hashbrown 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
 [[package]]
 name = "frost-coordinator"
 version = "0.0.1"
+source = "git+https://github.com/Trust-Machines/stacks-sbtc#1731a0e28c10d69411f54a30237b701bb84fc685"
 dependencies = [
  "backoff",
  "clap 4.4.1",
@@ -1258,6 +1259,7 @@ dependencies = [
 [[package]]
 name = "frost-signer"
 version = "0.0.1"
+source = "git+https://github.com/Trust-Machines/stacks-sbtc#1731a0e28c10d69411f54a30237b701bb84fc685"
 dependencies = [
  "aes-gcm 0.10.2",
  "backoff",
@@ -4648,6 +4650,8 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9822f9052b53d23fb9535781ee904e444cb5292788ae2f08e08de27eb765b39c"
 dependencies = [
  "bs58 0.5.0",
  "hashbrown 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "frost-coordinator"
 version = "0.0.1"
-source = "git+https://github.com/Trust-Machines/stacks-sbtc#1731a0e28c10d69411f54a30237b701bb84fc685"
+source = "git+https://github.com/Trust-Machines/stacks-sbtc#dbd060b99f9cdaf2c06d26d60da1f12744f1d600"
 dependencies = [
  "backoff",
  "clap 4.4.1",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "frost-signer"
 version = "0.0.1"
-source = "git+https://github.com/Trust-Machines/stacks-sbtc#1731a0e28c10d69411f54a30237b701bb84fc685"
+source = "git+https://github.com/Trust-Machines/stacks-sbtc#dbd060b99f9cdaf2c06d26d60da1f12744f1d600"
 dependencies = [
  "aes-gcm 0.10.2",
  "backoff",

--- a/libsigner/src/runloop.rs
+++ b/libsigner/src/runloop.rs
@@ -41,7 +41,7 @@ const STDERR: i32 = 2;
 /// Trait describing the needful components of a top-level runloop.
 /// This is where the signer business logic would go.
 /// Implement this, and you get all the multithreaded setup for free.
-pub trait SignerRunLoop<R: Send + Clone, CMD: Send> {
+pub trait SignerRunLoop<R: Send, CMD: Send> {
     /// Hint to set how long to wait for new events
     fn set_event_timeout(&mut self, timeout: Duration);
     /// Getter for the event poll timeout
@@ -102,7 +102,7 @@ pub trait SignerRunLoop<R: Send + Clone, CMD: Send> {
 /// The top-level signer implementation
 pub struct Signer<
     CMD: Send,
-    R: Send + Clone,
+    R: Send,
     SL: SignerRunLoop<R, CMD> + Send + Sync,
     EV: EventReceiver + Send,
 > {
@@ -199,7 +199,7 @@ pub fn set_runloop_signal_handler<ST: EventStopSignaler + Send + 'static>(mut st
 
 impl<
         CMD: Send + 'static,
-        R: Send + Clone + 'static,
+        R: Send + 'static,
         SL: SignerRunLoop<R, CMD> + Send + Sync + 'static,
         EV: EventReceiver + Send + 'static,
     > Signer<CMD, R, SL, EV>

--- a/libsigner/src/tests/mod.rs
+++ b/libsigner/src/tests/mod.rs
@@ -19,7 +19,7 @@ mod http;
 use std::io::Write;
 use std::mem;
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 use std::time::Duration;
 
@@ -69,6 +69,7 @@ impl SignerRunLoop<Vec<StackerDBChunksEvent>, Command> for SimpleRunLoop {
         &mut self,
         event: Option<StackerDBChunksEvent>,
         _cmd: Option<Command>,
+        _res: Sender<Vec<StackerDBChunksEvent>>,
     ) -> Option<Vec<StackerDBChunksEvent>> {
         debug!("Got event: {:?}", &event);
         if let Some(event) = event {
@@ -94,7 +95,8 @@ fn test_simple_signer() {
     )
     .unwrap()]);
     let (_cmd_send, cmd_recv) = channel();
-    let mut signer = Signer::new(SimpleRunLoop::new(5), ev, cmd_recv);
+    let (res_send, _res_recv) = channel();
+    let mut signer = Signer::new(SimpleRunLoop::new(5), ev, cmd_recv, res_send);
     let endpoint: SocketAddr = "127.0.0.1:30000".parse().unwrap();
     let thread_endpoint = endpoint.clone();
 

--- a/stacks-signer/src/crypto/frost.rs
+++ b/stacks-signer/src/crypto/frost.rs
@@ -180,16 +180,21 @@ impl Coordinator {
                         return Ok((
                             None,
                             Some(OperationResult::Sign(
-                                Signature {
-                                    R: self.signature.R,
-                                    z: self.signature.z,
-                                },
-                                SchnorrProof {
-                                    r: self.schnorr_proof.r,
-                                    s: self.schnorr_proof.s,
-                                },
+                                self.signature.clone(),
+                                self.schnorr_proof.clone(),
                             )),
                         ));
+                        /*
+                                    Signature {
+                                        R: self.signature.R,
+                                        z: self.signature.z,
+                                    },
+                                    SchnorrProof {
+                                        r: self.schnorr_proof.r,
+                                        s: self.schnorr_proof.s,
+                                    },
+                        )),
+                            */
                     }
                 }
             }

--- a/stacks-signer/src/crypto/frost.rs
+++ b/stacks-signer/src/crypto/frost.rs
@@ -180,21 +180,16 @@ impl Coordinator {
                         return Ok((
                             None,
                             Some(OperationResult::Sign(
-                                self.signature.clone(),
-                                self.schnorr_proof.clone(),
+                                Signature {
+                                    R: self.signature.R,
+                                    z: self.signature.z,
+                                },
+                                SchnorrProof {
+                                    r: self.schnorr_proof.r,
+                                    s: self.schnorr_proof.s,
+                                },
                             )),
                         ));
-                        /*
-                                    Signature {
-                                        R: self.signature.R,
-                                        z: self.signature.z,
-                                    },
-                                    SchnorrProof {
-                                        r: self.schnorr_proof.r,
-                                        s: self.schnorr_proof.s,
-                                    },
-                        )),
-                            */
                     }
                 }
             }

--- a/stacks-signer/src/crypto/mod.rs
+++ b/stacks-signer/src/crypto/mod.rs
@@ -15,6 +15,7 @@ pub enum Error {
 
 /// Result of a DKG or sign operation
 #[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub enum OperationResult {
     /// The DKG result
     Dkg(Point),

--- a/stacks-signer/src/crypto/mod.rs
+++ b/stacks-signer/src/crypto/mod.rs
@@ -15,7 +15,6 @@ pub enum Error {
 
 /// Result of a DKG or sign operation
 #[allow(dead_code)]
-#[derive(Clone, Debug)]
 pub enum OperationResult {
     /// The DKG result
     Dkg(Point),

--- a/stacks-signer/src/crypto/mod.rs
+++ b/stacks-signer/src/crypto/mod.rs
@@ -35,4 +35,6 @@ pub trait Coordinatable {
     fn start_distributed_key_generation(&mut self) -> Result<Message, Error>;
     /// Trigger a signing round
     fn start_signing_message(&mut self, _message: &[u8]) -> Result<Message, Error>;
+    /// Reset internal state
+    fn reset(&mut self);
 }

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -109,40 +109,34 @@ fn spawn_running_signer(path: &PathBuf) -> SpawnedSigner {
 
 // Process a DKG result
 fn process_dkg_result(dkg_res: &[OperationResult]) {
-    if dkg_res.len() != 1 {
-        warn!("Received unexpected number of results: {}", dkg_res.len());
-    }
-    for dkg in dkg_res {
-        match dkg {
-            OperationResult::Dkg(point) => {
-                println!("Received aggregate group key: {point}");
-            }
-            OperationResult::Sign(signature, schnorr_proof) => {
-                panic!(
-                    "Received unexpected signature ({},{}) and schnorr proof ({},{})",
-                    &signature.R, &signature.z, &schnorr_proof.r, &schnorr_proof.s
-                );
-            }
+    assert!(dkg_res.len() == 1, "Received unexpected number of results");
+    let dkg = dkg_res.first().unwrap();
+    match dkg {
+        OperationResult::Dkg(point) => {
+            println!("Received aggregate group key: {point}");
+        }
+        OperationResult::Sign(signature, schnorr_proof) => {
+            panic!(
+                "Received unexpected signature ({},{}) and schnorr proof ({},{})",
+                &signature.R, &signature.z, &schnorr_proof.r, &schnorr_proof.s
+            );
         }
     }
 }
 
 // Process a Sign result
 fn process_sign_result(sign_res: &[OperationResult]) {
-    if sign_res.len() != 1 {
-        warn!("Received unexpected number of results: {}", sign_res.len());
-    }
-    for sign in sign_res {
-        match sign {
-            OperationResult::Dkg(point) => {
-                panic!("Received unexpected aggregate group key: {point}");
-            }
-            OperationResult::Sign(signature, schnorr_proof) => {
-                println!(
-                    "Received good signature ({},{}) and schnorr proof ({},{})",
-                    &signature.R, &signature.z, &schnorr_proof.r, &schnorr_proof.s
-                );
-            }
+    assert!(sign_res.len() == 1, "Received unexpected number of results");
+    let sign = sign_res.first().unwrap();
+    match sign {
+        OperationResult::Dkg(point) => {
+            panic!("Received unexpected aggregate group key: {point}");
+        }
+        OperationResult::Sign(signature, schnorr_proof) => {
+            println!(
+                "Received good signature ({},{}) and schnorr proof ({},{})",
+                &signature.R, &signature.z, &schnorr_proof.r, &schnorr_proof.s
+            );
         }
     }
 }

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -30,7 +30,7 @@ use clap::Parser;
 use clarity::vm::types::QualifiedContractIdentifier;
 use libsigner::{RunningSigner, Signer, SignerSession, StackerDBEventReceiver, StackerDBSession};
 use libstackerdb::StackerDBChunkData;
-use slog::{slog_debug, slog_warn};
+use slog::slog_debug;
 use stacks_common::{
     address::{
         AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
@@ -38,7 +38,6 @@ use stacks_common::{
     },
     debug,
     types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey},
-    warn,
 };
 use stacks_signer::{
     cli::{


### PR DESCRIPTION
### Description

Right now the only way to find out what a `Signer` has done is to stop it and get the cached results.  

Add another channel which lets `Signer` send results as they come in.

### Applicable issues
- Closes https://github.com/stacks-network/stacks-blockchain/issues/3916

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
