### PR TITLE
feat: require signatures to prove control of `signer-key` in pox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - New RPC endpoint `/v2/stacker_set/{cycle_number}` to fetch stacker sets in PoX-4
 - New `/new_pox_anchor` endpoint for broadcasting PoX anchor block processing.
 - Stacker bitvec in NakamotoBlock
+- New [`pox-4` contract](./stackslib/src/chainstate/stacks/boot/pox-4.clar) that reflects changes in how Stackers are signers in Nakamoto:
+  - `stack-stx`, `stack-extend`, and `stack-aggregation-commit` now include a `signer-key` parameter, which represents the public key used by the Signer. This key is used for determining the signer set in Nakamoto.
+  - Functions that include a `signer-key` parameter also include a `signer-sig` parameter to demonstrate that the owner of `signer-key` is approving that particular Stacking operation. For more details, refer to the `verify-signer-key-sig` method in the `pox-4` contract.
 
 ### Modified
 

--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -129,9 +129,9 @@ fn create_event_info_data_code(
                         ;; equal to args[3]
                         lock-period: {lock_period},
                         ;; equal to args[4]
-                        signer-sig: {signer_sig}
+                        signer-sig: {signer_sig},
                         ;; equal to args[5]
-                        signer-key: {signer_key}
+                        signer-key: {signer_key},
                     }}
                 }}
                 "#,
@@ -167,7 +167,7 @@ fn create_event_info_data_code(
                         delegator: tx-sender,
                         ;; stacker
                         ;; equal to args[0]
-                        stacker: '{stacker}
+                        stacker: '{stacker},
                     }}
                 }}
                 "#,
@@ -252,13 +252,16 @@ fn create_event_info_data_code(
                         ;; new unlock burnchain block height
                         unlock-burn-height: new-unlock-ht,
                         ;; equal to args[2]
-                        signer-key: {signer_key}
+                        signer-sig: {signer_sig},
+                        ;; equal to args[3]
+                        signer-key: {signer_key},
                     }}
                 }})
                 "#,
                 extend_count = &args[0],
                 pox_addr = &args[1],
-                signer_key = &args.get(2).map_or("none".to_string(), |v| v.to_string()),
+                signer_sig = &args.get(2).unwrap_or(&Value::none()),
+                signer_key = &args.get(3).map_or("none".to_string(), |v| v.to_string()),
             )
         }
         "delegate-stack-extend" => {

--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -319,9 +319,9 @@ fn create_event_info_data_code(
                         ;; delegator (this is the caller)
                         delegator: tx-sender,
                         ;; equal to args[2]
-                        signer-sig: {signer_sig}
+                        signer-sig: {signer_sig},
                         ;; equal to args[3]
-                        signer-key: {signer_key}
+                        signer-key: {signer_key},
                     }}
                 }}
                 "#,

--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -129,6 +129,8 @@ fn create_event_info_data_code(
                         ;; equal to args[3]
                         lock-period: {lock_period},
                         ;; equal to args[4]
+                        signer-sig: {signer_sig}
+                        ;; equal to args[5]
                         signer-key: {signer_key}
                     }}
                 }}
@@ -137,7 +139,8 @@ fn create_event_info_data_code(
                 lock_period = &args[3],
                 pox_addr = &args[1],
                 start_burn_height = &args[2],
-                signer_key = &args.get(4).unwrap_or(&Value::none()),
+                signer_sig = &args.get(4).unwrap_or(&Value::none()),
+                signer_key = &args.get(5).unwrap_or(&Value::none()),
             )
         }
         "delegate-stack-stx" => {
@@ -313,13 +316,16 @@ fn create_event_info_data_code(
                         ;; delegator (this is the caller)
                         delegator: tx-sender,
                         ;; equal to args[2]
+                        signer-sig: {signer_sig}
+                        ;; equal to args[3]
                         signer-key: {signer_key}
                     }}
                 }}
                 "#,
                 pox_addr = &args[0],
                 reward_cycle = &args[1],
-                signer_key = &args.get(2).unwrap_or(&Value::none()),
+                signer_sig = &args.get(2).unwrap_or(&Value::none()),
+                signer_key = &args.get(3).unwrap_or(&Value::none()),
             )
         }
         "stack-aggregation-increase" => {

--- a/stacks-common/src/util/secp256k1.rs
+++ b/stacks-common/src/util/secp256k1.rs
@@ -109,6 +109,11 @@ impl MessageSignature {
             Err(_) => None,
         }
     }
