### PR TITLE
Nakamoto Fixes: IssueBlockCommit and Reward Maturity Lookups

### DIFF
--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -1,8 +1,8 @@
-use hashbrown::{HashMap, HashSet};
 use std::collections::VecDeque;
 use std::sync::mpsc::Sender;
 use std::time::Duration;
 
+use hashbrown::{HashMap, HashSet};
 use libsigner::{SignerRunLoop, StackerDBChunksEvent};
 use slog::{slog_debug, slog_error, slog_info, slog_warn};
 use stacks_common::{debug, error, info, warn};

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2435,7 +2435,7 @@ impl NakamotoChainState {
                 Self::calculate_matured_miner_rewards(
                     &mut clarity_tx,
                     sortition_dbconn.sqlite_conn(),
-                    parent_stacks_height,
+                    coinbase_height,
                     matured_rewards_schedule,
                 )
             })

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -779,8 +779,8 @@ impl RelayerThread {
 
         if should_commit {
             Some(RelayerDirective::IssueBlockCommit(
-                chain_tip_header.consensus_hash,
-                chain_tip_header.anchored_header.block_hash(),
+                chain_tip_tenure_start.consensus_hash,
+                chain_tip_tenure_start.anchored_header.block_hash(),
             ))
         } else {
             None


### PR DESCRIPTION
### Description

This fixes two issues surfaced by the interim blocks mining in nakamoto-node.

1. The IssueBlock directive should use the tenure block _not_ the chain tip block for the directive. The interim-mining integration test has been updated to deal with this.
2. `calculate_matured_miner_rewards` should use the `coinbase_height`, not the block height. This was caught by running a long-running node with interim mining turned on, rather than an integration test. There's no integration test for this new behavior, but there probably should be. The issue surface from a panicking assertion because the 150th Stacks block had a coinbase height < 100, so the maturity lookup returned an empty list, triggering a panic. In testing mode, the maturity height is _2_, which means that it would be hard to surface this exact panic in a test.