### PR TITLE
chore: Update `wsts` to `v5.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,9 +2353,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256k1"
-version = "5.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e81c2cb5a1936d3f26278f9d698932239d03ddf0d5818392d91cd5f98ffc79"
+checksum = "5afcf536d20c074ef45371ee9a654dcfc46fb2dde18ecc54ec30c936eb850fa2"
 dependencies = [
  "bindgen",
  "bitvec",
@@ -3548,7 +3548,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "libsigner",
- "p256k1",
  "pico-args",
  "rand 0.7.3",
  "regex",
@@ -3582,7 +3581,6 @@ dependencies = [
  "hashbrown 0.14.0",
  "libsigner",
  "libstackerdb",
- "p256k1",
  "rand_core 0.6.4",
  "reqwest",
  "secp256k1",
@@ -3618,7 +3616,6 @@ dependencies = [
  "libstackerdb",
  "mio 0.6.23",
  "nix",
- "p256k1",
  "percent-encoding",
  "pox-locking",
  "prometheus",
@@ -4711,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0c0ec44cbd35be82490c8c566ad4971f7b41ffe8508f1c9938140df7fe18b2"
+checksum = "2c250118354755b4abb091a83cb8d659b511c0ae211ccdb3b1254e3db199cb86"
 dependencies = [
  "aes-gcm 0.10.2",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ members = [
     "stacks-signer",
     "testnet/stacks-node"]
 
+# Dependencies we want to keep the same between workspace members
+[workspace.dependencies]  
+wsts = "5.0"
+
 # Use a bit more than default optimization for
 #  dev builds to speed up test execution
 [profile.dev]

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -27,7 +27,6 @@ clap = { version = "4.1.1", features = ["derive", "env"] }
 hashbrown = "0.14"
 libsigner = { path = "../libsigner" }
 libstackerdb = { path = "../libstackerdb" }
-p256k1 = "5.5"
 rand_core = "0.6"
 reqwest = { version = "0.11.22", features = ["blocking", "json"] }
 serde = "1"
@@ -42,7 +41,7 @@ thiserror = "1.0"
 toml = "0.5.6"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-wsts = "4.0.0"
+wsts = { workspace = true }
 
 [dependencies.serde_json]
 version = "1.0"

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -23,14 +23,14 @@ use std::time::Duration;
 use blockstack_lib::chainstate::stacks::TransactionVersion;
 use clarity::vm::types::QualifiedContractIdentifier;
 use hashbrown::HashMap;
-use p256k1::ecdsa;
-use p256k1::scalar::Scalar;
 use serde::Deserialize;
 use stacks_common::address::{
     AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
 use stacks_common::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET};
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
+use wsts::curve::ecdsa;
+use wsts::curve::scalar::Scalar;
 use wsts::state_machine::PublicKeys;
 
 /// List of key_ids for each signer_id

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -124,6 +124,9 @@ fn process_dkg_result(dkg_res: &[OperationResult]) {
                 &schnorr_proof.r, &schnorr_proof.s,
             );
         }
+        OperationResult::DkgError(..) | OperationResult::SignError(..) => {
+            todo!()
+        }
     }
 }
 
@@ -146,6 +149,9 @@ fn process_sign_result(sign_res: &[OperationResult]) {
                 "Received unexpected schnorr proof ({},{})",
                 &schnorr_proof.r, &schnorr_proof.s,
             );
+        }
+        OperationResult::DkgError(..) | OperationResult::SignError(..) => {
+            todo!()
         }
     }
 }

--- a/stacks-signer/src/stacks_client.rs
+++ b/stacks-signer/src/stacks_client.rs
@@ -18,8 +18,9 @@ use slog::{slog_debug, slog_warn};
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
 use stacks_common::{debug, warn};
+use wsts::curve::point::Point;
+use wsts::curve::scalar::Scalar;
 use wsts::net::{Message, Packet};
-use wsts::{Point, Scalar};
 
 use crate::config::Config;
 

--- a/stacks-signer/src/utils.rs
+++ b/stacks-signer/src/utils.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
-use p256k1::ecdsa;
 use rand_core::OsRng;
 use slog::slog_debug;
 use stacks_common::debug;
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey};
-use wsts::Scalar;
+use wsts::curve::ecdsa;
+use wsts::curve::scalar::Scalar;
 
 use crate::stacks_client::SLOTS_PER_USER;
 

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -55,8 +55,7 @@ stacks-common = { path = "../stacks-common" }
 pox-locking = { path = "../pox-locking" }
 libstackerdb = { path = "../libstackerdb" }
 siphasher = "0.3.7"
-wsts = "4.0.0"
-p256k1 = "5.5.0"
+wsts = {workspace = true}
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -658,10 +658,7 @@ pub enum TenureChangeError {
 
 /// Schnorr threshold signature using types from `wsts`
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ThresholdSignature {
-    R: wsts::Point,
-    z: wsts::Scalar,
-}
+pub struct ThresholdSignature(pub wsts::common::Signature);
 
 /// A transaction from Stackers to signal new mining tenure
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/stackslib/src/chainstate/stacks/transaction.rs
+++ b/stackslib/src/chainstate/stacks/transaction.rs
@@ -29,7 +29,9 @@ use stacks_common::types::StacksPublicKeyBuffer;
 use stacks_common::util::hash::{to_hex, MerkleHashFunc, MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::retry::BoundReader;
 use stacks_common::util::secp256k1::MessageSignature;
-use wsts::curve as p256k1;
+use wsts::common::Signature as Secp256k1Signature;
+use wsts::curve::point::{Compressed as Secp256k1Compressed, Point as Secp256k1Point};
+use wsts::curve::scalar::Scalar as Secp256k1Scalar;
 
 use crate::burnchains::Txid;
 use crate::chainstate::stacks::{TransactionPayloadID, *};
@@ -161,15 +163,11 @@ impl StacksMessageCodec for ThresholdSignature {
     }
 
     fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, codec_error> {
-        use p256k1::point::{Compressed, Point};
-        use p256k1::scalar::Scalar;
-        use wsts::common::Signature;
-
         // Read curve point
         let mut buf = [0u8; 33];
         fd.read_exact(&mut buf)
             .map_err(crate::codec::Error::ReadError)?;
-        let R = Point::try_from(&Compressed::from(buf)).map_err(|_| {
+        let R = Secp256k1Point::try_from(&Secp256k1Compressed::from(buf)).map_err(|_| {
             crate::codec::Error::DeserializeError("Failed to read curve point".into())
         })?;
 
@@ -177,26 +175,22 @@ impl StacksMessageCodec for ThresholdSignature {
         let mut buf = [0u8; 32];
         fd.read_exact(&mut buf)
             .map_err(crate::codec::Error::ReadError)?;
-        let z = Scalar::from(buf);
+        let z = Secp256k1Scalar::from(buf);
 
-        Ok(Self(Signature { R, z }))
+        Ok(Self(Secp256k1Signature { R, z }))
     }
 }
 
 impl ThresholdSignature {
-    pub fn verify(&self, public_key: &p256k1::point::Point, msg: &[u8]) -> bool {
+    pub fn verify(&self, public_key: &Secp256k1Point, msg: &[u8]) -> bool {
         self.0.verify(public_key, msg)
     }
 
     /// Create mock data for testing. Not valid data
     pub fn mock() -> Self {
-        use p256k1::point::Point;
-        use p256k1::scalar::Scalar;
-        use wsts::common::Signature;
-
-        Self(Signature {
-            R: Point::G(),
-            z: Scalar::new(),
+        Self(Secp256k1Signature {
+            R: Secp256k1Point::G(),
+            z: Secp256k1Scalar::new(),
         })
     }
 }

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -38,10 +38,9 @@ clarity = { path = "../../clarity", features = ["default", "testing"]}
 stacks-common = { path = "../../stacks-common", features = ["default", "testing"] }
 stacks = { package = "stackslib", path = "../../stackslib", features = ["default", "testing"] }
 stacks-signer = { path = "../../stacks-signer" }
-p256k1 = "5.5"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-wsts = "4.0"
+wsts = {workspace = true}
 
 [dependencies.rusqlite]
 version = "=0.24.2"

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -310,6 +310,9 @@ fn test_stackerdb_dkg() {
                         info!("Received SchnorrProof ({},{})", &proof.r, &proof.s);
                         schnorr_proof = Some(proof);
                     }
+                    OperationResult::DkgError(..) | OperationResult::SignError(..) => {
+                        todo!()
+                    }
                 }
             }
             if aggregate_group_key.is_some() && frost_signature.is_some() && schnorr_proof.is_some()


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Update `wsts` to `v5.0.0`

This commit also contains the following changes:
  - Make `ThresholdSignature` wrapper around `wsts::common::signature` in order to use `verify()`
  - Eliminate `p256k1` from `Cargo.toml`
  - Use a common version of `wsts` for all workspace members

I had to update all workspace members, including `stacks-signer`, because it wouldn't build if `stackslib` was using a different version of `wsts`
