### PR TITLE
PoX-4 signer key read/write with base Rust tests

### DIFF
--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -56,7 +56,7 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
 
     for sortition_height in 0..11 {
         // stack to pox-3 in cycle 7
@@ -68,6 +68,7 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
                 1_000_000_000_000_000_000,
                 PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone()),
                 12,
+                vec![0; 33],
                 34,
             );
             vec![stack_tx]
@@ -97,7 +98,7 @@ pub fn boot_nakamoto(
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
 
     // reward cycles are 5 blocks long
     // first 25 blocks are boot-up
@@ -141,8 +142,8 @@ fn make_replay_peer<'a>(peer: &'a mut TestPeer<'a>) -> TestPeer<'a> {
             replay_tip.block_height,
             &tip.sortition_id,
         )
-        .unwrap()
-        .unwrap();
+            .unwrap()
+            .unwrap();
         ancestor_tip
     };
 
@@ -220,7 +221,7 @@ fn replay_reward_cycle(
             &mut node.chainstate,
             block.clone(),
         )
-        .unwrap();
+            .unwrap();
         if accepted {
             test_debug!("Accepted Nakamoto block {block_id}");
             peer.coord.handle_new_nakamoto_stacks_block().unwrap();
@@ -296,7 +297,7 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
 
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
@@ -418,7 +419,7 @@ fn test_nakamoto_chainstate_getters() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
         function_name!(),
@@ -542,16 +543,16 @@ fn test_nakamoto_chainstate_getters() {
                 &tip.index_block_hash(),
                 coinbase_height,
             )
-            .unwrap();
+                .unwrap();
             let header = header_opt.expect("No tenure");
 
             if coinbase_height
                 <= tip
-                    .anchored_header
-                    .as_stacks_nakamoto()
-                    .unwrap()
-                    .chain_length
-                    - 10
+                .anchored_header
+                .as_stacks_nakamoto()
+                .unwrap()
+                .chain_length
+                - 10
             {
                 // all tenures except the last are epoch2
                 assert!(header.anchored_header.as_stacks_epoch2().is_some());
@@ -585,53 +586,53 @@ fn test_nakamoto_chainstate_getters() {
             sort_tx.tx(),
             &highest_tenure.tenure_id_consensus_hash,
         )
-        .unwrap()
-        .unwrap();
+            .unwrap()
+            .unwrap();
 
         // this tenure's TC tx is the first-ever TC
         let tenure_change_payload = blocks[0].get_tenure_change_tx_payload().unwrap().clone();
 
         assert!(NakamotoChainState::check_first_nakamoto_tenure_change(
             chainstate.db(),
-            &tenure_change_payload
+            &tenure_change_payload,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
             sort_tx.sqlite(),
             &blocks[0].header.consensus_hash,
-            &blocks[1].header
+            &blocks[1].header,
         )
-        .unwrap());
+            .unwrap());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &tenure_change_payload.tenure_consensus_hash
+            &tenure_change_payload.tenure_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &tenure_change_payload.prev_tenure_consensus_hash
+            &tenure_change_payload.prev_tenure_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &tenure_change_payload.burn_view_consensus_hash
+            &tenure_change_payload.burn_view_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
 
         // this should fail, since it's not idempotent -- the highest tenure _is_ this tenure
         assert!(NakamotoChainState::check_nakamoto_tenure(
             chainstate.db(),
             &mut sort_tx,
             &blocks[0].header,
-            &tenure_change_payload
+            &tenure_change_payload,
         )
-        .unwrap()
-        .is_none());
+            .unwrap()
+            .is_none());
 
         let cur_burn_tip = SortitionDB::get_canonical_burn_chain_tip(sort_tx.sqlite()).unwrap();
         let (cur_stacks_ch, cur_stacks_bhh, cur_stacks_height) =
@@ -650,17 +651,17 @@ fn test_nakamoto_chainstate_getters() {
             chainstate.db(),
             &blocks[0].header.consensus_hash,
         )
-        .unwrap();
+            .unwrap();
 
         // check works (this would be the first tenure)
         assert!(NakamotoChainState::check_nakamoto_tenure(
             chainstate.db(),
             &mut sort_tx,
             &blocks[0].header,
-            &tenure_change_payload
+            &tenure_change_payload,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
 
         // restore
         sort_tx
@@ -678,7 +679,7 @@ fn test_nakamoto_chainstate_getters() {
             1,
             &tenure_change_payload,
         )
-        .unwrap();
+            .unwrap();
     }
 
     debug!("\n======================================\nBegin second tenure\n===========================================\n");
@@ -715,7 +716,7 @@ fn test_nakamoto_chainstate_getters() {
         &next_consensus_hash,
         &txid,
     )
-    .unwrap();
+        .unwrap();
     assert_eq!(parent_vrf_proof, vrf_proof);
 
     // make the second tenure's blocks
@@ -782,61 +783,61 @@ fn test_nakamoto_chainstate_getters() {
 
         assert!(NakamotoChainState::check_first_nakamoto_tenure_change(
             chainstate.db(),
-            &tenure_change_payload
+            &tenure_change_payload,
         )
-        .unwrap()
-        .is_none());
+            .unwrap()
+            .is_none());
         assert!(NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
             sort_tx.sqlite(),
             &new_blocks[0].header.consensus_hash,
-            &new_blocks[1].header
+            &new_blocks[1].header,
         )
-        .unwrap());
+            .unwrap());
         assert!(!NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
             sort_tx.sqlite(),
             &blocks[0].header.consensus_hash,
-            &new_blocks[1].header
+            &new_blocks[1].header,
         )
-        .unwrap());
+            .unwrap());
 
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &tenure_change_payload.tenure_consensus_hash
+            &tenure_change_payload.tenure_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &tenure_change_payload.prev_tenure_consensus_hash
+            &tenure_change_payload.prev_tenure_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &tenure_change_payload.burn_view_consensus_hash
+            &tenure_change_payload.burn_view_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &old_tenure_change_payload.tenure_consensus_hash
+            &old_tenure_change_payload.tenure_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &old_tenure_change_payload.prev_tenure_consensus_hash
+            &old_tenure_change_payload.prev_tenure_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
-            &old_tenure_change_payload.burn_view_consensus_hash
+            &old_tenure_change_payload.burn_view_consensus_hash,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
 
         let cur_burn_tip = SortitionDB::get_canonical_burn_chain_tip(sort_tx.sqlite()).unwrap();
         let (cur_stacks_ch, cur_stacks_bhh, cur_stacks_height) =
@@ -854,26 +855,26 @@ fn test_nakamoto_chainstate_getters() {
             chainstate.db(),
             &new_blocks[0].header.consensus_hash,
         )
-        .unwrap();
+            .unwrap();
 
         assert!(NakamotoChainState::check_nakamoto_tenure(
             chainstate.db(),
             &mut sort_tx,
             &new_blocks[0].header,
-            &tenure_change_payload
+            &tenure_change_payload,
         )
-        .unwrap()
-        .is_some());
+            .unwrap()
+            .is_some());
 
         // checks on older confired tenures continue to fail
         assert!(NakamotoChainState::check_nakamoto_tenure(
             chainstate.db(),
             &mut sort_tx,
             &blocks[0].header,
-            &old_tenure_change_payload
+            &old_tenure_change_payload,
         )
-        .unwrap()
-        .is_none());
+            .unwrap()
+            .is_none());
 
         // restore
         sort_tx
@@ -891,7 +892,7 @@ fn test_nakamoto_chainstate_getters() {
             2,
             &tenure_change_payload,
         )
-        .unwrap();
+            .unwrap();
     }
 }
 
@@ -906,7 +907,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
 
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
@@ -929,7 +930,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
 
     for i in 0..10 {
         let (burn_ops, mut tenure_change, miner_key) =
@@ -1112,7 +1113,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
                 &tip.index_block_hash(),
                 i,
             )
-            .unwrap();
+                .unwrap();
             matured_rewards.push(matured_reward_opt);
         }
     }
@@ -1132,7 +1133,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
                 matured_reward.parent_miner.tx_fees,
                 MinerPaymentTxFees::Epoch2 {
                     anchored: 0,
-                    streamed: 0
+                    streamed: 0,
                 }
             );
         } else if i == 11 {
@@ -1166,7 +1167,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
                 miner_reward.tx_fees,
                 MinerPaymentTxFees::Epoch2 {
                     anchored: 0,
-                    streamed: 0
+                    streamed: 0,
                 }
             );
         } else if i == 10 {
@@ -1227,7 +1228,7 @@ fn test_simple_nakamoto_coordinator_2_tenures_3_sortitions() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
         function_name!(),
@@ -1555,7 +1556,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_and_extensions_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-    .unwrap();
+        .unwrap();
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
         function_name!(),

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -56,7 +56,7 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
 
     for sortition_height in 0..11 {
         // stack to pox-3 in cycle 7
@@ -98,7 +98,7 @@ pub fn boot_nakamoto(
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
 
     // reward cycles are 5 blocks long
     // first 25 blocks are boot-up
@@ -142,8 +142,8 @@ fn make_replay_peer<'a>(peer: &'a mut TestPeer<'a>) -> TestPeer<'a> {
             replay_tip.block_height,
             &tip.sortition_id,
         )
-            .unwrap()
-            .unwrap();
+        .unwrap()
+        .unwrap();
         ancestor_tip
     };
 
@@ -221,7 +221,7 @@ fn replay_reward_cycle(
             &mut node.chainstate,
             block.clone(),
         )
-            .unwrap();
+        .unwrap();
         if accepted {
             test_debug!("Accepted Nakamoto block {block_id}");
             peer.coord.handle_new_nakamoto_stacks_block().unwrap();
@@ -297,7 +297,7 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
 
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
@@ -419,7 +419,7 @@ fn test_nakamoto_chainstate_getters() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
         function_name!(),
@@ -543,16 +543,16 @@ fn test_nakamoto_chainstate_getters() {
                 &tip.index_block_hash(),
                 coinbase_height,
             )
-                .unwrap();
+            .unwrap();
             let header = header_opt.expect("No tenure");
 
             if coinbase_height
                 <= tip
-                .anchored_header
-                .as_stacks_nakamoto()
-                .unwrap()
-                .chain_length
-                - 10
+                    .anchored_header
+                    .as_stacks_nakamoto()
+                    .unwrap()
+                    .chain_length
+                    - 10
             {
                 // all tenures except the last are epoch2
                 assert!(header.anchored_header.as_stacks_epoch2().is_some());
@@ -586,8 +586,8 @@ fn test_nakamoto_chainstate_getters() {
             sort_tx.tx(),
             &highest_tenure.tenure_id_consensus_hash,
         )
-            .unwrap()
-            .unwrap();
+        .unwrap()
+        .unwrap();
 
         // this tenure's TC tx is the first-ever TC
         let tenure_change_payload = blocks[0].get_tenure_change_tx_payload().unwrap().clone();
@@ -596,33 +596,33 @@ fn test_nakamoto_chainstate_getters() {
             chainstate.db(),
             &tenure_change_payload,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
             sort_tx.sqlite(),
             &blocks[0].header.consensus_hash,
             &blocks[1].header,
         )
-            .unwrap());
+        .unwrap());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &tenure_change_payload.tenure_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &tenure_change_payload.prev_tenure_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &tenure_change_payload.burn_view_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
 
         // this should fail, since it's not idempotent -- the highest tenure _is_ this tenure
         assert!(NakamotoChainState::check_nakamoto_tenure(
@@ -631,8 +631,8 @@ fn test_nakamoto_chainstate_getters() {
             &blocks[0].header,
             &tenure_change_payload,
         )
-            .unwrap()
-            .is_none());
+        .unwrap()
+        .is_none());
 
         let cur_burn_tip = SortitionDB::get_canonical_burn_chain_tip(sort_tx.sqlite()).unwrap();
         let (cur_stacks_ch, cur_stacks_bhh, cur_stacks_height) =
@@ -651,7 +651,7 @@ fn test_nakamoto_chainstate_getters() {
             chainstate.db(),
             &blocks[0].header.consensus_hash,
         )
-            .unwrap();
+        .unwrap();
 
         // check works (this would be the first tenure)
         assert!(NakamotoChainState::check_nakamoto_tenure(
@@ -660,8 +660,8 @@ fn test_nakamoto_chainstate_getters() {
             &blocks[0].header,
             &tenure_change_payload,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
 
         // restore
         sort_tx
@@ -679,7 +679,7 @@ fn test_nakamoto_chainstate_getters() {
             1,
             &tenure_change_payload,
         )
-            .unwrap();
+        .unwrap();
     }
 
     debug!("\n======================================\nBegin second tenure\n===========================================\n");
@@ -716,7 +716,7 @@ fn test_nakamoto_chainstate_getters() {
         &next_consensus_hash,
         &txid,
     )
-        .unwrap();
+    .unwrap();
     assert_eq!(parent_vrf_proof, vrf_proof);
 
     // make the second tenure's blocks
@@ -785,59 +785,59 @@ fn test_nakamoto_chainstate_getters() {
             chainstate.db(),
             &tenure_change_payload,
         )
-            .unwrap()
-            .is_none());
+        .unwrap()
+        .is_none());
         assert!(NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
             sort_tx.sqlite(),
             &new_blocks[0].header.consensus_hash,
             &new_blocks[1].header,
         )
-            .unwrap());
+        .unwrap());
         assert!(!NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
             sort_tx.sqlite(),
             &blocks[0].header.consensus_hash,
             &new_blocks[1].header,
         )
