### PR TITLE
fix: handle epochs 2.5 and 3.0 correctly

### DIFF
--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -68,9 +68,8 @@ macro_rules! switch_on_global_epoch {
     };
 }
 
-use crate::vm::ClarityVersion;
-
 use super::errors::InterpreterError;
+use crate::vm::ClarityVersion;
 
 mod arithmetic;
 mod assets;

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -713,6 +713,8 @@ impl Config {
             StacksEpochId::Epoch22,
             StacksEpochId::Epoch23,
             StacksEpochId::Epoch24,
+            StacksEpochId::Epoch25,
+            StacksEpochId::Epoch30,
         ];
         for (expected_epoch, configured_epoch) in expected_list
             .iter()

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -178,7 +178,9 @@ use stacks::chainstate::stacks::{
     TransactionAnchorMode, TransactionPayload, TransactionVersion,
 };
 use stacks::core::mempool::MemPoolDB;
-use stacks::core::{FIRST_BURNCHAIN_CONSENSUS_HASH, STACKS_EPOCH_2_4_MARKER};
+use stacks::core::{
+    FIRST_BURNCHAIN_CONSENSUS_HASH, STACKS_EPOCH_2_4_MARKER, STACKS_EPOCH_3_0_MARKER,
+};
 use stacks::cost_estimates::metrics::{CostMetric, UnitMetric};
 use stacks::cost_estimates::{CostEstimator, FeeEstimator, UnitEstimator};
 use stacks::monitoring;
@@ -1317,7 +1319,7 @@ impl BlockMinerThread {
             apparent_sender: sender,
             key_block_ptr: key.block_height as u32,
             key_vtxindex: key.op_vtxindex as u16,
-            memo: vec![STACKS_EPOCH_2_4_MARKER],
+            memo: vec![STACKS_EPOCH_3_0_MARKER],
             new_seed: vrf_seed,
             parent_block_ptr,
             parent_vtxindex,


### PR DESCRIPTION
### Description
This fixes some issues with handling the new epochs, 2.5 and 3.0, that I ran into when attempting to get a devnet running.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
