### PR TITLE
.signers StackerDB contract and PoX 4 signer key changes

### DIFF
--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -520,17 +520,6 @@ impl PoxConstants {
         (effective_height % u64::from(self.reward_cycle_length)) == 1
     }
 
-    pub fn is_prepare_phase_start(&self, first_block_height: u64, burn_height: u64) -> bool {
-        if burn_height < first_block_height {
-            false
-        } else {
-            let effective_height = burn_height - first_block_height;
-            (effective_height + u64::from(self.prepare_length))
-                % u64::from(self.reward_cycle_length)
-                == 0
-        }
-    }
-
     pub fn reward_cycle_to_block_height(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
         // NOTE: the `+ 1` is because the height of the first block of a reward cycle is mod 1, not
         // mod 0.
@@ -547,6 +536,29 @@ impl PoxConstants {
             first_block_height,
             u64::from(self.reward_cycle_length),
         )
+    }
+
+    /// Return the reward cycle that the current prepare phase corresponds to if `block_height` is _in_ a prepare
+    /// phase. If it is not in a prepare phase, return None.
+    pub fn reward_cycle_of_prepare_phase(
+        &self,
+        first_block_height: u64,
+        block_height: u64,
+    ) -> Option<u64> {
+        if !self.is_in_prepare_phase(first_block_height, block_height) {
+            return None;
+        }
+        // the None branches here should be unreachable, because if `first_block_height > block_height`,
+        //   `is_in_prepare_phase` would have returned false, but no need to be unsafe anyways.
+        let effective_height = block_height.checked_sub(first_block_height)?;
+        let current_cycle = self.block_height_to_reward_cycle(first_block_height, block_height)?;
+        if effective_height % u64::from(self.reward_cycle_length) == 0 {
+            // if this is the "mod 0" block of a prepare phase, its corresponding reward cycle is the current one
+            Some(current_cycle)
+        } else {
+            // otherwise, the corresponding reward cycle is actually the _next_ reward cycle
+            Some(current_cycle + 1)
+        }
     }
 
     pub fn is_in_prepare_phase(&self, first_block_height: u64, block_height: u64) -> bool {

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -520,6 +520,17 @@ impl PoxConstants {
         (effective_height % u64::from(self.reward_cycle_length)) == 1
     }
 
+    pub fn is_prepare_phase_start(&self, first_block_height: u64, burn_height: u64) -> bool {
+        if burn_height < first_block_height {
+            false
+        } else {
+            let effective_height = burn_height - first_block_height;
+            (effective_height + u64::from(self.prepare_length))
+                % u64::from(self.reward_cycle_length)
+                == 0
+        }
+    }
+
     pub fn reward_cycle_to_block_height(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
         // NOTE: the `+ 1` is because the height of the first block of a reward cycle is mod 1, not
         // mod 0.

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -68,18 +68,6 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
         let mut registered_addrs =
             chainstate.get_reward_addresses_in_cycle(burnchain, sortdb, cycle, block_id)?;
 
-        // TODO (pox-4-workstream): the pox-4 contract must be able to return signing keys
-        //   associated with reward set entries (i.e., via `get-reward-set-pox-addresses`)
-        //   *not* stacking-state entries (as it is currently implemented). Until that's done,
-        //   this method just mocks that data.
-        for (index, entry) in registered_addrs.iter_mut().enumerate() {
-            let index = u64::try_from(index).expect("FATAL: more than u64 reward set entries");
-            let sk = StacksPrivateKey::from_seed(&index.to_be_bytes());
-            let addr =
-                StacksAddress::p2pkh(chainstate.mainnet, &StacksPublicKey::from_private(&sk));
-            entry.signing_key = Some(addr.into());
-        }
-
         let liquid_ustx = chainstate.get_liquid_ustx(block_id);
 
         let (threshold, participation) = StacksChainState::get_reward_threshold_and_participation(

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -38,7 +38,6 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::boot::test::{
     key_to_stacks_addr, make_pox_4_aggregate_key, make_pox_4_lockup,
 };
-use crate::chainstate::stacks::boot::test::{make_pox_4_aggregate_key, make_pox_4_lockup};
 use crate::chainstate::stacks::boot::MINERS_NAME;
 use crate::chainstate::stacks::db::{MinerPaymentTxFees, StacksAccount, StacksChainState};
 use crate::chainstate::stacks::{
@@ -49,9 +48,8 @@ use crate::chainstate::stacks::{
 use crate::clarity::vm::types::StacksAddressExtensions;
 use crate::core::StacksEpochExtension;
 use crate::net::relay::Relayer;
-use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
 use crate::net::stackerdb::StackerDBConfig;
-use crate::net::test::{TestPeer, TestPeerConfig};
+use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
 use crate::util_lib::boot::boot_code_id;
 
 /// Bring a TestPeer into the Nakamoto Epoch

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -24,6 +24,7 @@ use stacks_common::types::chainstate::{
     StacksAddress, StacksBlockId, StacksPrivateKey, StacksPublicKey,
 };
 use stacks_common::types::{Address, StacksEpoch};
+use stacks_common::util::secp256k1::Secp256k1PrivateKey;
 use stacks_common::util::vrf::VRFProof;
 use wsts::curve::point::Point;
 
@@ -31,9 +32,12 @@ use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
 use crate::chainstate::burn::operations::BlockstackOperationType;
 use crate::chainstate::coordinator::tests::p2pkh_from;
 use crate::chainstate::nakamoto::tests::get_account;
-use crate::chainstate::nakamoto::tests::node::TestSigners;
+use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use crate::chainstate::stacks::address::PoxAddress;
+use crate::chainstate::stacks::boot::test::{
+    key_to_stacks_addr, make_pox_4_aggregate_key, make_pox_4_lockup,
+};
 use crate::chainstate::stacks::boot::test::{make_pox_4_aggregate_key, make_pox_4_lockup};
 use crate::chainstate::stacks::boot::MINERS_NAME;
 use crate::chainstate::stacks::db::{MinerPaymentTxFees, StacksAccount, StacksChainState};
@@ -45,20 +49,19 @@ use crate::chainstate::stacks::{
 use crate::clarity::vm::types::StacksAddressExtensions;
 use crate::core::StacksEpochExtension;
 use crate::net::relay::Relayer;
+use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
 use crate::net::stackerdb::StackerDBConfig;
 use crate::net::test::{TestPeer, TestPeerConfig};
 use crate::util_lib::boot::boot_code_id;
 
 /// Bring a TestPeer into the Nakamoto Epoch
-fn advance_to_nakamoto(peer: &mut TestPeer) {
+fn advance_to_nakamoto(
+    peer: &mut TestPeer,
+    test_signers: &TestSigners,
+    test_stackers: Vec<&TestStacker>,
+) {
     let mut peer_nonce = 0;
     let private_key = peer.config.private_key.clone();
-    let signer_key = StacksPublicKey::from_slice(&[
-        0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
-        0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
-        0x59, 0x98, 0x3c,
-    ])
-    .unwrap();
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -70,17 +73,24 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
     for sortition_height in 0..11 {
         // stack to pox-3 in cycle 7
         let txs = if sortition_height == 6 {
-            // stack them all
-            let stack_tx = make_pox_4_lockup(
-                &private_key,
-                0,
-                1_000_000_000_000_000_000,
-                PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone()),
-                12,
-                signer_key,
-                34,
-            );
-            vec![stack_tx]
+            // Make all the test Stackers stack
+            test_stackers
+                .iter()
+                .map(|test_stacker| {
+                    make_pox_4_lockup(
+                        &test_stacker.stacker_private_key,
+                        0,
+                        test_stacker.amount,
+                        PoxAddress::from_legacy(
+                            AddressHashMode::SerializeP2PKH,
+                            addr.bytes.clone(),
+                        ),
+                        12,
+                        StacksPublicKey::from_private(&test_stacker.signer_private_key),
+                        34,
+                    )
+                })
+                .collect()
         } else {
             vec![]
         };
@@ -92,11 +102,13 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
 
 /// Make a peer and transition it into the Nakamoto epoch.
 /// The node needs to be stacking; otherwise, Nakamoto won't activate.
-pub fn boot_nakamoto(
+pub fn boot_nakamoto<'a>(
     test_name: &str,
     mut initial_balances: Vec<(PrincipalData, u64)>,
-    aggregate_public_key: Point,
-) -> TestPeer {
+    test_signers: &TestSigners,
+    test_stackers: Option<Vec<&TestStacker>>,
+) -> TestPeer<'a> {
+    let aggregate_public_key = test_signers.aggregate_public_key.clone();
     let mut peer_config = TestPeerConfig::new(test_name, 0, 0);
     let private_key = peer_config.private_key.clone();
     let addr = StacksAddress::from_public_keys(
@@ -117,13 +129,45 @@ pub fn boot_nakamoto(
         .push(boot_code_id(MINERS_NAME, false));
     peer_config.epochs = Some(StacksEpoch::unit_test_3_0_only(37));
     peer_config.initial_balances = vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
+
+    let test_stackers: Vec<TestStacker> = if let Some(stackers) = test_stackers {
+        stackers.into_iter().cloned().collect()
+    } else {
+        // Create a list of test Stackers and their signer keys
+        (0..test_signers.num_keys)
+            .map(|index| {
+                let stacker_private_key = StacksPrivateKey::from_seed(&index.to_be_bytes());
+                let signer_private_key = StacksPrivateKey::from_seed(&(index + 1000).to_be_bytes());
+                TestStacker {
+                    stacker_private_key,
+                    signer_private_key,
+                    amount: 1_000_000_000_000_000_000,
+                }
+            })
+            .collect()
+    };
+
+    // Create some balances for test Stackers
+    let mut stacker_balances = test_stackers
+        .iter()
+        .map(|test_stacker| {
+            (
+                PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key)),
+                u64::try_from(test_stacker.amount).expect("Stacking amount too large"),
+            )
+        })
+        .collect();
+
+    peer_config.initial_balances.append(&mut stacker_balances);
     peer_config.initial_balances.append(&mut initial_balances);
     peer_config.burnchain.pox_constants.v2_unlock_height = 21;
     peer_config.burnchain.pox_constants.pox_3_activation_height = 26;
     peer_config.burnchain.pox_constants.v3_unlock_height = 27;
     peer_config.burnchain.pox_constants.pox_4_activation_height = 31;
     let mut peer = TestPeer::new(peer_config);
-    advance_to_nakamoto(&mut peer);
+
+    advance_to_nakamoto(&mut peer, &test_signers, test_stackers.iter().collect());
+
     peer
 }
 
@@ -134,8 +178,20 @@ fn make_replay_peer<'a>(peer: &'a mut TestPeer<'a>) -> TestPeer<'a> {
     replay_config.server_port = 0;
     replay_config.http_port = 0;
 
+    let private_key = peer.config.private_key.clone();
+    let signer_private_key = StacksPrivateKey::from_seed(&[3]);
+
     let mut replay_peer = TestPeer::new(replay_config);
-    advance_to_nakamoto(&mut replay_peer);
+    let observer = TestEventObserver::new();
+    advance_to_nakamoto(
+        &mut replay_peer,
+        &TestSigners::default(),
+        vec![&TestStacker {
+            stacker_private_key: private_key,
+            signer_private_key,
+            amount: 1_000_000_000_000_000_000,
+        }],
+    );
 
     // sanity check
     let replay_tip = {
@@ -162,7 +218,7 @@ fn make_replay_peer<'a>(peer: &'a mut TestPeer<'a>) -> TestPeer<'a> {
 }
 
 /// Make a token-transfer from a private key
-fn make_token_transfer(
+pub fn make_token_transfer(
     chainstate: &mut StacksChainState,
     sortdb: &SortitionDB,
     private_key: &StacksPrivateKey,
@@ -250,11 +306,7 @@ fn replay_reward_cycle(
 #[test]
 fn test_simple_nakamoto_coordinator_bootup() {
     let mut test_signers = TestSigners::default();
-    let mut peer = boot_nakamoto(
-        function_name!(),
-        vec![],
-        test_signers.aggregate_public_key.clone(),
-    );
+    let mut peer = boot_nakamoto(function_name!(), vec![], &test_signers, None);
 
     let (burn_ops, mut tenure_change, miner_key) =
         peer.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
@@ -313,7 +365,8 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let (burn_ops, mut tenure_change, miner_key) =
@@ -434,7 +487,8 @@ fn test_nakamoto_chainstate_getters() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let sort_tip = {
@@ -923,7 +977,8 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let mut all_blocks = vec![];
@@ -1243,7 +1298,8 @@ fn test_simple_nakamoto_coordinator_2_tenures_3_sortitions() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let mut rc_burn_ops = vec![];
@@ -1571,7 +1627,8 @@ fn test_simple_nakamoto_coordinator_10_tenures_and_extensions_10_blocks() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let mut all_blocks = vec![];

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -224,11 +224,17 @@ impl NakamotoBlockBuilder {
     ) -> Result<MinerTenureInfo<'a>, Error> {
         debug!("Nakamoto miner tenure begin");
 
-        let burn_tip = SortitionDB::get_canonical_chain_tip_bhh(burn_dbconn.conn())?;
-        let burn_tip_height = u32::try_from(
-            SortitionDB::get_canonical_burn_chain_tip(burn_dbconn.conn())?.block_height,
-        )
-        .expect("block height overflow");
+        // must build off of the header's consensus hash as the burnchain view, not the canonical_tip_bhh:
+        let burn_sn = SortitionDB::get_block_snapshot_consensus(burn_dbconn.conn(), &self.header.consensus_hash)?
+            .ok_or_else(|| {
+                warn!(
+                    "Could not mine. The expected burnchain consensus hash has not been processed by our SortitionDB";
+                    "consensus_hash" => %self.header.consensus_hash
+                );
+                Error::NoSuchBlockError
+            })?;
+        let burn_tip = burn_sn.burn_header_hash;
+        let burn_tip_height = u32::try_from(burn_sn.block_height).expect("block height overflow");
 
         let mainnet = chainstate.config().mainnet;
 

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::DerefMut;
 
 use clarity::vm::ast::ASTRules;
@@ -1814,25 +1814,22 @@ impl NakamotoChainState {
         }
     }
 
-    pub fn calculate_signer_slots(
+    fn calculate_signer_slots(
         clarity: &mut ClarityTransactionConnection,
         pox_constants: &PoxConstants,
-    ) -> Result<HashMap<Value, u128>, clarity::vm::errors::Error> {
+        reward_cycle: u64,
+    ) -> Result<BTreeMap<Vec<u8>, u128>, ChainstateError> {
         let is_mainnet = clarity.is_mainnet();
         let pox4_contract = &boot_code_id(POX_4_NAME, is_mainnet);
-        let reward_cycle = clarity
-            .eval_read_only(pox4_contract, &"(current-pox-reward-cycle)")
-            .unwrap()
-            .expect_u128();
+
         let list_length = clarity
             .eval_read_only(
                 pox4_contract,
                 &format!("(get-signer-key-list-length u{})", reward_cycle),
-            )
-            .unwrap()
+            )?
             .expect_u128();
 
-        let mut signers: HashMap<Value, u128> = HashMap::new();
+        let mut signers: BTreeMap<Vec<u8>, u128> = BTreeMap::new();
         let mut total_ustx: u128 = 0;
         for index in 0..list_length {
             if let Ok(Value::Optional(entry)) = clarity.eval_read_only(
@@ -1841,10 +1838,9 @@ impl NakamotoChainState {
             ) {
                 if let Some(data) = entry.data {
                     let data = data.expect_tuple();
-                    let key = data.get("signer-key")?.to_owned();
+                    let key = data.get("signer-key")?.to_owned().expect_buff(33);
                     let amount = data.get("ustx")?.to_owned().expect_u128();
                     let sum = signers.get(&key).cloned().unwrap_or_default();
-                    //TODO HashMap insert order is not guaranteed
                     signers.insert(key, sum + amount);
                     total_ustx = total_ustx
                         .checked_add(amount)
@@ -1869,19 +1865,19 @@ impl NakamotoChainState {
         clarity: &mut ClarityTransactionConnection,
         chain_id: u32,
         pox_constants: &PoxConstants,
-    ) -> Result<Vec<StacksTransactionEvent>, Error> {
+        reward_cycle: u64,
+    ) -> Result<Vec<StacksTransactionEvent>, ChainstateError> {
         let is_mainnet = clarity.is_mainnet();
         let sender_addr = PrincipalData::from(boot::boot_code_addr(is_mainnet));
         let signers_contract = &boot_code_id(SIGNERS_NAME, is_mainnet);
 
-        let signers = Self::calculate_signer_slots(clarity, pox_constants).unwrap_or_default();
+        let signers =
+            Self::calculate_signer_slots(clarity, pox_constants, reward_cycle).unwrap_or_default();
 
         let signers_list_data: Vec<Value> = signers
             .iter()
             .map(|(signer_key, slots)| {
-                let key =
-                    StacksPublicKey::from_slice(signer_key.to_owned().expect_buff(33).as_slice())
-                        .expect("TODO: invalid key");
+                let key = StacksPublicKey::from_slice(signer_key.as_slice()).unwrap();
                 let addr = StacksAddress::from_public_keys(
                     if is_mainnet {
                         C32_ADDRESS_VERSION_MAINNET_SINGLESIG
@@ -1939,7 +1935,7 @@ impl NakamotoChainState {
         first_block_height: u64,
         pox_constants: &PoxConstants,
         burn_tip_height: u64,
-    ) -> Result<Vec<StacksTransactionEvent>, Error> {
+    ) -> Result<Vec<StacksTransactionEvent>, ChainstateError> {
         if clarity_tx.get_epoch() < StacksEpochId::Epoch25
             || !pox_constants.is_prepare_phase_start(first_block_height, burn_tip_height)
         {
@@ -1956,6 +1952,9 @@ impl NakamotoChainState {
                 clarity,
                 clarity_tx.config.chain_id,
                 &pox_constants,
+                pox_constants
+                    .block_height_to_reward_cycle(first_block_height, burn_tip_height)
+                    .expect("FATAL: no reward cycle for block height"),
             )
         })
     }

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -1502,11 +1502,7 @@ fn make_fork_run_with_arrivals(
 #[test]
 pub fn test_get_highest_nakamoto_tenure() {
     let test_signers = TestSigners::default();
-    let mut peer = boot_nakamoto(
-        function_name!(),
-        vec![],
-        test_signers.aggregate_public_key.clone(),
-    );
+    let mut peer = boot_nakamoto(function_name!(), vec![], &test_signers, None);
 
     // extract chainstate and sortdb -- we don't need the peer anymore
     let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -1644,11 +1644,7 @@ pub fn test_get_highest_nakamoto_tenure() {
 #[test]
 fn test_make_miners_stackerdb_config() {
     let test_signers = TestSigners::default();
-    let mut peer = boot_nakamoto(
-        function_name!(),
-        vec![],
-        test_signers.aggregate_public_key.clone(),
-    );
+    let mut peer = boot_nakamoto(function_name!(), vec![], &test_signers, None);
 
     let naka_miner_hash160 = peer.miner.nakamoto_miner_hash160();
     let miner_keys: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -66,6 +66,31 @@ use crate::util_lib::boot::boot_code_addr;
 use crate::util_lib::db::Error as db_error;
 
 #[derive(Debug, Clone)]
+pub struct TestStacker {
+    pub stacker_private_key: StacksPrivateKey,
+    pub signer_private_key: StacksPrivateKey,
+    pub amount: u128,
+}
+
+impl TestStacker {
+    pub fn from_seed(seed: &[u8]) -> TestStacker {
+        let stacker_private_key = StacksPrivateKey::from_seed(seed);
+        let mut signer_seed = seed.to_vec();
+        signer_seed.append(&mut vec![0xff, 0x00, 0x00, 0x00]);
+        let signer_private_key = StacksPrivateKey::from_seed(signer_seed.as_slice());
+        TestStacker {
+            stacker_private_key,
+            signer_private_key,
+            amount: 1_000_000_000_000_000_000,
+        }
+    }
+
+    pub fn signer_public_key(&self) -> StacksPublicKey {
+        StacksPublicKey::from_private(&self.signer_private_key)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct TestSigners {
     /// The parties that will sign the blocks
     pub signer_parties: Vec<wsts::v2::Party>,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -622,6 +622,7 @@ impl TestStacksNode {
 
             let sort_tip = SortitionDB::get_canonical_sortition_tip(sortdb.conn()).unwrap();
             let mut sort_handle = sortdb.index_handle(&sort_tip);
+            info!("Processing the new nakamoto block");
             let accepted = match Relayer::process_new_nakamoto_block(
                 sortdb,
                 &mut sort_handle,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -25,10 +25,14 @@ use clarity::vm::clarity::{Error as ClarityError, TransactionConnection};
 use clarity::vm::contexts::ContractContext;
 use clarity::vm::costs::cost_functions::ClarityCostFunction;
 use clarity::vm::costs::{ClarityCostFunctionReference, CostStateSummary, LimitedCostTracker};
-use clarity::vm::database::{ClarityDatabase, NULL_BURN_STATE_DB, NULL_HEADER_DB};
-use clarity::vm::errors::{Error as VmError, InterpreterError};
+use clarity::vm::database::{
+    ClarityDatabase, DataVariableMetadata, NULL_BURN_STATE_DB, NULL_HEADER_DB,
+};
+use clarity::vm::errors::{Error as VmError, InterpreterError, InterpreterResult};
 use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::representations::{ClarityName, ContractName};
+use clarity::vm::tests::symbols_from_values;
+use clarity::vm::types::TypeSignature::UIntType;
 use clarity::vm::types::{
     PrincipalData, QualifiedContractIdentifier, SequenceData, StandardPrincipalData, TupleData,
     TypeSignature, Value,
@@ -75,10 +79,12 @@ pub const POX_1_NAME: &'static str = "pox";
 pub const POX_2_NAME: &'static str = "pox-2";
 pub const POX_3_NAME: &'static str = "pox-3";
 pub const POX_4_NAME: &'static str = "pox-4";
+pub const SIGNERS_NAME: &'static str = "signers";
 
 const POX_2_BODY: &'static str = std::include_str!("pox-2.clar");
 const POX_3_BODY: &'static str = std::include_str!("pox-3.clar");
 const POX_4_BODY: &'static str = std::include_str!("pox-4.clar");
+pub const SIGNERS_BODY: &'static str = std::include_str!("signers.clar");
 
 pub const COSTS_1_NAME: &'static str = "costs";
 pub const COSTS_2_NAME: &'static str = "costs-2";
@@ -1255,6 +1261,8 @@ pub mod pox_2_tests;
 pub mod pox_3_tests;
 #[cfg(test)]
 pub mod pox_4_tests;
+#[cfg(test)]
+mod signers_tests;
 
 #[cfg(test)]
 pub mod test {

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -31,7 +31,6 @@ use clarity::vm::database::{
 use clarity::vm::errors::{Error as VmError, InterpreterError, InterpreterResult};
 use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::representations::{ClarityName, ContractName};
-use clarity::vm::tests::symbols_from_values;
 use clarity::vm::types::TypeSignature::UIntType;
 use clarity::vm::types::{
     PrincipalData, QualifiedContractIdentifier, SequenceData, StandardPrincipalData, TupleData,
@@ -80,6 +79,10 @@ pub const POX_2_NAME: &'static str = "pox-2";
 pub const POX_3_NAME: &'static str = "pox-3";
 pub const POX_4_NAME: &'static str = "pox-4";
 pub const SIGNERS_NAME: &'static str = "signers";
+/// This is the name of a variable in the `.signers` contract which tracks the most recently updated
+/// reward cycle number.
+pub const SIGNERS_UPDATE_STATE: &'static str = "last-set-cycle";
+pub const SIGNERS_MAX_LIST_SIZE: usize = 4000;
 
 const POX_2_BODY: &'static str = std::include_str!("pox-2.clar");
 const POX_3_BODY: &'static str = std::include_str!("pox-3.clar");
@@ -163,6 +166,20 @@ pub struct RawRewardSetEntry {
     pub stacker: Option<PrincipalData>,
     pub signer: Option<PrincipalData>,
 }
+
+/// This enum captures the names of the PoX contracts by version.
+// This should deprecate the const values `POX_version_NAME`, but
+// that is the kind of refactor that should be in its own PR.
+// Having an enum here is useful for a bunch of reasons, but chiefly:
+//   * we'll be able to add an Ord implementation, so that we can
+//     do much easier version checks
+//   * static enforcement of matches
+define_named_enum!(PoxVersions {
+    Pox1("pox"),
+    Pox2("pox-2"),
+    Pox3("pox-3"),
+    Pox4("pox-4"),
+});
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PoxStartCycleInfo {

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -86,7 +86,7 @@ fn get_tip(sortdb: Option<&SortitionDB>) -> BlockSnapshot {
     SortitionDB::get_canonical_burn_chain_tip(&sortdb.unwrap().conn()).unwrap()
 }
 
-fn make_test_epochs_pox() -> (Vec<StacksEpoch>, PoxConstants) {
+pub fn make_test_epochs_pox() -> (Vec<StacksEpoch>, PoxConstants) {
     let EMPTY_SORTITIONS = 25;
     let EPOCH_2_1_HEIGHT = EMPTY_SORTITIONS + 11; // 36
     let EPOCH_2_2_HEIGHT = EPOCH_2_1_HEIGHT + 14; // 50
@@ -1340,7 +1340,7 @@ fn pox_4_revoke_delegate_stx_events() {
     );
 }
 
-fn assert_latest_was_burn(peer: &mut TestPeer) {
+pub fn assert_latest_was_burn(peer: &mut TestPeer) {
     let tip = get_tip(peer.sortdb.as_ref());
     let tip_index_block = tip.get_canonical_stacks_block_id();
     let burn_height = tip.block_height - 1;

--- a/stackslib/src/chainstate/stacks/boot/signers.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers.clar
@@ -1,0 +1,24 @@
+(define-data-var stackerdb-signer-slots (list 4000 { signer: principal, num-slots: uint }) (list))
+
+(define-private (stackerdb-set-signer-slots (signer-slots (list 4000 { signer: principal, num-slots: uint })))
+	(begin
+		(print signer-slots)
+		(ok (var-set stackerdb-signer-slots signer-slots))
+	)
+)
+
+(define-read-only (stackerdb-get-signer-slots)
+	(ok (var-get stackerdb-signer-slots))
+)
+
+(define-read-only (stackerdb-get-config)
+	(ok
+		{
+		chunk-size: u4096,
+		write-freq: u0,
+		max-writes: u4096,
+		max-neighbors: u32,
+		hint-replicas: (list)
+		}
+	)
+)

--- a/stackslib/src/chainstate/stacks/boot/signers.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers.clar
@@ -1,24 +1,22 @@
+(define-data-var last-set-cycle uint u0)
 (define-data-var stackerdb-signer-slots (list 4000 { signer: principal, num-slots: uint }) (list))
 
-(define-private (stackerdb-set-signer-slots (signer-slots (list 4000 { signer: principal, num-slots: uint })))
+(define-private (stackerdb-set-signer-slots 
+                   (signer-slots (list 4000 { signer: principal, num-slots: uint }))
+                   (reward-cycle uint))
 	(begin
 		(print signer-slots)
-		(ok (var-set stackerdb-signer-slots signer-slots))
-	)
-)
+        (var-set last-set-cycle reward-cycle)
+		(ok (var-set stackerdb-signer-slots signer-slots))))
 
 (define-read-only (stackerdb-get-signer-slots)
-	(ok (var-get stackerdb-signer-slots))
-)
+	(ok (var-get stackerdb-signer-slots)))
 
 (define-read-only (stackerdb-get-config)
 	(ok
-		{
-		chunk-size: u4096,
-		write-freq: u0,
-		max-writes: u4096,
-		max-neighbors: u32,
-		hint-replicas: (list)
-		}
-	)
-)
+		{ chunk-size: u4096,
+		  write-freq: u0,
+		  max-writes: u4096,
+		  max-neighbors: u32,
+		  hint-replicas: (list) }
+	))

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -1,0 +1,305 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use clarity::vm::clarity::ClarityConnection;
+use clarity::vm::contexts::OwnedEnvironment;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::tests::symbols_from_values;
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, TupleData};
+use clarity::vm::Value::Principal;
+use clarity::vm::{ClarityName, ClarityVersion, ContractName, Value};
+use stacks_common::address::AddressHashMode;
+use stacks_common::types::chainstate::{
+    BurnchainHeaderHash, StacksBlockId, StacksPrivateKey, StacksPublicKey,
+};
+use stacks_common::types::PublicKey;
+
+use crate::burnchains::Burnchain;
+use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::burn::BlockSnapshot;
+use crate::chainstate::nakamoto::coordinator::tests::{boot_nakamoto, make_token_transfer};
+use crate::chainstate::nakamoto::tests::get_account;
+use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
+use crate::chainstate::stacks::address::PoxAddress;
+use crate::chainstate::stacks::boot::pox_2_tests::with_clarity_db_ro;
+use crate::chainstate::stacks::boot::pox_4_tests::{
+    assert_latest_was_burn, get_last_block_sender_transactions, make_test_epochs_pox,
+    prepare_pox4_test,
+};
+use crate::chainstate::stacks::boot::test::{
+    instantiate_pox_peer_with_epoch, key_to_stacks_addr, make_pox_4_lockup, with_sortdb,
+};
+use crate::chainstate::stacks::boot::SIGNERS_NAME;
+use crate::chainstate::stacks::index::marf::MarfConnection;
+use crate::chainstate::stacks::{
+    StacksTransaction, StacksTransactionSigner, TenureChangeCause, TransactionAuth,
+    TransactionPayload, TransactionPostConditionMode, TransactionVersion,
+};
+use crate::clarity_vm::database::HeadersDBConn;
+use crate::core::BITCOIN_REGTEST_FIRST_BLOCK_HASH;
+use crate::net::test::{TestEventObserver, TestPeer};
+use crate::util_lib::boot::{boot_code_addr, boot_code_id, boot_code_test_addr};
+
+#[test]
+fn signers_get_config() {
+    let (burnchain, mut peer, keys, latest_block, ..) = prepare_pox4_test(function_name!(), None);
+
+    assert_eq!(
+        readonly_call(
+            &mut peer,
+            &latest_block,
+            "signers".into(),
+            "stackerdb-get-config".into(),
+            vec![],
+        ),
+        Value::okay(Value::Tuple(
+            TupleData::from_data(vec![
+                ("chunk-size".into(), Value::UInt(4096)),
+                ("write-freq".into(), Value::UInt(0)),
+                ("max-writes".into(), Value::UInt(4096)),
+                ("max-neighbors".into(), Value::UInt(32)),
+                (
+                    "hint-replicas".into(),
+                    Value::cons_list_unsanitized(vec![]).unwrap()
+                )
+            ])
+            .unwrap()
+        ))
+        .unwrap()
+    );
+}
+
+#[test]
+fn signers_get_signer_keys_from_pox4() {
+    let stacker_1 = TestStacker::from_seed(&[3, 4]);
+    let stacker_2 = TestStacker::from_seed(&[5, 6]);
+
+    let (mut peer, test_signers, latest_block_id) =
+        prepare_signers_test(function_name!(), Some(vec![&stacker_1, &stacker_2]));
+
+    let private_key = peer.config.private_key.clone();
+
+    let stacker_1_addr = key_to_stacks_addr(&stacker_1.stacker_private_key);
+    let stacker_2_addr = key_to_stacks_addr(&stacker_2.stacker_private_key);
+
+    let stacker_1_info = readonly_call(
+        &mut peer,
+        &latest_block_id,
+        "pox-4".into(),
+        "get-stacker-info".into(),
+        vec![Value::Principal(PrincipalData::from(stacker_1_addr))],
+    );
+
+    let stacker_2_info = readonly_call(
+        &mut peer,
+        &latest_block_id,
+        "pox-4".into(),
+        "get-stacker-info".into(),
+        vec![Value::Principal(PrincipalData::from(stacker_2_addr))],
+    );
+
+    let stacker_1_tuple = stacker_1_info.expect_optional().unwrap().expect_tuple();
+    let stacker_2_tuple = stacker_2_info.expect_optional().unwrap().expect_tuple();
+
+    assert_eq!(
+        stacker_1_tuple.get_owned("signer-key").unwrap(),
+        Value::buff_from(stacker_1.signer_public_key().to_bytes_compressed()).unwrap()
+    );
+
+    assert_eq!(
+        stacker_2_tuple.get_owned("signer-key").unwrap(),
+        Value::buff_from(stacker_2.signer_public_key().to_bytes_compressed()).unwrap()
+    );
+}
+
+#[test]
+fn signers_get_signer_keys_from_stackerdb() {
+    let stacker_1 = TestStacker::from_seed(&[3, 4]);
+    let stacker_2 = TestStacker::from_seed(&[5, 6]);
+
+    let (mut peer, test_signers, latest_block_id) =
+        prepare_signers_test(function_name!(), Some(vec![&stacker_1, &stacker_2]));
+
+    let private_key = peer.config.private_key.clone();
+
+    let signer_1_addr = key_to_stacks_addr(&stacker_1.signer_private_key);
+    let signer_2_addr = key_to_stacks_addr(&stacker_2.signer_private_key);
+
+    let signers = readonly_call(
+        &mut peer,
+        &latest_block_id,
+        "signers".into(),
+        "stackerdb-get-signer-slots".into(),
+        vec![],
+    )
+    .expect_result_ok()
+    .expect_list();
+
+    let expected_tuple_1 = TupleData::from_data(vec![
+        (
+            "signer".into(),
+            Principal(PrincipalData::from(signer_1_addr)),
+        ),
+        ("num-slots".into(), Value::UInt(2000)),
+    ])
+    .unwrap();
+
+    let expected_tuple_2 = TupleData::from_data(vec![
+        (
+            "signer".into(),
+            Principal(PrincipalData::from(signer_2_addr)),
+        ),
+        ("num-slots".into(), Value::UInt(2000)),
+    ])
+    .unwrap();
+
+    assert_eq!(signers.len(), 2);
+
+    let first_tuple = signers.first().unwrap().clone().expect_tuple();
+    let second_tuple = signers.last().unwrap().clone().expect_tuple();
+
+    // Tuples can be in either order
+    if first_tuple
+        .get("signer")
+        .unwrap()
+        .clone()
+        .expect_principal()
+        == PrincipalData::from(signer_1_addr)
+    {
+        assert_eq!(first_tuple, expected_tuple_1);
+        assert_eq!(second_tuple, expected_tuple_2);
+    } else {
+        assert_eq!(first_tuple, expected_tuple_2);
+        assert_eq!(second_tuple, expected_tuple_1);
+    }
+}
+
+fn prepare_signers_test<'a>(
+    test_name: &str,
+    stackers: Option<Vec<&TestStacker>>,
+) -> (TestPeer<'a>, TestSigners, StacksBlockId) {
+    let mut test_signers = TestSigners::default();
+
+    let mut peer = boot_nakamoto(test_name, vec![], &test_signers, stackers);
+
+    let (burn_ops, mut tenure_change, miner_key) =
+        peer.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
+
+    let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
+
+    let vrf_proof = peer.make_nakamoto_vrf_proof(miner_key);
+
+    tenure_change.tenure_consensus_hash = consensus_hash.clone();
+    tenure_change.burn_view_consensus_hash = consensus_hash.clone();
+    let tenure_change_tx = peer
+        .miner
+        .make_nakamoto_tenure_change(tenure_change.clone());
+    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+
+    let blocks_and_sizes = peer.make_nakamoto_tenure(
+        tenure_change_tx,
+        coinbase_tx,
+        &mut test_signers,
+        |_miner, _chainstate, _sort_dbconn, _blocks| vec![],
+    );
+    let latest_block_id = blocks_and_sizes.last().unwrap().0.block_id();
+
+    (peer, test_signers, latest_block_id)
+}
+
+fn advance_blocks(
+    peer: &mut TestPeer,
+    test_signers: &mut TestSigners,
+    stacker_private_key: &StacksPrivateKey,
+    num_blocks: u64,
+) -> StacksBlockId {
+    let current_height = peer.get_burnchain_view().unwrap().burn_block_height;
+
+    //let key = peer.config.private_key;
+
+    let (burn_ops, mut tenure_change, miner_key) =
+        peer.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
+
+    let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
+
+    let vrf_proof = peer.make_nakamoto_vrf_proof(miner_key);
+
+    tenure_change.tenure_consensus_hash = consensus_hash.clone();
+    tenure_change.burn_view_consensus_hash = consensus_hash.clone();
+    let tenure_change_tx = peer
+        .miner
+        .make_nakamoto_tenure_change(tenure_change.clone());
+    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let recipient_addr = boot_code_addr(false);
+    let blocks_and_sizes = peer.make_nakamoto_tenure(
+        tenure_change_tx,
+        coinbase_tx.clone(),
+        test_signers,
+        |miner, chainstate, sortdb, blocks| {
+            if blocks.len() < num_blocks as usize {
+                let addr = key_to_stacks_addr(&stacker_private_key);
+                let account = get_account(chainstate, sortdb, &addr);
+                let stx_transfer = make_token_transfer(
+                    chainstate,
+                    sortdb,
+                    &stacker_private_key,
+                    account.nonce,
+                    1,
+                    1,
+                    &recipient_addr,
+                );
+                vec![stx_transfer]
+            } else {
+                vec![]
+            }
+        },
+    );
+    info!("tenure length {}", blocks_and_sizes.len());
+    let latest_block_id = blocks_and_sizes.last().unwrap().0.block_id();
+    latest_block_id
+}
+
+fn readonly_call(
+    peer: &mut TestPeer,
+    tip: &StacksBlockId,
+    boot_contract: ContractName,
+    function_name: ClarityName,
+    args: Vec<Value>,
+) -> Value {
+    with_sortdb(peer, |chainstate, sortdb| {
+        chainstate.with_read_only_clarity_tx(&sortdb.index_conn(), tip, |connection| {
+            connection
+                .with_readonly_clarity_env(
+                    false,
+                    0x80000000,
+                    ClarityVersion::Clarity2,
+                    PrincipalData::from(boot_code_addr(false)),
+                    None,
+                    LimitedCostTracker::new_free(),
+                    |env| {
+                        env.execute_contract_allow_private(
+                            &boot_code_id(&boot_contract, false),
+                            &function_name,
+                            &symbols_from_values(args),
+                            true,
+                        )
+                    },
+                )
+                .unwrap()
+        })
+    })
+    .unwrap()
+}

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -95,6 +95,9 @@ fn signers_get_signer_keys_from_pox4() {
     let stacker_1_addr = key_to_stacks_addr(&stacker_1.stacker_private_key);
     let stacker_2_addr = key_to_stacks_addr(&stacker_2.stacker_private_key);
 
+    let signer_1_addr = key_to_stacks_addr(&stacker_1.signer_private_key);
+    let signer_2_addr = key_to_stacks_addr(&stacker_2.signer_private_key);
+
     let stacker_1_info = readonly_call(
         &mut peer,
         &latest_block_id,
@@ -116,16 +119,17 @@ fn signers_get_signer_keys_from_pox4() {
 
     assert_eq!(
         stacker_1_tuple.get_owned("signer-key").unwrap(),
-        Value::buff_from(stacker_1.signer_public_key().to_bytes_compressed()).unwrap()
+        Value::Principal(PrincipalData::from(signer_1_addr))
     );
 
     assert_eq!(
         stacker_2_tuple.get_owned("signer-key").unwrap(),
-        Value::buff_from(stacker_2.signer_public_key().to_bytes_compressed()).unwrap()
+        Value::Principal(PrincipalData::from(signer_2_addr))
     );
 }
 
 #[test]
+#[ignore = "to be updated when the signer keys are processed in make_reward_set"]
 fn signers_get_signer_keys_from_stackerdb() {
     let stacker_1 = TestStacker::from_seed(&[3, 4]);
     let stacker_2 = TestStacker::from_seed(&[5, 6]);

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -129,7 +129,6 @@ fn signers_get_signer_keys_from_pox4() {
 }
 
 #[test]
-#[ignore = "to be updated when the signer keys are processed in make_reward_set"]
 fn signers_get_signer_keys_from_stackerdb() {
     let stacker_1 = TestStacker::from_seed(&[3, 4]);
     let stacker_2 = TestStacker::from_seed(&[5, 6]);
@@ -149,46 +148,34 @@ fn signers_get_signer_keys_from_stackerdb() {
         "stackerdb-get-signer-slots".into(),
         vec![],
     )
-    .expect_result_ok()
-    .expect_list();
+    .expect_result_ok();
 
-    let expected_tuple_1 = TupleData::from_data(vec![
-        (
-            "signer".into(),
-            Principal(PrincipalData::from(signer_1_addr)),
-        ),
-        ("num-slots".into(), Value::UInt(2000)),
-    ])
-    .unwrap();
-
-    let expected_tuple_2 = TupleData::from_data(vec![
-        (
-            "signer".into(),
-            Principal(PrincipalData::from(signer_2_addr)),
-        ),
-        ("num-slots".into(), Value::UInt(2000)),
-    ])
-    .unwrap();
-
-    assert_eq!(signers.len(), 2);
-
-    let first_tuple = signers.first().unwrap().clone().expect_tuple();
-    let second_tuple = signers.last().unwrap().clone().expect_tuple();
-
-    // Tuples can be in either order
-    if first_tuple
-        .get("signer")
+    assert_eq!(
+        signers,
+        Value::cons_list_unsanitized(vec![
+            Value::Tuple(
+                TupleData::from_data(vec![
+                    (
+                        "signer".into(),
+                        Principal(PrincipalData::from(signer_2_addr)),
+                    ),
+                    ("num-slots".into(), Value::UInt(2)),
+                ])
+                .unwrap()
+            ),
+            Value::Tuple(
+                TupleData::from_data(vec![
+                    (
+                        "signer".into(),
+                        Principal(PrincipalData::from(signer_1_addr)),
+                    ),
+                    ("num-slots".into(), Value::UInt(2)),
+                ])
+                .unwrap()
+            )
+        ])
         .unwrap()
-        .clone()
-        .expect_principal()
-        == PrincipalData::from(signer_1_addr)
-    {
-        assert_eq!(first_tuple, expected_tuple_1);
-        assert_eq!(second_tuple, expected_tuple_2);
-    } else {
-        assert_eq!(first_tuple, expected_tuple_2);
-        assert_eq!(second_tuple, expected_tuple_1);
-    }
+    );
 }
 
 fn prepare_signers_test<'a>(

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -5140,6 +5140,17 @@ impl StacksChainState {
             );
         }
 
+        // Handle signer stackerdb updates
+        let first_block_height = burn_dbconn.get_burn_start_height();
+        if evaluated_epoch >= StacksEpochId::Epoch25 {
+            let _events = NakamotoChainState::check_and_handle_prepare_phase_start(
+                &mut clarity_tx,
+                first_block_height.into(),
+                &pox_constants,
+                burn_tip_height.into(),
+            )?;
+        }
+
         debug!(
             "Setup block: ready to go for {}/{}",
             &chain_tip.consensus_hash,

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -463,7 +463,7 @@ pub type StacksDBTx<'a> = IndexDBTx<'a, (), StacksBlockId>;
 pub type StacksDBConn<'a> = IndexDBConn<'a, (), StacksBlockId>;
 
 pub struct ClarityTx<'a, 'b> {
-    pub block: ClarityBlockConnection<'a, 'b>,
+    block: ClarityBlockConnection<'a, 'b>,
     pub config: DBConfig,
 }
 

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -463,7 +463,7 @@ pub type StacksDBTx<'a> = IndexDBTx<'a, (), StacksBlockId>;
 pub type StacksDBConn<'a> = IndexDBConn<'a, (), StacksBlockId>;
 
 pub struct ClarityTx<'a, 'b> {
-    block: ClarityBlockConnection<'a, 'b>,
+    pub block: ClarityBlockConnection<'a, 'b>,
     pub config: DBConfig,
 }
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -49,6 +49,7 @@ use crate::chainstate::stacks::boot::{
     BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME, COSTS_2_NAME, COSTS_3_NAME,
     MINERS_NAME, POX_2_MAINNET_CODE, POX_2_NAME, POX_2_TESTNET_CODE, POX_3_MAINNET_CODE,
     POX_3_NAME, POX_3_TESTNET_CODE, POX_4_MAINNET_CODE, POX_4_NAME, POX_4_TESTNET_CODE,
+    SIGNERS_BODY, SIGNERS_NAME,
 };
 use crate::chainstate::stacks::db::{StacksAccount, StacksChainState};
 use crate::chainstate::stacks::events::{StacksTransactionEvent, StacksTransactionReceipt};
@@ -1415,6 +1416,42 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                 panic!(
                     "FATAL: Failure processing PoX 4 contract initialization: {:#?}",
                     &pox_4_initialization_receipt
+                );
+            }
+
+            let signers_contract_id = boot_code_id(SIGNERS_NAME, mainnet);
+            let payload = TransactionPayload::SmartContract(
+                TransactionSmartContract {
+                    name: ContractName::try_from(SIGNERS_NAME)
+                        .expect("FATAL: invalid boot-code contract name"),
+                    code_body: StacksString::from_str(SIGNERS_BODY)
+                        .expect("FATAL: invalid boot code body"),
+                },
+                Some(ClarityVersion::Clarity2),
+            );
+
+            let signers_contract_tx =
+                StacksTransaction::new(tx_version.clone(), boot_code_auth.clone(), payload);
+
+            let signers_initialization_receipt = self.as_transaction(|tx_conn| {
+                // initialize with a synthetic transaction
+                debug!("Instantiate {} contract", &signers_contract_id);
+                let receipt = StacksChainState::process_transaction_payload(
+                    tx_conn,
+                    &signers_contract_tx,
+                    &boot_code_account,
+                    ASTRules::PrecheckSize,
+                )
+                .expect("FATAL: Failed to process .miners contract initialization");
+                receipt
+            });
+
+            if signers_initialization_receipt.result != Value::okay_true()
+                || signers_initialization_receipt.post_condition_aborted
+            {
+                panic!(
+                    "FATAL: Failure processing signers contract initialization: {:#?}",
+                    &signers_initialization_receipt
                 );
             }
 

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -1594,7 +1594,7 @@ pub mod test {
     use crate::chainstate::burn::*;
     use crate::chainstate::coordinator::tests::*;
     use crate::chainstate::coordinator::*;
-    use crate::chainstate::nakamoto::tests::node::TestSigners;
+    use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
     use crate::chainstate::stacks::address::PoxAddress;
     use crate::chainstate::stacks::boot::test::get_parent_tip;
     use crate::chainstate::stacks::boot::*;
@@ -1928,6 +1928,7 @@ pub mod test {
         pub services: u16,
         /// aggregate public key to use
         pub aggregate_public_key: Option<Point>,
+        pub test_stackers: Option<Vec<TestStacker>>,
     }
 
     impl TestPeerConfig {
@@ -1992,6 +1993,7 @@ pub mod test {
                     | (ServiceFlags::RPC as u16)
                     | (ServiceFlags::STACKERDB as u16),
                 aggregate_public_key: None,
+                test_stackers: None,
             }
         }
 


### PR DESCRIPTION
### Description

Now rebased onto #4269.

Work in progress that adds:
- PoX4 changes, takes signer key `(buff 33)` parameter where needed, converts and stores them as `principal`.
- The `.signers` StackerDB contract.
- Uses #4269 Nakamoto `make_reward_set()` to calculate the signer slots.
- Fills in the mocks/todos in #4269 pertaining to the signers.
- Writes the signer set to `.signers`.
- Basic unit tests that Stacks using two different signer keys and checks they exist in the signers StackerDB contract.

As for the coupling of PoX reward slots and signer keys we have some open questions. (#4247 and others.)

This PR should unblock @friedger's work on the `.voting` boot contract.

### Applicable issues

Addresses:
- #4058
- #3980
- #3957

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
