### PR TITLE
Process coordinator messages to duplicate state between multiple coor…

### DIFF
--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -170,7 +170,7 @@ impl<C: Coordinator> RunLoop<C> {
         event: &StackerDBChunksEvent,
     ) -> (Vec<Packet>, Vec<OperationResult>) {
         // Determine the current coordinator id and public key for verification
-        let (coordinator_id, coordinator_public_key) =
+        let (_coordinator_id, coordinator_public_key) =
             calculate_coordinator(&self.signing_round.public_keys);
         // Filter out invalid messages
         let inbound_messages: Vec<Packet> = event
@@ -190,14 +190,11 @@ impl<C: Coordinator> RunLoop<C> {
             .signing_round
             .process_inbound_messages(&inbound_messages)
             .unwrap_or_default();
-        // If the signer is the coordinator, then next process the message as the coordinator
-        let (messages, results) = if self.signing_round.signer_id == coordinator_id {
-            self.coordinator
-                .process_inbound_messages(&inbound_messages)
-                .unwrap_or_default()
-        } else {
-            (vec![], vec![])
-        };
+        // Next process the message as the coordinator
+        let (messages, results) = self
+            .coordinator
+            .process_inbound_messages(&inbound_messages)
+            .unwrap_or_default();
         outbound_messages.extend(messages);
         (outbound_messages, results)
     }

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -189,12 +189,18 @@ impl<C: Coordinator> RunLoop<C> {
         let mut outbound_messages = self
             .signing_round
             .process_inbound_messages(&inbound_messages)
-            .unwrap_or_default();
+            .unwrap_or_else(|e| {
+                error!("Failed to process inbound messages as a signer: {e}");
+                vec![]
+            });
         // Next process the message as the coordinator
         let (messages, results) = self
             .coordinator
             .process_inbound_messages(&inbound_messages)
-            .unwrap_or_default();
+            .unwrap_or_else(|e| {
+                error!("Failed to process inbound messages as a coordinator: {e}");
+                (vec![], vec![])
+            });
         outbound_messages.extend(messages);
         (outbound_messages, results)
     }

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -201,8 +201,8 @@ fn test_stackerdb_dkg() {
         .init();
 
     // Generate Signer Data
-    let num_signers: u32 = 3;
-    let num_keys: u32 = 2;
+    let num_signers: u32 = 10;
+    let num_keys: u32 = 400;
     let publisher_private_key = StacksPrivateKey::new();
     let signer_stacks_private_keys = (0..num_signers)
         .map(|_| StacksPrivateKey::new())

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -201,8 +201,8 @@ fn test_stackerdb_dkg() {
         .init();
 
     // Generate Signer Data
-    let num_signers: u32 = 10;
-    let num_keys: u32 = 400;
+    let num_signers: u32 = 3;
+    let num_keys: u32 = 2;
     let publisher_private_key = StacksPrivateKey::new();
     let signer_stacks_private_keys = (0..num_signers)
         .map(|_| StacksPrivateKey::new())
@@ -240,7 +240,7 @@ fn test_stackerdb_dkg() {
     let mut running_signers = vec![];
     // Spawn all the signers first to listen to the coordinator request for dkg
     let mut signer_cmd_senders = Vec::new();
-    let mut signer_res_receivers = Vec::new();
+    let mut res_receivers = Vec::new();
     for i in (1..num_signers).rev() {
         let (cmd_send, cmd_recv) = channel();
         let (res_send, res_recv) = channel();
@@ -248,7 +248,7 @@ fn test_stackerdb_dkg() {
         let running_signer = spawn_signer(&signer_configs[i as usize], cmd_recv, res_send);
         running_signers.push(running_signer);
         signer_cmd_senders.push(cmd_send);
-        signer_res_receivers.push(res_recv);
+        res_receivers.push(res_recv);
     }
     // Spawn coordinator second
     let (coordinator_cmd_send, coordinator_cmd_recv) = channel();
@@ -259,6 +259,8 @@ fn test_stackerdb_dkg() {
         coordinator_cmd_recv,
         coordinator_res_send,
     );
+
+    res_receivers.push(coordinator_res_recv);
 
     // Let's wrap the node in a lifetime to ensure stopping the signers doesn't cause issues.
     {
@@ -291,38 +293,40 @@ fn test_stackerdb_dkg() {
                 merkle_root: None,
             })
             .expect("failed to send Sign command");
-
-        let mut aggregate_group_key = None;
-        let mut frost_signature = None;
-        let mut schnorr_proof = None;
-
-        loop {
-            let results = coordinator_res_recv.recv().expect("failed to recv results");
-            for result in results {
-                match result {
-                    OperationResult::Dkg(point) => {
-                        info!("Received aggregate_group_key {point}");
-                        aggregate_group_key = Some(point);
-                    }
-                    OperationResult::Sign(sig) => {
-                        info!("Received Signature ({},{})", &sig.R, &sig.z);
-                        frost_signature = Some(sig);
-                    }
-                    OperationResult::SignTaproot(proof) => {
-                        info!("Received SchnorrProof ({},{})", &proof.r, &proof.s);
-                        schnorr_proof = Some(proof);
-                    }
-                    OperationResult::DkgError(dkg_error) => {
-                        panic!("Received DkgError {}", dkg_error);
-                    }
-                    OperationResult::SignError(sign_error) => {
-                        panic!("Received SignError {}", sign_error);
+        for recv in res_receivers.iter() {
+            let mut aggregate_group_key = None;
+            let mut frost_signature = None;
+            let mut schnorr_proof = None;
+            loop {
+                let results = recv.recv().expect("failed to recv results");
+                for result in results {
+                    match result {
+                        OperationResult::Dkg(point) => {
+                            info!("Received aggregate_group_key {point}");
+                            aggregate_group_key = Some(point);
+                        }
+                        OperationResult::Sign(sig) => {
+                            info!("Received Signature ({},{})", &sig.R, &sig.z);
+                            frost_signature = Some(sig);
+                        }
+                        OperationResult::SignTaproot(proof) => {
+                            info!("Received SchnorrProof ({},{})", &proof.r, &proof.s);
+                            schnorr_proof = Some(proof);
+                        }
+                        OperationResult::DkgError(dkg_error) => {
+                            panic!("Received DkgError {:?}", dkg_error);
+                        }
+                        OperationResult::SignError(sign_error) => {
+                            panic!("Received SignError {}", sign_error);
+                        }
                     }
                 }
-            }
-            if aggregate_group_key.is_some() && frost_signature.is_some() && schnorr_proof.is_some()
-            {
-                break;
+                if aggregate_group_key.is_some()
+                    && frost_signature.is_some()
+                    && schnorr_proof.is_some()
+                {
+                    break;
+                }
             }
         }
         let elapsed = now.elapsed();


### PR DESCRIPTION
### Description

Coordinator state should be replicated between signers so that every signer can submit its aggregate key and also so it can pick up where other coordinators leave off if said coordinators go down.

### Applicable issues

- Closes #https://github.com/stacks-network/sbtc/issues/393

