### PR TITLE
Bugfix/nakamoto coordinator reward set prepare phase calcs

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -28,19 +28,10 @@ jobs:
         id: git_checkout
         uses: actions/checkout@v3
 
-      - name: Reclaim disk space
-        id: cleanup
-        run: |
-          sudo apt-get update
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo apt-get remove -y '^llvm-.*'
-          sudo apt-get remove -y 'php.*'
-          sudo apt-get remove -y '^mongodb-.*'
-          sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          docker system prune --force
+      ## cleanup runner
+      - name: Cleanup Runner
+        id: runner_cleanup
+        uses: stacks-network/actions/cleanup/disk@main
 
       - name: Build bitcoin integration testing image
         id: build_docker_image

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -61,8 +61,13 @@ impl OnChainRewardSetProvider {
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
     ) -> Result<RewardSet, Error> {
+        let cycle = burnchain
+            .block_height_to_reward_cycle(current_burn_height)
+            .expect("FATAL: no reward cycle for burn height")
+            + 1;
+
         let registered_addrs =
-            chainstate.get_reward_addresses(burnchain, sortdb, current_burn_height, block_id)?;
+            chainstate.get_reward_addresses_in_cycle(burnchain, sortdb, cycle, block_id)?;
 
         let liquid_ustx = chainstate.get_liquid_ustx(block_id);
 


### PR DESCRIPTION
### Description
This pulls some bugfixes out of other branches that have discovered them:
- The first commit was cherry picked from feat/nakamoto-validate-signer 
- The second commit was taken from feat/mockamoto-mining-redux
###  Fixes
- off by one bug in find_prepare_phase_sortitions which incorrectly included one BEFORE prepare phase in the list of sortitions
- off by one bug in get_reward_set_nakamoto which was incorrectly using the current reward cycle rather than the NEXT reward cycle for getting reward addresses. This bug was due to change in assumptions in Nakamoto vs pre-Nakamoto: Nakamoto calculates reward set DURING the prepare phase of the PRIOR reward cycle whereas pre-Nakamoto calculated reward set at the START of the CURRENT reward cycle.
