### PR TITLE
Only use a single slot for DKG and Signing and add second slot for fu…

### DIFF
--- a/stacks-signer/src/stacks_client.rs
+++ b/stacks-signer/src/stacks_client.rs
@@ -32,7 +32,7 @@ const BACKOFF_MAX_INTERVAL: u64 = 16384;
 /// Temporary placeholder for the number of slots allocated to a stacker-db writer. This will be retrieved from the stacker-db instance in the future
 /// See: https://github.com/stacks-network/stacks-blockchain/issues/3921
 /// Is equal to the number of message types
-pub const SLOTS_PER_USER: u32 = 10;
+pub const SLOTS_PER_USER: u32 = 2;
 
 #[derive(thiserror::Error, Debug)]
 /// Client error type
@@ -442,18 +442,9 @@ where
 }
 
 /// Helper function to determine the slot ID for the provided stacker-db writer id and the message type
-fn slot_id(id: u32, message: &Message) -> u32 {
-    let slot_id = match message {
-        Message::DkgBegin(_) => 0,
-        Message::DkgPrivateBegin(_) => 1,
-        Message::DkgEnd(_) => 2,
-        Message::DkgPublicShares(_) => 4,
-        Message::DkgPrivateShares(_) => 5,
-        Message::NonceRequest(_) => 6,
-        Message::NonceResponse(_) => 7,
-        Message::SignatureShareRequest(_) => 8,
-        Message::SignatureShareResponse(_) => 9,
-    };
+fn slot_id(id: u32, _message: &Message) -> u32 {
+    //TODO: update this to check the message type as either block message or signer message
+    let slot_id = 0;
     SLOTS_PER_USER * id + slot_id
 }
 

--- a/stacks-signer/src/tests/contracts/signers-stackerdb.clar
+++ b/stacks-signer/src/tests/contracts/signers-stackerdb.clar
@@ -3,23 +3,23 @@
             (ok (list
                 {
                     signer: 'ST24GDPTR7D9G3GFRR233JMWSD9HA296EXXG5XVGA,
-                    num-slots: u10
+                    num-slots: u2
                 }
                 {
                     signer: 'ST1MR26HR7MMDE847BE2QC1CTNQY4WKN9XDKNPEP3,
-                    num-slots: u10
+                    num-slots: u2
                 }
                 {
                     signer: 'ST110M4DRDXX2RF3W8EY1HCRQ25CS24PGY22DZ004,
-                    num-slots: u10
+                    num-slots: u2
                 }
                 {
                     signer: 'ST69990VH3BVCV39QWT6CJAVVA9QPB1715HTSN75,
-                    num-slots: u10
+                    num-slots: u2
                 }
                 {
                     signer: 'STCZSBZJK6C3MMAAW9N9RHSDKRKB9AKGJ2JMVDKN,
-                    num-slots: u10
+                    num-slots: u2
                 }
                 )))
 


### PR DESCRIPTION
Fixes https://github.com/stacks-network/stacks-core/issues/4152

We only need one slot for signer communication and a second slot for the miner to observe. note that we probably could get away with a single slot, but for now lets leave it like this so a miner can query the miner slot if it happens to miss an event. This enables the Clarity folks to use a single stacker db instance for both current and onboarding signers and the miners rather than having three sep stacker db instances (There is a limit of 4096 slots per stacker db instance and this ensures we are well under it for up to 2047 signers and two miners)

