### PR TITLE
Fix stackerdb tests

### DIFF
--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -64,9 +64,8 @@ macro_rules! switch_on_global_epoch {
     };
 }
 
-use crate::vm::ClarityVersion;
-
 use super::errors::InterpreterError;
+use crate::vm::ClarityVersion;
 
 mod arithmetic;
 mod assets;

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -133,10 +133,11 @@ fn setup_stx_btc_node(
 
     info!("Send pox contract-publish...");
 
+    let tx_fee = 100_000;
     let tx = make_contract_publish(
         publisher_private_key,
         0,
-        10_000,
+        tx_fee,
         &pox_contract_id.name,
         pox_contract,
     );
@@ -146,7 +147,7 @@ fn setup_stx_btc_node(
     let tx = make_contract_publish(
         publisher_private_key,
         1,
-        10_000,
+        tx_fee,
         &stackerdb_contract_id.name,
         stackerdb_contract,
     );

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -200,8 +200,8 @@ fn test_stackerdb_dkg() {
         .init();
 
     // Generate Signer Data
-    let num_signers: u32 = 100;
-    let num_keys: u32 = 4000;
+    let num_signers: u32 = 10;
+    let num_keys: u32 = 400;
     let publisher_private_key = StacksPrivateKey::new();
     let signer_stacks_private_keys = (0..num_signers)
         .map(|_| StacksPrivateKey::new())


### PR DESCRIPTION
### Description
stackerdb tests are currently broken in `develop` and `next`.  This PR fixes them in `develop`.  Once this is in, I'll fix `next`.

### Applicable issues

- fixes #4135 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
