### PR TITLE
Nakamoto: remove stacker signature fields from tenure change payload

### DIFF
--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -174,8 +174,6 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         previous_tenure_blocks: 1,
         cause: TenureChangeCause::BlockFound,
         pubkey_hash: Hash160([0x02; 20]),
-        signature: ThresholdSignature::mock(),
-        signers: vec![],
     };
 
     // non-sortition-inducing tenure change
@@ -187,8 +185,6 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         previous_tenure_blocks: 1,
         cause: TenureChangeCause::Extended,
         pubkey_hash: Hash160([0x02; 20]),
-        signature: ThresholdSignature::mock(),
-        signers: vec![],
     };
 
     let invalid_tenure_change_payload = TenureChangePayload {
@@ -200,8 +196,6 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         previous_tenure_blocks: 1,
         cause: TenureChangeCause::BlockFound,
         pubkey_hash: Hash160([0x02; 20]),
-        signature: ThresholdSignature::mock(),
-        signers: vec![],
     };
 
     let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
@@ -615,8 +609,6 @@ pub fn test_load_store_update_nakamoto_blocks() {
         previous_tenure_blocks: 1,
         cause: TenureChangeCause::BlockFound,
         pubkey_hash: Hash160([0x02; 20]),
-        signature: ThresholdSignature::mock(),
-        signers: vec![],
     };
 
     let tenure_change_tx_payload = TransactionPayload::TenureChange(tenure_change_payload.clone());
@@ -1255,8 +1247,6 @@ fn test_nakamoto_block_static_verification() {
         previous_tenure_blocks: 1,
         cause: TenureChangeCause::BlockFound,
         pubkey_hash: Hash160::from_node_public_key(&StacksPublicKey::from_private(&private_key)),
-        signature: ThresholdSignature::mock(),
-        signers: vec![],
     };
 
     let tenure_change_payload_bad_ch = TenureChangePayload {
@@ -1267,8 +1257,6 @@ fn test_nakamoto_block_static_verification() {
         previous_tenure_blocks: 1,
         cause: TenureChangeCause::BlockFound,
         pubkey_hash: Hash160::from_node_public_key(&StacksPublicKey::from_private(&private_key)),
-        signature: ThresholdSignature::mock(),
-        signers: vec![],
     };
 
     let tenure_change_payload_bad_miner_sig = TenureChangePayload {
@@ -1279,8 +1267,6 @@ fn test_nakamoto_block_static_verification() {
         previous_tenure_blocks: 1,
         cause: TenureChangeCause::BlockFound,
         pubkey_hash: Hash160([0x02; 20]), // wrong
-        signature: ThresholdSignature::mock(),
-        signers: vec![],
     };
 
     let tenure_change_tx_payload = TransactionPayload::TenureChange(tenure_change_payload.clone());
@@ -1551,8 +1537,6 @@ pub fn test_get_highest_nakamoto_tenure() {
             previous_tenure_blocks: 10,
             cause: TenureChangeCause::BlockFound,
             pubkey_hash: Hash160([0x00; 20]),
-            signature: ThresholdSignature::mock(),
-            signers: vec![],
         };
 
         let tx = chainstate.db_tx_begin().unwrap();

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -476,8 +476,6 @@ impl TestStacksNode {
             previous_tenure_blocks,
             cause: tenure_change_cause,
             pubkey_hash: miner.nakamoto_miner_hash160(),
-            signature: ThresholdSignature::mock(),
-            signers: vec![],
         };
 
         let block_commit_op = self.make_nakamoto_tenure_commitment(

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -1789,8 +1789,6 @@ mod test {
             previous_tenure_blocks: 0,
             cause: TenureChangeCause::BlockFound,
             pubkey_hash: Hash160([0x00; 20]),
-            signature: ThresholdSignature::mock(),
-            signers: vec![],
         };
         let tx_tenure_change = StacksTransaction::new(
             TransactionVersion::Testnet,

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -731,10 +731,6 @@ pub struct TenureChangePayload {
     pub cause: TenureChangeCause,
     /// The ECDSA public key hash of the current tenure
     pub pubkey_hash: Hash160,
-    /// The Stacker signature
-    pub signature: ThresholdSignature,
-    /// A bitmap of which Stackers signed
-    pub signers: Vec<u8>,
 }
 
 impl TenureChangePayload {
@@ -752,8 +748,6 @@ impl TenureChangePayload {
             previous_tenure_blocks: num_blocks_so_far,
             cause: TenureChangeCause::Extended,
             pubkey_hash: self.pubkey_hash.clone(),
-            signature: ThresholdSignature::mock(),
-            signers: vec![],
         }
     }
 }
@@ -1400,8 +1394,6 @@ pub mod test {
                 previous_tenure_blocks: 0,
                 cause: TenureChangeCause::BlockFound,
                 pubkey_hash: Hash160([0x00; 20]),
-                signature: ThresholdSignature::mock(),
-                signers: vec![],
             }),
         ];
 

--- a/stackslib/src/chainstate/stacks/transaction.rs
+++ b/stackslib/src/chainstate/stacks/transaction.rs
@@ -201,9 +201,7 @@ impl StacksMessageCodec for TenureChangePayload {
         write_next(fd, &self.previous_tenure_end)?;
         write_next(fd, &self.previous_tenure_blocks)?;
         write_next(fd, &self.cause)?;
-        write_next(fd, &self.pubkey_hash)?;
-        write_next(fd, &self.signature)?;
-        write_next(fd, &self.signers)
+        write_next(fd, &self.pubkey_hash)
     }
 
     fn consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, codec_error> {
@@ -215,8 +213,6 @@ impl StacksMessageCodec for TenureChangePayload {
             previous_tenure_blocks: read_next(fd)?,
             cause: read_next(fd)?,
             pubkey_hash: read_next(fd)?,
-            signature: read_next(fd)?,
-            signers: read_next(fd)?,
         })
     }
 }
