### PR TITLE
Make all miner settings configurable at runtime

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [alias]
 stacks-node = "run --package stacks-node --"
+fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 
 # Needed by perf to generate flamegraphs.
 #[target.x86_64-unknown-linux-gnu]

--- a/.github/actions/bitcoin-int-tests/Dockerfile.rustfmt
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.rustfmt
@@ -4,9 +4,10 @@ WORKDIR /src
 
 COPY ./rust-toolchain .
 COPY ./Cargo.toml .
+COPY ./.cargo .
 
 RUN rustup component add rustfmt
 
 COPY . .
 
-RUN cargo fmt --all -- --check
+RUN cargo fmt-stacks --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+- All miner-related settings can be changed in the config file and take effect
+  without a node restart (#4223)
+
 ## [2.4.0.0.4]
 
 This is a high-priority hotfix that addresses a bug in transaction processing which

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,24 @@ should reference the issue in the commit message. For example:
 fix: incorporate unlocks in mempool admitter, #3623
 ```
 
+## Recommended developer setup
+### Recommended githooks
+
+It is helpful to set up the pre-commit git hook set up, so that Rust formatting issues are caught before
+you push your code. Follow these instruction to set it up:
+
+1. Rename `.git/hooks/pre-commit.sample` to `.git/hooks/pre-commit`
+2. Change the content of `.git/hooks/pre-commit` to be the following
+```sh
+#!/bin/sh
+git diff --name-only --staged | grep '\.rs$' | xargs -P 8 -I {} rustfmt {} --edition 2021 --check --config group_imports=StdExternalCrate,imports_granularity=Module || (
+  echo 'rustfmt failed: run "cargo fmt-stacks"';
+  exit 1
+)
+```
+3. Make it executable by running `chmod +x .git/hooks/pre-commit`
+   That's it! Now your pre-commit hook should be configured on your local machine.
+
 # Creating and Reviewing PRs
 
 This section describes some best practices on how to create and review PRs in this context.  The target audience is people who have commit access to this repository (reviewers), and people who open PRs (submitters).  This is a living document -- developers can and should document their own additional guidelines here.
@@ -366,19 +384,20 @@ A test should be marked `#[ignore]` if:
 
 ## Formatting
 
-This repository uses the default rustfmt formatting style. PRs will be checked against `rustfmt` and will _fail_ if not
-properly formatted.
+PRs will be checked against `rustfmt` and will _fail_ if not properly formatted.
+Unfortunately, some config options that we require cannot currently be set in `.rustfmt` files, so arguments must be passed via the command line.
+Therefore, we handle `rustfmt` configuration using a Cargo alias: `cargo fmt-stacks`
 
 You can check the formatting locally via:
 
 ```bash
-cargo fmt --all -- --check --config group_imports=StdExternalCrate
+cargo fmt-stacks --check
 ```
 
 You can automatically reformat your commit via:
 
 ```bash
-cargo fmt --all -- --config group_imports=StdExternalCrate
+cargo fmt-stacks
 ```
 
 ## Comments

--- a/contrib/side-cars/config/fee-estimate.json
+++ b/contrib/side-cars/config/fee-estimate.json
@@ -1,0 +1,4 @@
+{
+    "toml_file_location": "Path/To/miner.toml",
+    "polling_delay_seconds": 60
+}

--- a/contrib/side-cars/config/stacks-block-delay-event-trigger.json
+++ b/contrib/side-cars/config/stacks-block-delay-event-trigger.json
@@ -1,0 +1,6 @@
+{
+    "polling_delay_seconds": 60,
+    "max_stacks_delay_seconds": 1500,
+    "recovery_delay_seconds": 660,
+    "shell_command": ["echo", "command not specified"]
+}

--- a/contrib/side-cars/fee-estimate.py
+++ b/contrib/side-cars/fee-estimate.py
@@ -23,7 +23,7 @@ from sys import argv
 FEE_ESTIMATIONS = [
     # Bitcoiner Live API
     (
-        'https://bitcoiner.live/api/fees/estimates/latest',
+        'https://bitcoiner.live/api/fees/estimates/latest?confidence=0.9',
         lambda response_json: response_json["estimates"]["30"]["sat_per_vbyte"],
     ),
 

--- a/contrib/side-cars/fee-estimate.py
+++ b/contrib/side-cars/fee-estimate.py
@@ -1,0 +1,188 @@
+"""
+Script to continuously update the `satoshis_per_byte` value in a TOML file with the
+mean fee estimate from a list of API endpoints.
+
+Usage:
+    $ COMMAND /path/to/miner.toml polling_delay_seconds
+
+Args:
+    toml_file_location (str): The path to the TOML file to update.
+    polling_delay_seconds (int): The frequency in seconds to check for fee updates.
+"""
+
+import toml
+import json
+import requests
+import time
+from backoff_utils import strategies
+from backoff_utils import apply_backoff
+from sys import argv
+
+# Fee estimation API URLS and their corresponding fee extraction functions.
+# At least one of these needs to be working in order for the script to function.
+FEE_ESTIMATIONS = [
+    # Bitcoiner Live API
+    (
+        'https://bitcoiner.live/api/fees/estimates/latest',
+        lambda response_json: response_json["estimates"]["30"]["sat_per_vbyte"],
+    ),
+
+    # Mempool Space API
+    (
+        'https://mempool.space/api/v1/fees/recommended',
+        lambda response_json: response_json["halfHourFee"],
+    ),
+
+    # Blockchain.info API
+    (
+        'https://api.blockchain.info/mempool/fees',
+        lambda response_json: response_json["regular"],
+    ),
+]
+
+def calculate_fee_estimate():
+    """
+    Calculates the mean fee estimate from a list of API URLs
+    and their corresponding fee extraction functions.
+
+    Args:
+        FEE_ESTIMATIONS (list): A list of tuples, where each tuple
+        contains the URL of an API endpoint and a function that extracts
+        the fee estimate from the JSON response.
+
+    Returns:
+        int: The mean fee estimate in sat/Byte.
+
+    Raises:
+        None
+    """
+
+    # Gather all API estimated fees in sat/Byte
+    estimated_fees = []
+    for api_url, unpack_fee_estimate in FEE_ESTIMATIONS:
+
+        try:
+            json_response = json.loads(get_from_api(api_url))
+            estimated_fee = unpack_fee_estimate(json_response)
+            estimated_fees.append(estimated_fee)
+
+        except Exception as e:
+            pass
+
+    # Calculate the mean fee estimate
+    mean_fee = int(sum(estimated_fees) / len(estimated_fees))
+
+    return mean_fee
+
+@apply_backoff(
+    strategy=strategies.Exponential,
+    catch_exceptions=(RuntimeError,),
+    max_tries=3,
+    max_delay=60,
+)
+def get_from_api(api_url: str) -> str:
+    """
+    Sends a GET request to the specified API URL and returns the string response.
+
+    Args:
+        api_url (str): The URL of the API endpoint to call.
+
+    Returns:
+        dict: The string response data.
+
+    Raises:
+        RuntimeError: If the API call fails.
+    """
+
+    try:
+        # Make a GET request to the API endpoint
+        response = requests.get(api_url)
+
+        # Check if the request was successful
+        if response.status_code == 200:
+            # Parse the response and return the data
+            return response.text
+
+    except Exception as e:
+        # If an exception occurs, raise a RuntimeError
+        raise RuntimeError("Failed to unpack JSON.")
+
+    # If the code reaches this point, it means the API call failed.
+    raise RuntimeError("Failed to get response.")
+
+
+def update_config_fee(toml_file_location: str, polling_delay_seconds: int):
+    """
+    Updates the `satoshis_per_byte` value in the specified TOML file
+    with the mean fee estimate from a list of API endpoints.
+
+    Args:
+        toml_file_location (str): The path to the TOML file to update.
+
+    Raises:
+        IOError: If the TOML file cannot be read or written.
+        RuntimeError: If the fee estimation process fails.
+    """
+
+    while True:
+        # Calculate mean fee estimate from the list of APIs
+        fee_estimate = calculate_fee_estimate()
+
+        # Read toml file data
+        with open(toml_file_location, 'r') as toml_file:
+            toml_data = toml.load(toml_file)
+
+        # Update satoshis_per_byte data
+        toml_data["burnchain"]["satoshis_per_byte"] = fee_estimate
+
+        # Update toml file with configuration changes
+        with open(toml_file_location, 'w') as toml_file:
+            toml.dump(toml_data, toml_file)
+
+        time.sleep()
+
+def read_config(config_location: str):
+    """
+    Reads and returns the contents of a configuration file.
+    """
+    with open(config_location, "r") as config_file:
+        return json.load(config_file)
+
+def main():
+    """
+    Continuously updates the `satoshis_per_byte` value in the specified
+    TOML file with the mean fee estimate from a list of API endpoints.
+
+    Usage:
+        $ {argv[0]} /path/to/miner.toml polling_delay
+    """
+
+    try:
+        configuration = {}
+
+        if len(argv) == 1:
+            configuration = read_config("./config/fee-estimate.json")
+        elif "-c" in argv:
+            # Load configuration from specified file
+            config_location = argv[argv.index("-c") + 1]
+            configuration = read_config(config_location)
+        else:
+            # Load configuration from command-line arguments
+            configuration = {
+                "toml_file_location": argv[1],
+                "polling_delay_seconds": int(argv[2]),
+            }
+
+        update_config_fee(**configuration)
+
+    # Print usage if there are errors.
+    except Exception as e:
+        print(f"Failed to run {argv[0]}")
+        print(f"\n\t$ COMMAND /path/to/miner.toml polling_delay_seconds")
+        print("\t\tOR")
+        print(f"\t$ COMMAND -c /path/to/config_file.json\n")
+        print(f"Error: {e}")
+
+# Execute main.
+if __name__ == "__main__":
+    main()

--- a/contrib/side-cars/fee-estimate.py
+++ b/contrib/side-cars/fee-estimate.py
@@ -139,7 +139,7 @@ def update_config_fee(toml_file_location: str, polling_delay_seconds: int):
         with open(toml_file_location, 'w') as toml_file:
             toml.dump(toml_data, toml_file)
 
-        time.sleep()
+        time.sleep(polling_delay_seconds)
 
 def read_config(config_location: str):
     """

--- a/contrib/side-cars/fee-estimate.sh
+++ b/contrib/side-cars/fee-estimate.sh
@@ -3,9 +3,14 @@
 ####################################
 # Usage
 # 
+# $ # one-shot fee-rate calculation
 # $ ./fee-estimate.sh
 # 161
 # 
+# $ # Check fees every 5 seconds and update `satoshis_per_byte` in `/path/to/miner.toml`
+# $ ./fee-estimate.sh watch /path/to/miner.toml 5
+# 
+# $ # Run unit tests and report result (0 means success)
 # $ ./fee-estimate.sh test; echo $?
 # 0
 ####################################

--- a/contrib/side-cars/fee-estimate.sh
+++ b/contrib/side-cars/fee-estimate.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+####################################
+# Usage
+# 
+# $ ./fee-estimate.sh
+# 161
+# 
+# $ ./fee-estimate.sh test; echo $?
+# 0
+####################################
+
+set -uoe pipefail
+
+function exit_error() {
+   echo >&2 "$@"
+   exit 1
+}
+
+####################################
+# Dependencies
+####################################
+# Dependencies
+for cmd in curl jq bc sed date grep; do
+   command -v "$cmd" >/dev/null 2>&1 || exit_error "Command not found: '$cmd'"
+done
+
+
+####################################
+# Functions
+####################################
+
+# Convert a fee/kb to fee/vbyte.
+# If there's a fractional part of the fee/kb (i.e. if it's not divisible by 1000),
+# then round up.
+# Arguments:
+#   $1 -- the fee per kb
+# Stdout: the satoshis per vbyte, as an integer
+# Stderr: none
+# Return:
+#   0 on success
+#   nonzero on error
+function fee_per_kb_to_fee_per_vbyte() {
+   local fee_per_kb="$1"
+   local fee_per_vbyte_float=
+   local fee_per_vbyte_ipart=
+   local fee_per_vbyte_fpart=
+   local fee_per_vbyte=
+
+   # must be an integer
+   if ! [[ "$fee_per_kb" =~ ^[0-9]+$ ]]; then
+      exit_error "Did not receive a fee/kb from $fee_endpoint, but got '$fee_per_kb'"
+   fi
+
+   # NOTE: round up -- get the fractional part, and if it's anything other than 000, then add 1
+   fee_per_vbyte_float="$(echo "scale=3; $fee_per_kb / 1000" | bc)"
+   fee_per_vbyte_ipart="$(echo "$fee_per_vbyte_float" | sed -r 's/^([0-9]*)\..+$/\1/g')"
+   fee_per_vbyte_fpart="$(echo "$fee_per_vbyte_float" | sed -r -e 's/.+\.([0-9]+)$/\1/g' -e 's/0//g')"
+   fee_per_vbyte="$fee_per_vbyte_ipart"
+   if [ -n "$fee_per_vbyte_fpart" ]; then
+      fee_per_vbyte="$((fee_per_vbyte + 1))"
+   fi
+
+   echo "$fee_per_vbyte"
+   return 0
+}
+
+# Determine satoshis per vbyte
+# Arguments: none
+# Stdout: the satoshis per vbyte, as an integer
+# Stderr: none
+# Return:
+#   0 on success
+#   nonzero on error
+function get_sats_per_vbyte() {
+   local fee_endpoint="https://api.blockcypher.com/v1/btc/main"
+   local fee_per_kb=
+
+   fee_per_kb="$(curl -sL "$fee_endpoint" | jq -r '.high_fee_per_kb')"
+   fee_per_kb_to_fee_per_vbyte "$fee_per_kb"
+   return 0
+}
+
+# Update the fee rate in the config file.
+# Arguments:
+#   $1 -- path to the config file
+#   $2 -- new fee to write
+# Stdout: (none)
+# Stderr: (none)
+# Returns:
+#   0 on success
+#   nonzero on error
+function update_fee() {
+   local config_path="$1"
+   local fee="$2"
+   sed -i -r "s/satoshis_per_byte[ \t]+=.*$/satoshis_per_byte = ${fee}/g" "$config_path"
+   return 0
+}
+
+# Poll fees every so often, and update a config file.
+# Runs indefinitely.
+# If the fee estimator endpoint cannot be reached, then the file is not modified.
+# Arguments:
+#   $1 -- path to file to watch
+#   $2 -- interval at which to poll, in seconds
+# Stdout: (none)
+# Stderr: (none)
+# Returns: (none)
+function watch_fees() {
+   local config_path="$1"
+   local interval="$2"
+
+   local fee=
+   local rc=
+
+   while true; do
+      # allow poll command to fail without killing the script
+      set +e
+      fee="$(get_sats_per_vbyte)"
+      rc="$?"
+      set -e
+
+      if [ $rc -ne 0 ]; then
+         echo >&2 "WARN[$(date +%s)]: failed to poll fees"
+      else
+         update_fee "$config_path" "$fee"
+      fi
+      sleep "$interval"
+   done
+}
+
+# Unit tests
+function unit_test() {
+   local test_config="/tmp/test-miner-config-$$.toml"
+   if [ "$(fee_per_kb_to_fee_per_vbyte 1000)" != "1" ]; then
+      exit_error "failed -- 1000 sats/kbyte != 1 sats/vbyte"
+   fi
+
+   if [ "$(fee_per_kb_to_fee_per_vbyte 1001)" != "2" ]; then
+      exit_error "failed -- 1001 sats/vbyte != 2 sats/vbyte"
+   fi
+
+   if [ "$(fee_per_kb_to_fee_per_vbyte 999)" != "1" ]; then 
+      exit_error "failed -- 999 sats/vbyte != 1 sats/vbyte"
+   fi
+
+   echo "satoshis_per_byte = 123" > "$test_config"
+   update_fee "$test_config" "456"
+   if ! grep 'satoshis_per_byte = 456' >/dev/null "$test_config"; then
+      exit_error "failed -- did not update satoshis_per_byte"
+   fi
+  
+   echo "" > "$test_config"
+   update_fee "$test_config" "456"
+   if grep "satoshis_per_byte" "$test_config" >/dev/null; then
+      exit_error "failed -- updated satoshis_per_byte in a config file without it"
+   fi
+
+   rm "$test_config"
+   return 0
+}
+
+####################################
+# Entry point
+####################################
+
+# Main body
+# Arguments
+#   $1: mode of operation.  Can be "test" or empty
+# Stdout: the fee rate, in sats/vbte
+# Stderr: None
+# Return: (no return)
+function main() {
+   local mode="$1"
+   local config_path=
+   local interval=
+
+   case "$mode" in
+      "test")
+         # run unit tests
+         echo "Run unit tests"
+         unit_test
+         exit 0
+         ;;
+      "watch")
+         # watch and update the file
+         if (( $# < 3 )); then
+            exit_error "Usage: $0 watch /path/to/miner.toml interval_in_seconds"
+         fi
+         
+         config_path="$2"
+         interval="$3"
+
+         watch_fees "$config_path" "$interval"
+         ;;
+
+      "")
+         # one-shot
+         get_sats_per_vbyte
+         ;;
+   esac
+   exit 0
+}
+
+if (( $# > 0 )); then
+   # got arguments
+   main "$@"
+else
+   # no arguments
+   main ""
+fi

--- a/contrib/side-cars/stacks-block-delay-event-trigger.py
+++ b/contrib/side-cars/stacks-block-delay-event-trigger.py
@@ -1,0 +1,226 @@
+"""
+Monitors the time difference between Stacks blocks and Bitcoin blocks, triggering an event
+when the time difference exceeds a specified threshold.
+
+This script continuously checks the time difference between the latest Stacks
+block and the latest Bitcoin block. If the time difference exceeds a user-defined
+threshold, the script executes a user-defined shell command. The script utilizes
+exponential backoff with retries and a maximum delay to handle temporary API outages.
+
+Usage:
+
+    $ COMMAND polling_delay_seconds max_stacks_delay_seconds recovery_delay_seconds shell_command...
+
+    OR
+
+    $ COMMAND -c /path/to/config_file
+
+Options:
+
+    polling_delay_seconds: The time interval between checking the time difference,
+        in seconds.
+    max_stacks_delay_seconds: The maximum acceptable time difference between
+        Stacks and Bitcoin blocks, in seconds.
+    recovery_delay_seconds: The delay after executing the shell command before
+        resuming monitoring, in seconds.
+    shell_command: The shell command to execute when the time difference exceeds
+        the threshold.
+
+Alternatively, you can provide a configuration file using the -c option.
+The configuration file should be a JSON file with the following fields:
+
+```json
+{
+    "polling_delay_seconds": <int>,
+    "max_stacks_delay_seconds": <int>,
+    "recovery_delay_seconds": <int>,
+    "shell_command": <list[str]>
+}
+```
+
+Example:
+```json
+{
+  "polling_delay_seconds": 60,
+  "max_stacks_delay_seconds": 60,
+  "recovery_delay_seconds": 60,
+  "shell_command": ["echo", "hello, world!"],
+}
+```
+"""
+
+import toml
+import json
+import requests
+import time
+from backoff_utils import strategies
+from backoff_utils import apply_backoff
+from datetime import datetime
+from sys import argv
+import subprocess
+
+# Stacks API endpoints.
+API_URL_LATEST_STACKS_BLOCK = "https://api.mainnet.hiro.so/extended/v1/block?limit=1"
+API_URL_LATEST_STACKS_TRANSACTION = "https://api.mainnet.hiro.so/extended/v1/tx/{transaction_id}"
+
+# Bitcoin API endpoints.
+API_URL_LATEST_BTC_BLOCK_HASH = "https://mempool.space/api/blocks/tip/hash"
+API_URL_BTC_BLOCK_FROM_HASH = "https://mempool.space/api/block/{block_hash}"
+
+@apply_backoff(
+    strategy=strategies.Exponential,
+    catch_exceptions=(RuntimeError,),
+    max_tries=3,
+    max_delay=60,
+)
+def get_from_api(api_url: str) -> dict:
+    """
+    Sends a GET request to the specified API URL and returns the string response.
+
+    Args:
+        api_url (str): The URL of the API endpoint to call.
+
+    Returns:
+        dict: The string response data.
+
+    Raises:
+        RuntimeError: If the API call fails or the response cannot be parsed as JSON.
+    """
+
+    try:
+        # Make a GET request to the API endpoint
+        response = requests.get(api_url)
+
+        # Check if the request was successful
+        if response.status_code == 200:
+            # Parse the response and return the data
+            return response.text
+
+    except Exception as e:
+        # If an exception occurs, raise a RuntimeError
+        raise RuntimeError("Failed to unpack JSON.")
+
+    # If the code reaches this point, it means the API call failed.
+    raise RuntimeError("Failed to get response.")
+
+
+def get_latest_bitcoin_block_timestamp() -> int:
+    """
+    Retrieves the timestamp of the latest Bitcoin block.
+
+    Returns:
+        int: The timestamp of the latest Bitcoin block.
+    """
+
+    latest_btc_block_hash = get_from_api(API_URL_LATEST_BTC_BLOCK_HASH)
+    json_response = json.loads(get_from_api(
+        API_URL_BTC_BLOCK_FROM_HASH.format(block_hash=latest_btc_block_hash)))
+    return json_response["timestamp"]
+
+
+def get_latest_stacks_block_timestamp() -> int:
+    """
+    Retrieves the timestamp of the latest Stacks block.
+
+    Returns:
+        int: The timestamp of the latest Stacks block.
+    """
+
+    latest_stacks_block_json = json.loads(get_from_api(API_URL_LATEST_STACKS_BLOCK))
+    return latest_stacks_block_json["results"][0]["burn_block_time"]
+
+def stacks_block_delay_event_listener(
+    polling_delay_seconds: int,
+    max_stacks_delay_seconds: int,
+    recovery_delay_seconds: int,
+    shell_command: list[str],
+):
+    """
+    Continuously monitors the time between Stacks blocks and Bitcoin blocks.
+
+    If the time difference exceeds a specified threshold, the script executes
+    a user-defined shell command. The script utilizes exponential backoff with
+    retries and a maximum delay to handle temporary API outages.
+
+    Args:
+        polling_delay_seconds (int): The time interval between checking the
+            time difference, in seconds (default: 60).
+        max_stacks_delay_seconds (int): The maximum acceptable time difference
+            between Stacks and Bitcoin blocks, in seconds (default: 60).
+        recovery_delay_seconds (int): The delay after executing the shell
+            command before resuming monitoring, in seconds (default: 60).
+        shell_command (list[str]): The shell command to execute when the time
+            difference exceeds the threshold (default: ["echo", "hello"]).
+    """
+
+    while True:
+
+        # Continuously retrieve the timestamps of the latest Stacks and Bitcoin blocks.
+        latest_stacks_block_timestamp = get_latest_stacks_block_timestamp()
+        latest_bitcoin_block_timestamp = get_latest_bitcoin_block_timestamp()
+
+        # Calculate the time difference between the latest Stacks and Bitcoin blocks.
+        stacks_block_delay = datetime.fromtimestamp(latest_bitcoin_block_timestamp) - \
+            datetime.fromtimestamp(latest_stacks_block_timestamp)
+
+        # If the time difference exceeds the specified threshold execute the shell command.
+        if stacks_block_delay.seconds > max_stacks_delay_seconds:
+            print(f"Delay between stacks and bitcoin block: {stacks_block_delay}")
+            print(f"$ {' '.join(shell_command)}")
+
+            subprocess.run(shell_command, shell=True)
+            time.sleep(recovery_delay_seconds) # Wait for the recovery period before resuming monitoring.
+
+        # If the time difference is within the acceptable range wait for the polling interval.
+        else:
+            time.sleep(polling_delay_seconds)
+
+def read_config(config_location: str):
+    """
+    Reads and returns the contents of a configuration file.
+    """
+    with open(config_location, "r") as config_file:
+        return json.load(config_file)
+
+def main():
+    """
+    Continuously monitors the time between Stacks blocks and Bitcoin blocks,
+    triggering an event when thresholds are exceeded.
+
+    If the time difference exceeds a specified threshold, the script executes
+    a user-defined shell command. It utilizes exponential backoff with
+    retries and a maximum delay to handle temporary API outages.
+    """
+
+    try:
+        configuration = {}
+
+        if len(argv) == 1:
+            configuration = read_config("./config/stacks-block-delay-event-trigger.json")
+        elif "-c" in argv:
+            # Load configuration from specified file
+            config_location = argv[argv.index("-c") + 1]
+            configuration = read_config(config_location)
+
+        else:
+            # Load configuration from command-line arguments
+            configuration = {
+                "polling_delay_seconds": int(argv[1]),
+                "max_stacks_delay_seconds": int(argv[2]),
+                "recovery_delay_seconds": int(argv[3]),
+                "shell_command": argv[4:],
+            }
+
+        stacks_block_delay_event_listener(**configuration)
+
+    # Print usage if there are errors.
+    except Exception as e:
+        print(f"Failed to run {argv[0]}")
+        print(f"\n\t$ COMMAND polling_delay_seconds max_stacks_delay_seconds recovery_delay_seconds shell_command...")
+        print("\t\tOR")
+        print(f"\t$ COMMAND -c /path/to/config_file.json\n")
+        print(f"Error: {e}")
+
+# Execute main.
+if __name__ == "__main__":
+    main()

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -162,6 +162,64 @@ pub fn make_bitcoin_indexer(config: &Config) -> BitcoinIndexer {
     burnchain_indexer
 }
 
+pub fn get_satoshis_per_byte(config: &Config) -> u64 {
+    match config.get_burnchain_config() {
+        Ok(s) => s.satoshis_per_byte,
+        Err(_) => {
+            info!("No config found. Using previous configuration.");
+            config.burnchain.satoshis_per_byte
+        }
+    }
+}
+
+pub fn get_rbf_fee_increment(config: &Config) -> u64 {
+    match config.get_burnchain_config() {
+        Ok(s) => s.rbf_fee_increment,
+        Err(_) => {
+            info!("No config found. Using previous configuration.");
+            config.burnchain.rbf_fee_increment
+        }
+    }
+}
+
+pub fn get_max_rbf(config: &Config) -> u64 {
+    match config.get_burnchain_config() {
+        Ok(s) => s.max_rbf,
+        Err(_) => {
+            info!("No config found. Using previous configuration.");
+            config.burnchain.max_rbf
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::DEFAULT_SATS_PER_VB;
+
+    use super::*;
+    use std::env::temp_dir;
+    use std::fs::File;
+    use std::io::Write;
+
+    #[test]
+    fn test_get_satoshis_per_byte() {
+        let dir = temp_dir();
+        let file_path = dir.as_path().join("config.toml");
+
+        let mut config = Config::default();
+
+        let satoshis_per_byte = get_satoshis_per_byte(&config);
+        assert_eq!(satoshis_per_byte, DEFAULT_SATS_PER_VB);
+
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "[burnchain]").unwrap();
+        writeln!(file, "satoshis_per_byte = 51").unwrap();
+        config.config_path = Some(file_path.to_str().unwrap().to_string());
+
+        assert_eq!(get_satoshis_per_byte(&config), 51);
+    }
+}
+
 impl LeaderBlockCommitFees {
     pub fn fees_from_previous_tx(
         &self,
@@ -171,7 +229,7 @@ impl LeaderBlockCommitFees {
         let mut fees = LeaderBlockCommitFees::estimated_fees_from_payload(payload, config);
         fees.spent_in_attempts = cmp::max(1, self.spent_in_attempts);
         fees.final_size = self.final_size;
-        fees.fee_rate = self.fee_rate + config.burnchain.rbf_fee_increment;
+        fees.fee_rate = self.fee_rate + get_rbf_fee_increment(&config);
         fees.is_rbf_enabled = true;
         fees
     }
@@ -190,7 +248,7 @@ impl LeaderBlockCommitFees {
         let value_per_transfer = payload.burn_fee / number_of_transfers;
         let sortition_fee = value_per_transfer * number_of_transfers;
         let spent_in_attempts = 0;
-        let fee_rate = config.burnchain.satoshis_per_byte;
+        let fee_rate = get_satoshis_per_byte(&config);
         let default_tx_size = config.burnchain.block_commit_tx_estimated_size;
 
         LeaderBlockCommitFees {
@@ -802,8 +860,9 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
 
-        let btc_miner_fee = self.config.burnchain.leader_key_tx_estimated_size
-            * self.config.burnchain.satoshis_per_byte;
+        // reload the config to find satoshis_per_byte changes
+        let satoshis_per_byte = get_satoshis_per_byte(&self.config);
+        let btc_miner_fee = self.config.burnchain.leader_key_tx_estimated_size * satoshis_per_byte;
         let budget_for_outputs = DUST_UTXO_LIMIT;
         let total_required = btc_miner_fee + budget_for_outputs;
 
@@ -831,7 +890,7 @@ impl BitcoinRegtestController {
 
         tx.output = vec![consensus_output];
 
-        let fee_rate = self.config.burnchain.satoshis_per_byte;
+        let fee_rate = get_satoshis_per_byte(&self.config);
 
         self.finalize_tx(
             epoch_id,
@@ -925,7 +984,6 @@ impl BitcoinRegtestController {
     ) -> Option<Transaction> {
         let public_key = signer.get_public_key();
         let max_tx_size = 230;
-
         let (mut tx, mut utxos) = if let Some(utxo) = utxo_to_use {
             (
                 Transaction {
@@ -943,7 +1001,7 @@ impl BitcoinRegtestController {
             self.prepare_tx(
                 epoch_id,
                 &public_key,
-                DUST_UTXO_LIMIT + max_tx_size * self.config.burnchain.satoshis_per_byte,
+                DUST_UTXO_LIMIT + max_tx_size * get_satoshis_per_byte(&self.config),
                 None,
                 None,
                 0,
@@ -977,7 +1035,7 @@ impl BitcoinRegtestController {
             DUST_UTXO_LIMIT,
             0,
             max_tx_size,
-            self.config.burnchain.satoshis_per_byte,
+            get_satoshis_per_byte(&self.config),
             &mut utxos,
             signer,
         )?;
@@ -1026,7 +1084,7 @@ impl BitcoinRegtestController {
             self.prepare_tx(
                 epoch_id,
                 &public_key,
-                DUST_UTXO_LIMIT + max_tx_size * self.config.burnchain.satoshis_per_byte,
+                DUST_UTXO_LIMIT + max_tx_size * get_satoshis_per_byte(&self.config),
                 None,
                 None,
                 0,
@@ -1060,7 +1118,7 @@ impl BitcoinRegtestController {
             DUST_UTXO_LIMIT,
             0,
             max_tx_size,
-            self.config.burnchain.satoshis_per_byte,
+            get_satoshis_per_byte(&self.config),
             &mut utxos,
             signer,
         )?;
@@ -1095,7 +1153,7 @@ impl BitcoinRegtestController {
         let public_key = signer.get_public_key();
         let max_tx_size = 280;
 
-        let output_amt = DUST_UTXO_LIMIT + max_tx_size * self.config.burnchain.satoshis_per_byte;
+        let output_amt = DUST_UTXO_LIMIT + max_tx_size * get_satoshis_per_byte(&self.config);
         let (mut tx, mut utxos) =
             self.prepare_tx(epoch_id, &public_key, output_amt, None, None, 0)?;
 
@@ -1124,7 +1182,7 @@ impl BitcoinRegtestController {
             output_amt,
             0,
             max_tx_size,
-            self.config.burnchain.satoshis_per_byte,
+            get_satoshis_per_byte(&self.config),
             &mut utxos,
             signer,
         )?;
@@ -1322,11 +1380,11 @@ impl BitcoinRegtestController {
 
         // Stop as soon as the fee_rate is ${self.config.burnchain.max_rbf} percent higher, stop RBF
         if ongoing_op.fees.fee_rate
-            > (self.config.burnchain.satoshis_per_byte * self.config.burnchain.max_rbf / 100)
+            > (get_satoshis_per_byte(&self.config) * get_max_rbf(&self.config) / 100)
         {
             warn!(
                 "RBF'd block commits reached {}% satoshi per byte fee rate, not resubmitting",
-                self.config.burnchain.max_rbf
+                get_max_rbf(&self.config)
             );
             self.ongoing_block_commit = Some(ongoing_op);
             return None;

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -414,7 +414,7 @@ impl Config {
     /// just return a clone of the current config.
     fn reload_config(&self) -> Result<Config, String> {
         let Some(path) = &self.config_path else {
-            return self.clone();
+            return Ok(self.clone());
         };
         let config_file = ConfigFile::from_path(path.as_str())?;
         Config::from_config_file(config_file)
@@ -1300,12 +1300,7 @@ impl Config {
         microblocks: bool,
         miner_status: Arc<Mutex<MinerStatus>>,
     ) -> BlockBuilderSettings {
-        let miner_config = if let Ok(miner_config) = self.get_miner_config() {
-            miner_config
-        } else {
-            self.miner.clone()
-        };
-
+        let miner_config = self.get_miner_config();
         BlockBuilderSettings {
             max_miner_time_ms: if microblocks {
                 miner_config.microblock_attempt_time_ms

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -414,18 +414,18 @@ impl Config {
     /// just return a clone of the current config.
     fn reload_config(&self) -> Result<Config, String> {
         let Some(path) = &self.config_path else {
-            return self.clone()
+            return self.clone();
         };
         let config_file = ConfigFile::from_path(path.as_str())?;
         Config::from_config_file(config_file)
     }
-    
-    /// re-read the up-to-date miner options from the config file's path, or if there is 
+
+    /// re-read the up-to-date miner options from the config file's path, or if there is
     /// no path or it is unreadable, just return the current miner config.
     pub fn get_miner_config(&self) -> MinerConfig {
         let config = self.reload_config().unwrap_or_else(|e| {
-             warn!("Failed to reload miner config: {e}");
-             self.clone()
+            warn!("Failed to reload miner config: {e}");
+            self.clone()
         });
         config.miner
     }

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -628,11 +628,7 @@ impl RunLoop {
         sortdb: &SortitionDB,
         last_stacks_pox_reorg_recover_time: &mut u128,
     ) {
-        let miner_config = if let Ok(miner_config) = config.get_miner_config() {
-            miner_config
-        } else {
-            config.miner.clone()
-        };
+        let miner_config = config.get_miner_config();
         let delay = cmp::max(
             config.node.chain_liveness_poll_time_secs,
             cmp::max(
@@ -753,11 +749,7 @@ impl RunLoop {
         last_burn_pox_reorg_recover_time: &mut u128,
         last_announce_time: &mut u128,
     ) {
-        let miner_config = if let Ok(miner_config) = config.get_miner_config() {
-            miner_config
-        } else {
-            config.miner.clone()
-        };
+        let miner_config = config.get_miner_config();
         let delay = cmp::max(
             config.node.chain_liveness_poll_time_secs,
             cmp::max(

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -628,11 +628,16 @@ impl RunLoop {
         sortdb: &SortitionDB,
         last_stacks_pox_reorg_recover_time: &mut u128,
     ) {
+        let miner_config = if let Ok(miner_config) = config.get_miner_config() {
+            miner_config
+        } else {
+            config.miner.clone()
+        };
         let delay = cmp::max(
             config.node.chain_liveness_poll_time_secs,
             cmp::max(
-                config.miner.first_attempt_time_ms,
-                config.miner.subsequent_attempt_time_ms,
+                miner_config.first_attempt_time_ms,
+                miner_config.subsequent_attempt_time_ms,
             ) / 1000,
         );
 
@@ -748,11 +753,16 @@ impl RunLoop {
         last_burn_pox_reorg_recover_time: &mut u128,
         last_announce_time: &mut u128,
     ) {
+        let miner_config = if let Ok(miner_config) = config.get_miner_config() {
+            miner_config
+        } else {
+            config.miner.clone()
+        };
         let delay = cmp::max(
             config.node.chain_liveness_poll_time_secs,
             cmp::max(
-                config.miner.first_attempt_time_ms,
-                config.miner.subsequent_attempt_time_ms,
+                miner_config.first_attempt_time_ms,
+                miner_config.subsequent_attempt_time_ms,
             ) / 1000,
         );
 


### PR DESCRIPTION
This PR backports #4061 from `develop` to `master` and further makes every setting in `[miner]` and most miner-related settings in `[burnchain]` configurable at runtime. The config file will be reloaded whenever the relevant fields are accessed. 