### PR TITLE
chore: Drop support for old x86_64 CPUs

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,9 +2,11 @@
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 
-# Build for modern x86_64 CPUs to take advantage of newer instructions
+# For x86_64 CPUs, default to `native` and override in CI for release builds
+# This makes it slightly faster for users running locally built binaries
+# TODO: Same for other targets?
 [target.'cfg(all(target_arch = "x86_64"))']
-rustflags = ["-Ctarget-cpu=x86-64-v3"]
+rustflags = ["-Ctarget-cpu=native"]
 
 # Needed by perf to generate flamegraphs.
 #[target.x86_64-unknown-linux-gnu]

--- a/.cargo/config
+++ b/.cargo/config
@@ -2,7 +2,12 @@
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 
+# Build for modern x86_64 CPUs to take advantage of newer instructions
+[target.'cfg(all(target_arch = "x86_64"))']
+rustflags = ["-Ctarget-cpu=x86-64-v3"]
+
 # Needed by perf to generate flamegraphs.
 #[target.x86_64-unknown-linux-gnu]
 #linker = "/usr/bin/clang"
 #rustflags = ["-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Wl,--no-rosegment"]
+

--- a/.github/workflows/create-source-binary-x64.yml
+++ b/.github/workflows/create-source-binary-x64.yml
@@ -1,6 +1,6 @@
 ## Github workflow to create multiarch binaries from source
 
-name: Create Binaries
+name: Create Binaries for x86_64
 
 on:
   workflow_call:
@@ -14,7 +14,13 @@ on:
         required: false
         type: string
         default: >-
-          ["linux-glibc-arm64", "linux-glibc-armv7", "linux-musl-arm64", "linux-musl-armv7"]
+          ["linux-glibc-x64", "linux-musl-x64", "macos-x64", "windows-x64"]
+      cpu:
+        description: "Stringified JSON object listing of target CPU matrix"
+        required: false
+        type: string
+        default: >-
+          ["x86-64", "x86-64-v3"]
 
 ## change the display name to the tag being built
 run-name: ${{ inputs.tag }}
@@ -39,13 +45,14 @@ jobs:
       max-parallel: 10
       matrix:
         platform: ${{ fromJson(inputs.arch) }}
+        cpu: ${{ fromJson(inputs.cpu) }}
     steps:
       ## Setup Docker for the builds
       - name: Docker setup
         uses: stacks-network/actions/docker@main
 
       ## Build the binaries using defined dockerfiles
-      - name: Build Binary (${{ matrix.platform }})
+      - name: Build Binary (${{ matrix.platform }}_${{ matrix.cpu }})
         id: build_binaries
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
         with:
@@ -54,17 +61,18 @@ jobs:
           build-args: |
             STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
             OS_ARCH=${{ matrix.platform }}
+            TARGET_CPU=${{ matrix.cpu }}
             GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
 
       ## Compress the binary artifact
       - name: Compress artifact
         id: compress_artifact
