### PR TITLE
Fix pox4 delegate-stack-extend

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -1158,8 +1158,8 @@
 (define-public (delegate-stack-extend
                     (stacker principal)
                     (pox-addr { version: (buff 1), hashbytes: (buff 32) })
-                    (signer-key (buff 33))
-                    (extend-count uint))
+                    (extend-count uint)
+                    (signer-key (buff 33)))
     (let ((stacker-info (stx-account stacker))
           ;; to extend, there must already be an entry in the stacking-state
           (stacker-state (unwrap! (get-stacker-info stacker) (err ERR_STACK_EXTEND_NOT_LOCKED)))


### PR DESCRIPTION
The `signer-key` arg was added in the wrong position in the `delegate-stack-extend` function. It broke the pox4 synthetic event generation here:
https://github.com/stacks-network/stacks-core/blob/2684ce5adb6692592a5b19963987441905acf759/pox-locking/src/events.rs#L287-L289

Error messages:
```
ERRO [1706021370.455103] [pox-locking/src/events.rs:437] [chains-coordinator-0.0.0.0:20443] Failed to run data-info code snippet for 'delegate-stack-extend': Unchecked(TypeValueError(UIntType, Sequence(Buffer(2296955a3ce00133e4eeaaeb62a667a77c42f71004bb0e4ee3118750b09e67fd22))))
ERRO [1706021370.455261] [pox-locking/src/events.rs:457] [chains-coordinator-0.0.0.0:20443] Failed to synthesize PoX event: Unchecked(TypeValueError(UIntType, Sequence(Buffer(2296955a3ce00133e4eeaaeb62a667a77c42f71004bb0e4ee3118750b09e67fd22))))
ERRO [1706021370.455275] [pox-locking/src/pox_4.rs:352] [chains-coordinator-0.0.0.0:20443] Failed to synthesize PoX-4 event info: Unchecked(TypeValueError(UIntType, Sequence(Buffer(2296955a3ce00133e4eeaaeb62a667a77c42f71004bb0e4ee3118750b09e67fd22))))
```

I moved the `signer-key` arg to the last position to match the other functions, which also fixes the event generation.