### PR TITLE
Fix: nakamoto-node shouldn't respawn prometheus thread

### DIFF
--- a/testnet/stacks-node/src/monitoring/mod.rs
+++ b/testnet/stacks-node/src/monitoring/mod.rs
@@ -5,8 +5,19 @@ pub use stacks::monitoring::{increment_errors_emitted_counter, increment_warning
 #[cfg(feature = "monitoring_prom")]
 mod prometheus;
 
-pub fn start_serving_monitoring_metrics(bind_address: String) {
-    info!("Start serving prometheus metrics");
-    #[cfg(feature = "monitoring_prom")]
-    prometheus::start_serving_prometheus_metrics(bind_address);
+#[derive(Debug)]
+pub enum MonitoringError {
+    AlreadyBound,
+    UnableToGetAddress,
+}
+
+#[cfg(feature = "monitoring_prom")]
+pub fn start_serving_monitoring_metrics(bind_address: String) -> Result<(), MonitoringError> {
+    prometheus::start_serving_prometheus_metrics(bind_address)
+}
+
+#[cfg(not(feature = "monitoring_prom"))]
+pub fn start_serving_monitoring_metrics(bind_address: String) -> Result<(), MonitoringError> {
+    warn!("Attempted to start monitoring service at bind_address = {bind_address}, but stacks-node was built without `monitoring_prom` feature.");
+    Ok(())
 }

--- a/testnet/stacks-node/src/monitoring/prometheus.rs
+++ b/testnet/stacks-node/src/monitoring/prometheus.rs
@@ -4,20 +4,26 @@ use async_std::task;
 use http_types::{Body, Response, StatusCode};
 use stacks::prometheus::{gather, Encoder, TextEncoder};
 
-pub fn start_serving_prometheus_metrics(bind_address: String) {
-    let addr = bind_address.clone();
+use super::MonitoringError;
 
-    async_std::task::block_on(async {
-        let listener = TcpListener::bind(addr)
+pub fn start_serving_prometheus_metrics(bind_address: String) -> Result<(), MonitoringError> {
+    task::block_on(async {
+        let listener = TcpListener::bind(bind_address)
             .await
-            .expect("Prometheus monitoring: unable to bind address");
-        let addr = format!(
-            "http://{}",
-            listener
+            .map_err(|_| {
+                warn!("Prometheus monitoring: unable to bind address, will not spawn prometheus endpoint service.");
+                MonitoringError::AlreadyBound
+            })?;
+        let local_addr = listener
                 .local_addr()
-                .expect("Prometheus monitoring: unable to get addr")
+                .map_err(|_| {
+                    warn!("Prometheus monitoring: unable to get local bind address, will not spawn prometheus endpoint service.");
+                    MonitoringError::UnableToGetAddress
+                })?;
+        info!(
+            "Prometheus monitoring: server listening on http://{}",
+            local_addr
         );
-        info!("Prometheus monitoring: server listening on {}", addr);
 
         let mut incoming = listener.incoming();
         while let Some(stream) = incoming.next().await {
@@ -25,21 +31,20 @@ pub fn start_serving_prometheus_metrics(bind_address: String) {
                 Ok(stream) => stream,
                 Err(err) => {
                     error!(
-                        "Prometheus monitoring: unable to open socket and serve metrics - {:?}",
-                        err
+                        "Prometheus monitoring: unable to open socket and serve metrics - {err:?}",
                     );
                     continue;
                 }
             };
-            let addr = addr.clone();
-
             task::spawn(async {
                 if let Err(err) = accept(stream).await {
-                    eprintln!("{}", err);
+                    error!("{err}");
                 }
             });
         }
-    });
+
+        Ok::<_, MonitoringError>(())
+    })
 }
 
 async fn accept(stream: TcpStream) -> http_types::Result<()> {

--- a/testnet/stacks-node/src/run_loop/boot_nakamoto.rs
+++ b/testnet/stacks-node/src/run_loop/boot_nakamoto.rs
@@ -54,7 +54,7 @@ impl BootRunLoop {
                 InnerLoops::Epoch2(neon),
             )
         } else {
-            let naka = NakaRunLoop::new(config.clone(), None, None);
+            let naka = NakaRunLoop::new(config.clone(), None, None, None);
             (
                 naka.get_coordinator_channel().unwrap(),
                 InnerLoops::Epoch3(naka),
@@ -122,6 +122,7 @@ impl BootRunLoop {
             .expect("FATAL: failed to spawn epoch-2/3-boot thread");
         neon_loop.start(burnchain_opt.clone(), mine_start);
 
+        let monitoring_thread = neon_loop.take_monitoring_thread();
         // did we exit because of the epoch-3.0 transition, or some other reason?
         let exited_for_transition = boot_thread
             .join()
@@ -136,6 +137,7 @@ impl BootRunLoop {
             self.config.clone(),
             Some(termination_switch),
             Some(counters),
+            monitoring_thread,
         );
         let new_coord_channels = naka
             .get_coordinator_channel()


### PR DESCRIPTION
### Description

This PR:
1. Updates the prometheus thread to return errors to the JoinHandle rather than panicking in an unchecked async task. The PR doesn't change the behavior to _handle_ or _exit_ on the error, it retains the previous behavior of "basically just issue a warning but otherwise execute the node". 
2. Stores the thread's `JoinHandle` to the runloop struct.
3. Moves the `JoinHandle` from the neon runloop to the nakamoto runloop (if the `boot_nakamoto` loop needed to start the neon runloop). If the nakamoto runloop has a thread handle, it doesn't attempt to spawn a new prometheus thread.
4. Extends the `nakamoto_integrations::simple_neon` test to check the prometheus output before and after nakamoto block processing.

### Applicable issues

- fixes #4214
