### PR TITLE
Enable approval or rejection of a block via signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,6 +3546,7 @@ dependencies = [
  "async-std",
  "backtrace",
  "base64 0.12.3",
+ "bincode",
  "chrono",
  "clarity",
  "hashbrown 0.14.0",

--- a/libsigner/src/runloop.rs
+++ b/libsigner/src/runloop.rs
@@ -79,14 +79,8 @@ pub trait SignerRunLoop<R: Send, CMD: Send> {
                     return None;
                 }
             };
-            let next_command_opt = match command_recv.recv_timeout(poll_timeout) {
-                Ok(cmd) => Some(cmd),
-                Err(RecvTimeoutError::Timeout) => None,
-                Err(RecvTimeoutError::Disconnected) => {
-                    info!("Command receiver disconnected");
-                    return None;
-                }
-            };
+            // Do not block for commands
+            let next_command_opt = command_recv.try_recv().ok();
             if let Some(final_state) =
                 self.run_one_pass(next_event_opt, next_command_opt, result_send.clone())
             {

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -36,7 +36,7 @@ use wsts::state_machine::PublicKeys;
 /// List of key_ids for each signer_id
 pub type SignerKeyIds = HashMap<u32, Vec<u32>>;
 
-const EVENT_TIMEOUT_MS: u64 = 50;
+const EVENT_TIMEOUT_MS: u64 = 5000;
 
 #[derive(thiserror::Error, Debug)]
 /// An error occurred parsing the provided configuration

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -44,6 +44,7 @@ stacks-signer = { path = "../../stacks-signer" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = {workspace = true}
+bincode = "1.3.3"
 
 [dependencies.rusqlite]
 version = "=0.24.2"

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -468,7 +468,7 @@ fn stackerdb_dkg_sign() {
                     }
                 }
             }
-            if frost_signature.is_some() && schnorr_proof.is_some()
+            if (frost_signature.is_some() && schnorr_proof.is_some())
                 || sign_now.elapsed() > Duration::from_secs(100)
             {
                 break;
@@ -482,8 +482,9 @@ fn stackerdb_dkg_sign() {
         );
         let schnorr_proof =
             schnorr_proof.expect("Failed to get schnorr proof signature within 100 seconds");
+        let tweaked_key = wsts::compute::tweaked_public_key(&key, None);
         assert!(
-            schnorr_proof.verify(&key.x(), &msg.as_slice()),
+            schnorr_proof.verify(&tweaked_key.x(), &msg.as_slice()),
             "Schnorr proof verification failed"
         );
     }

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -381,7 +381,7 @@ fn stackerdb_dkg_sign() {
         .to_vec();
     msg.push(b'n');
 
-    let signer_test = SignerTest::new(5, 5);
+    let signer_test = SignerTest::new(10, 400);
 
     info!("------------------------- Test DKG -------------------------");
     info!("signer_runloop: spawn send commands to do dkg");

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -4,29 +4,26 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{env, thread};
 
-use clarity::vm::ast::ASTRules;
 use clarity::vm::types::QualifiedContractIdentifier;
 use libsigner::{RunningSigner, Signer, SignerEventReceiver};
-use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
-use stacks::chainstate::nakamoto::miner::NakamotoBlockBuilder;
-use stacks::chainstate::nakamoto::NakamotoChainState;
+use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader};
 use stacks::chainstate::stacks::boot::MINERS_NAME;
-use stacks::chainstate::stacks::db::StacksChainState;
-use stacks::chainstate::stacks::miner::{BlockBuilder, BlockLimitFunction, TransactionResult};
-use stacks::chainstate::stacks::{
-    StacksPrivateKey, StacksTransaction, ThresholdSignature, TransactionPayload,
-};
+use stacks::chainstate::stacks::{StacksPrivateKey, ThresholdSignature};
 use stacks::net::api::postblock_proposal::BlockValidateResponse;
 use stacks::util_lib::boot::boot_code_id;
