### PR TITLE
Fix: commit burn out selection in nakamoto-node

### DIFF
--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -285,20 +285,21 @@ pub struct OnChainRewardSetProvider();
 impl RewardSetProvider for OnChainRewardSetProvider {
     fn get_reward_set(
         &self,
-        // Todo: `current_burn_height` is a misleading name: should be the `cycle_start_burn_height`
-        current_burn_height: u64,
+        cycle_start_burn_height: u64,
         chainstate: &mut StacksChainState,
         burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
     ) -> Result<RewardSet, Error> {
-        let cur_epoch = SortitionDB::get_stacks_epoch(sortdb.conn(), current_burn_height)?.expect(
-            &format!("FATAL: no epoch for burn height {}", current_burn_height),
-        );
+        let cur_epoch = SortitionDB::get_stacks_epoch(sortdb.conn(), cycle_start_burn_height)?
+            .expect(&format!(
+                "FATAL: no epoch for burn height {}",
+                cycle_start_burn_height
+            ));
         if cur_epoch.epoch_id < StacksEpochId::Epoch30 {
             // Stacks 2.x epoch
             return self.get_reward_set_epoch2(
-                current_burn_height,
+                cycle_start_burn_height,
                 chainstate,
                 burnchain,
                 sortdb,
@@ -308,7 +309,7 @@ impl RewardSetProvider for OnChainRewardSetProvider {
         } else {
             // Nakamoto epoch
             return self.get_reward_set_nakamoto(
-                current_burn_height,
+                cycle_start_burn_height,
                 chainstate,
                 burnchain,
                 sortdb,

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -248,6 +248,7 @@ pub enum Error {
     NotInPreparePhase,
     RewardSetAlreadyProcessed,
     PoXAnchorBlockRequired,
+    PoXNotProcessedYet,
 }
 
 impl From<BurnchainError> for Error {
@@ -675,124 +676,112 @@ pub fn get_reward_cycle_info<U: RewardSetProvider>(
     let epoch_at_height = SortitionDB::get_stacks_epoch(sort_db.conn(), burn_height)?.expect(
         &format!("FATAL: no epoch defined for burn height {}", burn_height),
     );
-    let reward_cycle_info = if burnchain.is_reward_cycle_start(burn_height) {
-        let reward_cycle = burnchain
-            .block_height_to_reward_cycle(burn_height)
-            .expect("FATAL: no reward cycle for burn height");
+    if !burnchain.is_reward_cycle_start(burn_height) {
+        return Ok(None);
+    }
 
-        if burnchain
-            .pox_constants
-            .is_after_pox_sunset_end(burn_height, epoch_at_height.epoch_id)
-        {
-            return Ok(Some(RewardCycleInfo {
-                reward_cycle,
-                anchor_status: PoxAnchorBlockStatus::NotSelected,
-            }));
-        }
+    let reward_cycle = burnchain
+        .block_height_to_reward_cycle(burn_height)
+        .expect("FATAL: no reward cycle for burn height");
 
-        debug!("Beginning reward cycle";
-              "burn_height" => burn_height,
-              "reward_cycle" => reward_cycle,
-              "reward_cycle_length" => burnchain.pox_constants.reward_cycle_length,
-              "prepare_phase_length" => burnchain.pox_constants.prepare_length);
+    if burnchain
+        .pox_constants
+        .is_after_pox_sunset_end(burn_height, epoch_at_height.epoch_id)
+    {
+        return Ok(Some(RewardCycleInfo {
+            reward_cycle,
+            anchor_status: PoxAnchorBlockStatus::NotSelected,
+        }));
+    }
 
-        let reward_cycle_info = {
-            let ic = sort_db.index_handle(sortition_tip);
-            let burnchain_db_conn_opt = if epoch_at_height.epoch_id >= StacksEpochId::Epoch21
-                || always_use_affirmation_maps
-            {
+    debug!("Beginning reward cycle";
+           "burn_height" => burn_height,
+           "reward_cycle" => reward_cycle,
+           "reward_cycle_length" => burnchain.pox_constants.reward_cycle_length,
+           "prepare_phase_length" => burnchain.pox_constants.prepare_length);
+
+    let reward_cycle_info = {
+        let ic = sort_db.index_handle(sortition_tip);
+        let burnchain_db_conn_opt =
+            if epoch_at_height.epoch_id >= StacksEpochId::Epoch21 || always_use_affirmation_maps {
                 // use the new block-commit-based PoX anchor block selection rules
                 Some(burnchain_db.conn())
             } else {
                 None
             };
 
-            ic.get_chosen_pox_anchor(burnchain_db_conn_opt, &parent_bhh, &burnchain.pox_constants)
-        }?;
-        if let Some((consensus_hash, stacks_block_hash, txid)) = reward_cycle_info {
-            debug!(
-                "Chosen PoX anchor is {}/{} txid {} for reward cycle starting {} at burn height {}",
-                &consensus_hash, &stacks_block_hash, &txid, reward_cycle, burn_height
-            );
-            info!(
-                "Anchor block selected for cycle {}: {}/{} (txid {})",
-                reward_cycle, &consensus_hash, &stacks_block_hash, &txid
-            );
-
-            let anchor_block_known = StacksChainState::is_stacks_block_processed(
-                &chain_state.db(),
-                &consensus_hash,
-                &stacks_block_hash,
-            )?;
-            let anchor_status = if anchor_block_known {
-                let block_id = StacksBlockId::new(&consensus_hash, &stacks_block_hash);
-                let reward_set = provider.get_reward_set(
-                    burn_height,
-                    chain_state,
-                    burnchain,
-                    sort_db,
-                    &block_id,
-                )?;
-                debug!(
-                    "Stacks anchor block {}/{} cycle {} txid {} is processed",
-                    &consensus_hash, &stacks_block_hash, reward_cycle, &txid
-                );
-                PoxAnchorBlockStatus::SelectedAndKnown(stacks_block_hash, txid, reward_set)
-            } else {
-                debug!(
-                    "Stacks anchor block {}/{} cycle {} txid {} is NOT processed",
-                    &consensus_hash, &stacks_block_hash, reward_cycle, &txid
-                );
-                PoxAnchorBlockStatus::SelectedAndUnknown(stacks_block_hash, txid)
-            };
-            Ok(Some(RewardCycleInfo {
-                reward_cycle,
-                anchor_status,
-            }))
+        ic.get_chosen_pox_anchor(burnchain_db_conn_opt, &parent_bhh, &burnchain.pox_constants)
+    }?;
+    let reward_cycle_info = if let Some((consensus_hash, stacks_block_hash, txid)) =
+        reward_cycle_info
+    {
+        let anchor_block_known = StacksChainState::is_stacks_block_processed(
+            &chain_state.db(),
+            &consensus_hash,
+            &stacks_block_hash,
+        )?;
+        info!(
+            "PoX Anchor block selected";
+            "cycle" => reward_cycle,
+            "consensus_hash" => %consensus_hash,
+            "block_hash" => %stacks_block_hash,
+            "block_id" => %StacksBlockId::new(&consensus_hash, &stacks_block_hash),
+            "is_known" => anchor_block_known,
+            "commit_txid" => %txid,
+            "cycle_burn_height" => burn_height
+        );
+        let anchor_status = if anchor_block_known {
+            let block_id = StacksBlockId::new(&consensus_hash, &stacks_block_hash);
+            let reward_set =
+                provider.get_reward_set(burn_height, chain_state, burnchain, sort_db, &block_id)?;
+            PoxAnchorBlockStatus::SelectedAndKnown(stacks_block_hash, txid, reward_set)
         } else {
-            debug!(
-                "PoX anchor block NOT chosen for reward cycle {} at burn height {}",
-                reward_cycle, burn_height
-            );
-            Ok(Some(RewardCycleInfo {
-                reward_cycle,
-                anchor_status: PoxAnchorBlockStatus::NotSelected,
-            }))
+            PoxAnchorBlockStatus::SelectedAndUnknown(stacks_block_hash, txid)
+        };
+        RewardCycleInfo {
+            reward_cycle,
+            anchor_status,
         }
     } else {
-        Ok(None)
+        info!(
+            "PoX anchor block NOT chosen for reward cycle {} at burn height {}",
+            reward_cycle, burn_height
+        );
+        RewardCycleInfo {
+            reward_cycle,
+            anchor_status: PoxAnchorBlockStatus::NotSelected,
+        }
     };
 
-    if let Ok(Some(reward_cycle_info)) = reward_cycle_info.as_ref() {
-        // cache the reward cycle info as of the first sortition in the prepare phase, so that
-        // the Nakamoto epoch can go find it later
-        let ic = sort_db.index_handle(sortition_tip);
-        let prev_reward_cycle = burnchain
-            .block_height_to_reward_cycle(burn_height)
-            .expect("FATAL: no reward cycle for burn height");
+    // cache the reward cycle info as of the first sortition in the prepare phase, so that
+    // the Nakamoto epoch can go find it later
+    let ic = sort_db.index_handle(sortition_tip);
+    let prev_reward_cycle = burnchain
+        .block_height_to_reward_cycle(burn_height)
+        .expect("FATAL: no reward cycle for burn height");
 
-        if prev_reward_cycle > 1 {
-            let prepare_phase_start = burnchain
-                .pox_constants
-                .prepare_phase_start(burnchain.first_block_height, prev_reward_cycle - 1);
-            let first_prepare_sn =
-                SortitionDB::get_ancestor_snapshot(&ic, prepare_phase_start, sortition_tip)?
-                    .expect("FATAL: no start-of-prepare-phase sortition");
+    if prev_reward_cycle > 1 {
+        let prepare_phase_start = burnchain
+            .pox_constants
+            .prepare_phase_start(burnchain.first_block_height, prev_reward_cycle - 1);
+        let first_prepare_sn =
+            SortitionDB::get_ancestor_snapshot(&ic, prepare_phase_start, sortition_tip)?
+                .expect("FATAL: no start-of-prepare-phase sortition");
 
-            let mut tx = sort_db.tx_begin()?;
-            if SortitionDB::get_preprocessed_reward_set(&mut tx, &first_prepare_sn.sortition_id)?
-                .is_none()
-            {
-                SortitionDB::store_preprocessed_reward_set(
-                    &mut tx,
-                    &first_prepare_sn.sortition_id,
-                    &reward_cycle_info,
-                )?;
-            }
-            tx.commit()?;
+        let mut tx = sort_db.tx_begin()?;
+        if SortitionDB::get_preprocessed_reward_set(&mut tx, &first_prepare_sn.sortition_id)?
+            .is_none()
+        {
+            SortitionDB::store_preprocessed_reward_set(
+                &mut tx,
+                &first_prepare_sn.sortition_id,
+                &reward_cycle_info,
+            )?;
         }
+        tx.commit()?;
     }
-    reward_cycle_info
+
+    Ok(Some(reward_cycle_info))
 }
 
 /// PoX payout event to be sent to connected event observers

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -53,18 +53,15 @@ pub mod tests;
 impl OnChainRewardSetProvider {
     pub fn get_reward_set_nakamoto(
         &self,
-        // NOTE: this value is the first burnchain block in the prepare phase which has a Stacks
-        // block (unlike in Stacks 2.x, where this is the first block of the reward phase)
-        current_burn_height: u64,
+        cycle_start_burn_height: u64,
         chainstate: &mut StacksChainState,
         burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
     ) -> Result<RewardSet, Error> {
         let cycle = burnchain
-            .block_height_to_reward_cycle(current_burn_height)
-            .expect("FATAL: no reward cycle for burn height")
-            + 1;
+            .block_height_to_reward_cycle(cycle_start_burn_height)
+            .expect("FATAL: no reward cycle for burn height");
 
         let registered_addrs =
             chainstate.get_reward_addresses_in_cycle(burnchain, sortdb, cycle, block_id)?;
@@ -77,10 +74,10 @@ impl OnChainRewardSetProvider {
             liquid_ustx,
         );
 
-        let cur_epoch =
-            SortitionDB::get_stacks_epoch(sortdb.conn(), current_burn_height)?.expect(&format!(
+        let cur_epoch = SortitionDB::get_stacks_epoch(sortdb.conn(), cycle_start_burn_height)?
+            .expect(&format!(
                 "FATAL: no epoch defined for burn height {}",
-                current_burn_height
+                cycle_start_burn_height
             ));
 
         if cur_epoch.epoch_id >= StacksEpochId::Epoch30 && participation == 0 {
@@ -90,7 +87,7 @@ impl OnChainRewardSetProvider {
         }
 
         info!("PoX reward cycle threshold computed";
-              "burn_height" => current_burn_height,
+              "burn_height" => cycle_start_burn_height,
               "threshold" => threshold,
               "participation" => participation,
               "liquid_ustx" => liquid_ustx,
@@ -182,6 +179,7 @@ pub fn get_nakamoto_reward_cycle_info<U: RewardSetProvider>(
         .block_height_to_reward_cycle(burn_height)
         .expect("FATAL: no reward cycle for burn height")
         + 1;
+    let reward_start_height = burnchain.reward_cycle_to_block_height(reward_cycle);
 
     debug!("Processing reward set for Nakamoto reward cycle";
           "burn_height" => burn_height,
@@ -258,7 +256,7 @@ pub fn get_nakamoto_reward_cycle_info<U: RewardSetProvider>(
                 .expect("FATAL: no parent for processed Stacks block in prepare phase");
 
         let anchor_block_header = match &parent_block_header.anchored_header {
-            StacksBlockHeaderTypes::Epoch2(..) => parent_block_header,
+            StacksBlockHeaderTypes::Epoch2(..) => parent_block_header.clone(),
             StacksBlockHeaderTypes::Nakamoto(..) => {
                 NakamotoChainState::get_nakamoto_tenure_start_block_header(
                     chain_state.db(),
@@ -289,12 +287,23 @@ pub fn get_nakamoto_reward_cycle_info<U: RewardSetProvider>(
         let txid = anchor_block_sn.winning_block_txid;
 
         info!(
-            "Anchor block selected for cycle {}: (ch {}) {}",
-            reward_cycle, &anchor_block_header.consensus_hash, &block_id
+            "Anchor block selected";
+            "cycle" => reward_cycle,
+            "block_id" => %block_id,
+            "consensus_hash" => %anchor_block_header.consensus_hash,
+            "burn_height" => anchor_block_header.burn_header_height,
+            "anchor_chain_tip" => %parent_block_header.index_block_hash(),
+            "anchor_chain_tip_height" => %parent_block_header.burn_header_height,
+            "first_prepare_sortition_id" => %first_sortition_id
         );
 
-        let reward_set =
-            provider.get_reward_set(burn_height, chain_state, burnchain, sort_db, &block_id)?;
+        let reward_set = provider.get_reward_set(
+            reward_start_height,
+            chain_state,
+            burnchain,
+            sort_db,
+            &block_id,
+        )?;
         debug!(
             "Stacks anchor block (ch {}) {} cycle {} is processed",
             &anchor_block_header.consensus_hash, &block_id, reward_cycle

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2382,7 +2382,7 @@ impl NakamotoChainState {
         pox_constants: &PoxConstants,
         parent_consensus_hash: ConsensusHash,
         parent_header_hash: BlockHeaderHash,
-        parent_stacks_height: u64,
+        _parent_stacks_height: u64,
         parent_burn_height: u32,
         burn_header_hash: BurnchainHeaderHash,
         burn_header_height: u32,

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -2694,10 +2694,18 @@ impl PeerNetwork {
                 }
             }
             Err(e) => {
-                warn!(
-                    "{:?}: failed to learn public IP: {:?}",
-                    &self.local_peer, &e
-                );
+                if !self
+                    .local_peer
+                    .addrbytes
+                    .to_socketaddr(80)
+                    .ip()
+                    .is_loopback()
+                {
+                    warn!(
+                        "{:?}: failed to learn public IP: {:?}",
+                        &self.local_peer, &e
+                    );
+                }
                 self.public_ip_reset();
                 return true;
             }

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -28,7 +28,7 @@ use stacks::chainstate::burn::operations::{
     BlockstackOperationType, LeaderBlockCommitOp, LeaderKeyRegisterOp,
 };
 use stacks::chainstate::burn::{BlockSnapshot, ConsensusHash};
-use stacks::chainstate::coordinator::{get_next_recipients, OnChainRewardSetProvider};
+use stacks::chainstate::nakamoto::coordinator::get_nakamoto_next_recipients;
 use stacks::chainstate::nakamoto::NakamotoChainState;
 use stacks::chainstate::stacks::address::PoxAddress;
 use stacks::chainstate::stacks::db::StacksChainState;
@@ -289,7 +289,7 @@ impl RelayerThread {
         self.last_network_download_passes = net_result.num_download_passes;
         self.last_network_inv_passes = net_result.num_inv_sync_passes;
         if self.has_waited_for_latest_blocks() {
-            info!("Relayer: did a download pass, so unblocking mining");
+            debug!("Relayer: did a download pass, so unblocking mining");
             signal_mining_ready(self.globals.get_miner_status());
         }
     }
@@ -414,18 +414,11 @@ impl RelayerThread {
                 .unwrap_or_else(|| VRFProof::empty());
 
         // let's figure out the recipient set!
-        let recipients = get_next_recipients(
-            &sort_tip,
-            &mut self.chainstate,
-            &mut self.sortdb,
-            &self.burnchain,
-            &OnChainRewardSetProvider(),
-            self.config.node.always_use_affirmation_maps,
-        )
-        .map_err(|e| {
-            error!("Relayer: Failure fetching recipient set: {:?}", e);
-            NakamotoNodeError::SnapshotNotFoundForChainTip
-        })?;
+        let recipients = get_nakamoto_next_recipients(&sort_tip, &mut self.sortdb, &self.burnchain)
+            .map_err(|e| {
+                error!("Relayer: Failure fetching recipient set: {:?}", e);
+                NakamotoNodeError::SnapshotNotFoundForChainTip
+            })?;
 
         let block_header =
             NakamotoChainState::get_block_header_by_consensus_hash(self.chainstate.db(), target_ch)
@@ -834,7 +827,7 @@ impl RelayerThread {
 
     /// Top-level dispatcher
     pub fn handle_directive(&mut self, directive: RelayerDirective) -> bool {
-        info!("Relayer: handling directive"; "directive" => %directive);
+        debug!("Relayer: handling directive"; "directive" => %directive);
         let continue_running = match directive {
             RelayerDirective::HandleNetResult(net_result) => {
                 self.process_network_result(net_result);

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -199,7 +199,7 @@ fn advance_to_2_1(
     // these should all succeed across the epoch 2.1 boundary
     for _i in 0..5 {
         let tip_info = get_chain_info(&conf);
-        let pox_info = get_pox_info(&http_origin);
+        let pox_info = get_pox_info(&http_origin).unwrap();
 
         eprintln!(
             "\nPoX info at {}\n{:?}\n\n",
@@ -1573,7 +1573,7 @@ fn transition_removes_pox_sunset() {
     assert_eq!(account.balance, first_bal as u128);
     assert_eq!(account.nonce, 0);
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
 
     assert_eq!(
         &pox_info.contract_id,
@@ -1616,7 +1616,7 @@ fn transition_removes_pox_sunset() {
     }
 
     // pox must activate
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
     eprintln!("pox_info in pox-1 = {:?}", &pox_info);
     assert_eq!(pox_info.current_cycle.is_pox_active, true);
     assert_eq!(
@@ -1631,7 +1631,7 @@ fn transition_removes_pox_sunset() {
         eprintln!("Sort height pox-1: {} <= {}", sort_height, epoch_21);
     }
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
 
     // pox is still "active" despite unlock, because there's enough participation, and also even
     // though the v1 block height has passed, the pox-2 contract won't be managing reward sets
@@ -1676,7 +1676,7 @@ fn transition_removes_pox_sunset() {
         sort_height
     );
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
     assert_eq!(pox_info.current_cycle.is_pox_active, true);
 
     // get pox back online
@@ -1686,7 +1686,7 @@ fn transition_removes_pox_sunset() {
         eprintln!("Sort height pox-2: {}", sort_height);
     }
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
     eprintln!("pox_info = {:?}", &pox_info);
     assert_eq!(pox_info.current_cycle.is_pox_active, true);
 
@@ -1864,7 +1864,7 @@ fn transition_empty_blocks() {
         // also, make *huge* block-commits with invalid marker bytes once we reach the new
         // epoch, and verify that it fails.
         let tip_info = get_chain_info(&conf);
-        let pox_info = get_pox_info(&http_origin);
+        let pox_info = get_pox_info(&http_origin).unwrap();
 
         eprintln!(
             "\nPoX info at {}\n{:?}\n\n",

--- a/testnet/stacks-node/src/tests/epoch_24.rs
+++ b/testnet/stacks-node/src/tests/epoch_24.rs
@@ -984,7 +984,7 @@ fn verify_auto_unlock_behavior() {
         }
         next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
-        let pox_info = get_pox_info(&http_origin);
+        let pox_info = get_pox_info(&http_origin).unwrap();
         info!(
             "curr height: {}, curr cycle id: {}, pox active: {}",
             tip_info.burn_block_height,
@@ -1003,7 +1003,7 @@ fn verify_auto_unlock_behavior() {
         }
         next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
-        let pox_info = get_pox_info(&http_origin);
+        let pox_info = get_pox_info(&http_origin).unwrap();
         info!(
             "curr height: {}, curr cycle id: {}, pox active: {}",
             tip_info.burn_block_height,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -22,6 +22,7 @@ use clarity::vm::costs::ExecutionCost;
 use clarity::vm::types::PrincipalData;
 use lazy_static::lazy_static;
 use stacks::burnchains::MagicBytes;
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::nakamoto::NakamotoChainState;
 use stacks::chainstate::stacks::db::StacksChainState;
@@ -44,7 +45,8 @@ use crate::neon::{Counters, RunLoopCounter};
 use crate::run_loop::boot_nakamoto;
 use crate::tests::make_stacks_transfer;
 use crate::tests::neon_integrations::{
-    next_block_and_wait, run_until_burnchain_height, submit_tx, test_observer, wait_for_runloop,
+    get_account, get_pox_info, next_block_and_wait, run_until_burnchain_height, submit_tx,
+    test_observer, wait_for_runloop,
 };
 use crate::{tests, BitcoinRegtestController, BurnchainController, Config, ConfigFile, Keychain};
 
@@ -697,6 +699,212 @@ fn mine_multiple_per_tenure_integration() {
         block_height_pre_3_0 + ((inter_blocks_per_tenure + 1) * tenure_count),
         "Should have mined (1 + interim_blocks_per_tenure) * tenure_count nakamoto blocks"
     );
+
+    coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    run_loop_stopper.store(false, Ordering::SeqCst);
+
+    run_loop_thread.join().unwrap();
+}
+
+#[test]
+#[ignore]
+fn correct_burn_outs() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
+    naka_conf.burnchain.pox_reward_length = Some(10);
+    naka_conf.burnchain.pox_prepare_length = Some(3);
+
+    {
+        let epochs = naka_conf.burnchain.epochs.as_mut().unwrap();
+        let epoch_24_ix = StacksEpoch::find_epoch_by_id(&epochs, StacksEpochId::Epoch24).unwrap();
+        let epoch_25_ix = StacksEpoch::find_epoch_by_id(&epochs, StacksEpochId::Epoch25).unwrap();
+        let epoch_30_ix = StacksEpoch::find_epoch_by_id(&epochs, StacksEpochId::Epoch30).unwrap();
+        epochs[epoch_24_ix].end_height = 208;
+        epochs[epoch_25_ix].start_height = 208;
+        epochs[epoch_25_ix].end_height = 225;
+        epochs[epoch_30_ix].start_height = 225;
+    }
+
+    naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1000);
+    naka_conf.initial_balances.clear();
+    let accounts: Vec<_> = (0..8)
+        .map(|ix| {
+            let sk = Secp256k1PrivateKey::from_seed(&[ix, ix, ix, ix]);
+            let address = PrincipalData::from(tests::to_addr(&sk));
+            (sk, address)
+        })
+        .collect();
+    for (_, ref addr) in accounts.iter() {
+        naka_conf.add_initial_balance(addr.to_string(), 10000000000000000);
+    }
+
+    let stacker_accounts = accounts[0..3].to_vec();
+
+    test_observer::spawn();
+    let observer_port = test_observer::EVENT_OBSERVER_PORT;
+    naka_conf.events_observers.insert(EventObserverConfig {
+        endpoint: format!("localhost:{observer_port}"),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(naka_conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .expect("Failed starting bitcoind");
+    let mut btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
+    btc_regtest_controller.bootstrap_chain(201);
+
+    let mut run_loop = boot_nakamoto::BootRunLoop::new(naka_conf.clone()).unwrap();
+    let run_loop_stopper = run_loop.get_termination_switch();
+    let Counters {
+        blocks_processed,
+        naka_submitted_vrfs: vrfs_submitted,
+        naka_submitted_commits: commits_submitted,
+        ..
+    } = run_loop.counters();
+
+    let coord_channel = run_loop.coordinator_channels();
+
+    let run_loop_thread = thread::Builder::new()
+        .name("run_loop".into())
+        .spawn(move || run_loop.start(None, 0))
+        .unwrap();
+    wait_for_runloop(&blocks_processed);
+
+    let epochs = naka_conf.burnchain.epochs.clone().unwrap();
+    let epoch_3 = &epochs[StacksEpoch::find_epoch_by_id(&epochs, StacksEpochId::Epoch30).unwrap()];
+    let epoch_25 = &epochs[StacksEpoch::find_epoch_by_id(&epochs, StacksEpochId::Epoch25).unwrap()];
+
+    info!(
+        "Chain bootstrapped to bitcoin block 201, starting Epoch 2x miner";
+        "Epoch 3.0 Boundary" => (epoch_3.start_height - 1),
+    );
+
+    run_until_burnchain_height(
+        &mut btc_regtest_controller,
+        &blocks_processed,
+        epoch_25.start_height + 1,
+        &naka_conf,
+    );
+
+    info!("Chain bootstrapped to Epoch 2.5, submitting stacker transaction");
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
+    let _stacker_thread = thread::Builder::new()
+        .name("stacker".into())
+        .spawn(move || loop {
+            thread::sleep(Duration::from_secs(2));
+            debug!("Checking for stacker-necessity");
+            let Some(pox_info) = get_pox_info(&http_origin) else {
+                warn!("Failed to get pox_info, waiting.");
+                continue;
+            };
+            if !pox_info.contract_id.ends_with(".pox-4") {
+                continue;
+            }
+            let next_cycle_stx = pox_info.next_cycle.stacked_ustx;
+            let min_stx = pox_info.next_cycle.min_threshold_ustx;
+            let min_stx = (min_stx * 3) / 2;
+            if next_cycle_stx >= min_stx {
+                debug!(
+                    "Next cycle has enough stacked, skipping stacking";
+                    "stacked" => next_cycle_stx,
+                    "min" => min_stx,
+                );
+                continue;
+            }
+            let Some(account) = stacker_accounts.iter().find_map(|(sk, addr)| {
+                let account = get_account(&http_origin, &addr);
+                if account.locked == 0 {
+                    Some((sk, addr, account))
+                } else {
+                    None
+                }
+            }) else {
+                continue;
+            };
+
+            let pox_addr_tuple = clarity::vm::tests::execute(&format!(
+                "{{ hashbytes: 0x{}, version: 0x{:02x} }}",
+                tests::to_addr(&account.0).bytes.to_hex(),
+                AddressHashMode::SerializeP2PKH as u8,
+            ));
+
+            let stacking_tx = tests::make_contract_call(
+                &account.0,
+                account.2.nonce,
+                1000,
+                &StacksAddress::burn_address(false),
+                "pox-4",
+                "stack-stx",
+                &[
+                    clarity::vm::Value::UInt(min_stx.into()),
+                    pox_addr_tuple,
+                    clarity::vm::Value::UInt(pox_info.current_burnchain_block_height.into()),
+                    clarity::vm::Value::UInt(1),
+                ],
+            );
+            let txid = submit_tx(&http_origin, &stacking_tx);
+            info!("Submitted stacking transaction: {txid}");
+            thread::sleep(Duration::from_secs(10));
+        })
+        .unwrap();
+
+    run_until_burnchain_height(
+        &mut btc_regtest_controller,
+        &blocks_processed,
+        epoch_3.start_height - 1,
+        &naka_conf,
+    );
+
+    info!("Bootstrapped to Epoch-3.0 boundary, Epoch2x miner should stop");
+
+    // first block wakes up the run loop, wait until a key registration has been submitted.
+    next_block_and(&mut btc_regtest_controller, 60, || {
+        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
+        Ok(vrf_count >= 1)
+    })
+    .unwrap();
+
+    // second block should confirm the VRF register, wait until a block commit is submitted
+    next_block_and(&mut btc_regtest_controller, 60, || {
+        let commits_count = commits_submitted.load(Ordering::SeqCst);
+        Ok(commits_count >= 1)
+    })
+    .unwrap();
+
+    info!("Bootstrapped to Epoch-3.0 boundary, mining nakamoto blocks");
+
+    let burnchain = naka_conf.get_burnchain();
+    let sortdb = burnchain.open_sortition_db(true).unwrap();
+
+    // Mine nakamoto tenures
+    for _i in 0..30 {
+        if let Err(e) = next_block_and_mine_commit(
+            &mut btc_regtest_controller,
+            30,
+            &coord_channel,
+            &commits_submitted,
+        ) {
+            warn!(
+                "Error while minting a bitcoin block and waiting for stacks-node activity: {e:?}"
+            );
+        }
+
+        let tip_sn = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+        assert!(
+            tip_sn.sortition,
+            "The new chain tip must have had a sortition"
+        );
+    }
 
     coord_channel
         .lock()

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1169,15 +1169,10 @@ pub fn get_account<F: std::fmt::Display>(http_origin: &str, account: &F) -> Acco
     }
 }
 
-pub fn get_pox_info(http_origin: &str) -> RPCPoxInfoData {
+pub fn get_pox_info(http_origin: &str) -> Option<RPCPoxInfoData> {
     let client = reqwest::blocking::Client::new();
     let path = format!("{}/v2/pox", http_origin);
-    client
-        .get(&path)
-        .send()
-        .unwrap()
-        .json::<RPCPoxInfoData>()
-        .unwrap()
+    client.get(&path).send().ok()?.json::<RPCPoxInfoData>().ok()
 }
 
 fn get_chain_tip(http_origin: &str) -> (ConsensusHash, BlockHeaderHash) {
@@ -6067,7 +6062,7 @@ fn pox_integration_test() {
     assert_eq!(account.balance, first_bal as u128);
     assert_eq!(account.nonce, 0);
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
 
     assert_eq!(
         &pox_info.contract_id,
@@ -6135,7 +6130,7 @@ fn pox_integration_test() {
         eprintln!("Sort height: {}", sort_height);
     }
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
 
     assert_eq!(
         &pox_info.contract_id,
@@ -6266,7 +6261,7 @@ fn pox_integration_test() {
         eprintln!("Sort height: {}", sort_height);
     }
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
 
     assert_eq!(
         &pox_info.contract_id,
@@ -6321,7 +6316,7 @@ fn pox_integration_test() {
         eprintln!("Sort height: {}", sort_height);
     }
 
-    let pox_info = get_pox_info(&http_origin);
+    let pox_info = get_pox_info(&http_origin).unwrap();
 
     assert_eq!(
         &pox_info.contract_id,


### PR DESCRIPTION
### Description

This PR fixes the "burn output" selection in the nakamoto-node to use `get_nakamoto_next_recipients()`. It also includes a refactor of the `get_reward_set()` invocations in nakamoto to pass in the cycle start height (as is done in 2.x) rather than "current burn height". This eliminates the need for the `+ 1` in the reward cycle number (commit eee3f20e78842abe0bb68eaf8fe60f70a3f49917)

### Additional info (benefits, drawbacks, caveats)

* Includes a test with alternating stackers, this ensures that the reward set changes between each cycle. Improper handling of `get_next_recipients()` would cause a block-commit to be rejected (and the test to fail).
