### PR TITLE
Feat: add an endpoint for listing which nodes host a stackerdb replica

### DIFF
--- a/stackslib/src/net/api/liststackerdbreplicas.rs
+++ b/stackslib/src/net/api/liststackerdbreplicas.rs
@@ -1,0 +1,197 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::{fs, io};
+
+use clarity::vm::clarity::ClarityConnection;
+use clarity::vm::representations::{
+    CONTRACT_NAME_REGEX_STRING, PRINCIPAL_DATA_REGEX_STRING, STANDARD_PRINCIPAL_REGEX_STRING,
+};
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{ClarityName, ContractName};
+use regex::{Captures, Regex};
+use serde::de::Error as de_Error;
+use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::types::chainstate::StacksBlockId;
+use stacks_common::types::net::PeerHost;
+use stacks_common::util::get_epoch_time_secs;
+use stacks_common::util::hash::to_hex;
+use {serde, serde_json};
+
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::{Error as ChainError, StacksBlock};
+use crate::net::db::PeerDB;
+use crate::net::http::{
+    parse_json, Error, HttpBadRequest, HttpChunkGenerator, HttpContentType, HttpNotFound,
+    HttpRequest, HttpRequestContents, HttpRequestPreamble, HttpResponse, HttpResponseContents,
+    HttpResponsePayload, HttpResponsePreamble, HttpServerError,
+};
+use crate::net::httpcore::{
+    request, HttpPreambleExtensions, HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp,
+    StacksHttpRequest, StacksHttpResponse,
+};
+use crate::net::{Error as NetError, NeighborAddress, StacksNodeState, TipRequest, MAX_HEADERS};
+use crate::util_lib::db::{DBConn, Error as DBError};
+
+/// Largest number of replicas returned
+pub const MAX_LIST_REPLICAS: usize = 64;
+
+#[derive(Clone)]
+pub struct RPCListStackerDBReplicasRequestHandler {
+    pub contract_identifier: Option<QualifiedContractIdentifier>,
+}
+
+impl RPCListStackerDBReplicasRequestHandler {
+    pub fn new() -> Self {
+        Self {
+            contract_identifier: None,
+        }
+    }
+}
+
+/// Decode the HTTP request
+impl HttpRequest for RPCListStackerDBReplicasRequestHandler {
+    fn verb(&self) -> &'static str {
+        "GET"
+    }
+
+    fn path_regex(&self) -> Regex {
+        Regex::new(&format!(
+            r#"^/v2/stackerdb/(?P<address>{})/(?P<contract>{})/replicas$"#,
+            *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING
+        ))
+        .unwrap()
+    }
+
+    /// Try to decode this request.
+    /// There's nothing to load here, so just make sure the request is well-formed.
+    fn try_parse_request(
+        &mut self,
+        preamble: &HttpRequestPreamble,
+        captures: &Captures,
+        query: Option<&str>,
+        _body: &[u8],
+    ) -> Result<HttpRequestContents, Error> {
+        if preamble.get_content_length() != 0 {
+            return Err(Error::DecodeError(
+                "Invalid Http request: expected 0-length body".to_string(),
+            ));
+        }
+
+        let contract_identifier = request::get_contract_address(captures, "address", "contract")?;
+        self.contract_identifier = Some(contract_identifier);
+
+        Ok(HttpRequestContents::new().query_string(query))
+    }
+}
+
+impl RPCRequestHandler for RPCListStackerDBReplicasRequestHandler {
+    /// Reset internal state
+    fn restart(&mut self) {
+        self.contract_identifier = None;
+    }
+
+    /// Make the response
+    fn try_handle_request(
+        &mut self,
+        preamble: HttpRequestPreamble,
+        _contents: HttpRequestContents,
+        node: &mut StacksNodeState,
+    ) -> Result<(HttpResponsePreamble, HttpResponseContents), NetError> {
+        let contract_identifier = self
+            .contract_identifier
+            .take()
+            .ok_or(NetError::SendError("`contract_identifier` not set".into()))?;
+
+        let replicas_resp =
+            node.with_node_state(|network, _sortdb, _chainstate, _mempool, _rpc_args| {
+                PeerDB::find_stacker_db_replicas(
+                    network.peerdb_conn(),
+                    network.bound_neighbor_key().network_id,
+                    &contract_identifier,
+                    get_epoch_time_secs().saturating_sub(network.get_connection_opts().max_neighbor_age),
+                    MAX_LIST_REPLICAS
+                )
+                .map_err(|e| {
+                    warn!("Failed to find stackerdb replicas"; "contract_id" => %contract_identifier, "error" => %e);
+                    StacksHttpResponse::new_error(
+                        &preamble,
+                        &HttpServerError::new("Unable to list replicas of StackerDB".to_string())
+                    )
+                })
+            });
+
+        let naddrs_resp = match replicas_resp {
+            Ok(neighbors) => neighbors
+                .into_iter()
+                .map(|neighbor| NeighborAddress::from_neighbor(&neighbor))
+                .collect::<Vec<_>>(),
+            Err(response) => {
+                return response.try_into_contents().map_err(NetError::from);
+            }
+        };
+
+        let mut preamble = HttpResponsePreamble::ok_json(&preamble);
+        preamble.set_canonical_stacks_tip_height(Some(node.canonical_stacks_tip_height()));
+        let body = HttpResponseContents::try_from_json(&naddrs_resp)?;
+        Ok((preamble, body))
+    }
+}
+
+/// Decode the HTTP response
+impl HttpResponse for RPCListStackerDBReplicasRequestHandler {
+    /// Decode this response from a byte stream.  This is called by the client to decode this
+    /// message
+    fn try_parse_response(
+        &self,
+        preamble: &HttpResponsePreamble,
+        body: &[u8],
+    ) -> Result<HttpResponsePayload, Error> {
+        let metadata: Vec<NeighborAddress> = parse_json(preamble, body)?;
+        Ok(HttpResponsePayload::try_from_json(metadata)?)
+    }
+}
+
+impl StacksHttpRequest {
+    pub fn new_list_stackerdb_replicas(
+        host: PeerHost,
+        stackerdb_contract_id: QualifiedContractIdentifier,
+    ) -> StacksHttpRequest {
+        StacksHttpRequest::new_for_peer(
+            host,
+            "GET".into(),
+            format!(
+                "/v2/stackerdb/{}/{}/replicas",
+                &stackerdb_contract_id.issuer, &stackerdb_contract_id.name
+            ),
+            HttpRequestContents::new(),
+        )
+        .expect("FATAL: failed to construct request from infallible data")
+    }
+}
+
+impl StacksHttpResponse {
+    /// Decode an HTTP response into a list of replicas
+    /// If it fails, return Self::Error(..)
+    pub fn decode_stackerdb_replicas(self) -> Result<Vec<NeighborAddress>, NetError> {
+        let contents = self.get_http_payload_ok()?;
+        let contents_json: serde_json::Value = contents.try_into()?;
+        let resp: Vec<NeighborAddress> = serde_json::from_value(contents_json)
+            .map_err(|_e| NetError::DeserializeError("Failed to load from JSON".to_string()))?;
+        Ok(resp)
+    }
+}

