### PR TITLE
test: Add `replay-block` command

### DIFF
--- a/stackslib/src/burnchains/burnchain.rs
+++ b/stackslib/src/burnchains/burnchain.rs
@@ -103,7 +103,6 @@ impl BurnchainStateTransition {
     ) -> Result<BurnchainStateTransition, burnchain_error> {
         // block commits and support burns discovered in this block.
         let mut block_commits: Vec<LeaderBlockCommitOp> = vec![];
-        let mut user_burns: Vec<UserBurnSupportOp> = vec![];
         let mut accepted_ops = Vec::with_capacity(block_ops.len());
 
         assert!(Burnchain::ops_are_sorted(block_ops));
@@ -141,7 +140,6 @@ impl BurnchainStateTransition {
                     // we don't know yet which user burns are going to be accepted until we have
                     // the burn distribution, so just account for them for now.
                     all_user_burns.insert(op.txid.clone(), op.clone());
-                    user_burns.push(op.clone());
                 }
             };
         }

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -88,8 +88,8 @@ impl StacksTransactionReceipt {
         cost: ExecutionCost,
     ) -> StacksTransactionReceipt {
         StacksTransactionReceipt {
-            events: events,
-            result: result,
+            events,
+            result,
             stx_burned: 0,
             post_condition_aborted: false,
             contract_analysis: None,

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -1212,7 +1212,6 @@ simulating a miner.
             }
 
             // process all new blocks
-            let mut epoch_receipts = vec![];
             loop {
                 let sortition_tip =
                     SortitionDB::get_canonical_burn_chain_tip(new_sortition_db.conn())
@@ -1230,11 +1229,6 @@ simulating a miner.
                     .unwrap();
                 if receipts.len() == 0 {
                     break;
-                }
-                for (epoch_receipt_opt, _) in receipts.into_iter() {
-                    if let Some(epoch_receipt) = epoch_receipt_opt {
-                        epoch_receipts.push(epoch_receipt);
-                    }
                 }
             }
         }

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -863,7 +863,7 @@ simulating a miner.
     if argv[1] == "replay-block" {
         if argv.len() < 2 {
             eprintln!(
-                "Usage: {} <chainstate_path> [--prefix <index-block-hash-prefix>] [--last <block_count>]",
+                "Usage: {} <chainstate_path> [--prefix <index-block-hash-prefix>] [<--last|--first> <block_count>]",
                 &argv[0]
             );
             process::exit(1);
@@ -878,6 +878,10 @@ simulating a miner.
         let query = match mode {
             Some("--prefix") => format!(
                 "SELECT index_block_hash FROM staging_blocks WHERE index_block_hash LIKE \"{}%\"",
+                argv[4]
+            ),
+            Some("--first") => format!(
+                "SELECT index_block_hash FROM staging_blocks ORDER BY height ASC LIMIT {}",
                 argv[4]
             ),
             Some("--last") => format!(
@@ -1533,9 +1537,9 @@ simulating a miner.
 
 fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
     let index_block_hash = StacksBlockId::from_hex(index_block_hash_hex).unwrap();
-    let chain_state_path = format!("{}/mainnet/chainstate/", stacks_path);
-    let sort_db_path = format!("{}/mainnet/burnchain/sortition", stacks_path);
-    let burn_db_path = format!("{}/mainnet/burnchain/burnchain.sqlite", stacks_path);
+    let chain_state_path = format!("{stacks_path}/mainnet/chainstate/");
+    let sort_db_path = format!("{stacks_path}/mainnet/burnchain/sortition");
+    let burn_db_path = format!("{stacks_path}/mainnet/burnchain/burnchain.sqlite");
     let burnchain_blocks_db = BurnchainDB::open(&burn_db_path, false).unwrap();
 
     let (mut chainstate, _) =

--- a/stackslib/src/net/inv/epoch2x.rs
+++ b/stackslib/src/net/inv/epoch2x.rs
@@ -2250,7 +2250,6 @@ impl PeerNetwork {
             );
 
             let mut all_done = true;
-            let mut fully_synced_peers = HashSet::new();
             let mut ibd_diverged_height: Option<u64> = None;
 
             let bootstrap_peers: HashSet<_> =
@@ -2352,8 +2351,6 @@ impl PeerNetwork {
                             network.pox_id.num_inventory_reward_cycles(),
                             &nk
                         );
-
-                        fully_synced_peers.insert(nk.clone());
                     }
                 }
             }


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Add `stacks-inspect replay-block` command to validate blocks. This already exists on various branches in the repository, but IMO is extremely useful and should be in `next`

### Additional info (benefits, drawbacks, caveats)

This is currently failing on some blocks. I don't know if it's a problem with the command, or there have been consensus breaking changes in `next`. Example of a failing block:

```console
❯ cargo build --release --bin=stacks-inspect
❯ target/release/stacks-inspect replay-block /home/jbencin/data/
...
Failed processing block! block = 0002e2d15493097bf26309cdf0b121d1fd240c458621fe66469d2b226ecb361d, error = InvalidStacksBlock("Block 9a3c37a60075192c8d1b4355d0efbc766781e291e6ca0656411b7a3c9e438ab0 state root mismatch: expected ae68136f3d621d4c3f8097f1973d04069540a6a0888551f1b541e2a61faf87cc, got 48203e518d722777b57cbff17a5592ea6e1e0101d4766edc06a4ad00a0f2c535")
```

#### UPDATE

This has been solved, the blocks actually did contain invalid transactions

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
