### PR TITLE
chore: Enable "fat" link-time optimizations for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ opt-level = 3
 
 [profile.release]
 debug = true
-
+lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,5 @@ opt-level = 3
 
 [profile.release]
 debug = true
+codegen-units = 1
 lto = "fat"


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Enable "fat" link-time optimization. This will slow down the linking stage of release builds slightly, but will allow the linker to optimize the code better by optimizing over the entire dependency graph

A quick benchmark with `hyperfine` shows an improvement of **1%** in processing the first 3000 blocks:

```console
❯ hyperfine -w 3 -r 10 "stacks-core.next/target/release/stacks-inspect.x86-64 replay-block /home/jbencin/data/next/ first 3000" "stacks-core.next/target/release/stacks-inspect.lto-fat replay-block /home/jbencin/data/next/ first 3000"
Benchmark 1: stacks-core.next/target/release/stacks-inspect.x86-64 replay-block /home/jbencin/data/next/ first 3000
  Time (mean ± σ):     31.134 s ±  0.073 s    [User: 27.134 s, System: 3.852 s]
  Range (min … max):   31.038 s … 31.303 s    10 runs
 
Benchmark 2: stacks-core.next/target/release/stacks-inspect.lto-fat replay-block /home/jbencin/data/next/ first 3000
  Time (mean ± σ):     30.866 s ±  0.085 s    [User: 26.770 s, System: 3.953 s]
  Range (min … max):   30.749 s … 31.031 s    10 runs
 
Summary
  stacks-core.next/target/release/stacks-inspect.lto-fat replay-block /home/jbencin/data/next/ first 3000 ran
    1.01 ± 0.00 times faster than stacks-core.next/target/release/stacks-inspect.x86-64 replay-block /home/jbencin/data/next/ first 3000
```

### Applicable issues

- #4316

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