--- a/stackslib/src/net/api/mod.rs
+++ b/stackslib/src/net/api/mod.rs
@@ -55,6 +55,7 @@ pub mod getstackerdbchunk;
 pub mod getstackerdbmetadata;
 pub mod getstxtransfercost;
 pub mod gettransaction_unconfirmed;
+pub mod liststackerdbreplicas;
 pub mod postblock;
 pub mod postfeerate;
 pub mod postmempoolquery;
@@ -105,6 +106,9 @@ impl StacksHttp {
         );
         self.register_rpc_endpoint(
             gettransaction_unconfirmed::RPCGetTransactionUnconfirmedRequestHandler::new(),
+        );
+        self.register_rpc_endpoint(
+            liststackerdbreplicas::RPCListStackerDBReplicasRequestHandler::new(),
         );
         self.register_rpc_endpoint(postblock::RPCPostBlockRequestHandler::new());
         self.register_rpc_endpoint(postfeerate::RPCPostFeeRateRequestHandler::new());

--- a/stackslib/src/net/api/tests/liststackerdbreplicas.rs
+++ b/stackslib/src/net/api/tests/liststackerdbreplicas.rs
@@ -1,0 +1,131 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StacksAddressExtensions};
+use clarity::vm::{ClarityName, ContractName, Value};
+use stacks_common::types::chainstate::StacksAddress;
+use stacks_common::types::net::{PeerAddress, PeerHost};
+use stacks_common::types::Address;
+use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
+use stacks_common::util::secp256k1::MessageSignature;
+
+use super::test_rpc;
+use crate::core::BLOCK_LIMIT_MAINNET_21;
+use crate::net::api::*;
+use crate::net::connection::ConnectionOptions;
+use crate::net::httpcore::{
+    HttpPreambleExtensions, HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp,
+    StacksHttpRequest,
+};
+use crate::net::{ProtocolFamily, TipRequest};
+
+#[test]
+fn test_try_parse_request() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+    let mut http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
+
+    let contract_identifier = QualifiedContractIdentifier::parse(
+        "ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R.hello-world-unconfirmed",
+    )
+    .unwrap();
+    let request =
+        StacksHttpRequest::new_list_stackerdb_replicas(addr.into(), contract_identifier.clone());
+    let bytes = request.try_serialize().unwrap();
+
+    debug!("Request:\n{}\n", std::str::from_utf8(&bytes).unwrap());
+
+    let (parsed_preamble, offset) = http.read_preamble(&bytes).unwrap();
+    let mut handler = liststackerdbreplicas::RPCListStackerDBReplicasRequestHandler::new();
+    let mut parsed_request = http
+        .handle_try_parse_request(
+            &mut handler,
+            &parsed_preamble.expect_request(),
+            &bytes[offset..],
+        )
+        .unwrap();
+
+    assert_eq!(
+        handler.contract_identifier,
+        Some(contract_identifier.clone())
+    );
+
+    // parsed request consumes headers that would not be in a constructed reqeuest
+    parsed_request.clear_headers();
+    let (preamble, contents) = parsed_request.destruct();
+
+    assert_eq!(&preamble, request.preamble());
+
+    handler.restart();
+    assert!(handler.contract_identifier.is_none());
+}
+
+#[test]
+fn test_try_make_response() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+
+    let mut requests = vec![];
+
+    let contract_identifier =
+        QualifiedContractIdentifier::parse("ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R.hello-world")
+            .unwrap();
+    let none_contract_identifier = QualifiedContractIdentifier::parse(
+        "ST2DS4MSWSGJ3W9FBC6BVT0Y92S345HY8N3T6AV7R.does-not-ext",
+    )
+    .unwrap();
+
+    let request =
+        StacksHttpRequest::new_list_stackerdb_replicas(addr.into(), contract_identifier.clone());
+    requests.push(request);
+
+    // no contract
+    let request = StacksHttpRequest::new_list_stackerdb_replicas(
+        addr.into(),
+        none_contract_identifier.clone(),
+    );
+    requests.push(request);
+
+    let mut responses = test_rpc(function_name!(), requests);
+
+    let response = responses.remove(0);
+    debug!(
+        "Response:\n{}\n",
+        std::str::from_utf8(&response.try_serialize().unwrap()).unwrap()
+    );
+    assert_eq!(
+        response.preamble().get_canonical_stacks_tip_height(),
+        Some(1)
+    );
+
+    let mut resp = response.decode_stackerdb_replicas().unwrap();
+    assert_eq!(resp.len(), 1);
+    let naddr = resp.pop().unwrap();
+    assert_eq!(naddr.addrbytes, PeerAddress::from_ipv4(127, 0, 0, 1));
+    assert_eq!(naddr.port, 0);
+    assert_eq!(
+        naddr.public_key_hash,
+        Hash160::from_hex("9b92533ccc243e25eb6197bd03c9164642c7c8a8").unwrap()
+    );
+
+    let response = responses.remove(0);
+    debug!(
+        "Response:\n{}\n",
+        std::str::from_utf8(&response.try_serialize().unwrap()).unwrap()
+    );
+    let resp = response.decode_stackerdb_replicas().unwrap();
+    assert_eq!(resp.len(), 0);
+}

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -24,6 +24,7 @@ use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, ConsensusHash, StacksAddress, StacksBlockId, StacksPrivateKey, StacksPublicKey,
 };
