### PR TITLE
PoX-4 Signing Keys Stacking-State

### DIFF
--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -25,7 +25,7 @@ use stacks_common::types::chainstate::{
 };
 use stacks_common::types::{Address, StacksEpoch};
 use stacks_common::util::vrf::VRFProof;
-use wsts::curve::point::Point;
+use wsts::curve::point::{Point, Compressed};
 
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
 use crate::chainstate::burn::operations::BlockstackOperationType;
@@ -50,6 +50,9 @@ use crate::net::test::{TestPeer, TestPeerConfig};
 fn advance_to_nakamoto(peer: &mut TestPeer) {
     let mut peer_nonce = 0;
     let private_key = peer.config.private_key.clone();
+    let public_key = StacksPublicKey::from_private(&private_key);
+    let compressed_key = Compressed::try_from(public_key.to_bytes_compressed().as_slice()).expect("Failed to convert public key to compressed struct");
+    let public_key_point = Point::try_from(&compressed_key).expect("Failed to convert public key to point");
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -69,6 +72,7 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
                 PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone()),
                 12,
                 34,
+                &public_key_point
             );
             vec![stack_tx]
         } else {

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -25,7 +25,7 @@ use stacks_common::types::chainstate::{
 };
 use stacks_common::types::{Address, StacksEpoch};
 use stacks_common::util::vrf::VRFProof;
-use wsts::curve::point::{Point, Compressed};
+use wsts::curve::point::{Compressed, Point};
 
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
 use crate::chainstate::burn::operations::BlockstackOperationType;
@@ -51,8 +51,10 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
     let mut peer_nonce = 0;
     let private_key = peer.config.private_key.clone();
     let public_key = StacksPublicKey::from_private(&private_key);
-    let compressed_key = Compressed::try_from(public_key.to_bytes_compressed().as_slice()).expect("Failed to convert public key to compressed struct");
-    let public_key_point = Point::try_from(&compressed_key).expect("Failed to convert public key to point");
+    let compressed_key = Compressed::try_from(public_key.to_bytes_compressed().as_slice())
+        .expect("Failed to convert public key to compressed struct");
+    let public_key_point =
+        Point::try_from(&compressed_key).expect("Failed to convert public key to point");
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -72,7 +74,7 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
                 PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone()),
                 12,
                 34,
