### PR TITLE
pox-4: remove pox-reject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,8 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256k1"
 version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afcf536d20c074ef45371ee9a654dcfc46fb2dde18ecc54ec30c936eb850fa2"
 dependencies = [
  "bindgen",
  "bitvec",
@@ -4711,6 +4713,8 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c250118354755b4abb091a83cb8d659b511c0ae211ccdb3b1254e3db199cb86"
 dependencies = [
  "aes-gcm 0.10.2",
  "bs58 0.5.0",

--- a/stackslib/src/chainstate/stacks/boot/docs.rs
+++ b/stackslib/src/chainstate/stacks/boot/docs.rs
@@ -43,7 +43,7 @@ This ensures that each entry in the reward set returned to the stacks-node is gr
   but does not require it be all locked up within a single transaction"),
         ("reject-pox", "Reject Stacking for this reward cycle.
 `tx-sender` votes all its uSTX for rejection.
-Note that unlike Stacking, rejecting PoX does not lock the tx-sender's tokens: PoX rejection acts like a coin vote."),
+Note that unlike Stacking, rejecting PoX does not lock the tx-sender's tokens: PoX rejection acts like a coin vote. Removed in pox-4."),
         ("can-stack-stx", "Evaluate if a participant can stack an amount of STX for a given period."),
         ("get-stacking-minimum", "Returns the absolute minimum amount that could be validly Stacked (the threshold to Stack in
 a given reward cycle may be higher than this"),

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -985,14 +985,6 @@ impl StacksChainState {
         block_id: &StacksBlockId,
         reward_cycle: u64,
     ) -> Result<Vec<RawRewardSetEntry>, Error> {
-        if !self.is_pox_active(sortdb, block_id, u128::from(reward_cycle), POX_4_NAME)? {
-            debug!(
-                "PoX was voted disabled in block {} (reward cycle {})",
-                block_id, reward_cycle
-            );
-            return Ok(vec![]);
-        }
-
         // how many in this cycle?
         let num_addrs = self
             .eval_boot_code_read_only(
@@ -1135,14 +1127,6 @@ impl StacksChainState {
         block_id: &StacksBlockId,
         reward_cycle: u64,
     ) -> Result<Option<Point>, Error> {
-        if !self.is_pox_active(sortdb, block_id, u128::from(reward_cycle), POX_4_NAME)? {
-            debug!(
-                "PoX was voted disabled in block {} (reward cycle {})",
-                block_id, reward_cycle
-            );
-            return Ok(None);
-        }
-
         let aggregate_public_key = self
             .eval_boot_code_read_only(
                 sortdb,

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -12,7 +12,7 @@
 (define-constant ERR_STACKING_THRESHOLD_NOT_MET 11)
 (define-constant ERR_STACKING_POX_ADDRESS_IN_USE 12)
 (define-constant ERR_STACKING_INVALID_POX_ADDRESS 13)
-(define-constant ERR_STACKING_ALREADY_REJECTED 17)
+
 (define-constant ERR_STACKING_INVALID_AMOUNT 18)
 (define-constant ERR_NOT_ALLOWED 19)
 (define-constant ERR_STACKING_ALREADY_DELEGATED 20)
@@ -27,9 +27,6 @@
 (define-constant ERR_DELEGATION_WRONG_REWARD_SLOT 29)
 (define-constant ERR_STACKING_IS_DELEGATED 30)
 (define-constant ERR_STACKING_NOT_DELEGATED 31)
-
-;; PoX disabling threshold (a percent)
-(define-constant POX_REJECTION_FRACTION u25)
 
 ;; Valid values for burnchain address versions.
 ;; These first four correspond to address hash modes in Stacks 2.1,
@@ -57,7 +54,6 @@
 ;; used in e.g. test harnesses.
 (define-data-var pox-prepare-cycle-length uint PREPARE_CYCLE_LENGTH)
 (define-data-var pox-reward-cycle-length uint REWARD_CYCLE_LENGTH)
-(define-data-var pox-rejection-fraction uint POX_REJECTION_FRACTION)
 (define-data-var first-burnchain-block-height uint u0)
 (define-data-var configured bool false)
 (define-data-var first-2-1-reward-cycle uint u0)
@@ -73,7 +69,6 @@
         (var-set first-burnchain-block-height first-burn-height)
         (var-set pox-prepare-cycle-length prepare-cycle-length)
         (var-set pox-reward-cycle-length reward-cycle-length)
-        (var-set pox-rejection-fraction rejection-fraction)
         (var-set first-2-1-reward-cycle begin-2-1-reward-cycle)
         (var-set configured true)
         (ok true))
@@ -190,37 +185,19 @@
     { stacked-amount: uint }
 )
 
-;; Amount of uSTX that reject PoX, by reward cycle
-(define-map stacking-rejection
-    { reward-cycle: uint }
-    { amount: uint }
-)
-
-;; Who rejected in which reward cycle
-(define-map stacking-rejectors
-    { stacker: principal, reward-cycle: uint }
-    { amount: uint }
-)
-
 ;; The stackers' aggregate public key
 ;;   for the given reward cycle
 (define-map aggregate-public-keys uint (buff 33))
 
 ;; Getter for stacking-rejectors
+;; always return none for backwards compatibility
 (define-read-only (get-pox-rejection (stacker principal) (reward-cycle uint))
-    (map-get? stacking-rejectors { stacker: stacker, reward-cycle: reward-cycle }))
+    none)
 
-;; Has PoX been rejected in the given reward cycle?
+;; Has PoX not been rejected in the given reward cycle?
+;; always return true for backwards compatibility
 (define-read-only (is-pox-active (reward-cycle uint))
-    (let (
-        (reject-votes
-            (default-to
-                u0
-                (get amount (map-get? stacking-rejection { reward-cycle: reward-cycle }))))
-    )
-    ;; (100 * reject-votes) / stx-liquid-supply < pox-rejection-fraction
-    (< (* u100 reject-votes)
-       (* (var-get pox-rejection-fraction) stx-liquid-supply)))
+    true
 )
 
 ;; What's the reward cycle number of the burnchain block height?
@@ -287,12 +264,6 @@
     (default-to
         u0
         (get len (map-get? reward-cycle-pox-address-list-len { reward-cycle: reward-cycle }))))
-
-;; How many rejection votes have we been accumulating for the next block
-(define-read-only (next-cycle-rejection-votes)
-    (default-to
-        u0
-        (get amount (map-get? stacking-rejection { reward-cycle: (+ u1 (current-pox-reward-cycle)) }))))
 
 ;; Add a single PoX address to a single reward cycle.
 ;; Used to build up a set of per-reward-cycle PoX addresses.
@@ -536,10 +507,6 @@
     ;; amount must be valid
     (asserts! (> amount-ustx u0)
               (err ERR_STACKING_INVALID_AMOUNT))
-
-    ;; sender principal must not have rejected in this upcoming reward cycle
-    (asserts! (is-none (get-pox-rejection tx-sender first-reward-cycle))
-              (err ERR_STACKING_ALREADY_REJECTED))
 
     ;; lock period must be in acceptable range.
     (asserts! (check-pox-lock-period num-cycles)
@@ -892,38 +859,6 @@
             lock-amount: amount-ustx,
             unlock-burn-height: unlock-burn-height })))
 
-;; Reject Stacking for this reward cycle.
-;; tx-sender votes all its uSTX for rejection.
-;; Note that unlike PoX, rejecting PoX does not lock the tx-sender's
-;; tokens.  PoX rejection acts like a coin vote.
-(define-public (reject-pox)
-    (let (
-        (balance (stx-get-balance tx-sender))
-        (vote-reward-cycle (+ u1 (current-pox-reward-cycle)))
-    )
-
-    ;; tx-sender principal must not have rejected in this upcoming reward cycle
-    (asserts! (is-none (get-pox-rejection tx-sender vote-reward-cycle))
-        (err ERR_STACKING_ALREADY_REJECTED))
-
-    ;; tx-sender can't be a stacker
-    (asserts! (is-none (get-stacker-info tx-sender))
-        (err ERR_STACKING_ALREADY_STACKED))
-
-    ;; vote for rejection
-    (map-set stacking-rejection
-        { reward-cycle: vote-reward-cycle }
-        { amount: (+ (next-cycle-rejection-votes) balance) }
-    )
-
-    ;; mark voted
-    (map-set stacking-rejectors
-        { stacker: tx-sender, reward-cycle: vote-reward-cycle }
-        { amount: balance }
-    )
-
-    (ok true))
-)
 
 ;; Used for PoX parameters discovery
 (define-read-only (get-pox-info)
@@ -933,8 +868,6 @@
         prepare-cycle-length: (var-get pox-prepare-cycle-length),
         first-burnchain-block-height: (var-get first-burnchain-block-height),
         reward-cycle-length: (var-get pox-reward-cycle-length),
-        rejection-fraction: (var-get pox-rejection-fraction),
-        current-rejection-votes: (next-cycle-rejection-votes),
         total-liquid-supply-ustx: stx-liquid-supply,
     })
 )