+use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
 use stacks_common::util::pipe::Pipe;
 
@@ -38,6 +39,7 @@ use crate::chainstate::stacks::{
     TransactionAuth, TransactionPayload, TransactionPostConditionMode, TransactionVersion,
 };
 use crate::core::MemPoolDB;
+use crate::net::db::PeerDB;
 use crate::net::httpcore::{StacksHttpRequest, StacksHttpResponse};
 use crate::net::relay::Relayer;
 use crate::net::rpc::ConversationHttp;
@@ -68,6 +70,7 @@ mod getstackerdbchunk;
 mod getstackerdbmetadata;
 mod getstxtransfercost;
 mod gettransaction_unconfirmed;
+mod liststackerdbreplicas;
 mod postblock;
 mod postfeerate;
 mod postmempoolquery;
@@ -237,6 +240,9 @@ impl<'a> TestRPC<'a> {
         let mut peer_1_config = TestPeerConfig::new(&format!("{}-peer1", test_name), 0, 0);
         let mut peer_2_config = TestPeerConfig::new(&format!("{}-peer2", test_name), 0, 0);
 
+        peer_1_config.private_key = privk1.clone();
+        peer_2_config.private_key = privk2.clone();
+
         peer_1_config.connection_opts.read_only_call_limit = ExecutionCost {
             write_length: 0,
             write_count: 0,
@@ -369,6 +375,31 @@ impl<'a> TestRPC<'a> {
                 .unwrap();
             bytes.len() as u64
         };
+
+        // force peer 2 to know about peer 1
+        {
+            let tx = peer_2.network.peerdb.tx_begin().unwrap();
+            let mut neighbor = peer_1.config.to_neighbor();
+            neighbor.last_contact_time = get_epoch_time_secs();
+            PeerDB::try_insert_peer(
+                &tx,
+                &neighbor,
+                &[QualifiedContractIdentifier::new(
+                    addr1.clone().into(),
+                    "hello-world".into(),
+                )],
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        // force peer 1 to know about peer 2
+        {
+            let tx = peer_1.network.peerdb.tx_begin().unwrap();
+            let mut neighbor = peer_2.config.to_neighbor();
+            neighbor.last_contact_time = get_epoch_time_secs();
+            PeerDB::try_insert_peer(&tx, &neighbor, &[]).unwrap();
+            tx.commit().unwrap();
+        }
 
         let tip =
             SortitionDB::get_canonical_burn_chain_tip(&peer_1.sortdb.as_ref().unwrap().conn())

--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -1770,29 +1770,27 @@ impl PeerDB {
     }
 
     /// Find out which peers replicate a particular stacker DB.
-    /// Return a randomized list of up to the given size.
+    /// Return a randomized list of up to the given size, where all
+    /// peers returned have a last-contact time greater than the given minimum age.
     pub fn find_stacker_db_replicas(
         conn: &DBConn,
         network_id: u32,
         smart_contract: &QualifiedContractIdentifier,
+        min_age: u64,
         max_count: usize,
     ) -> Result<Vec<Neighbor>, db_error> {
         if max_count == 0 {
             return Ok(vec![]);
         }
-        let mut slots = PeerDB::get_stacker_db_slots(conn, smart_contract)?;
-        slots.shuffle(&mut thread_rng());
-
-        let mut ret = vec![];
-        for slot in slots {
-            if let Some(neighbor) = PeerDB::get_peer_at(conn, network_id, slot)? {
-                ret.push(neighbor);
-                if ret.len() >= max_count {
-                    break;
-                }
-            }
-        }
-        Ok(ret)
+        let qry = "SELECT DISTINCT frontier.* FROM frontier JOIN stackerdb_peers ON stackerdb_peers.peer_slot = frontier.slot WHERE stackerdb_peers.smart_contract_id = ?1 AND frontier.network_id = ?2 AND frontier.last_contact_time >= ?3 ORDER BY RANDOM() LIMIT ?4";
+        let max_count_u32 = u32::try_from(max_count).unwrap_or(u32::MAX);
+        let args: &[&dyn ToSql] = &[
+            &smart_contract.to_string(),
+            &network_id,
+            &u64_to_sql(min_age)?,
+            &max_count_u32,
+        ];
+        query_rows(conn, qry, args)
     }
 }
 
@@ -2479,21 +2477,21 @@ mod test {
         }
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 1).unwrap();
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 0, 1).unwrap();
         assert_eq!(replicas.len(), 1);
         assert_eq!(replicas[0], neighbor);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 2).unwrap();
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 0, 2).unwrap();
         assert_eq!(replicas.len(), 1);
         assert_eq!(replicas[0], neighbor);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 0).unwrap();
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 0, 0).unwrap();
         assert_eq!(replicas.len(), 0);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef1, &stackerdbs[0], 1).unwrap();
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef1, &stackerdbs[0], 0, 1).unwrap();
         assert_eq!(replicas.len(), 0);
 
         // insert new stacker DBs -- keep one the same, and add a different one