+
+    /// Convert from VRS to RSV
+    pub fn to_rsv(&self) -> Vec<u8> {
+        [&self.0[1..], &self.0[0..1]].concat()
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -30,7 +30,7 @@ use wsts::curve::point::Point;
 
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
 use crate::chainstate::burn::operations::BlockstackOperationType;
-use crate::chainstate::coordinator::tests::p2pkh_from;
+use crate::chainstate::coordinator::tests::{p2pkh_from, pox_addr_from};
 use crate::chainstate::nakamoto::tests::get_account;
 use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
@@ -75,22 +75,17 @@ fn advance_to_nakamoto(
             test_stackers
                 .iter()
                 .map(|test_stacker| {
-                    let reward_cycle = 6;
-                    let stacker =
-                        PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key));
-                    let signature = make_signer_key_signature(
-                        &stacker,
-                        &test_stacker.signer_private_key,
-                        reward_cycle,
+                    let pox_addr = PoxAddress::from_legacy(
+                        AddressHashMode::SerializeP2PKH,
+                        addr.bytes.clone(),
                     );
+                    let signature =
+                        make_signer_key_signature(&pox_addr, &test_stacker.signer_private_key, 6);
                     make_pox_4_lockup(
                         &test_stacker.stacker_private_key,
                         0,
                         test_stacker.amount,
-                        PoxAddress::from_legacy(
-                            AddressHashMode::SerializeP2PKH,
-                            addr.bytes.clone(),
-                        ),
+                        pox_addr.clone(),
                         12,
                         StacksPublicKey::from_private(&test_stacker.signer_private_key),
                         34,

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -36,7 +36,7 @@ use crate::chainstate::nakamoto::tests::node::{TestSigners, TestStacker};
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::boot::test::{
-    key_to_stacks_addr, make_pox_4_aggregate_key, make_pox_4_lockup,
+    key_to_stacks_addr, make_pox_4_aggregate_key, make_pox_4_lockup, make_signer_key_signature,
 };
 use crate::chainstate::stacks::boot::MINERS_NAME;
 use crate::chainstate::stacks::db::{MinerPaymentTxFees, StacksAccount, StacksChainState};
@@ -75,6 +75,14 @@ fn advance_to_nakamoto(
             test_stackers
                 .iter()
                 .map(|test_stacker| {
+                    let reward_cycle = 6;
+                    let stacker =
+                        PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key));
+                    let signature = make_signer_key_signature(
+                        &stacker,
+                        &test_stacker.signer_private_key,
+                        reward_cycle,
+                    );
                     make_pox_4_lockup(
                         &test_stacker.stacker_private_key,
                         0,
@@ -86,6 +94,7 @@ fn advance_to_nakamoto(
                         12,
                         StacksPublicKey::from_private(&test_stacker.signer_private_key),
                         34,
+                        signature,
                     )
                 })
                 .collect()

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -51,6 +51,7 @@ use crate::net::relay::Relayer;
 use crate::net::stackerdb::StackerDBConfig;
 use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
 use crate::util_lib::boot::boot_code_id;
+use crate::util_lib::signed_structured_data::pox4::Pox4SignatureTopic;
 
 /// Bring a TestPeer into the Nakamoto Epoch
 fn advance_to_nakamoto(
@@ -79,8 +80,13 @@ fn advance_to_nakamoto(
                         AddressHashMode::SerializeP2PKH,
                         addr.bytes.clone(),
                     );
-                    let signature =
-                        make_signer_key_signature(&pox_addr, &test_stacker.signer_private_key, 6);
+                    let signature = make_signer_key_signature(
+                        &pox_addr,
+                        &test_stacker.signer_private_key,
+                        6,
+                        &Pox4SignatureTopic::StackStx,
+                        12_u128,
+                    );
                     make_pox_4_lockup(
                         &test_stacker.stacker_private_key,
                         0,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -2212,7 +2212,7 @@ pub mod test {
     }
 
     pub fn make_signer_key_signature(
-        stacker: &PrincipalData,
+        pox_addr: &PoxAddress,
         signer_key: &StacksPrivateKey,
         reward_cycle: u128,
     ) -> Vec<u8> {
@@ -2233,7 +2233,10 @@ pub mod test {
 
         let data_tuple = Value::Tuple(
             TupleData::from_data(vec![
-                ("stacker".into(), Value::Principal(stacker.clone())),
+                (
+                    "pox-addr".into(),
+                    pox_addr.clone().as_clarity_tuple().unwrap().into(),
+                ),
                 ("reward-cycle".into(), Value::UInt(reward_cycle)),
             ])
             .unwrap(),

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -2042,6 +2042,7 @@ pub mod test {
         addr: PoxAddress,
         lock_period: u128,
         signer_key: StacksPublicKey,
+        signature: Vec<u8>,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
@@ -2051,6 +2052,7 @@ pub mod test {
             vec![
                 Value::UInt(lock_period),
                 addr_tuple,
+                Value::buff_from(signature).unwrap(),
                 Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
             ],
         )
@@ -2238,19 +2240,6 @@ pub mod test {
         );
 
         let signature = sign_structured_data(data_tuple, domain_tuple, signer_key).unwrap();
-
-        {
-            // debugging
-            let key_hex = signer_key.to_hex();
-            let sig_hex = to_hex(&signature.to_rsv());
-            println!(
-                "\n\nDebugging signatures: {} {} {} {}\n\n",
-                stacker.to_string(),
-                reward_cycle,
-                sig_hex,
-                key_hex
-            );
-        }
 
         signature.to_rsv()
     }

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1401,6 +1401,9 @@ pub mod test {
     use crate::core::{StacksEpochId, *};
     use crate::net::test::*;
     use crate::util_lib::boot::{boot_code_id, boot_code_test_addr};
+    use crate::util_lib::signed_structured_data::pox4::{
+        make_pox_4_signer_key_signature, Pox4SignatureTopic,
+    };
     use crate::util_lib::signed_structured_data::{
         make_structured_data_domain, sign_structured_data,
     };
@@ -2222,21 +2225,18 @@ pub mod test {
         pox_addr: &PoxAddress,
         signer_key: &StacksPrivateKey,
         reward_cycle: u128,
+        topic: &Pox4SignatureTopic,
+        period: u128,
     ) -> Vec<u8> {
-        let domain_tuple = make_structured_data_domain("pox-4-signer", "1.0.0", CHAIN_ID_TESTNET);
-
-        let data_tuple = Value::Tuple(
-            TupleData::from_data(vec![
-                (
-                    "pox-addr".into(),
-                    pox_addr.clone().as_clarity_tuple().unwrap().into(),
-                ),
-                ("reward-cycle".into(), Value::UInt(reward_cycle)),
-            ])
-            .unwrap(),
-        );
-
-        let signature = sign_structured_data(data_tuple, domain_tuple, signer_key).unwrap();
+        let signature = make_pox_4_signer_key_signature(
+            pox_addr,
+            signer_key,
+            reward_cycle,
+            topic,
+            CHAIN_ID_TESTNET,
+            period,
+        )
+        .unwrap();
 
         signature.to_rsv()
     }

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1382,7 +1382,7 @@ pub mod test {
     use clarity::vm::types::*;
     use stacks_common::types::PrivateKey;
     use stacks_common::util::hash::Sha256Sum;
-    use stacks_common::util::secp256k1::Secp256k1PrivateKey;
+    use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
     use stacks_common::util::*;
 
     use super::*;
@@ -2146,17 +2146,22 @@ pub mod test {
     pub fn make_pox_4_aggregation_commit_indexed(
         key: &StacksPrivateKey,
         nonce: u64,
-        amount: u128,
-        delegate_to: PrincipalData,
-        until_burn_ht: Option<u128>,
-        pox_addr: PoxAddress,
+        pox_addr: &PoxAddress,
+        reward_cycle: u128,
+        signature: Vec<u8>,
+        signer_key: &Secp256k1PublicKey,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(pox_addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
             POX_4_NAME,
             "stack-aggregation-commit-indexed",
-            vec![addr_tuple, Value::UInt(amount)],
+            vec![
+                addr_tuple,
+                Value::UInt(reward_cycle),
+                Value::buff_from(signature).unwrap(),
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
+            ],
         )
         .unwrap();
 

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -2240,37 +2240,6 @@ pub mod test {
         signature.to_rsv()
     }
 
-    pub fn make_delegate_stx_signature(
-        stacker: &PrincipalData,
-        delegator_key: &Secp256k1PrivateKey,
-        reward_cycle: u128,
-    ) -> Vec<u8> {
-        let msg_tuple = Value::Tuple(
-            TupleData::from_data(vec![
-                ("stacker".into(), Value::Principal(stacker.clone())),
-                ("reward-cycle".into(), Value::UInt(reward_cycle)),
-            ])
-            .unwrap(),
-        );
-
-        let mut tuple_bytes = vec![];
-        msg_tuple
-            .serialize_write(&mut tuple_bytes)
-            .expect("Failed to serialize delegate sig data");
-        let msg_hash = Sha256Sum::from_data(&tuple_bytes).as_bytes().to_vec();
-
-        let signature = &delegator_key
-            .sign(&msg_hash)
-            .expect("Unable to sign delegate sig data");
-
-        // Convert signature into rsv as needed for `secp256k1-recover?`
-        let mut ret_bytes = Vec::new();
-        ret_bytes.extend(&signature[1..]);
-        ret_bytes.push(signature[0]);
-
-        ret_bytes
-    }
-
     fn make_tx(
         key: &StacksPrivateKey,
         nonce: u64,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1891,6 +1891,7 @@ pub mod test {
         lock_period: u128,
         signer_key: StacksPublicKey,
         burn_ht: u64,
+        signature: Vec<u8>,
     ) -> StacksTransaction {
         let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
         let payload = TransactionPayload::new_contract_call(
@@ -1902,6 +1903,7 @@ pub mod test {
                 addr_tuple,
                 Value::UInt(burn_ht as u128),
                 Value::UInt(lock_period),
+                Value::buff_from(signature).unwrap(),
                 Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
             ],
         )
@@ -2236,6 +2238,19 @@ pub mod test {
         );
 
         let signature = sign_structured_data(data_tuple, domain_tuple, signer_key).unwrap();
+
+        {
+            // debugging
+            let key_hex = signer_key.to_hex();
+            let sig_hex = to_hex(&signature.to_rsv());
+            println!(
+                "\n\nDebugging signatures: {} {} {} {}\n\n",
+                stacker.to_string(),
+                reward_cycle,
+                sig_hex,
+                key_hex
+            );
+        }
 
         signature.to_rsv()
     }

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1401,7 +1401,9 @@ pub mod test {
     use crate::core::{StacksEpochId, *};
     use crate::net::test::*;
     use crate::util_lib::boot::{boot_code_id, boot_code_test_addr};
-    use crate::util_lib::signed_structured_data::sign_structured_data;
+    use crate::util_lib::signed_structured_data::{
+        make_structured_data_domain, sign_structured_data,
+    };
 
     pub const TESTNET_STACKING_THRESHOLD_25: u128 = 8000;
 
@@ -2216,20 +2218,7 @@ pub mod test {
         signer_key: &StacksPrivateKey,
         reward_cycle: u128,
     ) -> Vec<u8> {
-        let domain_tuple = Value::Tuple(
-            TupleData::from_data(vec![
-                (
-                    "name".into(),
-                    Value::string_ascii_from_bytes("pox-4-signer".into()).unwrap(),
-                ),
-                (
-                    "version".into(),
-                    Value::string_ascii_from_bytes("1.0.0".into()).unwrap(),
-                ),
-                ("chain-id".into(), Value::UInt(CHAIN_ID_TESTNET.into())),
-            ])
-            .unwrap(),
-        );
+        let domain_tuple = make_structured_data_domain("pox-4-signer", "1.0.0", CHAIN_ID_TESTNET);
 
         let data_tuple = Value::Tuple(
             TupleData::from_data(vec![

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -30,6 +30,7 @@
 (define-constant ERR_INVALID_SIGNER_KEY 32)
 (define-constant ERR_REUSED_SIGNER_KEY 33)
 (define-constant ERR_DELEGATION_ALREADY_REVOKED 34)
+(define-constant ERR_DELEGATION_INVALID_SIGNATURE (err 35))
 
 ;; Valid values for burnchain address versions.
 ;; These first four correspond to address hash modes in Stacks 2.1,
@@ -636,6 +637,7 @@
                              (delegate-to principal)
                              (until-burn-ht (optional uint))
                              (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) })))
+                             
     (begin
       ;; must be called directly by the tx-sender or by an allowed contract-caller
       (asserts! (check-caller-allowed)
@@ -669,6 +671,43 @@
           pox-addr: pox-addr })
 
       (ok true)))
+
+(define-read-only (get-signer-key-message-hash (signer-key (buff 33)) (stacker principal))
+  (let
+    (
+      (domain { name: "pox-4-signer", version: "1.0.0", chain-id: chain-id })
+      (data-hash (sha256 (unwrap-panic 
+        (to-consensus-buff? { stacker: stacker, reward-cycle: (current-pox-reward-cycle) }))))
+      (domain-hash (sha256 (unwrap-panic (to-consensus-buff? domain))))
+    )
+    (sha256 (concat
+      0x534950303138
+      (concat domain-hash
+      data-hash)))
+  )
+)
+
+;; Verify a signature from the signing key for this specific stacker.
+;; The message hash is the sha256 of the consensus hash of the tuple 
+;; `{ stacker, reward-cycle }`. Note that `reward-cycle` corresponds to the
+;; _current_ reward cycle, not the reward cycle at which the delegation will start.
+;; The public key is recovered from the signature and compared to the pubkey hash
+;; of the delegator.
+(define-read-only (verify-signing-key-signature (stacker principal)
+                                                (signing-key (buff 33))
+                                                (signer-sig (buff 65)))
+  (let
+    (
+      ;; (msg { stacker: stacker, reward-cycle: (current-pox-reward-cycle) })
+      ;; (msg-bytes (unwrap! (to-consensus-buff? msg) ERR_DELEGATION_INVALID_SIGNATURE)) ;;TODO
+      ;; ;; (msg-hash (sha256 msg-bytes))
+      (msg-hash (get-signer-key-message-hash signing-key stacker))
+      (pubkey (unwrap! (secp256k1-recover? msg-hash signer-sig) ERR_DELEGATION_INVALID_SIGNATURE)) ;; TODO
+    )
+    (asserts! (is-eq pubkey signing-key) ERR_DELEGATION_INVALID_SIGNATURE)
+    (ok true)
+  )                                            
+)
 
 ;; Commit partially stacked STX and allocate a new PoX reward address slot.
 ;;   This allows a stacker/delegate to lock fewer STX than the minimal threshold in multiple transactions,

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -672,6 +672,7 @@
 
       (ok true)))
 
+;; Generate a message hash following the SIP018 standard.
 (define-read-only (get-signer-key-message-hash (signer-key (buff 33)) (stacker principal))
   (let
     (
@@ -698,9 +699,6 @@
                                                 (signer-sig (buff 65)))
   (let
     (
-      ;; (msg { stacker: stacker, reward-cycle: (current-pox-reward-cycle) })
-      ;; (msg-bytes (unwrap! (to-consensus-buff? msg) ERR_DELEGATION_INVALID_SIGNATURE)) ;;TODO
-      ;; ;; (msg-hash (sha256 msg-bytes))
       (msg-hash (get-signer-key-message-hash signing-key stacker))
       (pubkey (unwrap! (secp256k1-recover? msg-hash signer-sig) ERR_DELEGATION_INVALID_SIGNATURE)) ;; TODO
     )

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -732,6 +732,7 @@
 ;; *New in Stacks 2.1.*
 (define-private (inner-stack-aggregation-commit (pox-addr { version: (buff 1), hashbytes: (buff 32) })
                                                 (reward-cycle uint)
+                                                (signer-sig (buff 65))
                                                 (signer-key (buff 33)))
   (let ((partial-stacked
          ;; fetch the partial commitments
@@ -740,6 +741,7 @@
     ;; must be called directly by the tx-sender or by an allowed contract-caller
     (asserts! (check-caller-allowed)
               (err ERR_STACKING_PERMISSION_DENIED))
+    (try! (verify-signer-key-sig tx-sender signer-sig signer-key))
     (let ((amount-ustx (get stacked-amount partial-stacked)))
       (try! (can-stack-stx pox-addr amount-ustx reward-cycle u1))
       ;; Add the pox addr to the reward cycle, and extract the index of the PoX address
@@ -773,8 +775,9 @@
 ;; Returns (err ...) on failure.
 (define-public (stack-aggregation-commit (pox-addr { version: (buff 1), hashbytes: (buff 32) })
                                          (reward-cycle uint)
+                                         (signer-sig (buff 65))
                                          (signer-key (buff 33)))
-    (match (inner-stack-aggregation-commit pox-addr reward-cycle signer-key)
+    (match (inner-stack-aggregation-commit pox-addr reward-cycle signer-sig signer-key)
         pox-addr-index (ok true)
         commit-err (err commit-err)))
 
@@ -782,8 +785,9 @@
 ;; *New in Stacks 2.1.*
 (define-public (stack-aggregation-commit-indexed (pox-addr { version: (buff 1), hashbytes: (buff 32) })
                                                  (reward-cycle uint)
+                                                 (signer-sig (buff 65))
                                                  (signer-key (buff 33)))
-    (inner-stack-aggregation-commit pox-addr reward-cycle signer-key))
+    (inner-stack-aggregation-commit pox-addr reward-cycle signer-sig signer-key))
 
 ;; Commit partially stacked STX to a PoX address which has already received some STX (more than the Stacking min).
 ;; This allows a delegator to lock up marginally more STX from new delegates, even if they collectively do not

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -572,6 +572,7 @@
                           (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
                           (start-burn-ht uint)
                           (lock-period uint)
+                          (signer-sig (buff 65))
                           (signer-key (buff 33)))
     ;; this stacker's first reward cycle is the _next_ reward cycle
     (let ((first-reward-cycle (+ u1 (current-pox-reward-cycle)))
@@ -596,6 +597,9 @@
       ;; the Stacker must have sufficient unlocked funds
       (asserts! (>= (stx-get-balance tx-sender) amount-ustx)
         (err ERR_STACKING_INSUFFICIENT_FUNDS))
+
+      ;; Validate ownership of the given signer key
+      (try! (verify-signing-key-signature tx-sender signer-key signer-sig))
 
       ;; ensure that stacking can be performed
       (try! (can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -603,7 +603,7 @@
         (err ERR_STACKING_INSUFFICIENT_FUNDS))
 
       ;; Validate ownership of the given signer key
-      (try! (verify-signer-key-sig pox-addr signer-sig signer-key))
+      (try! (verify-signer-key-sig pox-addr (- first-reward-cycle u1) signer-sig signer-key))
 
       ;; ensure that stacking can be performed
       (try! (can-stack-stx pox-addr amount-ustx first-reward-cycle lock-period))
@@ -684,12 +684,12 @@
 ;; The message hash follows SIP018 for signing structured data. The structured data
 ;; is the tuple `{ pox-addr: { version, hashbytes }, reward-cycle }`. The domain is
 ;; `{ name: "pox-4-signer", version: "1.0.0", chain-id: chain-id }`.
-(define-read-only (get-signer-key-message-hash (pox-addr { version: (buff 1), hashbytes: (buff 32) }))
+(define-read-only (get-signer-key-message-hash (pox-addr { version: (buff 1), hashbytes: (buff 32) }) (reward-cycle uint))
   (let
     (
       (domain { name: "pox-4-signer", version: "1.0.0", chain-id: chain-id })
       (data-hash (sha256 (unwrap-panic
-        (to-consensus-buff? { pox-addr: pox-addr, reward-cycle: (current-pox-reward-cycle) }))))
+        (to-consensus-buff? { pox-addr: pox-addr, reward-cycle: reward-cycle }))))
       (domain-hash (sha256 (unwrap-panic (to-consensus-buff? domain))))
     )
     (sha256 (concat
@@ -706,11 +706,12 @@
 ;; not the reward cycle at which the delegation will start.
 ;; The public key is recovered from the signature and compared to `signer-key`.
 (define-read-only (verify-signer-key-sig (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+                                         (reward-cycle uint)
                                          (signer-sig (buff 65))
                                          (signer-key (buff 33)))
   (let
     (
-      (msg-hash (get-signer-key-message-hash pox-addr))
+      (msg-hash (get-signer-key-message-hash pox-addr reward-cycle))
       (pubkey (unwrap! (secp256k1-recover? msg-hash signer-sig) (err ERR_INVALID_SIGNATURE_RECOVER)))
     )
     (asserts! (is-eq pubkey signer-key) (err ERR_INVALID_SIGNATURE_PUBKEY))
@@ -741,7 +742,7 @@
     ;; must be called directly by the tx-sender or by an allowed contract-caller
     (asserts! (check-caller-allowed)
               (err ERR_STACKING_PERMISSION_DENIED))
-    (try! (verify-signer-key-sig pox-addr signer-sig signer-key))
+    (try! (verify-signer-key-sig pox-addr (- reward-cycle u1) signer-sig signer-key))
     (let ((amount-ustx (get stacked-amount partial-stacked)))
       (try! (can-stack-stx pox-addr amount-ustx reward-cycle u1))
       ;; Add the pox addr to the reward cycle, and extract the index of the PoX address
@@ -1061,7 +1062,7 @@
               (err ERR_STACKING_IS_DELEGATED))
 
     ;; Verify signature from delegate that allows this sender for this cycle
-    (try! (verify-signer-key-sig pox-addr signer-sig signer-key))
+    (try! (verify-signer-key-sig pox-addr cur-cycle signer-sig signer-key))
 
     ;; TODO: add more assertions to sanity check the `stacker-info` values with
     ;;       the `stacker-state` values

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -754,7 +754,7 @@
     ;; must be called directly by the tx-sender or by an allowed contract-caller
     (asserts! (check-caller-allowed)
               (err ERR_STACKING_PERMISSION_DENIED))
-    (try! (verify-signer-key-sig pox-addr (- reward-cycle u1) "agg-commit" u1 signer-sig signer-key))
+    (try! (verify-signer-key-sig pox-addr reward-cycle "agg-commit" u1 signer-sig signer-key))
     (let ((amount-ustx (get stacked-amount partial-stacked)))
       (try! (can-stack-stx pox-addr amount-ustx reward-cycle u1))
       ;; Add the pox addr to the reward cycle, and extract the index of the PoX address

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -688,24 +688,17 @@
                                                (reward-cycle uint)
                                                (topic (string-ascii 12))
                                                (period uint))
-  (let
-    (
-      (domain { name: "pox-4-signer", version: "1.0.0", chain-id: chain-id })
-      (data-hash (sha256 (unwrap-panic
+  (sha256 (concat
+    SIP018_MSG_PREFIX
+    (concat 
+      (sha256 (unwrap-panic (to-consensus-buff? { name: "pox-4-signer", version: "1.0.0", chain-id: chain-id })))
+      (sha256 (unwrap-panic
         (to-consensus-buff? { 
           pox-addr: pox-addr, 
           reward-cycle: reward-cycle,
           topic: topic,
           period: period,
-        }))))
-      (domain-hash (sha256 (unwrap-panic (to-consensus-buff? domain))))
-    )
-    (sha256 (concat
-      SIP018_MSG_PREFIX
-      (concat domain-hash
-      data-hash)))
-  )
-)
+        })))))))
 
 ;; Verify a signature from the signing key for this specific stacker.
 ;; See `get-signer-key-message-hash` for details on the message hash.
@@ -719,17 +712,13 @@
                                          (period uint)
                                          (signer-sig (buff 65))
                                          (signer-key (buff 33)))
-  (begin
-    (asserts! 
-      (is-eq 
-        (unwrap! (secp256k1-recover? 
-          (get-signer-key-message-hash pox-addr reward-cycle topic period) 
-          signer-sig) (err ERR_INVALID_SIGNATURE_RECOVER)) 
-        signer-key) 
-      (err ERR_INVALID_SIGNATURE_PUBKEY))
-    (ok true)
-  )
-)
+  (ok (asserts! 
+    (is-eq 
+      (unwrap! (secp256k1-recover? 
+        (get-signer-key-message-hash pox-addr reward-cycle topic period) 
+        signer-sig) (err ERR_INVALID_SIGNATURE_RECOVER)) 
+      signer-key) 
+    (err ERR_INVALID_SIGNATURE_PUBKEY))))
 
 ;; Commit partially stacked STX and allocate a new PoX reward address slot.
 ;;   This allows a stacker/delegate to lock fewer STX than the minimal threshold in multiple transactions,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -480,14 +480,6 @@ fn pox_extend_transition() {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    // Key 3
-    let alice_signer_private = keys.pop().unwrap();
-    let alice_signer_key = StacksPublicKey::from_private(&alice_signer_private);
-    let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
-
-    let alice_signature =
-        make_signer_key_signature(&alice_principal, &alice_signer_private, reward_cycle);
-
     let tip = get_tip(peer.sortdb.as_ref());
 
     let alice_signer_private = Secp256k1PrivateKey::new();
@@ -495,8 +487,13 @@ fn pox_extend_transition() {
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
+    let alice_pox_addr = PoxAddress::from_legacy(
+        AddressHashMode::SerializeP2PKH,
+        key_to_stacks_addr(&alice).bytes,
+    );
+
     let alice_signature =
-        make_signer_key_signature(&alice_principal, &alice_signer_private, reward_cycle);
+        make_signer_key_signature(&alice_pox_addr, &alice_signer_private, reward_cycle);
     let alice_lockup = make_pox_4_lockup(
         &alice,
         2,
@@ -553,38 +550,22 @@ fn pox_extend_transition() {
     }
 
     let bob_signer_private = Secp256k1PrivateKey::new();
-    let bob_signer_key = Secp256k1PublicKey::from_private(&bob_signer_private);
-
-    // let bob_signer_key: [u8; 33] = [
-    //     0x02, 0xb6, 0x19, 0x6d, 0xe8, 0x8b, 0xce, 0xe7, 0x93, 0xfa, 0x9a, 0x8a, 0x85, 0x96, 0x9b,
-    //     0x64, 0x7f, 0x84, 0xc9, 0x0e, 0x9d, 0x13, 0xf9, 0xc8, 0xb8, 0xce, 0x42, 0x6c, 0xc8, 0x1a,
-    //     0x59, 0x98, 0x3c,
-    // ];
-    // let alice_signer_key: [u8; 33] = [
-    //     0x03, 0xa0, 0xf9, 0x81, 0x8e, 0xa8, 0xc1, 0x4a, 0x82, 0x7b, 0xb1, 0x44, 0xae, 0xc9, 0xcf,
-    //     0xba, 0xeb, 0xa2, 0x25, 0xaf, 0x22, 0xbe, 0x18, 0xed, 0x78, 0xa2, 0xf2, 0x98, 0x10, 0x6f,
-    //     0x4e, 0x28, 0x1b,
-    // ];
-
-    let alice_signer_private = Secp256k1PrivateKey::new();
-    let alice_signer_key = Secp256k1PublicKey::from_private(&alice_signer_private);
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
-    let bob_signature =
-        make_signer_key_signature(&bob_principal, &bob_signer_private, reward_cycle);
-    let alice_signature =
-        make_signer_key_signature(&alice_principal, &alice_signer_private, reward_cycle);
+    let bob_pox_addr = PoxAddress::from_legacy(
+        AddressHashMode::SerializeP2PKH,
+        key_to_stacks_addr(&bob).bytes,
+    );
+
+    let bob_signature = make_signer_key_signature(&bob_pox_addr, &bob_signer_private, reward_cycle);
 
     let tip = get_tip(peer.sortdb.as_ref());
     let bob_lockup = make_pox_4_lockup(
         &bob,
         2,
         BOB_LOCKUP,
-        PoxAddress::from_legacy(
-            AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
-        ),
+        bob_pox_addr.clone(),
         3,
         StacksPublicKey::from_private(&bob_signer_private),
         tip.block_height,
@@ -596,16 +577,13 @@ fn pox_extend_transition() {
     let alice_signer_key = StacksPublicKey::from_private(&alice_signer_private);
 
     let alice_signature =
-        make_signer_key_signature(&alice_principal, &alice_signer_private, reward_cycle);
+        make_signer_key_signature(&alice_pox_addr, &alice_signer_private, reward_cycle);
 
     // Alice can stack-extend in PoX v2
     let alice_lockup = make_pox_4_extend(
         &alice,
         3,
-        PoxAddress::from_legacy(
-            AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
-        ),
+        alice_pox_addr.clone(),
         6,
         alice_signer_key,
         alice_signature,
@@ -864,8 +842,7 @@ fn pox_lock_unlock() {
             let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).bytes);
             let lock_period = if ix == 3 { 12 } else { lock_period };
             let signer_key = key;
-            let stacker = PrincipalData::from(key_to_stacks_addr(key));
-            let signature = make_signer_key_signature(&stacker, &signer_key, reward_cycle);
+            let signature = make_signer_key_signature(&pox_addr, &signer_key, reward_cycle);
             txs.push(make_pox_4_lockup(
                 key,
                 0,
@@ -1450,7 +1427,7 @@ fn pox_4_revoke_delegate_stx_events() {
 fn verify_signer_key_sig(
     signature: &Vec<u8>,
     signing_key: &Secp256k1PublicKey,
-    stacker: &PrincipalData,
+    pox_addr: &PoxAddress,
     peer: &mut TestPeer,
     latest_block: &StacksBlockId,
 ) -> Value {
@@ -1467,8 +1444,8 @@ fn verify_signer_key_sig(
                         LimitedCostTracker::new_free(),
                         |env| {
                             let program = format!(
-                                "(verify-signer-key-sig '{} 0x{} 0x{})",
-                                stacker.to_string(),
+                                "(verify-signer-key-sig {} 0x{} 0x{})",
+                                Value::Tuple(pox_addr.clone().as_clarity_tuple().unwrap()),
                                 to_hex(&signature),
                                 signing_key.to_hex(),
                             );
@@ -1508,12 +1485,10 @@ fn verify_signer_key_signatures() {
     // alice
     let alice = keys.pop().unwrap();
     let alice_address = key_to_stacks_addr(&alice);
-    let alice_principal = PrincipalData::from(alice_address.clone());
 
     // bob
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
-    let bob_principal = PrincipalData::from(bob_address.clone());
     let bob_public_key = StacksPublicKey::from_private(&bob);
 
     // Advance into pox4
@@ -1529,28 +1504,32 @@ fn verify_signer_key_signatures() {
 
     let expected_error = Value::error(Value::Int(35)).unwrap();
 
+    let alice_pox_addr =
+        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, alice_address.bytes.clone());
+    let bob_pox_addr = PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, bob_address.bytes);
+
     // Test 1: invalid reward cycle used in signature
 
     let last_reward_cycle = reward_cycle - 1;
-    let signature = make_signer_key_signature(&alice_principal, &bob, last_reward_cycle);
+    let signature = make_signer_key_signature(&bob_pox_addr, &bob, last_reward_cycle);
 
     let result = verify_signer_key_sig(
         &signature,
         &bob_public_key,
-        &alice_principal,
+        &bob_pox_addr,
         &mut peer,
         &latest_block,
     );
     assert_eq!(result, expected_error);
 
-    // Test 2: Invalid stacker used in signature
+    // Test 2: Invalid pox-addr used in signature
 
-    let signature = make_signer_key_signature(&bob_principal, &bob, reward_cycle);
+    let signature = make_signer_key_signature(&alice_pox_addr, &bob, reward_cycle);
 
     let result = verify_signer_key_sig(
         &signature,
         &bob_public_key,
-        &alice_principal, // different stacker
+        &bob_pox_addr, // wrong pox-addr
         &mut peer,
         &latest_block,
     );
@@ -1559,12 +1538,12 @@ fn verify_signer_key_signatures() {
 
     // Test 3: Invalid signer key used in signature
 
-    let signature = make_signer_key_signature(&alice_principal, &alice, reward_cycle);
+    let signature = make_signer_key_signature(&bob_pox_addr, &alice, reward_cycle);
 
     let result = verify_signer_key_sig(
         &signature,
         &bob_public_key, // different key
-        &alice_principal,
+        &bob_pox_addr,
         &mut peer,
         &latest_block,
     );
@@ -1573,12 +1552,12 @@ fn verify_signer_key_signatures() {
 
     // Test 4: using a valid signature
 
-    let signature = make_signer_key_signature(&alice_principal, &bob, reward_cycle);
+    let signature = make_signer_key_signature(&bob_pox_addr, &bob, reward_cycle);
 
     let result = verify_signer_key_sig(
         &signature,
         &bob_public_key,
-        &alice_principal,
+        &bob_pox_addr,
         &mut peer,
         &latest_block,
     );
@@ -1599,19 +1578,21 @@ fn stack_stx_verify_signer_sig() {
     let stacker_key = &keys[0];
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
     let stacker_addr = key_to_stacks_addr(&stacker_key);
-    let stacker = PrincipalData::from(stacker_addr);
     let signer_key = &keys[1];
     let signer_public_key = StacksPublicKey::from_private(signer_key);
     let pox_addr = pox_addr_from(&stacker_key);
 
     let second_stacker = &keys[2];
     let second_stacker_addr = key_to_stacks_addr(second_stacker);
-    let second_stacker_principal = PrincipalData::from(second_stacker_addr);
+    let second_stacker_pox_addr = PoxAddress::from_legacy(
+        AddressHashMode::SerializeP2PKH,
+        second_stacker_addr.bytes.clone(),
+    );
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
     // Test 1: invalid reward cycle
-    let signature = make_signer_key_signature(&stacker, &signer_key, reward_cycle - 1);
+    let signature = make_signer_key_signature(&pox_addr, &signer_key, reward_cycle - 1);
     let invalid_cycle_nonce = stacker_nonce;
     let invalid_cycle_stack = make_pox_4_lockup(
         &stacker_key,
@@ -1626,7 +1607,7 @@ fn stack_stx_verify_signer_sig() {
 
     // test 2: invalid stacker
     stacker_nonce += 1;
-    let signature = make_signer_key_signature(&second_stacker_principal, &signer_key, reward_cycle);
+    let signature = make_signer_key_signature(&second_stacker_pox_addr, &signer_key, reward_cycle);
     let invalid_stacker_nonce = stacker_nonce;
     let invalid_stacker_tx = make_pox_4_lockup(
         &stacker_key,
@@ -1641,7 +1622,7 @@ fn stack_stx_verify_signer_sig() {
 
     // Test 3: invalid key used to sign
     stacker_nonce += 1;
-    let signature = make_signer_key_signature(&stacker, &second_stacker, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &second_stacker, reward_cycle);
     let invalid_key_nonce = stacker_nonce;
     let invalid_key_tx = make_pox_4_lockup(
         &stacker_key,
@@ -1656,7 +1637,7 @@ fn stack_stx_verify_signer_sig() {
 
     // Test 4: valid signature
     stacker_nonce += 1;
-    let signature = make_signer_key_signature(&stacker, &signer_key, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &signer_key, reward_cycle);
     let valid_nonce = stacker_nonce;
     let valid_tx = make_pox_4_lockup(
         &stacker_key,
@@ -1705,7 +1686,6 @@ fn stack_extend_verify_sig() {
     let stacker_key = &keys[0];
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
     let stacker_addr = key_to_stacks_addr(&stacker_key);
-    let stacker = PrincipalData::from(stacker_addr);
     let signer_key = &keys[1];
     let signer_public_key = StacksPublicKey::from_private(signer_key);
     let pox_addr = pox_addr_from(&signer_key);
@@ -1713,7 +1693,7 @@ fn stack_extend_verify_sig() {
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
     // Setup: stack-stx
-    let signature = make_signer_key_signature(&stacker, &signer_key, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &signer_key, reward_cycle);
     let stack_nonce = stacker_nonce;
     let stack_tx = make_pox_4_lockup(
         &stacker_key,
@@ -1731,7 +1711,7 @@ fn stack_extend_verify_sig() {
     let signer_public_key = StacksPublicKey::from_private(&signer_key);
 
     // Test 1: invalid reward cycle
-    let signature = make_signer_key_signature(&stacker, &signer_key, reward_cycle - 1);
+    let signature = make_signer_key_signature(&pox_addr, &signer_key, reward_cycle - 1);
     stacker_nonce += 1;
     let invalid_cycle_nonce = stacker_nonce;
     let invalid_cycle_tx = make_pox_4_extend(
@@ -1743,10 +1723,10 @@ fn stack_extend_verify_sig() {
         signature,
     );
 
-    // Test 2: invalid stacker
+    // Test 2: invalid pox-addr
     stacker_nonce += 1;
-    let other_stacker = PrincipalData::from(key_to_stacks_addr(&Secp256k1PrivateKey::new()));
-    let signature = make_signer_key_signature(&other_stacker, &signer_key, reward_cycle);
+    let other_pox_addr = pox_addr_from(&Secp256k1PrivateKey::new());
+    let signature = make_signer_key_signature(&other_pox_addr, &signer_key, reward_cycle);
     let invalid_stacker_nonce = stacker_nonce;
     let invalid_stacker_tx = make_pox_4_extend(
         &stacker_key,
@@ -1760,7 +1740,7 @@ fn stack_extend_verify_sig() {
     // Test 3: invalid key used to sign
     stacker_nonce += 1;
     let other_key = Secp256k1PrivateKey::new();
-    let signature = make_signer_key_signature(&stacker, &other_key, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &other_key, reward_cycle);
     let invalid_key_nonce = stacker_nonce;
     let invalid_key_tx = make_pox_4_extend(
         &stacker_key,
@@ -1773,7 +1753,7 @@ fn stack_extend_verify_sig() {
 
     // Test 4: valid stack-extend
     stacker_nonce += 1;
-    let signature = make_signer_key_signature(&stacker, &signer_key, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &signer_key, reward_cycle);
     let valid_nonce = stacker_nonce;
     let valid_tx = make_pox_4_extend(
         &stacker_key,
@@ -1888,29 +1868,20 @@ fn stack_stx_signer_key() {
     let stacker_nonce = 0;
     let stacker_key = &keys[0];
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
-    let stacker = PrincipalData::from(key_to_stacks_addr(stacker_key));
     let signer_key = &keys[1];
     let signer_public_key = StacksPublicKey::from_private(signer_key);
     let signer_key_val = Value::buff_from(signer_public_key.to_bytes_compressed()).unwrap();
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
-    let signature = make_signer_key_signature(&stacker, &signer_key, reward_cycle);
-
     // (define-public (stack-stx (amount-ustx uint)
     //                       (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
     //                       (start-burn-ht uint)
     //                       (lock-period uint)
     //                       (signer-key (buff 33)))
-    let pox_addr = make_pox_addr(
-        AddressHashMode::SerializeP2WSH,
-        key_to_stacks_addr(stacker_key).bytes,
-    );
-
-    // let signer_bytes =
-    //     hex_bytes("03a0f9818ea8c14a827bb144aec9cfbaeba225af22be18ed78a2f298106f4e281b").unwrap();
-    // let signer_key = Secp256k1PublicKey::from_slice(&signer_bytes).unwrap();
-    // let signer_key_val = Value::buff_from(signer_bytes.clone()).unwrap();
+    let pox_addr = pox_addr_from(&stacker_key);
+    let pox_addr_val = Value::Tuple(pox_addr.clone().as_clarity_tuple().unwrap());
+    let signature = make_signer_key_signature(&pox_addr, &signer_key, reward_cycle);
 
     let txs = vec![make_pox_4_contract_call(
         stacker_key,
@@ -1918,7 +1889,7 @@ fn stack_stx_signer_key() {
         "stack-stx",
         vec![
             Value::UInt(min_ustx),
-            pox_addr.clone(),
+            pox_addr_val.clone(),
             Value::UInt(block_height as u128),
             Value::UInt(2),
             Value::buff_from(signature.clone()).unwrap(),
@@ -1943,7 +1914,7 @@ fn stack_stx_signer_key() {
     assert_eq!(reward_set.len(), 1);
     let reward_entry = reward_set.pop().unwrap();
     assert_eq!(
-        PoxAddress::try_from_pox_tuple(false, &pox_addr).unwrap(),
+        PoxAddress::try_from_pox_tuple(false, &pox_addr_val).unwrap(),
         reward_entry.reward_address
     );
     assert_eq!(
@@ -1960,24 +1931,16 @@ fn stack_extend_signer_key() {
 
     let mut stacker_nonce = 0;
     let stacker_key = &keys[0];
-    let stacker = PrincipalData::from(key_to_stacks_addr(stacker_key));
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block) * 2;
 
-    let pox_addr = PoxAddress::from_legacy(
-        AddressHashMode::SerializeP2WSH,
-        key_to_stacks_addr(stacker_key).bytes,
-    );
-    let pox_addr_val = make_pox_addr(
-        AddressHashMode::SerializeP2WSH,
-        key_to_stacks_addr(stacker_key).bytes,
-    );
+    let pox_addr = pox_addr_from(&stacker_key);
+    let pox_addr_val = Value::Tuple(pox_addr.clone().as_clarity_tuple().unwrap());
 
     let signer_sk = Secp256k1PrivateKey::from_seed(&[0]);
     let signer_extend_sk = Secp256k1PrivateKey::from_seed(&[1]);
 
     let signer_key = Secp256k1PublicKey::from_private(&signer_sk);
     let signer_bytes = signer_key.to_bytes_compressed();
-    let signer_key_val = Value::buff_from(signer_bytes.clone()).unwrap();
 
     let signer_extend_key = Secp256k1PublicKey::from_private(&signer_extend_sk);
     let signer_extend_bytes = signer_extend_key.to_bytes_compressed();
@@ -1986,13 +1949,10 @@ fn stack_extend_signer_key() {
     let next_reward_cycle = 1 + burnchain
         .block_height_to_reward_cycle(block_height)
         .unwrap();
-    // let signer_key = &keys[1];
-    // let signer_public_key = StacksPublicKey::from_private(signer_key);
-    // let signer_key_val = Value::buff_from(signer_public_key.to_bytes_compressed()).unwrap();
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
-    let signature = make_signer_key_signature(&stacker, &signer_sk, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &signer_sk, reward_cycle);
 
     let txs = vec![make_pox_4_lockup(
         &stacker_key,
@@ -2009,10 +1969,7 @@ fn stack_extend_signer_key() {
 
     let mut latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
 
-    let signer_key_new = &keys[2];
-    let signer_public_key_new = StacksPublicKey::from_private(signer_key_new);
-
-    let signature = make_signer_key_signature(&stacker, &signer_extend_sk, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &signer_extend_sk, reward_cycle);
 
     // (define-public (stack-extend (extend-count uint)
     //                          (pox-addr { version: (buff 1), hashbytes: (buff 32) })
@@ -2072,7 +2029,6 @@ fn delegate_stack_stx_signer_key() {
 
     let stacker_nonce = 0;
     let stacker_key = &keys[0];
-    let stacker_principal = PrincipalData::from(key_to_stacks_addr(stacker_key));
     let delegate_nonce = 0;
     let delegate_key = &keys[1];
     let delegate_principal = PrincipalData::from(key_to_stacks_addr(delegate_key));
@@ -2085,20 +2041,15 @@ fn delegate_stack_stx_signer_key() {
     //                          (delegate-to principal)
     //                          (until-burn-ht (optional uint))
     //                          (pox-addr (optional { version: (buff 1), hashbytes: (buff 32) })))
-    let pox_addr = make_pox_addr(
-        AddressHashMode::SerializeP2WSH,
-        key_to_stacks_addr(delegate_key).bytes,
-    );
+    let pox_addr = pox_addr_from(&stacker_key);
+    let pox_addr_val = Value::Tuple(pox_addr.clone().as_clarity_tuple().unwrap());
     let signer_sk = Secp256k1PrivateKey::from_seed(&[1, 1, 1]);
     let signer_key = Secp256k1PublicKey::from_private(&signer_sk);
     let signer_key_val = Value::buff_from(signer_key.to_bytes_compressed()).unwrap();
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
 
-    let signature = make_signer_key_signature(
-        &delegate_principal,
-        &signer_sk,
-        (next_reward_cycle - 1).into(),
-    );
+    let signature =
+        make_signer_key_signature(&pox_addr, &signer_sk, (next_reward_cycle - 1).into());
 
     let txs = vec![
         make_pox_4_contract_call(
@@ -2110,7 +2061,7 @@ fn delegate_stack_stx_signer_key() {
                 delegate_principal.clone().into(),
                 Value::none(),
                 Value::Optional(OptionalData {
-                    data: Some(Box::new(pox_addr.clone())),
+                    data: Some(Box::new(pox_addr_val.clone())),
                 }),
             ],
         ),
@@ -2121,7 +2072,7 @@ fn delegate_stack_stx_signer_key() {
             vec![
                 PrincipalData::from(key_to_stacks_addr(stacker_key)).into(),
                 Value::UInt(min_ustx + 1),
-                pox_addr.clone(),
+                pox_addr_val.clone(),
                 Value::UInt(block_height as u128),
                 Value::UInt(lock_period),
             ],
@@ -2131,7 +2082,7 @@ fn delegate_stack_stx_signer_key() {
             delegate_nonce + 1,
             "stack-aggregation-commit",
             vec![
-                pox_addr.clone(),
+                pox_addr_val.clone(),
                 Value::UInt(next_reward_cycle.into()),
                 Value::buff_from(signature).unwrap(),
                 signer_key_val.clone(),
@@ -2162,7 +2113,7 @@ fn delegate_stack_stx_signer_key() {
     assert_eq!(reward_set.len(), 1);
     let reward_entry = reward_set.pop().unwrap();
     assert_eq!(
-        PoxAddress::try_from_pox_tuple(false, &pox_addr).unwrap(),
+        PoxAddress::try_from_pox_tuple(false, &pox_addr_val).unwrap(),
         reward_entry.reward_address
     );
     assert_eq!(
@@ -2286,8 +2237,7 @@ fn delegate_stack_stx_extend_signer_key() {
 
     bob_nonce += 1;
 
-    let signature =
-        make_signer_key_signature(&bob_delegate_principal, &signer_sk, reward_cycle.into());
+    let signature = make_signer_key_signature(&pox_addr, &signer_sk, reward_cycle.into());
 
     let delegate_stack_extend = make_pox_4_delegate_stack_extend(
         bob_delegate_private_key,
@@ -2309,11 +2259,8 @@ fn delegate_stack_stx_extend_signer_key() {
         ],
     );
 
-    let extend_signature = make_signer_key_signature(
-        &bob_delegate_principal,
-        &signer_extend_sk,
-        reward_cycle.into(),
-    );
+    let extend_signature =
+        make_signer_key_signature(&pox_addr, &signer_extend_sk, reward_cycle.into());
 
     let agg_tx_1 = make_pox_4_contract_call(
         bob_delegate_private_key,
@@ -2381,15 +2328,9 @@ fn stack_increase() {
         key_to_stacks_addr(alice_stacking_private_key).bytes,
     );
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
-    let signature = make_signer_key_signature(
-        &PrincipalData::from(alice_address.clone()),
-        &signing_sk,
-        reward_cycle,
-    );
 
-    let alice_stacker = PrincipalData::from(alice_address.clone());
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
-    let signature = make_signer_key_signature(&alice_stacker, &signing_sk, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &signing_sk, reward_cycle);
 
     let stack_stx = make_pox_4_lockup(
         alice_stacking_private_key,
@@ -2522,11 +2463,8 @@ fn delegate_stack_increase() {
         min_ustx,
     );
 
-    let signature = make_signer_key_signature(
-        &bob_delegate_address,
-        &signer_sk,
-        (next_reward_cycle - 1).into(),
-    );
+    let signature =
+        make_signer_key_signature(&pox_addr, &signer_sk, (next_reward_cycle - 1).into());
 
     let agg_tx = make_pox_4_contract_call(
         bob_delegate_key,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -2325,19 +2325,12 @@ fn delegate_stack_stx_extend_signer_key() {
     .expect("No delegation state, delegate-stx failed")
     .expect_tuple();
 
-    let stacking_state = get_stacking_state_pox_4(
-        &mut peer,
-        &latest_block,
-        &key_to_stacks_addr(alice_stacker_key).into(),
-    )
-    .expect("No stacking state, stack-stx failed")
-    .expect_tuple();
     let delegation_state = get_delegation_state_pox_4(&mut peer, &latest_block, &alice_principal)
         .expect("No delegation state, delegate-stx failed")
         .expect_tuple();
 
     let stacking_state = get_stacking_state_pox_4(&mut peer, &latest_block, &alice_principal)
-        .expect("No stacking state, stack-stx failed")
+        .expect("No stacking state, bob called delegate-stack-stx that failed here")
         .expect_tuple();
 
     let reward_cycle = burnchain

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1430,6 +1430,7 @@ fn verify_signer_key_sig(
     pox_addr: &PoxAddress,
     peer: &mut TestPeer,
     latest_block: &StacksBlockId,
+    reward_cycle: u128,
 ) -> Value {
     let result: Value = with_sortdb(peer, |ref mut chainstate, ref mut sortdb| {
         chainstate
@@ -1444,8 +1445,9 @@ fn verify_signer_key_sig(
                         LimitedCostTracker::new_free(),
                         |env| {
                             let program = format!(
-                                "(verify-signer-key-sig {} 0x{} 0x{})",
+                                "(verify-signer-key-sig {} u{} 0x{} 0x{})",
                                 Value::Tuple(pox_addr.clone().as_clarity_tuple().unwrap()),
+                                reward_cycle,
                                 to_hex(&signature),
                                 signing_key.to_hex(),
                             );
@@ -1519,6 +1521,7 @@ fn verify_signer_key_signatures() {
         &bob_pox_addr,
         &mut peer,
         &latest_block,
+        reward_cycle,
     );
     assert_eq!(result, expected_error);
 
@@ -1532,6 +1535,7 @@ fn verify_signer_key_signatures() {
         &bob_pox_addr, // wrong pox-addr
         &mut peer,
         &latest_block,
+        reward_cycle,
     );
 
     assert_eq!(result, expected_error);
@@ -1546,6 +1550,7 @@ fn verify_signer_key_signatures() {
         &bob_pox_addr,
         &mut peer,
         &latest_block,
+        reward_cycle,
     );
 
     assert_eq!(result, expected_error);
@@ -1560,6 +1565,7 @@ fn verify_signer_key_signatures() {
         &bob_pox_addr,
         &mut peer,
         &latest_block,
+        reward_cycle,
     );
 
     assert_eq!(result, Value::okay_true());
@@ -2410,7 +2416,7 @@ fn delegate_stack_stx_extend_signer_key() {
     );
 
     let extend_signature =
-        make_signer_key_signature(&pox_addr, &signer_extend_sk, reward_cycle.into());
+        make_signer_key_signature(&pox_addr, &signer_extend_sk, (extend_cycle - 1).into());
 
     let agg_tx_1 = make_pox_4_contract_call(
         bob_delegate_private_key,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1670,7 +1670,9 @@ fn stack_stx_verify_signer_sig() {
     assert_eq!(tx_result(invalid_key_nonce), expected_error);
 
     // valid tx should succeed
-    tx_result(valid_nonce).expect_result_ok();
+    tx_result(valid_nonce)
+        .expect_result_ok()
+        .expect("Expected ok result from tx");
 }
 
 #[test]
@@ -1781,11 +1783,15 @@ fn stack_extend_verify_sig() {
         |nonce: u64| -> Value { stacker_txs.get(nonce as usize).unwrap().result.clone() };
 
     let expected_error = Value::error(Value::Int(35)).unwrap();
-    tx_result(stack_nonce).expect_result_ok();
+    tx_result(stack_nonce)
+        .expect_result_ok()
+        .expect("Expected ok result from tx");
     assert_eq!(tx_result(invalid_cycle_nonce), expected_error);
     assert_eq!(tx_result(invalid_stacker_nonce), expected_error);
     assert_eq!(tx_result(invalid_key_nonce), expected_error);
-    tx_result(valid_nonce).expect_result_ok();
+    tx_result(valid_nonce)
+        .expect_result_ok()
+        .expect("Expected ok result from tx");
 }
 
 #[test]
@@ -1912,11 +1918,15 @@ fn stack_agg_commit_verify_sig() {
 
     let expected_error = Value::error(Value::Int(35)).unwrap();
 
-    tx_result(delegate_stack_stx_nonce).expect_result_ok();
+    tx_result(delegate_stack_stx_nonce)
+        .expect_result_ok()
+        .expect("Expected ok result from tx");
     assert_eq!(tx_result(invalid_cycle_nonce), expected_error);
     assert_eq!(tx_result(invalid_pox_addr_nonce), expected_error);
     assert_eq!(tx_result(invalid_key_nonce), expected_error);
-    tx_result(valid_nonce).expect_result_ok();
+    tx_result(valid_nonce)
+        .expect_result_ok()
+        .expect("Expected ok result from tx");
 }
 
 pub fn assert_latest_was_burn(peer: &mut TestPeer) {

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1455,7 +1455,7 @@ fn verify_signer_key_sig(
     latest_block: &StacksBlockId,
     reward_cycle: u128,
     period: u128,
-    topic: &str,
+    topic: &Pox4SignatureTopic,
 ) -> Value {
     let result: Value = with_sortdb(peer, |ref mut chainstate, ref mut sortdb| {
         chainstate
@@ -1473,7 +1473,7 @@ fn verify_signer_key_sig(
                                 "(verify-signer-key-sig {} u{} \"{}\" u{} 0x{} 0x{})",
                                 Value::Tuple(pox_addr.clone().as_clarity_tuple().unwrap()),
                                 reward_cycle,
-                                topic,
+                                topic.get_name_str(),
                                 period,
                                 to_hex(&signature),
                                 signing_key.to_hex(),
@@ -1555,7 +1555,7 @@ fn verify_signer_key_signatures() {
         &latest_block,
         reward_cycle,
         period,
-        topic.as_str(),
+        &topic,
     );
     assert_eq!(result, expected_error);
 
@@ -1571,7 +1571,7 @@ fn verify_signer_key_signatures() {
         &latest_block,
         reward_cycle,
         period,
-        topic.as_str(),
+        &topic,
     );
 
     assert_eq!(result, expected_error);
@@ -1588,7 +1588,7 @@ fn verify_signer_key_signatures() {
         &latest_block,
         reward_cycle,
         period,
-        topic.as_str(),
+        &topic,
     );
 
     assert_eq!(result, expected_error);
@@ -1609,7 +1609,7 @@ fn verify_signer_key_signatures() {
         &latest_block,
         reward_cycle,
         period,
-        Pox4SignatureTopic::StackExtend.as_str(), // different
+        &Pox4SignatureTopic::StackExtend, // different
     );
 
     assert_eq!(result, expected_error);
@@ -1624,7 +1624,7 @@ fn verify_signer_key_signatures() {
         &latest_block,
         reward_cycle,
         period + 1, // different
-        topic.as_str(),
+        &topic,
     );
 
     assert_eq!(result, expected_error);
@@ -1641,7 +1641,7 @@ fn verify_signer_key_signatures() {
         &latest_block,
         reward_cycle,
         period,
-        topic.as_str(),
+        &topic,
     );
 
     assert_eq!(result, Value::okay_true());

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -328,6 +328,8 @@ impl NakamotoBootPlan {
                     &pox_addr,
                     &test_stacker.signer_private_key,
                     reward_cycle.into(),
+                    &crate::util_lib::signed_structured_data::pox4::Pox4SignatureTopic::StackStx,
+                    12_u128,
                 );
                 make_pox_4_lockup(
                     &test_stacker.stacker_private_key,

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -312,7 +312,8 @@ impl NakamotoBootPlan {
         let reward_cycle = peer
             .config
             .burnchain
-            .reward_cycle_to_block_height(sortition_height);
+            .block_height_to_reward_cycle(sortition_height.into())
+            .unwrap();
 
         // Make all the test Stackers stack
         let stack_txs: Vec<_> = peer

--- a/stackslib/src/util_lib/mod.rs
+++ b/stackslib/src/util_lib/mod.rs
@@ -2,6 +2,7 @@
 pub mod db;
 pub mod bloom;
 pub mod boot;
+pub mod signed_structured_data;
 pub mod strings;
 
 #[cfg(test)]

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -1,3 +1,19 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2021 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use clarity::vm::Value;
 use stacks_common::{
     codec::StacksMessageCodec,

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -1,0 +1,122 @@
+use clarity::vm::Value;
+use stacks_common::{
+    codec::StacksMessageCodec,
+    types::PrivateKey,
+    util::{
+        hash::{to_hex, Sha256Sum},
+        secp256k1::{MessageSignature, Secp256k1PrivateKey},
+    },
+};
+
+/// Message prefix for signed structured data. "SIP018" in ascii
+pub const STRUCTURED_DATA_PREFIX: [u8; 6] = [0x53, 0x49, 0x50, 0x30, 0x31, 0x38];
+
+pub fn structured_data_hash(value: Value) -> Sha256Sum {
+    let bytes = value.serialize_to_vec();
+    Sha256Sum::from_data(&bytes)
+}
+
+/// Generate a message hash for signing structured Clarity data.
+/// Reference [SIP018](https://github.com/stacksgov/sips/blob/main/sips/sip-018/sip-018-signed-structured-data.md) for more information.
+pub fn structured_data_message_hash(structured_data: Value, domain: Value) -> Sha256Sum {
+    let message = [
+        STRUCTURED_DATA_PREFIX.as_ref(),
+        structured_data_hash(domain).as_bytes(),
+        structured_data_hash(structured_data).as_bytes(),
+    ]
+    .concat();
+
+    Sha256Sum::from_data(&message)
+}
+
+/// Sign structured Clarity data with a given private key.
+/// Reference [SIP018](https://github.com/stacksgov/sips/blob/main/sips/sip-018/sip-018-signed-structured-data.md) for more information.
+pub fn sign_structured_data(
+    structured_data: Value,
+    domain: Value,
+    private_key: &Secp256k1PrivateKey,
+) -> Result<MessageSignature, &str> {
+    let msg_hash = structured_data_message_hash(structured_data, domain);
+    private_key.sign(msg_hash.as_bytes())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use clarity::vm::types::{TupleData, Value};
+    use stacks_common::{consts::CHAIN_ID_MAINNET, util::hash::to_hex};
+
+    /// [SIP18 test vectors](https://github.com/stacksgov/sips/blob/main/sips/sip-018/sip-018-signed-structured-data.md)
+    #[test]
+    fn test_sip18_ref_structured_data_hash() {
+        let value = Value::string_ascii_from_bytes("Hello World".into()).unwrap();
+        let msg_hash = structured_data_hash(value);
+        assert_eq!(
+            to_hex(msg_hash.as_bytes()),
+            "5297eef9765c466d945ad1cb2c81b30b9fed6c165575dc9226e9edf78b8cd9e8"
+        )
+    }
+
+    /// [SIP18 test vectors](https://github.com/stacksgov/sips/blob/main/sips/sip-018/sip-018-signed-structured-data.md)
+    #[test]
+    fn test_sip18_ref_message_hashing() {
+        let domain = Value::Tuple(
+            TupleData::from_data(vec![
+                (
+                    "name".into(),
+                    Value::string_ascii_from_bytes("Test App".into()).unwrap(),
+                ),
+                (
+                    "version".into(),
+                    Value::string_ascii_from_bytes("1.0.0".into()).unwrap(),
+                ),
+                ("chain-id".into(), Value::UInt(CHAIN_ID_MAINNET.into())),
+            ])
+            .unwrap(),
+        );
+        let data = Value::string_ascii_from_bytes("Hello World".into()).unwrap();
+
+        let msg_hash = structured_data_message_hash(data, domain);
+
+        assert_eq!(
+            to_hex(msg_hash.as_bytes()),
+            "1bfdab6d4158313ce34073fbb8d6b0fc32c154d439def12247a0f44bb2225259"
+        );
+    }
+
+    /// [SIP18 test vectors](https://github.com/stacksgov/sips/blob/main/sips/sip-018/sip-018-signed-structured-data.md)
+    #[test]
+    fn test_sip18_ref_signing() {
+        let key = Secp256k1PrivateKey::from_hex(
+            "753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601",
+        )
+        .unwrap();
+        let domain = Value::Tuple(
+            TupleData::from_data(vec![
+                (
+                    "name".into(),
+                    Value::string_ascii_from_bytes("Test App".into()).unwrap(),
+                ),
+                (
+                    "version".into(),
+                    Value::string_ascii_from_bytes("1.0.0".into()).unwrap(),
+                ),
+                ("chain-id".into(), Value::UInt(CHAIN_ID_MAINNET.into())),
+            ])
+            .unwrap(),
+        );
+        let data = Value::string_ascii_from_bytes("Hello World".into()).unwrap();
+        let signature =
+            sign_structured_data(data, domain, &key).expect("Failed to sign structured data");
+
+        let signature_rsv = signature.to_rsv();
+
+        assert_eq!(to_hex(signature_rsv.as_slice()), "8b94e45701d857c9f1d1d70e8b2ca076045dae4920fb0160be0642a68cd78de072ab527b5c5277a593baeb2a8b657c216b99f7abb5d14af35b4bf12ba6460ba401");
+    }
+
+    #[test]
+    fn test_prefix_bytes() {
+        let hex = to_hex(STRUCTURED_DATA_PREFIX.as_ref());
+        assert_eq!(hex, "534950303138");
+    }
+}

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use clarity::vm::Value;
+use clarity::vm::{types::TupleData, Value};
 use stacks_common::{
     codec::StacksMessageCodec,
     types::PrivateKey,
@@ -54,6 +54,24 @@ pub fn sign_structured_data(
 ) -> Result<MessageSignature, &str> {
     let msg_hash = structured_data_message_hash(structured_data, domain);
     private_key.sign(msg_hash.as_bytes())
+}
+
+// Helper function to generate domain for structured data hash
+pub fn make_structured_data_domain(name: &str, version: &str, chain_id: u32) -> Value {
+    Value::Tuple(
+        TupleData::from_data(vec![
+            (
+                "name".into(),
+                Value::string_ascii_from_bytes(name.into()).unwrap(),
+            ),
+            (
+                "version".into(),
+                Value::string_ascii_from_bytes(version.into()).unwrap(),
+            ),
+            ("chain-id".into(), Value::UInt(chain_id.into())),
+        ])
+        .unwrap(),
+    )
 }
 
 #[cfg(test)]

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -87,11 +87,6 @@ pub mod pox4 {
         AggregationCommit("agg-commit"),
         StackExtend("stack-extend"),
     });
-    pub enum Pox4SignatureTopicOld {
-        StackStx,
-        AggregationCommit,
-        StackExtend,
-    }
 
     pub fn make_pox_4_signed_data_domain(chain_id: u32) -> Value {
         make_structured_data_domain("pox-4-signer", "1.0.0", chain_id)

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -28,7 +28,8 @@ use stacks_common::{
 pub const STRUCTURED_DATA_PREFIX: [u8; 6] = [0x53, 0x49, 0x50, 0x30, 0x31, 0x38];
 
 pub fn structured_data_hash(value: Value) -> Sha256Sum {
-    let bytes = value.serialize_to_vec();
+    let mut bytes = vec![];
+    value.serialize_write(&mut bytes).unwrap();
     Sha256Sum::from_data(&bytes.as_slice())
 }
 

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -82,20 +82,15 @@ pub mod pox4 {
         make_structured_data_domain, structured_data_message_hash, MessageSignature, PoxAddress,
         PrivateKey, Sha256Sum, StacksPrivateKey, TupleData, Value,
     };
-    pub enum Pox4SignatureTopic {
+    define_named_enum!(Pox4SignatureTopic {
+        StackStx("stack-stx"),
+        AggregationCommit("agg-commit"),
+        StackExtend("stack-extend"),
+    });
+    pub enum Pox4SignatureTopicOld {
         StackStx,
         AggregationCommit,
         StackExtend,
-    }
-
-    impl Pox4SignatureTopic {
-        pub fn as_str(&self) -> &'static str {
-            match self {
-                Pox4SignatureTopic::StackStx => "stack-stx",
-                Pox4SignatureTopic::AggregationCommit => "agg-commit",
-                Pox4SignatureTopic::StackExtend => "stack-extend",
-            }
-        }
     }
 
     pub fn make_pox_4_signed_data_domain(chain_id: u32) -> Value {
@@ -120,7 +115,7 @@ pub mod pox4 {
                 ("period".into(), Value::UInt(period)),
                 (
                     "topic".into(),
-                    Value::string_ascii_from_bytes(topic.as_str().into()).unwrap(),
+                    Value::string_ascii_from_bytes(topic.get_name_str().into()).unwrap(),
                 ),
             ])
             .unwrap(),

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -29,7 +29,7 @@ pub const STRUCTURED_DATA_PREFIX: [u8; 6] = [0x53, 0x49, 0x50, 0x30, 0x31, 0x38]
 
 pub fn structured_data_hash(value: Value) -> Sha256Sum {
     let bytes = value.serialize_to_vec();
-    Sha256Sum::from_data(&bytes)
+    Sha256Sum::from_data(&bytes.as_slice())
 }
 
 /// Generate a message hash for signing structured Clarity data.

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -357,14 +357,19 @@ pub fn boot_to_epoch_3(
 
     // stack enough to activate pox-4
 
+    let block_height = btc_regtest_controller.get_headers_height();
+    let reward_cycle = btc_regtest_controller
+        .get_burnchain()
+        .block_height_to_reward_cycle(block_height)
+        .unwrap();
+
     let pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
         tests::to_addr(&stacker_sk).bytes,
     );
     let pox_addr_tuple: clarity::vm::Value = pox_addr.clone().as_clarity_tuple().unwrap().into();
-    let reward_cycle = 7 as u128;
     let signer_pubkey = StacksPublicKey::from_private(&signer_sk);
-    let signature = make_signer_key_signature(&pox_addr, &signer_sk, reward_cycle);
+    let signature = make_signer_key_signature(&pox_addr, &signer_sk, reward_cycle.into());
 
     let stacking_tx = tests::make_contract_call(
         &stacker_sk,

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -15,11 +15,9 @@ use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader};
 use stacks::chainstate::stacks::{StacksPrivateKey, ThresholdSignature};
 use stacks::net::api::postblock_proposal::BlockValidateResponse;
 use stacks_common::bitvec::BitVec;
-use stacks_common::types::chainstate::{
-    ConsensusHash, StacksAddress, StacksBlockId, StacksPublicKey, TrieHash,
-};
+use stacks_common::types::chainstate::{ConsensusHash, StacksAddress, StacksBlockId, TrieHash};
 use stacks_common::util::hash::{MerkleTree, Sha512Trunc256Sum};
-use stacks_common::util::secp256k1::MessageSignature;
+use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PrivateKey};
 use stacks_signer::client::StacksClient;
 use stacks_signer::config::Config as SignerConfig;
 use stacks_signer::runloop::{calculate_coordinator, RunLoopCommand};
@@ -321,7 +319,7 @@ fn setup_stx_btc_node(
         &naka_conf,
         &blocks_processed,
         stacker_sk,
-        StacksPublicKey::new(),
+        Secp256k1PrivateKey::default(),
         &mut btc_regtest_controller,
     );
 

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -114,6 +114,7 @@ impl SignerTest {
             &naka_conf.node.rpc_bind,
             &signers_stacker_db_contract_id.to_string(),
             Some(Duration::from_millis(128)), // Timeout defaults to 5 seconds. Let's override it to 128 milliseconds.
+            &Network::Testnet,
         );
 
         let mut running_signers = HashMap::new();

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -23,9 +23,7 @@ use stacks::net::api::postblock_proposal::BlockValidateResponse;
 use stacks::util_lib::strings::StacksString;
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::read_next;
-use stacks_common::types::chainstate::{
-    ConsensusHash, StacksAddress, StacksBlockId, StacksPublicKey, TrieHash,
-};
+use stacks_common::types::chainstate::{ConsensusHash, StacksAddress, StacksBlockId, TrieHash};
 use stacks_common::util::hash::{MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PrivateKey};
 use stacks_signer::client::{StackerDB, StacksClient};


### PR DESCRIPTION
This closes #4247, which is to ensure that all Signers are using signing keys that they either control, or are controlled by the account they're delegating to.

- closes #4247 

This is done by adding a `signer-sig` param to:

- stack-stx
- delegate-stack-stx
- stack-aggregation-commit

The signature follows [SIP018](https://github.com/stacksgov/sips/blob/main/sips/sip-018/sip-018-signed-structured-data.md) for signed structured data. Following SIP018 has the benefit of built-in wallet support, so signers can use hardware wallets and apps to generate these signatures. 

Following SIP018, the structured data is `{ reward-cycle, reward-cycle }`, where `reward-cycle` is the _current_ stacking cycle where the transaction is made. The `domain` is `{ app: "pox-4-signer", version: "1.0.0", chain-id }`.

Because we'll almost certainly be building the ability for `stacks-signer` to generate these signatures (ie via CLI), I added a SIP18 util library at `/stacksib/src/lib_util/signed_structured_data`. That library has tests that validate the functionality based on the test vectors in SIP018.

I added a function `to_rsv` to `MessageSignature` to match the byte order that Clarity uses for signatures.

Note that I added the new `signer-sig` param as the second-to-last argument because of other conversations around expected argument order, but I'm not really familiar with the requirements there. I also am not sure what other touch points use these functions where the arguments need to be updated. cc @zone117x regarding param order