### PR TITLE
Nakamoto-Node: Support for interim block mining

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -70,6 +70,7 @@ jobs:
           - tests::neon_integrations::use_latest_tip_integration_test
           - tests::should_succeed_handling_malformed_and_valid_txs
           - tests::nakamoto_integrations::simple_neon_integration
+          - tests::nakamoto_integrations::mine_multiple_per_tenure_integration
     steps:
       ## Setup test environment
       - name: Setup Test Environment

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 use std::sync::mpsc::Sender;
 use std::time::Duration;
 
-use backoff::default;
 use libsigner::{SignerRunLoop, StackerDBChunksEvent};
 use slog::{slog_debug, slog_error, slog_info, slog_warn};
 use stacks_common::{debug, error, info, warn};

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -53,8 +53,8 @@ use crate::chainstate::stacks::db::transactions::{
     handle_clarity_runtime_error, ClarityRuntimeTxError,
 };
 use crate::chainstate::stacks::db::{
-    ChainstateTx, ClarityTx, MinerRewardInfo, StacksChainState, StacksHeaderInfo,
-    MINER_REWARD_MATURITY,
+    ChainstateTx, ClarityTx, MinerRewardInfo, StacksBlockHeaderTypes, StacksChainState,
+    StacksHeaderInfo, MINER_REWARD_MATURITY,
 };
 use crate::chainstate::stacks::events::{StacksTransactionEvent, StacksTransactionReceipt};
 use crate::chainstate::stacks::miner::{
@@ -99,22 +99,18 @@ impl NakamotoTenureInfo {
 }
 
 pub struct NakamotoBlockBuilder {
-    /// if this is building atop an epoch 2 block, then this is that block's header
-    epoch2_parent_header: Option<(StacksBlockHeader, ConsensusHash)>,
-    /// if this is building atop an epoch 3 block, then this is that block's header
-    nakamoto_parent_header: Option<NakamotoBlockHeader>,
+    /// If there's a parent (i.e., not a genesis), this is Some(parent_header)    
+    parent_header: Option<StacksHeaderInfo>,
     /// Signed coinbase tx, if starting a new tenure
     coinbase_tx: Option<StacksTransaction>,
     /// Tenure change tx, if starting or extending a tenure
     tenure_tx: Option<StacksTransaction>,
     /// Total burn this block represents
     total_burn: u64,
-    /// parent block-commit hash value
-    parent_commit_hash_value: BlockHeaderHash,
     /// Matured miner rewards to process, if any.
     matured_miner_rewards_opt: Option<MaturedMinerRewards>,
     /// bytes of space consumed so far
-    bytes_so_far: u64,
+    pub bytes_so_far: u64,
     /// transactions selected
     txs: Vec<StacksTransaction>,
     /// header we're filling in
@@ -138,102 +134,16 @@ pub struct MinerTenureInfo<'a> {
 }
 
 impl NakamotoBlockBuilder {
-    /// Make a block builder atop a Nakamoto parent for a new tenure
-    pub fn new_tenure_from_nakamoto_parent(
-        parent_tenure_id: &StacksBlockId,
-        parent: &NakamotoBlockHeader,
-        tenure_id_consensus_hash: &ConsensusHash,
-        total_burn: u64,
-        tenure_change: &StacksTransaction,
-        coinbase: &StacksTransaction,
-    ) -> NakamotoBlockBuilder {
-        let parent_commit_hash_value = BlockHeaderHash(parent_tenure_id.0.clone());
-        NakamotoBlockBuilder {
-            epoch2_parent_header: None,
-            nakamoto_parent_header: Some(parent.clone()),
-            total_burn,
-            coinbase_tx: Some(coinbase.clone()),
-            tenure_tx: Some(tenure_change.clone()),
-            parent_commit_hash_value,
-            matured_miner_rewards_opt: None,
-            bytes_so_far: 0,
-            txs: vec![],
-            header: NakamotoBlockHeader::from_parent_empty(
-                parent.chain_length + 1,
-                total_burn,
-                tenure_id_consensus_hash.clone(),
-                parent.block_id(),
-            ),
-        }
-    }
-
-    /// Make a block builder atop a Nakamoto parent for a new block within a tenure
-    pub fn continue_tenure_from_nakamoto_parent(
-        parent: &NakamotoBlockHeader,
-        tenure_id_consensus_hash: &ConsensusHash,
-        total_burn: u64,
-        tenure_extend: Option<&StacksTransaction>,
-    ) -> NakamotoBlockBuilder {
-        let parent_commit_hash_value = BlockHeaderHash(parent.block_id().0.clone());
-        NakamotoBlockBuilder {
-            epoch2_parent_header: None,
-            nakamoto_parent_header: Some(parent.clone()),
-            total_burn,
-            coinbase_tx: None,
-            tenure_tx: tenure_extend.cloned(),
-            parent_commit_hash_value,
-            matured_miner_rewards_opt: None,
-            bytes_so_far: 0,
-            txs: vec![],
-            header: NakamotoBlockHeader::from_parent_empty(
-                parent.chain_length + 1,
-                total_burn,
-                tenure_id_consensus_hash.clone(),
-                parent.block_id(),
-            ),
-        }
-    }
-
-    /// Make a block builder atop an epoch 2 parent for a new tenure
-    pub fn new_tenure_from_epoch2_parent(
-        parent: &StacksBlockHeader,
-        parent_tenure_id_consensus_hash: &ConsensusHash,
-        tenure_id_consensus_hash: &ConsensusHash,
-        total_burn: u64,
-        tenure_change: &StacksTransaction,
-        coinbase: &StacksTransaction,
-    ) -> NakamotoBlockBuilder {
-        NakamotoBlockBuilder {
-            epoch2_parent_header: Some((parent.clone(), parent_tenure_id_consensus_hash.clone())),
-            nakamoto_parent_header: None,
-            total_burn,
-            coinbase_tx: Some(coinbase.clone()),
-            tenure_tx: Some(tenure_change.clone()),
-            parent_commit_hash_value: parent.block_hash(),
-            matured_miner_rewards_opt: None,
-            bytes_so_far: 0,
-            txs: vec![],
-            header: NakamotoBlockHeader::from_parent_empty(
-                parent.total_work.work + 1,
-                total_burn,
-                tenure_id_consensus_hash.clone(),
-                StacksBlockId::new(parent_tenure_id_consensus_hash, &parent.block_hash()),
-            ),
-        }
-    }
-
     /// Make a block builder from genesis (testing only)
-    pub fn new_tenure_from_genesis(
+    pub fn new_first_block(
         tenure_change: &StacksTransaction,
         coinbase: &StacksTransaction,
     ) -> NakamotoBlockBuilder {
         NakamotoBlockBuilder {
-            epoch2_parent_header: None,
-            nakamoto_parent_header: None,
+            parent_header: None,
             total_burn: 0,
             coinbase_tx: Some(coinbase.clone()),
             tenure_tx: Some(tenure_change.clone()),
-            parent_commit_hash_value: FIRST_STACKS_BLOCK_HASH.clone(),
             matured_miner_rewards_opt: None,
             bytes_so_far: 0,
             txs: vec![],
@@ -242,72 +152,59 @@ impl NakamotoBlockBuilder {
     }
 
     /// Make a Nakamoto block builder appropriate for building atop the given block header
-    pub fn new_from_parent(
-        // tenure ID -- this is the index block hash of the start block of the last tenure (i.e.
-        // the data we committed to in the block-commit).  If this is an epoch 2.x parent, then
-        // this is just the index block hash of the parent Stacks block.
-        parent_tenure_id: &StacksBlockId,
-        // Stacks header we're building off of.
+    ///
+    /// * `parent_stacker_header` - the stacks header this builder's block will build off
+    ///
+    /// * `tenure_id_consensus_hash` - consensus hash of this tenure's burnchain block.
+    ///    This is the consensus hash that goes into the block header.
+    ///
+    /// * `total_burn` - total BTC burnt so far in this fork.
+    ///
+    /// * `tenure_change` - the TenureChange tx if this is going to start or
+    ///    extend a tenure
+    ///
+    /// * `coinbase` - the coinbase tx if this is going to start a new tenure
+    ///
+    pub fn new(
         parent_stacks_header: &StacksHeaderInfo,
-        // consensus hash of this tenure's burnchain block. This is the consensus hash that goes
-        // into the block header.
         tenure_id_consensus_hash: &ConsensusHash,
-        // total BTC burn so far
         total_burn: u64,
-        // tenure change, if we're starting or extending a tenure
         tenure_change: Option<&StacksTransaction>,
-        // coinbase, if we're starting a new tenure
         coinbase: Option<&StacksTransaction>,
     ) -> Result<NakamotoBlockBuilder, Error> {
-        let builder = if let Some(parent_nakamoto_header) =
-            parent_stacks_header.anchored_header.as_stacks_nakamoto()
-        {
-            // building atop a nakamoto block
-            // new tenure?
-            if coinbase.is_some() && tenure_change.is_some() {
-                NakamotoBlockBuilder::new_tenure_from_nakamoto_parent(
-                    parent_tenure_id,
-                    parent_nakamoto_header,
-                    tenure_id_consensus_hash,
-                    total_burn,
-                    tenure_change.ok_or(Error::ExpectedTenureChange)?,
-                    coinbase.ok_or(Error::ExpectedTenureChange)?,
-                )
-            } else {
-                NakamotoBlockBuilder::continue_tenure_from_nakamoto_parent(
-                    parent_nakamoto_header,
-                    tenure_id_consensus_hash,
-                    total_burn,
-                    tenure_change,
-                )
-            }
-        } else if let Some(parent_epoch2_header) =
-            parent_stacks_header.anchored_header.as_stacks_epoch2()
-        {
+        let next_height = parent_stacks_header
+            .anchored_header
+            .height()
+            .checked_add(1)
+            .ok_or_else(|| Error::InvalidStacksBlock("Block height exceeded u64".into()))?;
+        if matches!(
+            parent_stacks_header.anchored_header,
+            StacksBlockHeaderTypes::Epoch2(_)
+        ) {
             // building atop a stacks 2.x block.
             // we are necessarily starting a new tenure
-            if tenure_change.is_some() && coinbase.is_some() {
-                NakamotoBlockBuilder::new_tenure_from_epoch2_parent(
-                    parent_epoch2_header,
-                    &parent_stacks_header.consensus_hash,
-                    tenure_id_consensus_hash,
-                    total_burn,
-                    tenure_change.ok_or(Error::ExpectedTenureChange)?,
-                    coinbase.ok_or(Error::ExpectedTenureChange)?,
-                )
-            } else {
+            if tenure_change.is_none() || coinbase.is_none() {
                 // not allowed
                 warn!("Failed to start a Nakamoto tenure atop a Stacks 2.x block -- missing a coinbase and/or tenure");
                 return Err(Error::ExpectedTenureChange);
             }
-        } else {
-            // not reachable -- no other choices
-            return Err(Error::InvalidStacksBlock(
-                "Parent is neither a Nakamoto block nor a Stacks 2.x block".into(),
-            ));
-        };
+        }
 
-        Ok(builder)
+        Ok(NakamotoBlockBuilder {
+            parent_header: Some(parent_stacks_header.clone()),
+            total_burn,
+            coinbase_tx: coinbase.cloned(),
+            tenure_tx: tenure_change.cloned(),
+            matured_miner_rewards_opt: None,
+            bytes_so_far: 0,
+            txs: vec![],
+            header: NakamotoBlockHeader::from_parent_empty(
+                next_height,
+                total_burn,
+                tenure_id_consensus_hash.clone(),
+                parent_stacks_header.index_block_hash(),
+            ),
+        })
     }
 
     /// This function should be called before `tenure_begin`.
@@ -330,74 +227,36 @@ impl NakamotoBlockBuilder {
 
         let mainnet = chainstate.config().mainnet;
 
-        let (chain_tip, parent_tenure_id_consensus_hash, parent_header_hash) =
-            if let Some(nakamoto_parent_header) = self.nakamoto_parent_header.as_ref() {
-                // parent is a nakamoto block
-                let parent_header_info = NakamotoChainState::get_block_header(
-                    chainstate.db(),
-                    &StacksBlockId::new(
-                        &nakamoto_parent_header.consensus_hash,
-                        &nakamoto_parent_header.block_hash(),
-                    ),
-                )?
-                .ok_or(Error::NoSuchBlockError)
-                .map_err(|e| {
-                    warn!(
-                        "No such Nakamoto parent block {}/{} ({})",
-                        &nakamoto_parent_header.consensus_hash,
-                        &nakamoto_parent_header.block_hash(),
-                        &nakamoto_parent_header.block_id()
-                    );
-                    e
-                })?;
-
-                (
-                    parent_header_info,
-                    nakamoto_parent_header.consensus_hash.clone(),
-                    nakamoto_parent_header.block_hash(),
-                )
-            } else if let Some((stacks_header, consensus_hash)) = self.epoch2_parent_header.as_ref()
-            {
-                // parent is a Stacks epoch2 block
-                let parent_header_info = NakamotoChainState::get_block_header(
-                    chainstate.db(),
-                    &StacksBlockId::new(consensus_hash, &stacks_header.block_hash()),
-                )?
-                .ok_or(Error::NoSuchBlockError)
-                .map_err(|e| {
-                    warn!(
-                        "No such Stacks 2.x parent block {}/{} ({})",
-                        &consensus_hash,
-                        &stacks_header.block_hash(),
-                        &StacksBlockId::new(&consensus_hash, &stacks_header.block_hash())
-                    );
-                    e
-                })?;
-
-                (
-                    parent_header_info,
-                    consensus_hash.clone(),
-                    stacks_header.block_hash(),
-                )
-            } else {
+        let (chain_tip, parent_consensus_hash, parent_header_hash) = match self.parent_header {
+            Some(ref header_info) => (
+                header_info.clone(),
+                header_info.consensus_hash.clone(),
+                header_info.anchored_header.block_hash(),
+            ),
+            None => {
                 // parent is genesis (testing only)
                 (
                     StacksHeaderInfo::regtest_genesis(),
                     FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
                     FIRST_STACKS_BLOCK_HASH.clone(),
                 )
-            };
+            }
+        };
 
-        let coinbase_height = if let Ok(Some(parent_coinbase_height)) =
-            NakamotoChainState::get_coinbase_height(
-                chainstate.db(),
-                &StacksBlockId::new(&parent_tenure_id_consensus_hash, &parent_header_hash),
-            ) {
+        let parent_block_id = StacksBlockId::new(&parent_consensus_hash, &parent_header_hash);
+        let parent_coinbase_height =
+            NakamotoChainState::get_coinbase_height(chainstate.db(), &parent_block_id)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+
+        let new_tenure = cause == Some(TenureChangeCause::BlockFound);
+        let coinbase_height = if new_tenure {
             parent_coinbase_height
                 .checked_add(1)
                 .expect("Blockchain overflow")
         } else {
-            0
+            parent_coinbase_height
         };
 
         // data won't be committed, so do a concurrent transaction
@@ -409,7 +268,7 @@ impl NakamotoBlockBuilder {
             burn_tip,
             burn_tip_height,
             mainnet,
-            parent_consensus_hash: parent_tenure_id_consensus_hash,
+            parent_consensus_hash,
             parent_header_hash,
             parent_stacks_block_height: chain_tip.stacks_block_height,
             parent_burn_block_height: chain_tip.burn_header_height,
@@ -526,9 +385,6 @@ impl NakamotoBlockBuilder {
         chainstate_handle: &StacksChainState,
         burn_dbconn: &SortitionDBConn,
         mempool: &mut MemPoolDB,
-        // tenure ID -- this is the index block hash of the start block of the last tenure (i.e.
-        // the data we committed to in the block-commit)
-        parent_tenure_id: &StacksBlockId,
         // Stacks header we're building off of.
         parent_stacks_header: &StacksHeaderInfo,
         // tenure ID consensus hash of this block
@@ -552,8 +408,7 @@ impl NakamotoBlockBuilder {
 
         let (mut chainstate, _) = chainstate_handle.reopen()?;
 
-        let mut builder = NakamotoBlockBuilder::new_from_parent(
-            parent_tenure_id,
+        let mut builder = NakamotoBlockBuilder::new(
             parent_stacks_header,
             tenure_id_consensus_hash,
             total_burn,
@@ -638,80 +493,6 @@ impl NakamotoBlockBuilder {
         );
 
         Ok((block, consumed, size))
-    }
-
-    #[cfg(test)]
-    pub fn make_nakamoto_block_from_txs(
-        mut self,
-        chainstate_handle: &StacksChainState,
-        burn_dbconn: &SortitionDBConn,
-        mut txs: Vec<StacksTransaction>,
-    ) -> Result<(NakamotoBlock, u64, ExecutionCost), Error> {
-        debug!("Build Nakamoto block from {} transactions", txs.len());
-        let (mut chainstate, _) = chainstate_handle.reopen()?;
-
-        let mut tenure_cause = None;
-        for tx in txs.iter() {
-            let TransactionPayload::TenureChange(payload) = &tx.payload else {
-                continue;
-            };
-            tenure_cause = Some(payload.cause);
-            break;
-        }
-
-        let mut miner_tenure_info =
-            self.load_tenure_info(&mut chainstate, burn_dbconn, tenure_cause)?;
-        let mut tenure_tx = self.tenure_begin(burn_dbconn, &mut miner_tenure_info)?;
-        for tx in txs.drain(..) {
-            let tx_len = tx.tx_len();
-            match self.try_mine_tx_with_len(
-                &mut tenure_tx,
-                &tx,
-                tx_len,
-                &BlockLimitFunction::NO_LIMIT_HIT,
-                ASTRules::PrecheckSize,
-            ) {
-                TransactionResult::Success(..) => {
-                    debug!("Included {}", &tx.txid());
-                }
-                TransactionResult::Skipped(TransactionSkipped { error, .. })
-                | TransactionResult::ProcessingError(TransactionError { error, .. }) => {
-                    match error {
-                        Error::BlockTooBigError => {
-                            // done mining -- our execution budget is exceeded.
-                            // Make the block from the transactions we did manage to get
-                            debug!("Block budget exceeded on tx {}", &tx.txid());
-                        }
-                        Error::InvalidStacksTransaction(_emsg, true) => {
-                            // if we have an invalid transaction that was quietly ignored, don't warn here either
-                            test_debug!(
-                                "Failed to apply tx {}: InvalidStacksTransaction '{:?}'",
-                                &tx.txid(),
-                                &_emsg
-                            );
-                            continue;
-                        }
-                        Error::ProblematicTransaction(txid) => {
-                            test_debug!("Encountered problematic transaction. Aborting");
-                            return Err(Error::ProblematicTransaction(txid));
-                        }
-                        e => {
-                            warn!("Failed to apply tx {}: {:?}", &tx.txid(), &e);
-                            continue;
-                        }
-                    }
-                }
-                TransactionResult::Problematic(TransactionProblematic { tx, .. }) => {
-                    // drop from the mempool
-                    debug!("Encountered problematic transaction {}", &tx.txid());
-                    return Err(Error::ProblematicTransaction(tx.txid()));
-                }
-            }
-        }
-        let block = self.mine_nakamoto_block(&mut tenure_tx);
-        let size = self.bytes_so_far;
-        let cost = self.tenure_finish(tenure_tx);
-        Ok((block, size, cost))
     }
 }
 

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -459,6 +459,10 @@ impl NakamotoBlockBuilder {
             return Err(Error::MinerAborted);
         }
 
+        if builder.txs.is_empty() {
+            return Err(Error::NoTransactionsToMine);
+        }
+
         // save the block so we can build microblocks off of it
         let block = builder.mine_nakamoto_block(&mut tenure_tx);
         let size = builder.bytes_so_far;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -8,8 +8,6 @@ use async_h1::client;
 use async_std::io::ReadExt;
 use async_std::net::TcpStream;
 use base64::encode;
-#[cfg(test)]
-use clarity::vm::types::PrincipalData;
 use http_types::{Method, Request, Url};
 use serde::Serialize;
 use serde_json::json;
@@ -52,8 +50,6 @@ use stacks_common::deps_common::bitcoin::network::serialize::deserialize as btc_
 use stacks_common::deps_common::bitcoin::network::serialize::RawEncoder;
 use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
-#[cfg(test)]
-use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::util::hash::{hex_bytes, Hash160};
 use stacks_common::util::secp256k1::Secp256k1PublicKey;
 use stacks_common::util::sleep_ms;

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -20,10 +20,8 @@ use std::thread;
 use std::thread::{sleep, JoinHandle};
 use std::time::Duration;
 
-use clarity::boot_util::boot_code_id;
 use clarity::vm::ast::ASTRules;
-use clarity::vm::clarity::TransactionConnection;
-use clarity::vm::{ClarityVersion, Value as ClarityValue};
+use clarity::vm::Value as ClarityValue;
 use lazy_static::lazy_static;
 use stacks::burnchains::bitcoin::address::{
     BitcoinAddress, LegacyBitcoinAddress, LegacyBitcoinAddressType,
@@ -50,9 +48,6 @@ use stacks::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, SetupBlockResult,
 };
 use stacks::chainstate::stacks::address::PoxAddress;
-use stacks::chainstate::stacks::boot::{
-    BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME, POX_4_NAME,
-};
 use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
 use stacks::chainstate::stacks::miner::{
     BlockBuilder, BlockBuilderSettings, BlockLimitFunction, MinerStatus, TransactionResult,
@@ -87,7 +82,6 @@ use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::hash::{to_hex, Hash160, MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PublicKey};
 use stacks_common::util::vrf::{VRFPrivateKey, VRFProof, VRFPublicKey, VRF};
-use wsts::curve::point::Point;
 
 use self::signer::SelfSigner;
 use crate::globals::{NeonGlobals as Globals, RelayerDirective};
@@ -803,9 +797,6 @@ impl MockamotoNode {
         let mut coinbase_tx_signer = StacksTransactionSigner::new(&coinbase_tx);
         coinbase_tx_signer.sign_origin(&self.miner_key).unwrap();
         let coinbase_tx = coinbase_tx_signer.get_tx().unwrap();
-
-        let miner_pk = Secp256k1PublicKey::from_private(&self.miner_key);
-        let miner_pk_hash = Hash160::from_node_public_key(&miner_pk);
 
         let miner_pk = Secp256k1PublicKey::from_private(&self.miner_key);
         let miner_pk_hash = Hash160::from_node_public_key(&miner_pk);

--- a/testnet/stacks-node/src/mockamoto/tests.rs
+++ b/testnet/stacks-node/src/mockamoto/tests.rs
@@ -1,26 +1,20 @@
 use std::thread;
 use std::time::{Duration, Instant};
 
-use clarity::boot_util::boot_code_addr;
 use clarity::vm::costs::ExecutionCost;
-use clarity::vm::Value;
-use rand_core::OsRng;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::nakamoto::NakamotoChainState;
-use stacks::chainstate::stacks::boot::POX_4_NAME;
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey};
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::to_hex;
-use wsts::curve::point::Point;
-use wsts::curve::scalar::Scalar;
 
 use super::MockamotoNode;
 use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon_node::PeerThread;
 use crate::tests::neon_integrations::{submit_tx, test_observer};
-use crate::tests::{make_contract_call, make_stacks_transfer, to_addr};
+use crate::tests::{make_stacks_transfer, to_addr};
 use crate::{Config, ConfigFile};
 
 #[test]
@@ -260,16 +254,13 @@ fn observe_set_aggregate_key() {
 
     let globals = mockamoto.globals.clone();
 
-    let mut mempool = PeerThread::connect_mempool_db(&conf);
-    let (mut chainstate, _) = StacksChainState::open(
+    StacksChainState::open(
         conf.is_mainnet(),
         conf.burnchain.chain_id,
         &conf.get_chainstate_path_str(),
         None,
     )
     .unwrap();
-    let burnchain = conf.get_burnchain();
-    let sortdb = burnchain.open_sortition_db(true).unwrap();
     let sortition_tip = SortitionDB::get_canonical_burn_chain_tip(mockamoto.sortdb.conn()).unwrap();
 
     let start = Instant::now();

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -489,11 +489,6 @@ impl BlockMinerThread {
             &chain_state,
             &burn_db.index_conn(),
             &mut mem_pool,
-            // TODO (refactor): the nakamoto block builder doesn't use the parent tenure ID,
-            //  it has to be included in the tenure change tx, which is an arg to the builder.
-            //  we should probably just remove this from the nakamoto block builder, so that
-            //  there isn't duplicated or unused logic here
-            &self.parent_tenure_id,
             &parent_block_info.stacks_parent_header,
             &self.burn_block.consensus_hash,
             self.burn_block.total_burn,

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -16,6 +16,7 @@
 use std::convert::TryFrom;
 use std::thread;
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use clarity::vm::types::PrincipalData;
 use stacks::burnchains::{Burnchain, BurnchainParameters};
@@ -30,7 +31,6 @@ use stacks::chainstate::stacks::{
     TransactionPayload, TransactionVersion,
 };
 use stacks::core::FIRST_BURNCHAIN_CONSENSUS_HASH;
-use stacks::util_lib::db::Error as DBError;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
 use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::hash::Hash160;
@@ -43,6 +43,10 @@ use crate::nakamoto_node::VRF_MOCK_MINER_KEY;
 use crate::run_loop::nakamoto::Globals;
 use crate::run_loop::RegisteredKey;
 use crate::{neon_node, ChainTip};
+
+/// If the miner was interrupted while mining a block, how long should the
+///  miner thread sleep before trying again?
+const ABORT_TRY_AGAIN_MS: u64 = 200;
 
 pub enum MinerDirective {
     /// The miner won sortition so they should begin a new tenure
@@ -81,10 +85,8 @@ pub struct BlockMinerThread {
     keychain: Keychain,
     /// burnchain configuration
     burnchain: Burnchain,
-    /// Set of blocks that we have mined, but are still potentially-broadcastable
-    /// (copied from RelayerThread since we need the info to determine the strategy for mining the
-    /// next block during this tenure).
-    last_mined_blocks: Vec<NakamotoBlock>,
+    /// Set of blocks that we have mined
+    mined_blocks: Vec<NakamotoBlock>,
     /// Copy of the node's registered VRF key
     registered_key: RegisteredKey,
     /// Burnchain block snapshot which elected this miner
@@ -108,7 +110,7 @@ impl BlockMinerThread {
             globals: rt.globals.clone(),
             keychain: rt.keychain.clone(),
             burnchain: rt.burnchain.clone(),
-            last_mined_blocks: vec![],
+            mined_blocks: vec![],
             registered_key,
             burn_block,
             event_dispatcher: rt.event_dispatcher.clone(),
@@ -133,26 +135,57 @@ impl BlockMinerThread {
         }
 
         // now, actually run this tenure
-        let new_block = match self.mine_block() {
-            Ok(x) => x,
-            Err(e) => {
-                warn!("Failed to mine block: {e:?}");
-                return;
-            }
-        };
+        loop {
+            let new_block = loop {
+                match self.mine_block() {
+                    Ok(x) => break x,
+                    Err(NakamotoNodeError::MiningFailure(ChainstateError::MinerAborted)) => {
+                        info!("Miner interrupted while mining, will try again");
+                        // sleep, and try again. if the miner was interrupted because the burnchain
+                        // view changed, the next `mine_block()` invocation will error
+                        thread::sleep(Duration::from_millis(ABORT_TRY_AGAIN_MS));
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!("Failed to mine block: {e:?}");
+                        return;
+                    }
+                }
+            };
 
-        if let Some(self_signer) = self.config.self_signing() {
-            if let Err(e) = self.self_sign_and_broadcast(self_signer, new_block.clone()) {
-                warn!("Error self-signing block: {e:?}");
-            } else {
-                self.globals.coord().announce_new_stacks_block();
+            if let Some(new_block) = new_block {
+                if let Some(self_signer) = self.config.self_signing() {
+                    if let Err(e) = self.self_sign_and_broadcast(self_signer, new_block.clone()) {
+                        warn!("Error self-signing block: {e:?}");
+                    } else {
+                        self.globals.coord().announce_new_stacks_block();
+                    }
+                } else {
+                    warn!("Not self-signing: nakamoto node does not support stacker-signer-protocol yet");
+                }
+
+                self.globals.counters.bump_naka_mined_blocks();
+                if self.mined_blocks.is_empty() {
+                    // this is the first block of the tenure, bump tenure counter
+                    self.globals.counters.bump_naka_mined_tenures();
+                }
+                self.mined_blocks.push(new_block);
             }
-        } else {
-            warn!("Not self-signing: nakamoto node does not support stacker-signer-protocol yet");
+
+            let wait_start = Instant::now();
+            let sort_db = SortitionDB::open(
+                &self.config.get_burn_db_file_path(),
+                true,
+                self.burnchain.pox_constants.clone(),
+            )
+            .expect("FATAL: could not open sortition DB");
+            while wait_start.elapsed() < self.config.miner.wait_on_interim_blocks {
+                thread::sleep(Duration::from_millis(ABORT_TRY_AGAIN_MS));
+                if self.check_burn_tip_changed(&sort_db).is_err() {
+                    return;
+                }
+            }
         }
-
-        self.globals.counters.bump_naka_mined_blocks();
-        self.last_mined_blocks.push(new_block);
     }
 
     fn self_sign_and_broadcast(
@@ -378,9 +411,8 @@ impl BlockMinerThread {
     /// burnchain block-commit transaction.  If we succeed, then return the assembled block data as
     /// well as the microblock private key to use to produce microblocks.
     /// Return None if we couldn't build a block for whatever reason.
-    fn mine_block(&mut self) -> Result<NakamotoBlock, NakamotoNodeError> {
+    fn mine_block(&mut self) -> Result<Option<NakamotoBlock>, NakamotoNodeError> {
         debug!("block miner thread ID is {:?}", thread::current().id());
-        neon_node::fault_injection_long_tenure();
 
         let burn_db_path = self.config.get_burn_db_file_path();
 
@@ -389,6 +421,9 @@ impl BlockMinerThread {
         let mut burn_db =
             SortitionDB::open(&burn_db_path, true, self.burnchain.pox_constants.clone())
                 .expect("FATAL: could not open sortition DB");
+
+        self.check_burn_tip_changed(&burn_db)?;
+        neon_node::fault_injection_long_tenure();
 
         let mut chain_state = neon_node::open_chainstate_with_faults(&self.config)
             .expect("FATAL: could not open chainstate DB");
@@ -408,7 +443,7 @@ impl BlockMinerThread {
             .make_vrf_proof()
             .ok_or_else(|| NakamotoNodeError::BadVrfConstruction)?;
 
-        if self.last_mined_blocks.is_empty() {
+        if self.mined_blocks.is_empty() {
             if parent_block_info.parent_tenure.is_none() {
                 warn!(
                     "Miner should be starting a new tenure, but failed to load parent tenure info"
@@ -446,8 +481,11 @@ impl BlockMinerThread {
 
         parent_block_info.stacks_parent_header.microblock_tail = None;
 
+        let block_num = u64::try_from(self.mined_blocks.len())
+            .map_err(|_| NakamotoNodeError::UnexpectedChainState)?
+            .saturating_add(1);
         // build the block itself
-        let (mut block, _, _) = match NakamotoBlockBuilder::build_nakamoto_block(
+        let (mut block, _, _) = NakamotoBlockBuilder::build_nakamoto_block(
             &chain_state,
             &burn_db.index_conn(),
             &mut mem_pool,
@@ -461,19 +499,22 @@ impl BlockMinerThread {
             self.burn_block.total_burn,
             tenure_start_info,
             self.config.make_block_builder_settings(
-                // TODO: the attempt counter needs a different configuration approach in nakamoto
-                1,
+                block_num,
                 false,
                 self.globals.get_miner_status(),
             ),
             Some(&self.event_dispatcher),
-        ) {
-            Ok(block) => block,
-            Err(e) => {
-                error!("Relayer: Failure mining anchored block: {}", e);
-                return Err(NakamotoNodeError::MiningFailure(e));
+        )
+        .map_err(|e| {
+            if !matches!(e, ChainstateError::MinerAborted) {
+                error!("Relayer: Failure mining anchored block: {e}");
             }
-        };
+            NakamotoNodeError::MiningFailure(e)
+        })?;
+
+        if block.txs.is_empty() {
+            return Ok(None);
+        }
 
         let mining_key = self.keychain.get_nakamoto_sk();
         let miner_signature = mining_key
@@ -502,16 +543,22 @@ impl BlockMinerThread {
         // last chance -- confirm that the stacks tip is unchanged (since it could have taken long
         // enough to build this block that another block could have arrived), and confirm that all
         // Stacks blocks with heights higher than the canoincal tip are processed.
-        let cur_burn_chain_tip = SortitionDB::get_canonical_burn_chain_tip(burn_db.conn())
+        self.check_burn_tip_changed(&burn_db)?;
+        Ok(Some(block))
+    }
+
+    /// Check if the tenure needs to change -- if so, return a BurnchainTipChanged error
+    fn check_burn_tip_changed(&self, sortdb: &SortitionDB) -> Result<(), NakamotoNodeError> {
+        let cur_burn_chain_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
             .expect("FATAL: failed to query sortition DB for canonical burn chain tip");
 
-        if cur_burn_chain_tip.consensus_hash != block.header.consensus_hash {
+        if cur_burn_chain_tip.consensus_hash != self.burn_block.consensus_hash {
             info!("Miner: Cancel block assembly; burnchain tip has changed");
             self.globals.counters.bump_missed_tenures();
-            return Err(NakamotoNodeError::BurnchainTipChanged);
+            Err(NakamotoNodeError::BurnchainTipChanged)
+        } else {
+            Ok(())
         }
-
-        Ok(block)
     }
 }
 

--- a/testnet/stacks-node/src/run_loop/nakamoto.rs
+++ b/testnet/stacks-node/src/run_loop/nakamoto.rs
@@ -19,10 +19,6 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::{cmp, thread};
 
-use clarity::boot_util::boot_code_id;
-use clarity::vm::ast::ASTRules;
-use clarity::vm::clarity::TransactionConnection;
-use clarity::vm::ClarityVersion;
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, LegacyBitcoinAddressType};
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
@@ -31,12 +27,12 @@ use stacks::chainstate::coordinator::comm::{CoordinatorChannels, CoordinatorRece
 use stacks::chainstate::coordinator::{
     ChainsCoordinator, ChainsCoordinatorConfig, CoordinatorCommunication,
 };
-use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
+use stacks::chainstate::stacks::db::{ChainStateBootData, StacksChainState};
 use stacks::chainstate::stacks::miner::{signal_mining_blocked, signal_mining_ready, MinerStatus};
 use stacks::core::StacksEpochId;
 use stacks::net::atlas::{AtlasConfig, AtlasDB, Attachment};
 use stacks_common::types::PublicKey;
-use stacks_common::util::hash::{to_hex, Hash160};
+use stacks_common::util::hash::Hash160;
 use stx_genesis::GenesisData;
 
 use crate::burnchains::make_bitcoin_indexer;

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -6,10 +6,6 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::{cmp, thread};
 
-use clarity::boot_util::boot_code_id;
-use clarity::vm::ast::ASTRules;
-use clarity::vm::clarity::TransactionConnection;
-use clarity::vm::ClarityVersion;
 use libc;
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, LegacyBitcoinAddressType};
 use stacks::burnchains::Burnchain;
@@ -73,6 +69,7 @@ pub struct Counters {
     pub naka_submitted_vrfs: RunLoopCounter,
     pub naka_submitted_commits: RunLoopCounter,
     pub naka_mined_blocks: RunLoopCounter,
+    pub naka_mined_tenures: RunLoopCounter,
 }
 
 impl Counters {
@@ -87,6 +84,7 @@ impl Counters {
             naka_submitted_vrfs: RunLoopCounter::new(AtomicU64::new(0)),
             naka_submitted_commits: RunLoopCounter::new(AtomicU64::new(0)),
             naka_mined_blocks: RunLoopCounter::new(AtomicU64::new(0)),
+            naka_mined_tenures: RunLoopCounter::new(AtomicU64::new(0)),
         }
     }
 
@@ -101,6 +99,7 @@ impl Counters {
             naka_submitted_vrfs: (),
             naka_submitted_commits: (),
             naka_mined_blocks: (),
+            naka_mined_tenures: (),
         }
     }
 
@@ -150,6 +149,10 @@ impl Counters {
 
     pub fn bump_naka_mined_blocks(&self) {
         Counters::inc(&self.naka_mined_blocks);
+    }
+
+    pub fn bump_naka_mined_tenures(&self) {
+        Counters::inc(&self.naka_mined_tenures);
     }
 
     pub fn set_microblocks_processed(&self, value: u64) {


### PR DESCRIPTION
### Description

This PR adds support to the nakamoto node for interim block mining (i.e., blocks within the current tenure) with a configurable wait time between such blocks. This PR also refactors the `chainstate::nakamoto::miner` module to match the actual usage of the miner interfaces, and moving the `TestPeer` specific method out into `TestPeer` itself.

This adds a new `nakamoto_integration` test which mines 10 nakamoto tenures, each with 2 blocks in the tenure.