### PR TITLE
fix: Address warning messages and errors in `cargo build` and `cargo build`

### DIFF
--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -2108,8 +2108,8 @@ pub mod test {
             );
 
             let contracts = vec![
-                contract_correct.clone(),
-                contract_correct.clone(),
+                contract_correct,
+                contract_correct,
                 contract_syntax_error, // should still be mined, even though analysis fails
             ];
 

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -301,7 +301,7 @@ impl<'a> TestRPC<'a> {
         let tx_coinbase_signed = tx_signer.get_tx().unwrap();
 
         // next the contract
-        let contract = TEST_CONTRACT.clone();
+        let contract = TEST_CONTRACT;
         let mut tx_contract = StacksTransaction::new(
             TransactionVersion::Testnet,
             TransactionAuth::from_p2pkh(&privk1).unwrap(),
@@ -343,7 +343,7 @@ impl<'a> TestRPC<'a> {
         };
 
         // make an unconfirmed contract
-        let unconfirmed_contract = TEST_CONTRACT_UNCONFIRMED.clone();
+        let unconfirmed_contract = TEST_CONTRACT_UNCONFIRMED;
         let mut tx_unconfirmed_contract = StacksTransaction::new(
             TransactionVersion::Testnet,
             TransactionAuth::from_p2pkh(&privk1).unwrap(),

--- a/stackslib/src/net/atlas/download.rs
+++ b/stackslib/src/net/atlas/download.rs
@@ -724,7 +724,7 @@ impl BatchedDNSLookupsState {
                     match url.host() {
                         Some(url::Host::Domain(domain)) => {
                             let res = dns_client.queue_lookup(
-                                domain.clone(),
+                                domain,
                                 port,
                                 get_epoch_time_ms() + connection_options.dns_timeout,
                             );

--- a/stackslib/src/net/download.rs
+++ b/stackslib/src/net/download.rs
@@ -350,7 +350,7 @@ impl BlockDownloader {
             match url.host() {
                 Some(url::Host::Domain(domain)) => {
                     match dns_client.queue_lookup(
-                        domain.clone(),
+                        domain,
                         port,
                         get_epoch_time_ms() + self.dns_timeout,
                     ) {

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -3483,7 +3483,7 @@ impl PeerNetwork {
             if let Some(ref mut dns_client) = dns_client_opt {
                 // begin DNS query
                 match dns_client.queue_lookup(
-                    domain.clone(),
+                    domain,
                     port,
                     get_epoch_time_ms() + self.connection_opts.dns_timeout,
                 ) {

--- a/stackslib/src/net/stackerdb/config.rs
+++ b/stackslib/src/net/stackerdb/config.rs
@@ -17,6 +17,7 @@
 /// This file implements the interface to the StackerDB smart contract for loading the DB's config.
 /// The smart contract must conform to this trait:
 ///
+/// ```clarity,ignore
 /// ;; Any StackerDB smart contract must conform to this trait.
 /// (define-trait stackerdb-trait
 ///
@@ -34,6 +35,7 @@
 ///         },
 ///         uint))
 /// )
+/// ```
 use std::collections::{HashMap, HashSet};
 use std::mem;
 

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -353,7 +353,7 @@ fn log_sql_eqp(conn: &Connection, sql_query: &str) {
         return;
     }
 
-    let mut parts = sql_query.clone().split(" ");
+    let mut parts = sql_query.split(" ");
     let mut full_sql = if let Some(part) = parts.next() {
         part.to_string()
     } else {

--- a/stackslib/src/util_lib/strings.rs
+++ b/stackslib/src/util_lib/strings.rs
@@ -331,8 +331,8 @@ mod test {
     fn tx_stacks_strings_codec() {
         let s = "hello-world";
         let stacks_str = StacksString::from_str(&s).unwrap();
-        let clarity_str = ClarityName::try_from(s.clone()).unwrap();
-        let contract_str = ContractName::try_from(s.clone()).unwrap();
+        let clarity_str = ClarityName::try_from(s).unwrap();
+        let contract_str = ContractName::try_from(s).unwrap();
 
         assert_eq!(stacks_str[..], s.as_bytes().to_vec()[..]);
         let s2 = stacks_str.to_string();

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -166,12 +166,12 @@ pub fn get_satoshis_per_byte(config: &Config) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::DEFAULT_SATS_PER_VB;
-
-    use super::*;
     use std::env::temp_dir;
     use std::fs::File;
     use std::io::Write;
+
+    use super::*;
+    use crate::config::DEFAULT_SATS_PER_VB;
 
     #[test]
     fn test_get_satoshis_per_byte() {


### PR DESCRIPTION
### Description

Fix compiler warnings while running `cargo build` and `cargo test`

Also fix doc comment in `stackslib/src/net/stackerdb/config.rs` that was incorrectly interpreted as a doc test and failing, causing an error

