### PR TITLE
Clarity-Wasm: fixes for the `principal` type

### DIFF
--- a/clarity/src/vm/analysis/type_checker/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/contexts.rs
@@ -20,7 +20,9 @@ use stacks_common::types::StacksEpochId;
 
 use crate::vm::analysis::errors::{CheckError, CheckErrors, CheckResult};
 use crate::vm::types::signatures::CallableSubtype;
-use crate::vm::types::{TraitIdentifier, TypeSignature};
+use crate::vm::types::{
+    ListTypeData, SequenceSubtype, TraitIdentifier, TupleTypeSignature, TypeSignature,
+};
 use crate::vm::{ClarityName, ClarityVersion, SymbolicExpression, MAX_CONTEXT_DEPTH};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -64,6 +66,20 @@ impl TypeMap {
 
     pub fn get_type(&self, expr: &SymbolicExpression) -> Option<&TypeSignature> {
         self.map.get(&expr.id)
+    }
+
+    /// Concretize tries to [concretize] all the types in the TypeMap.
+    ///
+    /// This is needed for Clarity-Wasm where all types should have a defined representation
+    /// in memory. Since [ListUnionType] doesn't have one, we need to concretize it.
+    ///
+    /// [concretize]: TypeSignature::concretize
+    /// [ListUnionType]: TypeSignature::ListUnionType
+    pub fn concretize(&mut self) -> CheckResult<()> {
+        for ty in self.map.values_mut() {
+            *ty = concretize_deep(ty.clone())?;
+        }
+        Ok(())
     }
 }
 
@@ -133,6 +149,49 @@ impl<'a> TypingContext<'a> {
                 Some(parent) => parent.lookup_trait_reference_type(name),
                 None => None,
             },
+        }
+    }
+}
+
+/// Subroutine of [TypeMap::concretize]
+fn concretize_deep(ty: TypeSignature) -> CheckResult<TypeSignature> {
+    match ty {
+        TypeSignature::NoType
+        | TypeSignature::IntType
+        | TypeSignature::UIntType
+        | TypeSignature::BoolType
+        | TypeSignature::PrincipalType
+        | TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
+        | TypeSignature::SequenceType(SequenceSubtype::StringType(_))
+        | TypeSignature::TraitReferenceType(_) => Ok(ty),
+        TypeSignature::OptionalType(opt_ty) => Ok(TypeSignature::OptionalType(Box::new(
+            concretize_deep(*opt_ty)?,
+        ))),
+        TypeSignature::ResponseType(resp_ty) => {
+            let (ok_ty, err_ty) = *resp_ty;
+            Ok(TypeSignature::ResponseType(Box::new((
+                concretize_deep(ok_ty)?,
+                concretize_deep(err_ty)?,
+            ))))
+        }
+        TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) => {
+            let (entry_ty, max_len) = ltd.destruct();
+            Ok(TypeSignature::SequenceType(SequenceSubtype::ListType(
+                ListTypeData::new_list(concretize_deep(entry_ty)?, max_len)?,
+            )))
+        }
+        TypeSignature::TupleType(tup_ty) => Ok(TupleTypeSignature::try_from(
+            tup_ty.get_type_map().clone().into_iter().try_fold(
+                std::collections::BTreeMap::new(),
+                |mut acc, (name, elem_ty)| -> CheckResult<_> {
+                    acc.insert(name, concretize_deep(elem_ty)?);
+                    Ok(acc)
+                },
+            )?,
+        )?
+        .into()),
+        TypeSignature::ListUnionType(_) | TypeSignature::CallableType(_) => {
+            ty.concretize().map_err(CheckError::new)
         }
     }
 }

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1793,10 +1793,7 @@ fn wasm_to_clarity_value(
                 StandardPrincipalData(principal_bytes[0], principal_bytes[1..].try_into().unwrap());
             let contract_name_length = buffer[0] as usize;
             if contract_name_length == 0 {
-                Ok((
-                    Some(Value::Principal(PrincipalData::Standard(standard))),
-                    STANDARD_PRINCIPAL_BYTES,
-                ))
+                Ok((Some(Value::Principal(PrincipalData::Standard(standard))), 2))
             } else {
                 let mut contract_name: Vec<u8> = vec![0; contract_name_length];
                 memory
@@ -1817,7 +1814,7 @@ fn wasm_to_clarity_value(
                             )?,
                         },
                     ))),
-                    STANDARD_PRINCIPAL_BYTES + contract_name_length,
+                    2,
                 ))
             }
         }

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -835,16 +835,12 @@ impl TypeSignature {
                     ListTypeData::new_list(entry_ty.concretize_deep()?, max_len)?,
                 )))
             }