@@ -1315,11 +1248,12 @@
 
 ;; How many uSTX have voted to reject PoX in a given reward cycle?
 ;; *New in Stacks 2.1*
+;; always return 0 for backwards compatibility
 (define-read-only (get-total-pox-rejection (reward-cycle uint))
-    (match (map-get? stacking-rejection { reward-cycle: reward-cycle })
-        rejected
-            (get amount rejected)
         u0
+        u0
+    )
+    u0
     )
 )
 

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -56,20 +56,19 @@
 (define-data-var pox-reward-cycle-length uint REWARD_CYCLE_LENGTH)
 (define-data-var first-burnchain-block-height uint u0)
 (define-data-var configured bool false)
-(define-data-var first-2-1-reward-cycle uint u0)
+(define-data-var first-pox-4-reward-cycle uint u0)
 
 ;; This function can only be called once, when it boots up
 (define-public (set-burnchain-parameters (first-burn-height uint)
                                          (prepare-cycle-length uint)
                                          (reward-cycle-length uint)
-                                         (rejection-fraction uint)
-                                         (begin-2-1-reward-cycle uint))
+                                         (begin-pox-4-reward-cycle uint))
     (begin
         (asserts! (not (var-get configured)) (err ERR_NOT_ALLOWED))
         (var-set first-burnchain-block-height first-burn-height)
         (var-set pox-prepare-cycle-length prepare-cycle-length)
         (var-set pox-reward-cycle-length reward-cycle-length)
-        (var-set first-2-1-reward-cycle begin-2-1-reward-cycle)
+        (var-set first-pox-4-reward-cycle begin-pox-4-reward-cycle)
         (var-set configured true)
         (ok true))
 )
