### PR TITLE
pox-4: disallow stacking during prepare phase

### DIFF
--- a/contrib/core-contract-tests/Clarinet.toml
+++ b/contrib/core-contract-tests/Clarinet.toml
@@ -8,3 +8,15 @@ costs_version = 1
 [contracts.bns]
 path = "../../stackslib/src/chainstate/stacks/boot/bns.clar"
 depends_on = []
+
+[contracts.pox-4]
+path = "../../stackslib/src/chainstate/stacks/boot/pox-4.clar"
+depends_on = []
+clarity = 2
+epoch = 2.4
+
+[contracts.pox-helper]
+path = "./contracts/pox/pox-helper.clar"
+depends_on = []
+clarity = 2
+epoch = 2.4

--- a/contrib/core-contract-tests/contracts/pox/pox-helper.clar
+++ b/contrib/core-contract-tests/contracts/pox/pox-helper.clar
@@ -1,0 +1,3 @@
+
+(define-read-only (get-bbh)
+    burn-block-height)

--- a/contrib/core-contract-tests/tests/bns/name_register.test.ts
+++ b/contrib/core-contract-tests/tests/bns/name_register.test.ts
@@ -366,8 +366,8 @@ describe("name revealing workflow", () => {
       Cl.tuple({
         owner: Cl.standardPrincipal(bob),
         ["zonefile-hash"]: Cl.bufferFromUtf8(cases[0].zonefile),
-        ["lease-ending-at"]: Cl.some(Cl.uint(16)),
-        ["lease-started-at"]: Cl.uint(6),
+        ["lease-ending-at"]: Cl.some(Cl.uint(simnet.blockHeight + 10)),
+        ["lease-started-at"]: Cl.uint(simnet.blockHeight),
       })
     );
   });
@@ -589,8 +589,8 @@ describe("register a name again before and after expiration", () => {
       Cl.tuple({
         owner: Cl.standardPrincipal(charlie),
         ["zonefile-hash"]: Cl.bufferFromAscii("CHARLIE"),
-        ["lease-ending-at"]: Cl.some(Cl.uint(5029)),
-        ["lease-started-at"]: Cl.uint(5019),
+        ["lease-ending-at"]: Cl.some(Cl.uint(simnet.blockHeight + 10)),
+        ["lease-started-at"]: Cl.uint(simnet.blockHeight),
       })
     );
   });

--- a/contrib/core-contract-tests/tests/bns/name_register_test.ts
+++ b/contrib/core-contract-tests/tests/bns/name_register_test.ts
@@ -98,7 +98,7 @@ Clarinet.test({
                 ], 
                 cases[0].nameOwner.address),
         ]);
-        assertEquals(block.height, 2);
+        assertEquals(block.height, 3);
         block.receipts[0].result
             .expectErr()
             .expectInt(1005);
@@ -119,7 +119,7 @@ Clarinet.test({
                 ], 
                 cases[1].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 3);
+        assertEquals(block.height, 4);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -136,7 +136,7 @@ Clarinet.test({
                 ], 
                 cases[1].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 4);
+        assertEquals(block.height, 5);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -158,7 +158,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 5);
+        assertEquals(block.height, 6);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -174,7 +174,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 6);
+        assertEquals(block.height, 7);
         block.receipts[0].result
             .expectErr()
             .expectInt(2004);
@@ -195,7 +195,7 @@ Clarinet.test({
                 ], 
                 cases[0].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 7);
+        assertEquals(block.height, 8);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -212,7 +212,7 @@ Clarinet.test({
                 ], 
                 cases[0].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 8);
+        assertEquals(block.height, 9);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -225,7 +225,7 @@ Clarinet.test({
                 ], 
                 cases[0].namespaceOwner.address),
         ]);
-        assertEquals(block.height, 9);
+        assertEquals(block.height, 10);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -244,7 +244,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 10);
+        assertEquals(block.height, 11);
         block.receipts[0].result
             .expectErr()
             .expectInt(2001);
@@ -266,7 +266,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 11);
+        assertEquals(block.height, 12);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -282,7 +282,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 12);
+        assertEquals(block.height, 13);
         block.receipts[0].result
             .expectErr()
             .expectInt(2007);
