### PR TITLE
Make signer_signature_hash infallible and use it instead of the entire block when passing around data in stackerdb

### DIFF
--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -340,9 +340,9 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use super::Network;
-    use super::{Config, RawConfigFile};
     use blockstack_lib::util_lib::boot::boot_code_id;
+
+    use super::{Config, Network, RawConfigFile};
 
     fn create_raw_config(overrides: impl FnOnce(&mut RawConfigFile)) -> RawConfigFile {
         let mut config = RawConfigFile {

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -256,11 +256,12 @@ impl<C: Coordinator> RunLoop<C> {
             BlockValidateResponse::Ok(block_validate_ok) => {
                 let Some(block_info) = self
                     .blocks
-                    .get_mut(&block_validate_ok.signer_signature_hash) else {
-                        // We have not seen this block before. Why are we getting a response for it?
-                        debug!("Received a block validate response for a block we have not seen before. Ignoring...");
-                        return;
-                    };
+                    .get_mut(&block_validate_ok.signer_signature_hash)
+                else {
+                    // We have not seen this block before. Why are we getting a response for it?
+                    debug!("Received a block validate response for a block we have not seen before. Ignoring...");
+                    return;
+                };
                 block_info.valid = Some(true);
                 block_info
             }
@@ -268,11 +269,12 @@ impl<C: Coordinator> RunLoop<C> {
                 // There is no point in triggering a sign round for this block if validation failed from the stacks node
                 let Some(block_info) = self
                     .blocks
-                    .get_mut(&block_validate_reject.signer_signature_hash) else {
-                        // We have not seen this block before. Why are we getting a response for it?
-                        debug!("Received a block validate response for a block we have not seen before. Ignoring...");
-                        return;
-                    };
+                    .get_mut(&block_validate_reject.signer_signature_hash)
+                else {
+                    // We have not seen this block before. Why are we getting a response for it?
+                    debug!("Received a block validate response for a block we have not seen before. Ignoring...");
+                    return;
+                };
                 block_info.valid = Some(false);
                 // Submit a rejection response to the .signers contract for miners
                 // to observe so they know to send another block and to prove signers are doing work);
@@ -566,7 +568,9 @@ impl<C: Coordinator> RunLoop<C> {
         } else {
             &message
         };
-        let Some(signer_signature_hash) = Sha512Trunc256Sum::from_bytes(signer_signature_hash_bytes) else {
+        let Some(signer_signature_hash) =
+            Sha512Trunc256Sum::from_bytes(signer_signature_hash_bytes)
+        else {
             debug!("Received a signature result for a signature over a non-block. Nothing to broadcast.");
             return;
         };

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -130,11 +130,7 @@ impl Default for TestSigners {
 impl TestSigners {
     pub fn sign_nakamoto_block(&mut self, block: &mut NakamotoBlock) {
         let mut rng = rand_core::OsRng;
-        let msg = block
-            .header
-            .signer_signature_hash()
-            .expect("Failed to determine the block header signature hash for signers.")
-            .0;
+        let msg = block.header.signer_signature_hash().0;
         let (nonces, sig_shares, key_ids) =
             wsts::v2::test_helpers::sign(msg.as_slice(), &mut self.signer_parties, &mut rng);
 

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -976,7 +976,7 @@ impl MockamotoNode {
 
         let miner_signature = self
             .miner_key
-            .sign(block.header.miner_signature_hash().unwrap().as_bytes())
+            .sign(block.header.miner_signature_hash().as_bytes())
             .unwrap();
 
         block.header.miner_signature = miner_signature;

--- a/testnet/stacks-node/src/mockamoto/signer.rs
+++ b/testnet/stacks-node/src/mockamoto/signer.rs
@@ -66,11 +66,7 @@ impl SelfSigner {
 
     pub fn sign_nakamoto_block(&mut self, block: &mut NakamotoBlock) {
         let mut rng = rand::rngs::OsRng::default();
-        let msg = block
-            .header
-            .signer_signature_hash()
-            .expect("Failed to determine the block header signature hash for signers.")
-            .0;
+        let msg = block.header.signer_signature_hash().0;
         let (nonces, sig_shares, key_ids) =
             wsts::v2::test_helpers::sign(msg.as_slice(), &mut self.signer_parties, &mut rng);
 

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -562,13 +562,7 @@ impl BlockMinerThread {
 
         let mining_key = self.keychain.get_nakamoto_sk();
         let miner_signature = mining_key
-            .sign(
-                block
-                    .header
-                    .miner_signature_hash()
-                    .map_err(|_| NakamotoNodeError::SigningError("Could not create sighash"))?
-                    .as_bytes(),
-            )
+            .sign(block.header.miner_signature_hash().as_bytes())
             .map_err(NakamotoNodeError::SigningError)?;
         block.header.miner_signature = miner_signature;
 


### PR DESCRIPTION
### Description
I realized I was unnecessarily sending around the entire block when the only thing that a miner needs is the signature corresponding to a signer signature hash of his proposed block. This change also enables signers who were not online during the nonce request portion of a signing round to broadcast signing round results as the signature cannot be spoofed enabling them to better contribute to the livliness of the chain.

NOTE: I have made the signer_signature_hash and miner_signature_hash unwrap the underlying hash functions similar to how we do block_hash. As far as I am aware...we cannot produce a NakamotoBlock that does not produce a valid signer and miner signature hash....But please correct me if I am wrong.