### PR TITLE
Chore/Additional PoX-4 Rust Tests

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1843,7 +1843,8 @@ pub mod test {
                 Value::UInt(lock_period),
                 Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
             ],
-        ).unwrap();
+        )
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1866,7 +1867,8 @@ pub mod test {
                 Value::UInt(extend_count),
                 Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
             ],
-        ).unwrap();
+        )
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1880,7 +1880,6 @@ pub mod test {
         pox_addr: PoxAddress,
         amount: u128,
     ) -> StacksTransaction {
-        //let addr_tuple = Value::Tuple(pox_addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
             POX_4_NAME,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1821,6 +1821,52 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
+    pub fn make_pox_4_delegate_increase(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        stacker: &PrincipalData,
+        pox_addr: Value,
+        amount: u128,
+    ) -> StacksTransaction {
+        //let addr_tuple = Value::Tuple(pox_addr.as_clarity_tuple().unwrap());
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            "delegate-stack-increase",
+            vec![
+                Value::Principal(stacker.clone()),
+                pox_addr,
+                Value::UInt(amount),
+            ],
+        )
+        .unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
+
+    pub fn make_pox_4_aggregation_commit_indexed(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        amount: u128,
+        delegate_to: PrincipalData,
+        until_burn_ht: Option<u128>,
+        pox_addr: PoxAddress,
+    ) -> StacksTransaction {
+        let addr_tuple = Value::Tuple(pox_addr.as_clarity_tuple().unwrap());
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            "stack-aggregation-commit-indexed",
+            vec![
+                addr_tuple,
+                Value::UInt(amount),
+            ],
+        ).unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
     pub fn make_pox_4_increase_stx(
         key: &StacksPrivateKey,
         nonce: u64,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1873,7 +1873,7 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
-    pub fn make_pox_4_delegate_increase(
+    pub fn make_pox_4_delegate_stack_increase(
         key: &StacksPrivateKey,
         nonce: u64,
         stacker: &PrincipalData,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1859,7 +1859,7 @@ pub mod test {
         let payload: TransactionPayload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
             POX_4_NAME,
-            "delegate-stack-stx",
+            "delegate-stack-extend",
             vec![
                 Value::Principal(stacker.clone()),
                 Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1877,7 +1877,7 @@ pub mod test {
         key: &StacksPrivateKey,
         nonce: u64,
         stacker: &PrincipalData,
-        pox_addr: Value,
+        pox_addr: PoxAddress,
         amount: u128,
     ) -> StacksTransaction {
         //let addr_tuple = Value::Tuple(pox_addr.as_clarity_tuple().unwrap());
@@ -1887,7 +1887,7 @@ pub mod test {
             "delegate-stack-increase",
             vec![
                 Value::Principal(stacker.clone()),
-                pox_addr,
+                Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),
                 Value::UInt(amount),
             ],
         )

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1848,6 +1848,29 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
+    pub fn make_pox_4_delegate_stack_extend(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        stacker: PrincipalData,
+        pox_addr: PoxAddress,
+        extend_count: u128,
+        signer_key: StacksPublicKey,
+    ) -> StacksTransaction {
+        let payload: TransactionPayload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            "delegate-stack-stx",
+            vec![
+                Value::Principal(stacker.clone()),
+                Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),
+                Value::UInt(extend_count),
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
+            ],
+        ).unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
     pub fn make_pox_4_delegate_increase(
         key: &StacksPrivateKey,
         nonce: u64,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1854,8 +1854,8 @@ pub mod test {
         nonce: u64,
         stacker: PrincipalData,
         pox_addr: PoxAddress,
-        extend_count: u128,
         signer_key: StacksPublicKey,
+        extend_count: u128,
     ) -> StacksTransaction {
         let payload: TransactionPayload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
@@ -1864,30 +1864,8 @@ pub mod test {
             vec![
                 Value::Principal(stacker.clone()),
                 Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),
-                Value::UInt(extend_count),
                 Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
-            ],
-        )
-        .unwrap();
-
-        make_tx(key, nonce, 0, payload)
-    }
-
-    pub fn make_pox_4_delegate_stack_increase(
-        key: &StacksPrivateKey,
-        nonce: u64,
-        stacker: &PrincipalData,
-        pox_addr: PoxAddress,
-        amount: u128,
-    ) -> StacksTransaction {
-        let payload = TransactionPayload::new_contract_call(
-            boot_code_test_addr(),
-            POX_4_NAME,
-            "delegate-stack-increase",
-            vec![
-                Value::Principal(stacker.clone()),
-                Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),
-                Value::UInt(amount),
+                Value::UInt(extend_count),
             ],
         )
         .unwrap();
@@ -1925,6 +1903,28 @@ pub mod test {
             POX_4_NAME,
             "stack-increase",
             vec![Value::UInt(amount)],
+        )
+        .unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
+    pub fn make_pox_4_delegate_stack_increase(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        stacker: &PrincipalData,
+        pox_addr: PoxAddress,
+        amount: u128,
+    ) -> StacksTransaction {
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            "delegate-stack-increase",
+            vec![
+                Value::Principal(stacker.clone()),
+                Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),
+                Value::UInt(amount),
+            ],
         )
         .unwrap();
 

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1821,6 +1821,33 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
+    pub fn make_pox_4_delegate_stack_stx(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        stacker: PrincipalData,
+        amount: u128,
+        pox_addr: PoxAddress,
+        start_burn_height: u128,
+        lock_period: u128,
+        signer_key: StacksPublicKey,
+    ) -> StacksTransaction {
+        let payload: TransactionPayload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            "delegate-stack-stx",
+            vec![
+                Value::Principal(stacker.clone()),
+                Value::UInt(amount),
+                Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),
+                Value::UInt(start_burn_height),
+                Value::UInt(lock_period),
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
+            ],
+        ).unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
     pub fn make_pox_4_delegate_increase(
         key: &StacksPrivateKey,
         nonce: u64,
@@ -1864,7 +1891,7 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
-    pub fn make_pox_4_increase_stx(
+    pub fn make_pox_4_stack_increase(
         key: &StacksPrivateKey,
         nonce: u64,
         amount: u128,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1821,6 +1821,24 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
+    pub fn make_pox_4_increase_stx(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        amount: u128,
+    ) -> StacksTransaction {
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            "stack-increase",
+            vec![
+                Value::UInt(amount),
+            ],
+        )
+        .unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
     pub fn make_pox_4_revoke_delegate_stx(key: &StacksPrivateKey, nonce: u64) -> StacksTransaction {
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1864,8 +1864,8 @@ pub mod test {
             vec![
                 Value::Principal(stacker.clone()),
                 Value::Tuple(pox_addr.as_clarity_tuple().unwrap()),
-                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
                 Value::UInt(extend_count),
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
             ],
         )
         .unwrap();

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1844,7 +1844,6 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
-
     pub fn make_pox_4_aggregation_commit_indexed(
         key: &StacksPrivateKey,
         nonce: u64,
@@ -1858,11 +1857,9 @@ pub mod test {
             boot_code_test_addr(),
             POX_4_NAME,
             "stack-aggregation-commit-indexed",
-            vec![
-                addr_tuple,
-                Value::UInt(amount),
-            ],
-        ).unwrap();
+            vec![addr_tuple, Value::UInt(amount)],
+        )
+        .unwrap();
 
         make_tx(key, nonce, 0, payload)
     }
@@ -1876,9 +1873,7 @@ pub mod test {
             boot_code_test_addr(),
             POX_4_NAME,
             "stack-increase",
-            vec![
-                Value::UInt(amount),
-            ],
+            vec![Value::UInt(amount)],
         )
         .unwrap();
 

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -1158,8 +1158,8 @@
 (define-public (delegate-stack-extend
                     (stacker principal)
                     (pox-addr { version: (buff 1), hashbytes: (buff 32) })
-                    (extend-count uint)
-                    (signer-key (buff 33)))
+                    (signer-key (buff 33))
+                    (extend-count uint))
     (let ((stacker-info (stx-account stacker))
           ;; to extend, there must already be an entry in the stacking-state
           (stacker-state (unwrap! (get-stacker-info stacker) (err ERR_STACK_EXTEND_NOT_LOCKED)))

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -1158,8 +1158,8 @@
 (define-public (delegate-stack-extend
                     (stacker principal)
                     (pox-addr { version: (buff 1), hashbytes: (buff 32) })
-                    (signer-key (buff 33))
-                    (extend-count uint))
+                    (extend-count uint)
+                    (signer-key (buff 33)))
     (let ((stacker-info (stx-account stacker))
           ;; to extend, there must already be an entry in the stacking-state
           (stacker-state (unwrap! (get-stacker-info stacker) (err ERR_STACK_EXTEND_NOT_LOCKED)))

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1923,7 +1923,113 @@ fn stack_increase() {
 
 }
 
+#[test]
+fn delegate_stack_increase() {
+    let lock_period: u128 = 2;
+    let observer = TestEventObserver::new();
+    let (burnchain, mut peer, keys, latest_block, block_height, mut coinbase_nonce) =
+        prepare_pox4_test(function_name!(), Some(&observer));
 
+    let mut stacker_nonce = 0;
+    let stacker_key = &keys[0];
+    let stacker_address = PrincipalData::from(
+        key_to_stacks_addr(stacker_key).to_account_principal(),
+    );
+    let delegate_nonce = 0;
+    let delegate_key = &keys[1];
+    let delegate_address = PrincipalData::from(
+        key_to_stacks_addr(delegate_key).to_account_principal(),
+    );
+    let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
+
+    // (define-public (delegate-stx (amount-ustx uint)
+    //                          (delegate-to principal)
+    //                          (until-burn-ht (optional uint))
+    //                          (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) })))
+    let pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2WSH,
+        key_to_stacks_addr(delegate_key).bytes,
+    );
+
+    let signer_key_val = Value::buff_from(vec![
+        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
+        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
+        0x4e, 0x28, 0x1b,
+    ])
+    .unwrap();
+
+    let txs = vec![
+        make_pox_4_contract_call(
+            stacker_key,
+            stacker_nonce,
+            "delegate-stx",
+            vec![
+                Value::UInt(min_ustx*2),
+                Value::Principal(delegate_address.clone()),
+                Value::none(),
+                Value::Optional(OptionalData {
+                    data: Some(Box::new(pox_addr.clone())),
+                }),
+            ],
+        ),
+        make_pox_4_contract_call(
+            delegate_key,
+            delegate_nonce,
+            "delegate-stack-stx",
+            vec![
+                Value::Principal(stacker_address.clone()),
+                Value::UInt(min_ustx),
+                pox_addr.clone(),
+                Value::UInt(block_height as u128),
+                Value::UInt(lock_period),
+                signer_key_val.clone(),
+            ],
+        ),
+    ];
+    // (define-public (delegate-stack-stx (stacker principal)
+    //                                (amount-ustx uint)
+    //                                (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+    //                                (start-burn-ht uint)
+    //                                (lock-period uint)
+    //                                (signer-key (buff 33)))
+
+    // (define-public (delegate-stack-extend (stacker principal)
+    //     (extend-count uint)
+    //     (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+    //     (signer-key (buff 33)))
+
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+
+    stacker_nonce += 1;
+
+    let delegate_increase = make_pox_4_delegate_increase(
+        delegate_key,
+        stacker_nonce,
+        &stacker_address,
+        pox_addr,
+        min_ustx,
+    );
+
+    let txs = vec![delegate_increase];
+
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+
+    let delegate_transactions =
+            get_last_block_sender_transactions(&observer, delegate_address.into());
+
+    println!("delegate_transactions: {:?}", delegate_transactions);
+
+    let stacker_transactions =
+            get_last_block_sender_transactions(&observer, stacker_address.into());
+    
+    println!("stacker_transactions: {:?}", stacker_transactions);
+
+    // let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
+    // assert_eq!(
+    //     state_signer_key_new.to_string(),
+    //     signer_key_new_val.to_string()
+    // );
+}
 
 pub fn get_stacking_state_pox_4(
     peer: &mut TestPeer,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{ HashMap, HashSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
 
 use clarity::vm::clarity::ClarityConnection;
@@ -1679,8 +1679,8 @@ fn delegate_stack_stx_signer_key() {
     let state_signer_key = stacking_state.get("signer-key").unwrap();
 
     assert_eq!(
-        state_signer_key.to_string(),
-        format!("0x{}", signer_public_key.to_hex())
+        state_signer_key,
+        signer_public_key
     );
 }
 
@@ -1724,6 +1724,8 @@ fn delegate_stack_stx_extend_signer_key() {
         signer_public_key.clone(),
     );
 
+    // Initial txs arr includes initial delegate_stx & delegate_stack_stx
+    // Both are pox_4 helpers found in mod.rs
     let txs = vec![delegate_stx, delegate_stack_stx];
 
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
@@ -1744,6 +1746,7 @@ fn delegate_stack_stx_extend_signer_key() {
     .expect("No stacking state, stack-stx failed")
     .expect_tuple();
 
+    // Testing initial signer-key correctly set
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(
         state_signer_key.to_string(),
@@ -1757,10 +1760,11 @@ fn delegate_stack_stx_extend_signer_key() {
         stacker_nonce,
         PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
         pox_addr.clone(),
-        1,
         new_signer_public_key.clone(),
+        1,
     );
 
+    // Next tx arr calls a delegate_stack_extend pox_4 helper found in mod.rs
     let txs = vec![delegate_stack_extend];
 
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
@@ -1772,6 +1776,7 @@ fn delegate_stack_stx_extend_signer_key() {
     .unwrap()
     .expect_tuple();
 
+    // Testing new signer-key correctly set
     let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
     assert_eq!(
         state_signer_key_new.to_string(),
@@ -1807,6 +1812,7 @@ fn stack_increase() {
         block_height as u64,
     );
 
+    // Initial tx arr includes a stack_stx pox_4 helper found in mod.rs
     let txs = vec![stack_stx];
 
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
@@ -1818,6 +1824,7 @@ fn stack_increase() {
     .expect("No stacking state, stack-stx failed")
     .expect_tuple();
 
+    // Testing initial signer-key correctly set
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(
         state_signer_key.to_string(),
@@ -1827,6 +1834,7 @@ fn stack_increase() {
     stacker_nonce += 1;
 
     let stack_increase = make_pox_4_stack_increase(stacker_key, stacker_nonce, min_ustx);
+    // Next tx arr includes a stack_increase pox_4 helper found in mod.rs
     let txs = vec![stack_increase];
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
     let stacker_transactions = get_last_block_sender_transactions(&observer, stacker_address);
@@ -1848,6 +1856,8 @@ fn stack_increase() {
     ))
     .unwrap();
 
+    // Testing stack_increase response is equal to expected response
+    // Test is straightforward because 'stack-increase' in PoX-4 is the same as PoX-3
     assert_eq!(actual_result, expected_result);
 }
 
@@ -1894,6 +1904,7 @@ fn delegate_stack_increase() {
         signer_public_key.clone(),
     );
 
+    // Initial tx arr includes a delegate_stx & delegate_stack_stx pox_4 helper found in mod.rs
     let txs = vec![delegate_stx, delegate_stack_stx];
 
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
@@ -1909,6 +1920,7 @@ fn delegate_stack_increase() {
         min_ustx,
     );
 
+    // Next tx arr includes a delegate_increase pox_4 helper found in mod.rs
     let txs = vec![delegate_increase];
 
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
@@ -1933,6 +1945,8 @@ fn delegate_stack_increase() {
     ))
     .unwrap();
 
+    // Testing stack_increase response is equal to expected response
+    // Test is straightforward because 'stack-increase' in PoX-4 is the same as PoX-3
     assert_eq!(actual_result, expected_result);
 }
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1681,7 +1681,7 @@ fn delegate_stack_stx_signer_key() {
 
     assert_eq!(
         state_signer_key.to_string(),
-        format!("0x,{}", signer_public_key.to_hex())
+        format!("0x{}", signer_public_key.to_hex())
     );
 }
 
@@ -1748,7 +1748,7 @@ fn delegate_stack_stx_extend_signer_key() {
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(
         state_signer_key.to_string(),
-        format!("0x,{}", signer_public_key.to_hex())
+        format!("0x{}", signer_public_key.to_hex())
     );
 
     stacker_nonce += 1;
@@ -1775,8 +1775,8 @@ fn delegate_stack_stx_extend_signer_key() {
 
     let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
     assert_eq!(
-        state_signer_key.to_string(),
-        format!("0x,{}", signer_public_key.to_hex())
+        state_signer_key_new.to_string(),
+        format!("0x{}", new_signer_public_key.to_hex())
     );
 }
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{ HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
 
 use clarity::vm::clarity::ClarityConnection;
@@ -1679,8 +1679,8 @@ fn delegate_stack_stx_signer_key() {
     let state_signer_key = stacking_state.get("signer-key").unwrap();
 
     assert_eq!(
-        state_signer_key.to_string(),
-        format!("0x{}", signer_public_key.to_hex())
+        state_signer_key,
+        &Value::buff_from(signer_public_key.to_bytes_compressed()).unwrap()
     );
 }
 
@@ -1749,8 +1749,8 @@ fn delegate_stack_stx_extend_signer_key() {
     // Testing initial signer-key correctly set
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(
-        state_signer_key.to_string(),
-        format!("0x{}", signer_public_key.to_hex())
+        state_signer_key,
+        &Value::buff_from(signer_public_key.to_bytes_compressed()).unwrap()
     );
 
     stacker_nonce += 1;
@@ -1779,8 +1779,8 @@ fn delegate_stack_stx_extend_signer_key() {
     // Testing new signer-key correctly set
     let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
     assert_eq!(
-        state_signer_key_new.to_string(),
-        format!("0x{}", new_signer_public_key.to_hex())
+        state_signer_key_new,
+        &Value::buff_from(new_signer_public_key.to_bytes_compressed()).unwrap()
     );
 }
 
@@ -1827,8 +1827,8 @@ fn stack_increase() {
     // Testing initial signer-key correctly set
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(
-        state_signer_key.to_string(),
-        format!("0x{}", signer_public_key.to_hex())
+        state_signer_key,
+        &Value::buff_from(signer_public_key.to_bytes_compressed()).unwrap()
     );
 
     stacker_nonce += 1;

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1680,8 +1680,8 @@ fn delegate_stack_stx_signer_key() {
     let state_signer_key = stacking_state.get("signer-key").unwrap();
 
     assert_eq!(
-        state_signer_key.to_string()[2..],
-        signer_public_key.to_hex()
+        state_signer_key.to_string(),
+        format!("0x,{}", signer_public_key.to_hex())
     );
 }
 
@@ -1745,8 +1745,8 @@ fn delegate_stack_stx_extend_signer_key() {
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(
-        state_signer_key.to_string()[2..],
-        signer_public_key.to_hex()
+        state_signer_key.to_string(),
+        format!("0x,{}", signer_public_key.to_hex())
     );
 
     stacker_nonce += 1;
@@ -1776,8 +1776,8 @@ fn delegate_stack_stx_extend_signer_key() {
 
     let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
     assert_eq!(
-        state_signer_key_new.to_string()[2..],
-        new_signer_public_key.to_hex()
+        state_signer_key.to_string(),
+        format!("0x,{}", signer_public_key.to_hex())
     );
 }
 
@@ -1822,8 +1822,8 @@ fn stack_increase() {
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
     assert_eq!(
-        state_signer_key.to_string()[2..],
-        signer_public_key.to_hex()
+        state_signer_key.to_string(),
+        format!("0x,{}", signer_public_key.to_hex())
     );
 
     stacker_nonce += 1;

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1679,8 +1679,8 @@ fn delegate_stack_stx_signer_key() {
     let state_signer_key = stacking_state.get("signer-key").unwrap();
 
     assert_eq!(
-        state_signer_key,
-        signer_public_key
+        state_signer_key.to_string(),
+        format!("0x{}", signer_public_key.to_hex())
     );
 }
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1698,6 +1698,8 @@ fn delegate_stack_stx_extend_signer_key() {
     let delegate_principal = PrincipalData::from(key_to_stacks_addr(delegate_key));
     let signer_private_key = &keys[2];
     let signer_public_key = StacksPublicKey::from_private(signer_private_key);
+    let new_signer_private_key = &keys[3];
+    let new_signer_public_key = StacksPublicKey::from_private(new_signer_private_key);
     let pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
         key_to_stacks_addr(delegate_key).bytes,
@@ -1750,9 +1752,6 @@ fn delegate_stack_stx_extend_signer_key() {
     );
 
     stacker_nonce += 1;
-
-    let new_signer_private_key = &keys[3];
-    let new_signer_public_key = StacksPublicKey::from_private(new_signer_private_key);
 
     let delegate_stack_extend = make_pox_4_delegate_stack_extend(
         delegate_key,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::any::Any;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1832,7 +1832,6 @@ fn stack_increase() {
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
     let stacker_transactions = get_last_block_sender_transactions(&observer, stacker_address);
 
-
     let transaction_result = stacker_transactions
         .first()
         .map(|tx| tx.result.clone())
@@ -1845,7 +1844,7 @@ fn stack_increase() {
         .expect("total-locked key not found")
         .clone()
         .expect_u128();
-    
+
     assert_eq!(total_locked, min_ustx * 2);
 }
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1637,25 +1637,26 @@ fn delegate_stack_stx_signer_key() {
         key_to_stacks_addr(delegate_key).bytes,
     );
 
-    let delegate_stx:StacksTransaction = make_pox_4_delegate_stx(
-        stacker_key, 
-        stacker_nonce, 
-        100, 
-        delegate_principal.clone().into(), 
-        None, 
+    let delegate_stx: StacksTransaction = make_pox_4_delegate_stx(
+        stacker_key,
+        stacker_nonce,
+        100,
+        delegate_principal.clone().into(),
+        None,
         Some(pox_addr.clone()),
     );
 
     let delegate_stack_stx = make_pox_4_delegate_stack_stx(
-        delegate_key, 
-        delegate_nonce, 
-        PrincipalData::from(key_to_stacks_addr(stacker_key)).into(), 
-        100, 
-        pox_addr.clone(), 
+        delegate_key,
+        delegate_nonce,
+        PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
+        100,
+        pox_addr.clone(),
         block_height as u128,
         lock_period,
-        signer_public_key);
-        
+        signer_public_key,
+    );
+
     let txs = vec![delegate_stx, delegate_stack_stx];
 
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
@@ -1678,7 +1679,10 @@ fn delegate_stack_stx_signer_key() {
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
 
-    assert_eq!(state_signer_key.to_string()[2..],signer_public_key.to_hex());
+    assert_eq!(
+        state_signer_key.to_string()[2..],
+        signer_public_key.to_hex()
+    );
 }
 
 #[test]
@@ -1699,29 +1703,30 @@ fn delegate_stack_stx_extend_signer_key() {
         key_to_stacks_addr(delegate_key).bytes,
     );
 
-    let delegate_stx:StacksTransaction = make_pox_4_delegate_stx(
-        stacker_key, 
-        stacker_nonce, 
-        100, 
-        delegate_principal.clone().into(), 
-        None, 
+    let delegate_stx: StacksTransaction = make_pox_4_delegate_stx(
+        stacker_key,
+        stacker_nonce,
+        100,
+        delegate_principal.clone().into(),
+        None,
         Some(pox_addr.clone()),
     );
 
     let delegate_stack_stx = make_pox_4_delegate_stack_stx(
-        delegate_key, 
-        delegate_nonce, 
-        PrincipalData::from(key_to_stacks_addr(stacker_key)).into(), 
-        100, 
-        pox_addr.clone(), 
+        delegate_key,
+        delegate_nonce,
+        PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
+        100,
+        pox_addr.clone(),
         block_height as u128,
         lock_period,
-        signer_public_key.clone());
+        signer_public_key.clone(),
+    );
 
     let txs = vec![delegate_stx, delegate_stack_stx];
 
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
-    
+
     let delegation_state = get_delegation_state_pox_4(
         &mut peer,
         &latest_block,
@@ -1739,10 +1744,12 @@ fn delegate_stack_stx_extend_signer_key() {
     .expect_tuple();
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
-    assert_eq!(state_signer_key.to_string()[2..], signer_public_key.to_hex());
+    assert_eq!(
+        state_signer_key.to_string()[2..],
+        signer_public_key.to_hex()
+    );
 
     stacker_nonce += 1;
-
 
     let new_signer_private_key = &keys[3];
     let new_signer_public_key = StacksPublicKey::from_private(new_signer_private_key);
@@ -1753,7 +1760,7 @@ fn delegate_stack_stx_extend_signer_key() {
         PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
         pox_addr.clone(),
         1,
-        new_signer_public_key.clone()
+        new_signer_public_key.clone(),
     );
 
     let txs = vec![delegate_stack_extend];
@@ -1768,7 +1775,10 @@ fn delegate_stack_stx_extend_signer_key() {
     .expect_tuple();
 
     let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
-    assert_eq!(state_signer_key_new.to_string()[2..],new_signer_public_key.to_hex());
+    assert_eq!(
+        state_signer_key_new.to_string()[2..],
+        new_signer_public_key.to_hex()
+    );
 }
 
 #[test]
@@ -1781,37 +1791,24 @@ fn stack_increase() {
     let mut stacker_nonce = 0;
     let stacker_key = &keys[0];
     let stacker_address = key_to_stacks_addr(stacker_key);
+    let signer_private_key = &keys[1];
+    let signer_public_key = StacksPublicKey::from_private(signer_private_key);
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
+    let pox_addr = PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, stacker_address.bytes);
 
-    // (define-public (stack-stx (amount-ustx uint)
-    //                       (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
-    //                       (start-burn-ht uint)
-    //                       (lock-period uint)
-    //                       (signer-key (buff 33)))
-    let pox_addr = make_pox_addr(
-        AddressHashMode::SerializeP2WSH,
-        key_to_stacks_addr(stacker_key).bytes,
-    );
-    let signer_key_val = Value::buff_from(vec![
-        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
-        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
-        0x4e, 0x28, 0x1b,
-    ])
-    .unwrap();
-    let first_txs = vec![make_pox_4_contract_call(
+    let stack_stx = make_pox_4_lockup(
         stacker_key,
         stacker_nonce,
-        "stack-stx",
-        vec![
-            Value::UInt(min_ustx),
-            pox_addr,
-            Value::UInt(block_height as u128),
-            Value::UInt(2),
-            signer_key_val.clone(),
-        ],
-    )];
+        min_ustx,
+        pox_addr.clone(),
+        lock_period,
+        signer_public_key.clone(),
+        block_height as u64,
+    );
 
-    let latest_block = peer.tenure_with_txs(&first_txs, &mut coinbase_nonce);
+    let txs = vec![stack_stx];
+
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
     let stacking_state = get_stacking_state_pox_4(
         &mut peer,
         &latest_block,
@@ -1821,13 +1818,16 @@ fn stack_increase() {
     .expect_tuple();
 
     let state_signer_key = stacking_state.get("signer-key").unwrap();
-    assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
+    assert_eq!(
+        state_signer_key.to_string()[2..],
+        signer_public_key.to_hex()
+    );
 
     stacker_nonce += 1;
 
-    // (define-public (stack-increase (increse-by uint)
     let stack_increase = make_pox_4_stack_increase(stacker_key, stacker_nonce, min_ustx);
-    let latest_block = peer.tenure_with_txs(&vec![stack_increase], &mut coinbase_nonce);
+    let txs = vec![stack_increase];
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
     let stacker_transactions = get_last_block_sender_transactions(&observer, stacker_address);
 
     let stacker_locked_amount: u128 = match &stacker_transactions[0].result {

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1701,6 +1701,140 @@ fn delegate_stack_stx_signer_key() {
     assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
 }
 
+#[test]
+fn delegate_stack_stx_extend_signer_key() {
+    let lock_period = 2;
+    let (burnchain, mut peer, keys, latest_block, block_height, mut coinbase_nonce) =
+        prepare_pox4_test(function_name!(), None);
+
+    let mut stacker_nonce = 0;
+    let stacker_key = &keys[0];
+    let delegate_nonce = 0;
+    let delegate_key = &keys[1];
+    let delegate_principal = PrincipalData::from(key_to_stacks_addr(delegate_key));
+
+    // (define-public (delegate-stx (amount-ustx uint)
+    //                          (delegate-to principal)
+    //                          (until-burn-ht (optional uint))
+    //                          (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) })))
+    let pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2WSH,
+        key_to_stacks_addr(delegate_key).bytes,
+    );
+    let signer_key_val = Value::buff_from(vec![
+        0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
+        0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
+        0x4e, 0x28, 0x1b,
+    ])
+    .unwrap();
+
+    let txs = vec![
+        make_pox_4_contract_call(
+            stacker_key,
+            stacker_nonce,
+            "delegate-stx",
+            vec![
+                Value::UInt(100),
+                delegate_principal.clone().into(),
+                Value::none(),
+                Value::Optional(OptionalData {
+                    data: Some(Box::new(pox_addr.clone())),
+                }),
+            ],
+        ),
+        make_pox_4_contract_call(
+            delegate_key,
+            delegate_nonce,
+            "delegate-stack-stx",
+            vec![
+                PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
+                Value::UInt(100),
+                pox_addr.clone(),
+                Value::UInt(block_height as u128),
+                Value::UInt(lock_period),
+                signer_key_val.clone(),
+            ],
+        ),
+    ];
+    // (define-public (delegate-stack-stx (stacker principal)
+    //                                (amount-ustx uint)
+    //                                (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+    //                                (start-burn-ht uint)
+    //                                (lock-period uint)
+    //                                (signer-key (buff 33)))
+
+    let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+    let delegation_state = get_delegation_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+    .expect("No delegation state, delegate-stx failed")
+    .expect_tuple();
+
+    let stacking_state = get_stacking_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+    .expect("No stacking state, stack-stx failed")
+    .expect_tuple();
+
+    let state_signer_key = stacking_state.get("signer-key").unwrap();
+    assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
+
+    // (define-public (delegate-stack-extend (stacker principal)
+    //     (extend-count uint)
+    //     (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+    //     (signer-key (buff 33)))
+
+    stacker_nonce += 1;
+
+    let mut latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+    let stacking_state = get_stacking_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+    .expect("No stacking state, stack-stx failed")
+    .expect_tuple();
+
+    let state_signer_key = stacking_state.get("signer-key").unwrap();
+    assert_eq!(state_signer_key.to_string(), signer_key_val.to_string());
+
+    // now stack-extend with a new signer-key
+    let signer_key_new_val = Value::buff_from(vec![
+        0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
+        0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
+        0x59, 0x98, 0x3c,
+    ])
+    .unwrap();
+
+    let update_txs = vec![make_pox_4_contract_call(
+        delegate_key,
+        stacker_nonce,
+        "delegate-stack-extend",
+        vec![PrincipalData::from(key_to_stacks_addr(stacker_key)).into(), pox_addr.clone(), signer_key_new_val.clone(), Value::UInt(1)],
+    )];
+
+    latest_block = peer.tenure_with_txs(&update_txs, &mut coinbase_nonce);
+    let new_stacking_state = get_stacking_state_pox_4(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(stacker_key).to_account_principal(),
+    )
+    .unwrap()
+    .expect_tuple();
+
+    let state_signer_key_new = new_stacking_state.get("signer-key").unwrap();
+    assert_eq!(
+        state_signer_key_new.to_string(),
+        signer_key_new_val.to_string()
+    );
+
+
+}
+
 pub fn get_stacking_state_pox_4(
     peer: &mut TestPeer,
     tip: &StacksBlockId,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1854,10 +1854,7 @@ fn stack_increase() {
     let latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
     let stacker_transactions = get_last_block_sender_transactions(&observer, alice_address);
 
-    let actual_result = stacker_transactions
-        .first()
-        .map(|tx| tx.result.clone())
-        .unwrap();
+    let actual_result = stacker_transactions.first().cloned().unwrap().result;
 
     let expected_result = Value::okay(Value::Tuple(
         TupleData::from_data(vec![
@@ -1947,10 +1944,7 @@ fn delegate_stack_increase() {
     let delegate_transactions =
         get_last_block_sender_transactions(&observer, bob_delegate_address.into());
 
-    let actual_result = delegate_transactions
-        .first()
-        .map(|tx| tx.result.clone())
-        .unwrap();
+    let actual_result = delegate_transactions.first().cloned().unwrap().result;
 
     let expected_result = Value::okay(Value::Tuple(
         TupleData::from_data(vec![

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -2042,6 +2042,3 @@ pub fn get_last_block_sender_transactions(
         })
         .collect::<Vec<_>>()
 }
-
-// TODO
-// Helper that gets amount locked for a given address


### PR DESCRIPTION
### Description

This PR introduces three tests for core public PoX-4 functions currently missing unit tests, specifically:

- Delegate-stack-extend
- Stack-increase
- Delegate-stack-increase

All three tests live in .boot/pox_4_tests.rs with a few helpers defined in .boot/contract_tests.rs.

### Applicable issues
N/A, general Argon/PoX-4 workflow.

### Additional info (benefits, drawbacks, caveats)

Increases code coverage for PoX-4. There's a Response(DataResponse...) extract that might end up being refactored for standardization but no immediate drawbacks.
