### PR TITLE
Use the same slot id for retrieving the proposed block

### DIFF
--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -1448,20 +1448,24 @@ fn miner_writes_proposed_block_to_stackerdb() {
         .expect("Failed to parse socket");
 
     let sortdb = naka_conf.get_burnchain().open_sortition_db(true).unwrap();
-    let burn_height = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
-        .unwrap()
-        .block_height as u32;
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+    let miner_pubkey =
+        StacksPublicKey::from_private(&naka_conf.get_miner_config().mining_key.unwrap());
+    let slot_id = NakamotoChainState::get_miner_slot(&sortdb, &tip, &miner_pubkey)
+        .expect("Unable to get miner slot")
+        .expect("No miner slot exists");
 
     let chunk = std::thread::spawn(move || {
         let miner_contract_id = boot_code_id(MINERS_NAME, false);
         let mut miners_stackerdb = StackerDBSession::new(rpc_sock, miner_contract_id);
         miners_stackerdb
-            .get_latest_chunk(burn_height % 2)
+            .get_latest_chunk(slot_id)
             .expect("Failed to get latest chunk from the miner slot ID")
             .expect("No chunk found")
     })
     .join()
     .expect("Failed to join chunk handle");
+
     // We should now successfully deserialize a chunk
     let proposed_block = NakamotoBlock::consensus_deserialize(&mut &chunk[..])
         .expect("Failed to deserialize chunk into block");


### PR DESCRIPTION
This builds off of https://github.com/stacks-network/stacks-core/pull/4337 which attempted to fix the slot id calculation to retrieve from the correct slot. 

However, it appears that the miner writes to a slot id with a different view of the chain than what we have inside our test (I think anyway....)

To fix this, I use the get_miner_slot function which uses the miner public key to determine where to write (always selecting the same slot as the miner had before. It only alternates to a different slot if it has a different public key)

This should work! :D


Here is the output to show the calculations being consistent between different runs (with alternating slots being written to by the miner)

RUN 1
```
GOT CHUNKS: [Some([0, 0, 0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 8, 139, 128, 108, 42, 240, 252, 91, 227, 78, 67, 30, 54, 78, 81, 155, 117, 150, 69, 43, 6, 250, 111, 135, 221, 43, 151, 222, 104, 204, 152, 8, 47, 119, 255, 157, 191, 20, 78, 104, 54, 137, 74, 133, 76, 241, 61, 182, 80, 206, 128, 95, 84, 65, 28, 48, 111, 87, 103, 73, 243, 30, 129, 38, 222, 160, 156, 217, 114, 88, 235, 121, 21, 46, 29, 238, 143, 161, 62, 58, 199, 208, 26, 148, 25, 65, 238, 41, 174, 240, 99, 115, 114, 233, 70, 89, 58, 240, 4, 156, 212, 98, 40, 112, 102, 19, 154, 25, 224, 154, 167, 114, 74, 52, 4, 236, 114, 218, 213, 1, 255, 70, 53, 115, 219, 134, 151, 161, 4, 225, 199, 78, 149, 168, 55, 15, 136, 50, 93, 190, 127, 215, 58, 213, 180, 178, 61, 189, 32, 33, 218, 203, 30, 123, 156, 12, 168, 177, 100, 58, 221, 223, 198, 122, 194, 37, 91, 73, 138, 151, 170, 160, 211, 59, 3, 163, 254, 233, 88, 97, 240, 55, 46, 87, 2, 121, 190, 102, 126, 249, 220, 187, 172, 85, 160, 98, 149, 206, 135, 11, 7, 2, 155, 252, 219, 45, 206, 40, 217, 89, 242, 129, 91, 22, 248, 23, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 2, 128, 128, 0, 0, 0, 4, 0, 139, 197, 20, 117, 37, 184, 244, 119, 240, 188, 69, 34, 168, 140, 131, 57, 178, 73, 77, 181, 0, 0, 0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 40, 213, 250, 184, 254, 76, 133, 89, 84, 176, 41, 73, 17, 24, 137, 96, 105, 244, 119, 101, 220, 10, 30, 172, 223, 94, 46, 78, 85, 243, 59, 0, 79, 118, 144, 206, 230, 174, 127, 252, 114, 176, 173, 224, 106, 76, 80, 18, 179, 61, 18, 183, 174, 103, 222, 159, 2, 112, 51, 172, 63, 11, 1, 143, 1, 2, 0, 0, 0, 0, 7, 108, 42, 240, 252, 91, 227, 78, 67, 30, 54, 78, 81, 155, 117, 150, 69, 43, 6, 250, 111, 243, 137, 128, 123, 98, 172, 227, 231, 116, 179, 234, 154, 186, 185, 46, 209, 77, 20, 146, 59, 108, 42, 240, 252, 91, 227, 78, 67, 30, 54, 78, 81, 155, 117, 150, 69, 43, 6, 250, 111, 135, 221, 43, 151, 222, 104, 204, 152, 8, 47, 119, 255, 157, 191, 20, 78, 104, 54, 137, 74, 133, 76, 241, 61, 182, 80, 206, 128, 95, 84, 65, 28, 0, 0, 0, 1, 0, 107, 197, 27, 51, 233, 243, 98, 105, 68, 235, 135, 145, 71, 225, 129, 17, 88, 31, 143, 155, 128, 128, 0, 0, 0, 4, 0, 139, 197, 20, 117, 37, 184, 244, 119, 240, 188, 69, 34, 168, 140, 131, 57, 178, 73, 77, 181, 0, 0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 182, 102, 44, 115, 228, 216, 17, 88, 158, 64, 12, 0, 245, 248, 77, 214, 128, 212, 133, 149, 99, 182, 196, 53, 25, 34, 43, 49, 230, 215, 88, 179, 58, 75, 155, 166, 87, 16, 17, 21, 180, 26, 216, 119, 182, 10, 50, 231, 29, 224, 55, 71, 182, 59, 105, 142, 173, 167, 73, 114, 25, 251, 140, 220, 1, 2, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 127, 63, 251, 221, 185, 200, 240, 130, 108, 91, 227, 214, 248, 188, 128, 7, 36, 191, 240, 220, 144, 84, 15, 68, 141, 205, 112, 180, 179, 67, 205, 210, 175, 224, 147, 119, 113, 63, 169, 100, 211, 27, 46, 57, 201, 4, 144, 170, 135, 175, 173, 222, 65, 221, 143, 223, 198, 67, 42, 120, 153, 101, 81, 114, 155, 184, 4, 244, 208, 191, 31, 137, 240, 168, 51, 127, 245, 26, 13, 10]), Some([])]
CHUNK SLOT ID USING BURN HEIGHT: 1
CHUNK SLOT ID USING FN: 0
CHUNK BURN HEIGHT: 233
```
RUN 2
```
GOT CHUNKS: [Some([0, 0, 0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 8, 139, 128, 241, 16, 190, 54, 28, 56, 36, 145, 228, 91, 25, 121, 234, 157, 178, 59, 224, 18, 239, 118, 113, 182, 90, 231, 239, 140, 61, 131, 16, 225, 123, 27, 189, 62, 251, 91, 243, 157, 85, 50, 218, 152, 25, 94, 79, 157, 202, 18, 81, 212, 237, 162, 186, 206, 68, 225, 26, 63, 161, 23, 183, 250, 54, 70, 0, 182, 119, 46, 61, 194, 100, 140, 49, 33, 119, 87, 33, 171, 98, 225, 74, 33, 130, 235, 100, 83, 131, 34, 146, 22, 151, 47, 35, 204, 161, 199, 114, 15, 212, 80, 179, 57, 47, 143, 119, 222, 28, 115, 186, 145, 78, 216, 126, 151, 120, 111, 0, 199, 11, 179, 110, 18, 231, 107, 246, 88, 106, 157, 163, 142, 31, 174, 230, 5, 36, 20, 73, 61, 203, 3, 116, 45, 53, 249, 114, 68, 144, 196, 137, 1, 69, 219, 164, 152, 245, 251, 117, 233, 193, 100, 239, 196, 11, 5, 196, 37, 89, 245, 9, 157, 241, 65, 95, 155, 249, 22, 165, 208, 158, 64, 218, 2, 121, 190, 102, 126, 249, 220, 187, 172, 85, 160, 98, 149, 206, 135, 11, 7, 2, 155, 252, 219, 45, 206, 40, 217, 89, 242, 129, 91, 22, 248, 23, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 2, 128, 128, 0, 0, 0, 4, 0, 139, 197, 20, 117, 37, 184, 244, 119, 240, 188, 69, 34, 168, 140, 131, 57, 178, 73, 77, 181, 0, 0, 0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 174, 177, 60, 71, 22, 252, 2, 83, 136, 21, 46, 193, 113, 56, 122, 10, 147, 232, 87, 80, 102, 3, 129, 28, 186, 238, 195, 226, 129, 23, 121, 57, 40, 83, 99, 160, 227, 212, 38, 191, 254, 198, 61, 254, 142, 21, 23, 98, 188, 209, 141, 128, 50, 61, 217, 50, 150, 175, 134, 17, 138, 191, 89, 136, 1, 2, 0, 0, 0, 0, 7, 241, 16, 190, 54, 28, 56, 36, 145, 228, 91, 25, 121, 234, 157, 178, 59, 224, 18, 239, 118, 175, 34, 177, 29, 54, 182, 150, 171, 62, 185, 159, 2, 197, 80, 64, 178, 126, 231, 117, 67, 241, 16, 190, 54, 28, 56, 36, 145, 228, 91, 25, 121, 234, 157, 178, 59, 224, 18, 239, 118, 113, 182, 90, 231, 239, 140, 61, 131, 16, 225, 123, 27, 189, 62, 251, 91, 243, 157, 85, 50, 218, 152, 25, 94, 79, 157, 202, 18, 81, 212, 237, 162, 0, 0, 0, 1, 0, 107, 197, 27, 51, 233, 243, 98, 105, 68, 235, 135, 145, 71, 225, 129, 17, 88, 31, 143, 155, 128, 128, 0, 0, 0, 4, 0, 139, 197, 20, 117, 37, 184, 244, 119, 240, 188, 69, 34, 168, 140, 131, 57, 178, 73, 77, 181, 0, 0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 179, 62, 235, 22, 29, 234, 89, 98, 29, 128, 242, 37, 32, 109, 233, 16, 143, 156, 100, 20, 132, 154, 177, 73, 11, 172, 54, 46, 233, 170, 20, 32, 33, 247, 41, 181, 13, 183, 199, 182, 184, 82, 197, 132, 131, 113, 162, 245, 113, 179, 175, 195, 165, 11, 120, 114, 166, 244, 123, 153, 16, 40, 130, 18, 1, 2, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 170, 155, 145, 192, 23, 253, 116, 205, 41, 78, 56, 172, 52, 41, 176, 160, 205, 254, 87, 239, 126, 254, 212, 154, 210, 82, 203, 65, 255, 201, 6, 213, 29, 173, 60, 145, 226, 175, 210, 153, 236, 179, 43, 168, 192, 84, 118, 53, 205, 122, 143, 199, 35, 154, 47, 158, 144, 164, 187, 255, 126, 95, 59, 119, 219, 15, 236, 119, 249, 71, 142, 207, 29, 230, 95, 187, 119, 242, 183, 9]), Some([])]
CHUNK SLOT ID USING BURN HEIGHT: 1
CHUNK SLOT ID USING FN: 0
CHUNK BURN HEIGHT: 233 
```

RUN 3
```
GOT CHUNKS: [Some([]), Some([0, 0, 0, 0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 8, 61, 96, 252, 66, 233, 191, 102, 167, 122, 152, 214, 130, 241, 243, 236, 38, 240, 184, 127, 122, 42, 183, 83, 240, 115, 58, 57, 187, 9, 201, 174, 241, 205, 182, 64, 87, 171, 25, 226, 175, 111, 111, 172, 174, 216, 154, 167, 184, 151, 59, 116, 204, 9, 233, 33, 32, 222, 212, 230, 211, 254, 123, 126, 12, 145, 227, 216, 188, 216, 239, 116, 84, 118, 112, 36, 207, 31, 94, 114, 77, 154, 3, 115, 134, 208, 225, 212, 222, 126, 148, 153, 62, 86, 70, 51, 200, 143, 194, 1, 30, 209, 142, 223, 125, 189, 32, 233, 180, 83, 113, 22, 132, 156, 94, 106, 81, 115, 18, 1, 38, 251, 17, 77, 8, 223, 32, 241, 63, 157, 228, 65, 69, 104, 211, 99, 248, 60, 83, 20, 185, 99, 3, 3, 121, 9, 132, 143, 135, 131, 189, 49, 74, 56, 210, 173, 103, 139, 206, 17, 41, 59, 42, 4, 10, 115, 200, 36, 66, 61, 72, 110, 221, 44, 204, 111, 48, 84, 2, 58, 123, 201, 69, 137, 2, 121, 190, 102, 126, 249, 220, 187, 172, 85, 160, 98, 149, 206, 135, 11, 7, 2, 155, 252, 219, 45, 206, 40, 217, 89, 242, 129, 91, 22, 248, 23, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 2, 128, 128, 0, 0, 0, 4, 0, 139, 197, 20, 117, 37, 184, 244, 119, 240, 188, 69, 34, 168, 140, 131, 57, 178, 73, 77, 181, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 194, 214, 219, 175, 201, 243, 18, 143, 234, 114, 25, 174, 35, 187, 204, 163, 37, 72, 34, 138, 19, 20, 214, 193, 245, 26, 144, 219, 212, 91, 179, 107, 77, 240, 52, 23, 114, 121, 255, 76, 69, 128, 168, 203, 239, 47, 233, 56, 192, 131, 85, 68, 114, 190, 152, 88, 234, 247, 74, 91, 85, 186, 75, 49, 1, 2, 0, 0, 0, 0, 7, 252, 66, 233, 191, 102, 167, 122, 152, 214, 130, 241, 243, 236, 38, 240, 184, 127, 122, 42, 183, 139, 202, 53, 98, 185, 97, 164, 72, 31, 208, 102, 175, 252, 49, 71, 246, 32, 223, 252, 65, 252, 66, 233, 191, 102, 167, 122, 152, 214, 130, 241, 243, 236, 38, 240, 184, 127, 122, 42, 183, 83, 240, 115, 58, 57, 187, 9, 201, 174, 241, 205, 182, 64, 87, 171, 25, 226, 175, 111, 111, 172, 174, 216, 154, 167, 184, 151, 59, 116, 204, 9, 233, 0, 0, 0, 1, 0, 107, 197, 27, 51, 233, 243, 98, 105, 68, 235, 135, 145, 71, 225, 129, 17, 88, 31, 143, 155, 128, 128, 0, 0, 0, 4, 0, 139, 197, 20, 117, 37, 184, 244, 119, 240, 188, 69, 34, 168, 140, 131, 57, 178, 73, 77, 181, 0, 0, 0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 160, 102, 184, 46, 202, 181, 215, 60, 89, 47, 217, 151, 120, 163, 57, 246, 217, 88, 106, 75, 0, 79, 129, 186, 126, 215, 192, 92, 38, 67, 215, 198, 41, 63, 89, 23, 22, 95, 209, 13, 239, 220, 160, 24, 178, 16, 233, 148, 151, 65, 148, 177, 173, 226, 254, 196, 95, 55, 19, 64, 235, 201, 89, 210, 1, 2, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 195, 89, 69, 5, 41, 24, 124, 10, 12, 236, 182, 29, 180, 177, 91, 92, 22, 81, 214, 219, 89, 113, 1, 93, 230, 171, 36, 196, 210, 56, 18, 250, 222, 37, 63, 17, 37, 175, 2, 192, 211, 245, 132, 17, 183, 8, 20, 28, 35, 102, 88, 200, 240, 167, 170, 111, 155, 252, 91, 110, 235, 236, 40, 133, 239, 233, 29, 126, 20, 23, 15, 46, 191, 176, 74, 0, 209, 158, 95, 1])]
CHUNK SLOT ID USING BURN HEIGHT: 1
CHUNK SLOT ID USING FN: 1
CHUNK BURN HEIGHT: 233
```