-use stacks_common::codec::StacksMessageCodec;
-use stacks_common::types::chainstate::{StacksAddress, StacksPublicKey};
+use stacks_common::types::chainstate::{
+    ConsensusHash, StacksAddress, StacksBlockId, StacksPublicKey, TrieHash,
+};
+use stacks_common::util::hash::{MerkleTree, Sha512Trunc256Sum};
+use stacks_common::util::secp256k1::MessageSignature;
 use stacks_signer::client::{BlockResponse, SignerMessage, SIGNER_SLOTS_PER_USER};
 use stacks_signer::config::{Config as SignerConfig, Network};
 use stacks_signer::runloop::RunLoopCommand;
 use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
+use wsts::curve::point::Point;
 use wsts::state_machine::coordinator::fire::Coordinator as FireCoordinator;
 use wsts::state_machine::OperationResult;
 use wsts::v2;
@@ -42,7 +39,7 @@ use crate::tests::nakamoto_integrations::{
 use crate::tests::neon_integrations::{
     next_block_and_wait, submit_tx, test_observer, wait_for_runloop,
 };
-use crate::tests::{make_contract_publish, make_stacks_transfer, to_addr};
+use crate::tests::{make_contract_publish, to_addr};
 use crate::{BitcoinRegtestController, BurnchainController};
 
 // Helper struct for holding the btc and stx neon nodes
@@ -72,8 +69,6 @@ struct SignerTest {
     pub running_coordinator: RunningSigner<SignerEventReceiver, Vec<OperationResult>>,
     // The running signer and its threads
     pub running_signers: Vec<RunningSigner<SignerEventReceiver, Vec<OperationResult>>>,
-    // The signer private keys
-    pub signer_stacks_private_keys: Vec<StacksPrivateKey>,
 }
 
 impl SignerTest {
@@ -151,7 +146,6 @@ impl SignerTest {
             coordinator_cmd_sender,
             running_coordinator,
             running_signers,
-            signer_stacks_private_keys,
         }
     }
 
@@ -350,9 +344,44 @@ fn stackerdb_dkg_sign() {
         .init();
 
     info!("------------------------- Test Setup -------------------------");
-    let mut signer_test = SignerTest::new(10, 400);
 
-    // First run DKG in order to sign the block that arrives from the miners following a nakamoto block production
+    info!("Creating an invalid block to sign...");
+    let header = NakamotoBlockHeader {
+        version: 1,
+        chain_length: 2,
+        burn_spent: 3,
+        consensus_hash: ConsensusHash([0x04; 20]),
+        parent_block_id: StacksBlockId([0x05; 32]),
+        tx_merkle_root: Sha512Trunc256Sum([0x06; 32]),
+        state_index_root: TrieHash([0x07; 32]),
+        miner_signature: MessageSignature::empty(),
+        signer_signature: ThresholdSignature::mock(),
+    };
+    let mut block = NakamotoBlock {
+        header,
+        txs: vec![],
+    };
+    let tx_merkle_root = {
+        let txid_vecs = block
+            .txs
+            .iter()
+            .map(|tx| tx.txid().as_bytes().to_vec())
+            .collect();
+
+        MerkleTree::<Sha512Trunc256Sum>::new(&txid_vecs).root()
+    };
+    block.header.tx_merkle_root = tx_merkle_root;
+
+    // The block is valid so the signers should return a signature across its hash + b'n'
+    let mut msg = block
+        .header
+        .signature_hash()
+        .expect("Failed to get signature hash")
+        .0
+        .to_vec();
+    msg.push(b'n');
+
+    let signer_test = SignerTest::new(5, 5);
 
     info!("------------------------- Test DKG -------------------------");
     info!("signer_runloop: spawn send commands to do dkg");
@@ -361,7 +390,7 @@ fn stackerdb_dkg_sign() {
         .coordinator_cmd_sender
         .send(RunLoopCommand::Dkg)
         .expect("failed to send Dkg command");
-    let mut aggregate_public_key_res = None;
+    let mut key = Point::default();
     for recv in signer_test.result_receivers.iter() {
         let mut aggregate_public_key = None;
         loop {
@@ -386,188 +415,13 @@ fn stackerdb_dkg_sign() {
                     }
                 }
             }
-            if aggregate_public_key.is_some() {
-                aggregate_public_key_res = aggregate_public_key;
+            if aggregate_public_key.is_some() || dkg_now.elapsed() > Duration::from_secs(100) {
                 break;
             }
         }
+        key = aggregate_public_key.expect("Failed to get aggregate public key within 100 seconds");
     }
-    aggregate_public_key_res.expect("Failed to get aggregate public key");
     let dkg_elapsed = dkg_now.elapsed();
-
-    let (vrfs_submitted, commits_submitted) = (
-        signer_test.running_nodes.vrfs_submitted.clone(),
-        signer_test.running_nodes.commits_submitted.clone(),
-    );
-
-    info!("------------------------- Mine a Nakamoto Tenure -------------------------");
-
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
-        60,
-        || {
-            let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-            Ok(vrf_count >= 1)
-        },
-    )
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
-    next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
-        60,
-        || {
-            let commits_count = commits_submitted.load(Ordering::SeqCst);
-            Ok(commits_count >= 1)
-        },
-    )
-    .unwrap();
-
-    // Mine 1 nakamoto tenures
-    next_block_and_mine_commit(
-        &mut signer_test.running_nodes.btc_regtest_controller,
-        60,
-        &signer_test.running_nodes.coord_channel,
-        &commits_submitted,
-    )
-    .unwrap();
-
-    // Ensure we signed the proposed block and flush the operation results receiver of it
-    for recv in signer_test.result_receivers.iter() {
-        let mut frost_signature = None;
-        loop {
-            let results = recv.recv().expect("failed to recv results");
-            for result in results {
-                match result {
-                    OperationResult::Sign(sig) => {
-                        info!("Received Signature ({},{})", &sig.R, &sig.z);
-                        frost_signature = Some(sig);
-                    }
-                    OperationResult::SignTaproot(proof) => {
-                        panic!("Received SchnorrProof ({},{})", &proof.r, &proof.s);
-                    }
-                    OperationResult::DkgError(dkg_error) => {
-                        panic!("Received DkgError {:?}", dkg_error);
-                    }
-                    OperationResult::SignError(sign_error) => {
-                        panic!("Received SignError {}", sign_error);
-                    }
-                    OperationResult::Dkg(point) => {
-                        panic!("Received aggregate_group_key {point}");
-                    }
-                }
-            }
-            if frost_signature.is_some() {
-                break;
-            }
-        }
-    }
-
-    info!("Generating a valid block to sign...");
-
-    let burnchain = signer_test.running_nodes.conf.get_burnchain();
-    let sortdb = burnchain.open_sortition_db(true).unwrap();
-    let (mut chainstate, _) = StacksChainState::open(
-        signer_test.running_nodes.conf.is_mainnet(),
-        signer_test.running_nodes.conf.burnchain.chain_id,
-        &signer_test.running_nodes.conf.get_chainstate_path_str(),
-        None,
-    )
-    .unwrap();
-
-    // TODO (hack) instantiate the sortdb in the burnchain
-    _ = signer_test
-        .running_nodes
-        .btc_regtest_controller
-        .sortdb_mut();
-
-    // ----- Setup boilerplate finished, test block proposal API endpoint -----
-
-    let tip = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
-        .unwrap()
-        .unwrap();
-
-    let privk = signer_test
-        .running_nodes
-        .conf
-        .miner
-        .mining_key
-        .unwrap()
-        .clone();
-    let sort_tip = SortitionDB::get_canonical_sortition_tip(sortdb.conn())
-        .expect("Failed to get sortition tip");
-    let db_handle = sortdb.index_handle(&sort_tip);
-    let snapshot = db_handle
-        .get_block_snapshot(&tip.burn_header_hash)
-        .expect("Failed to get block snapshot")
-        .expect("No snapshot");
-    // Double check we got the right sortition
-    assert_eq!(
-        snapshot.consensus_hash, tip.consensus_hash,
-        "Found incorrect block snapshot"
-    );
-    let total_burn = snapshot.total_burn;
-    let tenure_change = None;
-    let coinbase = None;
-
-    let tenure_cause = tenure_change.and_then(|tx: &StacksTransaction| match &tx.payload {
-        TransactionPayload::TenureChange(tc) => Some(tc.cause),
-        _ => None,
-    });
-
-    let mut block = {
-        let mut builder = NakamotoBlockBuilder::new(
-            &tip,
-            &tip.consensus_hash,
-            total_burn,
-            tenure_change,
-            coinbase,
-        )
-        .expect("Failed to build Nakamoto block");
-
-        let burn_dbconn = signer_test
-            .running_nodes
-            .btc_regtest_controller
-            .sortdb_ref()
-            .index_conn();
-        let mut miner_tenure_info = builder
-            .load_tenure_info(&mut chainstate, &burn_dbconn, tenure_cause)
-            .unwrap();
-        let mut tenure_tx = builder
-            .tenure_begin(&burn_dbconn, &mut miner_tenure_info)
-            .unwrap();
-
-        let tx = make_stacks_transfer(
-            &signer_test.signer_stacks_private_keys[0],
-            0,
-            100,
-            &to_addr(&signer_test.signer_stacks_private_keys[1]).into(),
-            10000,
-        );
-        let tx = StacksTransaction::consensus_deserialize(&mut &tx[..])
-            .expect("Failed to deserialize transaction");
-        let tx_len = tx.tx_len();
-
-        let res = builder.try_mine_tx_with_len(
-            &mut tenure_tx,
-            &tx,
-            tx_len,
-            &BlockLimitFunction::NO_LIMIT_HIT,
-            ASTRules::PrecheckSize,
-        );
-        assert!(
-            matches!(res, TransactionResult::Success(..)),
-            "Transaction failed"
-        );
-        builder.mine_nakamoto_block(&mut tenure_tx)
-    };
-
-    // Sign the block
-    block
-        .header
-        .sign_miner(&privk)
-        .expect("Miner failed to sign");
 
     info!("------------------------- Test Sign -------------------------");
     let sign_now = std::time::Instant::now();
