### PR TITLE
use pull_request to trigger ci runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,12 @@ on:
       tag:
         description: "The tag to create (optional)"
         required: false
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
     paths-ignore:
       - "**.md"
       - "**.yml"
@@ -143,7 +144,7 @@ jobs:
             github.event.review.state == 'approved'
           ) ||
           github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'pull_request_target' ||
+          github.event_name == 'pull_request' ||
           (
             contains('
               refs/heads/master


### PR DESCRIPTION
this is a minor fix in how the CI triggers due to issues noticed downstream in `next`. 
pull_request_target is not working the way that was expected, in that it is building against the target branch, and not the base branch. 
this commit fixes that. 

once merged, a second PR from develop-> next will be opened.

this is also addressed in master in https://github.com/stacks-network/stacks-core/pull/4160