-                &public_key_point
+                &public_key_point,
             );
             vec![stack_tx]
         } else {

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -62,6 +62,8 @@ lazy_static! {
         boot_code_id("pox-2", false);
     pub static ref COST_VOTING_CONTRACT_TESTNET: QualifiedContractIdentifier =
         boot_code_id("cost-voting", false);
+    pub static ref POX_4_CONTRACT_TESTNET: QualifiedContractIdentifier =
+        boot_code_id("pox-4", false);
     pub static ref USER_KEYS: Vec<StacksPrivateKey> =
         (0..50).map(|_| StacksPrivateKey::new()).collect();
     pub static ref POX_ADDRS: Vec<Value> = (0..50u64)
@@ -557,6 +559,31 @@ impl HeadersDB for TestSimHeadersDB {
         // if the block is defined at all, then return a constant
         self.get_burn_block_height_for_block(id_bhh).map(|_| 3000)
     }
+}
+
+#[test]
+fn pox_4_instantiates() {
+    let mut sim = ClarityTestSim::new();
+    sim.epoch_bounds = vec![0, 1, 2];
+    let delegator = StacksPrivateKey::new();
+
+    let expected_unlock_height = POX_TESTNET_CYCLE_LENGTH * 4;
+
+    // execute past 2.1 epoch initialization
+    sim.execute_next_block(|_env| {});
+    sim.execute_next_block(|_env| {});
+    sim.execute_next_block(|_env| {});
+
+    sim.execute_next_block(|env| {
+        env.initialize_versioned_contract(
+            POX_4_CONTRACT_TESTNET.clone(),
+            ClarityVersion::Clarity2,
+            &boot::POX_4_TESTNET_CODE,
+            None,
+            ASTRules::PrecheckSize,
+        )
+        .unwrap()
+    });
 }
 
 #[test]

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1666,11 +1666,6 @@ pub mod test {
         burn_ht: u64,
         public_key: &Point,
     ) -> StacksTransaction {
-        // ;; TODO: add signer key
-        // (define-public (stack-stx (amount-ustx uint)
-        //                           (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
-        //                           (burn-height uint)
-        //                           (lock-period uint))
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1664,6 +1664,7 @@ pub mod test {
         addr: PoxAddress,
         lock_period: u128,
         burn_ht: u64,
+        public_key: &Point,
     ) -> StacksTransaction {
         // ;; TODO: add signer key
         // (define-public (stack-stx (amount-ustx uint)
@@ -1680,6 +1681,8 @@ pub mod test {
                 addr_tuple,
                 Value::UInt(burn_ht as u128),
                 Value::UInt(lock_period),
+                Value::buff_from(public_key.compress().data.to_vec())
+            .expect("Failed to serialize aggregate public key")
             ],
         )
         .unwrap();
@@ -1792,13 +1795,17 @@ pub mod test {
         nonce: u64,
         addr: PoxAddress,
         lock_period: u128,
+        signing_key: Option<&Point>,
     ) -> StacksTransaction {
+        let signing_key = Value::Optional(OptionalData {
+            data: signing_key.map(|key| Box::new(Value::buff_from(key.compress().data.to_vec()).unwrap()))
+        });
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
             POX_4_NAME,
             "stack-extend",
-            vec![Value::UInt(lock_period), addr_tuple],
+            vec![Value::UInt(lock_period), addr_tuple, signing_key],
         )
         .unwrap();
 

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1677,7 +1677,7 @@ pub mod test {
                 Value::UInt(burn_ht as u128),
                 Value::UInt(lock_period),
                 Value::buff_from(public_key.compress().data.to_vec())
-            .expect("Failed to serialize aggregate public key")
+                    .expect("Failed to serialize aggregate public key"),
             ],
         )
         .unwrap();
@@ -1793,7 +1793,8 @@ pub mod test {
         signing_key: Option<&Point>,
     ) -> StacksTransaction {
         let signing_key = Value::Optional(OptionalData {
-            data: signing_key.map(|key| Box::new(Value::buff_from(key.compress().data.to_vec()).unwrap()))
+            data: signing_key
+                .map(|key| Box::new(Value::buff_from(key.compress().data.to_vec()).unwrap())),
         });
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -140,13 +140,6 @@
     { sender: principal, contract-caller: principal }
     { until-burn-ht: (optional uint) })
 
-;; The signing key slots for a reward cycle
-;; Written by a Stacks node as part of processing the first tenure-start-block after last tenure-start-block in previous reward cycle
-(define-map reward-cycle-signing-keys
-    { reward-cycle: uint, signer-address: principal }
-    { num-slots: uint, stx-amount: uint }
-)
-
 ;; How many uSTX are stacked in a given reward cycle.
 ;; Updated when a new PoX address is registered, or when more STX are granted
 ;; to it.
@@ -258,10 +251,6 @@
         ;; no state at all
         none
     ))