@@ -3782,8 +3778,6 @@ mod test {
                 previous_tenure_blocks: 0,
                 cause: TenureChangeCause::BlockFound,
                 pubkey_hash: Hash160([0x00; 20]),
-                signature: ThresholdSignature::mock(),
-                signers: vec![],
             }),
         );
 

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -813,8 +813,6 @@ impl MockamotoNode {
             previous_tenure_blocks: 1,
             cause: TenureChangeCause::BlockFound,
             pubkey_hash: miner_pk_hash,
-            signature: ThresholdSignature::mock(),
-            signers: vec![],
         });
         let mut tenure_tx = StacksTransaction::new(
             TransactionVersion::Testnet,

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -30,8 +30,8 @@ use stacks::chainstate::stacks::boot::MINERS_NAME;
 use stacks::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
 use stacks::chainstate::stacks::{
     CoinbasePayload, Error as ChainstateError, StacksTransaction, StacksTransactionSigner,
-    TenureChangeCause, TenureChangePayload, ThresholdSignature, TransactionAnchorMode,
-    TransactionPayload, TransactionVersion,
+    TenureChangeCause, TenureChangePayload, TransactionAnchorMode, TransactionPayload,
+    TransactionVersion,
 };
 use stacks::core::FIRST_BURNCHAIN_CONSENSUS_HASH;
 use stacks::net::stackerdb::StackerDBs;
@@ -299,11 +299,6 @@ impl BlockMinerThread {
         parent_tenure_blocks: u64,
         miner_pkh: Hash160,
     ) -> Result<StacksTransaction, NakamotoNodeError> {
-        if self.config.self_signing().is_none() {
-            // if we're not self-signing, then we can't generate a tenure change tx: it has to come from the signers.
-            warn!("Tried to generate a tenure change transaction, but we aren't self-signing");
-            return Err(NakamotoNodeError::CannotSelfSign);
-        }
         let is_mainnet = self.config.is_mainnet();
         let chain_id = self.config.burnchain.chain_id;
         let tenure_change_tx_payload = TransactionPayload::TenureChange(TenureChangePayload {
@@ -315,8 +310,6 @@ impl BlockMinerThread {
                 .expect("FATAL: more than u32 blocks in a tenure"),
             cause: TenureChangeCause::BlockFound,
             pubkey_hash: miner_pkh,
-            signers: vec![],
-            signature: ThresholdSignature::mock(),
         });
 
         let mut tx_auth = self.keychain.get_transaction_auth().unwrap();


### PR DESCRIPTION
### Description

Related to closing #3932 -- TenureChange payloads don't need stacker signatures, because stackers have to sign the block header, which incorporates the TenureChange payload in its tx hash.

The signer binary doesn't need to do anything special to validate these payloads: they have to sign off on blocks anyways, and the content of tenure change transactions is validated by the stacks-node's block proposal validation endpoint already.

Conveniently, this also doesn't place much of a burden on the stacks-node miner either: the nakamoto-neon miner was already constructing tenure change transactions in self-signing-mode , so this PR just makes it construct those transactions all the time.

Closes #4258