### PR TITLE
Add new docker tag to address repo name change

### DIFF
--- a/.github/workflows/image-build-alpine-binary.yml
+++ b/.github/workflows/image-build-alpine-binary.yml
@@ -55,6 +55,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
+            blockstack/stacks-blockchain
             blockstack/${{ github.event.repository.name }}
           tags: |
             type=raw,value=latest,enable=${{ inputs.tag != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )}}

--- a/.github/workflows/image-build-debian-binary.yml
+++ b/.github/workflows/image-build-debian-binary.yml
@@ -67,6 +67,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
+            blockstack/stacks-blockchain
             blockstack/${{ github.event.repository.name }}
           tags: |
             type=raw,value=latest-${{ inputs.linux_version }},enable=${{ inputs.tag != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )}}

--- a/.github/workflows/image-build-debian-source.yml
+++ b/.github/workflows/image-build-debian-source.yml
@@ -66,6 +66,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
+            blockstack/stacks-blockchain
             blockstack/${{ github.event.repository.name }}
           tags: |
             type=raw,value=${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Fix related to recent repo name change. 
@CharlieC3 

https://github.com/search?q=repo%3Astacks-network%2Fstacks-core%20github.event.repository.name&type=code

Fix is simple - add an extra docker tag to push an image to the `stacks-blockchain` docker repo, along with an image using the new name `stacks-core`