-            TypeSignature::TupleType(tup_ty) => Ok(TupleTypeSignature::try_from(
-                tup_ty.get_type_map().clone().into_iter().try_fold(
-                    std::collections::BTreeMap::new(),
-                    |mut acc, (name, elem_ty)| -> Result<_> {
-                        acc.insert(name, elem_ty.concretize_deep()?);
-                        Ok(acc)
-                    },
-                )?,
-            )?
-            .into()),
+            TypeSignature::TupleType(TupleTypeSignature { mut type_map }) => {
+                for ty in type_map.values_mut() {
+                    *ty = ty.clone().concretize_deep()?;
+                }
+                Ok(TupleTypeSignature { type_map }.into())
+            }
             TypeSignature::ListUnionType(_) | TypeSignature::CallableType(_) => self.concretize(),
         }
     }

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -829,12 +829,15 @@ impl TypeSignature {
                     err_ty.concretize_deep()?,
                 ))))
             }
-            TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) => {
-                let (entry_ty, max_len) = ltd.destruct();
-                Ok(TypeSignature::SequenceType(SequenceSubtype::ListType(
-                    ListTypeData::new_list(entry_ty.concretize_deep()?, max_len)?,
-                )))
-            }
+            TypeSignature::SequenceType(SequenceSubtype::ListType(ListTypeData {
+                max_len,
+                entry_type,
+            })) => Ok(TypeSignature::SequenceType(SequenceSubtype::ListType(
+                ListTypeData {
+                    max_len,
+                    entry_type: Box::new(entry_type.concretize_deep()?),
+                },
+            ))),
             TypeSignature::TupleType(TupleTypeSignature { mut type_map }) => {
                 for ty in type_map.values_mut() {
                     *ty = ty.clone().concretize_deep()?;

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -806,6 +806,48 @@ impl TypeSignature {
             _ => Ok(self.clone()),
         }
     }
+
+    /// Goes recursively through a type to [concretize](TypeSignature::concretize)
+    /// the inner [ListUnionType] and [CallableType] variants.
+    pub fn concretize_deep(self) -> Result<Self> {
+        match self {
+            TypeSignature::NoType
+            | TypeSignature::IntType
+            | TypeSignature::UIntType
+            | TypeSignature::BoolType
+            | TypeSignature::PrincipalType
+            | TypeSignature::SequenceType(SequenceSubtype::BufferType(_))
+            | TypeSignature::SequenceType(SequenceSubtype::StringType(_))
+            | TypeSignature::TraitReferenceType(_) => Ok(self),
+            TypeSignature::OptionalType(opt_ty) => Ok(TypeSignature::OptionalType(Box::new(
+                opt_ty.concretize_deep()?,
+            ))),
+            TypeSignature::ResponseType(resp_ty) => {
+                let (ok_ty, err_ty) = *resp_ty;
+                Ok(TypeSignature::ResponseType(Box::new((
+                    ok_ty.concretize_deep()?,
+                    err_ty.concretize_deep()?,
+                ))))
+            }
+            TypeSignature::SequenceType(SequenceSubtype::ListType(ltd)) => {
+                let (entry_ty, max_len) = ltd.destruct();
+                Ok(TypeSignature::SequenceType(SequenceSubtype::ListType(
+                    ListTypeData::new_list(entry_ty.concretize_deep()?, max_len)?,
+                )))
+            }
+            TypeSignature::TupleType(tup_ty) => Ok(TupleTypeSignature::try_from(
+                tup_ty.get_type_map().clone().into_iter().try_fold(
+                    std::collections::BTreeMap::new(),
+                    |mut acc, (name, elem_ty)| -> Result<_> {
+                        acc.insert(name, elem_ty.concretize_deep()?);
+                        Ok(acc)
+                    },
+                )?,
+            )?
+            .into()),
+            TypeSignature::ListUnionType(_) | TypeSignature::CallableType(_) => self.concretize(),
+        }
+    }
 }
 
 impl TryFrom<Vec<(ClarityName, TypeSignature)>> for TupleTypeSignature {


### PR DESCRIPTION
This PR fixes two issues for Clarity-Wasm:

1. The representation in memory is only two Wasm values, but we tried to read 22 (+`name`),
2. Creating lists of qualified principal would make both the compilation and the evaluation crash, because those would be typed as `ListUnionType`, which does not have a defined representation in our ABI.

Those fixes are extensively tested with property testing in the Clarity-Wasm repo.