### PR TITLE
Updated Vote Print Statement

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -96,7 +96,13 @@
         (map-set tally tally-key new-total)
         (map-set used-aggregate-public-keys key {reward-cycle: reward-cycle, round: round})
         (update-last-round reward-cycle round)
-        (print new-total)
+        (print { 
+            event: "voted", 
+            signer: tx-sender, 
+            reward-cycle: reward-cycle, 
+            round: round, 
+            key: key 
+            new-total: new-total })
         (ok true)))
 
 (define-private (update-last-round (reward-cycle uint) (round uint))

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -101,7 +101,7 @@
             signer: tx-sender, 
             reward-cycle: reward-cycle, 
             round: round, 
-            key: key 
+            key: key, 
             new-total: new-total })
         (ok true)))
 

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -96,7 +96,7 @@
         (map-set tally tally-key new-total)
         (map-set used-aggregate-public-keys key {reward-cycle: reward-cycle, round: round})
         (update-last-round reward-cycle round)
-        (print "voted")
+        (print new-total)
         (ok true)))
 
 (define-private (update-last-round (reward-cycle uint) (round uint))

--- a/stackslib/src/chainstate/stacks/boot/signers_voting_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_voting_tests.rs
@@ -76,7 +76,8 @@ use crate::chainstate::stacks::events::{StacksTransactionReceipt, TransactionOri
 use crate::chainstate::stacks::index::marf::MarfConnection;
 use crate::chainstate::stacks::index::MarfTrieId;
 use crate::chainstate::stacks::tests::make_coinbase;
-use crate::chainstate::{self, stacks::*};
+use crate::chainstate::stacks::*;
+use crate::chainstate::{self};
 use crate::clarity_vm::clarity::{ClarityBlockConnection, Error as ClarityError};
 use crate::clarity_vm::database::marf::{MarfedKV, WritableMarfStore};
 use crate::clarity_vm::database::HeadersDBConn;


### PR DESCRIPTION
As discussed during Un/block meeting, the simplest/fastest solution for #4231 is simply to update the print statement found in 'vote-for-aggregate-public-key.'

The node will then take this information & then check whether the consensus threshold was met / a new aggregate public key has been submitted. 

Since this is a simple print statement update there are no additional test to write.