-            .unwrap());
+        .unwrap());
 
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &tenure_change_payload.tenure_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &tenure_change_payload.prev_tenure_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &tenure_change_payload.burn_view_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &old_tenure_change_payload.tenure_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &old_tenure_change_payload.prev_tenure_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
         assert!(NakamotoChainState::check_valid_consensus_hash(
             &mut sort_tx,
             &old_tenure_change_payload.burn_view_consensus_hash,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
 
         let cur_burn_tip = SortitionDB::get_canonical_burn_chain_tip(sort_tx.sqlite()).unwrap();
         let (cur_stacks_ch, cur_stacks_bhh, cur_stacks_height) =
@@ -855,7 +855,7 @@ fn test_nakamoto_chainstate_getters() {
             chainstate.db(),
             &new_blocks[0].header.consensus_hash,
         )
-            .unwrap();
+        .unwrap();
 
         assert!(NakamotoChainState::check_nakamoto_tenure(
             chainstate.db(),
@@ -863,8 +863,8 @@ fn test_nakamoto_chainstate_getters() {
             &new_blocks[0].header,
             &tenure_change_payload,
         )
-            .unwrap()
-            .is_some());
+        .unwrap()
+        .is_some());
 
         // checks on older confired tenures continue to fail
         assert!(NakamotoChainState::check_nakamoto_tenure(
@@ -873,8 +873,8 @@ fn test_nakamoto_chainstate_getters() {
             &blocks[0].header,
             &old_tenure_change_payload,
         )
-            .unwrap()
-            .is_none());
+        .unwrap()
+        .is_none());
 
         // restore
         sort_tx
@@ -892,7 +892,7 @@ fn test_nakamoto_chainstate_getters() {
             2,
             &tenure_change_payload,
         )
-            .unwrap();
+        .unwrap();
     }
 }
 
@@ -907,7 +907,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
 
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
@@ -930,7 +930,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
 
     for i in 0..10 {
         let (burn_ops, mut tenure_change, miner_key) =
@@ -1113,7 +1113,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
                 &tip.index_block_hash(),
                 i,
             )
-                .unwrap();
+            .unwrap();
             matured_rewards.push(matured_reward_opt);
         }
     }
@@ -1228,7 +1228,7 @@ fn test_simple_nakamoto_coordinator_2_tenures_3_sortitions() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
         function_name!(),
@@ -1556,7 +1556,7 @@ fn test_simple_nakamoto_coordinator_10_tenures_and_extensions_10_blocks() {
         1,
         &vec![StacksPublicKey::from_private(&private_key)],
     )
-        .unwrap();
+    .unwrap();
     let mut test_signers = TestSigners::default();
     let mut peer = boot_nakamoto(
         function_name!(),

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -68,7 +68,7 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
                 1_000_000_000_000_000_000,
                 PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone()),
                 12,
-                vec![0; 33],
+                Point::default(),
                 34,
             );
             vec![stack_tx]

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -50,6 +50,12 @@ use crate::net::test::{TestPeer, TestPeerConfig};
 fn advance_to_nakamoto(peer: &mut TestPeer) {
     let mut peer_nonce = 0;
     let private_key = peer.config.private_key.clone();
+    let signer_key = StacksPublicKey::from_slice(&[
+        0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
+        0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
+        0x59, 0x98, 0x3c,
+    ])
+    .unwrap();
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -68,7 +74,7 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
                 1_000_000_000_000_000_000,
                 PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone()),
                 12,
-                Point::default(),
+                signer_key,
                 34,
             );
             vec![stack_tx]

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1646,7 +1646,7 @@ pub mod test {
         amount: u128,
         addr: PoxAddress,
         lock_period: u128,
-        signer_key: Point,
+        signer_key: StacksPublicKey,
         burn_ht: u64,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
@@ -1659,7 +1659,7 @@ pub mod test {
                 addr_tuple,
                 Value::UInt(burn_ht as u128),
                 Value::UInt(lock_period),
-                Value::buff_from(signer_key.compress().data.into()).unwrap(),
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
             ],
         )
         .unwrap();
@@ -1772,7 +1772,7 @@ pub mod test {
         nonce: u64,
         addr: PoxAddress,
         lock_period: u128,
-        signer_key: Point,
+        signer_key: StacksPublicKey,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
@@ -1782,7 +1782,7 @@ pub mod test {
             vec![
                 Value::UInt(lock_period),
                 addr_tuple,
-                Value::buff_from(signer_key.compress().data.into()).unwrap(),
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
             ],
         )
         .unwrap();

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -246,12 +246,12 @@ impl StacksChainState {
                         &format!(r#"
                             (unwrap-panic (map-get? stacking-state {{ stacker: '{unlocked_principal} }}))
                             "#,
-                            unlocked_principal = Value::Principal(principal.clone())
+                                 unlocked_principal = Value::Principal(principal.clone())
                         ),
-                        ASTRules::PrecheckSize
+                        ASTRules::PrecheckSize,
                     )
                 })
-                .expect("FATAL: failed to query unlocked principal");
+            .expect("FATAL: failed to query unlocked principal");
 
         user_stacking_state.expect_tuple()
     }
@@ -499,7 +499,7 @@ impl StacksChainState {
             "pox",
             &format!("(get-stacking-minimum)"),
         )
-        .map(|value| value.expect_u128())
+            .map(|value| value.expect_u128())
     }
 
     pub fn get_total_ustx_stacked(
@@ -553,7 +553,7 @@ impl StacksChainState {
             "pox",
             &format!("(get-total-ustx-stacked u{})", reward_cycle),
         )
-        .map(|value| value.expect_u128())
+            .map(|value| value.expect_u128())
     }
 
     /// Is PoX active in the given reward cycle?
@@ -570,7 +570,7 @@ impl StacksChainState {
             pox_contract,
             &format!("(is-pox-active u{})", reward_cycle),
         )
-        .map(|value| value.expect_bool())
+            .map(|value| value.expect_bool())
     }
 
     /// Given a threshold and set of registered addresses, return a reward set where
@@ -592,10 +592,10 @@ impl StacksChainState {
             addresses.sort_by_cached_key(|k| k.reward_address.to_burnchain_repr());
         }
         while let Some(RawRewardSetEntry {
-            reward_address: address,
-            amount_stacked: mut stacked_amt,
-            stacker,
-        }) = addresses.pop()
+                           reward_address: address,
+                           amount_stacked: mut stacked_amt,
+                           stacker,
+                       }) = addresses.pop()
         {
             let mut contributed_stackers = vec![];
             if let Some(stacker) = stacker.as_ref() {
@@ -1116,8 +1116,8 @@ impl StacksChainState {
         // there hasn't yet been a Stacks block.
         match result {
             Err(Error::ClarityError(ClarityError::Interpreter(VmError::Unchecked(
-                CheckErrors::NoSuchContract(_),
-            )))) => {
+                                                                  CheckErrors::NoSuchContract(_),
+                                                              )))) => {
                 warn!("Reward cycle attempted to calculate rewards before the PoX contract was instantiated");
                 return Ok(vec![]);
             }
@@ -1269,9 +1269,9 @@ pub mod test {
             StacksChainState::get_reward_threshold_and_participation(
                 &test_pox_constants,
                 &[],
-                liquid
+                liquid,
             )
-            .0,
+                .0,
             POX_THRESHOLD_STEPS_USTX
         );
         assert_eq!(
@@ -1280,11 +1280,11 @@ pub mod test {
                 &[RawRewardSetEntry {
                     reward_address: rand_pox_addr(),
                     amount_stacked: liquid,
-                    stacker: None
+                    stacker: None,
                 }],
-                liquid
+                liquid,
             )
-            .0,
+                .0,
             POX_THRESHOLD_STEPS_USTX
         );
 
@@ -1294,9 +1294,9 @@ pub mod test {
             StacksChainState::get_reward_threshold_and_participation(
                 &test_pox_constants,
                 &[],
-                liquid
+                liquid,
             )
-            .0,
+                .0,
             50_000 * MICROSTACKS_PER_STACKS as u128
         );
         // should be the same at 25% participation
@@ -1306,11 +1306,11 @@ pub mod test {
                 &[RawRewardSetEntry {
                     reward_address: rand_pox_addr(),
                     amount_stacked: liquid / 4,
-                    stacker: None
+                    stacker: None,
                 }],
-                liquid
+                liquid,
             )
-            .0,
+                .0,
             50_000 * MICROSTACKS_PER_STACKS as u128
         );
         // but not at 30% participation
@@ -1321,17 +1321,17 @@ pub mod test {
                     RawRewardSetEntry {
                         reward_address: rand_pox_addr(),
                         amount_stacked: liquid / 4,
-                        stacker: None
+                        stacker: None,
                     },
                     RawRewardSetEntry {
                         reward_address: rand_pox_addr(),
                         amount_stacked: 10_000_000 * (MICROSTACKS_PER_STACKS as u128),
-                        stacker: None
+                        stacker: None,
                     },
                 ],
-                liquid
+                liquid,
             )
-            .0,
+                .0,
             60_000 * MICROSTACKS_PER_STACKS as u128
         );
 
@@ -1343,17 +1343,17 @@ pub mod test {
                     RawRewardSetEntry {
                         reward_address: rand_pox_addr(),
                         amount_stacked: liquid / 4,
-                        stacker: None
+                        stacker: None,
                     },
                     RawRewardSetEntry {
                         reward_address: rand_pox_addr(),
                         amount_stacked: MICROSTACKS_PER_STACKS as u128,
-                        stacker: None
+                        stacker: None,
                     },
                 ],
-                liquid
+                liquid,
             )
-            .0,
+                .0,
             60_000 * MICROSTACKS_PER_STACKS as u128
         );
 
@@ -1364,11 +1364,11 @@ pub mod test {
                 &[RawRewardSetEntry {
                     reward_address: rand_pox_addr(),
                     amount_stacked: liquid,
-                    stacker: None
+                    stacker: None,
                 }],
-                liquid
+                liquid,
             )
-            .0,
+                .0,
             200_000 * MICROSTACKS_PER_STACKS as u128
         );
     }
@@ -1384,7 +1384,7 @@ pub mod test {
             1,
             &vec![StacksPublicKey::from_private(key)],
         )
-        .unwrap()
+            .unwrap()
     }
 
     pub fn instantiate_pox_peer<'a>(
@@ -1417,19 +1417,19 @@ pub mod test {
             StacksPrivateKey::from_hex(
                 "7e3ee1f2a0ae11b785a1f0e725a9b3ab0a5fd6cc057d43763b0a85f256fdec5d01",
             )
-            .unwrap(),
+                .unwrap(),
             StacksPrivateKey::from_hex(
                 "11d055ac8b0ab4f04c5eb5ea4b4def9c60ae338355d81c9411b27b4f49da2a8301",
             )
-            .unwrap(),
+                .unwrap(),
             StacksPrivateKey::from_hex(
                 "00eed368626b96e482944e02cc136979973367491ea923efb57c482933dd7c0b01",
             )
-            .unwrap(),
+                .unwrap(),
             StacksPrivateKey::from_hex(
                 "00380ff3c05350ee313f60f30313acb4b5fc21e50db4151bf0de4cd565eb823101",
             )
-            .unwrap(),
+                .unwrap(),
         ];
 
         let addrs: Vec<StacksAddress> = keys.iter().map(|pk| key_to_stacks_addr(pk)).collect();
@@ -1541,8 +1541,8 @@ pub mod test {
     }
 
     pub fn with_sortdb<F, R>(peer: &mut TestPeer, todo: F) -> R
-    where
-        F: FnOnce(&mut StacksChainState, &SortitionDB) -> R,
+        where
+            F: FnOnce(&mut StacksChainState, &SortitionDB) -> R,
     {
         let sortdb = peer.sortdb.take().unwrap();
         let r = todo(peer.chainstate(), &sortdb);
@@ -1592,7 +1592,7 @@ pub mod test {
                     })),
                 ),
             ])
-            .unwrap(),
+                .unwrap(),
         )
     }
 
@@ -1640,20 +1640,15 @@ pub mod test {
         make_pox_2_or_3_lockup(key, nonce, amount, addr, lock_period, burn_ht, POX_3_NAME)
     }
 
-    /// TODO: add signer key
     pub fn make_pox_4_lockup(
         key: &StacksPrivateKey,
         nonce: u64,
         amount: u128,
         addr: PoxAddress,
         lock_period: u128,
+        signer_key: Vec<u8>,
         burn_ht: u64,
     ) -> StacksTransaction {
-        // ;; TODO: add signer key
-        // (define-public (stack-stx (amount-ustx uint)
-        //                           (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
-        //                           (burn-height uint)
-        //                           (lock-period uint))
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
@@ -1664,9 +1659,10 @@ pub mod test {
                 addr_tuple,
                 Value::UInt(burn_ht as u128),
                 Value::UInt(lock_period),
+                Value::buff_from(signer_key).unwrap(),
             ],
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1696,7 +1692,7 @@ pub mod test {
                 Value::UInt(lock_period),
             ],
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1715,7 +1711,7 @@ pub mod test {
             "set-aggregate-public-key",
             vec![Value::UInt(reward_cycle as u128), aggregate_public_key],
         )
-        .unwrap();
+            .unwrap();
         make_tx(key, nonce, 0, payload)
     }
 
