### PR TITLE
fix: set maxburncap to 1BTC in sendrawtransaction (new in Bitcoin 25.0)

### DIFF
--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -64,9 +64,8 @@ macro_rules! switch_on_global_epoch {
     };
 }
 
-use crate::vm::ClarityVersion;
-
 use super::errors::InterpreterError;
+use crate::vm::ClarityVersion;
 
 mod arithmetic;
 mod assets;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -2350,7 +2350,8 @@ impl BitcoinRPCRequest {
     pub fn send_raw_transaction(config: &Config, tx: String) -> RPCResult<()> {
         let payload = BitcoinRPCRequest {
             method: "sendrawtransaction".to_string(),
-            params: vec![tx.into()],
+            // set maxfee (as uncapped) and maxburncap (new in bitcoin 25)
+            params: vec![tx.into(), 0.into(), 1_000_000.into()],
             id: "stacks".to_string(),
             jsonrpc: "2.0".to_string(),
         };


### PR DESCRIPTION
### Description

Set `maxburncap` argument in `sendrawtransaction` to allow the miner to submit transactions with burns (specifically to send to the `OP_RETURN` output, which is why only one test failed: only "sunset" burns fit in the category).

This was new behavior in Bitcoin 25.0: https://bitcoin.org/en/releases/25.0/#updated-rpcs

### Applicable issues

- Fixes the `neon_integrations::pox_integration` test