### PR TITLE
Fix: RPC endpoints should default to proof=1

### DIFF
--- a/stackslib/src/net/http/request.rs
+++ b/stackslib/src/net/http/request.rs
@@ -612,7 +612,7 @@ impl HttpRequestContents {
     }
 
     /// Get a query argument
-    pub fn get_query_arg(&self, key: &String) -> Option<&String> {
+    pub fn get_query_arg(&self, key: &str) -> Option<&String> {
         self.query_args.get(key)
     }
 

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -329,13 +329,12 @@ impl HttpRequestContentsExtensions for HttpRequestContents {
 
     /// Get the proof= query parameter value
     fn get_with_proof(&self) -> bool {
-        let with_proof = if let Some(proof_val) = self.get_query_arg(&"proof".to_string()) {
-            proof_val == "1"
-        } else {
-            false
-        };
-
-        with_proof
+        let proof_value = self
+            .get_query_arg("proof")
+            .map(|x| x.to_owned())
+            // default to "with proof"
+            .unwrap_or("1".into());
+        &proof_value == "1"
     }
 }
 


### PR DESCRIPTION
### Description

HTTP changes in `develop` changed the default behavior of the `proof` query string. In `master`, it defaults to `1`, but in `develop` it defaults to `0`.

I'm open to changing this default, but this is why `tests::integrations::integration_test_get_info` broke, and the change would need to be mentioned specifically in the changelog. I think the right thing to do here is to return to the prior behavior, and if we want to change the default, we can do that in another PR that also updates the tests.