-        run: zip --junk-paths ${{ matrix.platform }} ./release/${{ matrix.platform }}/*
+        run: zip --junk-paths ${{ matrix.platform }}_${{ matrix.cpu }} ./release/${{ matrix.platform }}/*
 
       ## Upload the binary artifact to the github action (used in `github-release.yml` to create a release)
       - name: Upload artifact
         id: upload_artifact
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
-          path: ${{ matrix.platform }}.zip
+          path: ${{ matrix.platform }}_${{ matrix.cpu }}.zip

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -36,6 +36,21 @@ jobs:
       tag: ${{ inputs.tag }}
     secrets: inherit
 
+  ## Build x86_64 binaries from source
+  ##
+  ## Runs when the following is true:
+  ##  - tag is provided
+  ##  - workflow is building default branch (master)
+  build-binaries-x64:
+    if: |
+      inputs.tag != '' && 
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    name: Build Binaries (x64_64)
+    uses: ./.github/workflows/create-source-binary-x64.yml
+    with:
+      tag: ${{ inputs.tag }}
+    secrets: inherit
+
   ## Runs when the following is true:
   ##  - tag is provided
   ##  - workflow is building default branch (master)
@@ -47,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-binaries
+      - build-binaries-x64
     steps:
       ## Downloads the artifacts built in `create-source-binary.yml`
       - name: Download Artifacts
@@ -95,6 +111,7 @@ jobs:
     uses: ./.github/workflows/image-build-binary.yml
     needs:
       - build-binaries
+      - build-binaries-x64
       - create-release
     with:
       tag: ${{ inputs.tag }}

--- a/build-scripts/Dockerfile.linux-glibc-x64
+++ b/build-scripts/Dockerfile.linux-glibc-x64
@@ -5,6 +5,8 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-gnu
+# Allow us to override the default `--target-cpu` for the given target triplet
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -15,7 +17,8 @@ RUN apt-get update && apt-get install -y git
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/build-scripts/Dockerfile.linux-musl-x64
+++ b/build-scripts/Dockerfile.linux-musl-x64
@@ -5,6 +5,8 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-musl
+# Allow us to override the default `--target-cpu` for the given target triplet
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -15,7 +17,8 @@ RUN apk update && apk add git musl-dev
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/build-scripts/Dockerfile.macos-x64
+++ b/build-scripts/Dockerfile.macos-x64
@@ -6,6 +6,7 @@ ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG OSXCROSS="https://github.com/hirosystems/docker-osxcross-rust/releases/download/MacOSX12.0.sdk/osxcross-d904031_MacOSX12.0.sdk.tar.zst"
 ARG TARGET=x86_64-apple-darwin
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -21,7 +22,8 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && . /opt/osxcross/env-macos-x86_64 \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/build-scripts/Dockerfile.windows-x64
+++ b/build-scripts/Dockerfile.windows-x64
@@ -5,6 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-pc-windows-gnu
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -17,6 +18,7 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && rustup target add ${TARGET} \
     && CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
     cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

When building for x86_64 CPUs, use the `x86-64-v3` target. This allows the compiler to use newer instructions in order to better optimize the code, like AVX, AVX2, and FMA. This also means older (pre-Haswell or pre-Bulldozer) CPUs won't be supported by default. See [here](https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels) for full details.

This would mean than users with 10+ year old CPUs would not be able to use the binaries we distribute, and in order to run `stacks-node` they would have to modify the config and build it themselves

If we are not comfortable with this trade-off, we could build and distribute both `x86-64` and `x86-64-v3` binaries

This gives a small performance boost of about **1.4%** on my Laptop (Intel Core i7-1270P) when processing the first 3000 blocks:

```console
❯ hyperfine -w 3 -r 10 "stacks-core.next/target/release/stacks-inspect.x86-64 replay-block /home/jbencin/data/next/ first 3000" "stacks-core.next/target/release/stacks-inspect.x86-64-v3 replay-block /home/jbencin/data/next/ first 3000"
Benchmark 1: stacks-core.next/target/release/stacks-inspect.x86-64 replay-block /home/jbencin/data/next/ first 3000
  Time (mean ± σ):     31.088 s ±  0.041 s    [User: 27.082 s, System: 3.844 s]
  Range (min … max):   31.024 s … 31.152 s    10 runs
 
Benchmark 2: stacks-core.next/target/release/stacks-inspect.x86-64-v3 replay-block /home/jbencin/data/next/ first 3000
  Time (mean ± σ):     30.645 s ±  0.046 s    [User: 26.541 s, System: 3.946 s]
  Range (min … max):   30.568 s … 30.719 s    10 runs
 
Summary
  stacks-core.next/target/release/stacks-inspect.x86-64-v3 replay-block /home/jbencin/data/next/ first 3000 ran
    1.01 ± 0.00 times faster than stacks-core.next/target/release/stacks-inspect.x86-64 replay-block /home/jbencin/data/next/ first 3000

```

### Applicable issues

- #4316

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