@@ -1730,7 +1726,7 @@ pub mod test {
             "stack-increase",
             vec![Value::UInt(amount)],
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1748,7 +1744,7 @@ pub mod test {
             "stack-extend",
             vec![Value::UInt(lock_period), addr_tuple],
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1766,7 +1762,7 @@ pub mod test {
             "stack-extend",
             vec![Value::UInt(lock_period), addr_tuple],
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1776,15 +1772,16 @@ pub mod test {
         nonce: u64,
         addr: PoxAddress,
         lock_period: u128,
+        signer_key: Vec<u8>,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
             POX_4_NAME,
             "stack-extend",
-            vec![Value::UInt(lock_period), addr_tuple],
+            vec![Value::UInt(lock_period), addr_tuple, Value::buff_from(signer_key).unwrap()],
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1820,7 +1817,7 @@ pub mod test {
             function_name,
             args,
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1837,7 +1834,7 @@ pub mod test {
             function_name,
             args,
         )
-        .unwrap();
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1854,7 +1851,24 @@ pub mod test {
             function_name,
             args,
         )
-        .unwrap();
+            .unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
+    pub fn make_pox_4_contract_call(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        function_name: &str,
+        args: Vec<Value>,
+    ) -> StacksTransaction {
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            function_name,
+            args,
+        )
+            .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1880,7 +1894,7 @@ pub mod test {
                     })),
                 ),
             ])
-            .unwrap(),
+                .unwrap(),
         );
 
         let generator = |amount, pox_addr, lock_period, nonce| {
@@ -2006,7 +2020,7 @@ pub mod test {
                 Value::UInt(lock_period),
             ],
         )
-        .unwrap();
+            .unwrap();
         make_tx(key, nonce, 0, payload)
     }
 
@@ -2024,7 +2038,7 @@ pub mod test {
             "withdraw-stx",
             vec![Value::UInt(amount)],
         )
-        .unwrap();
+            .unwrap();
         make_tx(key, nonce, 0, payload)
     }
 
@@ -2080,15 +2094,15 @@ pub mod test {
                     &tip.sortition_id,
                     &block.block_hash(),
                 )
-                .unwrap()
-                .unwrap(); // succeeds because we don't fork
+                    .unwrap()
+                    .unwrap(); // succeeds because we don't fork
                 StacksChainState::get_anchored_block_header_info(
                     chainstate.db(),
                     &snapshot.consensus_hash,
                     &snapshot.winning_stacks_block_hash,
                 )
-                .unwrap()
-                .unwrap()
+                    .unwrap()
+                    .unwrap()
             }
         };
         parent_tip
@@ -2142,7 +2156,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2150,7 +2164,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2264,7 +2278,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2272,7 +2286,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2351,7 +2365,6 @@ pub mod test {
                     let tx = make_tx(&alice, 7, 0, cc_payload.clone()); // should be allowed!
                     block_txs.push(alice_allowance);
                     block_txs.push(tx);
-
                 }
 
                 let block_builder = StacksBlockBuilder::make_regtest_block_builder(&parent_tip, vrf_proof, tip.total_burn, microblock_pubkeyhash).unwrap();
@@ -2455,7 +2468,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2463,7 +2476,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2499,8 +2512,8 @@ pub mod test {
                 state.db(),
                 &parent_block_id,
             )
-            .unwrap()
-            .unwrap();
+                .unwrap()
+                .unwrap();
 
         parent_header_info.burn_header_height as u64
     }
@@ -2565,7 +2578,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2573,7 +2586,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2601,7 +2614,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -2613,7 +2626,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -2645,7 +2658,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -2654,7 +2667,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -2662,7 +2675,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                .unwrap();
+                    .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -2782,7 +2795,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2790,7 +2803,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2852,7 +2865,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -2864,7 +2877,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when tokens get stacked
@@ -2898,7 +2911,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -2907,7 +2920,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -2915,7 +2928,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                .unwrap();
+                    .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -3039,7 +3052,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -3047,7 +3060,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -3067,7 +3080,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -3079,7 +3092,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3110,7 +3123,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -3119,7 +3132,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -3127,7 +3140,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                .unwrap();
+                    .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -3162,7 +3175,7 @@ pub mod test {
                                 &mut peer,
                                 &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                             )
-                            .unwrap();
+                                .unwrap();
                         eprintln!("\nContract: {} uSTX stacked for {} cycle(s); addr is {:?}; first reward cycle is {}\n", amount_ustx, lock_period, &pox_addr, first_reward_cycle);
 
                         // should be consistent with the API call
@@ -3313,7 +3326,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -3321,7 +3334,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -3346,7 +3359,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -3358,7 +3371,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3396,7 +3409,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -3405,7 +3418,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
 
                 eprintln!(
                     "\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\n",
@@ -3595,7 +3608,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3728,7 +3741,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -3736,7 +3749,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -3757,7 +3770,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -3769,7 +3782,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3799,7 +3812,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -3808,7 +3821,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -3816,7 +3829,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                .unwrap();
+                    .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -4026,7 +4039,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -4034,7 +4047,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -4060,15 +4073,15 @@ pub mod test {
             let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
             })
-            .unwrap();
+                .unwrap();
             let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.get_stacking_minimum(sortdb, &tip_index_block)
             })
-            .unwrap();
+                .unwrap();
             let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(sortdb, &tip_index_block, cur_reward_cycle)
             })
-            .unwrap();
+                .unwrap();
 
             if tenure_id <= 1 {
                 if tenure_id < 1 {
@@ -4082,7 +4095,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -4118,7 +4131,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -4169,7 +4182,7 @@ pub mod test {
                             &mut peer,
                             &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                         )
-                        .unwrap();
+                            .unwrap();
                     eprintln!("\nCharlie: {} uSTX stacked for {} cycle(s); addr is {:?}; first reward cycle is {}\n", amount_ustx, lock_period, &pox_addr, first_reward_cycle);
 
                     assert_eq!(first_reward_cycle, first_pox_reward_cycle);
@@ -4245,9 +4258,9 @@ pub mod test {
                     );
                     assert!(get_stacker_info(
                         &mut peer,
-                        &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into()
+                        &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                     )
-                    .is_none());
+                        .is_none());
 
                     // empty reward cycle
                     assert_eq!(reward_addrs.len(), 0);
@@ -4296,7 +4309,7 @@ pub mod test {
                             &mut peer,
                             &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                         )
-                        .unwrap();
+                            .unwrap();
                     eprintln!("\nCharlie: {} uSTX stacked for {} cycle(s); addr is {:?}; second reward cycle is {}\n", amount_ustx, lock_period, &pox_addr, second_reward_cycle);
 
                     assert_eq!(first_pox_reward_cycle, second_reward_cycle);
@@ -4378,9 +4391,9 @@ pub mod test {
                     );
                     assert!(get_stacker_info(
                         &mut peer,
-                        &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into()
+                        &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                     )
-                    .is_none());
+                        .is_none());
 
                     // empty reward cycle
                     assert_eq!(reward_addrs.len(), 0);
@@ -4606,7 +4619,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                    .unwrap();
+                        .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -4614,7 +4627,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                        .unwrap();
+                            .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -4704,15 +4717,15 @@ pub mod test {
             let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.get_stacking_minimum(sortdb, &tip_index_block)
             })
-            .unwrap();
+                .unwrap();
             let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
             })
-            .unwrap();
+                .unwrap();
             let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(sortdb, &tip_index_block, cur_reward_cycle)
             })
-            .unwrap();
+                .unwrap();
 
             eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -4720,7 +4733,7 @@ pub mod test {
                 if tenure_id < 1 {
                     // no one has locked
                     for (balance, expected_balance) in
-                        balances.iter().zip(balances_before_stacking.iter())
+                    balances.iter().zip(balances_before_stacking.iter())
                     {
                         assert_eq!(balance, expected_balance);
                     }
@@ -4736,7 +4749,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                .unwrap();
+                    .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -4754,9 +4767,9 @@ pub mod test {
                 // alice did _NOT_ spend
                 assert!(get_contract(
                     &mut peer,
-                    &make_contract_id(&key_to_stacks_addr(&alice), "alice-try-spend").into()
+                    &make_contract_id(&key_to_stacks_addr(&alice), "alice-try-spend").into(),
                 )
-                .is_none());
+                    .is_none());
             }
 
             if reward_cycle > 0 {
@@ -4775,7 +4788,7 @@ pub mod test {
 
                     // in stacker order
                     for (i, (pox_addr, expected_stacked)) in
-                        sorted_expected_pox_info.iter().enumerate()
+                    sorted_expected_pox_info.iter().enumerate()
                     {
                         assert_eq!((reward_addrs[i].0).version(), pox_addr.0);
                         assert_eq!((reward_addrs[i].0).hash160(), pox_addr.1);
@@ -4794,14 +4807,14 @@ pub mod test {
 
                     // all tokens locked
                     for (balance, expected_balance) in
-                        balances.iter().zip(balances_during_stacking.iter())
+                    balances.iter().zip(balances_during_stacking.iter())
                     {
                         assert_eq!(balance, expected_balance);
                     }
 
                     // Lock-up is consistent with stacker state
                     for (addr, expected_balance) in
-                        stacker_addrs.iter().zip(balances_stacked.iter())
+                    stacker_addrs.iter().zip(balances_stacked.iter())
                     {
                         let account = get_account(&mut peer, addr);
                         assert_eq!(account.stx_balance.amount_unlocked(), 0);
@@ -4819,14 +4832,14 @@ pub mod test {
                     if tenure_id < 11 {
                         // all balances should have been restored
                         for (balance, expected_balance) in
-                            balances.iter().zip(balances_after_stacking.iter())
+                        balances.iter().zip(balances_after_stacking.iter())
                         {
                             assert_eq!(balance, expected_balance);
                         }
                     } else {
                         // some balances reduced, but none are zero
                         for (balance, expected_balance) in
-                            balances.iter().zip(balances_after_spending.iter())
+                        balances.iter().zip(balances_after_spending.iter())
                         {
                             assert_eq!(balance, expected_balance);
                         }
@@ -4848,7 +4861,7 @@ pub mod test {
             if tenure_id >= 11 {
                 // all balances are restored
                 for (addr, expected_balance) in
-                    stacker_addrs.iter().zip(balances_after_spending.iter())
+                stacker_addrs.iter().zip(balances_after_spending.iter())
                 {
                     let account = get_account(&mut peer, addr);
                     assert_eq!(account.stx_balance.amount_unlocked(), *expected_balance);
@@ -4943,12 +4956,12 @@ pub mod test {
                     // Charlie tries to stack, but it should fail.
                     // Specifically, (stack-stx) should fail with (err 17).
                     let charlie_stack = make_bare_contract(&charlie, 2, 0, "charlie-try-stack",
-                        &format!(
-                            "(define-data-var test-passed bool false)
+                                                           &format!(
+                                                               "(define-data-var test-passed bool false)
                              (var-set test-passed (is-eq
                                (err 17)
                                (print (contract-call? '{}.pox stack-stx u10240000000000 {{ version: 0x01, hashbytes: 0x1111111111111111111111111111111111111111 }} burn-block-height u1))))",
-                               boot_code_test_addr()));
+                                                               boot_code_test_addr()));
 
                     block_txs.push(charlie_stack);
 
@@ -4957,24 +4970,24 @@ pub mod test {
                     // stacked.
                     // If it's the case, then this tx will NOT be mined
                     let alice_reject = make_bare_contract(&alice, 1, 0, "alice-try-reject",
-                        &format!(
-                            "(define-data-var test-passed bool false)
+                                                          &format!(
+                                                              "(define-data-var test-passed bool false)
                              (var-set test-passed (is-eq
                                (err 3)
                                (print (contract-call? '{}.pox reject-pox))))",
-                               boot_code_test_addr()));
+                                                              boot_code_test_addr()));
 
                     block_txs.push(alice_reject);
 
                     // Charlie tries to reject again, but it should fail.
                     // Specifically, (reject-pox) should fail with (err 17).
                     let charlie_reject = make_bare_contract(&charlie, 3, 0, "charlie-try-reject",
-                        &format!(
-                            "(define-data-var test-passed bool false)
+                                                            &format!(
+                                                                "(define-data-var test-passed bool false)
                              (var-set test-passed (is-eq
                                (err 17)
                                (print (contract-call? '{}.pox reject-pox))))",
-                               boot_code_test_addr()));
+                                                                boot_code_test_addr()));
 
                     block_txs.push(charlie_reject);
                 }
@@ -5006,15 +5019,15 @@ pub mod test {
             let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.get_stacking_minimum(sortdb, &tip_index_block)
             })
-            .unwrap();
+                .unwrap();
             let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
             })
-            .unwrap();
+                .unwrap();
             let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(sortdb, &tip_index_block, cur_reward_cycle)
             })
-            .unwrap();
+                .unwrap();
             let total_stacked_next = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(
                     sortdb,
@@ -5022,9 +5035,9 @@ pub mod test {
                     cur_reward_cycle + 1,
                 )
             })
-            .unwrap();
+                .unwrap();
 
-            eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\ntotal-stacked next: {}\n", 
+            eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\ntotal-stacked next: {}\n",
                       tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked, total_stacked_next);
 
             if tenure_id <= 1 {
@@ -5067,7 +5080,7 @@ pub mod test {
                         "charlie-try-stack",
                         "(var-get test-passed)",
                     )
-                    .expect_bool();
+                        .expect_bool();
                     assert!(result, "charlie-try-stack test should be `true`");
                     let result = eval_contract_at_tip(
                         &mut peer,
@@ -5075,7 +5088,7 @@ pub mod test {
                         "charlie-try-reject",
                         "(var-get test-passed)",
                     )
-                    .expect_bool();
+                        .expect_bool();
                     assert!(result, "charlie-try-reject test should be `true`");
                     let result = eval_contract_at_tip(
                         &mut peer,
@@ -5083,7 +5096,7 @@ pub mod test {
                         "alice-try-reject",
                         "(var-get test-passed)",
                     )
-                    .expect_bool();
+                        .expect_bool();
                     assert!(result, "alice-try-reject test should be `true`");
                 }
 

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -499,7 +499,7 @@ impl StacksChainState {
             "pox",
             &format!("(get-stacking-minimum)"),
         )
-            .map(|value| value.expect_u128())
+        .map(|value| value.expect_u128())
     }
 
     pub fn get_total_ustx_stacked(
@@ -553,7 +553,7 @@ impl StacksChainState {
             "pox",
             &format!("(get-total-ustx-stacked u{})", reward_cycle),
         )
-            .map(|value| value.expect_u128())
+        .map(|value| value.expect_u128())
     }
 
     /// Is PoX active in the given reward cycle?
@@ -570,7 +570,7 @@ impl StacksChainState {
             pox_contract,
             &format!("(is-pox-active u{})", reward_cycle),
         )
-            .map(|value| value.expect_bool())
+        .map(|value| value.expect_bool())
     }
 
     /// Given a threshold and set of registered addresses, return a reward set where
@@ -592,10 +592,10 @@ impl StacksChainState {
             addresses.sort_by_cached_key(|k| k.reward_address.to_burnchain_repr());
         }
         while let Some(RawRewardSetEntry {
-                           reward_address: address,
-                           amount_stacked: mut stacked_amt,
-                           stacker,
-                       }) = addresses.pop()
+            reward_address: address,
+            amount_stacked: mut stacked_amt,
+            stacker,
+        }) = addresses.pop()
         {
             let mut contributed_stackers = vec![];
             if let Some(stacker) = stacker.as_ref() {
@@ -1116,8 +1116,8 @@ impl StacksChainState {
         // there hasn't yet been a Stacks block.
         match result {
             Err(Error::ClarityError(ClarityError::Interpreter(VmError::Unchecked(
-                                                                  CheckErrors::NoSuchContract(_),
-                                                              )))) => {
+                CheckErrors::NoSuchContract(_),
+            )))) => {
                 warn!("Reward cycle attempted to calculate rewards before the PoX contract was instantiated");
                 return Ok(vec![]);
             }
@@ -1271,7 +1271,7 @@ pub mod test {
                 &[],
                 liquid,
             )
-                .0,
+            .0,
             POX_THRESHOLD_STEPS_USTX
         );
         assert_eq!(
@@ -1284,7 +1284,7 @@ pub mod test {
                 }],
                 liquid,
             )
-                .0,
+            .0,
             POX_THRESHOLD_STEPS_USTX
         );
 
@@ -1296,7 +1296,7 @@ pub mod test {
                 &[],
                 liquid,
             )
-                .0,
+            .0,
             50_000 * MICROSTACKS_PER_STACKS as u128
         );
         // should be the same at 25% participation
@@ -1310,7 +1310,7 @@ pub mod test {
                 }],
                 liquid,
             )
-                .0,
+            .0,
             50_000 * MICROSTACKS_PER_STACKS as u128
         );
         // but not at 30% participation
@@ -1331,7 +1331,7 @@ pub mod test {
                 ],
                 liquid,
             )
-                .0,
+            .0,
             60_000 * MICROSTACKS_PER_STACKS as u128
         );
 
@@ -1353,7 +1353,7 @@ pub mod test {
                 ],
                 liquid,
             )
-                .0,
+            .0,
             60_000 * MICROSTACKS_PER_STACKS as u128
         );
 
@@ -1368,7 +1368,7 @@ pub mod test {
                 }],
                 liquid,
             )