@@ -2523,16 +2521,49 @@ mod test {
         assert_eq!(neighbor_stackerdbs, changed_stackerdbs);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[0], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[0], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 1);
         assert_eq!(replicas[0], neighbor);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[1], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[1], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 1);
         assert_eq!(replicas[0], neighbor);
+
+        // query stacker DBs filtering by last-contact time
+        let replicas = PeerDB::find_stacker_db_replicas(
+            &db.conn,
+            0x9abcdef0,
+            &changed_stackerdbs[1],
+            1552509641,
+            1,
+        )
+        .unwrap();
+        assert_eq!(replicas.len(), 1);
+        assert_eq!(replicas[0], neighbor);
+
+        let replicas = PeerDB::find_stacker_db_replicas(
+            &db.conn,
+            0x9abcdef0,
+            &changed_stackerdbs[1],
+            1552509642,
+            1,
+        )
+        .unwrap();
+        assert_eq!(replicas.len(), 1);
+        assert_eq!(replicas[0], neighbor);
+
+        let replicas = PeerDB::find_stacker_db_replicas(
+            &db.conn,
+            0x9abcdef0,
+            &changed_stackerdbs[1],
+            1552509643,
+            1,
+        )
+        .unwrap();
+        assert_eq!(replicas.len(), 0);
 
         // clear stacker DBs
         {
@@ -2549,12 +2580,12 @@ mod test {
         assert_eq!(neighbor_stackerdbs, []);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[0], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[0], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 0);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[1], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[1], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 0);
 
