### PR TITLE
Feat/mockamoto genesis block routine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,8 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256k1"
 version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afcf536d20c074ef45371ee9a654dcfc46fb2dde18ecc54ec30c936eb850fa2"
 dependencies = [
  "bindgen",
  "bitvec",
@@ -4711,6 +4713,8 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c250118354755b4abb091a83cb8d659b511c0ae211ccdb3b1254e3db199cb86"
 dependencies = [
  "aes-gcm 0.10.2",
  "bs58 0.5.0",

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -81,6 +81,11 @@ const POX_4_BODY: &'static str = std::include_str!("pox-4.clar");
 pub const COSTS_1_NAME: &'static str = "costs";
 pub const COSTS_2_NAME: &'static str = "costs-2";
 pub const COSTS_3_NAME: &'static str = "costs-3";
+/// This contract name is used in testnet **only** to lookup an initial
+///  setting for the pox-4 aggregate key. This contract should contain a `define-read-only`
+///  function called `aggregate-key` with zero arguments which returns a (buff 33)
+pub const BOOT_TEST_POX_4_AGG_KEY_CONTRACT: &'static str = "pox-4-agg-test-booter";
+pub const BOOT_TEST_POX_4_AGG_KEY_FNAME: &'static str = "aggregate-key";
 
 pub mod docs;
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -38,16 +38,17 @@ use clarity::vm::types::{
 use clarity::vm::{analysis, ast, ClarityVersion, ContractName};
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::chainstate::{
-    BlockHeaderHash, BurnchainHeaderHash, SortitionId, StacksBlockId, TrieHash,
+    BlockHeaderHash, BurnchainHeaderHash, SortitionId, StacksAddress, StacksBlockId, TrieHash,
 };
 use stacks_common::util::secp256k1::MessageSignature;
 
 use crate::burnchains::{Burnchain, PoxConstants};
 use crate::chainstate::stacks::boot::{
     BOOT_CODE_COSTS, BOOT_CODE_COSTS_2, BOOT_CODE_COSTS_2_TESTNET, BOOT_CODE_COSTS_3,
-    BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET, COSTS_2_NAME,
-    COSTS_3_NAME, POX_2_MAINNET_CODE, POX_2_NAME, POX_2_TESTNET_CODE, POX_3_MAINNET_CODE,
-    POX_3_NAME, POX_3_TESTNET_CODE, POX_4_MAINNET_CODE, POX_4_NAME, POX_4_TESTNET_CODE,
+    BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET,
+    BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME, COSTS_2_NAME, COSTS_3_NAME,
+    POX_2_MAINNET_CODE, POX_2_NAME, POX_2_TESTNET_CODE, POX_3_MAINNET_CODE, POX_3_NAME,
+    POX_3_TESTNET_CODE, POX_4_MAINNET_CODE, POX_4_NAME, POX_4_TESTNET_CODE,
 };
 use crate::chainstate::stacks::db::{StacksAccount, StacksChainState};
 use crate::chainstate::stacks::events::{StacksTransactionEvent, StacksTransactionReceipt};
@@ -1343,6 +1344,32 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
             let pox_4_contract_tx =
                 StacksTransaction::new(tx_version.clone(), boot_code_auth.clone(), payload);
 
+            let initialized_agg_key = if !mainnet {
+                self.with_readonly_clarity_env(
+                    false,
+                    self.chain_id,
+                    ClarityVersion::Clarity2,
+                    StacksAddress::burn_address(false).into(),
+                    None,
+                    LimitedCostTracker::Free,
+                    |vm_env| {
+                        vm_env.execute_contract_allow_private(
+                            &boot_code_id(BOOT_TEST_POX_4_AGG_KEY_CONTRACT, false),
+                            BOOT_TEST_POX_4_AGG_KEY_FNAME,
+                            &[],
+                            true,
+                        )
+                    },
+                )
+                .ok()
+                .map(|agg_key_value| {
+                    Value::buff_from(agg_key_value.expect_buff(33))
+                        .expect("failed to reconstruct buffer")
+                })
+            } else {
+                None
+            };
+
             let pox_4_initialization_receipt = self.as_transaction(|tx_conn| {
                 // initialize with a synthetic transaction
                 debug!("Instantiate {} contract", &pox_4_contract_id);
@@ -1374,6 +1401,46 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                         |_, _| false,
                     )
                     .expect("Failed to set burnchain parameters in PoX-3 contract");
+
+                // set the aggregate public key for all pre-pox-4 cycles, if in testnet, and can fetch a boot-setting
+                if !mainnet {
+                    if let Some(ref agg_pub_key) = initialized_agg_key {
+                        for set_in_reward_cycle in 0..pox_4_first_cycle {
+                            info!(
+                                "Setting initial aggregate-public-key in PoX-4";
+                                "agg_pub_key" => %agg_pub_key,
+                                "reward_cycle" => set_in_reward_cycle,
+                            );
+                            tx_conn
+                                .with_abort_callback(
+                                    |vm_env| {
+                                        vm_env.execute_in_env(
+                                            StacksAddress::burn_address(false).into(),
+                                            None,
+                                            None,
+                                            |env| {
+                                                env.execute_contract_allow_private(
+                                                    &pox_4_contract_id,
+                                                    "set-aggregate-public-key",
+                                                    &[
+                                                        SymbolicExpression::atom_value(
+                                                            Value::UInt(set_in_reward_cycle.into()),
+                                                        ),
+                                                        SymbolicExpression::atom_value(
+                                                            agg_pub_key.clone(),
+                                                        ),
+                                                    ],
+                                                    false,
+                                                )
+                                            },
+                                        )
+                                    },
+                                    |_, _| false,
+                                )
+                                .unwrap();
+                        }
+                    }
+                }
 
                 receipt
             });

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -36,7 +36,7 @@ use stacks::chainstate::nakamoto::{
 };
 use stacks::chainstate::stacks::address::PoxAddress;
 use stacks::chainstate::stacks::boot::{
-    BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME,
+    BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME, POX_4_NAME,
 };
 use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
 use stacks::chainstate::stacks::miner::{
@@ -72,6 +72,7 @@ use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::hash::{to_hex, Hash160, MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PublicKey};
 use stacks_common::util::vrf::{VRFPrivateKey, VRFProof, VRFPublicKey, VRF};
+use wsts::curve::point::Point;
 
 use self::signer::SelfSigner;
 use crate::neon::Counters;
@@ -800,89 +801,46 @@ impl MockamotoNode {
             "chain_tip_ch" => %chain_tip_ch, "miner_account" => %miner_principal, "miner_nonce" => %miner_nonce,
         );
 
-        let vrf_proof = VRF::prove(&self.vrf_key, sortition_tip.sortition_hash.as_bytes());
-        let coinbase_tx_payload =
-            TransactionPayload::Coinbase(CoinbasePayload([1; 32]), None, Some(vrf_proof));
-        let mut coinbase_tx = StacksTransaction::new(
-            TransactionVersion::Testnet,
-            TransactionAuth::from_p2pkh(&self.miner_key).unwrap(),
-            coinbase_tx_payload,
-        );
-        coinbase_tx.chain_id = chain_id;
-        coinbase_tx.set_origin_nonce(miner_nonce + 1);
-        let mut coinbase_tx_signer = StacksTransactionSigner::new(&coinbase_tx);
-        coinbase_tx_signer.sign_origin(&self.miner_key).unwrap();
-        let coinbase_tx = coinbase_tx_signer.get_tx().unwrap();
-
-        let miner_pk = Secp256k1PublicKey::from_private(&self.miner_key);
-        let miner_pk_hash = Hash160::from_node_public_key(&miner_pk);
-
         // Add a tenure change transaction to the block:
         //  as of now every mockamoto block is a tenure-change.
         // If mockamoto mode changes to support non-tenure-changing blocks, this will have
         //  to be gated.
-        let tenure_change_tx_payload = TransactionPayload::TenureChange(TenureChangePayload {
-            tenure_consensus_hash: sortition_tip.consensus_hash.clone(),
-            prev_tenure_consensus_hash: chain_tip_ch.clone(),
-            burn_view_consensus_hash: sortition_tip.consensus_hash,
-            previous_tenure_end: parent_block_id,
-            previous_tenure_blocks: 1,
-            cause: TenureChangeCause::BlockFound,
-            pubkey_hash: miner_pk_hash,
-            signature: ThresholdSignature::mock(),
-            signers: vec![],
-        });
-        let mut tenure_tx = StacksTransaction::new(
-            TransactionVersion::Testnet,
-            TransactionAuth::from_p2pkh(&self.miner_key).unwrap(),
-            tenure_change_tx_payload,
+        let tenure_tx =
+            make_tenure_change_tx(&self.miner_key, miner_nonce, chain_id, parent_block_id, chain_tip_ch.clone(), &sortition_tip);
+        let vrf_proof = VRF::prove(&self.vrf_key, sortition_tip.sortition_hash.as_bytes());
+        let coinbase_tx =
+            make_coinbase_tx(&self.miner_key, miner_nonce + 1, chain_id, Some(vrf_proof));
+        let stacks_stx_tx = make_stacks_stx_tx(
+            &self.miner_key,
+            miner_nonce + 2,
+            chain_id,
+            parent_chain_length,
+            parent_burn_height,
         );
-        tenure_tx.chain_id = chain_id;
-        tenure_tx.set_origin_nonce(miner_nonce);
-        let mut tenure_tx_signer = StacksTransactionSigner::new(&tenure_tx);
-        tenure_tx_signer.sign_origin(&self.miner_key).unwrap();
-        let tenure_tx = tenure_tx_signer.get_tx().unwrap();
-
-        let pox_address = PoxAddress::Standard(
-            StacksAddress::burn_address(false),
-            Some(AddressHashMode::SerializeP2PKH),
+        // Set the aggregate public key for the NEXT reward cycle hence +1
+        let reward_cycle = self
+            .sortdb
+            .pox_constants
+            .block_height_to_reward_cycle(
+                self.sortdb.first_block_height,
+                sortition_tip.block_height,
+            )
+            .expect(
+                format!(
+                    "Failed to determine reward cycle of block height: {}",
+                    sortition_tip.block_height
+                )
+                .as_str(),
+            )
+            + 1;
+        let aggregate_tx = make_aggregate_tx(
+            &self.miner_key,
+            miner_nonce + 3,
+            chain_id,
+            &self.self_signer.aggregate_public_key,
+            reward_cycle,
         );
-
-        let stack_stx_payload = if parent_chain_length < 2 {
-            TransactionPayload::ContractCall(TransactionContractCall {
-                address: StacksAddress::burn_address(false),
-                contract_name: "pox-4".try_into().unwrap(),
-                function_name: "stack-stx".try_into().unwrap(),
-                function_args: vec![
-                    ClarityValue::UInt(99_000_000_000_000),
-                    pox_address.as_clarity_tuple().unwrap().into(),
-                    ClarityValue::UInt(u128::from(parent_burn_height)),
-                    ClarityValue::UInt(12),
-                ],
-            })
-        } else {
-            // NOTE: stack-extend doesn't currently work, because the PoX-4 lockup
-            //  special functions have not been implemented.
-            TransactionPayload::ContractCall(TransactionContractCall {
-                address: StacksAddress::burn_address(false),
-                contract_name: "pox-4".try_into().unwrap(),
-                function_name: "stack-extend".try_into().unwrap(),
-                function_args: vec![
-                    ClarityValue::UInt(5),
-                    pox_address.as_clarity_tuple().unwrap().into(),
-                ],
-            })
-        };
-        let mut stack_stx_tx = StacksTransaction::new(
-            TransactionVersion::Testnet,
-            TransactionAuth::from_p2pkh(&self.miner_key).unwrap(),
-            stack_stx_payload,
-        );
-        stack_stx_tx.chain_id = chain_id;
-        stack_stx_tx.set_origin_nonce(miner_nonce + 2);
-        let mut stack_stx_tx_signer = StacksTransactionSigner::new(&stack_stx_tx);
-        stack_stx_tx_signer.sign_origin(&self.miner_key).unwrap();
-        let stacks_stx_tx = stack_stx_tx_signer.get_tx().unwrap();
+        let txs = vec![tenure_tx, coinbase_tx, stacks_stx_tx, aggregate_tx];
 
         let sortdb_handle = self.sortdb.index_conn();
         let SetupBlockResult {
@@ -906,51 +864,6 @@ impl MockamotoNode {
             parent_chain_length + 1,
             false,
         )?;
-
-        // Set the aggregate public key for the NEXT reward cycle hence +1
-        let reward_cycle = self
-            .sortdb
-            .pox_constants
-            .block_height_to_reward_cycle(
-                self.sortdb.first_block_height,
-                sortition_tip.block_height,
-            )
-            .expect(
-                format!(
-                    "Failed to determine reward cycle of block height: {}",
-                    sortition_tip.block_height
-                )
-                .as_str(),
-            )
-            + 1;
-        let aggregate_payload = TransactionPayload::ContractCall(TransactionContractCall {
-            address: StacksAddress::burn_address(false),
-            contract_name: "pox-4".try_into().unwrap(),
-            function_name: "set-aggregate-public-key".try_into().unwrap(),
-            function_args: vec![
-                ClarityValue::UInt(u128::from(reward_cycle)),
-                ClarityValue::buff_from(
-                    self.self_signer
-                        .aggregate_public_key
-                        .compress()
-                        .data
-                        .to_vec(),
-                )
-                .expect("Failed to serialize aggregate public key"),
-            ],
-        });
-        let mut aggregate_tx: StacksTransaction = StacksTransaction::new(
-            TransactionVersion::Testnet,
-            TransactionAuth::from_p2pkh(&self.miner_key).unwrap(),
-            aggregate_payload,
-        );
-        aggregate_tx.chain_id = chain_id;
-        aggregate_tx.set_origin_nonce(miner_nonce + 3);
-        let mut aggregate_tx_signer = StacksTransactionSigner::new(&aggregate_tx);
-        aggregate_tx_signer.sign_origin(&self.miner_key).unwrap();
-        let aggregate_tx = aggregate_tx_signer.get_tx().unwrap();
-
-        let txs = vec![tenure_tx, coinbase_tx, stacks_stx_tx, aggregate_tx];
 
         let _ = match StacksChainState::process_block_transactions(
             &mut clarity_tx,
@@ -1079,4 +992,124 @@ impl MockamotoNode {
         staging_tx.commit()?;
         Ok(chain_length)
     }
+}
+
+// Helper function to make a signed tenure change transaction
+fn make_tenure_change_tx(
+    key: &StacksPrivateKey,
+    miner_nonce: u64,
+    chain_id: u32,
+    parent_block_id: StacksBlockId,
+    prev_tenure_consensus_hash: ConsensusHash,
+    sortition_tip: &BlockSnapshot,
+
+) -> StacksTransaction {
+    let pubkey = Secp256k1PublicKey::from_private(key);
+    let pubkey_hash = Hash160::from_node_public_key(&pubkey); 
+    let tenure_change_tx_payload = TransactionPayload::TenureChange(TenureChangePayload {
+        tenure_consensus_hash: sortition_tip.consensus_hash.clone(),
+        prev_tenure_consensus_hash,
+        burn_view_consensus_hash: sortition_tip.consensus_hash,
+        previous_tenure_end: parent_block_id,
+        previous_tenure_blocks: 1,
+        cause: TenureChangeCause::BlockFound,
+        pubkey_hash,
+        signature: ThresholdSignature::mock(),
+        signers: vec![],
+    });
+    make_tx(key, miner_nonce, tenure_change_tx_payload, chain_id)
+}
+
+// Helper function to make a signed coinbase transaction
+fn make_coinbase_tx(
+    key: &StacksPrivateKey,
+    miner_nonce: u64,
+    chain_id: u32,
+    vrf_proof: Option<VRFProof>,
+) -> StacksTransaction {
+    let coinbase_tx_payload =
+        TransactionPayload::Coinbase(CoinbasePayload([1; 32]), None, vrf_proof);
+    make_tx(key, miner_nonce, coinbase_tx_payload, chain_id)
+}
+
+// Helper function to make a signed stacks-stx transaction
+fn make_stacks_stx_tx(
+    key: &StacksPrivateKey,
+    miner_nonce: u64,
+    chain_id: u32,
+    parent_chain_length: u64,
+    parent_burn_height: u32,
+) -> StacksTransaction {
+    let pox_address = PoxAddress::Standard(
+        StacksAddress::burn_address(false),
+        Some(AddressHashMode::SerializeP2PKH),
+    );
+
+    let stack_stx_payload = if parent_chain_length < 2 {
+        TransactionPayload::ContractCall(TransactionContractCall {
+            address: StacksAddress::burn_address(false),
+            contract_name: POX_4_NAME.into(),
+            function_name: "stack-stx".try_into().unwrap(),
+            function_args: vec![
+                ClarityValue::UInt(99_000_000_000_000),
+                pox_address.as_clarity_tuple().unwrap().into(),
+                ClarityValue::UInt(u128::from(parent_burn_height)),
+                ClarityValue::UInt(12),
+            ],
+        })
+    } else {
+        // NOTE: stack-extend doesn't currently work, because the PoX-4 lockup
+        //  special functions have not been implemented.
+        TransactionPayload::ContractCall(TransactionContractCall {
+            address: StacksAddress::burn_address(false),
+            contract_name: POX_4_NAME.into(),
+            function_name: "stack-extend".try_into().unwrap(),
+            function_args: vec![
+                ClarityValue::UInt(5),
+                pox_address.as_clarity_tuple().unwrap().into(),
+            ],
+        })
+    };
+    make_tx(key, miner_nonce, stack_stx_payload, chain_id)
+}
+
+/// Helper function to make a set-aggregate-public-key transaction
+fn make_aggregate_tx(
+    key: &StacksPrivateKey,
+    nonce: u64,
+    chain_id: u32,
+    aggregate_public_key: &Point,
+    reward_cycle: u64,
+) -> StacksTransaction {
+    let aggregate_payload = TransactionPayload::ContractCall(TransactionContractCall {
+        address: StacksAddress::burn_address(false),
+        contract_name: POX_4_NAME.into(),
+        function_name: "set-aggregate-public-key".try_into().unwrap(),
+        function_args: vec![
+            ClarityValue::UInt(u128::from(reward_cycle)),
+            ClarityValue::buff_from(aggregate_public_key.compress().data.to_vec())
+                .expect("Failed to serialize aggregate public key"),
+        ],
+    });
+    make_tx(&key, nonce, aggregate_payload, chain_id)
+}
+
+/// Helper function to create a zero fee transaction
+/// TODO: this is duplicated in so many places. We should have a utils fn for this
+fn make_tx(
+    key: &StacksPrivateKey,
+    nonce: u64,
+    tx_payload: TransactionPayload,
+    chain_id: u32,
+) -> StacksTransaction {
+    let mut tx = StacksTransaction::new(
+        TransactionVersion::Testnet,
+        TransactionAuth::from_p2pkh(&key).unwrap(),
+        tx_payload,
+    );
+    tx.chain_id = chain_id;
+    tx.set_origin_nonce(nonce);
+    let mut tx_signer = StacksTransactionSigner::new(&tx);
+    tx_signer.sign_origin(&key).unwrap();
+    tx_signer.get_tx().unwrap()
 }

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -907,7 +907,50 @@ impl MockamotoNode {
             false,
         )?;
 
-        let txs = vec![tenure_tx, coinbase_tx, stacks_stx_tx];
+        // Set the aggregate public key for the NEXT reward cycle hence +1
+        let reward_cycle = self
+            .sortdb
+            .pox_constants
+            .block_height_to_reward_cycle(
+                self.sortdb.first_block_height,
+                sortition_tip.block_height,
+            )
+            .expect(
+                format!(
+                    "Failed to determine reward cycle of block height: {}",
+                    sortition_tip.block_height
+                )
+                .as_str(),
+            )
+            + 1;
+        let aggregate_payload = TransactionPayload::ContractCall(TransactionContractCall {
+            address: StacksAddress::burn_address(false),
+            contract_name: "pox-4".try_into().unwrap(),
+            function_name: "set-aggregate-public-key".try_into().unwrap(),
+            function_args: vec![
+                ClarityValue::UInt(u128::from(reward_cycle)),
+                ClarityValue::buff_from(
+                    self.self_signer
+                        .aggregate_public_key
+                        .compress()
+                        .data
+                        .to_vec(),
+                )
+                .expect("Failed to serialize aggregate public key"),
+            ],
+        });
+        let mut aggregate_tx: StacksTransaction = StacksTransaction::new(
+            TransactionVersion::Testnet,
+            TransactionAuth::from_p2pkh(&self.miner_key).unwrap(),
+            aggregate_payload,
+        );
+        aggregate_tx.chain_id = chain_id;
+        aggregate_tx.set_origin_nonce(miner_nonce + 3);
+        let mut aggregate_tx_signer = StacksTransactionSigner::new(&aggregate_tx);
+        aggregate_tx_signer.sign_origin(&self.miner_key).unwrap();
+        let aggregate_tx = aggregate_tx_signer.get_tx().unwrap();
+
+        let txs = vec![tenure_tx, coinbase_tx, stacks_stx_tx, aggregate_tx];
 
         let _ = match StacksChainState::process_block_transactions(
             &mut clarity_tx,

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -805,8 +805,14 @@ impl MockamotoNode {
         //  as of now every mockamoto block is a tenure-change.
         // If mockamoto mode changes to support non-tenure-changing blocks, this will have
         //  to be gated.
-        let tenure_tx =
-            make_tenure_change_tx(&self.miner_key, miner_nonce, chain_id, parent_block_id, chain_tip_ch.clone(), &sortition_tip);
+        let tenure_tx = make_tenure_change_tx(
+            &self.miner_key,
+            miner_nonce,
+            chain_id,
+            parent_block_id,
+            chain_tip_ch.clone(),
+            &sortition_tip,
+        );
         let vrf_proof = VRF::prove(&self.vrf_key, sortition_tip.sortition_hash.as_bytes());
         let coinbase_tx =
             make_coinbase_tx(&self.miner_key, miner_nonce + 1, chain_id, Some(vrf_proof));
@@ -1002,10 +1008,9 @@ fn make_tenure_change_tx(
     parent_block_id: StacksBlockId,
     prev_tenure_consensus_hash: ConsensusHash,
     sortition_tip: &BlockSnapshot,
-
 ) -> StacksTransaction {
     let pubkey = Secp256k1PublicKey::from_private(key);
-    let pubkey_hash = Hash160::from_node_public_key(&pubkey); 
+    let pubkey_hash = Hash160::from_node_public_key(&pubkey);
     let tenure_change_tx_payload = TransactionPayload::TenureChange(TenureChangePayload {
         tenure_consensus_hash: sortition_tip.consensus_hash.clone(),
         prev_tenure_consensus_hash,

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -108,6 +108,10 @@ fn observe_100_blocks() {
 
     globals.signal_stop();
 
+    node_thread
+        .join()
+        .expect("Failed to join node thread to exit");
+
     let transfer_tx_included = test_observer::get_blocks()
         .into_iter()
         .find(|block_json| {
@@ -129,9 +133,6 @@ fn observe_100_blocks() {
         completed,
         "Mockamoto node failed to produce and announce 100 blocks before timeout"
     );
-    node_thread
-        .join()
-        .expect("Failed to join node thread to exit");
 }
 
 #[test]
@@ -367,6 +368,10 @@ fn mempool_rpc_submit() {
 
     globals.signal_stop();
 
+    node_thread
+        .join()
+        .expect("Failed to join node thread to exit");
+
     let transfer_tx_included = test_observer::get_blocks()
         .into_iter()
         .find(|block_json| {
@@ -388,7 +393,4 @@ fn mempool_rpc_submit() {
         completed,
         "Mockamoto node failed to produce and announce 100 blocks before timeout"
     );
-    node_thread
-        .join()
-        .expect("Failed to join node thread to exit");
 }

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -1,18 +1,25 @@
 use std::thread;
 use std::time::{Duration, Instant};
 
+use clarity::boot_util::boot_code_addr;
 use clarity::vm::costs::ExecutionCost;
+use clarity::vm::Value;
+use rand_core::OsRng;
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::nakamoto::NakamotoChainState;
+use stacks::chainstate::stacks::boot::POX_4_NAME;
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey};
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::to_hex;
+use wsts::curve::point::Point;
+use wsts::curve::scalar::Scalar;
 
 use super::MockamotoNode;
 use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon_node::PeerThread;
 use crate::tests::neon_integrations::{submit_tx, test_observer};
-use crate::tests::{make_stacks_transfer, to_addr};
+use crate::tests::{make_contract_call, make_stacks_transfer, to_addr};
 use crate::{Config, ConfigFile};
 
 #[test]
@@ -54,7 +61,8 @@ fn observe_100_blocks() {
         .expect("FATAL: failed to start mockamoto main thread");
 
     // make a transfer tx to test that the mockamoto miner picks up txs from the mempool
-    let transfer_tx = make_stacks_transfer(&submitter_sk, 0, 300, &recipient_addr, 100);
+    let tx_fee = 200;
+    let transfer_tx = make_stacks_transfer(&submitter_sk, 0, tx_fee, &recipient_addr, 100);
     let transfer_tx_hex = format!("0x{}", to_hex(&transfer_tx));
 
     let mut sent_tx = false;
@@ -124,6 +132,160 @@ fn observe_100_blocks() {
     node_thread
         .join()
         .expect("Failed to join node thread to exit");
+}
+
+#[test]
+fn observe_set_aggregate_tx() {
+    let mut conf = Config::from_config_file(ConfigFile::mockamoto()).unwrap();
+    conf.node.mockamoto_time_ms = 10;
+
+    let submitter_sk = StacksPrivateKey::from_seed(&[1]);
+    let submitter_addr = to_addr(&submitter_sk);
+    conf.add_initial_balance(submitter_addr.to_string(), 1_000);
+
+    test_observer::spawn();
+    let observer_port = test_observer::EVENT_OBSERVER_PORT;
+    conf.events_observers.insert(EventObserverConfig {
+        endpoint: format!("localhost:{observer_port}"),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut mockamoto = MockamotoNode::new(&conf).unwrap();
+
+    let globals = mockamoto.globals.clone();
+
+    let mut mempool = PeerThread::connect_mempool_db(&conf);
+    let (mut chainstate, _) = StacksChainState::open(
+        conf.is_mainnet(),
+        conf.burnchain.chain_id,
+        &conf.get_chainstate_path_str(),
+        None,
+    )
+    .unwrap();
+    let burnchain = conf.get_burnchain();
+    let sortdb = burnchain.open_sortition_db(true).unwrap();
+    let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(mockamoto.sortdb.conn()).unwrap();
+
+    let start = Instant::now();
+    // Get a reward cycle to compare against
+    let reward_cycle = mockamoto
+        .sortdb
+        .pox_constants
+        .block_height_to_reward_cycle(
+            mockamoto.sortdb.first_block_height,
+            sortition_tip.block_height,
+        )
+        .expect(
+            format!(
+                "Failed to determine reward cycle of block height: {}",
+                sortition_tip.block_height
+            )
+            .as_str(),
+        );
+
+    let node_thread = thread::Builder::new()
+        .name("mockamoto-main".into())
+        .spawn(move || {
+            mockamoto.run();
+            let aggregate_key_block_header = NakamotoChainState::get_canonical_block_header(
+                mockamoto.chainstate.db(),
+                &mockamoto.sortdb,
+            )
+            .unwrap()
+            .unwrap();
+            // Get the aggregate public key to later verify that it was set correctly
+            mockamoto
+                .chainstate
+                .get_aggregate_public_key_pox_4(
+                    &mockamoto.sortdb,
+                    &aggregate_key_block_header.index_block_hash(),
+                    reward_cycle,
+                )
+                .unwrap()
+        })
+        .expect("FATAL: failed to start mockamoto main thread");
+
+    // Create a "set-aggregate-public-key" tx to verify it sets correctly
+    let mut rng = OsRng::default();
+    let x = Scalar::random(&mut rng);
+    let random_key = Point::from(x);
+
+    let tx_fee = 200;
+    let aggregate_public_key = Value::buff_from(random_key.compress().data.to_vec())
+        .expect("Failed to serialize aggregate public key");
+    let aggregate_tx = make_contract_call(
+        &submitter_sk,
+        0,
+        tx_fee,
+        &boot_code_addr(false),
+        POX_4_NAME,
+        "set-aggregate-public-key",
+        &[Value::UInt(u128::from(reward_cycle)), aggregate_public_key],
+    );
+    let aggregate_tx_hex = format!("0x{}", to_hex(&aggregate_tx));
+
+    // complete within 5 seconds or abort (we are only observing one block)
+    let completed = loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(5) {
+            break false;
+        }
+        let latest_block = test_observer::get_blocks().pop();
+        thread::sleep(Duration::from_secs(1));
+        let Some(ref latest_block) = latest_block else {
+            info!("No block observed yet!");
+            continue;
+        };
+        let stacks_block_height = latest_block.get("block_height").unwrap().as_u64().unwrap();
+        info!("Block height observed: {stacks_block_height}");
+
+        // Submit the aggregate tx for processing to update the aggregate public key
+        let tip = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+            .unwrap()
+            .unwrap();
+        mempool
+            .submit_raw(
+                &mut chainstate,
+                &sortdb,
+                &tip.consensus_hash,
+                &tip.anchored_header.block_hash(),
+                aggregate_tx.clone(),
+                &ExecutionCost::max_value(),
+                &StacksEpochId::Epoch30,
+            )
+            .unwrap();
+        break true;
+    };
+
+    globals.signal_stop();
+
+    let aggregate_key = node_thread
+        .join()
+        .expect("Failed to join node thread to exit");
+
+    // Did we set and retrieve the aggregate key correctly?
+    assert_eq!(aggregate_key.unwrap(), random_key);
+
+    let aggregate_tx_included = test_observer::get_blocks()
+        .into_iter()
+        .find(|block_json| {
+            block_json["transactions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|tx_json| tx_json["raw_tx"].as_str() == Some(&aggregate_tx_hex))
+                .is_some()
+        })
+        .is_some();
+
+    assert!(
+        aggregate_tx_included,
+        "Mockamoto node failed to include the aggregate tx"
+    );
+
+    assert!(
+        completed,
+        "Mockamoto node failed to produce and announce its block before timeout"
+    );
 }
 
 #[test]

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -151,6 +151,8 @@ fn observe_set_aggregate_tx() {
     });
 
     let mut mockamoto = MockamotoNode::new(&conf).unwrap();
+    // Get the aggregate public key of the original reward cycle to compare against
+    let orig_key = mockamoto.self_signer.aggregate_public_key;
 
     let globals = mockamoto.globals.clone();
 
@@ -167,7 +169,7 @@ fn observe_set_aggregate_tx() {
     let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(mockamoto.sortdb.conn()).unwrap();
 
     let start = Instant::now();
-    // Get a reward cycle to compare against
+    // Get the reward cycle of the sortition tip
     let reward_cycle = mockamoto
         .sortdb
         .pox_constants
@@ -193,15 +195,25 @@ fn observe_set_aggregate_tx() {
             )
             .unwrap()
             .unwrap();
-            // Get the aggregate public key to later verify that it was set correctly
-            mockamoto
+            // Get the aggregate public key of the original reward cycle
+            let orig_aggregate_key = mockamoto
                 .chainstate
                 .get_aggregate_public_key_pox_4(
                     &mockamoto.sortdb,
                     &aggregate_key_block_header.index_block_hash(),
                     reward_cycle,
                 )
-                .unwrap()
+                .unwrap();
+            // Get the aggregate public key of the next reward cycle that we manually overwrote
+            let new_aggregate_key = mockamoto
+                .chainstate
+                .get_aggregate_public_key_pox_4(
+                    &mockamoto.sortdb,
+                    &aggregate_key_block_header.index_block_hash(),
+                    reward_cycle + 1,
+                )
+                .unwrap();
+            (orig_aggregate_key, new_aggregate_key)
         })
         .expect("FATAL: failed to start mockamoto main thread");
 
@@ -220,7 +232,10 @@ fn observe_set_aggregate_tx() {
         &boot_code_addr(false),
         POX_4_NAME,
         "set-aggregate-public-key",
-        &[Value::UInt(u128::from(reward_cycle)), aggregate_public_key],
+        &[
+            Value::UInt(u128::from(reward_cycle + 1)),
+            aggregate_public_key,
+        ],
     );
     let aggregate_tx_hex = format!("0x{}", to_hex(&aggregate_tx));
 
@@ -258,12 +273,9 @@ fn observe_set_aggregate_tx() {
 
     globals.signal_stop();
 
-    let aggregate_key = node_thread
+    let (orig_aggregate_key, new_aggregate_key) = node_thread
         .join()
         .expect("Failed to join node thread to exit");
-
-    // Did we set and retrieve the aggregate key correctly?
-    assert_eq!(aggregate_key.unwrap(), random_key);
 
     let aggregate_tx_included = test_observer::get_blocks()
         .into_iter()
@@ -286,6 +298,10 @@ fn observe_set_aggregate_tx() {
         completed,
         "Mockamoto node failed to produce and announce its block before timeout"
     );
+
+    // Did we set and retrieve the aggregate key correctly?
+    assert_eq!(orig_aggregate_key.unwrap(), orig_key);
+    assert_eq!(new_aggregate_key.unwrap(), random_key);
 }
 
 #[test]


### PR DESCRIPTION
### Description
This does the following:
- It adds a bootup callback to instantiation to set the aggregate public key (required as pox-4 is not initialized until after genesis block).
- It adds a routine to the pox-4 instantiation to check if its in testnet, and if so, it checks if an initial agg key has been written.
- It makes sure to set al pre-pox-4 reward cycles aggregate public keys
- Every mockamoto block sets the aggregate public key for the following reward cycle
- It pulls the transaction creation into sep functions to cleanup the super long mine_stacks_block

Note every commit is a separation of concerns so feel free to review commit at a time if that is easier to grok.

### Applicable issues
- Closes https://github.com/stacks-network/stacks-core/issues/4028

