### PR TITLE
Hotfix/stackerdb stale view

### DIFF
--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3883,26 +3883,13 @@ impl SortitionDB {
             .unwrap_or(&burnchain.first_block_hash)
             .clone();
 
-        let rc = burnchain
-            .block_height_to_reward_cycle(chain_tip.block_height)
-            .expect("FATAL: block height does not have a reward cycle");
-
-        let rc_height = burnchain.reward_cycle_to_block_height(rc);
-        let rc_consensus_hash = SortitionDB::get_ancestor_snapshot(
-            conn,
-            cmp::min(chain_tip.block_height, rc_height),
-            &chain_tip.sortition_id,
-        )?
-        .map(|sn| sn.consensus_hash)
-        .ok_or(db_error::NotFoundError)?;
-
         test_debug!(
             "Chain view: {},{}-{},{},{}",
             chain_tip.block_height,
             chain_tip.burn_header_hash,
             stable_block_height,
             &burn_stable_block_hash,
-            &rc_consensus_hash,
+            &chain_tip.canonical_stacks_tip_consensus_hash,
         );
         Ok(BurnchainView {
             burn_block_height: chain_tip.block_height,
@@ -3910,7 +3897,7 @@ impl SortitionDB {
             burn_stable_block_height: stable_block_height,
             burn_stable_block_hash: burn_stable_block_hash,
             last_burn_block_hashes: last_burn_block_hashes,
-            rc_consensus_hash,
+            rc_consensus_hash: chain_tip.canonical_stacks_tip_consensus_hash,
         })
     }
 }
@@ -4097,6 +4084,21 @@ impl SortitionDB {
         let consensus_hash = sn.canonical_stacks_tip_consensus_hash;
 
         Ok((consensus_hash, stacks_block_hash))
+    }
+
+    #[cfg(test)]
+    pub fn set_canonical_stacks_chain_tip(
+        conn: &Connection,
+        ch: &ConsensusHash,
+        bhh: &BlockHeaderHash,
+        height: u64,
+    ) -> Result<(), db_error> {
+        let tip = SortitionDB::get_canonical_burn_chain_tip(conn)?;
+        let args: &[&dyn ToSql] = &[ch, bhh, &u64_to_sql(height)?, &tip.sortition_id];
+        conn.execute("UPDATE snapshots SET canonical_stacks_tip_consensus_hash = ?1, canonical_stacks_tip_hash = ?2, canonical_stacks_tip_height = ?3
+                    WHERE sortition_id = ?4", args)
+            .map_err(db_error::SqliteError)?;
+        Ok(())
     }
 
     /// Get the maximum arrival index for any known snapshot.

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -975,6 +975,7 @@ pub mod NackErrorCodes {
     pub const InvalidMessage: u32 = 5;
     pub const NoSuchDB: u32 = 6;
     pub const StaleVersion: u32 = 7;
+    pub const StaleView: u32 = 8;
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -997,7 +998,9 @@ pub struct NatPunchData {
 /// Inform the remote peer of (a page of) the list of stacker DB contracts this node supports
 #[derive(Debug, Clone, PartialEq)]
 pub struct StackerDBHandshakeData {
-    /// current reward cycle ID
+    /// current reward cycle consensus hash (i.e. the consensus hash of the Stacks tip in the
+    /// current reward cycle, which commits to both the Stacks block tip and the underlying PoX
+    /// history).
     pub rc_consensus_hash: ConsensusHash,
     /// list of smart contracts that we index.
     /// there can be as many as 256 entries.
@@ -1009,7 +1012,7 @@ pub struct StackerDBHandshakeData {
 pub struct StackerDBGetChunkInvData {
     /// smart contract being used to determine chunk quantity and order
     pub contract_id: QualifiedContractIdentifier,
-    /// consensus hash of the sortition that started this reward cycle
+    /// consensus hash of the Stacks chain tip in this reward cycle
     pub rc_consensus_hash: ConsensusHash,
 }
 
@@ -1028,7 +1031,7 @@ pub struct StackerDBChunkInvData {
 pub struct StackerDBGetChunkData {
     /// smart contract being used to determine slot quantity and order
     pub contract_id: QualifiedContractIdentifier,
-    /// consensus hash of the sortition that started this reward cycle
+    /// consensus hash of the Stacks chain tip in this reward cycle
     pub rc_consensus_hash: ConsensusHash,
     /// slot ID
     pub slot_id: u32,
@@ -1041,7 +1044,7 @@ pub struct StackerDBGetChunkData {
 pub struct StackerDBPushChunkData {
     /// smart contract being used to determine chunk quantity and order
     pub contract_id: QualifiedContractIdentifier,
-    /// consensus hash of the sortition that started this reward cycle
+    /// consensus hash of the Stacks chain tip in this reward cycle
     pub rc_consensus_hash: ConsensusHash,
     /// the pushed chunk
     pub chunk_data: StackerDBChunkData,

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -151,6 +151,8 @@ pub struct StackerDBSyncResult {
     dead: HashSet<NeighborKey>,
     /// neighbors that misbehaved while syncing
     broken: HashSet<NeighborKey>,
+    /// neighbors that have stale views, but are otherwise online
+    pub(crate) stale: HashSet<NeighborAddress>,
 }
 
 /// Settings for the Stacker DB
@@ -262,6 +264,8 @@ pub struct StackerDBSync<NC: NeighborComms> {
     /// whether or not we should immediately re-fetch chunks because we learned about new chunks
     /// from our peers when they replied to our chunk-pushes with new inventory state
     need_resync: bool,
+    /// Track stale neighbors
+    pub(crate) stale_neighbors: HashSet<NeighborAddress>,
 }
 
 impl StackerDBSyncResult {
@@ -274,6 +278,7 @@ impl StackerDBSyncResult {
             chunks_to_store: vec![chunk.chunk_data],
             dead: HashSet::new(),
             broken: HashSet::new(),
+            stale: HashSet::new(),
         }
     }
 }

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -346,6 +346,15 @@ impl Node {
         }
 
         let burnchain_config = config.get_burnchain();
+
+        // instantiate DBs
+        let _burnchain_db = BurnchainDB::connect(
+            &burnchain_config.get_burnchaindb_path(),
+            &burnchain_config,
+            true,
+        )
+        .expect("FATAL: failed to connect to burnchain DB");
+
         run_loop::announce_boot_receipts(
             &mut event_dispatcher,
             &chain_state,
@@ -526,6 +535,7 @@ impl Node {
         let consensus_hash = burnchain_tip.block_snapshot.consensus_hash;
 
         let burnchain = self.config.get_burnchain();
+
         let sortdb = SortitionDB::open(
             &self.config.get_burn_db_file_path(),
             true,


### PR DESCRIPTION
This fixes a race condition in the StackerDB system whereby two nodes that process a Stacks block with configuration updates at different times can accidentally declare each other as broken, and ban each other.  This can happen when, for example, the signer of a given slot changes and a node receives a chunk before it has processed the change.

The fix is to repurpose the `rc_consensus_hash` field to refer to the canonical Stacks tip consensus hash, instead of the reward-cycle starting consensus hash.  This not only captures the same information as `rc_consensus_hash`, but also acts as a "view ID" of the chainstate:  two nodes will agree on the same StackerDB replica configurations if they have processed the same Stacks tips.  Furthermore, nodes will NACK each other's requests for inventories and chunks early on if they disagree on the view; they won't ban each other.