### PR TITLE
Update wsts version to 6.0 and use Packet::verify function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c250118354755b4abb091a83cb8d659b511c0ae211ccdb3b1254e3db199cb86"
+checksum = "1b2cb1ef1b26d526daae40c1ee657c83bbedaeefd7196f827b40ca79d13f0f34"
 dependencies = [
  "aes-gcm 0.10.2",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 
 # Dependencies we want to keep the same between workspace members
 [workspace.dependencies]  
-wsts = "5.0"
+wsts = "6.0"
 rand_core = "0.6"
 rand = "0.8"
 


### PR DESCRIPTION
### Description
Need the newest wsts version changes for handling <100% participation in DKG
Also required for processing coordinator messages while in the IDLE state which enables DKG to be calculated by all signers simultaneously

### Applicable issues

- Part of https://github.com/stacks-network/stacks-core/issues/4111
- Part of https://github.com/stacks-network/stacks-core/issues/3972