@@ -188,17 +187,6 @@
 ;; The stackers' aggregate public key
 ;;   for the given reward cycle
 (define-map aggregate-public-keys uint (buff 33))
-
-;; Getter for stacking-rejectors
-;; always return none for backwards compatibility
-(define-read-only (get-pox-rejection (stacker principal) (reward-cycle uint))
-    none)
-
-;; Has PoX not been rejected in the given reward cycle?
-;; always return true for backwards compatibility
-(define-read-only (is-pox-active (reward-cycle uint))
-    true
-)
 
 ;; What's the reward cycle number of the burnchain block height?
 ;; Will runtime-abort if height is less than the first burnchain block (this is intentional)
@@ -1244,17 +1232,6 @@
 ;; *New in Stacks 2.1*
 (define-read-only (get-partial-stacked-by-cycle (pox-addr { version: (buff 1), hashbytes: (buff 32) }) (reward-cycle uint) (sender principal))
     (map-get? partial-stacked-by-cycle { pox-addr: pox-addr, reward-cycle: reward-cycle, sender: sender })
-)
-
-;; How many uSTX have voted to reject PoX in a given reward cycle?
-;; *New in Stacks 2.1*
-;; always return 0 for backwards compatibility
-(define-read-only (get-total-pox-rejection (reward-cycle uint))
-        u0
-        u0
-    )
-    u0
-    )
 )
 
 ;; What is the given reward cycle's stackers' aggregate public key?

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -74,7 +74,8 @@
 )
 
 ;; The Stacking lock-up state and associated metadata.
