### PR TITLE
Select stacks-signer coordinator dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,6 +3588,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "libsigner",
  "libstackerdb",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "reqwest",
  "secp256k1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,7 +3596,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_stacker",
- "sha2 0.10.6",
  "slog",
  "slog-json",
  "slog-term",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,6 +3595,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_stacker",
+ "sha2 0.10.6",
  "slog",
  "slog-json",
  "slog-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ members = [
 wsts = "7.0"
 rand_core = "0.6"
 rand = "0.8"
-sha2 = "0.10"
 
 # Use a bit more than default optimization for
 #  dev builds to speed up test execution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 wsts = "7.0"
 rand_core = "0.6"
 rand = "0.8"
+sha2 = "0.10"
 
 # Use a bit more than default optimization for
 #  dev builds to speed up test execution

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -42,7 +42,6 @@ toml = "0.5.6"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = { workspace = true }
-sha2 = { workspace = true }
 rand = { workspace = true }
 
 [dependencies.serde_json]

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -42,6 +42,7 @@ toml = "0.5.6"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = { workspace = true }
+sha2 = "0.10.6"
 
 [dependencies.serde_json]
 version = "1.0"

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -42,7 +42,8 @@ toml = "0.5.6"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = { workspace = true }
-sha2 = "0.10.6"
+sha2 = { workspace = true }
+rand = { workspace = true }
 
 [dependencies.serde_json]
 version = "1.0"

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -39,6 +39,9 @@ const BACKOFF_MAX_INTERVAL: u64 = 16384;
 #[derive(thiserror::Error, Debug)]
 /// Client error type
 pub enum ClientError {
+    /// Error for when a response's format does not match the expected structure
+    #[error("Unexpected response format: {0}")]
+    UnexpectedResponseFormat(String),
     /// An error occurred serializing the message
     #[error("Unable to serialize stacker-db message: {0}")]
     StackerDBSerializationError(#[from] CodecError),

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -17,7 +17,7 @@
 /// The stacker db module for communicating with the stackerdb contract
 mod stackerdb;
 /// The stacks node client module for communicating with the stacks node
-mod stacks_client;
+pub(crate) mod stacks_client;
 
 use std::time::Duration;
 

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -633,7 +633,7 @@ pub(crate) mod tests {
         let h = spawn(move || config.client.get_stacks_tip_consensus_hash());
         write_response(
             config.mock_server,
-            b"HTTP/1.1 200 OK\n\n{\"stacks_tip_consensus_hash\": \"4e99f99bc4a05437abb8c7d0c306618f45b203196498e2ebe287f10497124958\"}",
+            b"HTTP/1.1 200 OK\n\n{\"stacks_tip_consensus_hash\": \"3b593b712f8310768bf16e58f378aea999b8aa3b\"}",
         );
         assert!(h.join().unwrap().is_ok());
     }

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -799,14 +799,14 @@ impl<C: Coordinator> SignerRunLoop<Vec<OperationResult>, RunLoopCommand> for Run
 }
 
 /// Helper function for determining the coordinator public key given the the public keys
-fn calculate_coordinator(
+pub fn calculate_coordinator(
     public_keys: &PublicKeys,
     stacks_client: &StacksClient,
 ) -> (u32, ecdsa::PublicKey) {
     let stacks_tip_consensus_hash = match stacks_client.get_stacks_tip_consensus_hash() {
         Ok(hash) => hash,
         Err(e) => {
-            eprintln!("Error fetching consensus hash: {:?}", e); // Log the error
+            error!("Error in fetching consensus hash: {:?}", e);
             return (0, public_keys.signers.get(&0).cloned().unwrap());
         }
     };

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -310,7 +310,8 @@ impl<C: Coordinator> RunLoop<C> {
             };
             self.handle_packets(res, &[packet]);
         } else {
-            let (coordinator_id, _) = calculate_coordinator(&self.signing_round.public_keys);
+            let (coordinator_id, _) =
+                calculate_coordinator(&self.signing_round.public_keys, &self.stacks_client);
             if block_info.valid.unwrap_or(false)
                 && !block_info.signing_round
                 && coordinator_id == self.signing_round.signer_id
@@ -840,11 +841,14 @@ pub fn calculate_coordinator(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::client::stacks_client::tests::{write_response, TestConfig};
-    use rand::{distributions::Alphanumeric, Rng};
     use std::net::TcpListener;
     use std::thread::{sleep, spawn};
+
+    use rand::distributions::Alphanumeric;
+    use rand::Rng;
+
+    use super::*;
+    use crate::client::stacks_client::tests::{write_response, TestConfig};
 
     fn generate_random_consensus_hash(length: usize) -> String {
         let random_consensus_hash = rand::thread_rng()

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -1,9 +1,9 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{env, thread};
-use std::collections::HashMap;
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use libsigner::{RunningSigner, Signer, SignerEventReceiver};
@@ -112,7 +112,10 @@ impl SignerTest {
             let (cmd_send, cmd_recv) = channel();
             let (res_send, res_recv) = channel();
             info!("spawn signer");
-            running_signers.insert(i, spawn_signer(&signer_configs[i as usize], cmd_recv, res_send));
+            running_signers.insert(
+                i,
+                spawn_signer(&signer_configs[i as usize], cmd_recv, res_send),
+            );
             _signer_cmd_senders.insert(i, cmd_send);
             result_receivers.push(res_recv);
         }
@@ -131,12 +134,20 @@ impl SignerTest {
         // Calculate which signer will be selected as the coordinator
         let config = stacks_signer::config::Config::load_from_str(&signer_configs[0]).unwrap();
         let stacks_client = StacksClient::from(&config);
-        let (coordinator_id, coordinator_pk) = calculate_coordinator(&config.signer_ids_public_keys, &stacks_client);
-        debug!("selected coordinator id and pub key: {:?} : {:?}", &coordinator_id, &coordinator_pk);
+        let (coordinator_id, coordinator_pk) =
+            calculate_coordinator(&config.signer_ids_public_keys, &stacks_client);
+        debug!(
+            "selected coordinator id and pub key: {:?} : {:?}",
+            &coordinator_id, &coordinator_pk
+        );
 
         // Fetch the selected coordinator and its cmd_sender
-        let running_coordinator = running_signers.remove(&coordinator_id).expect("Coordinator not found");
-        let coordinator_cmd_sender = _signer_cmd_senders.remove(&coordinator_id).expect("Command sender not found");
+        let running_coordinator = running_signers
+            .remove(&coordinator_id)
+            .expect("Coordinator not found");
+        let coordinator_cmd_sender = _signer_cmd_senders
+            .remove(&coordinator_id)
+            .expect("Command sender not found");
 
         Self {
             running_nodes: node,


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
Introducing a deterministic but dynamic signer coordinator selection by hashing signer public keys and stacks tip consensus hash. 

### Applicable issues

- Relates to #3915

### Additional info (benefits, drawbacks, caveats)
- Not exactly a VRF selection so still open if a more complex selection process is needed.
- Selection is similar to the approach discussed [here](https://github.com/stacks-network/sbtc/discussions/335); but stacks_tip_consensus_hash is used instead of latest sortition VRF seed
- Signer Integ. tests are updated to use the calculate_coordinator instead of picking the coordinator statically .

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
