### PR TITLE
Update wsts to the correct 4.0.0 version and fix compile issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,9 +2230,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256k1"
-version = "5.4.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79583032ab00c9e23e8afadf907e9cdc862c72c01fd57048fb07f1107a05c88a"
+checksum = "22e81c2cb5a1936d3f26278f9d698932239d03ddf0d5818392d91cd5f98ffc79"
 dependencies = [
  "bindgen",
  "bitvec",
@@ -3376,7 +3376,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "libsigner",
- "p256k1",
  "pico-args",
  "rand 0.7.3",
  "regex",
@@ -3409,7 +3408,6 @@ dependencies = [
  "hashbrown 0.14.0",
  "libsigner",
  "libstackerdb",
- "p256k1",
  "rand_core 0.6.4",
  "secp256k1",
  "serde",
@@ -4503,7 +4501,8 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "4.0.0"
-source = "git+https://github.com/Trust-Machines/wsts?tag=4.0.0rc2#e87f997781c0e9d9b2951d75059d673296311eec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0c0ec44cbd35be82490c8c566ad4971f7b41ffe8508f1c9938140df7fe18b2"
 dependencies = [
  "aes-gcm 0.10.2",
  "bs58 0.5.0",

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -26,7 +26,6 @@ clap = { version = "4.1.1", features = ["derive", "env"] }
 hashbrown = "0.14"
 libsigner = { path = "../libsigner" }
 libstackerdb = { path = "../libstackerdb" }
-p256k1 = "5.4"
 rand_core = "0.6"
 serde = "1"
 serde_derive = "1"
@@ -39,7 +38,7 @@ thiserror = "1.0"
 toml = "0.5.6"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-wsts = { git = "https://github.com/Trust-Machines/wsts", tag = "4.0.0rc2" }
+wsts = "4.0.0"
 
 [dependencies.serde_json]
 version = "1.0"

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -16,7 +16,6 @@
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use hashbrown::HashMap;
-use p256k1::{ecdsa, scalar::Scalar};
 use serde::Deserialize;
 use stacks_common::types::chainstate::StacksPrivateKey;
 use std::{
@@ -26,7 +25,7 @@ use std::{
     path::PathBuf,
     time::Duration,
 };
-use wsts::state_machine::PublicKeys;
+use wsts::{ecdsa, state_machine::PublicKeys, Scalar};
 
 /// List of key_ids for each signer_id
 pub type SignerKeyIds = HashMap<u32, Vec<u32>>;

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -58,7 +58,7 @@ use std::{
 };
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use wsts::{
-    state_machine::{coordinator::Coordinator as FrostCoordinator, OperationResult},
+    state_machine::{coordinator::frost::Coordinator as FrostCoordinator, OperationResult},
     v2,
 };
 

--- a/stacks-signer/src/utils.rs
+++ b/stacks-signer/src/utils.rs
@@ -1,13 +1,12 @@
 use std::time::Duration;
 
-use p256k1::ecdsa;
 use rand_core::OsRng;
 use slog::slog_debug;
 use stacks_common::{
     debug,
     types::chainstate::{StacksAddress, StacksPrivateKey},
 };
-use wsts::Scalar;
+use wsts::{ecdsa, Scalar};
 
 use crate::stacks_client::SLOTS_PER_USER;
 

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -38,10 +38,9 @@ clarity = { path = "../../clarity", features = ["default", "testing"]}
 stacks-common = { path = "../../stacks-common", features = ["default", "testing"] }
 stacks = { package = "stackslib", path = "../../stackslib", features = ["default", "testing"] }
 stacks-signer = { path = "../../stacks-signer" }
-p256k1 = "5.4"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-wsts = { git = "https://github.com/Trust-Machines/wsts", tag = "4.0.0rc2" }
+wsts = "4.0.0"
 
 [dependencies.rusqlite]
 version = "=0.24.2"


### PR DESCRIPTION
### Description
This breaks work out of the nakamoto signature validation ticket to fix the wsts version. 


### Applicable issues
- fixes https://github.com/stacks-network/stacks-blockchain/issues/4040

### Additional info (benefits, drawbacks, caveats)
I also was able to remove the p256k1 dependency by utilizing just the wsts code.