-;; Records are inserted into this map via `delegate-stack-stx` and `delegate-stack-extend`.
+;; Records are inserted into this map via `stack-stx`, `delegate-stack-stx`, `stack-extend`
+;;  `delegate-stack-extend` and burnchain transactions for invoking `stack-stx`, etc.
 ;; Records will be deleted from this map when auto-unlocks are processed
 ;;
 ;; This map de-normalizes some state from the `reward-cycle-pox-address-list` map
@@ -107,7 +108,7 @@
         ;; these indexes are only valid looking forward from
         ;;  `first-reward-cycle` (i.e., they do not correspond
         ;;  to entries in the reward set that may have been from
-        ;;  previous stacking calls, or prior to an extend)
+        ;;  previous stack-stx calls, or prior to an extend)
         reward-set-indexes: (list 12 uint),
         ;; principal of the delegate, if stacker has delegated
         delegated-to: (optional principal)
@@ -528,6 +529,65 @@
                { sender: tx-sender, contract-caller: caller }
                { until-burn-ht: until-burn-ht }))))
 
+;; Lock up some uSTX for stacking!  Note that the given amount here is in micro-STX (uSTX).
+;; The STX will be locked for the given number of reward cycles (lock-period).
+;; This is the self-service interface.  tx-sender will be the Stacker.
+;;
+;; * The given stacker cannot currently be stacking.
+;; * You will need the minimum uSTX threshold.  This will be determined by (get-stacking-minimum)
+;; at the time this method is called.
+;; * You may need to increase the amount of uSTX locked up later, since the minimum uSTX threshold
+;; may increase between reward cycles.
+;; * The Stacker will receive rewards in the reward cycle following `start-burn-ht`.
+;; Importantly, `start-burn-ht` may not be further into the future than the next reward cycle,
+;; and in most cases should be set to the current burn block height.
+;;
+;; The tokens will unlock and be returned to the Stacker (tx-sender) automatically.
+(define-public (stack-stx (amount-ustx uint)
+                          (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
+                          (start-burn-ht uint)
+                          (lock-period uint))
+    ;; this stacker's first reward cycle is the _next_ reward cycle
+    (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle)))
+          (specified-reward-cycle (+ u1 (burn-height-to-reward-cycle start-burn-ht))))
+      ;; the start-burn-ht must result in the next reward cycle, do not allow stackers
+      ;;  to "post-date" their `stack-stx` transaction
+      (asserts! (is-eq first-reward-cycle specified-reward-cycle)
+                (err ERR_INVALID_START_BURN_HEIGHT))
+
+      ;; must be called directly by the tx-sender or by an allowed contract-caller
+      (asserts! (check-caller-allowed)
+                (err ERR_STACKING_PERMISSION_DENIED))
+
+      ;; tx-sender principal must not be stacking
+      (asserts! (is-none (get-stacker-info tx-sender))
+        (err ERR_STACKING_ALREADY_STACKED))
+
+      ;; tx-sender must not be delegating
+      (asserts! (is-none (get-check-delegation tx-sender))
+        (err ERR_STACKING_ALREADY_DELEGATED))
+
+      ;; the Stacker must have sufficient unlocked funds
+      (asserts! (>= (stx-get-balance tx-sender) amount-ustx)
+        (err ERR_STACKING_INSUFFICIENT_FUNDS))
+
+      ;; ensure that stacking can be performed
+      (try! (can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))
+
+      ;; register the PoX address with the amount stacked
+      (let ((reward-set-indexes (try! (add-pox-addr-to-reward-cycles pox-addr first-reward-cycle lock-period amount-ustx tx-sender))))
+          ;; add stacker record
+         (map-set stacking-state
+           { stacker: tx-sender }
+           { pox-addr: pox-addr,
+             reward-set-indexes: reward-set-indexes,
+             first-reward-cycle: first-reward-cycle,
+             lock-period: lock-period,
+             delegated-to: none })
+
+          ;; return the lock-up information, so the node can actually carry out the lock.
+          (ok { stacker: tx-sender, lock-amount: amount-ustx, unlock-burn-height: (reward-cycle-to-burn-height (+ first-reward-cycle lock-period)) }))))
+
 (define-public (revoke-delegate-stx)
   (begin
     ;; must be called directly by the tx-sender or by an allowed contract-caller
@@ -834,6 +894,130 @@
                     reward-cycle: (+ u1 reward-cycle),
                     stacker: (get stacker data),
                     add-amount: (get add-amount data) })))))
