### PR TITLE
Signer votes on dkg result

### DIFF
--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -89,6 +89,24 @@ impl StacksClient {
         Ok(())
     }
 
+    /// cast for for aggregate public key
+    pub fn cast_vote_for_aggregate_public_key(
+        &self,
+        aggreagte_public_key_point: Point,
+    ) -> Result<Txid, ClientError> {
+        let aggregate_public_key = Value::Sequence(aggreagte_public_key_point.to_bytes().to_vec());
+        let reward_cycle_value = Value::UInt(reward_cycle);
+        let round_value = Value::UInt(0);
+        let tapleaves_value = Value::Sequence(vec![]);
+
+        transaction_contract_call(
+            boot_code_addr(self.chain_id == CHAIN_ID_MAINNET),
+            POX_4_VOTE_NAME,
+            ClarityName::try_from("vote-for-aggregate-public-key").unwrap(),
+            &[aggregate_public_key, reward_cycle_value, round, tapleaves],
+        )
+    }
+
     /// Retrieve the current DKG aggregate public key
     pub fn get_aggregate_public_key(&self) -> Result<Option<Point>, ClientError> {
         let reward_cycle = self.get_current_reward_cycle()?;


### PR DESCRIPTION
### Description

This PR adds voting on the aggregate public key to the signer run loop.

### Applicable issues

- fixes #3973 
- related to #3968

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
