### PR TITLE
Update `wsts` dependency to get malicious DkgPrivateShares handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,9 +2372,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256k1"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afcf536d20c074ef45371ee9a654dcfc46fb2dde18ecc54ec30c936eb850fa2"
+checksum = "3a64d160b891178fb9d43d1a58ddcafb6502daeb54d810e5e92a7c3c9bfacc07"
 dependencies = [
  "bindgen",
  "bitvec",
@@ -4791,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c398736468f3322a43b6419be5315e68ae035e6565628603503c2a62ad726f36"
+checksum = "06eee6f3bb38f8c8dca03053572130be2e5006a31dc7e5d8c62e375952b2ff38"
 dependencies = [
  "aes-gcm 0.10.2",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 
 # Dependencies we want to keep the same between workspace members
 [workspace.dependencies]  
-wsts = "7.0"
+wsts = "8.0"
 rand_core = "0.6"
 rand = "0.8"
 

--- a/libsigner/src/messages.rs
+++ b/libsigner/src/messages.rs
@@ -30,7 +30,7 @@ use blockstack_lib::net::api::postblock_proposal::{
 use blockstack_lib::util_lib::boot::boot_code_id;
 use clarity::vm::types::serialization::SerializationError;
 use clarity::vm::types::QualifiedContractIdentifier;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use stacks_common::codec::{
     read_next, read_next_at_most, read_next_exact, write_next, Error as CodecError,
@@ -40,12 +40,13 @@ use stacks_common::util::hash::Sha512Trunc256Sum;
 use tiny_http::{
     Method as HttpMethod, Request as HttpRequest, Response as HttpResponse, Server as HttpServer,
 };
-use wsts::common::{PolyCommitment, PublicNonce, Signature, SignatureShare};
+use wsts::common::{PolyCommitment, PublicNonce, Signature, SignatureShare, TupleProof};
 use wsts::curve::point::{Compressed, Point};
 use wsts::curve::scalar::Scalar;
 use wsts::net::{
-    DkgBegin, DkgEnd, DkgEndBegin, DkgPrivateBegin, DkgPrivateShares, DkgPublicShares, DkgStatus,
-    Message, NonceRequest, NonceResponse, Packet, SignatureShareRequest, SignatureShareResponse,
+    BadPrivateShare, DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin, DkgPrivateShares,
+    DkgPublicShares, DkgStatus, Message, NonceRequest, NonceResponse, Packet,
+    SignatureShareRequest, SignatureShareResponse,
 };
 use wsts::schnorr::ID;
 use wsts::state_machine::signer;
@@ -247,6 +248,119 @@ impl StacksMessageCodecExtensions for Point {
     }
 }
 
+#[allow(non_snake_case)]
+impl StacksMessageCodecExtensions for TupleProof {
+    fn inner_consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError> {
+        self.R.inner_consensus_serialize(fd)?;
+        self.rB.inner_consensus_serialize(fd)?;
+        self.z.inner_consensus_serialize(fd)
+    }
+    fn inner_consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, CodecError> {
+        let R = Point::inner_consensus_deserialize(fd)?;
+        let rB = Point::inner_consensus_deserialize(fd)?;
+        let z = Scalar::inner_consensus_deserialize(fd)?;
+        Ok(Self { R, rB, z })
+    }
+}
+
+impl StacksMessageCodecExtensions for BadPrivateShare {
+    fn inner_consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError> {
+        self.shared_key.inner_consensus_serialize(fd)?;
+        self.tuple_proof.inner_consensus_serialize(fd)
+    }
+    fn inner_consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, CodecError> {
+        let shared_key = Point::inner_consensus_deserialize(fd)?;
+        let tuple_proof = TupleProof::inner_consensus_deserialize(fd)?;
+        Ok(Self {
+            shared_key,
+            tuple_proof,
+        })
+    }
+}
+
+impl StacksMessageCodecExtensions for HashSet<u32> {
+    fn inner_consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError> {
+        write_next(fd, &(self.len() as u32))?;
+        for i in self {
+            write_next(fd, i)?;
+        }
+        Ok(())
+    }
+    fn inner_consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, CodecError> {
+        let mut set = Self::new();
+        let len = read_next::<u32, _>(fd)?;
+        for _ in 0..len {
+            let i = read_next::<u32, _>(fd)?;
+            set.insert(i);
+        }
+        Ok(set)
+    }
+}
+
+impl StacksMessageCodecExtensions for DkgFailure {
+    fn inner_consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError> {
+        match self {
+            DkgFailure::BadState => write_next(fd, &0u8),
+            DkgFailure::MissingPublicShares(shares) => {
+                write_next(fd, &1u8)?;
+                shares.inner_consensus_serialize(fd)
+            }
+            DkgFailure::BadPublicShares(shares) => {
+                write_next(fd, &2u8)?;
+                shares.inner_consensus_serialize(fd)
+            }
+            DkgFailure::MissingPrivateShares(shares) => {
+                write_next(fd, &3u8)?;
+                shares.inner_consensus_serialize(fd)
+            }
+            DkgFailure::BadPrivateShares(shares) => {
+                write_next(fd, &4u8)?;
+                write_next(fd, &(shares.len() as u32))?;
+                for (id, share) in shares {
+                    write_next(fd, id)?;
+                    share.inner_consensus_serialize(fd)?;
+                }
+                Ok(())
+            }
+        }
+    }
+    fn inner_consensus_deserialize<R: Read>(fd: &mut R) -> Result<Self, CodecError> {
+        let failure_type_prefix = read_next::<u8, _>(fd)?;
+        let failure_type = match failure_type_prefix {
+            0 => DkgFailure::BadState,
+            1 => {
+                let set = HashSet::<u32>::inner_consensus_deserialize(fd)?;
+                DkgFailure::MissingPublicShares(set)
+            }
+            2 => {
+                let set = HashSet::<u32>::inner_consensus_deserialize(fd)?;
+                DkgFailure::BadPublicShares(set)
+            }
+            3 => {
+                let set = HashSet::<u32>::inner_consensus_deserialize(fd)?;
+                DkgFailure::MissingPrivateShares(set)
+            }
+            4 => {
+                let mut map = HashMap::new();
+                let len = read_next::<u32, _>(fd)?;
+                for _ in 0..len {
+                    let i = read_next::<u32, _>(fd)?;
+                    let bad_share = BadPrivateShare::inner_consensus_deserialize(fd)?;
+                    map.insert(i, bad_share);
+                }
+                DkgFailure::BadPrivateShares(map)
+            }
+            _ => {
+                return Err(CodecError::DeserializeError(format!(
+                    "Unknown DkgFailure type prefix: {}",
+                    failure_type_prefix
+                )))
+            }
+        };
+        Ok(failure_type)
+    }
+}
+
 impl StacksMessageCodecExtensions for DkgBegin {
     fn inner_consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError> {
         write_next(fd, &self.dkg_id)
@@ -301,7 +415,7 @@ impl StacksMessageCodecExtensions for DkgEnd {
             DkgStatus::Success => write_next(fd, &0u8),
             DkgStatus::Failure(failure) => {
                 write_next(fd, &1u8)?;
-                write_next(fd, &failure.as_bytes().to_vec())
+                failure.inner_consensus_serialize(fd)
             }
         }
     }
@@ -312,9 +426,7 @@ impl StacksMessageCodecExtensions for DkgEnd {
         let status = match status_type_prefix {
             0 => DkgStatus::Success,
             1 => {
-                let failure_bytes: Vec<u8> = read_next(fd)?;
-                let failure = String::from_utf8(failure_bytes)
-                    .map_err(|e| CodecError::DeserializeError(e.to_string()))?;
+                let failure = DkgFailure::inner_consensus_deserialize(fd)?;
                 DkgStatus::Failure(failure)
             }
             _ => {
@@ -1122,7 +1234,7 @@ mod test {
         test_fixture_packet(Message::DkgEnd(DkgEnd {
             dkg_id,
             signer_id,
-            status: DkgStatus::Failure("failure".to_string()),
+            status: DkgStatus::Failure(DkgFailure::BadState),
         }));
 
         // Test DKG public shares Packet


### PR DESCRIPTION
### Description

### Applicable issues

- fixes #4289 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
