### PR TITLE
Argon: Pox 4 - Adjust Lease Timing for Epoch 2.4 Compatibility in BNS tests

### DIFF
--- a/contrib/core-contract-tests/tests/bns/name_register.test.ts
+++ b/contrib/core-contract-tests/tests/bns/name_register.test.ts
@@ -366,8 +366,8 @@ describe("name revealing workflow", () => {
       Cl.tuple({
         owner: Cl.standardPrincipal(bob),
         ["zonefile-hash"]: Cl.bufferFromUtf8(cases[0].zonefile),
-        ["lease-ending-at"]: Cl.some(Cl.uint(16)),
-        ["lease-started-at"]: Cl.uint(6),
+        ["lease-ending-at"]: Cl.some(Cl.uint(simnet.blockHeight + 10)),
+        ["lease-started-at"]: Cl.uint(simnet.blockHeight),
       })
     );
   });
@@ -589,8 +589,8 @@ describe("register a name again before and after expiration", () => {
       Cl.tuple({
         owner: Cl.standardPrincipal(charlie),
         ["zonefile-hash"]: Cl.bufferFromAscii("CHARLIE"),
-        ["lease-ending-at"]: Cl.some(Cl.uint(5029)),
-        ["lease-started-at"]: Cl.uint(5019),
+        ["lease-ending-at"]: Cl.some(Cl.uint(simnet.blockHeight + 10)),
+        ["lease-started-at"]: Cl.uint(simnet.blockHeight),
       })
     );
   });

--- a/contrib/core-contract-tests/tests/bns/name_register_test.ts
+++ b/contrib/core-contract-tests/tests/bns/name_register_test.ts
@@ -98,7 +98,7 @@ Clarinet.test({
                 ], 
                 cases[0].nameOwner.address),
         ]);
-        assertEquals(block.height, 2);
+        assertEquals(block.height, 3);
         block.receipts[0].result
             .expectErr()
             .expectInt(1005);
@@ -119,7 +119,7 @@ Clarinet.test({
                 ], 
                 cases[1].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 3);
+        assertEquals(block.height, 4);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -136,7 +136,7 @@ Clarinet.test({
                 ], 
                 cases[1].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 4);
+        assertEquals(block.height, 5);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -158,7 +158,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 5);
+        assertEquals(block.height, 6);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -174,7 +174,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 6);
+        assertEquals(block.height, 7);
         block.receipts[0].result
             .expectErr()
             .expectInt(2004);
@@ -195,7 +195,7 @@ Clarinet.test({
                 ], 
                 cases[0].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 7);
+        assertEquals(block.height, 8);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -212,7 +212,7 @@ Clarinet.test({
                 ], 
                 cases[0].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 8);
+        assertEquals(block.height, 9);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -225,7 +225,7 @@ Clarinet.test({
                 ], 
                 cases[0].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 9);
+        assertEquals(block.height, 10);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -244,7 +244,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 10);
+        assertEquals(block.height, 11);
         block.receipts[0].result
             .expectErr()
             .expectInt(2001);
@@ -266,7 +266,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 11);
+        assertEquals(block.height, 12);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -282,7 +282,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 12);
+        assertEquals(block.height, 13);
         block.receipts[0].result
             .expectErr()
             .expectInt(2007);
@@ -304,7 +304,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 13);
+        assertEquals(block.height, 14);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -320,7 +320,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 14);
+        assertEquals(block.height, 15);
         block.receipts[0].result
             .expectErr()
             .expectInt(2022);
@@ -342,7 +342,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 15);
+        assertEquals(block.height, 16);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -358,7 +358,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 16);
+        assertEquals(block.height, 17);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -388,7 +388,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 17);
+        assertEquals(block.height, 18);
         block.receipts[0].result
             .expectErr()
             .expectInt(2004);
@@ -412,7 +412,7 @@ Clarinet.test({
                 ], 
                 charlie.address),
         ]);
-        assertEquals(block.height, 18);
+        assertEquals(block.height, 19);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -428,7 +428,7 @@ Clarinet.test({
                 ], 
                 charlie.address),
         ]);
-        assertEquals(block.height, 19);
+        assertEquals(block.height, 20);
         block.receipts[0].result
             .expectErr()
             .expectInt(2004);
@@ -452,7 +452,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 20);
+        assertEquals(block.height, 21);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -468,7 +468,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 21);
+        assertEquals(block.height, 22);
         block.receipts[0].result
             .expectErr()
             .expectInt(3001);


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Epoch 2.4 introduced an extra block in the simnet start sequence, causing names to expire one block later than before. This fixes the failing tests in `feat/pox-4`.

### Applicable issues
- fixes failing tests in https://github.com/stacks-network/stacks-core/pull/4085

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
