### PR TITLE
Add `/status` endpoint to signer

### DIFF
--- a/libsigner/src/events.rs
+++ b/libsigner/src/events.rs
@@ -211,6 +211,8 @@ pub enum SignerEvent {
     SignerMessages(Vec<SignerMessage>),
     /// A new block proposal validation response from the node
     BlockValidationResponse(BlockValidateResponse),
+    /// Status endpoint request
+    StatusCheck,
 }
 
 /// Trait to implement a stop-signaler for the event receiver thread.
@@ -381,6 +383,20 @@ impl EventReceiver for SignerEventReceiver {
                 return Err(EventError::Terminated);
             }
             let request = http_server.recv()?;
+
+            if request.method() == &HttpMethod::Get {
+                if request.url() == "/status" {
+                    request
+                    .respond(HttpResponse::from_string("OK"))
+                    .expect("response failed");
+                    return Ok(SignerEvent::StatusCheck);
+                }
+                return Err(EventError::MalformedRequest(format!(
+                    "Unrecognized GET request '{}'",
+                    &request.url(),
+                )));
+            }
+
             if request.method() != &HttpMethod::Post {
                 return Err(EventError::MalformedRequest(format!(
                     "Unrecognized method '{}'",

--- a/libsigner/src/events.rs
+++ b/libsigner/src/events.rs
@@ -384,17 +384,11 @@ impl EventReceiver for SignerEventReceiver {
             }
             let request = http_server.recv()?;
 
-            if request.method() == &HttpMethod::Get {
-                if request.url() == "/status" {
-                    request
-                    .respond(HttpResponse::from_string("OK"))
-                    .expect("response failed");
-                    return Ok(SignerEvent::StatusCheck);
-                }
-                return Err(EventError::MalformedRequest(format!(
-                    "Unrecognized GET request '{}'",
-                    &request.url(),
-                )));
+            if request.url() == "/status" {
+                request
+                .respond(HttpResponse::from_string("OK"))
+                .expect("response failed");
+                return Ok(SignerEvent::StatusCheck);
             }
 
             if request.method() != &HttpMethod::Post {

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -805,6 +805,9 @@ impl<C: Coordinator> SignerRunLoop<Vec<OperationResult>, RunLoopCommand> for Run
                 debug!("Received block proposals from the miners...");
                 self.handle_proposed_blocks(blocks);
             }
+            Some(SignerEvent::StatusCheck) => {
+                debug!("Received a status check event.")
+            }
             None => {
                 // No event. Do nothing.
                 debug!("No event received")


### PR DESCRIPTION
I've been documenting the workflow for running the signer, and I think it would be helpful to expose a `GET /status` endpoint to help setup and monitor the signer. This PR responds with `200 OK` for that endpoint.

Note that this could potentially conflict with an event observer path in the future. I'm not sure if the Stacks Blockchain API exposes a similar endpoint on the event receiver, but if so, we should follow use same route. @zone117x does that exist?

I could also imagine having an endpoint similar to `/v2/status` on the node, where more helpful state is returned, but I'm not sure how much we want to expose the fact that a specific IP is running a specific signer.