### PR TITLE
Enable `FIRE` coordinator for `stacks-signer`

### DIFF
--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -119,6 +119,14 @@ pub struct Config {
     pub signer_id: u32,
     /// The time to wait for a response from the stacker-db instance
     pub event_timeout: Duration,
+    /// timeout to gather DkgPublicShares messages
+    pub dkg_public_timeout: Option<Duration>,
+    /// timeout to gather DkgEnd messages
+    pub dkg_end_timeout: Option<Duration>,
+    /// timeout to gather nonces
+    pub nonce_timeout: Option<Duration>,
+    /// timeout to gather signature shares
+    pub sign_timeout: Option<Duration>,
 }
 
 /// Internal struct for loading up the config file signer data
@@ -290,6 +298,10 @@ impl TryFrom<RawConfigFile> for Config {
             signer_id: raw_data.signer_id,
             signer_key_ids,
             event_timeout,
+            dkg_end_timeout: None,
+            dkg_public_timeout: None,
+            nonce_timeout: None,
+            sign_timeout: None,
         })
     }
 }

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -52,7 +52,7 @@ use stacks_signer::runloop::{RunLoop, RunLoopCommand};
 use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
-use wsts::state_machine::coordinator::fire::Coordinator as FrostCoordinator;
+use wsts::state_machine::coordinator::fire::Coordinator as FireCoordinator;
 use wsts::state_machine::OperationResult;
 use wsts::v2;
 
@@ -88,11 +88,11 @@ fn spawn_running_signer(path: &PathBuf) -> SpawnedSigner {
     let (cmd_send, cmd_recv) = channel();
     let (res_send, res_recv) = channel();
     let ev = StackerDBEventReceiver::new(vec![config.stackerdb_contract_id.clone()]);
-    let runloop: RunLoop<FrostCoordinator<v2::Aggregator>> = RunLoop::from(&config);
+    let runloop: RunLoop<FireCoordinator<v2::Aggregator>> = RunLoop::from(&config);
     let mut signer: Signer<
         RunLoopCommand,
         Vec<OperationResult>,
-        RunLoop<FrostCoordinator<v2::Aggregator>>,
+        RunLoop<FireCoordinator<v2::Aggregator>>,
         StackerDBEventReceiver,
     > = Signer::new(runloop, ev, cmd_recv, res_send);
     let endpoint = config.endpoint;

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -52,7 +52,7 @@ use stacks_signer::runloop::{RunLoop, RunLoopCommand};
 use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
-use wsts::state_machine::coordinator::frost::Coordinator as FrostCoordinator;
+use wsts::state_machine::coordinator::fire::Coordinator as FrostCoordinator;
 use wsts::state_machine::OperationResult;
 use wsts::v2;
 

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -124,8 +124,11 @@ fn process_dkg_result(dkg_res: &[OperationResult]) {
                 &schnorr_proof.r, &schnorr_proof.s,
             );
         }
-        OperationResult::DkgError(..) | OperationResult::SignError(..) => {
-            todo!()
+        OperationResult::DkgError(dkg_error) => {
+            panic!("Received DkgError {}", dkg_error);
+        }
+        OperationResult::SignError(sign_error) => {
+            panic!("Received SignError {}", sign_error);
         }
     }
 }
@@ -150,8 +153,11 @@ fn process_sign_result(sign_res: &[OperationResult]) {
                 &schnorr_proof.r, &schnorr_proof.s,
             );
         }