@@ -2587,32 +2618,54 @@ mod test {
             assert_eq!(neighbor_stackerdbs, replace_stackerdbs);
 
             let replicas =
-                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdee0, &stackerdbs[0], 1).unwrap();
-            assert_eq!(replicas.len(), 0);
-
-            let replicas =
-                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdee0, &stackerdbs[1], 1).unwrap();
-            assert_eq!(replicas.len(), 0);
-
-            let replicas =
-                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[0], 1)
+                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdee0, &stackerdbs[0], 0, 1)
                     .unwrap();
             assert_eq!(replicas.len(), 0);
 
             let replicas =
-                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[1], 1)
+                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdee0, &stackerdbs[1], 0, 1)
                     .unwrap();
             assert_eq!(replicas.len(), 0);
 
-            let replicas =
-                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &replace_stackerdbs[0], 1)
-                    .unwrap();
+            let replicas = PeerDB::find_stacker_db_replicas(
+                &db.conn,
+                0x9abcdef0,
+                &changed_stackerdbs[0],
+                0,
+                1,
+            )
+            .unwrap();
+            assert_eq!(replicas.len(), 0);
+
+            let replicas = PeerDB::find_stacker_db_replicas(
+                &db.conn,
+                0x9abcdef0,
+                &changed_stackerdbs[1],
+                0,
+                1,
+            )
+            .unwrap();
+            assert_eq!(replicas.len(), 0);
+
+            let replicas = PeerDB::find_stacker_db_replicas(
+                &db.conn,
+                0x9abcdef0,
+                &replace_stackerdbs[0],
+                0,
+                1,
+            )
+            .unwrap();
             assert_eq!(replicas.len(), 1);
             assert_eq!(replicas[0], neighbor);
 
-            let replicas =
-                PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &replace_stackerdbs[1], 1)
-                    .unwrap();
+            let replicas = PeerDB::find_stacker_db_replicas(
+                &db.conn,
+                0x9abcdef0,
+                &replace_stackerdbs[1],
+                0,
+                1,
+            )
+            .unwrap();
             assert_eq!(replicas.len(), 1);
             assert_eq!(replicas[0], neighbor);
         }
@@ -2631,30 +2684,30 @@ mod test {
         }
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 1).unwrap();
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[0], 0, 1).unwrap();
         assert_eq!(replicas.len(), 0);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[1], 1).unwrap();
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &stackerdbs[1], 0, 1).unwrap();
         assert_eq!(replicas.len(), 0);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[0], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[0], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 0);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[1], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &changed_stackerdbs[1], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 0);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &replace_stackerdbs[0], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &replace_stackerdbs[0], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 0);
 
         let replicas =
-            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &replace_stackerdbs[1], 1)
+            PeerDB::find_stacker_db_replicas(&db.conn, 0x9abcdef0, &replace_stackerdbs[1], 0, 1)
                 .unwrap();
         assert_eq!(replicas.len(), 0);
     }

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2145,6 +2145,7 @@ pub mod test {
                     peerdb.conn(),
                     local_peer.network_id,
                     &contract_id,
+                    0,
                     10000000,
                 )
                 .unwrap()

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -93,6 +93,8 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                 network.peerdb_conn(),
                 network.get_local_peer().network_id,
                 &self.smart_contract_id,
+                get_epoch_time_secs()
+                    .saturating_sub(network.get_connection_opts().max_neighbor_age),
                 self.max_neighbors,
             )?
             .into_iter()
@@ -554,6 +556,8 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                 network.peerdb_conn(),
                 network.get_local_peer().network_id,
                 &self.smart_contract_id,
+                get_epoch_time_secs()
+                    .saturating_sub(network.get_connection_opts().max_neighbor_age),
                 self.max_neighbors,
             )?
             .into_iter()


### PR DESCRIPTION
Got one quick PR for the upcoming 2.4.0.1.0 release -- the ability to ask a node for the list of nodes it knows replicate a given StackerDB.  If a user adds a StackerDB replica to their node, they can assess how quickly other (public) nodes learn of it.