-                .0,
+            .0,
             200_000 * MICROSTACKS_PER_STACKS as u128
         );
     }
@@ -1384,7 +1384,7 @@ pub mod test {
             1,
             &vec![StacksPublicKey::from_private(key)],
         )
-            .unwrap()
+        .unwrap()
     }
 
     pub fn instantiate_pox_peer<'a>(
@@ -1417,19 +1417,19 @@ pub mod test {
             StacksPrivateKey::from_hex(
                 "7e3ee1f2a0ae11b785a1f0e725a9b3ab0a5fd6cc057d43763b0a85f256fdec5d01",
             )
-                .unwrap(),
+            .unwrap(),
             StacksPrivateKey::from_hex(
                 "11d055ac8b0ab4f04c5eb5ea4b4def9c60ae338355d81c9411b27b4f49da2a8301",
             )
-                .unwrap(),
+            .unwrap(),
             StacksPrivateKey::from_hex(
                 "00eed368626b96e482944e02cc136979973367491ea923efb57c482933dd7c0b01",
             )
-                .unwrap(),
+            .unwrap(),
             StacksPrivateKey::from_hex(
                 "00380ff3c05350ee313f60f30313acb4b5fc21e50db4151bf0de4cd565eb823101",
             )
-                .unwrap(),
+            .unwrap(),
         ];
 
         let addrs: Vec<StacksAddress> = keys.iter().map(|pk| key_to_stacks_addr(pk)).collect();
@@ -1541,8 +1541,8 @@ pub mod test {
     }
 
     pub fn with_sortdb<F, R>(peer: &mut TestPeer, todo: F) -> R
-        where
-            F: FnOnce(&mut StacksChainState, &SortitionDB) -> R,
+    where
+        F: FnOnce(&mut StacksChainState, &SortitionDB) -> R,
     {
         let sortdb = peer.sortdb.take().unwrap();
         let r = todo(peer.chainstate(), &sortdb);
@@ -1592,7 +1592,7 @@ pub mod test {
                     })),
                 ),
             ])
-                .unwrap(),
+            .unwrap(),
         )
     }
 
@@ -1662,7 +1662,7 @@ pub mod test {
                 Value::buff_from(signer_key).unwrap(),
             ],
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1692,7 +1692,7 @@ pub mod test {
                 Value::UInt(lock_period),
             ],
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1711,7 +1711,7 @@ pub mod test {
             "set-aggregate-public-key",
             vec![Value::UInt(reward_cycle as u128), aggregate_public_key],
         )
-            .unwrap();
+        .unwrap();
         make_tx(key, nonce, 0, payload)
     }
 
@@ -1726,7 +1726,7 @@ pub mod test {
             "stack-increase",
             vec![Value::UInt(amount)],
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1744,7 +1744,7 @@ pub mod test {
             "stack-extend",
             vec![Value::UInt(lock_period), addr_tuple],
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1762,7 +1762,7 @@ pub mod test {
             "stack-extend",
             vec![Value::UInt(lock_period), addr_tuple],
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1779,9 +1779,13 @@ pub mod test {
             boot_code_test_addr(),
             POX_4_NAME,
             "stack-extend",
-            vec![Value::UInt(lock_period), addr_tuple, Value::buff_from(signer_key).unwrap()],
+            vec![
+                Value::UInt(lock_period),
+                addr_tuple,
+                Value::buff_from(signer_key).unwrap(),
+            ],
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1817,7 +1821,7 @@ pub mod test {
             function_name,
             args,
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1834,7 +1838,7 @@ pub mod test {
             function_name,
             args,
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1851,7 +1855,7 @@ pub mod test {
             function_name,
             args,
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1868,7 +1872,7 @@ pub mod test {
             function_name,
             args,
         )
-            .unwrap();
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1894,7 +1898,7 @@ pub mod test {
                     })),
                 ),
             ])
-                .unwrap(),
+            .unwrap(),
         );
 
         let generator = |amount, pox_addr, lock_period, nonce| {
@@ -2020,7 +2024,7 @@ pub mod test {
                 Value::UInt(lock_period),
             ],
         )
-            .unwrap();
+        .unwrap();
         make_tx(key, nonce, 0, payload)
     }
 
@@ -2038,7 +2042,7 @@ pub mod test {
             "withdraw-stx",
             vec![Value::UInt(amount)],
         )
-            .unwrap();
+        .unwrap();
         make_tx(key, nonce, 0, payload)
     }
 
@@ -2094,15 +2098,15 @@ pub mod test {
                     &tip.sortition_id,
                     &block.block_hash(),
                 )
-                    .unwrap()
-                    .unwrap(); // succeeds because we don't fork
+                .unwrap()
+                .unwrap(); // succeeds because we don't fork
                 StacksChainState::get_anchored_block_header_info(
                     chainstate.db(),
                     &snapshot.consensus_hash,
                     &snapshot.winning_stacks_block_hash,
                 )
-                    .unwrap()
-                    .unwrap()
+                .unwrap()
+                .unwrap()
             }
         };
         parent_tip
@@ -2156,7 +2160,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2164,7 +2168,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2278,7 +2282,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2286,7 +2290,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2468,7 +2472,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2476,7 +2480,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2512,8 +2516,8 @@ pub mod test {
                 state.db(),
                 &parent_block_id,
             )
-                .unwrap()
-                .unwrap();
+            .unwrap()
+            .unwrap();
 
         parent_header_info.burn_header_height as u64
     }
@@ -2578,7 +2582,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2586,7 +2590,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2614,7 +2618,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -2626,7 +2630,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -2658,7 +2662,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -2667,7 +2671,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -2675,7 +2679,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                    .unwrap();
+                .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -2795,7 +2799,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -2803,7 +2807,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -2865,7 +2869,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -2877,7 +2881,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when tokens get stacked
@@ -2911,7 +2915,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -2920,7 +2924,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -2928,7 +2932,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                    .unwrap();
+                .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -3052,7 +3056,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -3060,7 +3064,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -3080,7 +3084,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -3092,7 +3096,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3123,7 +3127,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -3132,7 +3136,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -3140,7 +3144,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                    .unwrap();
+                .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -3175,7 +3179,7 @@ pub mod test {
                                 &mut peer,
                                 &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                             )
-                                .unwrap();
+                            .unwrap();
                         eprintln!("\nContract: {} uSTX stacked for {} cycle(s); addr is {:?}; first reward cycle is {}\n", amount_ustx, lock_period, &pox_addr, first_reward_cycle);
 
                         // should be consistent with the API call
@@ -3326,7 +3330,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -3334,7 +3338,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -3359,7 +3363,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -3371,7 +3375,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3409,7 +3413,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -3418,7 +3422,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
 
                 eprintln!(
                     "\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\n",
@@ -3608,7 +3612,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3741,7 +3745,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -3749,7 +3753,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -3770,7 +3774,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -3782,7 +3786,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -3812,7 +3816,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     get_reward_addresses_with_par_tip(
                         chainstate,
@@ -3821,7 +3825,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.test_get_total_ustx_stacked(
                         sortdb,
@@ -3829,7 +3833,7 @@ pub mod test {
                         cur_reward_cycle,
                     )
                 })
-                    .unwrap();
+                .unwrap();
 
                 eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -4039,7 +4043,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -4047,7 +4051,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -4073,15 +4077,15 @@ pub mod test {
             let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
             })
-                .unwrap();
+            .unwrap();
             let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.get_stacking_minimum(sortdb, &tip_index_block)
             })
-                .unwrap();
+            .unwrap();
             let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(sortdb, &tip_index_block, cur_reward_cycle)
             })
-                .unwrap();
+            .unwrap();
 
             if tenure_id <= 1 {
                 if tenure_id < 1 {
@@ -4095,7 +4099,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -4131,7 +4135,7 @@ pub mod test {
                 let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                     chainstate.get_stacking_minimum(sortdb, &tip_index_block)
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(min_ustx, total_liquid_ustx / TESTNET_STACKING_THRESHOLD_25);
 
                 // no reward addresses
@@ -4182,7 +4186,7 @@ pub mod test {
                             &mut peer,
                             &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                         )
-                            .unwrap();
+                        .unwrap();
                     eprintln!("\nCharlie: {} uSTX stacked for {} cycle(s); addr is {:?}; first reward cycle is {}\n", amount_ustx, lock_period, &pox_addr, first_reward_cycle);
 
                     assert_eq!(first_reward_cycle, first_pox_reward_cycle);
@@ -4260,7 +4264,7 @@ pub mod test {
                         &mut peer,
                         &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                     )
-                        .is_none());
+                    .is_none());
 
                     // empty reward cycle
                     assert_eq!(reward_addrs.len(), 0);
@@ -4309,7 +4313,7 @@ pub mod test {
                             &mut peer,
                             &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                         )
-                            .unwrap();
+                        .unwrap();
                     eprintln!("\nCharlie: {} uSTX stacked for {} cycle(s); addr is {:?}; second reward cycle is {}\n", amount_ustx, lock_period, &pox_addr, second_reward_cycle);
 
                     assert_eq!(first_pox_reward_cycle, second_reward_cycle);
@@ -4393,7 +4397,7 @@ pub mod test {
                         &mut peer,
                         &make_contract_id(&key_to_stacks_addr(&bob), "do-lockup").into(),
                     )
-                        .is_none());
+                    .is_none());
 
                     // empty reward cycle
                     assert_eq!(reward_addrs.len(), 0);
@@ -4619,7 +4623,7 @@ pub mod test {
                         tip.total_burn,
                         microblock_pubkeyhash,
                     )
-                        .unwrap();
+                    .unwrap();
                     let (anchored_block, _size, _cost) =
                         StacksBlockBuilder::make_anchored_block_from_txs(
                             block_builder,
@@ -4627,7 +4631,7 @@ pub mod test {
                             &sortdb.index_conn(),
                             block_txs,
                         )
-                            .unwrap();
+                        .unwrap();
                     (anchored_block, vec![])
                 },
             );
@@ -4717,15 +4721,15 @@ pub mod test {
             let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.get_stacking_minimum(sortdb, &tip_index_block)
             })
-                .unwrap();
+            .unwrap();
             let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
             })