+
+;; Increase the number of STX locked.
+;; *New in Stacks 2.1*
+;; This method locks up an additional amount of STX from `tx-sender`'s, indicated
+;; by `increase-by`.  The `tx-sender` must already be Stacking.
+(define-public (stack-increase (increase-by uint))
+   (let ((stacker-info (stx-account tx-sender))
+         (amount-stacked (get locked stacker-info))
+         (amount-unlocked (get unlocked stacker-info))
+         (unlock-height (get unlock-height stacker-info))
+         (cur-cycle (current-pox-reward-cycle))
+         (first-increased-cycle (+ cur-cycle u1))
+         (stacker-state (unwrap! (map-get? stacking-state
+                                          { stacker: tx-sender })
+                                          (err ERR_STACK_INCREASE_NOT_LOCKED))))
+      ;; tx-sender must be currently locked
+      (asserts! (> amount-stacked u0)
+                (err ERR_STACK_INCREASE_NOT_LOCKED))
+      ;; must be called with positive `increase-by`
+      (asserts! (>= increase-by u1)
+                (err ERR_STACKING_INVALID_AMOUNT))
+      ;; stacker must have enough stx to lock
+      (asserts! (>= amount-unlocked increase-by)
+                (err ERR_STACKING_INSUFFICIENT_FUNDS))
+      ;; must be called directly by the tx-sender or by an allowed contract-caller
+      (asserts! (check-caller-allowed)
+                (err ERR_STACKING_PERMISSION_DENIED))
+      ;; stacker must be directly stacking
+      (asserts! (> (len (get reward-set-indexes stacker-state)) u0)
+                (err ERR_STACKING_IS_DELEGATED))
+      ;; stacker must not be delegating
+      (asserts! (is-none (get delegated-to stacker-state))
+                (err ERR_STACKING_IS_DELEGATED))
+      ;; update reward cycle amounts
+      (asserts! (is-some (fold increase-reward-cycle-entry
+            (get reward-set-indexes stacker-state)
+            (some { first-cycle: first-increased-cycle,
+                    reward-cycle: (get first-reward-cycle stacker-state),
+                    stacker: tx-sender,
+                    add-amount: increase-by })))
+            (err ERR_STACKING_UNREACHABLE))
+      ;; NOTE: stacking-state map is unchanged: it does not track amount-stacked in PoX-4
+      (ok { stacker: tx-sender, total-locked: (+ amount-stacked increase-by)})))
+
+;; Extend an active Stacking lock.
+;; *New in Stacks 2.1*
+;; This method extends the `tx-sender`'s current lockup for an additional `extend-count`
+;;    and associates `pox-addr` with the rewards
+(define-public (stack-extend (extend-count uint)
+                             (pox-addr { version: (buff 1), hashbytes: (buff 32) }))
+   (let ((stacker-info (stx-account tx-sender))
+         ;; to extend, there must already be an etry in the stacking-state
+         (stacker-state (unwrap! (get-stacker-info tx-sender) (err ERR_STACK_EXTEND_NOT_LOCKED)))
+         (amount-ustx (get locked stacker-info))
+         (unlock-height (get unlock-height stacker-info))
+         (cur-cycle (current-pox-reward-cycle))
+         ;; first-extend-cycle will be the cycle in which tx-sender *would have* unlocked
+         (first-extend-cycle (burn-height-to-reward-cycle unlock-height))
+         ;; new first cycle should be max(cur-cycle, stacker-state.first-reward-cycle)
+         (cur-first-reward-cycle (get first-reward-cycle stacker-state))
+         (first-reward-cycle (if (> cur-cycle cur-first-reward-cycle) cur-cycle cur-first-reward-cycle)))
+
+    ;; must be called with positive extend-count
+    (asserts! (>= extend-count u1)
+              (err ERR_STACKING_INVALID_LOCK_PERIOD))
+
+    ;; stacker must be directly stacking
+      (asserts! (> (len (get reward-set-indexes stacker-state)) u0)
+                (err ERR_STACKING_IS_DELEGATED))
+
+    ;; stacker must not be delegating
+    (asserts! (is-none (get delegated-to stacker-state))
+              (err ERR_STACKING_IS_DELEGATED))
+
+    ;; TODO: add more assertions to sanity check the `stacker-info` values with
+    ;;       the `stacker-state` values
+
+    (let ((last-extend-cycle  (- (+ first-extend-cycle extend-count) u1))
+          (lock-period (+ u1 (- last-extend-cycle first-reward-cycle)))
+          (new-unlock-ht (reward-cycle-to-burn-height (+ u1 last-extend-cycle))))
+
+      ;; first cycle must be after the current cycle
+      (asserts! (> first-extend-cycle cur-cycle) (err ERR_STACKING_INVALID_LOCK_PERIOD))
+      ;; lock period must be positive
+      (asserts! (> lock-period u0) (err ERR_STACKING_INVALID_LOCK_PERIOD))
+
+      ;; must be called directly by the tx-sender or by an allowed contract-caller
+      (asserts! (check-caller-allowed)
+                (err ERR_STACKING_PERMISSION_DENIED))
+
+      ;; tx-sender must be locked
+      (asserts! (> amount-ustx u0)
+        (err ERR_STACK_EXTEND_NOT_LOCKED))
+
+      ;; tx-sender must not be delegating
+      (asserts! (is-none (get-check-delegation tx-sender))
+        (err ERR_STACKING_ALREADY_DELEGATED))
+
+      ;; standard can-stack-stx checks
+      (try! (can-stack-stx pox-addr amount-ustx first-extend-cycle lock-period))
+
+      ;; register the PoX address with the amount stacked
+      ;;   for the new cycles
+      (let ((extended-reward-set-indexes (try! (add-pox-addr-to-reward-cycles pox-addr first-extend-cycle extend-count amount-ustx tx-sender)))
+            (reward-set-indexes
+                ;; use the active stacker state and extend the existing reward-set-indexes
+                (let ((cur-cycle-index (- first-reward-cycle (get first-reward-cycle stacker-state)))
+                      (old-indexes (get reward-set-indexes stacker-state))
+                      ;; build index list by taking the old-indexes starting from cur cycle
+                      ;;  and adding the new indexes to it. this way, the index is valid starting from the current cycle
+                      (new-list (concat (default-to (list) (slice? old-indexes cur-cycle-index (len old-indexes)))
+                                        extended-reward-set-indexes)))
+                  (unwrap-panic (as-max-len? new-list u12)))))
+          ;; update stacker record
+          (map-set stacking-state
+            { stacker: tx-sender }
+            { pox-addr: pox-addr,
+              reward-set-indexes: reward-set-indexes,
+              first-reward-cycle: first-reward-cycle,
+              lock-period: lock-period,
+              delegated-to: none })
+
+        ;; return lock-up information
+        (ok { stacker: tx-sender, unlock-burn-height: new-unlock-ht })))))
 
 ;; As a delegator, increase an active Stacking lock, issuing a "partial commitment" for the
 ;;   increased cycles.

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -1360,7 +1360,6 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     Value::UInt(u128::from(first_block_height)),
                     Value::UInt(u128::from(pox_prepare_length)),
                     Value::UInt(u128::from(pox_reward_cycle_length)),
