### PR TITLE
Fix: RBF-mechanism should check bitcoin RPC

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -68,6 +68,7 @@ jobs:
           - tests::neon_integrations::test_problematic_microblocks_are_not_relayed_or_stored
           - tests::neon_integrations::test_problematic_txs_are_not_stored
           - tests::neon_integrations::use_latest_tip_integration_test
+          - tests::neon_integrations::confirm_unparsed_ongoing_ops
           - tests::should_succeed_handling_malformed_and_valid_txs
           - tests::nakamoto_integrations::simple_neon_integration
           - tests::nakamoto_integrations::mine_multiple_per_tenure_integration

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -68,7 +68,7 @@ use super::{
     make_microblock, make_stacks_transfer, make_stacks_transfer_mblock_only, to_addr, ADDR_4, SK_1,
     SK_2,
 };
-use crate::burnchains::bitcoin_regtest_controller::{BitcoinRPCRequest, UTXO};
+use crate::burnchains::bitcoin_regtest_controller::{self, BitcoinRPCRequest, UTXO};
 use crate::config::{EventKeyType, EventObserverConfig, FeeEstimatorName, InitialBalance};
 use crate::operations::BurnchainOpSigner;
 use crate::stacks_common::types::PrivateKey;
@@ -924,6 +924,103 @@ fn bitcoind_integration_test() {
         assert!(res.contains("stacks_node_last_mined_block_runtime 0"));
         assert!(res.contains("stacks_node_last_mined_block_transaction_count 1"));
     }
+    test_observer::clear();
+    channel.stop_chains_coordinator();
+}
+
+#[test]
+#[ignore]
+/// Test that the RBF/ongoing_ops mechanism can detect that a submitted
+/// tx has been confirmed even if the burnchaindb doesn't parse it.
+/// This test forces the neon_node to submit a block commit with bad
+///  magic bytes, and then checks if mining can continue afterwards.
+fn confirm_unparsed_ongoing_ops() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+    conf.node.wait_time_for_blocks = 1000;
+    conf.burnchain.pox_reward_length = Some(500);
+    conf.burnchain.max_rbf = 1000000;
+
+    test_observer::spawn();
+
+    conf.events_observers.insert(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf);
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // this block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second bitcoin block will contain the first mined Stacks block, and then issue a 2nd valid commit
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // now, let's alter the miner's magic bytes
+    bitcoin_regtest_controller::TEST_MAGIC_BYTES
+        .lock()
+        .unwrap()
+        .replace(['Z' as u8, 'Z' as u8]);
+
+    // let's trigger another mining loop: this should create an invalid block commit.
+    // this bitcoin block will contain the valid commit created before (so, a second stacks block)
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // reset the miner's magic bytes
+    bitcoin_regtest_controller::TEST_MAGIC_BYTES
+        .lock()
+        .unwrap()
+        .take()
+        .unwrap();
+
+    // trigger another mining loop: this will mine the invalid block commit into a bitcoin block
+    //  if the block wasn't created in 25 seconds, just timeout -- the test will fail
+    //  at the final checks
+    // in correct behavior, this will create a 3rd valid block commit
+    next_block_and_wait_with_timeout(&mut btc_regtest_controller, &blocks_processed, 25);
+
+    // trigger another mining loop: this will mine the last valid block commit. after this,
+    //  the node *should* see 3 stacks blocks.
+    next_block_and_wait_with_timeout(&mut btc_regtest_controller, &blocks_processed, 25);
+
+    // query the miner's account nonce
+
+    eprintln!("Miner account: {}", miner_account);
+
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.balance, 0);
+    assert_eq!(
+        account.nonce, 3,
+        "Miner should have mined 3 coinbases -- one should be invalid"
+    );
+
     test_observer::clear();
     channel.stop_chains_coordinator();
 }


### PR DESCRIPTION
### Description

The stacks miner's bitcoin operation handling tracks submitted transactions via the `ongoing_op` mechanism. When deciding whether or not to attempt an RBF, it checks if the `ongoing_op` has been confirmed. Currently, it does this via the burnchain_db, however, this will not work if the transaction is confirmed, but it was unparseable. In this case, the miner will continuously attempt to RBF an already confirmed transaction, leading to bitcoin mempool rejections.

### Relevant Scenario

This scenario surfaced during the nakamoto "controlled testnet" testing through a pretty convoluted series of events:

1. The neon_node (required for booting through epochs 2.0-2.5) is set to mine very quickly (i.e., very low `wait_on_blocks` time)
2. The regtest bitcoind network is set to mine a new block whenever it sees a bitcoin tx in the mempool.
3. Not infrequently, the stacks miner will assemble and attempt to submit a block during bitcoin block 1 (usually this is a "resubmission" of an identical block commit), but when actually submitted, bitcoin block 2 has already arrived. This requires some pretty specific interlacing of events to occur. The `bitcoin_regtest_controller` normally performs a check to see if the `ongoing_op` matches the about-to-submit op, but since bitcoin block 2 has now been mined, ongoing_op is confirmed, so the 'resubmission' is submitted.
4. When the above scenario happens at a _reward cycle boundary_, the block commit _fails to parse_: instead of having PoX outputs, its a prepare phase single-burn-output commit.
5. The ongoing_op never appears in the burnchaindb even though it has been confirmed, so the miner tries to RBF it, but it gets rejected.

Actually fixing the timing issue in step 3 above isn't possible: no matter how late the `stacks-node` checks for a new bitcoin block before submitting the block commit, it's always possible that the bitcoin block arrives right "before" the commit is submitted (or equivalently, the bitcoin block just doesn't include the commit). But fixing the tracking of `ongoing_op` is possible, and that's what this PR does.

### Additional info (benefits, drawbacks, caveats)

In theory, this could be opened against `develop` rather than `next`. I don't get a sense that this is a huge issue in practice, otherwise I'd expect there'd be a bug report already. In which case, this seems mostly relevant for the testing infrastructures for `next`, so I just want to simplify the workstream by opening this against `next` directly.