-
-;; Get the number of slots & amount of STX for a given reward cycle signer
-(define-read-only (get-signer-info-for-cycle (signer-principal principal) (reward-cycle uint))
-    (map-get? reward-cycle-signing-keys { reward-cycle: reward-cycle, signer-address: signer-principal }))
 
 (define-read-only (check-caller-allowed)
     (or (is-eq tx-sender contract-caller)

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -56,8 +56,8 @@ use crate::chainstate::stacks::boot::pox_2_tests::{
     get_stacking_state_pox_2, get_stx_account_at, PoxPrintFields, StackingStateCheckData,
 };
 use crate::chainstate::stacks::boot::{
-    BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET, POX_2_NAME,
-    POX_3_NAME,
+    Compressed, Point, BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING,
+    BOOT_CODE_POX_TESTNET, POX_2_NAME, POX_3_NAME,
 };
 use crate::chainstate::stacks::db::{
     MinerPaymentSchedule, StacksChainState, StacksHeaderInfo, MINER_REWARD_MATURITY,
@@ -74,8 +74,6 @@ use crate::core::*;
 use crate::net::test::{TestEventObserver, TestPeer};
 use crate::util_lib::boot::boot_code_id;
 use crate::util_lib::db::{DBConn, FromRow};
-use crate::chainstate::stacks::boot::Compressed;
-use crate::chainstate::stacks::boot::Point;
 
 const USTX_PER_HOLDER: u128 = 1_000_000;
 
@@ -216,14 +214,18 @@ fn pox_extend_transition() {
 
     let alice = keys.pop().unwrap();
     let alice_pubkey = StacksPublicKey::from_private(&alice);
-    let alice_compressed = Compressed::try_from(alice_pubkey.to_bytes_compressed().as_slice()).expect("Failed to convert public key to compressed struct");
-    let alice_point = Point::try_from(&alice_compressed).expect("Failed to convert Alice's public key to point");
+    let alice_compressed = Compressed::try_from(alice_pubkey.to_bytes_compressed().as_slice())
+        .expect("Failed to convert public key to compressed struct");
+    let alice_point =
+        Point::try_from(&alice_compressed).expect("Failed to convert Alice's public key to point");
     let alice_address = key_to_stacks_addr(&alice);
     let alice_principal = PrincipalData::from(alice_address.clone());
     let bob = keys.pop().unwrap();
     let bob_pubkey = StacksPublicKey::from_private(&bob);
-    let bob_compressed = Compressed::try_from(bob_pubkey.to_bytes_compressed().as_slice()).expect("Failed to convert public key to compressed struct");
-    let bob_point = Point::try_from(&bob_compressed).expect("Failed to convert Bob's public key to point");
+    let bob_compressed = Compressed::try_from(bob_pubkey.to_bytes_compressed().as_slice())
+        .expect("Failed to convert public key to compressed struct");
+    let bob_point =
+        Point::try_from(&bob_compressed).expect("Failed to convert Bob's public key to point");
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
 
@@ -494,7 +496,7 @@ fn pox_extend_transition() {
         ),
         4,
         tip.block_height,
-        &alice_point
+        &alice_point,
     );
     let alice_pox_4_lock_nonce = 2;
     let alice_first_pox_4_unlock_height =
@@ -549,7 +551,7 @@ fn pox_extend_transition() {
         ),
         3,
         tip.block_height,
-        &bob_point
+        &bob_point,
     );
 
     // Alice can stack-extend in PoX v2
@@ -561,7 +563,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&alice).bytes,
         ),
         6,
-         Some(&alice_point)
+        Some(&alice_point),
     );
 
     let alice_pox_4_extend_nonce = 3;
@@ -809,8 +811,10 @@ fn pox_lock_unlock() {
         ])
         .map(|(key, hash_mode)| {
             let key_public = StacksPublicKey::from_private(key);
-            let key_compressed = Compressed::try_from(key_public.to_bytes_compressed().as_slice()).expect("Failed to convert public key to compressed struct");
-            let key_point = Point::try_from(&key_compressed).expect("Failed to convert Alice's public key to point");
+            let key_compressed = Compressed::try_from(key_public.to_bytes_compressed().as_slice())
+                .expect("Failed to convert public key to compressed struct");
+            let key_point = Point::try_from(&key_compressed)
+                .expect("Failed to convert Alice's public key to point");
             let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).bytes);
             txs.push(make_pox_4_lockup(
                 key,
@@ -819,7 +823,7 @@ fn pox_lock_unlock() {
                 pox_addr.clone(),
                 lock_period,
                 tip_height,
-                &key_point
+                &key_point,
             ));
             pox_addr
         })


### PR DESCRIPTION
# PoX-4 Signing Key Stacking-State Update
## Summary of Changes

This PR is meant to introduce, not complete, the core logic around signing keys in PoX-4 & address #4057 . The focus is specifically on updating the 'stacking-state' map & all the functions that read & write from it. This includes updates to the following public functions:

1. (stack-stx)
2. (delegate-stack-stx)
3. (stack-extend)
4. (delegate-stack-extend)

_what this does not include_
Getters & setters to the new map 'reward-cycle-signing-keys,' that'll be in another PR. This PR also does not include any logic that'll be used in relevant issues #4058, #4059, & #3970.

## Testing
### How were these changes tested?

This was only tested locally for syntax errors / clarinet check.

### What future testing should occur?
As soon as this is merged I'll open an issue with the user stories that require testing for @moodmosaic to work into pox_4_tests.rs.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
