### PR TITLE
Fix wrong return value in `wasm_to_clarity_value`

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1813,7 +1813,7 @@ fn wasm_to_clarity_value(
                 index += increment;
             }
             let tuple = TupleData::from_data(data_map)?;
-            Ok((Some(tuple.into()), index))
+            Ok((Some(tuple.into()), index - value_index))
         }
         TypeSignature::TraitReferenceType(_t) => {
             todo!("Wasm value type not implemented: {:?}", type_sig)


### PR DESCRIPTION
### Description

We return the `index` instead of the increment in the Tuple's match branch in `wasm_to_clarity_value` .

### Additional info (benefits, drawbacks, caveats)

Added tests will be in the [`clarity-wasm` repo](https://github.com/stacks-network/clarity-wasm).