-                .unwrap();
+            .unwrap();
             let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(sortdb, &tip_index_block, cur_reward_cycle)
             })
-                .unwrap();
+            .unwrap();
 
             eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\n", tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked);
 
@@ -4733,7 +4737,7 @@ pub mod test {
                 if tenure_id < 1 {
                     // no one has locked
                     for (balance, expected_balance) in
-                    balances.iter().zip(balances_before_stacking.iter())
+                        balances.iter().zip(balances_before_stacking.iter())
                     {
                         assert_eq!(balance, expected_balance);
                     }
@@ -4749,7 +4753,7 @@ pub mod test {
                         &tip_index_block,
                     )
                 })
-                    .unwrap();
+                .unwrap();
                 assert_eq!(reward_addrs.len(), 0);
 
                 // record the first reward cycle when Alice's tokens get stacked
@@ -4769,7 +4773,7 @@ pub mod test {
                     &mut peer,
                     &make_contract_id(&key_to_stacks_addr(&alice), "alice-try-spend").into(),
                 )
-                    .is_none());
+                .is_none());
             }
 
             if reward_cycle > 0 {
@@ -4788,7 +4792,7 @@ pub mod test {
 
                     // in stacker order
                     for (i, (pox_addr, expected_stacked)) in
-                    sorted_expected_pox_info.iter().enumerate()
+                        sorted_expected_pox_info.iter().enumerate()
                     {
                         assert_eq!((reward_addrs[i].0).version(), pox_addr.0);
                         assert_eq!((reward_addrs[i].0).hash160(), pox_addr.1);
@@ -4807,14 +4811,14 @@ pub mod test {
 
                     // all tokens locked
                     for (balance, expected_balance) in
-                    balances.iter().zip(balances_during_stacking.iter())
+                        balances.iter().zip(balances_during_stacking.iter())
                     {
                         assert_eq!(balance, expected_balance);
                     }
 
                     // Lock-up is consistent with stacker state
                     for (addr, expected_balance) in
-                    stacker_addrs.iter().zip(balances_stacked.iter())
+                        stacker_addrs.iter().zip(balances_stacked.iter())
                     {
                         let account = get_account(&mut peer, addr);
                         assert_eq!(account.stx_balance.amount_unlocked(), 0);
@@ -4832,14 +4836,14 @@ pub mod test {
                     if tenure_id < 11 {
                         // all balances should have been restored
                         for (balance, expected_balance) in
-                        balances.iter().zip(balances_after_stacking.iter())
+                            balances.iter().zip(balances_after_stacking.iter())
                         {
                             assert_eq!(balance, expected_balance);
                         }
                     } else {
                         // some balances reduced, but none are zero
                         for (balance, expected_balance) in
-                        balances.iter().zip(balances_after_spending.iter())
+                            balances.iter().zip(balances_after_spending.iter())
                         {
                             assert_eq!(balance, expected_balance);
                         }
@@ -4861,7 +4865,7 @@ pub mod test {
             if tenure_id >= 11 {
                 // all balances are restored
                 for (addr, expected_balance) in
-                stacker_addrs.iter().zip(balances_after_spending.iter())
+                    stacker_addrs.iter().zip(balances_after_spending.iter())
                 {
                     let account = get_account(&mut peer, addr);
                     assert_eq!(account.stx_balance.amount_unlocked(), *expected_balance);
@@ -5019,15 +5023,15 @@ pub mod test {
             let min_ustx = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.get_stacking_minimum(sortdb, &tip_index_block)
             })
-                .unwrap();
+            .unwrap();
             let reward_addrs = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
             })
-                .unwrap();
+            .unwrap();
             let total_stacked = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(sortdb, &tip_index_block, cur_reward_cycle)
             })
-                .unwrap();
+            .unwrap();
             let total_stacked_next = with_sortdb(&mut peer, |ref mut chainstate, ref sortdb| {
                 chainstate.test_get_total_ustx_stacked(
                     sortdb,
@@ -5035,7 +5039,7 @@ pub mod test {
                     cur_reward_cycle + 1,
                 )
             })
-                .unwrap();
+            .unwrap();
 
             eprintln!("\ntenure: {}\nreward cycle: {}\nmin-uSTX: {}\naddrs: {:?}\ntotal_liquid_ustx: {}\ntotal-stacked: {}\ntotal-stacked next: {}\n",
                       tenure_id, cur_reward_cycle, min_ustx, &reward_addrs, total_liquid_ustx, total_stacked, total_stacked_next);
@@ -5080,7 +5084,7 @@ pub mod test {
                         "charlie-try-stack",
                         "(var-get test-passed)",
                     )
-                        .expect_bool();
+                    .expect_bool();
                     assert!(result, "charlie-try-stack test should be `true`");
                     let result = eval_contract_at_tip(
                         &mut peer,
@@ -5088,7 +5092,7 @@ pub mod test {
                         "charlie-try-reject",
                         "(var-get test-passed)",
                     )
-                        .expect_bool();
+                    .expect_bool();
                     assert!(result, "charlie-try-reject test should be `true`");
                     let result = eval_contract_at_tip(
                         &mut peer,
@@ -5096,7 +5100,7 @@ pub mod test {
                         "alice-try-reject",
                         "(var-get test-passed)",
                     )
-                        .expect_bool();
+                    .expect_bool();
                     assert!(result, "alice-try-reject test should be `true`");
                 }
 

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1646,7 +1646,7 @@ pub mod test {
         amount: u128,
         addr: PoxAddress,
         lock_period: u128,
-        signer_key: Vec<u8>,
+        signer_key: Point,
         burn_ht: u64,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
@@ -1659,7 +1659,7 @@ pub mod test {
                 addr_tuple,
                 Value::UInt(burn_ht as u128),
                 Value::UInt(lock_period),
-                Value::buff_from(signer_key).unwrap(),
+                Value::buff_from(signer_key.compress().data.into()).unwrap(),
             ],
         )
         .unwrap();
@@ -1772,7 +1772,7 @@ pub mod test {
         nonce: u64,
         addr: PoxAddress,
         lock_period: u128,
-        signer_key: Vec<u8>,
+        signer_key: Point,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
@@ -1782,7 +1782,7 @@ pub mod test {
             vec![
                 Value::UInt(lock_period),
                 addr_tuple,
-                Value::buff_from(signer_key).unwrap(),
+                Value::buff_from(signer_key.compress().data.into()).unwrap(),
             ],
         )
         .unwrap();

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -27,6 +27,8 @@
 (define-constant ERR_DELEGATION_WRONG_REWARD_SLOT 29)
 (define-constant ERR_STACKING_IS_DELEGATED 30)
 (define-constant ERR_STACKING_NOT_DELEGATED 31)
+(define-constant ERR_INVALID_SIGNER_KEY 32)
+(define-constant ERR_REQUESTED_SIGNER_KEY_MISMATCH 33)
 
 ;; Valid values for burnchain address versions.
 ;; These first four correspond to address hash modes in Stacks 2.1,
@@ -111,7 +113,8 @@
         ;;  previous stack-stx calls, or prior to an extend)
         reward-set-indexes: (list 12 uint),
         ;; principal of the delegate, if stacker has delegated
-        delegated-to: (optional principal)
+        delegated-to: (optional principal),
+        signer-key: (buff 33)
     }
 )
 
@@ -124,7 +127,8 @@
         until-burn-ht: (optional uint), ;; how long does the delegation last?
         ;; does the delegate _need_ to use a specific
         ;; pox recipient address?
-        pox-addr: (optional { version: (buff 1), hashbytes: (buff 32) })
+        pox-addr: (optional { version: (buff 1), hashbytes: (buff 32) }),
+        signer-key: (optional (buff 33))
     }
 )
 
@@ -538,6 +542,7 @@
 ;; at the time this method is called.
 ;; * You may need to increase the amount of uSTX locked up later, since the minimum uSTX threshold
 ;; may increase between reward cycles.
+;; * You need to provide a signer key to be used in the signer DKG process.
 ;; * The Stacker will receive rewards in the reward cycle following `start-burn-ht`.
 ;; Importantly, `start-burn-ht` may not be further into the future than the next reward cycle,
 ;; and in most cases should be set to the current burn block height.
@@ -546,7 +551,8 @@
 (define-public (stack-stx (amount-ustx uint)
                           (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
                           (start-burn-ht uint)
-                          (lock-period uint))
+                          (lock-period uint)
+                          (signer-key (buff 33)))
     ;; this stacker's first reward cycle is the _next_ reward cycle
     (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle)))
           (specified-reward-cycle (+ u1 (burn-height-to-reward-cycle start-burn-ht))))
@@ -574,6 +580,9 @@
       ;; ensure that stacking can be performed
       (try! (can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))
 
+      ;; ensure the signer key is valid
+      (try! (is-signer-key-valid signer-key))
+
       ;; register the PoX address with the amount stacked
       (let ((reward-set-indexes (try! (add-pox-addr-to-reward-cycles pox-addr first-reward-cycle lock-period amount-ustx tx-sender))))
           ;; add stacker record
@@ -583,10 +592,11 @@
              reward-set-indexes: reward-set-indexes,
              first-reward-cycle: first-reward-cycle,
              lock-period: lock-period,
-             delegated-to: none })
+             delegated-to: none,
+             signer-key: signer-key })
 
           ;; return the lock-up information, so the node can actually carry out the lock.
-          (ok { stacker: tx-sender, lock-amount: amount-ustx, unlock-burn-height: (reward-cycle-to-burn-height (+ first-reward-cycle lock-period)) }))))
+          (ok { stacker: tx-sender, lock-amount: amount-ustx, signer-key: signer-key, unlock-burn-height: (reward-cycle-to-burn-height (+ first-reward-cycle lock-period)) }))))
 
 (define-public (revoke-delegate-stx)
   (begin
@@ -602,11 +612,12 @@
 ;;   * amount-ustx: the total amount of ustx the delegate may be allowed to lock
 ;;   * until-burn-ht: an optional burn height at which this delegation expires
 ;;   * pox-addr: an optional address to which any rewards *must* be sent
+;;   * signer-key: an optional signer key, that when set the delegate must use.
 (define-public (delegate-stx (amount-ustx uint)
                              (delegate-to principal)
                              (until-burn-ht (optional uint))
-                             (pox-addr (optional { version: (buff 1),
-                                                   hashbytes: (buff 32) })))
+                             (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) }))
+                             (signer-key (optional (buff 33))))
     (begin
       ;; must be called directly by the tx-sender or by an allowed contract-caller
       (asserts! (check-caller-allowed)
@@ -631,13 +642,17 @@
       (asserts! (is-none (get-check-delegation tx-sender))
         (err ERR_STACKING_ALREADY_DELEGATED))
 
+      ;; ensure the signer key is valid, if it is set
+      (match signer-key key (try! (is-signer-key-valid key)) true)
+
       ;; add delegation record
       (map-set delegation-state
         { stacker: tx-sender }
         { amount-ustx: amount-ustx,
           delegated-to: delegate-to,
           until-burn-ht: until-burn-ht,
-          pox-addr: pox-addr })
+          pox-addr: pox-addr,
+          signer-key: signer-key })
 
       (ok true)))
 
@@ -784,7 +799,8 @@
                                    (amount-ustx uint)
                                    (pox-addr { version: (buff 1), hashbytes: (buff 32) })
                                    (start-burn-ht uint)
-                                   (lock-period uint))
+                                   (lock-period uint)
+                                   (signer-key (buff 33)))
     ;; this stacker's first reward cycle is the _next_ reward cycle
     (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle)))
           (specified-reward-cycle (+ u1 (burn-height-to-reward-cycle start-burn-ht)))
@@ -816,7 +832,12 @@
                          until-burn-ht (>= until-burn-ht
                                            unlock-burn-height)
                       true)
-                  (err ERR_DELEGATION_EXPIRES_DURING_LOCK)))
+                  (err ERR_DELEGATION_EXPIRES_DURING_LOCK))
+        ;; if the delegatee set a signer-key, it must be equal to the delegate signer-key
+        (asserts!
+            (or (is-none (get signer-key delegation-info)) (is-eq (get signer-key delegation-info) (some signer-key)))
+            (err ERR_REQUESTED_SIGNER_KEY_MISMATCH)
+        ))
 
       ;; stacker principal must not be stacking
       (asserts! (is-none (get-stacker-info stacker))
@@ -825,6 +846,9 @@
       ;; the Stacker must have sufficient unlocked funds
       (asserts! (>= (stx-get-balance stacker) amount-ustx)
         (err ERR_STACKING_INSUFFICIENT_FUNDS))
+
+      ;; ensure the signer key is valid
+      (try! (is-signer-key-valid signer-key))
 
       ;; ensure that stacking can be performed
       (try! (minimal-can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))
@@ -840,7 +864,8 @@
           first-reward-cycle: first-reward-cycle,
           reward-set-indexes: (list),
           lock-period: lock-period,
-          delegated-to: (some tx-sender) })
+          delegated-to: (some tx-sender),
+          signer-key: signer-key })
 
       ;; return the lock-up information, so the node can actually carry out the lock.
       (ok { stacker: stacker,
@@ -941,9 +966,11 @@
 ;; Extend an active Stacking lock.
 ;; *New in Stacks 2.1*
 ;; This method extends the `tx-sender`'s current lockup for an additional `extend-count`
-;;    and associates `pox-addr` with the rewards
+;;    and associates `pox-addr` with the rewards, The `signer-key` will be the key
+;;    used for signing. The `tx-sender` can thus decide to change the key when extending.
 (define-public (stack-extend (extend-count uint)
-                             (pox-addr { version: (buff 1), hashbytes: (buff 32) }))
+                             (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+                             (signer-key (buff 33)))
    (let ((stacker-info (stx-account tx-sender))
          ;; to extend, there must already be an etry in the stacking-state
          (stacker-state (unwrap! (get-stacker-info tx-sender) (err ERR_STACK_EXTEND_NOT_LOCKED)))
@@ -967,6 +994,9 @@
     ;; stacker must not be delegating
     (asserts! (is-none (get delegated-to stacker-state))
               (err ERR_STACKING_IS_DELEGATED))
+
+    ;; ensure the signer key is valid
+    (try! (is-signer-key-valid signer-key))
 
     ;; TODO: add more assertions to sanity check the `stacker-info` values with
     ;;       the `stacker-state` values
@@ -1014,7 +1044,8 @@
               reward-set-indexes: reward-set-indexes,
               first-reward-cycle: first-reward-cycle,
               lock-period: lock-period,
-              delegated-to: none })
+              delegated-to: none,
+              signer-key: signer-key })
 
         ;; return lock-up information
         (ok { stacker: tx-sender, unlock-burn-height: new-unlock-ht })))))
