### PR TITLE
master: update default testnet hiro bootstrap node

### DIFF
--- a/testnet/stacks-node/conf/testnet-follower-conf.toml
+++ b/testnet/stacks-node/conf/testnet-follower-conf.toml
@@ -2,7 +2,7 @@
 # working_dir = "/dir/to/save/chainstate"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:20444"
+bootstrap_node = "029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:30444"
 wait_time_for_microblocks = 10000
 
 [burnchain]

--- a/testnet/stacks-node/conf/testnet-miner-conf.toml
+++ b/testnet/stacks-node/conf/testnet-miner-conf.toml
@@ -5,7 +5,7 @@ p2p_bind = "0.0.0.0:20444"
 seed = "<YOUR_SEED>"
 local_peer_seed = "<YOUR_SEED>"
 miner = true
-bootstrap_node = "029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:20444"
+bootstrap_node = "029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:30444"
 wait_time_for_microblocks = 10000
 
 [burnchain]

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -206,7 +206,7 @@ impl ConfigFile {
         };
 
         let node = NodeConfigFile {
-            bootstrap_node: Some("029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:20444".to_string()),
+            bootstrap_node: Some("029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:30444".to_string()),
             miner: Some(false),
             ..NodeConfigFile::default()
         };


### PR DESCRIPTION
Relevant forum post with details: https://forum.stacks.org/t/minor-network-changes-and-dns-updates-on-january-16th-2024/16125

I made two PRs to propogate this change to `master` and `develop` branches quickly.
Related PR: https://github.com/stacks-network/stacks-core/pull/4237

Updates the testnet Hiro bootstrap nodes to use a different port for the testnet seeds.

~DO NOT MERGE UNTIL CHANGES ARE LIVE (Est Jan 16th, an update will be made to the forum post).~

Good to merge!