### PR TITLE
Feat: trigger stackerdb refresh when .signers is written

### DIFF
--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -711,6 +711,7 @@ impl<'a, T: BlockEventDispatcher, U: RewardSetProvider, B: BurnchainHeaderReader
             atlas_db: Some(atlas_db),
             config: ChainsCoordinatorConfig::new(),
             burnchain_indexer,
+            refresh_stacker_db: Arc::new(AtomicBool::new(false)),
         }
     }
 }

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -578,6 +578,12 @@ impl<
                 break;
             };
 
+            if block_receipt.signers_updated {
+                // notify p2p thread via globals
+                self.refresh_stacker_db
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+
             let block_hash = block_receipt.header.anchored_header.block_hash();
             let (
                 canonical_stacks_block_id,

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -3106,6 +3106,7 @@ impl NakamotoChainState {
         // store the reward set calculated during this block if it happened
         // NOTE: miner and proposal evaluation should not invoke this because
         //  it depends on knowing the StacksBlockId.
+        let signers_updated = signer_set_calc.is_some();
         if let Some(signer_calculation) = signer_set_calc {
             Self::write_reward_set(chainstate_tx, &new_block_id, &signer_calculation.reward_set)?
         }
@@ -3146,6 +3147,7 @@ impl NakamotoChainState {
             parent_burn_block_timestamp,
             evaluated_epoch,
             epoch_transition: applied_epoch_transition,
+            signers_updated,
         };
 
         NakamotoChainState::set_block_processed(&chainstate_tx, &new_block_id)?;

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -5686,6 +5686,7 @@ impl StacksChainState {
         // store the reward set calculated during this block if it happened
         // NOTE: miner and proposal evaluation should not invoke this because
         //  it depends on knowing the StacksBlockId.
+        let signers_updated = signer_set_calc.is_some();
         if let Some(signer_calculation) = signer_set_calc {
             let new_block_id = new_tip.index_block_hash();
             NakamotoChainState::write_reward_set(
@@ -5712,6 +5713,7 @@ impl StacksChainState {
             parent_burn_block_timestamp,
             evaluated_epoch,
             epoch_transition: applied_epoch_transition,
+            signers_updated,
         };
 
         Ok((epoch_receipt, clarity_commit))

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -220,6 +220,8 @@ pub struct StacksEpochReceipt {
     /// in.
     pub evaluated_epoch: StacksEpochId,
     pub epoch_transition: bool,
+    /// Was .signers updated during this block?
+    pub signers_updated: bool,
 }
 
 /// Headers we serve over the network

--- a/stackslib/src/cost_estimates/tests/common.rs
+++ b/stackslib/src/cost_estimates/tests/common.rs
@@ -50,5 +50,6 @@ pub fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksE
         parent_burn_block_timestamp: 1,
         evaluated_epoch: StacksEpochId::Epoch20,
         epoch_transition: false,
+        signers_updated: false,
     }
 }

--- a/testnet/stacks-node/src/nakamoto_node/peer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/peer.rs
@@ -202,6 +202,21 @@ impl PeerThread {
         }
     }
 
+    fn check_stackerdb_reload(&mut self) {
+        if !self.globals.coord_comms.need_stackerdb_update() {
+            return;
+        }
+
+        if let Err(e) = self
+            .net
+            .refresh_stacker_db_configs(&self.sortdb, &mut self.chainstate)
+        {
+            warn!("Failed to update StackerDB configs: {e}");
+        }
+
+        self.globals.coord_comms.set_stackerdb_update(false);
+    }
+
     /// Run one pass of the p2p/http state machine
     /// Return true if we should continue running passes; false if not
     pub(crate) fn run_one_pass<B: BurnchainHeaderReader>(
@@ -227,6 +242,8 @@ impl PeerThread {
         } else {
             self.poll_timeout
         };
+
+        self.check_stackerdb_reload();
 
         // do one pass
         let p2p_res = {

--- a/testnet/stacks-node/src/nakamoto_node/peer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/peer.rs
@@ -202,7 +202,10 @@ impl PeerThread {
         }
     }
 
-    fn check_stackerdb_reload(&mut self) {
+    /// Check if the StackerDB config needs to be updated (by looking
+    ///  at the signal in `self.globals`), and if so, refresh the
+    ///  StackerDB config
+    fn refresh_stackerdb(&mut self) {
         if !self.globals.coord_comms.need_stackerdb_update() {
             return;
         }
@@ -243,7 +246,7 @@ impl PeerThread {
             self.poll_timeout
         };
 
-        self.check_stackerdb_reload();
+        self.refresh_stackerdb();
 
         // do one pass
         let p2p_res = {


### PR DESCRIPTION
### Description

This implements #4328 by adding a signaling bool to the coordinator channels structs. It's a bit cludgier than I would otherwise want, but I think it's the best we can do without majorly refactoring the coordinator's signatures (which is probably a good idea, but one best left to the future).

This is a draft for now, because it depends on `feat/larger-stackerdb`, but it could be cherry-picked/rebased to `next` instead.