### PR TITLE
Nakamoto: Add stacker/signer bit vector and event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Next-Branch]
+
+### Added
+
+- New `/new_pox_anchor` endpoint for broadcasting PoX anchor block processing.
+- Stacker bitvec in NakamotoBlock
+
 ## [2.4.0.0.4]
 
 This is a high-priority hotfix that addresses a bug in transaction processing which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - New `/new_pox_anchor` endpoint for broadcasting PoX anchor block processing.
 - Stacker bitvec in NakamotoBlock
 
+### Modified
+
+- `pox-4.aggregation-commit` contains a signing-key parameter (like
+  `stack-stx` and `stack-extend`), the signing-key parameter is removed from
+  `delegate-*` functions.
+
 ## [2.4.0.0.4]
 
 This is a high-priority hotfix that addresses a bug in transaction processing which

--- a/clarity/src/vm/types/mod.rs
+++ b/clarity/src/vm/types/mod.rs
@@ -1411,15 +1411,6 @@ impl From<StandardPrincipalData> for StacksAddress {
     }
 }
 
-impl From<PrincipalData> for StacksAddress {
-    fn from(principal: PrincipalData) -> Self {
-        match principal {
-            PrincipalData::Standard(standard_principal) => standard_principal.into(),
-            PrincipalData::Contract(contract_principal) => contract_principal.issuer.into(),
-        }
-    }
-}
-
 impl From<StandardPrincipalData> for Value {
     fn from(principal: StandardPrincipalData) -> Self {
         Value::Principal(PrincipalData::from(principal))

--- a/stacks-common/src/address/mod.rs
+++ b/stacks-common/src/address/mod.rs
@@ -150,7 +150,7 @@ impl TryFrom<u8> for AddressHashMode {
 /// Internally, the Stacks blockchain encodes address the same as Bitcoin
 /// single-sig address (p2pkh)
 /// Get back the hash of the address
-fn to_bits_p2pkh<K: PublicKey>(pubk: &K) -> Hash160 {
+pub fn to_bits_p2pkh<K: PublicKey>(pubk: &K) -> Hash160 {
     Hash160::from_data(&pubk.to_bytes())
 }
 

--- a/stacks-common/src/bitvec.rs
+++ b/stacks-common/src/bitvec.rs
@@ -1,0 +1,195 @@
+use crate::codec::{
+    read_next, read_next_exact, write_next, Error as CodecError, StacksMessageCodec,
+};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct BitVec {
+    data: Vec<u8>,
+    len: u16,
+}
+
+impl TryFrom<&[bool]> for BitVec {
+    type Error = String;
+
+    fn try_from(value: &[bool]) -> Result<Self, Self::Error> {
+        let len = value
+            .len()
+            .try_into()
+            .map_err(|_| "BitVec length must be u16")?;
+        if len == 0 {
+            return Err("BitVec length must be positive".into());
+        }
+        let mut bitvec = BitVec::zeros(len);
+        for (ix, bool_value) in value.iter().enumerate() {
+            let ix = ix.try_into().map_err(|_| "BitVec length must be u16")?;
+            // only need to set the bitvec value if `bool_value` is true,
+            // because we initialized with zeros
+            if *bool_value {
+                bitvec.set(ix, true)?;
+            }
+        }
+        Ok(bitvec)
+    }
+}
+
+impl StacksMessageCodec for BitVec {
+    fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), CodecError> {
+        write_next(fd, &self.len)?;
+        write_next(fd, &self.data)
+    }
+
+    fn consensus_deserialize<R: std::io::Read>(fd: &mut R) -> Result<Self, CodecError> {
+        let len = read_next(fd)?;
+        if len == 0 {
+            return Err(CodecError::DeserializeError(
+                "BitVec lengths must be positive".to_string(),
+            ));
+        }
+
+        let data = read_next_exact(fd, Self::data_len(len).into())?;
+        Ok(BitVec { data, len })
+    }
+}
+
+impl BitVec {
+    /// Construct a new BitVec with all entries set to `false` and total length `len`
+    pub fn zeros(len: u16) -> BitVec {
+        let data = vec![0; usize::from(Self::data_len(len))];
+        BitVec { data, len }
+    }
+
+    pub fn len(&self) -> u16 {
+        self.len
+    }
+
+    fn data_len(len: u16) -> u16 {
+        len / 8 + if len % 8 == 0 { 0 } else { 1 }
+    }
+
+    /// Get a u8 with the (index % 8)th bit set to 1.
+    fn bit_index(index: u16) -> u8 {
+        1 << u8::try_from(index % 8).expect("FATAL: remainder 8 returned a non-u8 value")
+    }
+
+    pub fn get(&self, i: u16) -> Option<bool> {
+        if i >= self.len {
+            return None;
+        }
+        let vec_index = usize::from(i / 8);
+        let byte = self.data.get(vec_index)?;
+        let bit_index = Self::bit_index(i);
+        Some((*byte & bit_index) != 0)
+    }
+
+    pub fn set(&mut self, i: u16, val: bool) -> Result<(), String> {
+        if i >= self.len {
+            return Err(format!(
+                "Index `{i}` outside of bitvec length `{}`",
+                self.len
+            ));
+        }
+        let vec_index = usize::from(i / 8);
+        let Some(byte) = self.data.get_mut(vec_index) else {
+            return Err(format!(
+                "Index `{i}/8` outside of bitvec data length `{}`",
+                self.data.len()
+            ));
+        };
+        let bit_index = Self::bit_index(i);
+        if val {
+            *byte |= bit_index;
+        } else {
+            *byte &= !bit_index;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::BitVec;
+    use crate::codec::StacksMessageCodec;
+
+    fn check_set_get(mut input: BitVec) {
+        let original_input = input.clone();
+        for i in 0..input.len() {
+            let original_value = input.get(i).unwrap();
+            input.set(i, false).unwrap();
+            assert_eq!(input.len(), original_input.len());
+            for j in 0..input.len() {
+                if j == i {
+                    continue;
+                }
+                assert_eq!(original_input.get(j), input.get(j));
+            }
+            assert_eq!(input.get(i), Some(false));
+            input.set(i, true).unwrap();
+            for j in 0..input.len() {
+                if j == i {
+                    continue;
+                }
+                assert_eq!(original_input.get(j), input.get(j));
+            }
+            assert_eq!(input.get(i), Some(true));
+            input.set(i, original_value).unwrap();
+            assert_eq!(input.get(i), Some(original_value));
+        }
+        assert_eq!(input, original_input);
+        assert!(input.set(input.len(), false).is_err());
+    }
+
+    fn check_serialization(input: &BitVec) {
+        let byte_ser = input.serialize_to_vec();
+        let deserialized = BitVec::consensus_deserialize(&mut byte_ser.as_slice()).unwrap();
+        assert_eq!(input, &deserialized);
+    }
+
+    fn check_ok_vector(input: &[bool]) {
+        let bitvec = BitVec::try_from(input).unwrap();
+        assert_eq!(bitvec.len(), input.len() as u16);
+        for (ix, value) in input.iter().enumerate() {
+            assert_eq!(bitvec.get(u16::try_from(ix).unwrap()), Some(*value));
+        }
+
+        check_serialization(&bitvec);
+        check_set_get(bitvec);
+    }
+
+    #[test]
+    fn vectors() {
+        let mut inputs = vec![
+            vec![true; 8],
+            vec![false; 8],
+            vec![true; 12],
+            vec![false; 12],
+            vec![false],
+            vec![true],
+            vec![false, true],
+            vec![true, false],
+        ];
+        for i in 0..8 {
+            let mut single_set_vec = vec![false; 8];
+            let mut single_unset_vec = vec![true; 8];
+            single_unset_vec[i] = false;
+            single_set_vec[i] = true;
+            inputs.push(single_set_vec);
+            inputs.push(single_unset_vec);
+        }
+        let large_set_vec = vec![false; u16::MAX.into()];
+        let large_unset_vec = vec![true; u16::MAX.into()];
+        inputs.push(large_set_vec);
+        inputs.push(large_unset_vec);
+
+        for i in 1..128 {
+            let mut bool_vec = vec![false; i];
+            for (j, val) in bool_vec.iter_mut().enumerate() {
+                *val = j % 2 == 0;
+            }
+            inputs.push(bool_vec);
+        }
+
+        for i in inputs.into_iter() {
+            check_ok_vector(i.as_slice());
+        }
+    }
+}

--- a/stacks-common/src/bitvec.rs
+++ b/stacks-common/src/bitvec.rs
@@ -8,12 +8,21 @@ use crate::codec::{
 use crate::util::hash::{bytes_to_hex, hex_bytes};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct BitVec {
+/// This data structure represents a list of booleans
+/// as a bitvector.
+///
+/// The generic argument `MAX_SIZE` specifies the maximum number of
+/// elements that the bit vector can hold. It is not the _actual_ size
+/// of the bitvec: if there are only 8 entries, the bitvector will
+/// just have a single byte, even if the MAX_SIZE is u16::MAX. This
+/// type parameter ensures that constructors and deserialization routines
+/// error if input data is too long.
+pub struct BitVec<const MAX_SIZE: u16> {
     data: Vec<u8>,
     len: u16,
 }
 
-impl TryFrom<&[bool]> for BitVec {
+impl<const MAX_SIZE: u16> TryFrom<&[bool]> for BitVec<MAX_SIZE> {
     type Error = String;
 
     fn try_from(value: &[bool]) -> Result<Self, Self::Error> {
@@ -24,7 +33,12 @@ impl TryFrom<&[bool]> for BitVec {
         if len == 0 {
             return Err("BitVec length must be positive".into());
         }
-        let mut bitvec = BitVec::zeros(len);
+        if len > MAX_SIZE {
+            return Err(format!(
+                "BitVec length is too long. Max size = {MAX_SIZE}, Input len = {len}"
+            ));
+        }
+        let mut bitvec = BitVec::zeros(len)?;
         for (ix, bool_value) in value.iter().enumerate() {
             let ix = ix.try_into().map_err(|_| "BitVec length must be u16")?;
             // only need to set the bitvec value if `bool_value` is true,
@@ -37,7 +51,7 @@ impl TryFrom<&[bool]> for BitVec {
     }
 }
 
-impl StacksMessageCodec for BitVec {
+impl<const MAX_SIZE: u16> StacksMessageCodec for BitVec<MAX_SIZE> {
     fn consensus_serialize<W: std::io::Write>(&self, fd: &mut W) -> Result<(), CodecError> {
         write_next(fd, &self.len)?;
         write_next(fd, &self.data)
@@ -50,20 +64,25 @@ impl StacksMessageCodec for BitVec {
                 "BitVec lengths must be positive".to_string(),
             ));
         }
+        if len > MAX_SIZE {
+            return Err(CodecError::DeserializeError(format!(
+                "BitVec length exceeded maximum. Max size = {MAX_SIZE}, len = {len}"
+            )));
+        }
 
         let data = read_next_exact(fd, Self::data_len(len).into())?;
         Ok(BitVec { data, len })
     }
 }
 
-impl Serialize for BitVec {
+impl<const MAX_SIZE: u16> Serialize for BitVec<MAX_SIZE> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let hex = bytes_to_hex(self.serialize_to_vec().as_slice());
         serializer.serialize_str(&hex)
     }
 }
 
-impl<'de> Deserialize<'de> for BitVec {
+impl<'de, const MAX_SIZE: u16> Deserialize<'de> for BitVec<MAX_SIZE> {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let hex: &str = Deserialize::deserialize(deserializer)?;
         let bytes = hex_bytes(hex).map_err(serde::de::Error::custom)?;
@@ -71,7 +90,7 @@ impl<'de> Deserialize<'de> for BitVec {
     }
 }
 
-impl FromSql for BitVec {
+impl<const MAX_SIZE: u16> FromSql for BitVec<MAX_SIZE> {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         let bytes = hex_bytes(value.as_str()?).map_err(|e| FromSqlError::Other(Box::new(e)))?;
         Self::consensus_deserialize(&mut bytes.as_slice())
@@ -79,18 +98,23 @@ impl FromSql for BitVec {
     }
 }
 
-impl ToSql for BitVec {
+impl<const MAX_SIZE: u16> ToSql for BitVec<MAX_SIZE> {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         let hex = bytes_to_hex(self.serialize_to_vec().as_slice());
         Ok(hex.into())
     }
 }
 
-impl BitVec {
+impl<const MAX_SIZE: u16> BitVec<MAX_SIZE> {
     /// Construct a new BitVec with all entries set to `false` and total length `len`
-    pub fn zeros(len: u16) -> BitVec {
+    pub fn zeros(len: u16) -> Result<BitVec<MAX_SIZE>, String> {
+        if len > MAX_SIZE {
+            return Err(format!(
+                "BitVec length is too long. Max size = {MAX_SIZE}, Input len = {len}"
+            ));
+        }
         let data = vec![0; usize::from(Self::data_len(len))];
-        BitVec { data, len }
+        Ok(BitVec { data, len })
     }
 
     pub fn len(&self) -> u16 {
@@ -145,7 +169,7 @@ mod test {
     use super::BitVec;
     use crate::codec::StacksMessageCodec;
 
-    fn check_set_get(mut input: BitVec) {
+    fn check_set_get(mut input: BitVec<{ u16::MAX }>) {
         let original_input = input.clone();
         for i in 0..input.len() {
             let original_value = input.get(i).unwrap();
@@ -173,7 +197,7 @@ mod test {
         assert!(input.set(input.len(), false).is_err());
     }
 
-    fn check_serialization(input: &BitVec) {
+    fn check_serialization(input: &BitVec<{ u16::MAX }>) {
         let byte_ser = input.serialize_to_vec();
         let deserialized = BitVec::consensus_deserialize(&mut byte_ser.as_slice()).unwrap();
         assert_eq!(input, &deserialized);
@@ -185,9 +209,46 @@ mod test {
         for (ix, value) in input.iter().enumerate() {
             assert_eq!(bitvec.get(u16::try_from(ix).unwrap()), Some(*value));
         }
+        // check that a length check will fail
+        let passed_len_2_check = BitVec::<2>::try_from(input).is_ok();
+        if input.len() <= 2 {
+            assert!(
+                passed_len_2_check,
+                "BitVec should pass assembly in length-2 max because input is length-2"
+            );
+        } else {
+            assert!(!passed_len_2_check, "BitVec should fail assembly in length-2 max because input is greater that length-2");
+        }
+        // check that a length check will fail on deserialization
+        let serialization = bitvec.serialize_to_vec();
+        let passed_len_2_deser =
+            BitVec::<2>::consensus_deserialize(&mut serialization.as_slice()).is_ok();
+        if input.len() <= 2 {
+            assert!(
+                passed_len_2_deser,
+                "BitVec should pass assembly in length-2 max because input is length-2"
+            );
+        } else {
+            assert!(!passed_len_2_deser, "BitVec should fail assembly in length-2 max because input is greater that length-2");
+        }
 
         check_serialization(&bitvec);
         check_set_get(bitvec);
+    }
+
+    #[test]
+    fn zeros_constructor() {
+        let bitvec_zero_10 = BitVec::<10>::zeros(10).unwrap();
+        for i in 0..10 {
+            assert!(
+                !bitvec_zero_10.get(i).unwrap(),
+                "All values of zero vec should be false"
+            );
+        }
+        assert!(
+            BitVec::<2>::zeros(3).is_err(),
+            "Should fail to construct a length 3 zero vec when bound to bitlength 2"
+        );
     }
 
     #[test]

--- a/stacks-common/src/libcommon.rs
+++ b/stacks-common/src/libcommon.rs
@@ -31,6 +31,8 @@ pub mod address;
 
 pub mod deps_common;
 
+pub mod bitvec;
+
 use crate::types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, SortitionId, StacksBlockId};
 
 pub mod consts {

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -4,9 +4,9 @@ use std::fmt;
 
 use crate::address::c32::{c32_address, c32_address_decode};
 use crate::address::{
-    public_keys_to_address_hash, AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-    C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-    C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+    public_keys_to_address_hash, to_bits_p2pkh, AddressHashMode,
+    C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+    C32_ADDRESS_VERSION_TESTNET_MULTISIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
 use crate::deps_common::bitcoin::blockdata::transaction::TxOut;
 use crate::types::chainstate::{StacksAddress, StacksPublicKey};
@@ -211,6 +211,17 @@ impl StacksAddress {
 
         let hash_bits = public_keys_to_address_hash(hash_mode, num_sigs, pubkeys);
         Some(StacksAddress::new(version, hash_bits))
+    }
+
+    /// Make a P2PKH StacksAddress
+    pub fn p2pkh(mainnet: bool, pubkey: &StacksPublicKey) -> StacksAddress {
+        let version = if mainnet {
+            C32_ADDRESS_VERSION_MAINNET_SINGLESIG
+        } else {
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG
+        };
+        let bytes = to_bits_p2pkh(pubkey);
+        Self { version, bytes }
     }
 }
 

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -215,13 +215,21 @@ impl StacksAddress {
 
     /// Make a P2PKH StacksAddress
     pub fn p2pkh(mainnet: bool, pubkey: &StacksPublicKey) -> StacksAddress {
+        let bytes = to_bits_p2pkh(pubkey);
+        Self::p2pkh_from_hash(mainnet, bytes)
+    }
+
+    /// Make a P2PKH StacksAddress
+    pub fn p2pkh_from_hash(mainnet: bool, hash: Hash160) -> StacksAddress {
         let version = if mainnet {
             C32_ADDRESS_VERSION_MAINNET_SINGLESIG
         } else {
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG
         };
-        let bytes = to_bits_p2pkh(pubkey);
-        Self { version, bytes }
+        Self {
+            version,
+            bytes: hash,
+        }
     }
 }
 

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -520,17 +520,6 @@ impl PoxConstants {
         (effective_height % u64::from(self.reward_cycle_length)) == 1
     }
 
-    pub fn is_prepare_phase_start(&self, first_block_height: u64, burn_height: u64) -> bool {
-        if burn_height < first_block_height {
-            false
-        } else {
-            let effective_height = burn_height - first_block_height;
-            (effective_height + u64::from(self.prepare_length))
-                % u64::from(self.reward_cycle_length)
-                == 0
-        }
-    }
-
     pub fn reward_cycle_to_block_height(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
         // NOTE: the `+ 1` is because the height of the first block of a reward cycle is mod 1, not
         // mod 0.
@@ -547,6 +536,29 @@ impl PoxConstants {
             first_block_height,
             u64::from(self.reward_cycle_length),
         )
+    }
+
+    /// Return the reward cycle that the current prepare phase corresponds to if `block_height` is _in_ a prepare
+    /// phase. If it is not in a prepare phase, return None.
+    pub fn reward_cycle_of_prepare_phase(
+        &self,
+        first_block_height: u64,
+        block_height: u64,
+    ) -> Option<u64> {
+        if !self.is_in_prepare_phase(first_block_height, block_height) {
+            return None;
+        }
+        // the None branches here should be unreachable, because if `first_block_height > block_height`,
+        //   `is_in_prepare_phase` would have returned false, but no need to be unsafe anyways.
+        let effective_height = block_height.checked_sub(first_block_height)?;
+        let current_cycle = self.block_height_to_reward_cycle(first_block_height, block_height)?;
+        if effective_height % u64::from(self.reward_cycle_length) == 0 {
+            // if this is the "mod 0" block of a prepare phase, its corresponding reward cycle is the current one
+            Some(current_cycle)
+        } else {
+            // otherwise, the corresponding reward cycle is actually the _next_ reward cycle
+            Some(current_cycle + 1)
+        }
     }
 
     pub fn is_in_prepare_phase(&self, first_block_height: u64, block_height: u64) -> bool {

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -520,6 +520,17 @@ impl PoxConstants {
         (effective_height % u64::from(self.reward_cycle_length)) == 1
     }
 
+    pub fn is_prepare_phase_start(&self, first_block_height: u64, burn_height: u64) -> bool {
+        if burn_height < first_block_height {
+            false
+        } else {
+            let effective_height = burn_height - first_block_height;
+            (effective_height + u64::from(self.prepare_length))
+                % u64::from(self.reward_cycle_length)
+                == 0
+        }
+    }
+
     pub fn reward_cycle_to_block_height(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
         // NOTE: the `+ 1` is because the height of the first block of a reward cycle is mod 1, not
         // mod 0.

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -442,6 +442,14 @@ impl BlockEventDispatcher for NullEventDispatcher {
         _slot_holders: Vec<PoxAddress>,
     ) {
     }
+
+    fn announce_reward_set(
+        &self,
+        _reward_set: &RewardSet,
+        _block_id: &StacksBlockId,
+        _cycle_number: u64,
+    ) {
+    }
 }
 
 pub fn make_coordinator<'a>(

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -447,15 +447,22 @@ impl BlockEventDispatcher for NullEventDispatcher {
 pub fn make_coordinator<'a>(
     path: &str,
     burnchain: Option<Burnchain>,
-) -> ChainsCoordinator<'a, NullEventDispatcher, (), OnChainRewardSetProvider, (), (), BitcoinIndexer>
-{
+) -> ChainsCoordinator<
+    'a,
+    NullEventDispatcher,
+    (),
+    OnChainRewardSetProvider<'a, NullEventDispatcher>,
+    (),
+    (),
+    BitcoinIndexer,
+> {
     let burnchain = burnchain.unwrap_or_else(|| get_burnchain(path, None));
     let indexer = BitcoinIndexer::new_unit_test(&burnchain.working_dir);
     ChainsCoordinator::test_new(
         &burnchain,
         0x80000000,
         path,
-        OnChainRewardSetProvider(),
+        OnChainRewardSetProvider(None),
         indexer,
     )
 }
@@ -464,15 +471,22 @@ pub fn make_coordinator_atlas<'a>(
     path: &str,
     burnchain: Option<Burnchain>,
     atlas_config: Option<AtlasConfig>,
-) -> ChainsCoordinator<'a, NullEventDispatcher, (), OnChainRewardSetProvider, (), (), BitcoinIndexer>
-{
+) -> ChainsCoordinator<
+    'a,
+    NullEventDispatcher,
+    (),
+    OnChainRewardSetProvider<'a, NullEventDispatcher>,
+    (),
+    (),
+    BitcoinIndexer,
+> {
     let burnchain = burnchain.unwrap_or_else(|| get_burnchain(path, None));
     let indexer = BitcoinIndexer::new_unit_test(&burnchain.working_dir);
     ChainsCoordinator::test_new_full(
         &burnchain,
         0x80000000,
         path,
-        OnChainRewardSetProvider(),
+        OnChainRewardSetProvider(None),
         None,
         indexer,
         atlas_config,
@@ -495,6 +509,7 @@ impl RewardSetProvider for StubbedRewardSetProvider {
             start_cycle_state: PoxStartCycleInfo {
                 missed_reward_slots: vec![],
             },
+            signers: None,
         })
     }
 }

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -94,7 +94,10 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
                 cycle_start_burn_height
             ));
 
-        if cur_epoch.epoch_id >= StacksEpochId::Epoch30 && participation == 0 {
+        // This method should only ever called if the current reward cycle is a nakamoto reward cycle
+        //  (i.e., its reward set is fetched for determining signer sets (and therefore agg keys).
+        //  Non participation is fatal.
+        if participation == 0 {
             // no one is stacking
             error!("No PoX participation");
             return Err(Error::PoXAnchorBlockRequired);

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -68,18 +68,6 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
         let mut registered_addrs =
             chainstate.get_reward_addresses_in_cycle(burnchain, sortdb, cycle, block_id)?;
 
-        // TODO (pox-4-workstream): the pox-4 contract must be able to return signing keys
-        //   associated with reward set entries (i.e., via `get-reward-set-pox-addresses`)
-        //   *not* stacking-state entries (as it is currently implemented). Until that's done,
-        //   this method just mocks that data.
-        for (index, entry) in registered_addrs.iter_mut().enumerate() {
-            let index = u64::try_from(index).expect("FATAL: more than u64 reward set entries");
-            let sk = StacksPrivateKey::from_seed(&index.to_be_bytes());
-            let addr =
-                StacksAddress::p2pkh(chainstate.mainnet, &StacksPublicKey::from_private(&sk));
-            entry.signing_key = Some(addr.into());
-        }
-
         let liquid_ustx = chainstate.get_liquid_ustx(block_id);
 
         let (threshold, participation) = StacksChainState::get_reward_threshold_and_participation(

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -38,7 +38,6 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::boot::test::{
     key_to_stacks_addr, make_pox_4_aggregate_key, make_pox_4_lockup,
 };
-use crate::chainstate::stacks::boot::test::{make_pox_4_aggregate_key, make_pox_4_lockup};
 use crate::chainstate::stacks::boot::MINERS_NAME;
 use crate::chainstate::stacks::db::{MinerPaymentTxFees, StacksAccount, StacksChainState};
 use crate::chainstate::stacks::{
@@ -49,9 +48,8 @@ use crate::chainstate::stacks::{
 use crate::clarity::vm::types::StacksAddressExtensions;
 use crate::core::StacksEpochExtension;
 use crate::net::relay::Relayer;
-use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
 use crate::net::stackerdb::StackerDBConfig;
-use crate::net::test::{TestPeer, TestPeerConfig};
+use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
 use crate::util_lib::boot::boot_code_id;
 
 /// Bring a TestPeer into the Nakamoto Epoch

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -24,6 +24,7 @@ use stacks_common::types::chainstate::{
     StacksAddress, StacksBlockId, StacksPrivateKey, StacksPublicKey,
 };
 use stacks_common::types::{Address, StacksEpoch};
+use stacks_common::util::secp256k1::Secp256k1PrivateKey;
 use stacks_common::util::vrf::VRFProof;
 use wsts::curve::point::Point;
 
@@ -31,9 +32,12 @@ use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
 use crate::chainstate::burn::operations::BlockstackOperationType;
 use crate::chainstate::coordinator::tests::p2pkh_from;
 use crate::chainstate::nakamoto::tests::get_account;
-use crate::chainstate::nakamoto::tests::node::TestSigners;
+use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use crate::chainstate::stacks::address::PoxAddress;
+use crate::chainstate::stacks::boot::test::{
+    key_to_stacks_addr, make_pox_4_aggregate_key, make_pox_4_lockup,
+};
 use crate::chainstate::stacks::boot::test::{make_pox_4_aggregate_key, make_pox_4_lockup};
 use crate::chainstate::stacks::boot::MINERS_NAME;
 use crate::chainstate::stacks::db::{MinerPaymentTxFees, StacksAccount, StacksChainState};
@@ -45,20 +49,19 @@ use crate::chainstate::stacks::{
 use crate::clarity::vm::types::StacksAddressExtensions;
 use crate::core::StacksEpochExtension;
 use crate::net::relay::Relayer;
+use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
 use crate::net::stackerdb::StackerDBConfig;
 use crate::net::test::{TestPeer, TestPeerConfig};
 use crate::util_lib::boot::boot_code_id;
 
 /// Bring a TestPeer into the Nakamoto Epoch
-fn advance_to_nakamoto(peer: &mut TestPeer) {
+fn advance_to_nakamoto(
+    peer: &mut TestPeer,
+    test_signers: &TestSigners,
+    test_stackers: Vec<&TestStacker>,
+) {
     let mut peer_nonce = 0;
     let private_key = peer.config.private_key.clone();
-    let signer_key = StacksPublicKey::from_slice(&[
-        0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
-        0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
-        0x59, 0x98, 0x3c,
-    ])
-    .unwrap();
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -70,17 +73,24 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
     for sortition_height in 0..11 {
         // stack to pox-3 in cycle 7
         let txs = if sortition_height == 6 {
-            // stack them all
-            let stack_tx = make_pox_4_lockup(
-                &private_key,
-                0,
-                1_000_000_000_000_000_000,
-                PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone()),
-                12,
-                signer_key,
-                34,
-            );
-            vec![stack_tx]
+            // Make all the test Stackers stack
+            test_stackers
+                .iter()
+                .map(|test_stacker| {
+                    make_pox_4_lockup(
+                        &test_stacker.stacker_private_key,
+                        0,
+                        test_stacker.amount,
+                        PoxAddress::from_legacy(
+                            AddressHashMode::SerializeP2PKH,
+                            addr.bytes.clone(),
+                        ),
+                        12,
+                        StacksPublicKey::from_private(&test_stacker.signer_private_key),
+                        34,
+                    )
+                })
+                .collect()
         } else {
             vec![]
         };
@@ -92,11 +102,13 @@ fn advance_to_nakamoto(peer: &mut TestPeer) {
 
 /// Make a peer and transition it into the Nakamoto epoch.
 /// The node needs to be stacking; otherwise, Nakamoto won't activate.
-pub fn boot_nakamoto(
+pub fn boot_nakamoto<'a>(
     test_name: &str,
     mut initial_balances: Vec<(PrincipalData, u64)>,
-    aggregate_public_key: Point,
-) -> TestPeer {
+    test_signers: &TestSigners,
+    test_stackers: Option<Vec<&TestStacker>>,
+) -> TestPeer<'a> {
+    let aggregate_public_key = test_signers.aggregate_public_key.clone();
     let mut peer_config = TestPeerConfig::new(test_name, 0, 0);
     let private_key = peer_config.private_key.clone();
     let addr = StacksAddress::from_public_keys(
@@ -117,13 +129,45 @@ pub fn boot_nakamoto(
         .push(boot_code_id(MINERS_NAME, false));
     peer_config.epochs = Some(StacksEpoch::unit_test_3_0_only(37));
     peer_config.initial_balances = vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
+
+    let test_stackers: Vec<TestStacker> = if let Some(stackers) = test_stackers {
+        stackers.into_iter().cloned().collect()
+    } else {
+        // Create a list of test Stackers and their signer keys
+        (0..test_signers.num_keys)
+            .map(|index| {
+                let stacker_private_key = StacksPrivateKey::from_seed(&index.to_be_bytes());
+                let signer_private_key = StacksPrivateKey::from_seed(&(index + 1000).to_be_bytes());
+                TestStacker {
+                    stacker_private_key,
+                    signer_private_key,
+                    amount: 1_000_000_000_000_000_000,
+                }
+            })
+            .collect()
+    };
+
+    // Create some balances for test Stackers
+    let mut stacker_balances = test_stackers
+        .iter()
+        .map(|test_stacker| {
+            (
+                PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key)),
+                u64::try_from(test_stacker.amount).expect("Stacking amount too large"),
+            )
+        })
+        .collect();
+
+    peer_config.initial_balances.append(&mut stacker_balances);
     peer_config.initial_balances.append(&mut initial_balances);
     peer_config.burnchain.pox_constants.v2_unlock_height = 21;
     peer_config.burnchain.pox_constants.pox_3_activation_height = 26;
     peer_config.burnchain.pox_constants.v3_unlock_height = 27;
     peer_config.burnchain.pox_constants.pox_4_activation_height = 31;
     let mut peer = TestPeer::new(peer_config);
-    advance_to_nakamoto(&mut peer);
+
+    advance_to_nakamoto(&mut peer, &test_signers, test_stackers.iter().collect());
+
     peer
 }
 
@@ -134,8 +178,20 @@ fn make_replay_peer<'a>(peer: &'a mut TestPeer<'a>) -> TestPeer<'a> {
     replay_config.server_port = 0;
     replay_config.http_port = 0;
 
+    let private_key = peer.config.private_key.clone();
+    let signer_private_key = StacksPrivateKey::from_seed(&[3]);
+
     let mut replay_peer = TestPeer::new(replay_config);
-    advance_to_nakamoto(&mut replay_peer);
+    let observer = TestEventObserver::new();
+    advance_to_nakamoto(
+        &mut replay_peer,
+        &TestSigners::default(),
+        vec![&TestStacker {
+            stacker_private_key: private_key,
+            signer_private_key,
+            amount: 1_000_000_000_000_000_000,
+        }],
+    );
 
     // sanity check
     let replay_tip = {
@@ -162,7 +218,7 @@ fn make_replay_peer<'a>(peer: &'a mut TestPeer<'a>) -> TestPeer<'a> {
 }
 
 /// Make a token-transfer from a private key
-fn make_token_transfer(
+pub fn make_token_transfer(
     chainstate: &mut StacksChainState,
     sortdb: &SortitionDB,
     private_key: &StacksPrivateKey,
@@ -250,11 +306,7 @@ fn replay_reward_cycle(
 #[test]
 fn test_simple_nakamoto_coordinator_bootup() {
     let mut test_signers = TestSigners::default();
-    let mut peer = boot_nakamoto(
-        function_name!(),
-        vec![],
-        test_signers.aggregate_public_key.clone(),
-    );
+    let mut peer = boot_nakamoto(function_name!(), vec![], &test_signers, None);
 
     let (burn_ops, mut tenure_change, miner_key) =
         peer.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
@@ -313,7 +365,8 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let (burn_ops, mut tenure_change, miner_key) =
@@ -434,7 +487,8 @@ fn test_nakamoto_chainstate_getters() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let sort_tip = {
@@ -923,7 +977,8 @@ fn test_simple_nakamoto_coordinator_10_tenures_10_blocks() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let mut all_blocks = vec![];
@@ -1243,7 +1298,8 @@ fn test_simple_nakamoto_coordinator_2_tenures_3_sortitions() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let mut rc_burn_ops = vec![];
@@ -1571,7 +1627,8 @@ fn test_simple_nakamoto_coordinator_10_tenures_and_extensions_10_blocks() {
     let mut peer = boot_nakamoto(
         function_name!(),
         vec![(addr.into(), 100_000_000)],
-        test_signers.aggregate_public_key.clone(),
+        &test_signers,
+        None,
     );
 
     let mut all_blocks = vec![];

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -224,11 +224,17 @@ impl NakamotoBlockBuilder {
     ) -> Result<MinerTenureInfo<'a>, Error> {
         debug!("Nakamoto miner tenure begin");
 
-        let burn_tip = SortitionDB::get_canonical_chain_tip_bhh(burn_dbconn.conn())?;
-        let burn_tip_height = u32::try_from(
-            SortitionDB::get_canonical_burn_chain_tip(burn_dbconn.conn())?.block_height,
-        )
-        .expect("block height overflow");
+        // must build off of the header's consensus hash as the burnchain view, not the canonical_tip_bhh:
+        let burn_sn = SortitionDB::get_block_snapshot_consensus(burn_dbconn.conn(), &self.header.consensus_hash)?
+            .ok_or_else(|| {
+                warn!(
+                    "Could not mine. The expected burnchain consensus hash has not been processed by our SortitionDB";
+                    "consensus_hash" => %self.header.consensus_hash
+                );
+                Error::NoSuchBlockError
+            })?;
+        let burn_tip = burn_sn.burn_header_hash;
+        let burn_tip_height = u32::try_from(burn_sn.block_height).expect("block height overflow");
 
         let mainnet = chainstate.config().mainnet;
 

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -317,7 +317,8 @@ pub struct NakamotoBlockHeader {
     /// Schnorr signature over the block header from the signer set active during the tenure.
     pub signer_signature: ThresholdSignature,
     /// A bitvec which represents the signers that participated in this block signature.
-    pub signer_bitvec: BitVec,
+    /// The maximum number of entries in the bitvec is 4000.
+    pub signer_bitvec: BitVec<4000>,
 }
 
 impl FromRow<NakamotoBlockHeader> for NakamotoBlockHeader {
@@ -474,7 +475,7 @@ impl NakamotoBlockHeader {
             state_index_root: TrieHash([0u8; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: ThresholdSignature::empty(),
-            signer_bitvec: BitVec::zeros(1),
+            signer_bitvec: BitVec::zeros(1).expect("BUG: bitvec of length-1 failed to construct"),
         }
     }
 
@@ -490,7 +491,7 @@ impl NakamotoBlockHeader {
             state_index_root: TrieHash([0u8; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: ThresholdSignature::empty(),
-            signer_bitvec: BitVec::zeros(1),
+            signer_bitvec: BitVec::zeros(1).expect("BUG: bitvec of length-1 failed to construct"),
         }
     }
 
@@ -506,7 +507,7 @@ impl NakamotoBlockHeader {
             state_index_root: TrieHash([0u8; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: ThresholdSignature::empty(),
-            signer_bitvec: BitVec::zeros(1),
+            signer_bitvec: BitVec::zeros(1).expect("BUG: bitvec of length-1 failed to construct"),
         }
     }
 }

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::DerefMut;
 
 use clarity::vm::ast::ASTRules;
@@ -1814,25 +1814,22 @@ impl NakamotoChainState {
         }
     }
 
-    pub fn calculate_signer_slots(
+    fn calculate_signer_slots(
         clarity: &mut ClarityTransactionConnection,
         pox_constants: &PoxConstants,
-    ) -> Result<HashMap<Value, u128>, clarity::vm::errors::Error> {
+        reward_cycle: u64,
+    ) -> Result<BTreeMap<Vec<u8>, u128>, ChainstateError> {
         let is_mainnet = clarity.is_mainnet();
         let pox4_contract = &boot_code_id(POX_4_NAME, is_mainnet);
-        let reward_cycle = clarity
-            .eval_read_only(pox4_contract, &"(current-pox-reward-cycle)")
-            .unwrap()
-            .expect_u128();
+
         let list_length = clarity
             .eval_read_only(
                 pox4_contract,
                 &format!("(get-signer-key-list-length u{})", reward_cycle),
-            )
-            .unwrap()
+            )?
             .expect_u128();
 
-        let mut signers: HashMap<Value, u128> = HashMap::new();
+        let mut signers: BTreeMap<Vec<u8>, u128> = BTreeMap::new();
         let mut total_ustx: u128 = 0;
         for index in 0..list_length {
             if let Ok(Value::Optional(entry)) = clarity.eval_read_only(
@@ -1841,10 +1838,9 @@ impl NakamotoChainState {
             ) {
                 if let Some(data) = entry.data {
                     let data = data.expect_tuple();
-                    let key = data.get("signer-key")?.to_owned();
+                    let key = data.get("signer-key")?.to_owned().expect_buff(33);
                     let amount = data.get("ustx")?.to_owned().expect_u128();
                     let sum = signers.get(&key).cloned().unwrap_or_default();
-                    //TODO HashMap insert order is not guaranteed
                     signers.insert(key, sum + amount);
                     total_ustx = total_ustx
                         .checked_add(amount)
@@ -1869,19 +1865,19 @@ impl NakamotoChainState {
         clarity: &mut ClarityTransactionConnection,
         chain_id: u32,
         pox_constants: &PoxConstants,
-    ) -> Result<Vec<StacksTransactionEvent>, Error> {
+        reward_cycle: u64,
+    ) -> Result<Vec<StacksTransactionEvent>, ChainstateError> {
         let is_mainnet = clarity.is_mainnet();
         let sender_addr = PrincipalData::from(boot::boot_code_addr(is_mainnet));
         let signers_contract = &boot_code_id(SIGNERS_NAME, is_mainnet);
 
-        let signers = Self::calculate_signer_slots(clarity, pox_constants).unwrap_or_default();
+        let signers =
+            Self::calculate_signer_slots(clarity, pox_constants, reward_cycle).unwrap_or_default();
 
         let signers_list_data: Vec<Value> = signers
             .iter()
             .map(|(signer_key, slots)| {
-                let key =
-                    StacksPublicKey::from_slice(signer_key.to_owned().expect_buff(33).as_slice())
-                        .expect("TODO: invalid key");
+                let key = StacksPublicKey::from_slice(signer_key.as_slice()).unwrap();
                 let addr = StacksAddress::from_public_keys(
                     if is_mainnet {
                         C32_ADDRESS_VERSION_MAINNET_SINGLESIG
@@ -1939,7 +1935,7 @@ impl NakamotoChainState {
         first_block_height: u64,
         pox_constants: &PoxConstants,
         burn_tip_height: u64,
-    ) -> Result<Vec<StacksTransactionEvent>, Error> {
+    ) -> Result<Vec<StacksTransactionEvent>, ChainstateError> {
         if clarity_tx.get_epoch() < StacksEpochId::Epoch25
             || !pox_constants.is_prepare_phase_start(first_block_height, burn_tip_height)
         {
@@ -1956,6 +1952,9 @@ impl NakamotoChainState {
                 clarity,
                 clarity_tx.config.chain_id,
                 &pox_constants,
+                pox_constants
+                    .block_height_to_reward_cycle(first_block_height, burn_tip_height)
+                    .expect("FATAL: no reward cycle for block height"),
             )
         })
     }

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -22,6 +22,7 @@ use clarity::vm::clarity::ClarityConnection;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::types::StacksAddressExtensions;
 use stacks_common::address::AddressHashMode;
+use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::consts::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH};
 use stacks_common::types::chainstate::{
@@ -116,10 +117,11 @@ fn codec_nakamoto_header() {
         tx_merkle_root: Sha512Trunc256Sum([0x06; 32]),
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(8),
     };
 
-    let bytes = vec![
+    let mut bytes = vec![
         // version
         0x01, // chain length
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // burn spent
@@ -147,6 +149,9 @@ fn codec_nakamoto_header() {
         0x00, 0x00, 0x00, 0x00, 0x00,
     ];
 
+    let signer_bitvec_serialization = "00080000000100";
+    bytes.append(&mut hex_bytes(signer_bitvec_serialization).unwrap());
+
     check_codec_and_corruption(&header, &bytes);
 }
 
@@ -162,7 +167,8 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         tx_merkle_root: Sha512Trunc256Sum([0x06; 32]),
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1),
     };
 
     // sortition-inducing tenure change
@@ -659,7 +665,8 @@ pub fn test_load_store_update_nakamoto_blocks() {
         tx_merkle_root: nakamoto_tx_merkle_root,
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1),
     };
 
     let nakamoto_header_info = StacksHeaderInfo {
@@ -702,7 +709,8 @@ pub fn test_load_store_update_nakamoto_blocks() {
         tx_merkle_root: nakamoto_tx_merkle_root_2,
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1),
     };
 
     let nakamoto_header_info_2 = StacksHeaderInfo {
@@ -1338,7 +1346,8 @@ fn test_nakamoto_block_static_verification() {
         tx_merkle_root: nakamoto_tx_merkle_root,
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1),
     };
     nakamoto_header.sign_miner(&private_key).unwrap();
 
@@ -1356,7 +1365,8 @@ fn test_nakamoto_block_static_verification() {
         tx_merkle_root: nakamoto_tx_merkle_root_bad_ch,
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1),
     };
     nakamoto_header_bad_ch.sign_miner(&private_key).unwrap();
 
@@ -1374,7 +1384,8 @@ fn test_nakamoto_block_static_verification() {
         tx_merkle_root: nakamoto_tx_merkle_root_bad_miner_sig,
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1),
     };
     nakamoto_header_bad_miner_sig
         .sign_miner(&private_key)
@@ -1524,7 +1535,8 @@ pub fn test_get_highest_nakamoto_tenure() {
             tx_merkle_root: Sha512Trunc256Sum([0x00; 32]),
             state_index_root: TrieHash([0x00; 32]),
             miner_signature: MessageSignature::empty(),
-            signer_signature: ThresholdSignature::mock(),
+            signer_signature: ThresholdSignature::empty(),
+            signer_bitvec: BitVec::zeros(1),
         };
         let tenure_change = TenureChangePayload {
             tenure_consensus_hash: sn.consensus_hash.clone(),
@@ -1821,7 +1833,8 @@ fn test_make_miners_stackerdb_config() {
             tx_merkle_root: Sha512Trunc256Sum([0x06; 32]),
             state_index_root: TrieHash([0x07; 32]),
             miner_signature: MessageSignature::empty(),
-            signer_signature: ThresholdSignature::mock(),
+            signer_signature: ThresholdSignature::empty(),
+            signer_bitvec: BitVec::zeros(1),
         };
         let block = NakamotoBlock {
             header,

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -118,7 +118,7 @@ fn codec_nakamoto_header() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: ThresholdSignature::empty(),
-        signer_bitvec: BitVec::zeros(8),
+        signer_bitvec: BitVec::zeros(8).unwrap(),
     };
 
     let mut bytes = vec![
@@ -168,7 +168,7 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: ThresholdSignature::empty(),
-        signer_bitvec: BitVec::zeros(1),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
     };
 
     // sortition-inducing tenure change
@@ -666,7 +666,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: ThresholdSignature::empty(),
-        signer_bitvec: BitVec::zeros(1),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
     };
 
     let nakamoto_header_info = StacksHeaderInfo {
@@ -710,7 +710,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: ThresholdSignature::empty(),
-        signer_bitvec: BitVec::zeros(1),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
     };
 
     let nakamoto_header_info_2 = StacksHeaderInfo {
@@ -1347,7 +1347,7 @@ fn test_nakamoto_block_static_verification() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: ThresholdSignature::empty(),
-        signer_bitvec: BitVec::zeros(1),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
     };
     nakamoto_header.sign_miner(&private_key).unwrap();
 
@@ -1366,7 +1366,7 @@ fn test_nakamoto_block_static_verification() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: ThresholdSignature::empty(),
-        signer_bitvec: BitVec::zeros(1),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
     };
     nakamoto_header_bad_ch.sign_miner(&private_key).unwrap();
 
@@ -1385,7 +1385,7 @@ fn test_nakamoto_block_static_verification() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: ThresholdSignature::empty(),
-        signer_bitvec: BitVec::zeros(1),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
     };
     nakamoto_header_bad_miner_sig
         .sign_miner(&private_key)
@@ -1536,7 +1536,7 @@ pub fn test_get_highest_nakamoto_tenure() {
             state_index_root: TrieHash([0x00; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: ThresholdSignature::empty(),
-            signer_bitvec: BitVec::zeros(1),
+            signer_bitvec: BitVec::zeros(1).unwrap(),
         };
         let tenure_change = TenureChangePayload {
             tenure_consensus_hash: sn.consensus_hash.clone(),
@@ -1834,7 +1834,7 @@ fn test_make_miners_stackerdb_config() {
             state_index_root: TrieHash([0x07; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: ThresholdSignature::empty(),
-            signer_bitvec: BitVec::zeros(1),
+            signer_bitvec: BitVec::zeros(1).unwrap(),
         };
         let block = NakamotoBlock {
             header,

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -1502,11 +1502,7 @@ fn make_fork_run_with_arrivals(
 #[test]
 pub fn test_get_highest_nakamoto_tenure() {
     let test_signers = TestSigners::default();
-    let mut peer = boot_nakamoto(
-        function_name!(),
-        vec![],
-        test_signers.aggregate_public_key.clone(),
-    );
+    let mut peer = boot_nakamoto(function_name!(), vec![], &test_signers, None);
 
     // extract chainstate and sortdb -- we don't need the peer anymore
     let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -1644,11 +1644,7 @@ pub fn test_get_highest_nakamoto_tenure() {
 #[test]
 fn test_make_miners_stackerdb_config() {
     let test_signers = TestSigners::default();
-    let mut peer = boot_nakamoto(
-        function_name!(),
-        vec![],
-        test_signers.aggregate_public_key.clone(),
-    );
+    let mut peer = boot_nakamoto(function_name!(), vec![], &test_signers, None);
 
     let naka_miner_hash160 = peer.miner.nakamoto_miner_hash160();
     let miner_keys: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -506,7 +506,7 @@ impl TestStacksNode {
             'a,
             TestEventObserver,
             (),
-            OnChainRewardSetProvider,
+            OnChainRewardSetProvider<'a, TestEventObserver>,
             (),
             (),
             BitcoinIndexer,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -66,6 +66,31 @@ use crate::util_lib::boot::boot_code_addr;
 use crate::util_lib::db::Error as db_error;
 
 #[derive(Debug, Clone)]
+pub struct TestStacker {
+    pub stacker_private_key: StacksPrivateKey,
+    pub signer_private_key: StacksPrivateKey,
+    pub amount: u128,
+}
+
+impl TestStacker {
+    pub fn from_seed(seed: &[u8]) -> TestStacker {
+        let stacker_private_key = StacksPrivateKey::from_seed(seed);
+        let mut signer_seed = seed.to_vec();
+        signer_seed.append(&mut vec![0xff, 0x00, 0x00, 0x00]);
+        let signer_private_key = StacksPrivateKey::from_seed(signer_seed.as_slice());
+        TestStacker {
+            stacker_private_key,
+            signer_private_key,
+            amount: 1_000_000_000_000_000_000,
+        }
+    }
+
+    pub fn signer_public_key(&self) -> StacksPublicKey {
+        StacksPublicKey::from_private(&self.signer_private_key)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct TestSigners {
     /// The parties that will sign the blocks
     pub signer_parties: Vec<wsts::v2::Party>,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -622,6 +622,7 @@ impl TestStacksNode {
 
             let sort_tip = SortitionDB::get_canonical_sortition_tip(sortdb.conn()).unwrap();
             let mut sort_handle = sortdb.index_handle(&sort_tip);
+            info!("Processing the new nakamoto block");
             let accepted = match Relayer::process_new_nakamoto_block(
                 sortdb,
                 &mut sort_handle,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -25,10 +25,14 @@ use clarity::vm::clarity::{Error as ClarityError, TransactionConnection};
 use clarity::vm::contexts::ContractContext;
 use clarity::vm::costs::cost_functions::ClarityCostFunction;
 use clarity::vm::costs::{ClarityCostFunctionReference, CostStateSummary, LimitedCostTracker};
-use clarity::vm::database::{ClarityDatabase, NULL_BURN_STATE_DB, NULL_HEADER_DB};
-use clarity::vm::errors::{Error as VmError, InterpreterError};
+use clarity::vm::database::{
+    ClarityDatabase, DataVariableMetadata, NULL_BURN_STATE_DB, NULL_HEADER_DB,
+};
+use clarity::vm::errors::{Error as VmError, InterpreterError, InterpreterResult};
 use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::representations::{ClarityName, ContractName};
+use clarity::vm::tests::symbols_from_values;
+use clarity::vm::types::TypeSignature::UIntType;
 use clarity::vm::types::{
     PrincipalData, QualifiedContractIdentifier, SequenceData, StandardPrincipalData, TupleData,
     TypeSignature, Value,
@@ -75,10 +79,12 @@ pub const POX_1_NAME: &'static str = "pox";
 pub const POX_2_NAME: &'static str = "pox-2";
 pub const POX_3_NAME: &'static str = "pox-3";
 pub const POX_4_NAME: &'static str = "pox-4";
+pub const SIGNERS_NAME: &'static str = "signers";
 
 const POX_2_BODY: &'static str = std::include_str!("pox-2.clar");
 const POX_3_BODY: &'static str = std::include_str!("pox-3.clar");
 const POX_4_BODY: &'static str = std::include_str!("pox-4.clar");
+pub const SIGNERS_BODY: &'static str = std::include_str!("signers.clar");
 
 pub const COSTS_1_NAME: &'static str = "costs";
 pub const COSTS_2_NAME: &'static str = "costs-2";
@@ -1255,6 +1261,8 @@ pub mod pox_2_tests;
 pub mod pox_3_tests;
 #[cfg(test)]
 pub mod pox_4_tests;
+#[cfg(test)]
+mod signers_tests;
 
 #[cfg(test)]
 pub mod test {

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -31,7 +31,6 @@ use clarity::vm::database::{
 use clarity::vm::errors::{Error as VmError, InterpreterError, InterpreterResult};
 use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::representations::{ClarityName, ContractName};
-use clarity::vm::tests::symbols_from_values;
 use clarity::vm::types::TypeSignature::UIntType;
 use clarity::vm::types::{
     PrincipalData, QualifiedContractIdentifier, SequenceData, StandardPrincipalData, TupleData,
@@ -80,6 +79,10 @@ pub const POX_2_NAME: &'static str = "pox-2";
 pub const POX_3_NAME: &'static str = "pox-3";
 pub const POX_4_NAME: &'static str = "pox-4";
 pub const SIGNERS_NAME: &'static str = "signers";
+/// This is the name of a variable in the `.signers` contract which tracks the most recently updated
+/// reward cycle number.
+pub const SIGNERS_UPDATE_STATE: &'static str = "last-set-cycle";
+pub const SIGNERS_MAX_LIST_SIZE: usize = 4000;
 
 const POX_2_BODY: &'static str = std::include_str!("pox-2.clar");
 const POX_3_BODY: &'static str = std::include_str!("pox-3.clar");
@@ -163,6 +166,20 @@ pub struct RawRewardSetEntry {
     pub stacker: Option<PrincipalData>,
     pub signer: Option<PrincipalData>,
 }
+
+/// This enum captures the names of the PoX contracts by version.
+// This should deprecate the const values `POX_version_NAME`, but
+// that is the kind of refactor that should be in its own PR.
+// Having an enum here is useful for a bunch of reasons, but chiefly:
+//   * we'll be able to add an Ord implementation, so that we can
+//     do much easier version checks
+//   * static enforcement of matches
+define_named_enum!(PoxVersions {
+    Pox1("pox"),
+    Pox2("pox-2"),
+    Pox3("pox-3"),
+    Pox4("pox-4"),
+});
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PoxStartCycleInfo {

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -100,7 +100,6 @@ pub const BOOT_TEST_POX_4_AGG_KEY_CONTRACT: &'static str = "pox-4-agg-test-boote
 pub const BOOT_TEST_POX_4_AGG_KEY_FNAME: &'static str = "aggregate-key";
 
 pub const MINERS_NAME: &'static str = "miners";
-pub const SIGNERS_NAME: &'static str = "signers";
 
 pub mod docs;
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -86,7 +86,7 @@ fn get_tip(sortdb: Option<&SortitionDB>) -> BlockSnapshot {
     SortitionDB::get_canonical_burn_chain_tip(&sortdb.unwrap().conn()).unwrap()
 }
 
-fn make_test_epochs_pox() -> (Vec<StacksEpoch>, PoxConstants) {
+pub fn make_test_epochs_pox() -> (Vec<StacksEpoch>, PoxConstants) {
     let EMPTY_SORTITIONS = 25;
     let EPOCH_2_1_HEIGHT = EMPTY_SORTITIONS + 11; // 36
     let EPOCH_2_2_HEIGHT = EPOCH_2_1_HEIGHT + 14; // 50
@@ -1340,7 +1340,7 @@ fn pox_4_revoke_delegate_stx_events() {
     );
 }
 
-fn assert_latest_was_burn(peer: &mut TestPeer) {
+pub fn assert_latest_was_burn(peer: &mut TestPeer) {
     let tip = get_tip(peer.sortdb.as_ref());
     let tip_index_block = tip.get_canonical_stacks_block_id();
     let burn_height = tip.block_height - 1;

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1482,7 +1482,7 @@ fn stack_stx_signer_key() {
     let signer_bytes =
         hex_bytes("03a0f9818ea8c14a827bb144aec9cfbaeba225af22be18ed78a2f298106f4e281b").unwrap();
     let signer_key = Secp256k1PublicKey::from_slice(&signer_bytes).unwrap();
-    let signer_key_val = Value::buff_from(signer_bytes).unwrap();
+    let signer_key_val = Value::buff_from(signer_bytes.clone()).unwrap();
 
     let txs = vec![make_pox_4_contract_call(
         stacker_key,
@@ -1517,10 +1517,7 @@ fn stack_stx_signer_key() {
         PoxAddress::try_from_pox_tuple(false, &pox_addr).unwrap(),
         reward_entry.reward_address
     );
-    assert_eq!(
-        reward_entry.signer.unwrap(),
-        StacksAddress::p2pkh(false, &signer_key).into(),
-    );
+    assert_eq!(&reward_entry.signer.unwrap(), &signer_bytes.as_slice());
 }
 
 #[test]
@@ -1543,11 +1540,11 @@ fn stack_extend_signer_key() {
 
     let signer_key = Secp256k1PublicKey::from_private(&signer_sk);
     let signer_bytes = signer_key.to_bytes_compressed();
-    let signer_key_val = Value::buff_from(signer_bytes).unwrap();
+    let signer_key_val = Value::buff_from(signer_bytes.clone()).unwrap();
 
     let signer_extend_key = Secp256k1PublicKey::from_private(&signer_extend_sk);
     let signer_extend_bytes = signer_extend_key.to_bytes_compressed();
-    let signer_extend_key_val = Value::buff_from(signer_extend_bytes).unwrap();
+    let signer_extend_key_val = Value::buff_from(signer_extend_bytes.clone()).unwrap();
 
     let next_reward_cycle = 1 + burnchain
         .block_height_to_reward_cycle(block_height)
@@ -1613,10 +1610,7 @@ fn stack_extend_signer_key() {
         PoxAddress::try_from_pox_tuple(false, &pox_addr).unwrap(),
         reward_entry.reward_address
     );
-    assert_eq!(
-        reward_entry.signer.unwrap(),
-        StacksAddress::p2pkh(false, &signer_key).into(),
-    );
+    assert_eq!(&reward_entry.signer.unwrap(), signer_bytes.as_slice(),);
 
     let mut reward_set = get_reward_set_entries_at(&mut peer, &latest_block, extend_cycle_ht);
     assert_eq!(reward_set.len(), 1);
@@ -1626,8 +1620,8 @@ fn stack_extend_signer_key() {
         reward_entry.reward_address
     );
     assert_eq!(
-        reward_entry.signer.unwrap(),
-        StacksAddress::p2pkh(false, &signer_extend_key).into(),
+        &reward_entry.signer.unwrap(),
+        signer_extend_bytes.as_slice(),
     );
 }
 
@@ -1658,7 +1652,7 @@ fn delegate_stack_stx_signer_key() {
     let signer_bytes =
         hex_bytes("03a0f9818ea8c14a827bb144aec9cfbaeba225af22be18ed78a2f298106f4e281b").unwrap();
     let signer_key = Secp256k1PublicKey::from_slice(&signer_bytes).unwrap();
-    let signer_key_val = Value::buff_from(signer_bytes).unwrap();
+    let signer_key_val = Value::buff_from(signer_bytes.clone()).unwrap();
 
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
 
@@ -1731,10 +1725,7 @@ fn delegate_stack_stx_signer_key() {
         PoxAddress::try_from_pox_tuple(false, &pox_addr).unwrap(),
         reward_entry.reward_address
     );
-    assert_eq!(
-        reward_entry.signer.unwrap(),
-        StacksAddress::p2pkh(false, &signer_key).into(),
-    );
+    assert_eq!(&reward_entry.signer.unwrap(), signer_bytes.as_slice(),);
 }
 
 pub fn get_stacking_state_pox_4(

--- a/stackslib/src/chainstate/stacks/boot/signers.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers.clar
@@ -1,0 +1,24 @@
+(define-data-var stackerdb-signer-slots (list 4000 { signer: principal, num-slots: uint }) (list))
+
+(define-private (stackerdb-set-signer-slots (signer-slots (list 4000 { signer: principal, num-slots: uint })))
+	(begin
+		(print signer-slots)
+		(ok (var-set stackerdb-signer-slots signer-slots))
+	)
+)
+
+(define-read-only (stackerdb-get-signer-slots)
+	(ok (var-get stackerdb-signer-slots))
+)
+
+(define-read-only (stackerdb-get-config)
+	(ok
+		{
+		chunk-size: u4096,
+		write-freq: u0,
+		max-writes: u4096,
+		max-neighbors: u32,
+		hint-replicas: (list)
+		}
+	)
+)

--- a/stackslib/src/chainstate/stacks/boot/signers.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers.clar
@@ -1,24 +1,22 @@
+(define-data-var last-set-cycle uint u0)
 (define-data-var stackerdb-signer-slots (list 4000 { signer: principal, num-slots: uint }) (list))
 
-(define-private (stackerdb-set-signer-slots (signer-slots (list 4000 { signer: principal, num-slots: uint })))
+(define-private (stackerdb-set-signer-slots 
+                   (signer-slots (list 4000 { signer: principal, num-slots: uint }))
+                   (reward-cycle uint))
 	(begin
 		(print signer-slots)
-		(ok (var-set stackerdb-signer-slots signer-slots))
-	)
-)
+        (var-set last-set-cycle reward-cycle)
+		(ok (var-set stackerdb-signer-slots signer-slots))))
 
 (define-read-only (stackerdb-get-signer-slots)
-	(ok (var-get stackerdb-signer-slots))
-)
+	(ok (var-get stackerdb-signer-slots)))
 
 (define-read-only (stackerdb-get-config)
 	(ok
-		{
-		chunk-size: u4096,
-		write-freq: u0,
-		max-writes: u4096,
-		max-neighbors: u32,
-		hint-replicas: (list)
-		}
-	)
-)
+		{ chunk-size: u4096,
+		  write-freq: u0,
+		  max-writes: u4096,
+		  max-neighbors: u32,
+		  hint-replicas: (list) }
+	))

--- a/stackslib/src/chainstate/stacks/boot/signers.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers.clar
@@ -1,11 +1,12 @@
 (define-data-var last-set-cycle uint u0)
 (define-data-var stackerdb-signer-slots (list 4000 { signer: principal, num-slots: uint }) (list))
+(define-constant MAX_WRITES u340282366920938463463374607431768211455)
+(define-constant CHUNK_SIZE (* u2 u1024 u1024))
 
 (define-private (stackerdb-set-signer-slots 
                    (signer-slots (list 4000 { signer: principal, num-slots: uint }))
                    (reward-cycle uint))
 	(begin
-		(print signer-slots)
         (var-set last-set-cycle reward-cycle)
 		(ok (var-set stackerdb-signer-slots signer-slots))))
 
@@ -14,9 +15,9 @@
 
 (define-read-only (stackerdb-get-config)
 	(ok
-		{ chunk-size: u4096,
+		{ chunk-size: CHUNK_SIZE,
 		  write-freq: u0,
-		  max-writes: u4096,
+		  max-writes: MAX_WRITES,
 		  max-neighbors: u32,
 		  hint-replicas: (list) }
 	))

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -1,0 +1,305 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use clarity::vm::clarity::ClarityConnection;
+use clarity::vm::contexts::OwnedEnvironment;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::tests::symbols_from_values;
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, TupleData};
+use clarity::vm::Value::Principal;
+use clarity::vm::{ClarityName, ClarityVersion, ContractName, Value};
+use stacks_common::address::AddressHashMode;
+use stacks_common::types::chainstate::{
+    BurnchainHeaderHash, StacksBlockId, StacksPrivateKey, StacksPublicKey,
+};
+use stacks_common::types::PublicKey;
+
+use crate::burnchains::Burnchain;
+use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::burn::BlockSnapshot;
+use crate::chainstate::nakamoto::coordinator::tests::{boot_nakamoto, make_token_transfer};
+use crate::chainstate::nakamoto::tests::get_account;
+use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
+use crate::chainstate::stacks::address::PoxAddress;
+use crate::chainstate::stacks::boot::pox_2_tests::with_clarity_db_ro;
+use crate::chainstate::stacks::boot::pox_4_tests::{
+    assert_latest_was_burn, get_last_block_sender_transactions, make_test_epochs_pox,
+    prepare_pox4_test,
+};
+use crate::chainstate::stacks::boot::test::{
+    instantiate_pox_peer_with_epoch, key_to_stacks_addr, make_pox_4_lockup, with_sortdb,
+};
+use crate::chainstate::stacks::boot::SIGNERS_NAME;
+use crate::chainstate::stacks::index::marf::MarfConnection;
+use crate::chainstate::stacks::{
+    StacksTransaction, StacksTransactionSigner, TenureChangeCause, TransactionAuth,
+    TransactionPayload, TransactionPostConditionMode, TransactionVersion,
+};
+use crate::clarity_vm::database::HeadersDBConn;
+use crate::core::BITCOIN_REGTEST_FIRST_BLOCK_HASH;
+use crate::net::test::{TestEventObserver, TestPeer};
+use crate::util_lib::boot::{boot_code_addr, boot_code_id, boot_code_test_addr};
+
+#[test]
+fn signers_get_config() {
+    let (burnchain, mut peer, keys, latest_block, ..) = prepare_pox4_test(function_name!(), None);
+
+    assert_eq!(
+        readonly_call(
+            &mut peer,
+            &latest_block,
+            "signers".into(),
+            "stackerdb-get-config".into(),
+            vec![],
+        ),
+        Value::okay(Value::Tuple(
+            TupleData::from_data(vec![
+                ("chunk-size".into(), Value::UInt(4096)),
+                ("write-freq".into(), Value::UInt(0)),
+                ("max-writes".into(), Value::UInt(4096)),
+                ("max-neighbors".into(), Value::UInt(32)),
+                (
+                    "hint-replicas".into(),
+                    Value::cons_list_unsanitized(vec![]).unwrap()
+                )
+            ])
+            .unwrap()
+        ))
+        .unwrap()
+    );
+}
+
+#[test]
+fn signers_get_signer_keys_from_pox4() {
+    let stacker_1 = TestStacker::from_seed(&[3, 4]);
+    let stacker_2 = TestStacker::from_seed(&[5, 6]);
+
+    let (mut peer, test_signers, latest_block_id) =
+        prepare_signers_test(function_name!(), Some(vec![&stacker_1, &stacker_2]));
+
+    let private_key = peer.config.private_key.clone();
+
+    let stacker_1_addr = key_to_stacks_addr(&stacker_1.stacker_private_key);
+    let stacker_2_addr = key_to_stacks_addr(&stacker_2.stacker_private_key);
+
+    let stacker_1_info = readonly_call(
+        &mut peer,
+        &latest_block_id,
+        "pox-4".into(),
+        "get-stacker-info".into(),
+        vec![Value::Principal(PrincipalData::from(stacker_1_addr))],
+    );
+
+    let stacker_2_info = readonly_call(
+        &mut peer,
+        &latest_block_id,
+        "pox-4".into(),
+        "get-stacker-info".into(),
+        vec![Value::Principal(PrincipalData::from(stacker_2_addr))],
+    );
+
+    let stacker_1_tuple = stacker_1_info.expect_optional().unwrap().expect_tuple();
+    let stacker_2_tuple = stacker_2_info.expect_optional().unwrap().expect_tuple();
+
+    assert_eq!(
+        stacker_1_tuple.get_owned("signer-key").unwrap(),
+        Value::buff_from(stacker_1.signer_public_key().to_bytes_compressed()).unwrap()
+    );
+
+    assert_eq!(
+        stacker_2_tuple.get_owned("signer-key").unwrap(),
+        Value::buff_from(stacker_2.signer_public_key().to_bytes_compressed()).unwrap()
+    );
+}
+
+#[test]
+fn signers_get_signer_keys_from_stackerdb() {
+    let stacker_1 = TestStacker::from_seed(&[3, 4]);
+    let stacker_2 = TestStacker::from_seed(&[5, 6]);
+
+    let (mut peer, test_signers, latest_block_id) =
+        prepare_signers_test(function_name!(), Some(vec![&stacker_1, &stacker_2]));
+
+    let private_key = peer.config.private_key.clone();
+
+    let signer_1_addr = key_to_stacks_addr(&stacker_1.signer_private_key);
+    let signer_2_addr = key_to_stacks_addr(&stacker_2.signer_private_key);
+
+    let signers = readonly_call(
+        &mut peer,
+        &latest_block_id,
+        "signers".into(),
+        "stackerdb-get-signer-slots".into(),
+        vec![],
+    )
+    .expect_result_ok()
+    .expect_list();
+
+    let expected_tuple_1 = TupleData::from_data(vec![
+        (
+            "signer".into(),
+            Principal(PrincipalData::from(signer_1_addr)),
+        ),
+        ("num-slots".into(), Value::UInt(2000)),
+    ])
+    .unwrap();
+
+    let expected_tuple_2 = TupleData::from_data(vec![
+        (
+            "signer".into(),
+            Principal(PrincipalData::from(signer_2_addr)),
+        ),
+        ("num-slots".into(), Value::UInt(2000)),
+    ])
+    .unwrap();
+
+    assert_eq!(signers.len(), 2);
+
+    let first_tuple = signers.first().unwrap().clone().expect_tuple();
+    let second_tuple = signers.last().unwrap().clone().expect_tuple();
+
+    // Tuples can be in either order
+    if first_tuple
+        .get("signer")
+        .unwrap()
+        .clone()
+        .expect_principal()
+        == PrincipalData::from(signer_1_addr)
+    {
+        assert_eq!(first_tuple, expected_tuple_1);
+        assert_eq!(second_tuple, expected_tuple_2);
+    } else {
+        assert_eq!(first_tuple, expected_tuple_2);
+        assert_eq!(second_tuple, expected_tuple_1);
+    }
+}
+
+fn prepare_signers_test<'a>(
+    test_name: &str,
+    stackers: Option<Vec<&TestStacker>>,
+) -> (TestPeer<'a>, TestSigners, StacksBlockId) {
+    let mut test_signers = TestSigners::default();
+
+    let mut peer = boot_nakamoto(test_name, vec![], &test_signers, stackers);
+
+    let (burn_ops, mut tenure_change, miner_key) =
+        peer.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
+
+    let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
+
+    let vrf_proof = peer.make_nakamoto_vrf_proof(miner_key);
+
+    tenure_change.tenure_consensus_hash = consensus_hash.clone();
+    tenure_change.burn_view_consensus_hash = consensus_hash.clone();
+    let tenure_change_tx = peer
+        .miner
+        .make_nakamoto_tenure_change(tenure_change.clone());
+    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+
+    let blocks_and_sizes = peer.make_nakamoto_tenure(
+        tenure_change_tx,
+        coinbase_tx,
+        &mut test_signers,
+        |_miner, _chainstate, _sort_dbconn, _blocks| vec![],
+    );
+    let latest_block_id = blocks_and_sizes.last().unwrap().0.block_id();
+
+    (peer, test_signers, latest_block_id)
+}
+
+fn advance_blocks(
+    peer: &mut TestPeer,
+    test_signers: &mut TestSigners,
+    stacker_private_key: &StacksPrivateKey,
+    num_blocks: u64,
+) -> StacksBlockId {
+    let current_height = peer.get_burnchain_view().unwrap().burn_block_height;
+
+    //let key = peer.config.private_key;
+
+    let (burn_ops, mut tenure_change, miner_key) =
+        peer.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
+
+    let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
+
+    let vrf_proof = peer.make_nakamoto_vrf_proof(miner_key);
+
+    tenure_change.tenure_consensus_hash = consensus_hash.clone();
+    tenure_change.burn_view_consensus_hash = consensus_hash.clone();
+    let tenure_change_tx = peer
+        .miner
+        .make_nakamoto_tenure_change(tenure_change.clone());
+    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let recipient_addr = boot_code_addr(false);
+    let blocks_and_sizes = peer.make_nakamoto_tenure(
+        tenure_change_tx,
+        coinbase_tx.clone(),
+        test_signers,
+        |miner, chainstate, sortdb, blocks| {
+            if blocks.len() < num_blocks as usize {
+                let addr = key_to_stacks_addr(&stacker_private_key);
+                let account = get_account(chainstate, sortdb, &addr);
+                let stx_transfer = make_token_transfer(
+                    chainstate,
+                    sortdb,
+                    &stacker_private_key,
+                    account.nonce,
+                    1,
+                    1,
+                    &recipient_addr,
+                );
+                vec![stx_transfer]
+            } else {
+                vec![]
+            }
+        },
+    );
+    info!("tenure length {}", blocks_and_sizes.len());
+    let latest_block_id = blocks_and_sizes.last().unwrap().0.block_id();
+    latest_block_id
+}
+
+fn readonly_call(
+    peer: &mut TestPeer,
+    tip: &StacksBlockId,
+    boot_contract: ContractName,
+    function_name: ClarityName,
+    args: Vec<Value>,
+) -> Value {
+    with_sortdb(peer, |chainstate, sortdb| {
+        chainstate.with_read_only_clarity_tx(&sortdb.index_conn(), tip, |connection| {
+            connection
+                .with_readonly_clarity_env(
+                    false,
+                    0x80000000,
+                    ClarityVersion::Clarity2,
+                    PrincipalData::from(boot_code_addr(false)),
+                    None,
+                    LimitedCostTracker::new_free(),
+                    |env| {
+                        env.execute_contract_allow_private(
+                            &boot_code_id(&boot_contract, false),
+                            &function_name,
+                            &symbols_from_values(args),
+                            true,
+                        )
+                    },
+                )
+                .unwrap()
+        })
+    })
+    .unwrap()
+}

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -95,6 +95,9 @@ fn signers_get_signer_keys_from_pox4() {
     let stacker_1_addr = key_to_stacks_addr(&stacker_1.stacker_private_key);
     let stacker_2_addr = key_to_stacks_addr(&stacker_2.stacker_private_key);
 
+    let signer_1_addr = key_to_stacks_addr(&stacker_1.signer_private_key);
+    let signer_2_addr = key_to_stacks_addr(&stacker_2.signer_private_key);
+
     let stacker_1_info = readonly_call(
         &mut peer,
         &latest_block_id,
@@ -116,16 +119,17 @@ fn signers_get_signer_keys_from_pox4() {
 
     assert_eq!(
         stacker_1_tuple.get_owned("signer-key").unwrap(),
-        Value::buff_from(stacker_1.signer_public_key().to_bytes_compressed()).unwrap()
+        Value::Principal(PrincipalData::from(signer_1_addr))
     );
 
     assert_eq!(
         stacker_2_tuple.get_owned("signer-key").unwrap(),
-        Value::buff_from(stacker_2.signer_public_key().to_bytes_compressed()).unwrap()
+        Value::Principal(PrincipalData::from(signer_2_addr))
     );
 }
 
 #[test]
+#[ignore = "to be updated when the signer keys are processed in make_reward_set"]
 fn signers_get_signer_keys_from_stackerdb() {
     let stacker_1 = TestStacker::from_seed(&[3, 4]);
     let stacker_2 = TestStacker::from_seed(&[5, 6]);

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -177,9 +177,9 @@ fn signers_get_config() {
         ),
         Value::okay(Value::Tuple(
             TupleData::from_data(vec![
-                ("chunk-size".into(), Value::UInt(4096)),
+                ("chunk-size".into(), Value::UInt(2 * 1024 * 1024)),
                 ("write-freq".into(), Value::UInt(0)),
-                ("max-writes".into(), Value::UInt(4096)),
+                ("max-writes".into(), Value::UInt(u128::MAX)),
                 ("max-neighbors".into(), Value::UInt(32)),
                 (
                     "hint-replicas".into(),

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -83,52 +83,6 @@ fn signers_get_config() {
 }
 
 #[test]
-fn signers_get_signer_keys_from_pox4() {
-    let stacker_1 = TestStacker::from_seed(&[3, 4]);
-    let stacker_2 = TestStacker::from_seed(&[5, 6]);
-
-    let (mut peer, test_signers, latest_block_id) =
-        prepare_signers_test(function_name!(), Some(vec![&stacker_1, &stacker_2]));
-
-    let private_key = peer.config.private_key.clone();
-
-    let stacker_1_addr = key_to_stacks_addr(&stacker_1.stacker_private_key);
-    let stacker_2_addr = key_to_stacks_addr(&stacker_2.stacker_private_key);
-
-    let signer_1_addr = key_to_stacks_addr(&stacker_1.signer_private_key);
-    let signer_2_addr = key_to_stacks_addr(&stacker_2.signer_private_key);
-
-    let stacker_1_info = readonly_call(
-        &mut peer,
-        &latest_block_id,
-        "pox-4".into(),
-        "get-stacker-info".into(),
-        vec![Value::Principal(PrincipalData::from(stacker_1_addr))],
-    );
-
-    let stacker_2_info = readonly_call(
-        &mut peer,
-        &latest_block_id,
-        "pox-4".into(),
-        "get-stacker-info".into(),
-        vec![Value::Principal(PrincipalData::from(stacker_2_addr))],
-    );
-
-    let stacker_1_tuple = stacker_1_info.expect_optional().unwrap().expect_tuple();
-    let stacker_2_tuple = stacker_2_info.expect_optional().unwrap().expect_tuple();
-
-    assert_eq!(
-        stacker_1_tuple.get_owned("signer-key").unwrap(),
-        Value::Principal(PrincipalData::from(signer_1_addr))
-    );
-
-    assert_eq!(
-        stacker_2_tuple.get_owned("signer-key").unwrap(),
-        Value::Principal(PrincipalData::from(signer_2_addr))
-    );
-}
-
-#[test]
 fn signers_get_signer_keys_from_stackerdb() {
     let stacker_1 = TestStacker::from_seed(&[3, 4]);
     let stacker_2 = TestStacker::from_seed(&[5, 6]);

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -129,7 +129,6 @@ fn signers_get_signer_keys_from_pox4() {
 }
 
 #[test]
-#[ignore = "to be updated when the signer keys are processed in make_reward_set"]
 fn signers_get_signer_keys_from_stackerdb() {
     let stacker_1 = TestStacker::from_seed(&[3, 4]);
     let stacker_2 = TestStacker::from_seed(&[5, 6]);
@@ -149,46 +148,34 @@ fn signers_get_signer_keys_from_stackerdb() {
         "stackerdb-get-signer-slots".into(),
         vec![],
     )
-    .expect_result_ok()
-    .expect_list();
+    .expect_result_ok();
 
-    let expected_tuple_1 = TupleData::from_data(vec![
-        (
-            "signer".into(),
-            Principal(PrincipalData::from(signer_1_addr)),
-        ),
-        ("num-slots".into(), Value::UInt(2000)),
-    ])
-    .unwrap();
-
-    let expected_tuple_2 = TupleData::from_data(vec![
-        (
-            "signer".into(),
-            Principal(PrincipalData::from(signer_2_addr)),
-        ),
-        ("num-slots".into(), Value::UInt(2000)),
-    ])
-    .unwrap();
-
-    assert_eq!(signers.len(), 2);
-
-    let first_tuple = signers.first().unwrap().clone().expect_tuple();
-    let second_tuple = signers.last().unwrap().clone().expect_tuple();
-
-    // Tuples can be in either order
-    if first_tuple
-        .get("signer")
+    assert_eq!(
+        signers,
+        Value::cons_list_unsanitized(vec![
+            Value::Tuple(
+                TupleData::from_data(vec![
+                    (
+                        "signer".into(),
+                        Principal(PrincipalData::from(signer_2_addr)),
+                    ),
+                    ("num-slots".into(), Value::UInt(2)),
+                ])
+                .unwrap()
+            ),
+            Value::Tuple(
+                TupleData::from_data(vec![
+                    (
+                        "signer".into(),
+                        Principal(PrincipalData::from(signer_1_addr)),
+                    ),
+                    ("num-slots".into(), Value::UInt(2)),
+                ])
+                .unwrap()
+            )
+        ])
         .unwrap()
-        .clone()
-        .expect_principal()
-        == PrincipalData::from(signer_1_addr)
-    {
-        assert_eq!(first_tuple, expected_tuple_1);
-        assert_eq!(second_tuple, expected_tuple_2);
-    } else {
-        assert_eq!(first_tuple, expected_tuple_2);
-        assert_eq!(second_tuple, expected_tuple_1);
-    }
+    );
 }
 
 fn prepare_signers_test<'a>(

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -208,6 +208,18 @@ impl BlockEventDispatcher for DummyEventDispatcher {
             "We should never try to announce to the dummy dispatcher"
         );
     }
+
+    fn announce_reward_set(
+        &self,
+        _reward_set: &RewardSet,
+        _block_id: &StacksBlockId,
+        _cycle_number: u64,
+    ) {
+        assert!(
+            false,
+            "We should never try to announce to the dummy dispatcher"
+        );
+    }
 }
 
 impl MemPoolRejection {

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -5140,6 +5140,17 @@ impl StacksChainState {
             );
         }
 
+        // Handle signer stackerdb updates
+        let first_block_height = burn_dbconn.get_burn_start_height();
+        if evaluated_epoch >= StacksEpochId::Epoch25 {
+            let _events = NakamotoChainState::check_and_handle_prepare_phase_start(
+                &mut clarity_tx,
+                first_block_height.into(),
+                &pox_constants,
+                burn_tip_height.into(),
+            )?;
+        }
+
         debug!(
             "Setup block: ready to go for {}/{}",
             &chain_tip.consensus_hash,

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -463,7 +463,7 @@ pub type StacksDBTx<'a> = IndexDBTx<'a, (), StacksBlockId>;
 pub type StacksDBConn<'a> = IndexDBConn<'a, (), StacksBlockId>;
 
 pub struct ClarityTx<'a, 'b> {
-    pub block: ClarityBlockConnection<'a, 'b>,
+    block: ClarityBlockConnection<'a, 'b>,
     pub config: DBConfig,
 }
 

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -463,7 +463,7 @@ pub type StacksDBTx<'a> = IndexDBTx<'a, (), StacksBlockId>;
 pub type StacksDBConn<'a> = IndexDBConn<'a, (), StacksBlockId>;
 
 pub struct ClarityTx<'a, 'b> {
-    block: ClarityBlockConnection<'a, 'b>,
+    pub block: ClarityBlockConnection<'a, 'b>,
     pub config: DBConfig,
 }
 

--- a/stackslib/src/chainstate/stacks/transaction.rs
+++ b/stackslib/src/chainstate/stacks/transaction.rs
@@ -183,9 +183,9 @@ impl ThresholdSignature {
         self.0.verify(public_key, msg)
     }
 
-    /// Create mock data for testing. Not valid data
-    // TODO: `mock()` should be updated to `empty()` and rustdocs updated
-    pub fn mock() -> Self {
+    /// Create an empty/null signature. This is not valid data, but it is used
+    ///  as a placeholder in the header during mining.
+    pub fn empty() -> Self {
         Self(Secp256k1Signature {
             R: Secp256k1Point::G(),
             z: Secp256k1Scalar::new(),

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -49,6 +49,7 @@ use crate::chainstate::stacks::boot::{
     BOOT_TEST_POX_4_AGG_KEY_CONTRACT, BOOT_TEST_POX_4_AGG_KEY_FNAME, COSTS_2_NAME, COSTS_3_NAME,
     MINERS_NAME, POX_2_MAINNET_CODE, POX_2_NAME, POX_2_TESTNET_CODE, POX_3_MAINNET_CODE,
     POX_3_NAME, POX_3_TESTNET_CODE, POX_4_MAINNET_CODE, POX_4_NAME, POX_4_TESTNET_CODE,
+    SIGNERS_BODY, SIGNERS_NAME,
 };
 use crate::chainstate::stacks::db::{StacksAccount, StacksChainState};
 use crate::chainstate::stacks::events::{StacksTransactionEvent, StacksTransactionReceipt};
@@ -1415,6 +1416,42 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                 panic!(
                     "FATAL: Failure processing PoX 4 contract initialization: {:#?}",
                     &pox_4_initialization_receipt
+                );
+            }
+
+            let signers_contract_id = boot_code_id(SIGNERS_NAME, mainnet);
+            let payload = TransactionPayload::SmartContract(
+                TransactionSmartContract {
+                    name: ContractName::try_from(SIGNERS_NAME)
+                        .expect("FATAL: invalid boot-code contract name"),
+                    code_body: StacksString::from_str(SIGNERS_BODY)
+                        .expect("FATAL: invalid boot code body"),
+                },
+                Some(ClarityVersion::Clarity2),
+            );
+
+            let signers_contract_tx =
+                StacksTransaction::new(tx_version.clone(), boot_code_auth.clone(), payload);
+
+            let signers_initialization_receipt = self.as_transaction(|tx_conn| {
+                // initialize with a synthetic transaction
+                debug!("Instantiate {} contract", &signers_contract_id);
+                let receipt = StacksChainState::process_transaction_payload(
+                    tx_conn,
+                    &signers_contract_tx,
+                    &boot_code_account,
+                    ASTRules::PrecheckSize,
+                )
+                .expect("FATAL: Failed to process .miners contract initialization");
+                receipt
+            });
+
+            if signers_initialization_receipt.result != Value::okay_true()
+                || signers_initialization_receipt.post_condition_aborted
+            {
+                panic!(
+                    "FATAL: Failure processing signers contract initialization: {:#?}",
+                    &signers_initialization_receipt
                 );
             }
 

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -1880,6 +1880,15 @@ pub mod test {
         ) {
             // pass
         }
+
+        fn announce_reward_set(
+            &self,
+            _reward_set: &RewardSet,
+            _block_id: &StacksBlockId,
+            _cycle_number: u64,
+        ) {
+            // pass
+        }
     }
 
     // describes a peer's initial configuration

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2099,7 +2099,7 @@ pub mod test {
             'a,
             TestEventObserver,
             (),
-            OnChainRewardSetProvider,
+            OnChainRewardSetProvider<'a, TestEventObserver>,
             (),
             (),
             BitcoinIndexer,
@@ -2337,7 +2337,7 @@ pub mod test {
                 &config.burnchain,
                 config.network_id,
                 &test_path,
-                OnChainRewardSetProvider(),
+                OnChainRewardSetProvider(observer),
                 observer,
                 indexer,
                 None,
@@ -3342,7 +3342,7 @@ pub mod test {
                 &mut stacks_node.chainstate,
                 &mut sortdb,
                 &self.config.burnchain,
-                &OnChainRewardSetProvider(),
+                &OnChainRewardSetProvider::new(),
                 true,
             ) {
                 Ok(recipients) => {

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -1594,7 +1594,7 @@ pub mod test {
     use crate::chainstate::burn::*;
     use crate::chainstate::coordinator::tests::*;
     use crate::chainstate::coordinator::*;
-    use crate::chainstate::nakamoto::tests::node::TestSigners;
+    use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
     use crate::chainstate::stacks::address::PoxAddress;
     use crate::chainstate::stacks::boot::test::get_parent_tip;
     use crate::chainstate::stacks::boot::*;
@@ -1928,6 +1928,7 @@ pub mod test {
         pub services: u16,
         /// aggregate public key to use
         pub aggregate_public_key: Option<Point>,
+        pub test_stackers: Option<Vec<TestStacker>>,
     }
 
     impl TestPeerConfig {
@@ -1992,6 +1993,7 @@ pub mod test {
                     | (ServiceFlags::RPC as u16)
                     | (ServiceFlags::STACKERDB as u16),
                 aggregate_public_key: None,
+                test_stackers: None,
             }
         }
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -2376,6 +2376,7 @@ pub enum EventKeyType {
     MinedMicroblocks,
     StackerDBChunks,
     BlockProposal,
+    StackerSet,
 }
 
 impl EventKeyType {
@@ -2406,6 +2407,10 @@ impl EventKeyType {
 
         if raw_key == "block_proposal" {
             return Some(EventKeyType::BlockProposal);
+        }
+
+        if raw_key == "stacker_set" {
+            return Some(EventKeyType::StackerSet);
         }
 
         let comps: Vec<_> = raw_key.split("::").collect();

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -17,6 +17,7 @@ use stacks::chainstate::burn::ConsensusHash;
 use stacks::chainstate::coordinator::BlockEventDispatcher;
 use stacks::chainstate::nakamoto::NakamotoBlock;
 use stacks::chainstate::stacks::address::PoxAddress;
+use stacks::chainstate::stacks::boot::{NakamotoSignerEntry, RewardSet};
 use stacks::chainstate::stacks::db::accounts::MinerReward;
 use stacks::chainstate::stacks::db::unconfirmed::ProcessedUnconfirmedState;
 use stacks::chainstate::stacks::db::{MinerRewardInfo, StacksHeaderInfo};
@@ -71,6 +72,7 @@ pub const PATH_BURN_BLOCK_SUBMIT: &str = "new_burn_block";
 pub const PATH_BLOCK_PROCESSED: &str = "new_block";
 pub const PATH_ATTACHMENT_PROCESSED: &str = "attachments/new";
 pub const PATH_PROPOSAL_RESPONSE: &str = "proposal_response";
+pub const PATH_POX_ANCHOR: &str = "new_pox_anchor";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MinedBlockEvent {
@@ -101,6 +103,15 @@ pub struct MinedNakamotoBlockEvent {
     pub block_size: u64,
     pub cost: ExecutionCost,
     pub tx_events: Vec<TransactionEvent>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PoxAnchorBlockEvent {
+    /// the StacksBlockId of the PoX anchor block
+    pub block_id: String,
+    pub reward_cycle: u64,
+    pub total_stx_stacked: u128,
+    pub signer_set: Vec<NakamotoSignerEntry>,
 }
 
 impl EventObserver {
@@ -613,6 +624,15 @@ impl BlockEventDispatcher for EventDispatcher {
             burns,
             recipient_info,
         )
+    }
+
+    fn announce_reward_set(
+        &self,
+        reward_set: &RewardSet,
+        block_id: &StacksBlockId,
+        cycle_number: u64,
+    ) {
+        todo!("Announce PoX block `{block_id}` for cycle `{cycle_number}`: {reward_set:?}");
     }
 }
 

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -72,7 +72,7 @@ pub const PATH_BURN_BLOCK_SUBMIT: &str = "new_burn_block";
 pub const PATH_BLOCK_PROCESSED: &str = "new_block";
 pub const PATH_ATTACHMENT_PROCESSED: &str = "attachments/new";
 pub const PATH_PROPOSAL_RESPONSE: &str = "proposal_response";
-pub const PATH_POX_ANCHOR: &str = "new_pox_anchor";
+pub const PATH_POX_ANCHOR: &str = "new_pox_set";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MinedBlockEvent {
@@ -452,6 +452,7 @@ pub struct EventDispatcher {
     mined_microblocks_observers_lookup: HashSet<u16>,
     stackerdb_observers_lookup: HashSet<u16>,
     block_proposal_observers_lookup: HashSet<u16>,
+    pox_stacker_set_observers_lookup: HashSet<u16>,
 }
 
 /// This struct is used specifically for receiving proposal responses.
@@ -632,7 +633,7 @@ impl BlockEventDispatcher for EventDispatcher {
         block_id: &StacksBlockId,
         cycle_number: u64,
     ) {
-        todo!("Announce PoX block `{block_id}` for cycle `{cycle_number}`: {reward_set:?}");
+        self.process_stacker_set(reward_set, block_id, cycle_number)
     }
 }
 
@@ -651,6 +652,7 @@ impl EventDispatcher {
             mined_microblocks_observers_lookup: HashSet::new(),
             stackerdb_observers_lookup: HashSet::new(),
             block_proposal_observers_lookup: HashSet::new(),
+            pox_stacker_set_observers_lookup: HashSet::new(),
         }
     }
 
@@ -663,18 +665,7 @@ impl EventDispatcher {
         recipient_info: Vec<PoxAddress>,
     ) {
         // lazily assemble payload only if we have observers
-        let interested_observers: Vec<_> = self
-            .registered_observers
-            .iter()
-            .enumerate()
-            .filter(|(obs_id, _observer)| {
-                self.burn_block_observers_lookup
-                    .contains(&(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")))
-                    || self.any_event_observers_lookup.contains(
-                        &(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")),
-                    )
-            })
-            .collect();
+        let interested_observers = self.filter_observers(&self.burn_block_observers_lookup, true);
         if interested_observers.len() < 1 {
             return;
         }
@@ -687,7 +678,7 @@ impl EventDispatcher {
             recipient_info,
         );
 
-        for (_, observer) in interested_observers.iter() {
+        for observer in interested_observers.iter() {
             observer.send_new_burn_block(&payload);
         }
     }
@@ -926,27 +917,58 @@ impl EventDispatcher {
         }
     }
 
-    pub fn process_new_mempool_txs(&self, txs: Vec<StacksTransaction>) {
-        // lazily assemble payload only if we have observers
-        let interested_observers: Vec<_> = self
-            .registered_observers
+    fn filter_observers(&self, lookup: &HashSet<u16>, include_any: bool) -> Vec<&EventObserver> {
+        self.registered_observers
             .iter()
             .enumerate()
-            .filter(|(obs_id, _observer)| {
-                self.mempool_observers_lookup
-                    .contains(&(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")))
-                    || self.any_event_observers_lookup.contains(
-                        &(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")),
-                    )
+            .filter_map(|(obs_id, observer)| {
+                let lookup_ix = u16::try_from(obs_id).expect("FATAL: more than 2^16 observers");
+                if lookup.contains(&lookup_ix) {
+                    return Some(observer);
+                } else if include_any && self.any_event_observers_lookup.contains(&lookup_ix) {
+                    return Some(observer);
+                } else {
+                    return None;
+                }
             })
-            .collect();
+            .collect()
+    }
+
+    fn process_stacker_set(
+        &self,
+        reward_set: &RewardSet,
+        block_id: &StacksBlockId,
+        cycle_number: u64,
+    ) {
+        let interested_observers =
+            self.filter_observers(&self.pox_stacker_set_observers_lookup, false);
+
+        if interested_observers.is_empty() {
+            return;
+        }
+
+        let payload = json!({
+            "stacker_set": reward_set,
+            "block_id": block_id,
+            "cycle_number": cycle_number
+        });
+
+        for observer in interested_observers.iter() {
+            observer.send_payload(&payload, PATH_POX_ANCHOR);
+        }
+    }
+
+    pub fn process_new_mempool_txs(&self, txs: Vec<StacksTransaction>) {
+        // lazily assemble payload only if we have observers
+        let interested_observers = self.filter_observers(&self.mempool_observers_lookup, true);
+
         if interested_observers.len() < 1 {
             return;
         }
 
         let payload = EventObserver::make_new_mempool_txs_payload(txs);
 
-        for (_, observer) in interested_observers.iter() {
+        for observer in interested_observers.iter() {
             observer.send_new_mempool_txs(&payload);
         }
     }
@@ -960,15 +982,8 @@ impl EventDispatcher {
         confirmed_microblock_cost: &ExecutionCost,
         tx_events: Vec<TransactionEvent>,
     ) {
-        let interested_observers: Vec<_> = self
-            .registered_observers
-            .iter()
-            .enumerate()
-            .filter(|(obs_id, _observer)| {
-                self.miner_observers_lookup
-                    .contains(&(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")))
-            })
-            .collect();
+        let interested_observers = self.filter_observers(&self.miner_observers_lookup, false);
+
         if interested_observers.len() < 1 {
             return;
         }
@@ -984,7 +999,7 @@ impl EventDispatcher {
         })
         .unwrap();
 
-        for (_, observer) in interested_observers.iter() {
+        for observer in interested_observers.iter() {
             observer.send_mined_block(&payload);
         }
     }
@@ -996,15 +1011,8 @@ impl EventDispatcher {
         anchor_block_consensus_hash: ConsensusHash,
         anchor_block: BlockHeaderHash,
     ) {
-        let interested_observers: Vec<_> = self
-            .registered_observers
-            .iter()
-            .enumerate()
-            .filter(|(obs_id, _observer)| {
-                self.mined_microblocks_observers_lookup
-                    .contains(&(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")))
-            })
-            .collect();
+        let interested_observers =
+            self.filter_observers(&self.mined_microblocks_observers_lookup, false);
         if interested_observers.len() < 1 {
             return;
         }
@@ -1018,7 +1026,7 @@ impl EventDispatcher {
         })
         .unwrap();
 
-        for (_, observer) in interested_observers.iter() {
+        for observer in interested_observers.iter() {
             observer.send_mined_microblock(&payload);
         }
     }
@@ -1031,15 +1039,7 @@ impl EventDispatcher {
         consumed: &ExecutionCost,
         tx_events: Vec<TransactionEvent>,
     ) {
-        let interested_observers: Vec<_> = self
-            .registered_observers
-            .iter()
-            .enumerate()
-            .filter(|(obs_id, _observer)| {
-                self.miner_observers_lookup
-                    .contains(&(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")))
-            })
-            .collect();
+        let interested_observers = self.filter_observers(&self.miner_observers_lookup, false);
         if interested_observers.len() < 1 {
             return;
         }
@@ -1055,7 +1055,7 @@ impl EventDispatcher {
         })
         .unwrap();
 
-        for (_, observer) in interested_observers.iter() {
+        for observer in interested_observers.iter() {
             observer.send_mined_nakamoto_block(&payload);
         }
     }
@@ -1067,15 +1067,8 @@ impl EventDispatcher {
         contract_id: QualifiedContractIdentifier,
         new_chunks: Vec<StackerDBChunkData>,
     ) {
-        let interested_observers: Vec<_> = self
-            .registered_observers
-            .iter()
-            .enumerate()
-            .filter(|(obs_id, _observer)| {
-                self.stackerdb_observers_lookup
-                    .contains(&(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")))
-            })
-            .collect();
+        let interested_observers = self.filter_observers(&self.stackerdb_observers_lookup, false);
+
         if interested_observers.len() < 1 {
             return;
         }
@@ -1086,25 +1079,15 @@ impl EventDispatcher {
         })
         .expect("FATAL: failed to serialize StackerDBChunksEvent to JSON");
 
-        for (_, observer) in interested_observers.iter() {
+        for observer in interested_observers.iter() {
             observer.send_stackerdb_chunks(&payload);
         }
     }
 
     pub fn process_dropped_mempool_txs(&self, txs: Vec<Txid>, reason: MemPoolDropReason) {
         // lazily assemble payload only if we have observers
-        let interested_observers: Vec<_> = self
-            .registered_observers
-            .iter()
-            .enumerate()
-            .filter(|(obs_id, _observer)| {
-                self.mempool_observers_lookup
-                    .contains(&(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")))
-                    || self.any_event_observers_lookup.contains(
-                        &(u16::try_from(*obs_id).expect("FATAL: more than 2^16 observers")),
-                    )
-            })
-            .collect();
+        let interested_observers = self.filter_observers(&self.mempool_observers_lookup, true);
+
         if interested_observers.len() < 1 {
             return;
         }
@@ -1119,7 +1102,7 @@ impl EventDispatcher {
             "reason": reason.to_string(),
         });
 
-        for (_, observer) in interested_observers.iter() {
+        for observer in interested_observers.iter() {
             observer.send_dropped_mempool_txs(&payload);
         }
     }
@@ -1218,6 +1201,9 @@ impl EventDispatcher {
                 }
                 EventKeyType::BlockProposal => {
                     self.block_proposal_observers_lookup.insert(observer_index);
+                }
+                EventKeyType::StackerSet => {
+                    self.pox_stacker_set_observers_lookup.insert(observer_index);
                 }
             }
         }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -17,7 +17,7 @@ use stacks::chainstate::burn::ConsensusHash;
 use stacks::chainstate::coordinator::BlockEventDispatcher;
 use stacks::chainstate::nakamoto::NakamotoBlock;
 use stacks::chainstate::stacks::address::PoxAddress;
-use stacks::chainstate::stacks::boot::{NakamotoSignerEntry, RewardSet};
+use stacks::chainstate::stacks::boot::RewardSet;
 use stacks::chainstate::stacks::db::accounts::MinerReward;
 use stacks::chainstate::stacks::db::unconfirmed::ProcessedUnconfirmedState;
 use stacks::chainstate::stacks::db::{MinerRewardInfo, StacksHeaderInfo};
@@ -103,15 +103,6 @@ pub struct MinedNakamotoBlockEvent {
     pub block_size: u64,
     pub cost: ExecutionCost,
     pub tx_events: Vec<TransactionEvent>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PoxAnchorBlockEvent {
-    /// the StacksBlockId of the PoX anchor block
-    pub block_id: String,
-    pub reward_cycle: u64,
-    pub total_stx_stacked: u128,
-    pub signer_set: Vec<NakamotoSignerEntry>,
 }
 
 impl EventObserver {

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -70,6 +70,7 @@ use stacks::net::relay::Relayer;
 use stacks::net::stackerdb::StackerDBs;
 use stacks::util_lib::db::Error as DBError;
 use stacks_common::address::{AddressHashMode, C32_ADDRESS_VERSION_TESTNET_SINGLESIG};
+use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::consts::{
     FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH, STACKS_EPOCH_MAX,
@@ -966,10 +967,11 @@ impl MockamotoNode {
                 burn_spent: sortition_tip.total_burn,
                 tx_merkle_root: tx_merkle_tree.root(),
                 state_index_root,
-                signer_signature: ThresholdSignature::mock(),
+                signer_signature: ThresholdSignature::empty(),
                 miner_signature: MessageSignature::empty(),
                 consensus_hash: sortition_tip.consensus_hash.clone(),
                 parent_block_id: StacksBlockId::new(&chain_tip_ch, &chain_tip_bh),
+                signer_bitvec: BitVec::zeros(1),
             },
             txs: builder.txs,
         };

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -971,7 +971,8 @@ impl MockamotoNode {
                 miner_signature: MessageSignature::empty(),
                 consensus_hash: sortition_tip.consensus_hash.clone(),
                 parent_block_id: StacksBlockId::new(&chain_tip_ch, &chain_tip_bh),
-                signer_bitvec: BitVec::zeros(1),
+                signer_bitvec: BitVec::zeros(1)
+                    .expect("BUG: bitvec of length-1 failed to construct"),
             },
             txs: builder.txs,
         };

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1454,7 +1454,7 @@ impl BlockMinerThread {
             chain_state,
             burn_db,
             &self.burnchain,
-            &OnChainRewardSetProvider(),
+            &OnChainRewardSetProvider::new(),
             self.config.node.always_use_affirmation_maps,
         ) {
             Ok(x) => x,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -1420,7 +1420,7 @@ fn miner_writes_proposed_block_to_stackerdb() {
 
     let mut proposed_zero_block = proposed_block.clone();
     proposed_zero_block.header.miner_signature = MessageSignature::empty();
-    proposed_zero_block.header.signer_signature = ThresholdSignature::mock();
+    proposed_zero_block.header.signer_signature = ThresholdSignature::empty();
     let proposed_zero_block_hash = format!("0x{}", proposed_zero_block.header.block_hash());
 
     coord_channel

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -46,7 +46,8 @@ use stacks_common::address::AddressHashMode;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::consts::STACKS_EPOCH_MAX;
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
-use stacks_common::util::hash::to_hex;
+use stacks_common::types::PrivateKey;
+use stacks_common::util::hash::{to_hex, Sha512Sum};
 use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PrivateKey};
 
 use super::bitcoin_regtest::BitcoinCoreController;
@@ -814,7 +815,7 @@ fn correct_burn_outs() {
     let observer_port = test_observer::EVENT_OBSERVER_PORT;
     naka_conf.events_observers.insert(EventObserverConfig {
         endpoint: format!("localhost:{observer_port}"),
-        events_keys: vec![EventKeyType::AnyEvent],
+        events_keys: vec![EventKeyType::AnyEvent, EventKeyType::StackerSet],
     });
 
     let mut btcd_controller = BitcoinCoreController::new(naka_conf.clone());
@@ -901,6 +902,12 @@ fn correct_burn_outs() {
                 tests::to_addr(&account.0).bytes.to_hex(),
                 AddressHashMode::SerializeP2PKH as u8,
             ));
+            // create a new SK, mixing in the nonce, because signing keys cannot (currently)
+            //  be reused.
+            let mut seed_inputs = account.0.to_bytes();
+            seed_inputs.extend_from_slice(&account.2.nonce.to_be_bytes());
+            let new_sk = StacksPrivateKey::from_seed(Sha512Sum::from_data(&seed_inputs).as_bytes());
+            let pk_bytes = StacksPublicKey::from_private(&new_sk).to_bytes_compressed();
 
             let stacking_tx = tests::make_contract_call(
                 &account.0,
@@ -914,6 +921,7 @@ fn correct_burn_outs() {
                     pox_addr_tuple,
                     clarity::vm::Value::UInt(pox_info.current_burnchain_block_height.into()),
                     clarity::vm::Value::UInt(1),
+                    clarity::vm::Value::buff_from(pk_bytes).unwrap(),
                 ],
             );
             let txid = submit_tx(&http_origin, &stacking_tx);
@@ -952,6 +960,9 @@ fn correct_burn_outs() {
 
     // Mine nakamoto tenures
     for _i in 0..30 {
+        let prior_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
+            .unwrap()
+            .block_height;
         if let Err(e) = next_block_and_mine_commit(
             &mut btc_regtest_controller,
             30,
@@ -961,12 +972,17 @@ fn correct_burn_outs() {
             warn!(
                 "Error while minting a bitcoin block and waiting for stacks-node activity: {e:?}"
             );
+            panic!();
         }
 
         let tip_sn = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         assert!(
             tip_sn.sortition,
             "The new chain tip must have had a sortition"
+        );
+        assert!(
+            tip_sn.block_height > prior_tip,
+            "The new burnchain tip must have been processed"
         );
     }
 
@@ -975,6 +991,34 @@ fn correct_burn_outs() {
         .expect("Mutex poisoned")
         .stop_chains_coordinator();
     run_loop_stopper.store(false, Ordering::SeqCst);
+
+    let stacker_sets = test_observer::get_stacker_sets();
+    info!("Stacker sets announced {:#?}", stacker_sets);
+    let mut sorted_stacker_sets = stacker_sets.clone();
+    sorted_stacker_sets.sort_by_key(|(_block_id, cycle_num, _reward_set)| *cycle_num);
+    assert_eq!(
+        sorted_stacker_sets, stacker_sets,
+        "Stacker set should be sorted by cycle number already"
+    );
+
+    let first_epoch_3_cycle = burnchain
+        .block_height_to_reward_cycle(epoch_3.start_height)
+        .unwrap();
+    for (_, cycle_number, reward_set) in stacker_sets.iter() {
+        if *cycle_number < first_epoch_3_cycle {
+            assert!(reward_set.signers.is_none());
+            // nothing else to check for < first_epoch_3_cycle
+            continue;
+        }
+        let Some(signers) = reward_set.signers.clone() else {
+            panic!("Signers should be set in any epoch-3 cycles. First epoch-3 cycle: {first_epoch_3_cycle}. Checked cycle number: {cycle_number}");
+        };
+        // there should be 1 stacker signer, and 1 reward address
+        assert_eq!(reward_set.rewarded_addresses.len(), 1);
+        assert_eq!(signers.len(), 1);
+        // the signer should have 1 "slot", because they stacked the minimum stacking amount
+        assert_eq!(signers[0].slots, 1);
+    }
 
     run_loop_thread.join().unwrap();
 }

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -14,7 +14,6 @@ use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader};
 use stacks::chainstate::stacks::{StacksPrivateKey, ThresholdSignature};
 use stacks::net::api::postblock_proposal::BlockValidateResponse;
-use stacks::util_lib::boot::boot_code_id;
 use stacks_common::bitvec::BitVec;
 use stacks_common::types::chainstate::{
     ConsensusHash, StacksAddress, StacksBlockId, StacksPublicKey, TrieHash,

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -13,6 +13,7 @@ use stacks::chainstate::stacks::boot::MINERS_NAME;
 use stacks::chainstate::stacks::{StacksPrivateKey, ThresholdSignature};
 use stacks::net::api::postblock_proposal::BlockValidateResponse;
 use stacks::util_lib::boot::boot_code_id;
+use stacks_common::bitvec::BitVec;
 use stacks_common::types::chainstate::{
     ConsensusHash, StacksAddress, StacksBlockId, StacksPublicKey, TrieHash,
 };
@@ -365,7 +366,8 @@ fn stackerdb_dkg_sign() {
         tx_merkle_root: Sha512Trunc256Sum([0x06; 32]),
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
-        signer_signature: ThresholdSignature::mock(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
     };
     let mut block = NakamotoBlock {
         header,


### PR DESCRIPTION
### Description

This PR implements a handful of things:

1. It adds a `BitVec` class to stacks-common. This PR is at least the third implementation of a bit vector in the codebase, so it seemed like adding a simple data struct would be useful here.
2. Adds a `BitVec` field to the `NakamotoBlockHeader`, this is included in the consensus serialization and the stacker/signer signature hash. It is _not_ included in the miner's signature hash.
3. Adds a `new_pox_set` endpoint for the event dispatcher. This endpoint announces when a reward set is calculated in a PoX anchor block. It relays information about the reward set:
      * The cycle number of the set
      * The StacksBlockId of the anchor block
      * The canonically ordered list of reward addresses (with repetitions for addresses with multiple slots)
      * The canonically ordered list of signers, each entry containing a signing address (C32-encoded), the number of signing slots, and the amount stacked. This canonical ordering is what will be used for entries in the bit vector.
4. It implements `make_signer_set`, which is invoked by `make_reward_set` to translate the list of `RawRewardEntry`s into signing set entries. Currently, it does this by summing all entries with the same public key and assigning slots based on the slot thresholds.
5. It mocks data for the signing key in raw reward entries in `nakamoto_get_reward_set()`
6. It alters the logic deciding between using `nakamoto` reward set fetching and `2.x`: any reward set that is used by Nakamoto should be fetched via the `nakamoto` reward set endpoint. The first nakamoto reward set _will_ occur in epoch 2.5.
7. It fixes a broken integration test `correct_burn_outs` -- this integration test wasn't asserting that the sortition db advanced, so it missed the fact that the recent update in `next` to require signing keys (and unique ones) broke the test. The test now asserts the sortition db advances _and_ it works.
8. It update the `correct_burn_outs` test to check the results of the `new_pox_set` event observer API are correct.

### Still needs test coverage

- `make_signer_set` needs unit testing. This is easy enough to add and I will add it before this merges, but before I did that, I wanted to get feedback on this PR because if `make_signer_set` needs to change, it seems like a waste to write the unit tests now.

### Relevant issues

#4241 - this is the `stacks-node` side of tracking. this PR doesn't implement the punishment for non-participation, though.
#4256 - this PR emits this list
#4255 - summing over the signer set entries in this PR gives the amount of active lockup. the amount of total lockup (which could include people who miss the threshold) would need to be added as another field in the return. This should be simple to add and I can do it if its useful (@zone117x).