@@ -304,7 +304,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 13);
+        assertEquals(block.height, 14);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -320,7 +320,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 14);
+        assertEquals(block.height, 15);
         block.receipts[0].result
             .expectErr()
             .expectInt(2022);
@@ -342,7 +342,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 15);
+        assertEquals(block.height, 16);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -358,7 +358,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 16);
+        assertEquals(block.height, 17);
         block.receipts[0].result
             .expectOk()
             .expectBool(true);
@@ -388,7 +388,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 17);
+        assertEquals(block.height, 18);
         block.receipts[0].result
             .expectErr()
             .expectInt(2004);
@@ -412,7 +412,7 @@ Clarinet.test({
                 ], 
                 charlie.address),
         ]);
-        assertEquals(block.height, 18);
+        assertEquals(block.height, 19);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -428,7 +428,7 @@ Clarinet.test({
                 ], 
                 charlie.address),
         ]);
-        assertEquals(block.height, 19);
+        assertEquals(block.height, 20);
         block.receipts[0].result
             .expectErr()
             .expectInt(2004);
@@ -452,7 +452,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 20);
+        assertEquals(block.height, 21);
         block.receipts[0].result
             .expectOk()
             .expectUint(144 + block.height - 1);
@@ -468,7 +468,7 @@ Clarinet.test({
                 ], 
                 bob.address),
         ]);
-        assertEquals(block.height, 21);
+        assertEquals(block.height, 22);
         block.receipts[0].result
             .expectErr()
             .expectInt(3001);

--- a/contrib/core-contract-tests/tests/pox/check_not_prepare_phase.test.ts
+++ b/contrib/core-contract-tests/tests/pox/check_not_prepare_phase.test.ts
@@ -1,0 +1,54 @@
+import { Cl } from "@stacks/transactions";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+
+const accounts = simnet.getAccounts();
+const alice = accounts.get("wallet_1")!;
+const bob = accounts.get("wallet_2")!;
+const charlie = accounts.get("wallet_3")!;
+
+function expectBurnBlockHeight(height: number) {
+  const { result: bbh } = simnet.callReadOnlyFn(
+    "pox-helper",
+    "get-bbh",
+    [],
+    alice
+  );
+  expect(bbh).toBeUint(height);
+}
+
+describe("test pox prepare phase check", () => {
+  it("should return true during prepare phase (1000 - 1049)", () => {
+    let { result } = simnet.callReadOnlyFn(
+      "pox-4",
+      "check-prepare-phase",
+      [Cl.uint(999)],
+      alice
+    );
+    expect(result).toBeBool(false);
+
+    ({ result } = simnet.callReadOnlyFn(
+      "pox-4",
+      "check-prepare-phase",
+      [Cl.uint(1000)],
+      alice
+    ));
+    expect(result).toBeBool(true);
+
+    ({ result } = simnet.callReadOnlyFn(
+      "pox-4",
+      "check-prepare-phase",
+      [Cl.uint(1049)],
+      alice
+    ));
+    expect(result).toBeBool(true);
+
+    ({ result } = simnet.callReadOnlyFn(
+      "pox-4",
+      "check-prepare-phase",
+      [Cl.uint(1050)],
+      alice
+    ));
+    expect(result).toBeBool(false);
+  });
+});

--- a/pox-locking/src/pox_3.rs
+++ b/pox-locking/src/pox_3.rs
@@ -33,6 +33,33 @@ use crate::{LockingError, POX_3_NAME};
 
 /////////////////////// PoX-3 /////////////////////////////////
 