@@ -1115,6 +1146,7 @@
 (define-public (delegate-stack-extend
                     (stacker principal)
                     (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+                    (signer-key (buff 33))
                     (extend-count uint))
     (let ((stacker-info (stx-account stacker))
           ;; to extend, there must already be an entry in the stacking-state
@@ -1181,7 +1213,12 @@
                          until-burn-ht (>= until-burn-ht
                                            new-unlock-ht)
                       true)
-                  (err ERR_DELEGATION_EXPIRES_DURING_LOCK)))
+                  (err ERR_DELEGATION_EXPIRES_DURING_LOCK))
+        ;; if the stacker set a signer-key, it must be equal to the delegate signer-key
+        (asserts!
+            (or (is-none (get signer-key delegation-info)) (is-eq (get signer-key delegation-info) (some signer-key)))
+            (err ERR_REQUESTED_SIGNER_KEY_MISMATCH)
+        ))
 
       ;; delegate stacking does minimal-can-stack-stx
       (try! (minimal-can-stack-stx pox-addr amount-ustx first-extend-cycle lock-period))
@@ -1196,7 +1233,8 @@
           reward-set-indexes: (list),
           first-reward-cycle: first-reward-cycle,
           lock-period: lock-period,
-          delegated-to: (some tx-sender) })
+          delegated-to: (some tx-sender),
+          signer-key: signer-key })
 
       ;; return the lock-up information, so the node can actually carry out the lock.
       (ok { stacker: stacker,
@@ -1246,4 +1284,10 @@
     (begin
         (ok (map-set aggregate-public-keys reward-cycle aggregate-public-key))
     )
+)
+
+;; Check if a provided signer key is valid. For now it only asserts length.
+;; *New in Stacks 3.0*
+(define-read-only (is-signer-key-valid (signer-key (buff 33)))
+    (ok (asserts! (is-eq (len signer-key) u33) (err ERR_INVALID_SIGNER_KEY)))
 )

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -486,7 +486,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&alice).bytes,
         ),
         4,
-        Point::default(),
+        StacksPublicKey::default(),
         tip.block_height,
     );
     let alice_pox_4_lock_nonce = 2;
@@ -552,7 +552,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&bob).bytes,
         ),
         3,
-        Point::try_from(&Compressed::from(bob_signer_key)).unwrap(),
+        StacksPublicKey::from_slice(&bob_signer_key).unwrap(),
         tip.block_height,
     );
 
@@ -565,7 +565,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&alice).bytes,
         ),
         6,
-        Point::try_from(&Compressed::from(alice_signer_key)).unwrap(),
+        StacksPublicKey::from_slice(&alice_signer_key).unwrap(),
     );
 
     let alice_pox_4_extend_nonce = 3;
@@ -819,7 +819,7 @@ fn pox_lock_unlock() {
                 1024 * POX_THRESHOLD_STEPS_USTX,
                 pox_addr.clone(),
                 lock_period,
-                Point::default(),
+                StacksPublicKey::default(),
                 tip_height,
             ));
             pox_addr

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -42,6 +42,7 @@ use stacks_common::types::chainstate::{
 use stacks_common::types::Address;
 use stacks_common::util::hash::{hex_bytes, to_hex, Sha256Sum, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::Secp256k1PrivateKey;
+use wsts::curve::point::{Compressed, Point};
 
 use super::test::*;
 use super::RawRewardSetEntry;
@@ -485,7 +486,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&alice).bytes,
         ),
         4,
-        vec![0; 33],
+        Point::default(),
         tip.block_height,
     );
     let alice_pox_4_lock_nonce = 2;
@@ -530,12 +531,12 @@ fn pox_extend_transition() {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let bob_signer_key = vec![
+    let bob_signer_key: [u8; 33] = [
         0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
         0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
         0x59, 0x98, 0x3c,
     ];
-    let alice_signer_key = vec![
+    let alice_signer_key: [u8; 33] = [
         0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
         0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
         0x4e, 0x28, 0x1b,
@@ -551,7 +552,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&bob).bytes,
         ),
         3,
-        bob_signer_key,
+        Point::try_from(&Compressed::from(bob_signer_key)).unwrap(),
         tip.block_height,
     );
 
@@ -564,7 +565,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&alice).bytes,
         ),
         6,
-        alice_signer_key,
+        Point::try_from(&Compressed::from(alice_signer_key)).unwrap(),
     );
 
     let alice_pox_4_extend_nonce = 3;
