### PR TITLE
Test: fix httpcore test for defaulting in proof query string

### DIFF
--- a/stackslib/src/net/tests/httpcore.rs
+++ b/stackslib/src/net/tests/httpcore.rs
@@ -1012,7 +1012,7 @@ fn test_http_parse_proof_request_query() {
     let proof_req = HttpRequestContents::new()
         .query_string(Some(query_txt))
         .get_with_proof();
-    assert!(!proof_req);
+    assert!(proof_req);
 
     let query_txt = "proof=0";
     let proof_req = HttpRequestContents::new()


### PR DESCRIPTION
### Description

PR #4139 updated the defaulting proof query string behavior, but didn't update the unit test for that behavior in `net::tests`