-        OperationResult::DkgError(..) | OperationResult::SignError(..) => {
-            todo!()
+        OperationResult::DkgError(dkg_error) => {
+            panic!("Received DkgError {}", dkg_error);
+        }
+        OperationResult::SignError(sign_error) => {
+            panic!("Received SignError {}", sign_error);
         }
     }
 }

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -235,12 +235,12 @@ impl From<&Config> for RunLoop<FireCoordinator<v2::Aggregator>> {
             .map(|i| i - 1) // Signer::new (unlike Signer::from) doesn't do this
             .collect::<Vec<u32>>();
         // signer uses a Vec<u32> for its key_ids, but coordinator uses a HashSet for each signer since it needs to do lots of lookups
-        let mut signer_key_ids = HashMap::new();
-        for (signer_id, key_ids) in &config.signer_key_ids {
-            let ids = key_ids.iter().map(|i| *i - 1).collect::<HashSet<u32>>();
+        let signer_key_ids = config
+            .signer_key_ids
+            .iter()
+            .map(|(i, ids)| (*i, ids.iter().map(|id| id - 1).collect::<HashSet<u32>>()))
+            .collect::<HashMap<u32, HashSet<u32>>>();
 
-            signer_key_ids.insert(*signer_id, ids);
-        }
         let coordinator_config = CoordinatorConfig {
             threshold,
             num_signers: total_signers,

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -237,10 +237,9 @@ impl From<&Config> for RunLoop<FrostCoordinator<v2::Aggregator>> {
         // signer uses a Vec<u32> for its key_ids, but coordinator uses a HashSet for each signer since it needs to do lots of lookups
         let mut signer_key_ids = HashMap::new();
         for (signer_id, key_ids) in &config.signer_key_ids {
-            let id = signer_id - 1;
-            let ids = key_ids.iter().map(|i| *i).collect::<HashSet<u32>>();
+            let ids = key_ids.iter().map(|i| *i - 1).collect::<HashSet<u32>>();
 
-            signer_key_ids.insert(id, ids);
+            signer_key_ids.insert(*signer_id, ids);
         }
         let coordinator_config = CoordinatorConfig {
             threshold,

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -9,7 +9,7 @@ use stacks_common::{debug, error, info, warn};
 use wsts::common::MerkleRoot;
 use wsts::curve::ecdsa;
 use wsts::net::{Message, Packet, Signable};
-use wsts::state_machine::coordinator::fire::Coordinator as FrostCoordinator;
+use wsts::state_machine::coordinator::fire::Coordinator as FireCoordinator;
 use wsts::state_machine::coordinator::{Config as CoordinatorConfig, Coordinator};
 use wsts::state_machine::signer::Signer;
 use wsts::state_machine::{OperationResult, PublicKeys};
@@ -207,7 +207,7 @@ impl<C: Coordinator> RunLoop<C> {
     }
 }
 
-impl From<&Config> for RunLoop<FrostCoordinator<v2::Aggregator>> {
+impl From<&Config> for RunLoop<FireCoordinator<v2::Aggregator>> {
     /// Creates new runloop from a config
     fn from(config: &Config) -> Self {
         // TODO: this should be a config option
@@ -252,7 +252,7 @@ impl From<&Config> for RunLoop<FrostCoordinator<v2::Aggregator>> {
             sign_timeout: config.sign_timeout,
             signer_key_ids,
         };
-        let coordinator = FrostCoordinator::new(coordinator_config);
+        let coordinator = FireCoordinator::new(coordinator_config);
         let signing_round = Signer::new(
             threshold,
             total_signers,

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -8,7 +8,7 @@ use stacks_common::{debug, error, info, warn};
 use wsts::common::MerkleRoot;
 use wsts::curve::ecdsa;
 use wsts::net::{Message, Packet, Signable};
-use wsts::state_machine::coordinator::frost::Coordinator as FrostCoordinator;
+use wsts::state_machine::coordinator::fire::Coordinator as FrostCoordinator;
 use wsts::state_machine::coordinator::{Config as CoordinatorConfig, Coordinator};
 use wsts::state_machine::signer::Signer;
 use wsts::state_machine::{OperationResult, PublicKeys};

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -312,8 +312,11 @@ fn test_stackerdb_dkg() {
                         info!("Received SchnorrProof ({},{})", &proof.r, &proof.s);
                         schnorr_proof = Some(proof);
                     }
-                    OperationResult::DkgError(..) | OperationResult::SignError(..) => {
-                        todo!()
+                    OperationResult::DkgError(dkg_error) => {
+                        panic!("Received DkgError {}", dkg_error);
+                    }
+                    OperationResult::SignError(sign_error) => {
+                        panic!("Received SignError {}", sign_error);
                     }
                 }
             }

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -11,7 +11,7 @@ use stacks_signer::runloop::RunLoopCommand;
 use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
-use wsts::state_machine::coordinator::frost::Coordinator as FrostCoordinator;
+use wsts::state_machine::coordinator::fire::Coordinator as FrostCoordinator;
 use wsts::state_machine::OperationResult;
 use wsts::v2;
 

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -11,7 +11,7 @@ use stacks_signer::runloop::RunLoopCommand;
 use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
-use wsts::state_machine::coordinator::fire::Coordinator as FrostCoordinator;
+use wsts::state_machine::coordinator::fire::Coordinator as FireCoordinator;
 use wsts::state_machine::OperationResult;
 use wsts::v2;
 
@@ -39,12 +39,12 @@ fn spawn_signer(
 ) -> RunningSigner<StackerDBEventReceiver, Vec<OperationResult>> {
     let config = stacks_signer::config::Config::load_from_str(data).unwrap();
     let ev = StackerDBEventReceiver::new(vec![config.stackerdb_contract_id.clone()]);
-    let runloop: stacks_signer::runloop::RunLoop<FrostCoordinator<v2::Aggregator>> =
+    let runloop: stacks_signer::runloop::RunLoop<FireCoordinator<v2::Aggregator>> =
         stacks_signer::runloop::RunLoop::from(&config);
     let mut signer: Signer<
         RunLoopCommand,
         Vec<OperationResult>,
-        stacks_signer::runloop::RunLoop<FrostCoordinator<v2::Aggregator>>,
+        stacks_signer::runloop::RunLoop<FireCoordinator<v2::Aggregator>>,
         StackerDBEventReceiver,
     > = Signer::new(runloop, ev, receiver, sender);
     let endpoint = config.endpoint;


### PR DESCRIPTION
### Description
`stacks-signer` is currently using a very basic `wsts` `Coordinator` implementation that doesn't handle non-responsive or malicious signers.  This has been fine for testing so far, but for Nakamoto we will need to sign all blocks using `wsts`, so we have to handle these and other errors.

`wsts` has a better `Coordinator` which supports the `FIRE` meta-protocol; it uses timeouts to handle non-responsive signers, returns errors identifying malicious signers, and correctly identifies when the number of malicious and/or non-responsive signers is large enough to make progress on any round impossible.

This PR therefore enables the `FIRE` coordinator.

### Applicable issues

- fixes #4169 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