@@ -818,7 +819,7 @@ fn pox_lock_unlock() {
                 1024 * POX_THRESHOLD_STEPS_USTX,
                 pox_addr.clone(),
                 lock_period,
-                vec![0; 33],
+                Point::default(),
                 tip_height,
             ));
             pox_addr

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -88,8 +88,8 @@ fn make_test_epochs_pox() -> (Vec<StacksEpoch>, PoxConstants) {
     let EPOCH_2_1_HEIGHT = EMPTY_SORTITIONS + 11; // 36
     let EPOCH_2_2_HEIGHT = EPOCH_2_1_HEIGHT + 14; // 50
     let EPOCH_2_3_HEIGHT = EPOCH_2_2_HEIGHT + 2; // 52
-    // epoch-2.4 will start at the first block of cycle 11!
-    //  this means that cycle 11 should also be treated like a "burn"
+                                                 // epoch-2.4 will start at the first block of cycle 11!
+                                                 //  this means that cycle 11 should also be treated like a "burn"
     let EPOCH_2_4_HEIGHT = EPOCH_2_3_HEIGHT + 4; // 56
     let EPOCH_2_5_HEIGHT = EPOCH_2_4_HEIGHT + 44; // 100
 
@@ -341,7 +341,7 @@ fn pox_extend_transition() {
     let min_ustx = with_sortdb(&mut peer, |chainstate, sortdb| {
         chainstate.get_stacking_minimum(sortdb, &tip_index_block)
     })
-        .unwrap();
+    .unwrap();
     assert_eq!(
         min_ustx,
         total_liquid_ustx / POX_TESTNET_STACKING_THRESHOLD_25
@@ -351,7 +351,7 @@ fn pox_extend_transition() {
     let reward_addrs = with_sortdb(&mut peer, |chainstate, sortdb| {
         get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
     })
-        .unwrap();
+    .unwrap();
     assert_eq!(reward_addrs.len(), 0);
 
     // check the first reward cycle when Alice's tokens get stacked
@@ -530,8 +530,16 @@ fn pox_extend_transition() {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let bob_signer_key = vec![0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b, 0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a, 0x59, 0x98, 0x3c];
-    let alice_signer_key = vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b];
+    let bob_signer_key = vec![
+        0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
+        0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
+        0x59, 0x98, 0x3c,
+    ];
+    let alice_signer_key = vec![
+        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
+        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
+        0x4e, 0x28, 0x1b,
+    ];
 
     let tip = get_tip(peer.sortdb.as_ref());
     let bob_lockup = make_pox_4_lockup(
@@ -732,10 +740,10 @@ fn get_burn_pox_addr_info(peer: &mut TestPeer) -> (Vec<PoxAddress>, u128) {
             .unwrap();
         addrs
     })
-        .unwrap()
-        .expect_optional()
-        .expect("FATAL: expected list")
-        .expect_tuple();
+    .unwrap()
+    .expect_optional()
+    .expect("FATAL: expected list")
+    .expect_tuple();
 
     let addrs = addrs_and_payout
         .get("addrs")
@@ -1245,13 +1253,8 @@ fn balances_from_keys(
 #[test]
 fn stack_stx_signer_key() {
     let lock_period = 2;
-    let (
-        burnchain,
-        mut peer,
-        keys,
-        latest_block,
-        block_height,
-        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+    let (burnchain, mut peer, keys, latest_block, block_height, mut coinbase_nonce) =
+        prepare_pox4_test(function_name!());
 
     let stacker_nonce = 0;
     let stacker_key = &keys[0];
@@ -1262,8 +1265,16 @@ fn stack_stx_signer_key() {
     //                       (start-burn-ht uint)
     //                       (lock-period uint)
     //                       (signer-key (buff 33)))
-    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(stacker_key).bytes);
-    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
+    let pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2WSH,
+        key_to_stacks_addr(stacker_key).bytes,
+    );
+    let signer_key_val = Value::buff_from(vec![
+        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
+        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
+        0x4e, 0x28, 0x1b,
+    ])
+    .unwrap();
     let txs = vec![make_pox_4_contract_call(
         stacker_key,
         stacker_nonce,
@@ -1283,8 +1294,8 @@ fn stack_stx_signer_key() {
         &latest_block,
         &key_to_stacks_addr(stacker_key).to_account_principal(),
     )
-        .expect("No stacking state, stack-stx failed")
-        .expect_tuple();
+    .expect("No stacking state, stack-stx failed")
+    .expect_tuple();
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
@@ -1293,13 +1304,8 @@ fn stack_stx_signer_key() {
 #[test]
 fn delegate_stx_signer_key() {
     let lock_period = 2;
-    let (
-        burnchain,
-        mut peer,
-        keys,
-        latest_block,
-        block_height,
-        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+    let (burnchain, mut peer, keys, latest_block, block_height, mut coinbase_nonce) =
+        prepare_pox4_test(function_name!());
 
     let stacker_nonce = 0;
     let stacker_key = &keys[0];
@@ -1311,8 +1317,16 @@ fn delegate_stx_signer_key() {
     //                          (until-burn-ht (optional uint))
     //                          (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) }))
     //                          (signer-key (optional (buff 33))))
-    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(delegate_key).bytes);
-    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
+    let pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2WSH,
+        key_to_stacks_addr(delegate_key).bytes,
+    );
+    let signer_key_val = Value::buff_from(vec![
+        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
+        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
+        0x4e, 0x28, 0x1b,
+    ])
+    .unwrap();
     let txs = vec![make_pox_4_contract_call(
         stacker_key,
         stacker_nonce,
@@ -1321,8 +1335,12 @@ fn delegate_stx_signer_key() {
             Value::UInt(100),
             delegate_principal.clone().into(),
             Value::none(),
-            Value::Optional(OptionalData { data: Some(Box::new(pox_addr)) }),
-            Value::Optional(OptionalData { data: Some(signer_key_val.clone().into()) }),
+            Value::Optional(OptionalData {
+                data: Some(Box::new(pox_addr)),
+            }),
+            Value::Optional(OptionalData {
+                data: Some(signer_key_val.clone().into()),
+            }),
         ],
     )];
 
@@ -1332,34 +1350,40 @@ fn delegate_stx_signer_key() {
         &latest_block,
         &key_to_stacks_addr(stacker_key).to_account_principal(),
     )
-        .expect("No delegation state, delegate-stx failed")
-        .expect_tuple();
+    .expect("No delegation state, delegate-stx failed")
+    .expect_tuple();
 
     let state_signer_key_optional = delegation_state.get("signer-key").unwrap();
     assert_eq!(
         state_signer_key_optional.to_string(),
-        Value::Optional(OptionalData { data: Some(Box::new(signer_key_val)) }).to_string()
+        Value::Optional(OptionalData {
+            data: Some(Box::new(signer_key_val))
+        })
+        .to_string()
     );
 }
 
 #[test]
 fn stack_extend_signer_key() {
     let lock_period = 2;
-    let (
-        burnchain,
-        mut peer,
-        keys,
-        latest_block,
-        block_height,
-        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+    let (burnchain, mut peer, keys, latest_block, block_height, mut coinbase_nonce) =
+        prepare_pox4_test(function_name!());
 
     let mut stacker_nonce = 0;
     let stacker_key = &keys[0];
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block) * 2;
 
-    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(stacker_key).bytes);
+    let pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2WSH,
+        key_to_stacks_addr(stacker_key).bytes,
+    );
 
-    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
+    let signer_key_val = Value::buff_from(vec![
+        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
+        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
+        0x4e, 0x28, 0x1b,
+    ])
+    .unwrap();
     let txs = vec![make_pox_4_contract_call(
         stacker_key,
         stacker_nonce,
@@ -1381,14 +1405,19 @@ fn stack_extend_signer_key() {
         &latest_block,
         &key_to_stacks_addr(stacker_key).to_account_principal(),
     )
-        .expect("No stacking state, stack-stx failed")
-        .expect_tuple();
+    .expect("No stacking state, stack-stx failed")
+    .expect_tuple();
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
 
     // now stack-extend with a new signer-key
-    let signer_key_new_val = Value::buff_from(vec![0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b, 0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a, 0x59, 0x98, 0x3c]).unwrap();
+    let signer_key_new_val = Value::buff_from(vec![
+        0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
+        0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
+        0x59, 0x98, 0x3c,
+    ])
+    .unwrap();
 
     // (define-public (stack-extend (extend-count uint)
     //                          (pox-addr { version: (buff 1), hashbytes: (buff 32) })
@@ -1397,11 +1426,7 @@ fn stack_extend_signer_key() {
         stacker_key,
         stacker_nonce,
         "stack-extend",
-        vec![
-            Value::UInt(1),
-            pox_addr,
-            signer_key_new_val.clone(),
-        ],
+        vec![Value::UInt(1), pox_addr, signer_key_new_val.clone()],
     )];
 
     latest_block = peer.tenure_with_txs(&update_txs, &mut coinbase_nonce);
@@ -1410,23 +1435,21 @@ fn stack_extend_signer_key() {
         &latest_block,
         &key_to_stacks_addr(stacker_key).to_account_principal(),
     )
-        .unwrap()
-        .expect_tuple();
+    .unwrap()
+    .expect_tuple();
 
     let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
-    assert_eq!(state_signer_key_new.to_string(), signer_key_new_val.to_string());
+    assert_eq!(
+        state_signer_key_new.to_string(),
+        signer_key_new_val.to_string()
+    );
 }
 
 #[test]
 fn delegate_stack_stx_signer_key() {
     let lock_period = 2;
-    let (
-        burnchain,
-        mut peer,
-        keys,
-        latest_block,
-        block_height,
-        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+    let (burnchain, mut peer, keys, latest_block, block_height, mut coinbase_nonce) =
+        prepare_pox4_test(function_name!());
 
     let stacker_nonce = 0;
     let stacker_key = &keys[0];
@@ -1439,32 +1462,47 @@ fn delegate_stack_stx_signer_key() {
     //                          (until-burn-ht (optional uint))
     //                          (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) }))
     //                          (signer-key (optional (buff 33))))
-    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(delegate_key).bytes);
-    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
-    let txs = vec![make_pox_4_contract_call(
-        stacker_key,
-        stacker_nonce,
-        "delegate-stx",
-        vec![
-            Value::UInt(100),
-            delegate_principal.clone().into(),
-            Value::none(),
-            Value::Optional(OptionalData { data: Some(Box::new(pox_addr.clone())) }),
-            Value::Optional(OptionalData { data: Some(signer_key_val.clone().into()) }),
-        ],
-    ), make_pox_4_contract_call(
-        delegate_key,
-        delegate_nonce,
-        "delegate-stack-stx",
-        vec![
-            PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
-            Value::UInt(100),
-            pox_addr,
-            Value::UInt(block_height as u128),
-            Value::UInt(lock_period),
-            signer_key_val.clone(),
-        ],
-    )];
+    let pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2WSH,
+        key_to_stacks_addr(delegate_key).bytes,
+    );
+    let signer_key_val = Value::buff_from(vec![
+        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
+        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
+        0x4e, 0x28, 0x1b,
+    ])
+    .unwrap();
+    let txs = vec![
+        make_pox_4_contract_call(
+            stacker_key,
+            stacker_nonce,
+            "delegate-stx",
+            vec![
+                Value::UInt(100),
+                delegate_principal.clone().into(),
+                Value::none(),
+                Value::Optional(OptionalData {
+                    data: Some(Box::new(pox_addr.clone())),
+                }),
+                Value::Optional(OptionalData {
+                    data: Some(signer_key_val.clone().into()),
+                }),
+            ],
+        ),
+        make_pox_4_contract_call(
+            delegate_key,
+            delegate_nonce,
+            "delegate-stack-stx",
+            vec![
+                PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
+                Value::UInt(100),
+                pox_addr,
+                Value::UInt(block_height as u128),
+                Value::UInt(lock_period),
+                signer_key_val.clone(),
+            ],
+        ),
+    ];
     // (define-public (delegate-stack-stx (stacker principal)
     //                                (amount-ustx uint)
     //                                (pox-addr { version: (buff 1), hashbytes: (buff 32) })
@@ -1478,13 +1516,16 @@ fn delegate_stack_stx_signer_key() {
         &latest_block,
         &key_to_stacks_addr(stacker_key).to_account_principal(),
     )
-        .expect("No delegation state, delegate-stx failed")
-        .expect_tuple();
+    .expect("No delegation state, delegate-stx failed")
+    .expect_tuple();
 
     let state_signer_key_optional = delegation_state.get("signer-key").unwrap();
     assert_eq!(
         state_signer_key_optional.to_string(),
-        Value::Optional(OptionalData { data: Some(Box::new(signer_key_val.clone())) }).to_string()
+        Value::Optional(OptionalData {
+            data: Some(Box::new(signer_key_val.clone()))
+        })
+        .to_string()
     );
 
     let stacking_state = get_stacking_state_pox_4(
@@ -1492,8 +1533,8 @@ fn delegate_stack_stx_signer_key() {
         &latest_block,
         &key_to_stacks_addr(stacker_key).to_account_principal(),
     )
-        .expect("No stacking state, stack-stx failed")
-        .expect_tuple();
+    .expect("No stacking state, stack-stx failed")
+    .expect_tuple();
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
@@ -1515,8 +1556,8 @@ pub fn get_stacking_state_pox_4(
             &lookup_tuple,
             &epoch,
         )
-            .unwrap()
-            .expect_optional()
+        .unwrap()
+        .expect_optional()
     })
 }
 
@@ -1536,14 +1577,14 @@ pub fn get_delegation_state_pox_4(
             &lookup_tuple,
             &epoch,
         )
-            .unwrap()
-            .expect_optional()
+        .unwrap()
+        .expect_optional()
     })
 }
 
 pub fn with_clarity_db_ro<F, R>(peer: &mut TestPeer, tip: &StacksBlockId, todo: F) -> R
-    where
-        F: FnOnce(&mut ClarityDatabase) -> R,
+where
+    F: FnOnce(&mut ClarityDatabase) -> R,
 {
     with_sortdb(peer, |ref mut c, ref sortdb| {
         let headers_db = HeadersDBConn(c.state_index.sqlite_conn());
@@ -1558,10 +1599,20 @@ pub fn with_clarity_db_ro<F, R>(peer: &mut TestPeer, tip: &StacksBlockId, todo: 
 pub fn get_stacking_minimum(peer: &mut TestPeer, latest_block: &StacksBlockId) -> u128 {
     with_sortdb(peer, |ref mut chainstate, ref sortdb| {
         chainstate.get_stacking_minimum(sortdb, &latest_block)
-    }).unwrap()
+    })
+    .unwrap()
 }
 
-pub fn prepare_pox4_test<'a>(test_name: &str) -> (Burnchain, TestPeer<'a>, Vec<StacksPrivateKey>, StacksBlockId, u64, usize) {
+pub fn prepare_pox4_test<'a>(
+    test_name: &str,
+) -> (
+    Burnchain,
+    TestPeer<'a>,
+    Vec<StacksPrivateKey>,
+    StacksBlockId,
+    u64,
+    usize,
+) {
     let (epochs, pox_constants) = make_test_epochs_pox();
 
     let mut burnchain = Burnchain::default_unittest(
@@ -1570,7 +1621,8 @@ pub fn prepare_pox4_test<'a>(test_name: &str) -> (Burnchain, TestPeer<'a>, Vec<S
     );
     burnchain.pox_constants = pox_constants.clone();
 
-    let (mut peer, keys) = instantiate_pox_peer_with_epoch(&burnchain, test_name, Some(epochs.clone()), None);
+    let (mut peer, keys) =
+        instantiate_pox_peer_with_epoch(&burnchain, test_name, Some(epochs.clone()), None);
 
     assert_eq!(burnchain.pox_constants.reward_slots(), 6);
     let mut coinbase_nonce = 0;
@@ -1588,10 +1640,14 @@ pub fn prepare_pox4_test<'a>(test_name: &str) -> (Burnchain, TestPeer<'a>, Vec<S
 
     let block_height = get_tip(peer.sortdb.as_ref()).block_height;
 
-    info!(
-        "Block height: {}",
-        block_height
-    );
+    info!("Block height: {}", block_height);
 
-    (burnchain, peer, keys, latest_block, block_height, coinbase_nonce)
+    (
+        burnchain,
+        peer,
+        keys,
+        latest_block,
+        block_height,
+        coinbase_nonce,
+    )
 }

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -88,8 +88,8 @@ fn make_test_epochs_pox() -> (Vec<StacksEpoch>, PoxConstants) {
     let EPOCH_2_1_HEIGHT = EMPTY_SORTITIONS + 11; // 36
     let EPOCH_2_2_HEIGHT = EPOCH_2_1_HEIGHT + 14; // 50
     let EPOCH_2_3_HEIGHT = EPOCH_2_2_HEIGHT + 2; // 52
-                                                 // epoch-2.4 will start at the first block of cycle 11!
-                                                 //  this means that cycle 11 should also be treated like a "burn"
+    // epoch-2.4 will start at the first block of cycle 11!
+    //  this means that cycle 11 should also be treated like a "burn"
     let EPOCH_2_4_HEIGHT = EPOCH_2_3_HEIGHT + 4; // 56
     let EPOCH_2_5_HEIGHT = EPOCH_2_4_HEIGHT + 44; // 100
 
@@ -341,7 +341,7 @@ fn pox_extend_transition() {
     let min_ustx = with_sortdb(&mut peer, |chainstate, sortdb| {
         chainstate.get_stacking_minimum(sortdb, &tip_index_block)
     })
-    .unwrap();
+        .unwrap();
     assert_eq!(
         min_ustx,
         total_liquid_ustx / POX_TESTNET_STACKING_THRESHOLD_25
@@ -351,7 +351,7 @@ fn pox_extend_transition() {
     let reward_addrs = with_sortdb(&mut peer, |chainstate, sortdb| {
         get_reward_addresses_with_par_tip(chainstate, &burnchain, sortdb, &tip_index_block)
     })
-    .unwrap();
+        .unwrap();
     assert_eq!(reward_addrs.len(), 0);
 
     // check the first reward cycle when Alice's tokens get stacked
@@ -485,6 +485,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&alice).bytes,
         ),
         4,
+        vec![0; 33],
         tip.block_height,
     );
     let alice_pox_4_lock_nonce = 2;
@@ -529,6 +530,9 @@ fn pox_extend_transition() {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
+    let bob_signer_key = vec![0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b, 0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a, 0x59, 0x98, 0x3c];
+    let alice_signer_key = vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b];
+
     let tip = get_tip(peer.sortdb.as_ref());
     let bob_lockup = make_pox_4_lockup(
         &bob,
@@ -539,6 +543,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&bob).bytes,
         ),
         3,
+        bob_signer_key,
         tip.block_height,
     );
 
@@ -551,6 +556,7 @@ fn pox_extend_transition() {
             key_to_stacks_addr(&alice).bytes,
         ),
         6,
+        alice_signer_key,
     );
 
     let alice_pox_4_extend_nonce = 3;
@@ -726,10 +732,10 @@ fn get_burn_pox_addr_info(peer: &mut TestPeer) -> (Vec<PoxAddress>, u128) {
             .unwrap();
         addrs
     })
-    .unwrap()
-    .expect_optional()
-    .expect("FATAL: expected list")
-    .expect_tuple();
+        .unwrap()
+        .expect_optional()
+        .expect("FATAL: expected list")
+        .expect_tuple();
 
     let addrs = addrs_and_payout
         .get("addrs")
@@ -804,6 +810,7 @@ fn pox_lock_unlock() {
                 1024 * POX_THRESHOLD_STEPS_USTX,
                 pox_addr.clone(),
                 lock_period,
+                vec![0; 33],
                 tip_height,
             ));
             pox_addr
@@ -1233,4 +1240,358 @@ fn balances_from_keys(
         .map(|addr| PrincipalData::from(addr))
         .map(|principal| get_stx_account_at(peer, tip, &principal))
         .collect()
+}
+
+#[test]
+fn stack_stx_signer_key() {
+    let lock_period = 2;
+    let (
+        burnchain,
+        mut peer,
+        keys,
+        latest_block,
+        block_height,
+        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+
+    let stacker_nonce = 0;
+    let stacker_key = &keys[0];
+    let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
+
+    // (define-public (stack-stx (amount-ustx uint)
+    //                       (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
+    //                       (start-burn-ht uint)
+    //                       (lock-period uint)
+    //                       (signer-key (buff 33)))
+    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(stacker_key).bytes);
+    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
+    let txs = vec![make_pox_4_contract_call(
+        stacker_key,
+        stacker_nonce,
+        "stack-stx",
+        vec![
+            Value::UInt(min_ustx),
+            pox_addr,
+            Value::UInt(block_height as u128),
+            Value::UInt(2),
+            signer_key_val.clone(),
+        ],
+    )];
+
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+    let stacking_state = get_stacking_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+        .expect("No stacking state, stack-stx failed")
+        .expect_tuple();
+
+    let state_signer_key = stacking_state.get("signer-key").unwrap();
+    assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
+}
+
+#[test]
+fn delegate_stx_signer_key() {
+    let lock_period = 2;
+    let (
+        burnchain,
+        mut peer,
+        keys,
+        latest_block,
+        block_height,
+        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+
+    let stacker_nonce = 0;
+    let stacker_key = &keys[0];
+    let delegate_key = &keys[1];
+    let delegate_principal = PrincipalData::from(key_to_stacks_addr(delegate_key));
+
+    // (define-public (delegate-stx (amount-ustx uint)
+    //                          (delegate-to principal)
+    //                          (until-burn-ht (optional uint))
+    //                          (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) }))
+    //                          (signer-key (optional (buff 33))))
+    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(delegate_key).bytes);
+    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
+    let txs = vec![make_pox_4_contract_call(
+        stacker_key,
+        stacker_nonce,
+        "delegate-stx",
+        vec![
+            Value::UInt(100),
+            delegate_principal.clone().into(),
+            Value::none(),
+            Value::Optional(OptionalData { data: Some(Box::new(pox_addr)) }),
+            Value::Optional(OptionalData { data: Some(signer_key_val.clone().into()) }),
+        ],
+    )];
+
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+    let delegation_state = get_delegation_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+        .expect("No delegation state, delegate-stx failed")
+        .expect_tuple();
+
+    let state_signer_key_optional = delegation_state.get("signer-key").unwrap();
+    assert_eq!(
+        state_signer_key_optional.to_string(),
+        Value::Optional(OptionalData { data: Some(Box::new(signer_key_val)) }).to_string()
+    );
+}
+
+#[test]
+fn stack_extend_signer_key() {
+    let lock_period = 2;
+    let (
+        burnchain,
+        mut peer,
+        keys,
+        latest_block,
+        block_height,
+        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+
+    let mut stacker_nonce = 0;
+    let stacker_key = &keys[0];
+    let min_ustx = get_stacking_minimum(&mut peer, &latest_block) * 2;
+
+    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(stacker_key).bytes);
+
+    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
+    let txs = vec![make_pox_4_contract_call(
+        stacker_key,
+        stacker_nonce,
+        "stack-stx",
+        vec![
+            Value::UInt(min_ustx),
+            pox_addr.clone(),
+            Value::UInt(block_height as u128),
+            Value::UInt(2),
+            signer_key_val.clone(),
+        ],
+    )];
+
+    stacker_nonce += 1;
+
+    let mut latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+    let stacking_state = get_stacking_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+        .expect("No stacking state, stack-stx failed")
+        .expect_tuple();
+
+    let state_signer_key = stacking_state.get("signer-key").unwrap();
+    assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
+
+    // now stack-extend with a new signer-key
+    let signer_key_new_val = Value::buff_from(vec![0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b, 0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a, 0x59, 0x98, 0x3c]).unwrap();
+
+    // (define-public (stack-extend (extend-count uint)
+    //                          (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+    //                          (signer-key (buff 33)))
+    let update_txs = vec![make_pox_4_contract_call(
+        stacker_key,
+        stacker_nonce,
+        "stack-extend",
+        vec![
+            Value::UInt(1),
+            pox_addr,
+            signer_key_new_val.clone(),
+        ],
+    )];
+
+    latest_block = peer.tenure_with_txs(&update_txs, &mut coinbase_nonce);
+    let new_stacking_state = get_stacking_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+        .unwrap()
+        .expect_tuple();
+
+    let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
+    assert_eq!(state_signer_key_new.to_string(), signer_key_new_val.to_string());
+}
+
+#[test]
+fn delegate_stack_stx_signer_key() {
+    let lock_period = 2;
+    let (
+        burnchain,
+        mut peer,
+        keys,
+        latest_block,
+        block_height,
+        mut coinbase_nonce) = prepare_pox4_test(function_name!());
+
+    let stacker_nonce = 0;
+    let stacker_key = &keys[0];
+    let delegate_nonce = 0;
+    let delegate_key = &keys[1];
+    let delegate_principal = PrincipalData::from(key_to_stacks_addr(delegate_key));
+
+    // (define-public (delegate-stx (amount-ustx uint)
+    //                          (delegate-to principal)
+    //                          (until-burn-ht (optional uint))
+    //                          (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) }))
+    //                          (signer-key (optional (buff 33))))
+    let pox_addr = make_pox_addr(AddressHashMode::SerializeP2WSH, key_to_stacks_addr(delegate_key).bytes);
+    let signer_key_val = Value::buff_from(vec![0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf, 0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f, 0x4e, 0x28, 0x1b]).unwrap();
+    let txs = vec![make_pox_4_contract_call(
+        stacker_key,
+        stacker_nonce,
+        "delegate-stx",
+        vec![
+            Value::UInt(100),
+            delegate_principal.clone().into(),
+            Value::none(),
+            Value::Optional(OptionalData { data: Some(Box::new(pox_addr.clone())) }),
+            Value::Optional(OptionalData { data: Some(signer_key_val.clone().into()) }),
+        ],
+    ), make_pox_4_contract_call(
+        delegate_key,
+        delegate_nonce,
+        "delegate-stack-stx",
+        vec![
+            PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
+            Value::UInt(100),
+            pox_addr,
+            Value::UInt(block_height as u128),
+            Value::UInt(lock_period),
+            signer_key_val.clone(),
+        ],
+    )];
+    // (define-public (delegate-stack-stx (stacker principal)
+    //                                (amount-ustx uint)
+    //                                (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+    //                                (start-burn-ht uint)
+    //                                (lock-period uint)
+    //                                (signer-key (buff 33)))
+
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+    let delegation_state = get_delegation_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+        .expect("No delegation state, delegate-stx failed")
+        .expect_tuple();
+
+    let state_signer_key_optional = delegation_state.get("signer-key").unwrap();
+    assert_eq!(
+        state_signer_key_optional.to_string(),
+        Value::Optional(OptionalData { data: Some(Box::new(signer_key_val.clone())) }).to_string()
+    );
+
+    let stacking_state = get_stacking_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+        .expect("No stacking state, stack-stx failed")
+        .expect_tuple();
+
+    let state_signer_key = stacking_state.get("signer-key").unwrap();
+    assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
+}
+
+pub fn get_stacking_state_pox_4(
+    peer: &mut TestPeer,
+    tip: &StacksBlockId,
+    account: &PrincipalData,
+) -> Option<Value> {
+    with_clarity_db_ro(peer, tip, |db| {
+        let lookup_tuple = Value::Tuple(
+            TupleData::from_data(vec![("stacker".into(), account.clone().into())]).unwrap(),
+        );
+        let epoch = db.get_clarity_epoch_version();
+        db.fetch_entry_unknown_descriptor(
+            &boot_code_id(boot::POX_4_NAME, false),
+            "stacking-state",
+            &lookup_tuple,
+            &epoch,
+        )
+            .unwrap()
+            .expect_optional()
+    })
+}
+
+pub fn get_delegation_state_pox_4(
+    peer: &mut TestPeer,
+    tip: &StacksBlockId,
+    account: &PrincipalData,
+) -> Option<Value> {
+    with_clarity_db_ro(peer, tip, |db| {
+        let lookup_tuple = Value::Tuple(
+            TupleData::from_data(vec![("stacker".into(), account.clone().into())]).unwrap(),
+        );
+        let epoch = db.get_clarity_epoch_version();
+        db.fetch_entry_unknown_descriptor(
+            &boot_code_id(boot::POX_4_NAME, false),
+            "delegation-state",
+            &lookup_tuple,
+            &epoch,
+        )
+            .unwrap()
+            .expect_optional()
+    })
+}
+
+pub fn with_clarity_db_ro<F, R>(peer: &mut TestPeer, tip: &StacksBlockId, todo: F) -> R
+    where
+        F: FnOnce(&mut ClarityDatabase) -> R,
+{
+    with_sortdb(peer, |ref mut c, ref sortdb| {
+        let headers_db = HeadersDBConn(c.state_index.sqlite_conn());
+        let burn_db = sortdb.index_conn();
+        let mut read_only_clar = c
+            .clarity_state
+            .read_only_connection(tip, &headers_db, &burn_db);
+        read_only_clar.with_clarity_db_readonly(todo)
+    })
+}
+
+pub fn get_stacking_minimum(peer: &mut TestPeer, latest_block: &StacksBlockId) -> u128 {
+    with_sortdb(peer, |ref mut chainstate, ref sortdb| {
+        chainstate.get_stacking_minimum(sortdb, &latest_block)
+    }).unwrap()
+}
+
+pub fn prepare_pox4_test<'a>(test_name: &str) -> (Burnchain, TestPeer<'a>, Vec<StacksPrivateKey>, StacksBlockId, u64, usize) {
+    let (epochs, pox_constants) = make_test_epochs_pox();
+
+    let mut burnchain = Burnchain::default_unittest(
+        0,
+        &BurnchainHeaderHash::from_hex(BITCOIN_REGTEST_FIRST_BLOCK_HASH).unwrap(),
+    );
+    burnchain.pox_constants = pox_constants.clone();
+
+    let (mut peer, keys) = instantiate_pox_peer_with_epoch(&burnchain, test_name, Some(epochs.clone()), None);
+
+    assert_eq!(burnchain.pox_constants.reward_slots(), 6);
+    let mut coinbase_nonce = 0;
+
+    // Advance into pox4
+    let target_height = burnchain.pox_constants.pox_4_activation_height;
+    let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
+    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+        latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
+        // if we reach epoch 2.1, perform the check
+        if get_tip(peer.sortdb.as_ref()).block_height > epochs[3].start_height {
+            assert_latest_was_burn(&mut peer);
+        }
+    }
+
+    let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+
+    info!(
+        "Block height: {}",
+        block_height
+    );
+
+    (burnchain, peer, keys, latest_block, block_height, coinbase_nonce)
 }

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -832,6 +832,9 @@ impl MockamotoNode {
             Some(AddressHashMode::SerializeP2PKH),
         );
 