@@ -610,14 +464,28 @@ fn stackerdb_dkg_sign() {
                         panic!("Received SignError {}", sign_error);
                     }
                     OperationResult::Dkg(point) => {
-                        info!("Received aggregate_group_key {point}");
+                        panic!("Received aggregate_group_key {point}");
                     }
                 }
             }
-            if frost_signature.is_some() && schnorr_proof.is_some() {
+            if frost_signature.is_some() && schnorr_proof.is_some()
+                || sign_now.elapsed() > Duration::from_secs(100)
+            {
                 break;
             }
         }
+        let frost_signature =
+            frost_signature.expect("Failed to get frost signature within 100 seconds");
+        assert!(
+            frost_signature.verify(&key, msg.as_slice()),
+            "Signature verification failed"
+        );
+        let schnorr_proof =
+            schnorr_proof.expect("Failed to get schnorr proof signature within 100 seconds");
+        assert!(
+            schnorr_proof.verify(&key.x(), &msg.as_slice()),
+            "Schnorr proof verification failed"
+        );
     }
     let sign_elapsed = sign_now.elapsed();
 


### PR DESCRIPTION
### Description
This uses the results of a verification to determine whether to vote no or approve a block proposal.
It also broadcasts either a rejection or an approval back to the miners to observe in the .signers contract.


### Applicable issues

- Closes https://github.com/stacks-network/stacks-core/issues/3930
- Relates to https://github.com/stacks-network/stacks-core/issues/4242
### Additional info (benefits, drawbacks, caveats)
 Depends on https://github.com/Trust-Machines/wsts/pull/46
