### PR TITLE
Hotfix: Ignore logging errors (from PR #3784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [2.4.0.0.2]
+
+This is a hotfix that changes the logging failure behavior from panicking to dropping
+the log message (PR #3784).
+
 ## [2.4.0.0.1]
 
 This is a minor change to add `txid` fields into the log messages from failing

--- a/stacks-common/src/util/log.rs
+++ b/stacks-common/src/util/log.rs
@@ -205,8 +205,8 @@ fn make_json_logger() -> Logger {
                       }),
     );
 
-    let drain = Mutex::new(slog_json::Json::default(std::io::stderr())).map(slog::Fuse);
-    let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).fuse();
+    let drain = Mutex::new(slog_json::Json::default(std::io::stderr()));
+    let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).ignore_res();
     slog::Logger::root(filtered_drain, def_keys)
 }
 
@@ -225,7 +225,7 @@ fn make_logger() -> Logger {
         let decorator = slog_term::PlainSyncDecorator::new(std::io::stderr());
         let atty = isatty(Stream::Stderr);
         let drain = TermFormat::new(decorator, pretty_print, debug, atty);
-        let logger = Logger::root(drain.fuse(), o!());
+        let logger = Logger::root(drain.ignore_res(), o!());
         logger
     }
 }
@@ -239,7 +239,7 @@ fn make_logger() -> Logger {
         let plain = slog_term::PlainSyncDecorator::new(slog_term::TestStdoutWriter);
         let isatty = isatty(Stream::Stdout);
         let drain = TermFormat::new(plain, false, debug, isatty);
-        let logger = Logger::root(drain.fuse(), o!());
+        let logger = Logger::root(drain.ignore_res(), o!());
         logger
     }
 }


### PR DESCRIPTION
### Description

This cherry-picks the commit from #3784 to fix the behavior where a node would panic when log messages failed to flush.
