### PR TITLE
Clarity-Wasm: fix inconsistencies between reading and writing values in memory

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1211,7 +1211,9 @@ fn write_to_wasm(
             // written to the memory at `offset`. The `in_mem_offset` for the
             // list elements should be after their representations.
             let val_offset = in_mem_offset;
-            let val_in_mem_offset = in_mem_offset + get_type_in_memory_size(ty, false);
+            let val_in_mem_offset = in_mem_offset
+                + list_data.data.len() as i32
+                    * get_type_size(list_data.type_signature.get_list_item_type());
             let mut val_written = 0;
             let mut val_in_mem_written = 0;
             for elem in &list_data.data {

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -792,7 +792,7 @@ fn read_indirect_offset_and_length(
 /// memory, then read the actual value.
 fn read_from_wasm_indirect(
     memory: Memory,
-    mut store: &mut impl AsContextMut,
+    store: &mut impl AsContextMut,
     ty: &TypeSignature,
     mut offset: i32,
     epoch: StacksEpochId,

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1327,6 +1327,8 @@ fn write_to_wasm(
                 )?;
                 written += new_written;
                 in_mem_written += new_in_mem_written;
+            } else {
+                written += get_type_size(&inner_ty);
             }
             Ok((written, in_mem_written))
         }


### PR DESCRIPTION
This PR fixes a few inconsistencies between reading and writing of values in Wasm memory.

The tests for this PR will exist in the [clarity-wasm repo](https://github.com/stacks-network/clarity-wasm), since those issues are linked to property testing in this repo.