### PR TITLE
Feat/signers write transactions to stackerdb

### DIFF
--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -49,6 +49,7 @@ pub use crate::events::{
 };
 pub use crate::messages::{
     BlockRejection, BlockResponse, RejectCode, SignerMessage, BLOCK_SLOT_ID, SIGNER_SLOTS_PER_USER,
+    TRANSACTIONS_SLOT_ID,
 };
 pub use crate::runloop::{RunningSigner, Signer, SignerRunLoop};
 pub use crate::session::{SignerSession, StackerDBSession};

--- a/libsigner/src/messages.rs
+++ b/libsigner/src/messages.rs
@@ -944,10 +944,15 @@ impl SignerMessage {
 #[cfg(test)]
 mod test {
 
-    use blockstack_lib::{chainstate::stacks::{TransactionAnchorMode, TransactionAuth, TransactionPayload, TransactionPostConditionMode, TransactionSmartContract, TransactionVersion}, util_lib::strings::StacksString};
+    use blockstack_lib::chainstate::stacks::{
+        TransactionAnchorMode, TransactionAuth, TransactionPayload, TransactionPostConditionMode,
+        TransactionSmartContract, TransactionVersion,
+    };
+    use blockstack_lib::util_lib::strings::StacksString;
     use rand::Rng;
     use rand_core::OsRng;
-    use stacks_common::{consts::CHAIN_ID_TESTNET, types::chainstate::StacksPrivateKey};
+    use stacks_common::consts::CHAIN_ID_TESTNET;
+    use stacks_common::types::chainstate::StacksPrivateKey;
     use wsts::common::Signature;
 
     use super::{StacksMessageCodecExtensions, *};
@@ -1259,7 +1264,7 @@ mod test {
             read_next::<SignerMessage, _>(&mut &serialized_signer_message[..])
                 .expect("Failed to deserialize SignerMessage");
         assert_eq!(signer_message, deserialized_signer_message);
-    
+
         let sk = StacksPrivateKey::new();
         let tx = StacksTransaction {
             version: TransactionVersion::Testnet,

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -50,3 +50,4 @@ features = ["arbitrary_precision", "unbounded_depth"]
 [dependencies.secp256k1]
 version = "0.24.3"
 features = ["serde", "recovery"]
+

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -122,6 +122,7 @@ pub(crate) mod tests {
         pub(crate) mock_server: TcpListener,
         pub(crate) client: StacksClient,
         pub(crate) stackerdb: StackerDB,
+        pub(crate) config: Config,
     }
 
     impl TestConfig {
@@ -142,6 +143,20 @@ pub(crate) mod tests {
                 mock_server,
                 client,
                 stackerdb,
+                config,
+            }
+        }
+
+        pub(crate) fn from_config(config: Config) -> Self {
+            let mock_server = TcpListener::bind(config.node_host).unwrap();
+
+            let client = StacksClient::from(&config);
+            let stackerdb = StackerDB::from(&config);
+            Self {
+                mock_server,
+                client,
+                stackerdb,
+                config,
             }
         }
     }

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -116,11 +116,14 @@ impl StackerDB {
             if !chunk_ack.is_empty() {
                 for chunk in chunk_ack {
                     if let Some(data) = chunk {
-                        let message: SignerMessage = bincode::deserialize(&data).unwrap();
-                        if let SignerMessage::Transactions(chunk_transactions) = message {
-                            transactions.extend(chunk_transactions);
+                        if let Ok(message) = bincode::deserialize::<SignerMessage>(&data) {
+                            if let SignerMessage::Transactions(chunk_transactions) = message {
+                                transactions.extend(chunk_transactions);
+                            } else {
+                                warn!("Signer wrote an unexpected type to the transactions slot");
+                            }
                         } else {
-                            warn!("Signer wrote an unexpected type to the transactions slot");
+                            warn!("Failed to deserialize chunk data into a SignerMessage");
                         }
                     }
                 }

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -120,7 +120,7 @@ impl StackerDB {
     pub fn get_signer_transactions_with_retry(
         &mut self,
         signer_ids: &[u32],
-    ) -> Result<Vec<(u32, Vec<StacksTransaction>)>, ClientError> {
+    ) -> Result<Vec<StacksTransaction>, ClientError> {
         let slot_ids: Vec<_> = signer_ids
             .iter()
             .map(|id| id * SIGNER_SLOTS_PER_USER + TRANSACTIONS_SLOT_ID)
@@ -148,7 +148,7 @@ impl StackerDB {
                             chunk_transactions.len(),
                             signer_id
                         );
-                        transactions.push((signer_id, chunk_transactions));
+                        transactions.extend(chunk_transactions);
                     } else {
                         warn!("Signer wrote an unexpected type to the transactions slot");
                     }
@@ -212,7 +212,6 @@ mod tests {
         response_bytes.extend(message);
         write_response(config.mock_server, response_bytes.as_slice());
         let transactions = h.join().unwrap().unwrap();
-        assert_eq!(transactions.len(), 1);
-        assert_eq!(transactions[0], (0, vec![tx]));
+        assert_eq!(transactions, vec![tx]);
     }
 }

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -202,7 +202,7 @@ mod tests {
         let signer_message = SignerMessage::Transactions(vec![tx.clone()]);
         let message = signer_message.serialize_to_vec();
 
-        let signer_ids = vec![0];
+        let signer_ids = vec![0, 1];
         let h = spawn(move || {
             config
                 .stackerdb
@@ -211,6 +211,14 @@ mod tests {
         let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
         response_bytes.extend(message);
         write_response(config.mock_server, response_bytes.as_slice());
+
+        let signer_message = SignerMessage::Transactions(vec![]);
+        let message = signer_message.serialize_to_vec();
+        let test_config = TestConfig::from_config(config.config);
+        let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
+        response_bytes.extend(message);
+        write_response(test_config.mock_server, response_bytes.as_slice());
+
         let transactions = h.join().unwrap().unwrap();
         assert_eq!(transactions, vec![tx]);
     }

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -106,7 +106,7 @@ impl StackerDB {
                 .collect();
 
             let send_request = || {
-                     self.signers_stackerdb_session
+                self.signers_stackerdb_session
                     .get_latest_chunks(&slot_ids)
                     .map_err(backoff::Error::transient)
             };
@@ -114,7 +114,7 @@ impl StackerDB {
             let mut transactions = Vec::new();
 
             if !chunk_ack.is_empty() {
-                for chunk in chunk_ack{
+                for chunk in chunk_ack {
                     if let Some(data) = chunk {
                         let message: SignerMessage = bincode::deserialize(&data).unwrap();
                         if let SignerMessage::Transactions(chunk_transactions) = message {
@@ -124,7 +124,7 @@ impl StackerDB {
                         }
                     }
                 }
-                return Ok(transactions)
+                return Ok(transactions);
             } else {
                 warn!("Recieved empty chuncks from stackerdb: {:?}", chunk_ack);
             }

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -369,49 +369,13 @@ impl StacksClient {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
-    use std::io::{BufWriter, Read, Write};
-    use std::net::{SocketAddr, TcpListener};
+mod tests {
+    use std::io::{BufWriter, Write};
     use std::thread::spawn;
 
     use super::*;
+    use crate::client::tests::{write_response, TestConfig};
     use crate::client::ClientError;
-
-    pub(crate) struct TestConfig {
-        pub(crate) mock_server: TcpListener,
-        pub(crate) client: StacksClient,
-    }
-
-    impl TestConfig {
-        pub(crate) fn new() -> Self {
-            let mut config = Config::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
-
-            let mut mock_server_addr = SocketAddr::from(([127, 0, 0, 1], 0));
-            // Ask the OS to assign a random port to listen on by passing 0
-            let mock_server = TcpListener::bind(mock_server_addr).unwrap();
-
-            // Update the config to use this port
-            mock_server_addr.set_port(mock_server.local_addr().unwrap().port());
-            config.node_host = mock_server_addr;
-
-            let client = StacksClient::from(&config);
-            Self {
-                mock_server,
-                client,
-            }
-        }
-    }
-
-    pub(crate) fn write_response(mock_server: TcpListener, bytes: &[u8]) -> [u8; 1024] {
-        debug!("Writing a response...");
-        let mut request_bytes = [0u8; 1024];
-        {
-            let mut stream = mock_server.accept().unwrap().0;
-            let _ = stream.read(&mut request_bytes).unwrap();
-            stream.write_all(bytes).unwrap();
-        }
-        request_bytes
-    }
 
     #[test]
     fn read_only_contract_call_200_success() {

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -22,7 +22,8 @@ use blockstack_lib::chainstate::stacks::{
     TransactionSpendingCondition, TransactionVersion,
 };
 use blockstack_lib::core::{
-    BITCOIN_MAINNET_STACKS_30_BURN_HEIGHT, BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT,
+    BITCOIN_MAINNET_STACKS_25_BURN_HEIGHT, BITCOIN_MAINNET_STACKS_30_BURN_HEIGHT,
+    BITCOIN_TESTNET_STACKS_25_BURN_HEIGHT, BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT,
 };
 use blockstack_lib::net::api::callreadonly::CallReadOnlyResponse;
 use blockstack_lib::net::api::getaccount::AccountEntryResponse;
@@ -61,6 +62,17 @@ pub struct StacksClient {
     stacks_node_client: reqwest::blocking::Client,
 }
 
+/// The supported epoch IDs
+#[derive(Debug, PartialEq)]
+pub enum EpochId {
+    /// The mainnet epoch ID
+    Epoch30,
+    /// The testnet epoch ID
+    Epoch25,
+    /// Unsuporrted epoch ID
+    UnsupportedEpoch,
+}
+
 impl From<&Config> for StacksClient {
     fn from(config: &Config) -> Self {
         Self {
@@ -83,13 +95,13 @@ impl StacksClient {
         let function_name_str = "stackerdb-get-signer-slots";
         let function_name = ClarityName::from(function_name_str);
         let function_args = &[];
-        let contract_response_hex = self.read_only_contract_call_with_retry(
+        let value = self.read_only_contract_call_with_retry(
             &stackerdb_contract.issuer.clone().into(),
             &stackerdb_contract.name,
             &function_name,
             function_args,
         )?;
-        self.parse_signer_slots(&contract_response_hex)
+        self.parse_signer_slots(value)
     }
     /// Retrieve the stacks tip consensus hash from the stacks node
     pub fn get_stacks_tip_consensus_hash(&self) -> Result<ConsensusHash, ClientError> {
@@ -97,16 +109,30 @@ impl StacksClient {
         Ok(peer_info.stacks_tip_consensus_hash)
     }
 
-    /// Determine if the stacks node is pre or post epoch 3.0 activation
-    pub fn is_pre_nakamoto(&self) -> Result<bool, ClientError> {
+    /// Determine the stacks node current epoch
+    pub fn get_node_epoch(&self) -> Result<EpochId, ClientError> {
         let is_mainnet = self.chain_id == CHAIN_ID_MAINNET;
         let burn_block_height = self.get_burn_block_height()?;
-        let epoch_30_activation_height = if is_mainnet {
-            BITCOIN_MAINNET_STACKS_30_BURN_HEIGHT
+
+        let (epoch25_activation_height, epoch_30_activation_height) = if is_mainnet {
+            (
+                BITCOIN_MAINNET_STACKS_25_BURN_HEIGHT,
+                BITCOIN_MAINNET_STACKS_30_BURN_HEIGHT,
+            )
         } else {
-            BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT
+            (
+                BITCOIN_TESTNET_STACKS_25_BURN_HEIGHT,
+                BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT,
+            )
         };
-        Ok(burn_block_height >= epoch_30_activation_height)
+
+        if burn_block_height < epoch25_activation_height {
+            Ok(EpochId::UnsupportedEpoch)
+        } else if burn_block_height < epoch_30_activation_height {
+            Ok(EpochId::Epoch25)
+        } else {
+            Ok(EpochId::Epoch30)
+        }
     }
 
     /// Submit the block proposal to the stacks node. The block will be validated and returned via the HTTP endpoint for Block events.
@@ -138,13 +164,13 @@ impl StacksClient {
         let function_name = ClarityName::from(function_name_str);
         let pox_contract_id = boot_code_id(POX_4_NAME, self.chain_id == CHAIN_ID_MAINNET);
         let function_args = &[ClarityValue::UInt(reward_cycle as u128)];
-        let contract_response_hex = self.read_only_contract_call_with_retry(
+        let value = self.read_only_contract_call_with_retry(
             &pox_contract_id.issuer.into(),
             &pox_contract_id.name,
             &function_name,
             function_args,
         )?;
-        self.parse_aggregate_public_key(&contract_response_hex)
+        self.parse_aggregate_public_key(value)
     }
 
     /// Retrieve the current account nonce for the provided address
@@ -227,11 +253,14 @@ impl StacksClient {
     }
 
     /// Helper function that attempts to deserialize a clarity hex string as the aggregate public key
-    fn parse_aggregate_public_key(&self, hex: &str) -> Result<Option<Point>, ClientError> {
-        debug!("Parsing aggregate public key: {hex}...");
+    fn parse_aggregate_public_key(
+        &self,
+        value: ClarityValue,
+    ) -> Result<Option<Point>, ClientError> {
+        debug!("Parsing aggregate public key...");
         // Due to pox 4 definition, the aggregate public key is always an optional clarity value hence the use of expect
         // If this fails, we have bigger problems than the signer crashing...
-        let value_opt = ClarityValue::try_deserialize_hex_untyped(hex)?.expect_optional()?;
+        let value_opt = value.expect_optional()?;
         let Some(value) = value_opt else {
             return Ok(None);
         };
@@ -248,11 +277,14 @@ impl StacksClient {
     }
 
     /// Helper function  that attempts to deserialize a clarity hext string as a list of signer slots and their associated number of signer slots
-    fn parse_signer_slots(&self, hex: &str) -> Result<Vec<(StacksAddress, u128)>, ClientError> {
-        debug!("Parsing signer slots: {hex}...");
-        // Due to .signers definition, the  signer slots is always a result of a list of tuples of signer addresses and the number of slots they have
+    fn parse_signer_slots(
+        &self,
+        value: ClarityValue,
+    ) -> Result<Vec<(StacksAddress, u128)>, ClientError> {
+        debug!("Parsing signer slots...");
+        // Due to .signers definition, the  signer slots is always an OK result of a list of tuples of signer addresses and the number of slots they have
         // If this fails, we have bigger problems than the signer crashing...
-        let value = ClarityValue::try_deserialize_hex_untyped(hex)?.expect_result_ok()?;
+        let value = value.clone().expect_result_ok()?;
         let values = value.expect_list()?;
         let mut signer_slots = Vec::with_capacity(values.len());
         for value in values {
@@ -279,61 +311,20 @@ impl StacksClient {
         function_args: &[ClarityValue],
     ) -> Result<Txid, ClientError> {
         debug!("Making a contract call to {contract_addr}.{contract_name}...");
-        let signed_tx = self.build_signed_transaction(
+        let nonce = self.get_account_nonce(&self.stacks_address)?;
+        // TODO: make tx_fee configurable
+        let signed_tx = Self::build_signed_contract_call_transaction(
             contract_addr,
             contract_name,
             function_name,
             function_args,
+            &self.stacks_private_key,
+            self.tx_version,
+            self.chain_id,
+            nonce,
+            10_000,
         )?;
         self.submit_tx(&signed_tx)
-    }
-
-    /// Helper function to create a stacks transaction for a modifying contract call
-    fn build_signed_transaction(
-        &self,
-        contract_addr: &StacksAddress,
-        contract_name: ContractName,
-        function_name: ClarityName,
-        function_args: &[ClarityValue],
-    ) -> Result<StacksTransaction, ClientError> {
-        let tx_payload = TransactionPayload::ContractCall(TransactionContractCall {
-            address: *contract_addr,
-            contract_name,
-            function_name,
-            function_args: function_args.to_vec(),
-        });
-        let public_key = StacksPublicKey::from_private(&self.stacks_private_key);
-        let tx_auth = TransactionAuth::Standard(
-            TransactionSpendingCondition::new_singlesig_p2pkh(public_key).ok_or(
-                ClientError::TransactionGenerationFailure(format!(
-                    "Failed to create spending condition from public key: {}",
-                    public_key.to_hex()
-                )),
-            )?,
-        );
-
-        let mut unsigned_tx = StacksTransaction::new(self.tx_version, tx_auth, tx_payload);
-
-        // FIXME: Because signers are given priority, we can put down a tx fee of 0
-        // https://github.com/stacks-network/stacks-blockchain/issues/4006
-        // Note: if set to 0 now, will cause a failure (MemPoolRejection::FeeTooLow)
-        unsigned_tx.set_tx_fee(10_000);
-        unsigned_tx.set_origin_nonce(self.get_account_nonce(&self.stacks_address)?);
-
-        unsigned_tx.anchor_mode = TransactionAnchorMode::Any;
-        unsigned_tx.post_condition_mode = TransactionPostConditionMode::Allow;
-        unsigned_tx.chain_id = self.chain_id;
-
-        let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
-        tx_signer
-            .sign_origin(&self.stacks_private_key)
-            .map_err(|e| ClientError::TransactionGenerationFailure(e.to_string()))?;
-
-        tx_signer
-            .get_tx()
-            .ok_or(ClientError::TransactionGenerationFailure(
-                "Failed to generate transaction from a transaction signer".to_string(),
-            ))
     }
 
     /// Helper function to submit a transaction to the Stacks node
@@ -362,7 +353,7 @@ impl StacksClient {
         contract_name: &ContractName,
         function_name: &ClarityName,
         function_args: &[ClarityValue],
-    ) -> Result<String, ClientError> {
+    ) -> Result<ClarityValue, ClientError> {
         debug!(
             "Calling read-only function {function_name} with args {:?}...",
             function_args
@@ -401,7 +392,9 @@ impl StacksClient {
                     .unwrap_or("unknown".to_string())
             )));
         }
-        Ok(call_read_only_response.result.unwrap_or_default())
+        let hex = call_read_only_response.result.unwrap_or_default();
+        let value = ClarityValue::try_deserialize_hex_untyped(&hex)?;
+        Ok(value)
     }
 
     fn pox_path(&self) -> String {
@@ -433,7 +426,59 @@ impl StacksClient {
     }
 
     fn accounts_path(&self, stacks_address: &StacksAddress) -> String {
-        format!("{}/v2/accounts/{stacks_address}", self.http_origin)
+        format!("{}/v2/accounts/{stacks_address}?proof=0", self.http_origin)
+    }
+
+    /// Helper function to create a stacks transaction for a modifying contract call
+    pub fn build_signed_contract_call_transaction(
+        contract_addr: &StacksAddress,
+        contract_name: ContractName,
+        function_name: ClarityName,
+        function_args: &[ClarityValue],
+        stacks_private_key: &StacksPrivateKey,
+        tx_version: TransactionVersion,
+        chain_id: u32,
+        nonce: u64,
+        tx_fee: u64,
+    ) -> Result<StacksTransaction, ClientError> {
+        let tx_payload = TransactionPayload::ContractCall(TransactionContractCall {
+            address: *contract_addr,
+            contract_name,
+            function_name,
+            function_args: function_args.to_vec(),
+        });
+        let public_key = StacksPublicKey::from_private(stacks_private_key);
+        let tx_auth = TransactionAuth::Standard(
+            TransactionSpendingCondition::new_singlesig_p2pkh(public_key).ok_or(
+                ClientError::TransactionGenerationFailure(format!(
+                    "Failed to create spending condition from public key: {}",
+                    public_key.to_hex()
+                )),
+            )?,
+        );
+
+        let mut unsigned_tx = StacksTransaction::new(tx_version, tx_auth, tx_payload);
+
+        // FIXME: Because signers are given priority, we can put down a tx fee of 0
+        // https://github.com/stacks-network/stacks-blockchain/issues/4006
+        // Note: if set to 0 now, will cause a failure (MemPoolRejection::FeeTooLow)
+        unsigned_tx.set_tx_fee(tx_fee);
+        unsigned_tx.set_origin_nonce(nonce);
+
+        unsigned_tx.anchor_mode = TransactionAnchorMode::Any;
+        unsigned_tx.post_condition_mode = TransactionPostConditionMode::Allow;
+        unsigned_tx.chain_id = chain_id;
+
+        let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
+        tx_signer
+            .sign_origin(stacks_private_key)
+            .map_err(|e| ClientError::TransactionGenerationFailure(e.to_string()))?;
+
+        tx_signer
+            .get_tx()
+            .ok_or(ClientError::TransactionGenerationFailure(
+                "Failed to generate transaction from a transaction signer".to_string(),
+            ))
     }
 }
 
@@ -443,6 +488,8 @@ mod tests {
     use std::thread::spawn;
 
     use libsigner::SIGNER_SLOTS_PER_USER;
+    use stacks_common::consts::CHAIN_ID_TESTNET;
+    use wsts::curve::scalar::Scalar;
 
     use super::*;
     use crate::client::tests::{write_response, TestConfig};
@@ -451,6 +498,9 @@ mod tests {
     #[test]
     fn read_only_contract_call_200_success() {
         let config = TestConfig::new();
+        let value = ClarityValue::UInt(10_u128);
+        let hex = value.to_string();
+        let response_bytes = format!("HTTP/1.1 200 OK\n\n{{\"okay\":true,\"result\":\"{hex}\"}}",);
         let h = spawn(move || {
             config.client.read_only_contract_call_with_retry(
                 &config.client.stacks_address,
@@ -459,17 +509,17 @@ mod tests {
                 &[],
             )
         });
-        write_response(
-            config.mock_server,
-            b"HTTP/1.1 200 OK\n\n{\"okay\":true,\"result\":\"0x070d0000000473425443\"}",
-        );
+        write_response(config.mock_server, response_bytes.as_bytes());
         let result = h.join().unwrap().unwrap();
-        assert_eq!(result, "0x070d0000000473425443");
+        assert_eq!(result, value);
     }
 
     #[test]
     fn read_only_contract_call_with_function_args_200_success() {
         let config = TestConfig::new();
+        let value = ClarityValue::UInt(10_u128);
+        let hex = value.to_string();
+        let response_bytes = format!("HTTP/1.1 200 OK\n\n{{\"okay\":true,\"result\":\"{hex}\"}}",);
         let h = spawn(move || {
             config.client.read_only_contract_call_with_retry(
                 &config.client.stacks_address,
@@ -478,12 +528,9 @@ mod tests {
                 &[ClarityValue::UInt(10_u128)],
             )
         });
-        write_response(
-            config.mock_server,
-            b"HTTP/1.1 200 OK\n\n{\"okay\":true,\"result\":\"0x070d0000000473425443\"}",
-        );
+        write_response(config.mock_server, response_bytes.as_bytes());
         let result = h.join().unwrap().unwrap();
-        assert_eq!(result, "0x070d0000000473425443");
+        assert_eq!(result, value);
     }
 
     #[test]
@@ -584,52 +631,95 @@ mod tests {
     }
 
     #[test]
+    fn get_aggregate_public_key_should_succeed() {
+        let current_reward_cycle_response = b"HTTP/1.1 200 Ok\n\n{\"contract_id\":\"ST000000000000000000002AMW42H.pox-3\",\"pox_activation_threshold_ustx\":829371801288885,\"first_burnchain_block_height\":2000000,\"current_burnchain_block_height\":2572192,\"prepare_phase_block_length\":50,\"reward_phase_block_length\":1000,\"reward_slots\":2000,\"rejection_fraction\":12,\"total_liquid_supply_ustx\":41468590064444294,\"current_cycle\":{\"id\":544,\"min_threshold_ustx\":5190000000000,\"stacked_ustx\":853258144644000,\"is_pox_active\":true},\"next_cycle\":{\"id\":545,\"min_threshold_ustx\":5190000000000,\"min_increment_ustx\":5183573758055,\"stacked_ustx\":847278759574000,\"prepare_phase_start_block_height\":2572200,\"blocks_until_prepare_phase\":8,\"reward_phase_start_block_height\":2572250,\"blocks_until_reward_phase\":58,\"ustx_until_pox_rejection\":4976230807733304},\"min_amount_ustx\":5190000000000,\"prepare_cycle_length\":50,\"reward_cycle_id\":544,\"reward_cycle_length\":1050,\"rejection_votes_left_required\":4976230807733304,\"next_reward_cycle_in\":58,\"contract_versions\":[{\"contract_id\":\"ST000000000000000000002AMW42H.pox\",\"activation_burnchain_block_height\":2000000,\"first_reward_cycle_id\":0},{\"contract_id\":\"ST000000000000000000002AMW42H.pox-2\",\"activation_burnchain_block_height\":2422102,\"first_reward_cycle_id\":403},{\"contract_id\":\"ST000000000000000000002AMW42H.pox-3\",\"activation_burnchain_block_height\":2432545,\"first_reward_cycle_id\":412}]}";
+        let orig_point = Point::from(Scalar::random(&mut rand::thread_rng()));
+        let clarity_value = ClarityValue::some(
+            ClarityValue::buff_from(orig_point.compress().as_bytes().to_vec())
+                .expect("BUG: Failed to create clarity value from point"),
+        )
+        .expect("BUG: Failed to create clarity value from point");
+        let hex = clarity_value
+            .serialize_to_hex()
+            .expect("Failed to serialize clarity value");
+        let response = format!("HTTP/1.1 200 OK\n\n{{\"okay\":true,\"result\":\"{hex}\"}}");
+
+        let test_config = TestConfig::new();
+        let config = test_config.config;
+        let h = spawn(move || test_config.client.get_aggregate_public_key());
+        write_response(test_config.mock_server, current_reward_cycle_response);
+
+        let test_config = TestConfig::from_config(config);
+        write_response(test_config.mock_server, response.as_bytes());
+        let res = h.join().unwrap().unwrap();
+        assert_eq!(res, Some(orig_point));
+
+        let clarity_value = ClarityValue::none();
+        let hex = clarity_value
+            .serialize_to_hex()
+            .expect("Failed to serialize clarity value");
+        let response = format!("HTTP/1.1 200 OK\n\n{{\"okay\":true,\"result\":\"{hex}\"}}");
+
+        let test_config = TestConfig::new();
+        let config = test_config.config;
+        let h = spawn(move || test_config.client.get_aggregate_public_key());
+        write_response(test_config.mock_server, current_reward_cycle_response);
+
+        let test_config = TestConfig::from_config(config);
+        write_response(test_config.mock_server, response.as_bytes());
+
+        let res = h.join().unwrap().unwrap();
+        assert!(res.is_none());
+    }
+
+    #[test]
     fn parse_valid_aggregate_public_key_should_succeed() {
         let config = TestConfig::new();
-        let clarity_value_hex =
-            "0x0a020000002103beca18a0e51ea31d8e66f58a245d54791b277ad08e1e9826bf5f814334ac77e0";
+        let orig_point = Point::from(Scalar::random(&mut rand::thread_rng()));
+        let clarity_value = ClarityValue::some(
+            ClarityValue::buff_from(orig_point.compress().as_bytes().to_vec())
+                .expect("BUG: Failed to create clarity value from point"),
+        )
+        .expect("BUG: Failed to create clarity value from point");
         let result = config
             .client
-            .parse_aggregate_public_key(clarity_value_hex)
+            .parse_aggregate_public_key(clarity_value)
             .unwrap();
-        assert_eq!(
-            result.map(|point| point.to_string()),
-            Some("27XiJwhYDWdUrYAFNejKDhmY22jU1hmwyQ5nVDUJZPmbm".to_string())
-        );
+        assert_eq!(result, Some(orig_point));
 
-        let clarity_value_hex = "0x09";
-        let result = config
-            .client
-            .parse_aggregate_public_key(clarity_value_hex)
-            .unwrap();
+        let value = ClarityValue::none();
+        let result = config.client.parse_aggregate_public_key(value).unwrap();
         assert!(result.is_none());
     }
 
     #[test]
     fn parse_invalid_aggregate_public_key_should_fail() {
         let config = TestConfig::new();
-        let clarity_value_hex = "0x00";
-        let result = config.client.parse_aggregate_public_key(clarity_value_hex);
+        let value = ClarityValue::UInt(10_u128);
+        let result = config.client.parse_aggregate_public_key(value);
         assert!(matches!(
             result,
             Err(ClientError::ClaritySerializationError(..))
         ));
-        // TODO: add further tests for malformed clarity values (an optional of any other type for example)
     }
 
     #[ignore]
     #[test]
     fn transaction_contract_call_should_send_bytes_to_node() {
         let config = TestConfig::new();
-        let tx = config
-            .client
-            .build_signed_transaction(
-                &config.client.stacks_address,
-                ContractName::from("contract-name"),
-                ClarityName::from("function-name"),
-                &[],
-            )
-            .unwrap();
+        let private_key = StacksPrivateKey::new();
+        let tx = StacksClient::build_signed_contract_call_transaction(
+            &config.client.stacks_address,
+            ContractName::from("contract-name"),
+            ClarityName::from("function-name"),
+            &[],
+            &private_key,
+            TransactionVersion::Testnet,
+            CHAIN_ID_TESTNET,
+            0,
+            10_000,
+        )
+        .unwrap();
 
         let mut tx_bytes = [0u8; 1024];
         {
@@ -740,7 +830,7 @@ mod tests {
         let h = spawn(move || config.client.get_account_nonce(&address));
         write_response(
             config.mock_server,
-            b"HTTP/1.1 200 OK\n\n{\"nonce\":0,\"balance\":\"0x00000000000000000000000000000000\",\"locked\":\"0x00000000000000000000000000000000\",\"unlock_height\":0,\"balance_proof\":\"\",\"nonce_proof\":\"\"}"
+            b"HTTP/1.1 200 OK\n\n{\"nonce\":0,\"balance\":\"0x00000000000000000000000000000000\",\"locked\":\"0x00000000000000000000000000000000\",\"unlock_height\":0}"
         );
         let nonce = h.join().unwrap().expect("Failed to deserialize response");
         assert_eq!(nonce, 0);
@@ -753,7 +843,7 @@ mod tests {
         let h = spawn(move || config.client.get_account_nonce(&address));
         write_response(
             config.mock_server,
-            b"HTTP/1.1 200 OK\n\n{\"nonce\":\"invalid nonce\",\"balance\":\"0x00000000000000000000000000000000\",\"locked\":\"0x00000000000000000000000000000000\",\"unlock_height\":0,\"balance_proof\":\"\",\"nonce_proof\":\"\"}"
+            b"HTTP/1.1 200 OK\n\n{\"nonce\":\"invalid nonce\",\"balance\":\"0x00000000000000000000000000000000\",\"locked\":\"0x00000000000000000000000000000000\",\"unlock_height\":0}"
         );
         assert!(h.join().unwrap().is_err());
     }
@@ -763,10 +853,51 @@ mod tests {
         let config = TestConfig::new();
         let clarity_value_hex =
             "0x070b000000050c00000002096e756d2d736c6f7473010000000000000000000000000000000c067369676e6572051a8195196a9a7cf9c37cb13e1ed69a7bc047a84e050c00000002096e756d2d736c6f7473010000000000000000000000000000000c067369676e6572051a6505471146dcf722f0580911183f28bef30a8a890c00000002096e756d2d736c6f7473010000000000000000000000000000000c067369676e6572051a1d7f8e3936e5da5f32982cc47f31d7df9fb1b38a0c00000002096e756d2d736c6f7473010000000000000000000000000000000c067369676e6572051a126d1a814313c952e34c7840acec9211e1727fb80c00000002096e756d2d736c6f7473010000000000000000000000000000000c067369676e6572051a7374ea6bb39f2e8d3d334d62b9f302a977de339a";
-        let signer_slots = config.client.parse_signer_slots(clarity_value_hex).unwrap();
+        let value = ClarityValue::try_deserialize_hex_untyped(clarity_value_hex).unwrap();
+        let signer_slots = config.client.parse_signer_slots(value).unwrap();
         assert_eq!(signer_slots.len(), 5);
         signer_slots
             .into_iter()
             .for_each(|(_address, slots)| assert!(slots == SIGNER_SLOTS_PER_USER as u128));
+    }
+
+    #[test]
+    fn get_node_epoch_should_succeed() {
+        let config = TestConfig::new();
+        let h = spawn(move || config.client.get_node_epoch());
+        write_response(
+            config.mock_server,
+            b"HTTP/1.1 200 OK\n\n{\"burn_block_height\":2575799,\"peer_version\":4207599113,\"pox_consensus\":\"64c8c3049ff6b939c65828e3168210e6bb32d880\",\"stable_pox_consensus\":\"72277bf9a3b115e13c0942825480d6cee0e9a0e8\",\"stable_burn_block_height\":2575792,\"server_version\":\"stacks-node d657bdd (feat/epoch-2.4:d657bdd, release build, linux [x86_64])\",\"network_id\":2147483648,\"parent_network_id\":118034699,\"stacks_tip_height\":145152,\"stacks_tip\":\"77219884fe434c0fa270d65592b4f082ab3e5d9922ac2bdaac34310aedc3d298\",\"stacks_tip_consensus_hash\":\"64c8c3049ff6b939c65828e3168210e6bb32d880\",\"genesis_chainstate_hash\":\"74237aa39aa50a83de11a4f53e9d3bb7d43461d1de9873f402e5453ae60bc59b\",\"unanchored_tip\":\"dde44222b6e6d81583b6b9c55db83e8716943ae9d0dc332fc39448ddd9b99dc2\",\"unanchored_seq\":0,\"exit_at_block_height\":null,\"node_public_key\":\"023c940136d5795d9dd82c0e87f4dd6a2a1db245444e7d70e34bb9605c3c3917b0\",\"node_public_key_hash\":\"e26cce8f6abe06b9fc81c3b11bcc821d2f1b8fd0\"}",
+        );
+        let epoch = h.join().unwrap().expect("Failed to deserialize response");
+        assert_eq!(epoch, EpochId::UnsupportedEpoch);
+
+        let config = TestConfig::new();
+        let h = spawn(move || config.client.get_node_epoch());
+        let height = BITCOIN_TESTNET_STACKS_25_BURN_HEIGHT;
+        let response_bytes = format!("HTTP/1.1 200 OK\n\n{{\"burn_block_height\":{height},\"peer_version\":4207599113,\"pox_consensus\":\"64c8c3049ff6b939c65828e3168210e6bb32d880\",\"stable_pox_consensus\":\"72277bf9a3b115e13c0942825480d6cee0e9a0e8\",\"stable_burn_block_height\":2575792,\"server_version\":\"stacks-node d657bdd (feat/epoch-2.4:d657bdd, release build, linux [x86_64])\",\"network_id\":2147483648,\"parent_network_id\":118034699,\"stacks_tip_height\":145152,\"stacks_tip\":\"77219884fe434c0fa270d65592b4f082ab3e5d9922ac2bdaac34310aedc3d298\",\"stacks_tip_consensus_hash\":\"64c8c3049ff6b939c65828e3168210e6bb32d880\",\"genesis_chainstate_hash\":\"74237aa39aa50a83de11a4f53e9d3bb7d43461d1de9873f402e5453ae60bc59b\",\"unanchored_tip\":\"dde44222b6e6d81583b6b9c55db83e8716943ae9d0dc332fc39448ddd9b99dc2\",\"unanchored_seq\":0,\"exit_at_block_height\":null,\"node_public_key\":\"023c940136d5795d9dd82c0e87f4dd6a2a1db245444e7d70e34bb9605c3c3917b0\",\"node_public_key_hash\":\"e26cce8f6abe06b9fc81c3b11bcc821d2f1b8fd0\"}}");
+
+        write_response(config.mock_server, response_bytes.as_bytes());
+        let epoch = h.join().unwrap().expect("Failed to deserialize response");
+        assert_eq!(epoch, EpochId::Epoch25);
+
+        let config = TestConfig::new();
+        let h = spawn(move || config.client.get_node_epoch());
+        let height = BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT;
+        let response_bytes = format!("HTTP/1.1 200 OK\n\n{{\"burn_block_height\":{height},\"peer_version\":4207599113,\"pox_consensus\":\"64c8c3049ff6b939c65828e3168210e6bb32d880\",\"stable_pox_consensus\":\"72277bf9a3b115e13c0942825480d6cee0e9a0e8\",\"stable_burn_block_height\":2575792,\"server_version\":\"stacks-node d657bdd (feat/epoch-2.4:d657bdd, release build, linux [x86_64])\",\"network_id\":2147483648,\"parent_network_id\":118034699,\"stacks_tip_height\":145152,\"stacks_tip\":\"77219884fe434c0fa270d65592b4f082ab3e5d9922ac2bdaac34310aedc3d298\",\"stacks_tip_consensus_hash\":\"64c8c3049ff6b939c65828e3168210e6bb32d880\",\"genesis_chainstate_hash\":\"74237aa39aa50a83de11a4f53e9d3bb7d43461d1de9873f402e5453ae60bc59b\",\"unanchored_tip\":\"dde44222b6e6d81583b6b9c55db83e8716943ae9d0dc332fc39448ddd9b99dc2\",\"unanchored_seq\":0,\"exit_at_block_height\":null,\"node_public_key\":\"023c940136d5795d9dd82c0e87f4dd6a2a1db245444e7d70e34bb9605c3c3917b0\",\"node_public_key_hash\":\"e26cce8f6abe06b9fc81c3b11bcc821d2f1b8fd0\"}}");
+        write_response(config.mock_server, response_bytes.as_bytes());
+        let epoch = h.join().unwrap().expect("Failed to deserialize response");
+        assert_eq!(epoch, EpochId::Epoch30);
+    }
+
+    #[test]
+    fn get_node_epoch_should_fail() {
+        let config = TestConfig::new();
+        let h = spawn(move || config.client.get_node_epoch());
+        write_response(
+            config.mock_server,
+            b"HTTP/1.1 200 OK\n\n4e99f99bc4a05437abb8c7d0c306618f45b203196498e2ebe287f10497124958",
+        );
+        assert!(h.join().unwrap().is_err());
     }
 }

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -81,8 +81,7 @@ impl StacksClient {
         stackerdb_contract: &QualifiedContractIdentifier,
     ) -> Result<Vec<(StacksAddress, u128)>, ClientError> {
         let function_name_str = "stackerdb-get-signer-slots";
-        let function_name = ClarityName::try_from(function_name_str)
-            .map_err(|_| ClientError::InvalidClarityName(function_name_str.to_string()))?;
+        let function_name = ClarityName::from(function_name_str);
         let function_args = &[];
         let contract_response_hex = self.read_only_contract_call_with_retry(
             &stackerdb_contract.issuer.clone().into(),
@@ -136,8 +135,7 @@ impl StacksClient {
     pub fn get_aggregate_public_key(&self) -> Result<Option<Point>, ClientError> {
         let reward_cycle = self.get_current_reward_cycle()?;
         let function_name_str = "get-aggregate-public-key";
-        let function_name = ClarityName::try_from(function_name_str)
-            .map_err(|_| ClientError::InvalidClarityName(function_name_str.to_string()))?;
+        let function_name = ClarityName::from(function_name_str);
         let pox_contract_id = boot_code_id(POX_4_NAME, self.chain_id == CHAIN_ID_MAINNET);
         let function_args = &[ClarityValue::UInt(reward_cycle as u128)];
         let contract_response_hex = self.read_only_contract_call_with_retry(
@@ -456,8 +454,8 @@ mod tests {
         let h = spawn(move || {
             config.client.read_only_contract_call_with_retry(
                 &config.client.stacks_address,
-                &ContractName::try_from("contract-name").unwrap(),
-                &ClarityName::try_from("function-name").unwrap(),
+                &ContractName::from("contract-name"),
+                &ClarityName::from("function-name"),
                 &[],
             )
         });
@@ -475,8 +473,8 @@ mod tests {
         let h = spawn(move || {
             config.client.read_only_contract_call_with_retry(
                 &config.client.stacks_address,
-                &ContractName::try_from("contract-name").unwrap(),
-                &ClarityName::try_from("function-name").unwrap(),
+                &ContractName::from("contract-name"),
+                &ClarityName::from("function-name"),
                 &[ClarityValue::UInt(10_u128)],
             )
         });
@@ -494,8 +492,8 @@ mod tests {
         let h = spawn(move || {
             config.client.read_only_contract_call_with_retry(
                 &config.client.stacks_address,
-                &ContractName::try_from("contract-name").unwrap(),
-                &ClarityName::try_from("function-name").unwrap(),
+                &ContractName::from("contract-name"),
+                &ClarityName::from("function-name"),
                 &[],
             )
         });
@@ -514,8 +512,8 @@ mod tests {
         let h = spawn(move || {
             config.client.read_only_contract_call_with_retry(
                 &config.client.stacks_address,
-                &ContractName::try_from("contract-name").unwrap(),
-                &ClarityName::try_from("function-name").unwrap(),
+                &ContractName::from("contract-name"),
+                &ClarityName::from("function-name"),
                 &[],
             )
         });
@@ -536,8 +534,8 @@ mod tests {
         let h = spawn(move || {
             config.client.read_only_contract_call_with_retry(
                 &config.client.stacks_address,
-                &ContractName::try_from("contract-name").unwrap(),
-                &ClarityName::try_from("function-name").unwrap(),
+                &ContractName::from("contract-name"),
+                &ClarityName::from("function-name"),
                 &[],
             )
         });
@@ -627,8 +625,8 @@ mod tests {
             .client
             .build_signed_transaction(
                 &config.client.stacks_address,
-                ContractName::try_from("contract-name").unwrap(),
-                ClarityName::try_from("function-name").unwrap(),
+                ContractName::from("contract-name"),
+                ClarityName::from("function-name"),
                 &[],
             )
             .unwrap();
@@ -674,8 +672,8 @@ mod tests {
         let h = spawn(move || {
             config.client.transaction_contract_call(
                 &config.client.stacks_address,
-                ContractName::try_from("contract-name").unwrap(),
-                ClarityName::try_from("function-name").unwrap(),
+                ContractName::from("contract-name"),
+                ClarityName::from("function-name"),
                 &[],
             )
         });

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -115,6 +115,7 @@ impl Network {
 }
 
 /// The parsed configuration for the signer
+#[derive(Clone, Debug)]
 pub struct Config {
     /// endpoint to the stacks node
     pub node_host: SocketAddr,

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -42,19 +42,16 @@ use libsigner::{
 };
 use libstackerdb::StackerDBChunkData;
 use slog::{slog_debug, slog_error};
-use stacks_common::address::{
-    AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-};
 use stacks_common::codec::read_next;
-use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
+use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey};
 use stacks_common::{debug, error};
 use stacks_signer::cli::{
     Cli, Command, GenerateFilesArgs, GetChunkArgs, GetLatestChunkArgs, PutChunkArgs, RunDkgArgs,
     SignArgs, StackerDBArgs,
 };
-use stacks_signer::config::{Config, Network};
+use stacks_signer::config::Config;
 use stacks_signer::runloop::{RunLoop, RunLoopCommand};
-use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract};
+use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract, to_addr};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 use wsts::state_machine::coordinator::fire::Coordinator as FireCoordinator;
@@ -302,6 +299,7 @@ fn handle_generate_files(args: GenerateFilesArgs) {
         &args.host.to_string(),
         &args.signers_contract.to_string(),
         args.timeout.map(Duration::from_millis),
+        &args.network,
     );
     debug!("Built {:?} signer config tomls.", signer_config_tomls.len());
     for (i, file_contents) in signer_config_tomls.iter().enumerate() {
@@ -355,20 +353,6 @@ fn main() {
             handle_generate_files(args);
         }
     }
-}
-
-fn to_addr(stacks_private_key: &StacksPrivateKey, network: &Network) -> StacksAddress {
-    let version = match network {
-        Network::Mainnet => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-        Network::Testnet | Network::Mocknet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-    };
-    StacksAddress::from_public_keys(
-        version,
-        &AddressHashMode::SerializeP2PKH,
-        1,
-        &vec![StacksPublicKey::from_private(stacks_private_key)],
-    )
-    .unwrap()
 }
 
 #[cfg(test)]

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -262,7 +262,7 @@ fn handle_run(args: RunDkgArgs) {
 fn handle_generate_files(args: GenerateFilesArgs) {
     debug!("Generating files...");
     let signer_stacks_private_keys = if let Some(path) = args.private_keys {
-        let file = File::open(&path).unwrap();
+        let file = File::open(path).unwrap();
         let reader = io::BufReader::new(file);
 
         let private_keys: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -297,7 +297,7 @@ impl<C: Coordinator> RunLoop<C> {
                 .keys()
                 .cloned()
                 .collect();
-            let Ok(transactions) = self.stackerdb.get_signer_transactions(&signer_ids) else {
+            let Ok(transactions) = self.stackerdb.get_signer_transactions_with_retry(&signer_ids) else {
                 // Failed to connect to the stacks node to get transcations. Cannot validate the block.
                 return;
             };
@@ -481,7 +481,7 @@ impl<C: Coordinator> RunLoop<C> {
             .keys()
             .cloned()
             .collect();
-        let Ok(transactions) = self.stackerdb.get_signer_transactions(&signer_ids) else {
+        let Ok(transactions) = self.stackerdb.get_signer_transactions_with_retry(&signer_ids) else {
             // Failed to connect to the stacks node to get transcations. Cannot validate the block.
             return false;
         };

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -329,7 +329,7 @@ impl<C: Coordinator> RunLoop<C> {
         let packets: Vec<Packet> = messages
             .into_iter()
             .filter_map(|msg| match msg {
-                SignerMessage::BlockResponse(_) => None,
+                SignerMessage::BlockResponse(_) | SignerMessage::Transactions(_) => None,
                 SignerMessage::Packet(packet) => {
                     self.verify_packet(packet, &coordinator_public_key)
                 }

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -593,10 +593,7 @@ impl<C: Coordinator> RunLoop<C> {
                     }
                     // Always broadcast the transactions to stackerdb so miners and signers can observe it when building and validating the block, respectively.
                     let signer_message = SignerMessage::Transactions(self.transactions.clone());
-                    if let Err(e) = self
-                        .stackerdb
-                        .send_message_with_retry(self.signing_round.signer_id, signer_message)
-                    {
+                    if let Err(e) = self.stackerdb.send_message_with_retry(signer_message) {
                         warn!("Failed to update transactions in stacker-db: {:?}", e);
                     }
                 }

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -927,7 +927,7 @@ mod tests {
     use rand::Rng;
 
     use super::*;
-    use crate::client::stacks_client::tests::{write_response, TestConfig};
+    use crate::client::tests::{write_response, TestConfig};
 
     fn generate_random_consensus_hash() -> String {
         let rng = rand::thread_rng();

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -289,7 +289,7 @@ impl<C: Coordinator> RunLoop<C> {
                 block_info.valid = Some(false);
                 // Submit a rejection response to the .signers contract for miners
                 // to observe so they know to send another block and to prove signers are doing work);
-                debug!("Broadcasting a block rejection due to stacks node validation failure...");
+                warn!("Broadcasting a block rejection due to stacks node validation failure...");
                 if let Err(e) = self
                     .stackerdb
                     .send_message_with_retry(block_validate_reject.into())
@@ -1363,35 +1363,35 @@ mod tests {
 
         // Simulate the response to the request for transactions with the expected transaction
         let signer_message = SignerMessage::Transactions(vec![valid_tx]);
-        let message = bincode::serialize(&signer_message).unwrap();
+        let message = signer_message.serialize_to_vec();
         let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
         response_bytes.extend(message);
         let test_config = TestConfig::from_config(config.clone());
         write_response(test_config.mock_server, response_bytes.as_slice());
 
         let signer_message = SignerMessage::Transactions(vec![]);
-        let message = bincode::serialize(&signer_message).unwrap();
+        let message = signer_message.serialize_to_vec();
         let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
         response_bytes.extend(message);
         let test_config = TestConfig::from_config(config.clone());
         write_response(test_config.mock_server, response_bytes.as_slice());
 
         let signer_message = SignerMessage::Transactions(vec![]);
-        let message = bincode::serialize(&signer_message).unwrap();
+        let message = signer_message.serialize_to_vec();
         let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
         response_bytes.extend(message);
         let test_config = TestConfig::from_config(config.clone());
         write_response(test_config.mock_server, response_bytes.as_slice());
 
         let signer_message = SignerMessage::Transactions(vec![]);
-        let message = bincode::serialize(&signer_message).unwrap();
+        let message = signer_message.serialize_to_vec();
         let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
         response_bytes.extend(message);
         let test_config = TestConfig::from_config(config.clone());
         write_response(test_config.mock_server, response_bytes.as_slice());
 
         let signer_message = SignerMessage::Transactions(vec![]);
-        let message = bincode::serialize(&signer_message).unwrap();
+        let message = signer_message.serialize_to_vec();
         let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
         response_bytes.extend(message);
         let test_config = TestConfig::from_config(config.clone());

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -587,6 +587,18 @@ impl<C: Coordinator> RunLoop<C> {
                 }
                 OperationResult::Dkg(_point) => {
                     // TODO: cast the aggregate public key for the latest round here
+                    // Broadcast via traditional methods to the stacks node if we are pre nakamoto or we cannot determine our Epoch
+                    if self.stacks_client.is_pre_nakamoto().unwrap_or(false) {
+                        // We are in the pre-nakamoto phase. Broadcast the aggregate public key stx transaction to the stacks node via the mempool
+                    }
+                    // Always broadcast the transactions to stackerdb so miners and signers can observe it when building and validating the block, respectively.
+                    let signer_message = SignerMessage::Transactions(self.transactions.clone());
+                    if let Err(e) = self
+                        .stackerdb
+                        .send_message_with_retry(self.signing_round.signer_id, signer_message)
+                    {
+                        warn!("Failed to update transactions in stacker-db: {:?}", e);
+                    }
                 }
                 OperationResult::SignError(e) => {
                     self.process_sign_error(e);

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -297,7 +297,10 @@ impl<C: Coordinator> RunLoop<C> {
                 .keys()
                 .cloned()
                 .collect();
-            let Ok(transactions) = self.stackerdb.get_signer_transactions_with_retry(&signer_ids) else {
+            let Ok(transactions) = self
+                .stackerdb
+                .get_signer_transactions_with_retry(&signer_ids)
+            else {
                 // Failed to connect to the stacks node to get transcations. Cannot validate the block.
                 return;
             };
@@ -481,7 +484,10 @@ impl<C: Coordinator> RunLoop<C> {
             .keys()
             .cloned()
             .collect();
-        let Ok(transactions) = self.stackerdb.get_signer_transactions_with_retry(&signer_ids) else {
+        let Ok(transactions) = self
+            .stackerdb
+            .get_signer_transactions_with_retry(&signer_ids)
+        else {
             // Failed to connect to the stacks node to get transcations. Cannot validate the block.
             return false;
         };

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -880,14 +880,16 @@ mod tests {
         let bytes: Vec<u8> = rng.sample_iter(Standard).take(20).collect();
         bytes.iter().map(|b| format!("{:02x}", b)).collect()
     }
+
     fn mock_stacks_client_response(mock_server: TcpListener, random_consensus: bool) {
         let consensus_hash = match random_consensus {
             true => generate_random_consensus_hash(),
-            false => "static_hash_value".to_string(),
+            false => "64c8c3049ff6b939c65828e3168210e6bb32d880".to_string(),
         };
 
+        println!("{}", consensus_hash);
         let response = format!(
-            "HTTP/1.1 200 OK\n\n{{\"stacks_tip_consensus_hash\": \"{}\"}}",
+            "HTTP/1.1 200 OK\n\n{{\"stacks_tip_consensus_hash\":\"{}\",\"peer_version\":4207599113,\"pox_consensus\":\"64c8c3049ff6b939c65828e3168210e6bb32d880\",\"burn_block_height\":2575799,\"stable_pox_consensus\":\"72277bf9a3b115e13c0942825480d6cee0e9a0e8\",\"stable_burn_block_height\":2575792,\"server_version\":\"stacks-node d657bdd (feat/epoch-2.4:d657bdd, release build, linux [x86_64])\",\"network_id\":2147483648,\"parent_network_id\":118034699,\"stacks_tip_height\":145152,\"stacks_tip\":\"77219884fe434c0fa270d65592b4f082ab3e5d9922ac2bdaac34310aedc3d298\",\"genesis_chainstate_hash\":\"74237aa39aa50a83de11a4f53e9d3bb7d43461d1de9873f402e5453ae60bc59b\",\"unanchored_tip\":\"dde44222b6e6d81583b6b9c55db83e8716943ae9d0dc332fc39448ddd9b99dc2\",\"unanchored_seq\":0,\"exit_at_block_height\":null,\"node_public_key\":\"023c940136d5795d9dd82c0e87f4dd6a2a1db245444e7d70e34bb9605c3c3917b0\",\"node_public_key_hash\":\"e26cce8f6abe06b9fc81c3b11bcc821d2f1b8fd0\"}}",
             consensus_hash
         );
 

--- a/stacks-signer/src/tests/conf/signer-0.toml
+++ b/stacks-signer/src/tests/conf/signer-0.toml
@@ -1,19 +1,14 @@
 
-message_private_key = "2ZCxUV9BAKJrGnTPaamKHb4HVgj9ArQgEhowuTe7uRt3"
-stacks_private_key = "69be0e68947fa7128702761151dc8d9b39ee1401e547781bb2ec3e5b4eb1b36f01"
+stacks_private_key = "6a1fc1a3183018c6d79a4e11e154d2bdad2d89ac8bc1b0a021de8b4d28774fbb01"
 node_host = "127.0.0.1:20443"
 endpoint = "localhost:30000"
 network = "testnet"
 stackerdb_contract_id = "ST11Z60137Y96MF89K1KKRTA3CR6B25WY1Y931668.signers-stackerdb"
 signer_id = 0
 signers = [
-            {public_key = "swBaKxfzs4pQne7spxhrkF6AtB34WEcreAkJ8mPcqx3t", key_ids = [1, 2, 3, 4]}
-        ,
-            {public_key = "yDJhntuJczbss1XGDmyWtG9Wpw5NDqoBBnedxmyhKiFN", key_ids = [5, 6, 7, 8]}
-        ,
-            {public_key = "xNVCph6zd7HLLJcuwrWz1gNbFoPHjXxn7cyRvvTYhP3U", key_ids = [9, 10, 11, 12]}
-        ,
-            {public_key = "p2wFfLEbwGCmxCR5eGa46Ct6i3BVjFrvBixRn7FnCQjA", key_ids = [13, 14, 15, 16]}
-        ,
-            {public_key = "26jpUNnJPvzDJRJg3hfBn5s5MR4eQ4LLTokjrSDzByh4i", key_ids = [17, 18, 19, 20]}
-        ]
+    {public_key = "27MvzC7LYTFfjBQdZropBqzWSKQYgFVHWh3YXchYrh5Ug", key_ids = [1, 2, 3, 4]},
+    {public_key = "f1Y6JdedrZyaZLnScbXbc1A7DhdLMjCipKCxkKUA93YQ", key_ids = [5, 6, 7, 8]},
+    {public_key = "nKPew4JetMvV97EghsdikNMhgyYF37ZeNvmJNSJueyjQ", key_ids = [9, 10, 11, 12]},
+    {public_key = "x3LcNnYgKKFBUaf9fZTEGHghFCQQyd6F9XNWj7nRXLt7", key_ids = [13, 14, 15, 16]},
+    {public_key = "nUVH972kFxpKbD62muCb9L48nTKqNw11yp3vFM9VDzqw", key_ids = [17, 18, 19, 20]}
+]

--- a/stacks-signer/src/tests/conf/signer-1.toml
+++ b/stacks-signer/src/tests/conf/signer-1.toml
@@ -1,19 +1,14 @@
 
-message_private_key = "vZTMaCTufQ9YtZPUcqqKRgbxWWkLTxU5iySooPw81D1"
-stacks_private_key = "fd5a538e8548e9d6a4a4060a43d0142356df022a4b8fd8ed4a7d0663825f8d2c01"
+stacks_private_key = "126e916e77359ccf521e168feea1fcb9626c59dc375cae00c7464303381c7dff01"
 node_host = "127.0.0.1:20443"
 endpoint = "localhost:30001"
 network = "testnet"
 stackerdb_contract_id = "ST11Z60137Y96MF89K1KKRTA3CR6B25WY1Y931668.signers-stackerdb"
 signer_id = 1
 signers = [
-            {public_key = "swBaKxfzs4pQne7spxhrkF6AtB34WEcreAkJ8mPcqx3t", key_ids = [1, 2, 3, 4]}
-        ,
-            {public_key = "yDJhntuJczbss1XGDmyWtG9Wpw5NDqoBBnedxmyhKiFN", key_ids = [5, 6, 7, 8]}
-        ,
-            {public_key = "xNVCph6zd7HLLJcuwrWz1gNbFoPHjXxn7cyRvvTYhP3U", key_ids = [9, 10, 11, 12]}
-        ,
-            {public_key = "p2wFfLEbwGCmxCR5eGa46Ct6i3BVjFrvBixRn7FnCQjA", key_ids = [13, 14, 15, 16]}
-        ,
-            {public_key = "26jpUNnJPvzDJRJg3hfBn5s5MR4eQ4LLTokjrSDzByh4i", key_ids = [17, 18, 19, 20]}
-        ]
+    {public_key = "27MvzC7LYTFfjBQdZropBqzWSKQYgFVHWh3YXchYrh5Ug", key_ids = [1, 2, 3, 4]},
+    {public_key = "f1Y6JdedrZyaZLnScbXbc1A7DhdLMjCipKCxkKUA93YQ", key_ids = [5, 6, 7, 8]},
+    {public_key = "nKPew4JetMvV97EghsdikNMhgyYF37ZeNvmJNSJueyjQ", key_ids = [9, 10, 11, 12]},
+    {public_key = "x3LcNnYgKKFBUaf9fZTEGHghFCQQyd6F9XNWj7nRXLt7", key_ids = [13, 14, 15, 16]},
+    {public_key = "nUVH972kFxpKbD62muCb9L48nTKqNw11yp3vFM9VDzqw", key_ids = [17, 18, 19, 20]}
+]

--- a/stacks-signer/src/tests/conf/signer-2.toml
+++ b/stacks-signer/src/tests/conf/signer-2.toml
@@ -1,19 +1,14 @@
 
-message_private_key = "BZNqcMp82XykQ2z6NLc2h5cTJpPcLQ9AuKVtG4Ut7FY3"
-stacks_private_key = "74e8e8550a5210b89461128c600e4bf611d1553e6809308bc012dbb0fbb4818d01"
+stacks_private_key = "b169d0d1408f66d16beb321857f525f9014dfc289f1aeedbcf96e78afeb8eb4001"
 node_host = "127.0.0.1:20443"
 endpoint = "localhost:30002"
 network = "testnet"
 stackerdb_contract_id = "ST11Z60137Y96MF89K1KKRTA3CR6B25WY1Y931668.signers-stackerdb"
 signer_id = 2
 signers = [
-            {public_key = "swBaKxfzs4pQne7spxhrkF6AtB34WEcreAkJ8mPcqx3t", key_ids = [1, 2, 3, 4]}
-        ,
-            {public_key = "yDJhntuJczbss1XGDmyWtG9Wpw5NDqoBBnedxmyhKiFN", key_ids = [5, 6, 7, 8]}
-        ,
-            {public_key = "xNVCph6zd7HLLJcuwrWz1gNbFoPHjXxn7cyRvvTYhP3U", key_ids = [9, 10, 11, 12]}
-        ,
-            {public_key = "p2wFfLEbwGCmxCR5eGa46Ct6i3BVjFrvBixRn7FnCQjA", key_ids = [13, 14, 15, 16]}
-        ,
-            {public_key = "26jpUNnJPvzDJRJg3hfBn5s5MR4eQ4LLTokjrSDzByh4i", key_ids = [17, 18, 19, 20]}
-        ]
+    {public_key = "27MvzC7LYTFfjBQdZropBqzWSKQYgFVHWh3YXchYrh5Ug", key_ids = [1, 2, 3, 4]},
+    {public_key = "f1Y6JdedrZyaZLnScbXbc1A7DhdLMjCipKCxkKUA93YQ", key_ids = [5, 6, 7, 8]},
+    {public_key = "nKPew4JetMvV97EghsdikNMhgyYF37ZeNvmJNSJueyjQ", key_ids = [9, 10, 11, 12]},
+    {public_key = "x3LcNnYgKKFBUaf9fZTEGHghFCQQyd6F9XNWj7nRXLt7", key_ids = [13, 14, 15, 16]},
+    {public_key = "nUVH972kFxpKbD62muCb9L48nTKqNw11yp3vFM9VDzqw", key_ids = [17, 18, 19, 20]}
+]

--- a/stacks-signer/src/tests/conf/signer-3.toml
+++ b/stacks-signer/src/tests/conf/signer-3.toml
@@ -1,19 +1,14 @@
 
-message_private_key = "3fMkii13QRwRqrwgcLtxmAAcqCfGwpY3ANZLYMWD8qUj"
-stacks_private_key = "803fa7b9c8a39ed368f160b3dcbfaa8f677fc157ffbccb46ee3e4a32a37f12d201"
+stacks_private_key = "63cef3cd8880969b7f2450ca13b9ca57fd3cd3f7ee57ec6ed7654a84d39181e401"
 node_host = "127.0.0.1:20443"
 endpoint = "localhost:30003"
 network = "testnet"
 stackerdb_contract_id = "ST11Z60137Y96MF89K1KKRTA3CR6B25WY1Y931668.signers-stackerdb"
 signer_id = 3
 signers = [
-            {public_key = "swBaKxfzs4pQne7spxhrkF6AtB34WEcreAkJ8mPcqx3t", key_ids = [1, 2, 3, 4]}
-        ,
-            {public_key = "yDJhntuJczbss1XGDmyWtG9Wpw5NDqoBBnedxmyhKiFN", key_ids = [5, 6, 7, 8]}
-        ,
-            {public_key = "xNVCph6zd7HLLJcuwrWz1gNbFoPHjXxn7cyRvvTYhP3U", key_ids = [9, 10, 11, 12]}
-        ,
-            {public_key = "p2wFfLEbwGCmxCR5eGa46Ct6i3BVjFrvBixRn7FnCQjA", key_ids = [13, 14, 15, 16]}
-        ,
-            {public_key = "26jpUNnJPvzDJRJg3hfBn5s5MR4eQ4LLTokjrSDzByh4i", key_ids = [17, 18, 19, 20]}
-        ]
+    {public_key = "27MvzC7LYTFfjBQdZropBqzWSKQYgFVHWh3YXchYrh5Ug", key_ids = [1, 2, 3, 4]},
+    {public_key = "f1Y6JdedrZyaZLnScbXbc1A7DhdLMjCipKCxkKUA93YQ", key_ids = [5, 6, 7, 8]},
+    {public_key = "nKPew4JetMvV97EghsdikNMhgyYF37ZeNvmJNSJueyjQ", key_ids = [9, 10, 11, 12]},
+    {public_key = "x3LcNnYgKKFBUaf9fZTEGHghFCQQyd6F9XNWj7nRXLt7", key_ids = [13, 14, 15, 16]},
+    {public_key = "nUVH972kFxpKbD62muCb9L48nTKqNw11yp3vFM9VDzqw", key_ids = [17, 18, 19, 20]}
+]

--- a/stacks-signer/src/tests/conf/signer-4.toml
+++ b/stacks-signer/src/tests/conf/signer-4.toml
@@ -1,19 +1,14 @@
 
-message_private_key = "9hn4j7pm37WyG6WMX25dn8j8v8E2uyTCDRPNrucjDWn1"
-stacks_private_key = "1bfdf386114aacf355fe018a1ec7ac728fa05ca20a6131a70f686291bb9b31ca01"
+stacks_private_key = "e427196ae29197b1db6d5495ff26bf0675f48a4f07b200c0814b95734ecda60f01"
 node_host = "127.0.0.1:20443"
 endpoint = "localhost:30004"
 network = "testnet"
 stackerdb_contract_id = "ST11Z60137Y96MF89K1KKRTA3CR6B25WY1Y931668.signers-stackerdb"
 signer_id = 4
 signers = [
-            {public_key = "swBaKxfzs4pQne7spxhrkF6AtB34WEcreAkJ8mPcqx3t", key_ids = [1, 2, 3, 4]}
-        ,
-            {public_key = "yDJhntuJczbss1XGDmyWtG9Wpw5NDqoBBnedxmyhKiFN", key_ids = [5, 6, 7, 8]}
-        ,
-            {public_key = "xNVCph6zd7HLLJcuwrWz1gNbFoPHjXxn7cyRvvTYhP3U", key_ids = [9, 10, 11, 12]}
-        ,
-            {public_key = "p2wFfLEbwGCmxCR5eGa46Ct6i3BVjFrvBixRn7FnCQjA", key_ids = [13, 14, 15, 16]}
-        ,
-            {public_key = "26jpUNnJPvzDJRJg3hfBn5s5MR4eQ4LLTokjrSDzByh4i", key_ids = [17, 18, 19, 20]}
-        ]
+    {public_key = "27MvzC7LYTFfjBQdZropBqzWSKQYgFVHWh3YXchYrh5Ug", key_ids = [1, 2, 3, 4]},
+    {public_key = "f1Y6JdedrZyaZLnScbXbc1A7DhdLMjCipKCxkKUA93YQ", key_ids = [5, 6, 7, 8]},
+    {public_key = "nKPew4JetMvV97EghsdikNMhgyYF37ZeNvmJNSJueyjQ", key_ids = [9, 10, 11, 12]},
+    {public_key = "x3LcNnYgKKFBUaf9fZTEGHghFCQQyd6F9XNWj7nRXLt7", key_ids = [13, 14, 15, 16]},
+    {public_key = "nUVH972kFxpKbD62muCb9L48nTKqNw11yp3vFM9VDzqw", key_ids = [17, 18, 19, 20]}
+]

--- a/stacks-signer/src/utils.rs
+++ b/stacks-signer/src/utils.rs
@@ -16,9 +16,6 @@
 use std::time::Duration;
 
 use slog::slog_debug;
-use stacks_common::address::{
-    AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-};
 use stacks_common::debug;
 use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
 use stacks_common::types::PrivateKey;
@@ -146,15 +143,8 @@ pub fn build_stackerdb_contract(
 
 /// Helper function to convert a private key to a Stacks address
 pub fn to_addr(stacks_private_key: &StacksPrivateKey, network: &Network) -> StacksAddress {
-    let version = match network {
-        Network::Mainnet => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-        Network::Testnet | Network::Mocknet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-    };
-    StacksAddress::from_public_keys(
-        version,
-        &AddressHashMode::SerializeP2PKH,
-        1,
-        &vec![StacksPublicKey::from_private(stacks_private_key)],
+    StacksAddress::p2pkh(
+        network.is_mainnet(),
+        &StacksPublicKey::from_private(stacks_private_key),
     )
-    .expect("BUG: failed to generate address from private key")
 }

--- a/stacks-signer/src/utils.rs
+++ b/stacks-signer/src/utils.rs
@@ -15,23 +15,28 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use std::time::Duration;
 
-use rand_core::OsRng;
 use slog::slog_debug;
+use stacks_common::address::{
+    AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+};
 use stacks_common::debug;
-use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey};
+use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
+use stacks_common::types::PrivateKey;
 use wsts::curve::ecdsa;
 use wsts::curve::scalar::Scalar;
 
+use crate::config::Network;
+
 /// Helper function for building a signer config for each provided signer private key
 pub fn build_signer_config_tomls(
-    signer_stacks_private_keys: &[StacksPrivateKey],
+    stacks_private_keys: &[StacksPrivateKey],
     num_keys: u32,
     node_host: &str,
     stackerdb_contract_id: &str,
     timeout: Option<Duration>,
+    network: &Network,
 ) -> Vec<String> {
-    let num_signers = signer_stacks_private_keys.len() as u32;
-    let mut rng = OsRng;
+    let num_signers = stacks_private_keys.len() as u32;
     let keys_per_signer = num_keys / num_signers;
     let mut key_id: u32 = 1;
     let mut key_ids = Vec::new();
@@ -52,40 +57,40 @@ pub fn build_signer_config_tomls(
         }
         key_ids.push(ids.join(", "));
     }
-    let signer_ecdsa_private_keys = (0..num_signers)
-        .map(|_| Scalar::random(&mut rng))
-        .collect::<Vec<Scalar>>();
 
     let mut signer_config_tomls = vec![];
     let mut signers_array = String::new();
+
     signers_array += "signers = [";
-    for (i, private_key) in signer_ecdsa_private_keys.iter().enumerate() {
-        let ecdsa_public_key = ecdsa::PublicKey::new(private_key).unwrap().to_string();
+    for (i, stacks_private_key) in stacks_private_keys.iter().enumerate() {
+        let scalar = Scalar::try_from(&stacks_private_key.to_bytes()[..32])
+            .expect("BUG: failed to convert the StacksPrivateKey to a Scalar");
+        let ecdsa_public_key = ecdsa::PublicKey::new(&scalar)
+            .expect("BUG: failed to get a ecdsa::PublicKey from the provided Scalar")
+            .to_string();
         let ids = key_ids[i].clone();
         signers_array += &format!(
             r#"
-            {{public_key = "{ecdsa_public_key}", key_ids = [{ids}]}}
-        "#
+    {{public_key = "{ecdsa_public_key}", key_ids = [{ids}]}}"#
         );
-        if i != signer_ecdsa_private_keys.len() - 1 {
+        if i != stacks_private_keys.len() - 1 {
             signers_array += ",";
         }
     }
-    signers_array += "]";
+    signers_array += "\n]";
+
     let mut port = 30000;
-    for (i, stacks_private_key) in signer_stacks_private_keys.iter().enumerate() {
+    for (i, stacks_private_key) in stacks_private_keys.iter().enumerate() {
         let endpoint = format!("localhost:{}", port);
         port += 1;
         let id = i;
-        let message_private_key = signer_ecdsa_private_keys[i].to_string();
         let stacks_private_key = stacks_private_key.to_hex();
         let mut signer_config_toml = format!(
             r#"
-message_private_key = "{message_private_key}"
 stacks_private_key = "{stacks_private_key}"
 node_host = "{node_host}"
 endpoint = "{endpoint}"
-network = "testnet"
+network = "{network}"
 stackerdb_contract_id = "{stackerdb_contract_id}"
 signer_id = {id}
 {signers_array}
@@ -137,4 +142,19 @@ pub fn build_stackerdb_contract(
     stackerdb_contract += "            }))\n";
     stackerdb_contract += "    ";
     stackerdb_contract
+}
+
+/// Helper function to convert a private key to a Stacks address
+pub fn to_addr(stacks_private_key: &StacksPrivateKey, network: &Network) -> StacksAddress {
+    let version = match network {
+        Network::Mainnet => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+        Network::Testnet | Network::Mocknet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+    };
+    StacksAddress::from_public_keys(
+        version,
+        &AddressHashMode::SerializeP2PKH,
+        1,
+        &vec![StacksPublicKey::from_private(stacks_private_key)],
+    )
+    .expect("BUG: failed to generate address from private key")
 }

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
@@ -7,13 +8,19 @@ use std::{env, thread};
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use libsigner::{
-    BlockResponse, RunningSigner, Signer, SignerEventReceiver, SignerMessage, BLOCK_SLOT_ID,
-    SIGNER_SLOTS_PER_USER,
+    BlockResponse, RejectCode, RunningSigner, Signer, SignerEventReceiver, SignerMessage,
+    BLOCK_SLOT_ID, SIGNER_SLOTS_PER_USER,
 };
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader};
-use stacks::chainstate::stacks::{StacksPrivateKey, ThresholdSignature};
+use stacks::chainstate::stacks::boot::SIGNERS_NAME;
+use stacks::chainstate::stacks::{
+    StacksPrivateKey, StacksTransaction, ThresholdSignature, TransactionAnchorMode,
+    TransactionAuth, TransactionPayload, TransactionPostConditionMode, TransactionSmartContract,
+    TransactionVersion,
+};
 use stacks::net::api::postblock_proposal::BlockValidateResponse;
+use stacks::util_lib::strings::StacksString;
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::read_next;
 use stacks_common::types::chainstate::{
@@ -21,8 +28,8 @@ use stacks_common::types::chainstate::{
 };
 use stacks_common::util::hash::{MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::MessageSignature;
-use stacks_signer::client::StacksClient;
-use stacks_signer::config::Config as SignerConfig;
+use stacks_signer::client::{StackerDB, StacksClient};
+use stacks_signer::config::{Config as SignerConfig, Network};
 use stacks_signer::runloop::{calculate_coordinator, RunLoopCommand};
 use stacks_signer::utils::{build_signer_config_tomls, build_stackerdb_contract};
 use tracing_subscriber::prelude::*;
@@ -73,6 +80,8 @@ struct SignerTest {
     pub running_coordinator: RunningSigner<SignerEventReceiver, Vec<OperationResult>>,
     // The running signer and its threads
     pub running_signers: HashMap<u32, RunningSigner<SignerEventReceiver, Vec<OperationResult>>>,
+    // the private keys of the signers
+    pub signer_stacks_private_keys: Vec<StacksPrivateKey>,
 }
 
 impl SignerTest {
@@ -105,6 +114,7 @@ impl SignerTest {
             &naka_conf.node.rpc_bind,
             &signers_stacker_db_contract_id.to_string(),
             Some(Duration::from_millis(128)), // Timeout defaults to 5 seconds. Let's override it to 128 milliseconds.
+            &Network::Testnet,
         );
 
         let mut running_signers = HashMap::new();
@@ -159,6 +169,7 @@ impl SignerTest {
             coordinator_cmd_sender,
             running_coordinator,
             running_signers,
+            signer_stacks_private_keys,
         }
     }
 
@@ -683,6 +694,217 @@ fn stackerdb_block_proposal() {
     {
         assert_eq!(block_signer_signature_hash, proposed_signer_signature_hash);
         assert_eq!(block_signature, ThresholdSignature(signature));
+    } else {
+        panic!("Received unexpected message");
+    }
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Test that signers will reject a miners block proposal if it is missing expected transactions
+///
+/// Test Setup:
+/// The test spins up five stacks signers, one miner Nakamoto node, and a corresponding bitcoind.
+/// The stacks node is advanced to epoch 3.0. and signers perform a DKG round (this should be removed
+/// once we have proper casting of the vote during epoch 2.5).
+///
+/// Test Execution:
+/// The node attempts to mine a Nakamoto tenure, sending a block to the observing signers via the
+/// .miners stacker db instance. The signers submit the block to the stacks node for verification.
+/// Upon receiving a Block Validation response approving the block, the signers verify that it contains
+/// all expected transactions. As it does not, the signers reject the block and do not sign it.
+///
+/// Test Assertion:
+/// Signers broadcast rejections with the list of missing transactions back to the miners stackerdb instance
+fn stackerdb_block_proposal_missing_transactions() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    info!("------------------------- Test Setup -------------------------");
+    let mut signer_test = SignerTest::new(5, 5);
+
+    let host = signer_test
+        .running_nodes
+        .conf
+        .node
+        .rpc_bind
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
+    let signer_stacker_db = signer_test
+        .running_nodes
+        .conf
+        .node
+        .stacker_dbs
+        .iter()
+        .find(|id| id.name.to_string() == SIGNERS_NAME)
+        .unwrap()
+        .clone();
+    let signer_id = 0;
+    let signer_private_key = signer_test
+        .signer_stacks_private_keys
+        .get(signer_id)
+        .expect("Cannot find signer private key for signer id 0")
+        .clone();
+    let mut stackerdb = StackerDB::new(host, signer_stacker_db, signer_private_key, 0);
+    // Create a valid transaction signed by the signer private key coresponding to the slot into which it is being inserted (signer id 0)
+    let mut valid_tx = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: 0,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::SmartContract(
+            TransactionSmartContract {
+                name: "test-contract".into(),
+                code_body: StacksString::from_str("(/ 1 0)").unwrap(),
+            },
+            None,
+        ),
+    };
+    valid_tx.set_origin_nonce(0);
+
+    // Create a transaction signed by a different private key
+    // This transaction will be invalid as it is signed by a different private key than the one that corresponds to the slot into which it is being inserted
+    let invalid_signer_id = 1;
+    let invalid_signer_private_key = signer_test
+        .signer_stacks_private_keys
+        .get(invalid_signer_id)
+        .expect("Cannot find signer private key for signer id 1")
+        .clone();
+    let mut invalid_tx = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: 0,
+        auth: TransactionAuth::from_p2pkh(&invalid_signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::SmartContract(
+            TransactionSmartContract {
+                name: "test-contract".into(),
+                code_body: StacksString::from_str("(/ 1 0)").unwrap(),
+            },
+            None,
+        ),
+    };
+    invalid_tx.set_origin_nonce(0);
+
+    // First run DKG in order to sign the block that arrives from the miners following a nakamoto block production
+    // TODO: remove this forcibly running DKG once we have casting of the vote automagically happening during epoch 2.5
+    info!("signer_runloop: spawn send commands to do dkg");
+    signer_test
+        .coordinator_cmd_sender
+        .send(RunLoopCommand::Dkg)
+        .expect("failed to send Dkg command");
+    let recv = signer_test
+        .result_receivers
+        .last()
+        .expect("Failed to get coordinator recv");
+    let results = recv
+        .recv_timeout(Duration::from_secs(30))
+        .expect("failed to recv dkg results");
+    for result in results {
+        match result {
+            OperationResult::Dkg(point) => {
+                info!("Received aggregate_group_key {point}");
+                break;
+            }
+            _ => {
+                panic!("Received Unexpected result");
+            }
+        }
+    }
+
+    // Following stacker DKG, submit transactions to stackerdb for the signers to pick up during block verification
+    stackerdb
+        .send_message_with_retry(SignerMessage::Transactions(vec![
+            valid_tx.clone(),
+            invalid_tx,
+        ]))
+        .expect("Failed to write expected transactions to stackerdb");
+
+    let (vrfs_submitted, commits_submitted) = (
+        signer_test.running_nodes.vrfs_submitted.clone(),
+        signer_test.running_nodes.commits_submitted.clone(),
+    );
+
+    info!("------------------------- Test Block Rejected -------------------------");
+
+    info!("Mining a Nakamoto tenure...");
+
+    // first block wakes up the run loop, wait until a key registration has been submitted.
+    next_block_and(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        60,
+        || {
+            let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
+            Ok(vrf_count >= 1)
+        },
+    )
+    .unwrap();
+
+    // second block should confirm the VRF register, wait until a block commit is submitted
+    next_block_and(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        60,
+        || {
+            let commits_count = commits_submitted.load(Ordering::SeqCst);
+            Ok(commits_count >= 1)
+        },
+    )
+    .unwrap();
+
+    // Mine 1 nakamoto tenure
+    next_block_and_mine_commit(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        60,
+        &signer_test.running_nodes.coord_channel,
+        &commits_submitted,
+    )
+    .unwrap();
+
+    // Verify that the signers broadcasted a series of rejections with missing transactions back to the miner
+    let t_start = Instant::now();
+    let mut chunk = None;
+    while chunk.is_none() {
+        assert!(
+            t_start.elapsed() < Duration::from_secs(30),
+            "Timed out while waiting for signers block response stacker db event"
+        );
+
+        let nakamoto_blocks = test_observer::get_stackerdb_chunks();
+        for event in nakamoto_blocks {
+            // Only care about the miners block slot
+            for slot in event.modified_slots {
+                if slot.slot_id == BLOCK_SLOT_ID {
+                    chunk = Some(slot.data);
+                    break;
+                }
+            }
+            if chunk.is_some() {
+                break;
+            }
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+    let chunk = chunk.unwrap();
+    let signer_message = read_next::<SignerMessage, _>(&mut &chunk[..]).unwrap();
+    if let SignerMessage::BlockResponse(BlockResponse::Rejected(block_rejection)) = signer_message {
+        // Verify we are missing the valid tx that we expect to see in the block
+        if let RejectCode::MissingTransactions(missing_txs) = block_rejection.reason_code {
+            assert_eq!(missing_txs, vec![valid_tx]);
+        } else {
+            panic!("Received unexpected rejection reason");
+        }
     } else {
         panic!("Received unexpected message");
     }

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -774,13 +774,8 @@ fn stackerdb_block_proposal_missing_transactions() {
     valid_tx.set_origin_nonce(0);
 
     // Create a transaction signed by a different private key
-    // This transaction will be invalid as it is signed by a different private key than the one that corresponds to the slot into which it is being inserted
-    let invalid_signer_id = 1;
-    let invalid_signer_private_key = signer_test
-        .signer_stacks_private_keys
-        .get(invalid_signer_id)
-        .expect("Cannot find signer private key for signer id 1")
-        .clone();
+    // This transaction will be invalid as it is signed by a non signer private key
+    let invalid_signer_private_key = StacksPrivateKey::new();
     let mut invalid_tx = StacksTransaction {
         version: TransactionVersion::Testnet,
         chain_id: 0,

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -661,7 +661,7 @@ fn stackerdb_block_proposal() {
 
         let nakamoto_blocks = test_observer::get_stackerdb_chunks();
         for event in nakamoto_blocks {
-            // The tenth slot is the miners block slot
+            // Only care about the miners block slot
             for slot in event.modified_slots {
                 if slot.slot_id == BLOCK_SLOT_ID {
                     chunk = Some(slot.data);


### PR DESCRIPTION
### Description
Signers must broadcast their cast aggregate public key transaction to the mempool if in pre nakamoto rules, and always broadcast the transaction to stackerdb for signers and miners to observe when validating and building the block, respectively. 

### Applicable issues

- fixes #https://github.com/stacks-network/stacks-core/issues/4006

For this to be fully tested, we need to have the cast aggregate public key transaction happening
