### PR TITLE
Make `set-aggregate-public-key` private

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -81,6 +81,11 @@ const POX_4_BODY: &'static str = std::include_str!("pox-4.clar");
 pub const COSTS_1_NAME: &'static str = "costs";
 pub const COSTS_2_NAME: &'static str = "costs-2";
 pub const COSTS_3_NAME: &'static str = "costs-3";
+/// This contract name is used in testnet **only** to lookup an initial
+///  setting for the pox-4 aggregate key. This contract should contain a `define-read-only`
+///  function called `aggregate-key` with zero arguments which returns a (buff 33)
+pub const BOOT_TEST_POX_4_AGG_KEY_CONTRACT: &'static str = "pox-4-agg-test-booter";
+pub const BOOT_TEST_POX_4_AGG_KEY_FNAME: &'static str = "aggregate-key";
 
 pub mod docs;
 

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -1330,9 +1330,8 @@
 )
 
 ;; Set the aggregate public key to the provided value
-;; TODO: https://github.com/stacks-network/stacks-core/issues/4101
 ;; *New in Stacks 3.0*
-(define-public (set-aggregate-public-key (reward-cycle uint) (aggregate-public-key (buff 33)))
+(define-private (set-aggregate-public-key (reward-cycle uint) (aggregate-public-key (buff 33)))
     (begin
         (ok (map-set aggregate-public-keys reward-cycle aggregate-public-key))
     )

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -38,16 +38,17 @@ use clarity::vm::types::{
 use clarity::vm::{analysis, ast, ClarityVersion, ContractName};
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::chainstate::{
-    BlockHeaderHash, BurnchainHeaderHash, SortitionId, StacksBlockId, TrieHash,
+    BlockHeaderHash, BurnchainHeaderHash, SortitionId, StacksAddress, StacksBlockId, TrieHash,
 };
 use stacks_common::util::secp256k1::MessageSignature;
 
 use crate::burnchains::{Burnchain, PoxConstants};
 use crate::chainstate::stacks::boot::{
     BOOT_CODE_COSTS, BOOT_CODE_COSTS_2, BOOT_CODE_COSTS_2_TESTNET, BOOT_CODE_COSTS_3,
-    BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET, COSTS_2_NAME,
-    COSTS_3_NAME, POX_2_MAINNET_CODE, POX_2_NAME, POX_2_TESTNET_CODE, POX_3_MAINNET_CODE,
-    POX_3_NAME, POX_3_TESTNET_CODE, POX_4_MAINNET_CODE, POX_4_NAME, POX_4_TESTNET_CODE,
+    BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET,
+    BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME, COSTS_2_NAME, COSTS_3_NAME,
+    POX_2_MAINNET_CODE, POX_2_NAME, POX_2_TESTNET_CODE, POX_3_MAINNET_CODE, POX_3_NAME,
+    POX_3_TESTNET_CODE, POX_4_MAINNET_CODE, POX_4_NAME, POX_4_TESTNET_CODE,
 };
 use crate::chainstate::stacks::db::{StacksAccount, StacksChainState};
 use crate::chainstate::stacks::events::{StacksTransactionEvent, StacksTransactionReceipt};
@@ -1343,6 +1344,32 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
             let pox_4_contract_tx =
                 StacksTransaction::new(tx_version.clone(), boot_code_auth.clone(), payload);
 
+            let initialized_agg_key = if !mainnet {
+                self.with_readonly_clarity_env(
+                    false,
+                    self.chain_id,
+                    ClarityVersion::Clarity2,
+                    StacksAddress::burn_address(false).into(),
+                    None,
+                    LimitedCostTracker::Free,
+                    |vm_env| {
+                        vm_env.execute_contract_allow_private(
+                            &boot_code_id(BOOT_TEST_POX_4_AGG_KEY_CONTRACT, false),
+                            BOOT_TEST_POX_4_AGG_KEY_FNAME,
+                            &[],
+                            true,
+                        )
+                    },
+                )
+                .ok()
+                .map(|agg_key_value| {
+                    Value::buff_from(agg_key_value.expect_buff(33))
+                        .expect("failed to reconstruct buffer")
+                })
+            } else {
+                None
+            };
+
             let pox_4_initialization_receipt = self.as_transaction(|tx_conn| {
                 // initialize with a synthetic transaction
                 debug!("Instantiate {} contract", &pox_4_contract_id);
@@ -1374,6 +1401,46 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                         |_, _| false,
                     )
                     .expect("Failed to set burnchain parameters in PoX-3 contract");
+
+                // set the aggregate public key for all pre-pox-4 cycles, if in testnet, and can fetch a boot-setting
+                if !mainnet {
+                    if let Some(ref agg_pub_key) = initialized_agg_key {
+                        for set_in_reward_cycle in 0..pox_4_first_cycle {
+                            info!(
+                                "Setting initial aggregate-public-key in PoX-4";
+                                "agg_pub_key" => %agg_pub_key,
+                                "reward_cycle" => set_in_reward_cycle,
+                            );
+                            tx_conn
+                                .with_abort_callback(
+                                    |vm_env| {
+                                        vm_env.execute_in_env(
+                                            StacksAddress::burn_address(false).into(),
+                                            None,
+                                            None,
+                                            |env| {
+                                                env.execute_contract_allow_private(
+                                                    &pox_4_contract_id,
+                                                    "set-aggregate-public-key",
+                                                    &[
+                                                        SymbolicExpression::atom_value(
+                                                            Value::UInt(set_in_reward_cycle.into()),
+                                                        ),
+                                                        SymbolicExpression::atom_value(
+                                                            agg_pub_key.clone(),
+                                                        ),
+                                                    ],
+                                                    false,
+                                                )
+                                            },
+                                        )
+                                    },
+                                    |_, _| false,
+                                )
+                                .unwrap();
+                        }
+                    }
+                }
 
                 receipt
             });

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -5,8 +5,10 @@ use std::thread;
 use std::thread::{sleep, JoinHandle};
 use std::time::Duration;
 
+use clarity::boot_util::boot_code_id;
 use clarity::vm::ast::ASTRules;
-use clarity::vm::Value as ClarityValue;
+use clarity::vm::clarity::TransactionConnection;
+use clarity::vm::{ClarityVersion, Value as ClarityValue};
 use lazy_static::lazy_static;
 use stacks::burnchains::bitcoin::address::{
     BitcoinAddress, LegacyBitcoinAddress, LegacyBitcoinAddressType,
@@ -33,6 +35,9 @@ use stacks::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, SetupBlockResult,
 };
 use stacks::chainstate::stacks::address::PoxAddress;
+use stacks::chainstate::stacks::boot::{
+    BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME,
+};
 use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
 use stacks::chainstate::stacks::miner::{
     BlockBuilder, BlockBuilderSettings, BlockLimitFunction, MinerStatus, TransactionResult,
@@ -64,7 +69,7 @@ use stacks_common::types::chainstate::{
     StacksPrivateKey, VRFSeed,
 };
 use stacks_common::types::{PrivateKey, StacksEpochId};
-use stacks_common::util::hash::{Hash160, MerkleTree, Sha512Trunc256Sum};
+use stacks_common::util::hash::{to_hex, Hash160, MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::{MessageSignature, SchnorrSignature, Secp256k1PublicKey};
 use stacks_common::util::vrf::{VRFPrivateKey, VRFProof, VRFPublicKey, VRF};
 
@@ -405,7 +410,40 @@ impl MockamotoNode {
 
         initial_balances.push((stacker.into(), 100_000_000_000_000));
 
-        let mut boot_data = ChainStateBootData::new(&burnchain, initial_balances, None);
+        // Create a boot contract to initialize the aggregate public key prior to Pox-4 activation
+        let self_signer = SelfSigner::single_signer();
+        let agg_pub_key = to_hex(&self_signer.aggregate_public_key.compress().data);
+        info!("Mockamoto node setting agg public key"; "agg_pub_key" => &agg_pub_key);
+        let callback = move |clarity_tx: &mut ClarityTx| {
+            let contract_content = format!(
+                "(define-read-only ({}) 0x{})",
+                BOOT_TEST_POX_4_AGG_KEY_FNAME, agg_pub_key
+            );
+            let contract_id = boot_code_id(BOOT_TEST_POX_4_AGG_KEY_CONTRACT, false);
+            clarity_tx.connection().as_transaction(|clarity| {
+                let (ast, analysis) = clarity
+                    .analyze_smart_contract(
+                        &contract_id,
+                        ClarityVersion::Clarity2,
+                        &contract_content,
+                        ASTRules::PrecheckSize,
+                    )
+                    .unwrap();
+                clarity
+                    .initialize_smart_contract(
+                        &contract_id,
+                        ClarityVersion::Clarity2,
+                        &ast,
+                        &contract_content,
+                        None,
+                        |_, _| false,
+                    )
+                    .unwrap();
+                clarity.save_analysis(&contract_id, &analysis).unwrap();
+            })
+        };
+        let mut boot_data =
+            ChainStateBootData::new(&burnchain, initial_balances, Some(Box::new(callback)));
         let (chainstate, boot_receipts) = StacksChainState::open_and_exec(
             config.is_mainnet(),
             config.burnchain.chain_id,
@@ -446,7 +484,7 @@ impl MockamotoNode {
 
         Ok(MockamotoNode {
             sortdb,
-            self_signer: SelfSigner::single_signer(),
+            self_signer,
             chainstate,
             miner_key,
             vrf_key,

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -998,7 +998,28 @@ impl MockamotoNode {
         let config = self.chainstate.config();
         let chain_length = block.header.chain_length;
         let sortition_handle = self.sortdb.index_handle_at_tip();
-        let aggregate_public_key = self.self_signer.aggregate_public_key;
+        let aggregate_public_key = if chain_length <= 1 {
+            self.self_signer.aggregate_public_key
+        } else {
+            let block_sn = SortitionDB::get_block_snapshot_consensus(
+                sortition_handle.conn(),
+                &block.header.consensus_hash,
+            )?
+            .ok_or(ChainstateError::DBError(DBError::NotFoundError))?;
+            // TODO: https://github.com/stacks-network/stacks-core/issues/4109
+            // Update this to retrieve the last block in the last reward cycle rather than chain tip
+            let aggregate_key_block_header =
+                NakamotoChainState::get_canonical_block_header(self.chainstate.db(), &self.sortdb)?
+                    .unwrap();
+            let aggregate_public_key = NakamotoChainState::get_aggregate_public_key(
+                &self.sortdb,
+                &sortition_handle,
+                &mut self.chainstate,
+                block_sn.block_height,
+                &aggregate_key_block_header.index_block_hash(),
+            )?;
+            aggregate_public_key
+        };
         self.self_signer.sign_nakamoto_block(&mut block);
         let staging_tx = self.chainstate.staging_db_tx_begin()?;
         NakamotoChainState::accept_block(

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -139,7 +139,7 @@ fn observe_set_aggregate_tx() {
 
     test_observer::spawn();
     let observer_port = test_observer::EVENT_OBSERVER_PORT;
-    conf.events_observers.push(EventObserverConfig {
+    conf.events_observers.insert(EventObserverConfig {
         endpoint: format!("localhost:{observer_port}"),
         events_keys: vec![EventKeyType::AnyEvent],
     });

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -1,18 +1,25 @@
 use std::thread;
 use std::time::{Duration, Instant};
 
+use clarity::boot_util::boot_code_addr;
 use clarity::vm::costs::ExecutionCost;
+use clarity::vm::Value;
+use rand_core::OsRng;
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::nakamoto::NakamotoChainState;
+use stacks::chainstate::stacks::boot::POX_4_NAME;
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey};
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::to_hex;
+use wsts::curve::point::Point;
+use wsts::curve::scalar::Scalar;
 
 use super::MockamotoNode;
 use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon_node::PeerThread;
 use crate::tests::neon_integrations::test_observer;
-use crate::tests::{make_stacks_transfer, to_addr};
+use crate::tests::{make_contract_call, make_stacks_transfer, to_addr};
 use crate::{Config, ConfigFile};
 
 #[test]
@@ -119,4 +126,157 @@ fn observe_100_blocks() {
     node_thread
         .join()
         .expect("Failed to join node thread to exit");
+}
+
+#[test]
+fn observe_set_aggregate_tx() {
+    let mut conf = Config::from_config_file(ConfigFile::mockamoto()).unwrap();
+    conf.node.mockamoto_time_ms = 10;
+
+    let submitter_sk = StacksPrivateKey::from_seed(&[1]);
+    let submitter_addr = to_addr(&submitter_sk);
+    conf.add_initial_balance(submitter_addr.to_string(), 1_000);
+
+    test_observer::spawn();
+    let observer_port = test_observer::EVENT_OBSERVER_PORT;
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{observer_port}"),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut mockamoto = MockamotoNode::new(&conf).unwrap();
+
+    let globals = mockamoto.globals.clone();
+
+    let mut mempool = PeerThread::connect_mempool_db(&conf);
+    let (mut chainstate, _) = StacksChainState::open(
+        conf.is_mainnet(),
+        conf.burnchain.chain_id,
+        &conf.get_chainstate_path_str(),
+        None,
+    )
+    .unwrap();
+    let burnchain = conf.get_burnchain();
+    let sortdb = burnchain.open_sortition_db(true).unwrap();
+    let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(mockamoto.sortdb.conn()).unwrap();
+
+    let start = Instant::now();
+    // Get a reward cycle to compare against
+    let reward_cycle = mockamoto
+        .sortdb
+        .pox_constants
+        .block_height_to_reward_cycle(
+            mockamoto.sortdb.first_block_height,
+            sortition_tip.block_height,
+        )
+        .expect(
+            format!(
+                "Failed to determine reward cycle of block height: {}",
+                sortition_tip.block_height
+            )
+            .as_str(),
+        );
+
+    let node_thread = thread::Builder::new()
+        .name("mockamoto-main".into())
+        .spawn(move || {
+            mockamoto.run();
+            let aggregate_key_block_header = NakamotoChainState::get_canonical_block_header(
+                mockamoto.chainstate.db(),
+                &mockamoto.sortdb,
+            )
+            .unwrap()
+            .unwrap();
+            // Get the aggregate public key to later verify that it was set correctly
+            mockamoto
+                .chainstate
+                .get_aggregate_public_key_pox_4(
+                    &mockamoto.sortdb,
+                    &aggregate_key_block_header.index_block_hash(),
+                    reward_cycle,
+                )
+                .unwrap()
+        })
+        .expect("FATAL: failed to start mockamoto main thread");
+
+    // Create a "set-aggregate-public-key" tx to verify it sets correctly
+    let mut rng = OsRng::default();
+    let x = Scalar::random(&mut rng);
+    let random_key = Point::from(x);
+
+    let aggregate_public_key = Value::buff_from(random_key.compress().data.to_vec())
+        .expect("Failed to serialize aggregate public key");
+    let aggregate_tx = make_contract_call(
+        &submitter_sk,
+        0,
+        10,
+        &boot_code_addr(false),
+        POX_4_NAME,
+        "set-aggregate-public-key",
+        &[Value::UInt(u128::from(reward_cycle)), aggregate_public_key],
+    );
+    let aggregate_tx_hex = format!("0x{}", to_hex(&aggregate_tx));
+
+    // complete within 5 seconds or abort (we are only observing one block)
+    let completed = loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(5) {
+            break false;
+        }
+        let latest_block = test_observer::get_blocks().pop();
+        thread::sleep(Duration::from_secs(1));
+        let Some(ref latest_block) = latest_block else {
+            info!("No block observed yet!");
+            continue;
+        };
+        let stacks_block_height = latest_block.get("block_height").unwrap().as_u64().unwrap();
+        info!("Block height observed: {stacks_block_height}");
+
+        // Submit the aggregate tx for processing to update the aggregate public key
+        let tip = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+            .unwrap()
+            .unwrap();
+        mempool
+            .submit_raw(
+                &mut chainstate,
+                &sortdb,
+                &tip.consensus_hash,
+                &tip.anchored_header.block_hash(),
+                aggregate_tx.clone(),
+                &ExecutionCost::max_value(),
+                &StacksEpochId::Epoch30,
+            )
+            .unwrap();
+        break true;
+    };
+
+    globals.signal_stop();
+
+    let aggregate_key = node_thread
+        .join()
+        .expect("Failed to join node thread to exit");
+
+    // Did we set and retrieve the aggregate key correctly?
+    assert_eq!(aggregate_key.unwrap(), random_key);
+
+    let aggregate_tx_included = test_observer::get_blocks()
+        .into_iter()
+        .find(|block_json| {
+            block_json["transactions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|tx_json| tx_json["raw_tx"].as_str() == Some(&aggregate_tx_hex))
+                .is_some()
+        })
+        .is_some();
+
+    assert!(
+        aggregate_tx_included,
+        "Mockamoto node failed to include the aggregate tx"
+    );
+
+    assert!(
+        completed,
+        "Mockamoto node failed to produce and announce its block before timeout"
+    );
 }

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -213,7 +213,7 @@ fn observe_set_aggregate_key() {
 
     // complete within 5 seconds or abort (we are only observing one block)
     let completed = loop {
-        if Instant::now().duration_since(start) > Duration::from_secs(5) {
+        if Instant::now().duration_since(start) > Duration::from_secs(120) {
             break false;
         }
         let latest_block = test_observer::get_blocks().pop();
@@ -224,8 +224,9 @@ fn observe_set_aggregate_key() {
         };
         let stacks_block_height = latest_block.get("block_height").unwrap().as_u64().unwrap();
         info!("Block height observed: {stacks_block_height}");
-
-        break true;
+        if stacks_block_height >= 100 {
+            break true;
+        }
     };
 
     globals.signal_stop();


### PR DESCRIPTION
### Description
Currently, the `set-aggregate-public-key` function in `pox-4` is public, but it needs to be private.  This will require that the key is set when a new reward cycle begins.

In the future this will only happen after `DKG` completes, but for now just set the key to that of the previous cycle.

### Applicable issues

- fixes #4101 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