-                    Value::UInt(u128::from(pox_rejection_fraction)),
                     Value::UInt(u128::from(pox_4_first_cycle)),
                 ];
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -1282,7 +1282,6 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
             let first_block_height = self.burn_state_db.get_burn_start_height();
             let pox_prepare_length = self.burn_state_db.get_pox_prepare_length();
             let pox_reward_cycle_length = self.burn_state_db.get_pox_reward_cycle_length();
-            let pox_rejection_fraction = self.burn_state_db.get_pox_rejection_fraction();
             let pox_4_activation_height = self.burn_state_db.get_pox_4_activation_height();
 
             let pox_4_first_cycle = PoxConstants::static_block_height_to_reward_cycle(

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -14,7 +14,7 @@ use super::MockamotoNode;
 use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon_node::PeerThread;
 use crate::tests::neon_integrations::{get_pox_info, submit_tx, test_observer};
-use crate::tests::{make_contract_call, make_stacks_transfer, to_addr};
+use crate::tests::{make_stacks_transfer, to_addr};
 use crate::{Config, ConfigFile};
 
 #[test]

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -19,7 +19,7 @@ use wsts::curve::scalar::Scalar;
 use super::MockamotoNode;
 use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon_node::PeerThread;
-use crate::tests::neon_integrations::{submit_tx, test_observer};
+use crate::tests::neon_integrations::{get_pox_info, submit_tx, test_observer};
 use crate::tests::{make_contract_call, make_stacks_transfer, to_addr};
 use crate::{Config, ConfigFile};
 
@@ -353,4 +353,64 @@ fn observe_set_aggregate_key() {
     // Did we set and retrieve the aggregate key correctly?
     assert_eq!(orig_aggregate_key.unwrap(), orig_key);
     assert_eq!(new_aggregate_key.unwrap(), orig_key);
+}
+
+#[test]
+fn rpc_pox_info() {
+    let mut conf = Config::from_config_file(ConfigFile::mockamoto()).unwrap();
+    conf.node.mockamoto_time_ms = 10;
+    conf.node.rpc_bind = "127.0.0.1:19543".into();
+    conf.node.p2p_bind = "127.0.0.1:19544".into();
+
+    let observer_port = 19500;
+    test_observer::spawn_at(observer_port);
+    conf.events_observers.insert(EventObserverConfig {
+        endpoint: format!("localhost:{observer_port}"),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut mockamoto = MockamotoNode::new(&conf).unwrap();
+    let globals = mockamoto.globals.clone();
+
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    let start = Instant::now();
+
+    let node_thread = thread::Builder::new()
+        .name("mockamoto-main".into())
+        .spawn(move || mockamoto.run())
+        .expect("FATAL: failed to start mockamoto main thread");
+
+    // mine 5 blocks
+    let completed = loop {
+        // complete within 2 minutes or abort
+        if Instant::now().duration_since(start) > Duration::from_secs(120) {
+            break false;
+        }
+        let latest_block = test_observer::get_blocks().pop();
+        thread::sleep(Duration::from_secs(1));
+        let Some(ref latest_block) = latest_block else {
+            info!("No block observed yet!");
+            continue;
+        };
+        let stacks_block_height = latest_block.get("block_height").unwrap().as_u64().unwrap();
+        info!("Block height observed: {stacks_block_height}");
+
+        if stacks_block_height >= 5 {
+            break true;
+        }
+    };
+
+    // fetch rpc poxinfo
+    let _pox_info = get_pox_info(&http_origin);
+
+    globals.signal_stop();
+
+    assert!(
+        completed,
+        "Mockamoto node failed to produce and announce 100 blocks before timeout"
+    );
+    node_thread
+        .join()
+        .expect("Failed to join node thread to exit");
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -5992,7 +5992,7 @@ fn pox_integration_test() {
     );
     assert_eq!(
         pox_info.rejection_fraction,
-        pox_constants.pox_rejection_fraction
+        Some(pox_constants.pox_rejection_fraction)
     );
     assert_eq!(pox_info.reward_cycle_id, 0);
     assert_eq!(pox_info.current_cycle.id, 0);
@@ -6060,7 +6060,7 @@ fn pox_integration_test() {
     );
     assert_eq!(
         pox_info.rejection_fraction,
-        pox_constants.pox_rejection_fraction
+        Some(pox_constants.pox_rejection_fraction)
     );
     assert_eq!(pox_info.reward_cycle_id, 14);
     assert_eq!(pox_info.current_cycle.id, 14);
@@ -6191,7 +6191,7 @@ fn pox_integration_test() {
     );
     assert_eq!(
         pox_info.rejection_fraction,
-        pox_constants.pox_rejection_fraction
+        Some(pox_constants.pox_rejection_fraction)
     );
     assert_eq!(pox_info.reward_cycle_id, 14);
     assert_eq!(pox_info.current_cycle.id, 14);


### PR DESCRIPTION
### Description
This PR removes `pox-reject` from pox-4 and relevant code in boot/mod.rs

### Applicable issues

- fixes #4108 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