+/// is a PoX-3 function call read only?
+pub(crate) fn is_read_only(func_name: &str) -> bool {
+    "get-pox-rejection" == func_name
+        || "is-pox-active" == func_name
+        || "burn-height-to-reward-cycle" == func_name
+        || "reward-cycle-to-burn-height" == func_name
+        || "current-pox-reward-cycle" == func_name
+        || "get-stacker-info" == func_name
+        || "get-check-delegation" == func_name
+        || "get-reward-set-size" == func_name
+        || "next-cycle-rejection-votes" == func_name
+        || "get-total-ustx-stacked" == func_name
+        || "get-reward-set-pox-address" == func_name
+        || "get-stacking-minimum" == func_name
+        || "check-pox-addr-version" == func_name
+        || "check-pox-addr-hashbytes" == func_name
+        || "check-pox-lock-period" == func_name
+        || "can-stack-stx" == func_name
+        || "minimal-can-stack-stx" == func_name
+        || "get-pox-info" == func_name
+        || "get-delegation-info" == func_name
+        || "get-allowance-contract-callers" == func_name
+        || "get-num-reward-set-pox-addresses" == func_name
+        || "get-partial-stacked-by-cycle" == func_name
+        || "get-total-pox-rejection" == func_name
+}
+
 /// Lock up STX for PoX for a time.  Does NOT touch the account nonce.
 pub fn pox_lock_v3(
     db: &mut ClarityDatabase,

--- a/pox-locking/src/pox_3.rs
+++ b/pox-locking/src/pox_3.rs
@@ -33,33 +33,6 @@ use crate::{LockingError, POX_3_NAME};
 
 /////////////////////// PoX-3 /////////////////////////////////
 
-/// is a PoX-3 function call read only?
-pub(crate) fn is_read_only(func_name: &str) -> bool {
-    "get-pox-rejection" == func_name
-        || "is-pox-active" == func_name
-        || "burn-height-to-reward-cycle" == func_name
-        || "reward-cycle-to-burn-height" == func_name
-        || "current-pox-reward-cycle" == func_name
-        || "get-stacker-info" == func_name
-        || "get-check-delegation" == func_name
-        || "get-reward-set-size" == func_name
-        || "next-cycle-rejection-votes" == func_name
-        || "get-total-ustx-stacked" == func_name
-        || "get-reward-set-pox-address" == func_name
-        || "get-stacking-minimum" == func_name
-        || "check-pox-addr-version" == func_name
-        || "check-pox-addr-hashbytes" == func_name
-        || "check-pox-lock-period" == func_name
-        || "can-stack-stx" == func_name
-        || "minimal-can-stack-stx" == func_name
-        || "get-pox-info" == func_name
-        || "get-delegation-info" == func_name
-        || "get-allowance-contract-callers" == func_name
-        || "get-num-reward-set-pox-addresses" == func_name
-        || "get-partial-stacked-by-cycle" == func_name
-        || "get-total-pox-rejection" == func_name
-}
-
 /// Lock up STX for PoX for a time.  Does NOT touch the account nonce.
 pub fn pox_lock_v3(
     db: &mut ClarityDatabase,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -97,10 +97,8 @@ lazy_static! {
         format!("{}\n{}", BOOT_CODE_POX_MAINNET_CONSTS, POX_3_BODY);
     pub static ref POX_3_TESTNET_CODE: String =
         format!("{}\n{}", BOOT_CODE_POX_TESTNET_CONSTS, POX_3_BODY);
-    pub static ref POX_4_MAINNET_CODE: String =
-        format!("{}\n{}", BOOT_CODE_POX_MAINNET_CONSTS, POX_4_BODY);
-    pub static ref POX_4_TESTNET_CODE: String =
-        format!("{}\n{}", BOOT_CODE_POX_TESTNET_CONSTS, POX_4_BODY);
+    pub static ref POX_4_MAINNET_CODE: String = format!("{}", POX_4_BODY);
+    pub static ref POX_4_TESTNET_CODE: String = format!("{}", POX_4_BODY);
     pub static ref BOOT_CODE_COST_VOTING_TESTNET: String = make_testnet_cost_voting();
     pub static ref STACKS_BOOT_CODE_MAINNET: [(&'static str, &'static str); 6] = [
         ("pox", &BOOT_CODE_POX_MAINNET),


### PR DESCRIPTION
### Description
This PR update pox-4 to disallow stacking during the prepare phase

### Applicable issues
- fixes #3775 

### Additional info (benefits, drawbacks, caveats)
When user stack stx during the prepare phase, their stx is locked, but they do not earn rewards. In addition, pool operators have extra work to remove these pool members.

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
