### PR TITLE
Hotfix/masked result

### DIFF
--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1359,7 +1359,7 @@ impl<'a, 'b, 'hooks> Environment<'a, 'b, 'hooks> {
         self.global_context.begin();
         let result = stx_transfer_consolidated(self, from, to, amount, memo);
         match result {
-            Ok(value) => match value.clone().expect_result() {
+            Ok(value) => match value.clone().expect_result()? {
                 Ok(_) => {
                     self.global_context.commit()?;
                     Ok(value)

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3883,26 +3883,13 @@ impl SortitionDB {
             .unwrap_or(&burnchain.first_block_hash)
             .clone();
 
-        let rc = burnchain
-            .block_height_to_reward_cycle(chain_tip.block_height)
-            .expect("FATAL: block height does not have a reward cycle");
-
-        let rc_height = burnchain.reward_cycle_to_block_height(rc);
-        let rc_consensus_hash = SortitionDB::get_ancestor_snapshot(
-            conn,
-            cmp::min(chain_tip.block_height, rc_height),
-            &chain_tip.sortition_id,
-        )?
-        .map(|sn| sn.consensus_hash)
-        .ok_or(db_error::NotFoundError)?;
-
         test_debug!(
             "Chain view: {},{}-{},{},{}",
             chain_tip.block_height,
             chain_tip.burn_header_hash,
             stable_block_height,
             &burn_stable_block_hash,
-            &rc_consensus_hash,
+            &chain_tip.canonical_stacks_tip_consensus_hash,
         );
         Ok(BurnchainView {
             burn_block_height: chain_tip.block_height,
@@ -3910,7 +3897,7 @@ impl SortitionDB {
             burn_stable_block_height: stable_block_height,
             burn_stable_block_hash: burn_stable_block_hash,
             last_burn_block_hashes: last_burn_block_hashes,
-            rc_consensus_hash,
+            rc_consensus_hash: chain_tip.canonical_stacks_tip_consensus_hash,
         })
     }
 }
@@ -4097,6 +4084,21 @@ impl SortitionDB {
         let consensus_hash = sn.canonical_stacks_tip_consensus_hash;
 
         Ok((consensus_hash, stacks_block_hash))
+    }
+
+    #[cfg(test)]
+    pub fn set_canonical_stacks_chain_tip(
+        conn: &Connection,
+        ch: &ConsensusHash,
+        bhh: &BlockHeaderHash,
+        height: u64,
+    ) -> Result<(), db_error> {
+        let tip = SortitionDB::get_canonical_burn_chain_tip(conn)?;
+        let args: &[&dyn ToSql] = &[ch, bhh, &u64_to_sql(height)?, &tip.sortition_id];
+        conn.execute("UPDATE snapshots SET canonical_stacks_tip_consensus_hash = ?1, canonical_stacks_tip_hash = ?2, canonical_stacks_tip_height = ?3
+                    WHERE sortition_id = ?4", args)
+            .map_err(db_error::SqliteError)?;
+        Ok(())
     }
 
     /// Get the maximum arrival index for any known snapshot.


### PR DESCRIPTION
This fixes a bug in block validation whereby a STX transfer transaction may succeed with an insufficient balance due to a change in how `Value::expect_result()` behaves.