+        let mut signer_key = miner_nonce.to_be_bytes().to_vec();
+        signer_key.resize(33, 0);
+
         let stack_stx_payload = if parent_chain_length < 2 {
             TransactionPayload::ContractCall(TransactionContractCall {
                 address: StacksAddress::burn_address(false),
@@ -842,6 +845,7 @@ impl MockamotoNode {
                     pox_address.as_clarity_tuple().unwrap().into(),
                     ClarityValue::UInt(u128::from(parent_burn_height)),
                     ClarityValue::UInt(12),
+                    ClarityValue::buff_from(signer_key).unwrap(),
                 ],
             })
         } else {
@@ -854,6 +858,7 @@ impl MockamotoNode {
                 function_args: vec![
                     ClarityValue::UInt(5),
                     pox_address.as_clarity_tuple().unwrap().into(),
+                    ClarityValue::buff_from(signer_key).unwrap(),
                 ],
             })
         };

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -337,6 +337,7 @@ fn boot_to_epoch_3(
             pox_addr_tuple,
             clarity::vm::Value::UInt(205),
             clarity::vm::Value::UInt(12),
+            clarity::vm::Value::buff_from(vec![0; 33]).unwrap(), // TODO: replace once signer key calculation is implemented
         ],
     );
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -33,7 +33,7 @@ use stacks::core::{
 };
 use stacks_common::address::AddressHashMode;
 use stacks_common::consts::STACKS_EPOCH_MAX;
-use stacks_common::types::chainstate::StacksAddress;
+use stacks_common::types::chainstate::{StacksAddress, StacksPublicKey};
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::Secp256k1PrivateKey;
 
@@ -303,6 +303,7 @@ fn boot_to_epoch_3(
     naka_conf: &Config,
     blocks_processed: &RunLoopCounter,
     stacker_sk: Secp256k1PrivateKey,
+    signer_pk: StacksPublicKey,
     btc_regtest_controller: &mut BitcoinRegtestController,
 ) {
     let epochs = naka_conf.burnchain.epochs.clone().unwrap();
@@ -337,7 +338,7 @@ fn boot_to_epoch_3(
             pox_addr_tuple,
             clarity::vm::Value::UInt(205),
             clarity::vm::Value::UInt(12),
-            clarity::vm::Value::buff_from(vec![0; 33]).unwrap(), // TODO: replace once signer key calculation is implemented
+            clarity::vm::Value::buff_from(signer_pk.to_bytes_compressed()).unwrap(),
         ],
     );
 
@@ -373,6 +374,7 @@ fn simple_neon_integration() {
     let sender_sk = Secp256k1PrivateKey::new();
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
+    let sender_signer_key = StacksPublicKey::new();
     let send_amt = 1000;
     let send_fee = 100;
     naka_conf.add_initial_balance(
@@ -413,6 +415,7 @@ fn simple_neon_integration() {
         &naka_conf,
         &blocks_processed,
         stacker_sk,
+        sender_signer_key,
         &mut btc_regtest_controller,
     );
 
@@ -553,6 +556,7 @@ fn mine_multiple_per_tenure_integration() {
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let sender_sk = Secp256k1PrivateKey::new();
+    let sender_signer_key = StacksPublicKey::new();
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
     // setup sender + recipient for some test stx transfers
@@ -601,6 +605,7 @@ fn mine_multiple_per_tenure_integration() {
         &naka_conf,
         &blocks_processed,
         stacker_sk,
+        sender_signer_key,
         &mut btc_regtest_controller,
     );
 


### PR DESCRIPTION
 ### Description

This PR adds pox4 signer key read/write and useful helpers to interact with pox4 functions. The focus is to add base Rust tests to be used as a foundation for upcoming work items like #4059, #4058, #4147, and so on. There is also a basic check to make sure that a signer key is 33 bytes and to prevent key reuse. 

### Applicable issues

- #3970
- #4207

### Additional info (benefits, drawbacks, caveats)

I kept this PR as narrow as possible for the purpose of unblocking other work and to (hopefully) make a merge straightforward. Processing the signer keys, calculating the aggregate key, and the signer StackerDB work is slated for subsequent PRs.

Comprehensive PoX4 smart contract tests will also be introduced in a different PR. (Pending `clarunit` tooling.)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
