### PR TITLE
Separate Nakamoto DB for staging blocks

### DIFF
--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4556,6 +4556,22 @@ impl SortitionDB {
         })
     }
 
+    /// Determine if a burnchain block has been processed
+    pub fn has_block_snapshot_consensus(
+        conn: &Connection,
+        consensus_hash: &ConsensusHash,
+    ) -> Result<bool, db_error> {
+        let qry = "SELECT 1 FROM snapshots WHERE consensus_hash = ?1";
+        let args = [&consensus_hash];
+        let res: Option<i64> = query_row_panic(conn, qry, &args, || {
+            format!(
+                "FATAL: multiple block snapshots for the same block with consensus hash {}",
+                consensus_hash
+            )
+        })?;
+        Ok(res.is_some())
+    }
+
     /// Get a snapshot for an processed sortition.
     /// The snapshot may not be valid
     pub fn get_block_snapshot(

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -887,7 +887,7 @@ impl<
 
             // mark this burn block as processed in the nakamoto chainstate
             let tx = self.chain_state_db.staging_db_tx_begin()?;
-            NakamotoChainState::set_burn_block_processed(&tx, &next_snapshot.consensus_hash)?;
+            tx.set_burn_block_processed(&next_snapshot.consensus_hash)?;
             tx.commit().map_err(DBError::SqliteError)?;
 
             let sortition_id = next_snapshot.sortition_id;

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -1,0 +1,401 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fs;
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+
+use lazy_static::lazy_static;
+use rusqlite::types::{FromSql, FromSqlError};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql, NO_PARAMS};
+use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
+use stacks_common::util::{get_epoch_time_secs, sleep_ms};
+
+use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
+use crate::chainstate::burn::BlockSnapshot;
+use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::index::marf::MarfConnection;
+use crate::chainstate::stacks::{Error as ChainstateError, StacksBlock, StacksBlockHeader};
+use crate::stacks_common::codec::StacksMessageCodec;
+use crate::util_lib::db::{
+    query_int, query_row, query_row_panic, query_rows, sqlite_open, tx_begin_immediate, u64_to_sql,
+    DBConn, Error as DBError, FromRow,
+};
+
+lazy_static! {
+    pub static ref NAKAMOTO_STAGING_DB_SCHEMA_1: Vec<String> = vec![
+      r#"
+      -- Table for staging nakamoto blocks
+      CREATE TABLE nakamoto_staging_blocks (
+                     -- SHA512/256 hash of this block
+                     block_hash TEXT NOT NULL,
+                     -- the consensus hash of the burnchain block that selected this block's miner's block-commit
+                     consensus_hash TEXT NOT NULL,
+                     -- the parent index_block_hash
+                     parent_block_id TEXT NOT NULL,
+
+                     -- has the burnchain block with this block's `consensus_hash` been processed?
+                     burn_attachable INT NOT NULL,
+                     -- has this block been processed?
+                     processed INT NOT NULL,
+                     -- set to 1 if this block can never be attached
+                     orphaned INT NOT NULL,
+
+                     height INT NOT NULL,
+
+                     -- used internally -- this is the StacksBlockId of this block's consensus hash and block hash
+                     index_block_hash TEXT NOT NULL,
+                     -- how long the block was in-flight
+                     download_time INT NOT NULL,
+                     -- when this block was stored
+                     arrival_time INT NOT NULL,
+                     -- when this block was processed
+                     processed_time INT NOT NULL,
+
+                     -- block data
+                     data BLOB NOT NULL,
+                    
+                     PRIMARY KEY(block_hash,consensus_hash)
+        );"#
+        .into(),
+        r#"CREATE INDEX by_index_block_hash ON nakamoto_staging_blocks(index_block_hash);"#.into()
+    ];
+}
+
+pub struct NakamotoStagingBlocksConn(rusqlite::Connection);
+
+impl Deref for NakamotoStagingBlocksConn {
+    type Target = rusqlite::Connection;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for NakamotoStagingBlocksConn {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl NakamotoStagingBlocksConn {
+    pub fn conn(&self) -> NakamotoStagingBlocksConnRef {
+        NakamotoStagingBlocksConnRef(&self.0)
+    }
+}
+
+pub struct NakamotoStagingBlocksConnRef<'a>(&'a rusqlite::Connection);
+
+impl<'a> NakamotoStagingBlocksConnRef<'a> {
+    pub fn conn(&self) -> NakamotoStagingBlocksConnRef<'a> {
+        NakamotoStagingBlocksConnRef(self.0)
+    }
+}
+
+impl Deref for NakamotoStagingBlocksConnRef<'_> {
+    type Target = rusqlite::Connection;
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+pub struct NakamotoStagingBlocksTx<'a>(rusqlite::Transaction<'a>);
+
+impl<'a> NakamotoStagingBlocksTx<'a> {
+    pub fn commit(self) -> Result<(), rusqlite::Error> {
+        self.0.commit()
+    }
+
+    pub fn conn(&self) -> NakamotoStagingBlocksConnRef {
+        NakamotoStagingBlocksConnRef(self.0.deref())
+    }
+}
+
+impl<'a> Deref for NakamotoStagingBlocksTx<'a> {
+    type Target = rusqlite::Transaction<'a>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for NakamotoStagingBlocksTx<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a> NakamotoStagingBlocksConnRef<'a> {
+    /// Determine whether or not we have processed at least one Nakamoto block in this sortition history.
+    /// NOTE: the relevant field queried from `nakamoto_staging_blocks` is updated by a separate
+    /// tx from block-processing, so it's imperative that the thread that calls this function is
+    /// the *same* thread as the one that processes blocks.
+    /// Returns Ok(true) if at least one block in `nakamoto_staging_blocks` has `processed = 1`
+    /// Returns Ok(false) if not
+    /// Returns Err(..) on DB error
+    fn has_processed_nakamoto_block<SH: SortitionHandle>(
+        &self,
+        sortition_handle: &SH,
+    ) -> Result<bool, ChainstateError> {
+        let Some((ch, bhh, _height)) = sortition_handle.get_nakamoto_tip()? else {
+            return Ok(false);
+        };
+
+        // this block must be a processed Nakamoto block
+        let ibh = StacksBlockId::new(&ch, &bhh);
+        let qry = "SELECT 1 FROM nakamoto_staging_blocks WHERE processed = 1 AND index_block_hash = ?1 LIMIT 1";
+        let args: &[&dyn ToSql] = &[&ibh];
+        let res: Option<i64> = query_row(self, qry, args)?;
+        Ok(res.is_some())
+    }
+
+    /// Get a Nakamoto block by index block hash, as well as its size.
+    /// Verifies its integrity.
+    /// Returns Ok(Some(block, size)) if the block was present
+    /// Returns Ok(None) if there were no such rows.
+    /// Returns Err(..) on DB error, including block corruption
+    pub fn get_nakamoto_block(
+        &self,
+        index_block_hash: &StacksBlockId,
+    ) -> Result<Option<(NakamotoBlock, u64)>, ChainstateError> {
+        let qry = "SELECT data FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
+        let args: &[&dyn ToSql] = &[index_block_hash];
+        let res: Option<Vec<u8>> = query_row(self, qry, args)?;
+        let Some(block_bytes) = res else {
+            return Ok(None);
+        };
+        let block = NakamotoBlock::consensus_deserialize(&mut block_bytes.as_slice())?;
+        if &block.header.block_id() != index_block_hash {
+            error!(
+                "Staging DB corruption: expected {}, got {}",
+                index_block_hash,
+                &block.header.block_id()
+            );
+            return Err(DBError::Corruption.into());
+        }
+        Ok(Some((
+            block,
+            u64::try_from(block_bytes.len()).expect("FATAL: block is greater than a u64"),
+        )))
+    }
+
+    /// Find the next ready-to-process Nakamoto block, given a connection to the staging blocks DB.
+    /// NOTE: the relevant field queried from `nakamoto_staging_blocks` are updated by a separate
+    /// tx from block-processing, so it's imperative that the thread that calls this function is
+    /// the *same* thread that goes to process blocks.
+    /// Returns (the block, the size of the block)
+    pub(crate) fn next_ready_nakamoto_block<SH: SortitionHandle>(
+        &self,
+        header_conn: &Connection,
+        sortition_handle: &SH,
+    ) -> Result<Option<(NakamotoBlock, u64)>, ChainstateError> {
+        let query = "SELECT child.data FROM nakamoto_staging_blocks child JOIN nakamoto_staging_blocks parent
+                     ON child.parent_block_id = parent.index_block_hash
+                     WHERE child.burn_attachable = 1
+                       AND child.orphaned = 0
+                       AND child.processed = 0
+                       AND parent.processed = 1
+                     ORDER BY child.height ASC";
+        self
+            .query_row_and_then(query, NO_PARAMS, |row| {
+                let data: Vec<u8> = row.get("data")?;
+                let block = NakamotoBlock::consensus_deserialize(&mut data.as_slice())?;
+                Ok(Some((
+                    block,
+                    u64::try_from(data.len()).expect("FATAL: block is bigger than a u64"),
+                )))
+            })
+            .or_else(|e| {
+                if let ChainstateError::DBError(DBError::SqliteError(
+                    rusqlite::Error::QueryReturnedNoRows,
+                )) = e
+                {
+                    // This query can fail if the parent of `child` is not a Nakamoto block, which
+                    // is allowed -- a Nakamoto block can descend from an epoch2 block (but since
+                    // Nakamoto does not fork without a Bitcoin fork, it'll be the only such child
+                    // within that Bitcoin forok).
+                    //
+                    // So, if at least one Nakamoto block is processed in this Bitcoin fork,
+                    // then the next ready block's parent *must* be a Nakamoto block.  So
+                    // if the below is true, then there are no ready blocks.
+                    if self.has_processed_nakamoto_block(sortition_handle)? {
+                        return Ok(None);
+                    }
+
+                    // no nakamoto blocks processed yet, so the parent *must* be an epoch2 block!
+                    // go find it.  Note that while this is expensive, it only has to be done
+                    // _once_, and it will only touch at most one reward cycle's worth of blocks.
+                    let sql = "SELECT index_block_hash,parent_block_id FROM nakamoto_staging_blocks WHERE processed = 0 AND orphaned = 0 AND burn_attachable = 1 ORDER BY height ASC";
+                    let mut stmt = self.deref().prepare(sql)?;
+                    let mut qry = stmt.query(NO_PARAMS)?;
+                    let mut next_nakamoto_block_id = None;
+                    while let Some(row) = qry.next()? {
+                        let index_block_hash : StacksBlockId = row.get(0)?;
+                        let parent_block_id : StacksBlockId = row.get(1)?;
+
+                        let Some(_parent_epoch2_block) = NakamotoChainState::get_block_header_epoch2(header_conn, &parent_block_id)? else {
+                            continue;
+                        };
+
+                        // epoch2 parent exists, so this Nakamoto block is processable!
+                        next_nakamoto_block_id = Some(index_block_hash);
+                        break;
+                    }
+                    let Some(next_nakamoto_block_id) = next_nakamoto_block_id else {
+                        // no stored nakamoto block had an epoch2 parent
+                        return Ok(None);
+                    };
+
+                    // need qry and stmt to stop borrowing self before we can use it
+                    // again
+                    // drop(qry);
+                    // drop(stmt);
+
+                    self.get_nakamoto_block(&next_nakamoto_block_id)
+                } else {
+                    Err(e)
+                }
+            })
+    }
+}
+
+impl<'a> NakamotoStagingBlocksTx<'a> {
+    /// Notify the staging database that a given stacks block has been processed.
+    /// This will update the attachable status for children blocks, as well as marking the stacks
+    ///  block itself as processed.
+    pub fn set_block_processed(&self, block: &StacksBlockId) -> Result<(), ChainstateError> {
+        let clear_staged_block =
+            "UPDATE nakamoto_staging_blocks SET processed = 1, processed_time = ?2
+                                  WHERE index_block_hash = ?1";
+        self.execute(
+            &clear_staged_block,
+            params![&block, &u64_to_sql(get_epoch_time_secs())?],
+        )?;
+
+        Ok(())
+    }
+
+    /// Modify the staging database that a given stacks block can never be processed.
+    /// This will update the attachable status for children blocks, as well as marking the stacks
+    /// block itself as orphaned.
+    pub fn set_block_orphaned(&self, block: &StacksBlockId) -> Result<(), ChainstateError> {
+        let update_dependents = "UPDATE nakamoto_staging_blocks SET orphaned = 1
+                                 WHERE parent_block_id = ?";
+
+        self.execute(&update_dependents, &[&block])?;
+
+        let clear_staged_block =
+            "UPDATE nakamoto_staging_blocks SET processed = 1, processed_time = ?2, orphaned = 1
+                                  WHERE index_block_hash = ?1";
+        self.execute(
+            &clear_staged_block,
+            params![&block, &u64_to_sql(get_epoch_time_secs())?],
+        )?;
+
+        Ok(())
+    }
+
+    /// Notify the staging database that a given burn block has been processed.
+    /// This is required for staged blocks to be eligible for processing.
+    pub fn set_burn_block_processed(
+        &self,
+        consensus_hash: &ConsensusHash,
+    ) -> Result<(), ChainstateError> {
+        let update_dependents = "UPDATE nakamoto_staging_blocks SET burn_attachable = 1
+                                 WHERE consensus_hash = ?";
+        self.execute(&update_dependents, &[consensus_hash])?;
+
+        Ok(())
+    }
+}
+
+impl StacksChainState {
+    /// Begin a transaction against the staging blocks DB.
+    /// Note that this DB is (or will eventually be) in a separate database from the headers.
+    pub fn staging_db_tx_begin<'a>(
+        &'a mut self,
+    ) -> Result<NakamotoStagingBlocksTx<'a>, ChainstateError> {
+        let tx = tx_begin_immediate(&mut self.nakamoto_staging_blocks_conn)?;
+        Ok(NakamotoStagingBlocksTx(tx))
+    }
+
+    /// Begin a tx to both the headers DB and the staging DB
+    pub fn headers_and_staging_tx_begin<'a>(
+        &'a mut self,
+    ) -> Result<(rusqlite::Transaction<'a>, NakamotoStagingBlocksTx<'a>), ChainstateError> {
+        let header_tx = self
+            .state_index
+            .storage_tx()
+            .map_err(ChainstateError::DBError)?;
+        let staging_tx = tx_begin_immediate(&mut self.nakamoto_staging_blocks_conn)?;
+        Ok((header_tx, NakamotoStagingBlocksTx(staging_tx)))
+    }
+
+    /// Open a connection to the headers DB, and open a tx to the staging DB
+    pub fn headers_conn_and_staging_tx_begin<'a>(
+        &'a mut self,
+    ) -> Result<(&'a rusqlite::Connection, NakamotoStagingBlocksTx<'a>), ChainstateError> {
+        let header_conn = self.state_index.sqlite_conn();
+        let staging_tx = tx_begin_immediate(&mut self.nakamoto_staging_blocks_conn)?;
+        Ok((header_conn, NakamotoStagingBlocksTx(staging_tx)))
+    }
+
+    /// Get a ref to the nakamoto staging blocks connection
+    pub fn nakamoto_blocks_db(&self) -> NakamotoStagingBlocksConnRef {
+        NakamotoStagingBlocksConnRef(&self.nakamoto_staging_blocks_conn)
+    }
+
+    /// Get the path to the Nakamoto staging blocks DB.
+    /// It's separate from the headers DB in order to avoid DB contention between downloading
+    /// blocks and processing them.
+    pub fn get_nakamoto_staging_blocks_path(root_path: PathBuf) -> Result<String, ChainstateError> {
+        let mut nakamoto_blocks_path = Self::blocks_path(root_path);
+        nakamoto_blocks_path.push("nakamoto.sqlite");
+        Ok(nakamoto_blocks_path
+            .to_str()
+            .ok_or(ChainstateError::DBError(DBError::ParseError))?
+            .to_string())
+    }
+
+    /// Open and set up a DB for nakamoto staging blocks.
+    /// If it doesn't exist, then instantiate it if `readwrite` is true.
+    pub fn open_nakamoto_staging_blocks(
+        path: &str,
+        readwrite: bool,
+    ) -> Result<NakamotoStagingBlocksConn, ChainstateError> {
+        let exists = fs::metadata(&path).is_ok();
+        let flags = if !exists {
+            // try to instantiate
+            if readwrite {
+                OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE
+            } else {
+                return Err(DBError::NotFoundError.into());
+            }
+        } else {
+            if readwrite {
+                OpenFlags::SQLITE_OPEN_READ_WRITE
+            } else {
+                OpenFlags::SQLITE_OPEN_READ_ONLY
+            }
+        };
+        let conn = sqlite_open(path, flags, false)?;
+        if !exists {
+            for cmd in NAKAMOTO_STAGING_DB_SCHEMA_1.iter() {
+                conn.execute(cmd, NO_PARAMS)?;
+            }
+        }
+        Ok(NakamotoStagingBlocksConn(conn))
+    }
+}

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -258,11 +258,6 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
                         return Ok(None);
                     };
 
-                    // need qry and stmt to stop borrowing self before we can use it
-                    // again
-                    // drop(qry);
-                    // drop(stmt);
-
                     self.get_nakamoto_block(&next_nakamoto_block_id)
                 } else {
                     Err(e)

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -36,45 +36,42 @@ use crate::util_lib::db::{
     DBConn, Error as DBError, FromRow,
 };
 
-lazy_static! {
-    pub static ref NAKAMOTO_STAGING_DB_SCHEMA_1: Vec<String> = vec![
-      r#"
-      -- Table for staging nakamoto blocks
-      CREATE TABLE nakamoto_staging_blocks (
-                     -- SHA512/256 hash of this block
-                     block_hash TEXT NOT NULL,
-                     -- the consensus hash of the burnchain block that selected this block's miner's block-commit
-                     consensus_hash TEXT NOT NULL,
-                     -- the parent index_block_hash
-                     parent_block_id TEXT NOT NULL,
+pub const NAKAMOTO_STAGING_DB_SCHEMA_1: &'static [&'static str] = &[
+    r#"
+  -- Table for staging nakamoto blocks
+  CREATE TABLE nakamoto_staging_blocks (
+                 -- SHA512/256 hash of this block
+                 block_hash TEXT NOT NULL,
+                 -- the consensus hash of the burnchain block that selected this block's miner's block-commit
+                 consensus_hash TEXT NOT NULL,
+                 -- the parent index_block_hash
+                 parent_block_id TEXT NOT NULL,
 
-                     -- has the burnchain block with this block's `consensus_hash` been processed?
-                     burn_attachable INT NOT NULL,
-                     -- has this block been processed?
-                     processed INT NOT NULL,
-                     -- set to 1 if this block can never be attached
-                     orphaned INT NOT NULL,
+                 -- has the burnchain block with this block's `consensus_hash` been processed?
+                 burn_attachable INT NOT NULL,
+                 -- has this block been processed?
+                 processed INT NOT NULL,
+                 -- set to 1 if this block can never be attached
+                 orphaned INT NOT NULL,
 
-                     height INT NOT NULL,
+                 height INT NOT NULL,
 
-                     -- used internally -- this is the StacksBlockId of this block's consensus hash and block hash
-                     index_block_hash TEXT NOT NULL,
-                     -- how long the block was in-flight
-                     download_time INT NOT NULL,
-                     -- when this block was stored
-                     arrival_time INT NOT NULL,
-                     -- when this block was processed
-                     processed_time INT NOT NULL,
+                 -- used internally -- this is the StacksBlockId of this block's consensus hash and block hash
+                 index_block_hash TEXT NOT NULL,
+                 -- how long the block was in-flight
+                 download_time INT NOT NULL,
+                 -- when this block was stored
+                 arrival_time INT NOT NULL,
+                 -- when this block was processed
+                 processed_time INT NOT NULL,
 
-                     -- block data
-                     data BLOB NOT NULL,
-                    
-                     PRIMARY KEY(block_hash,consensus_hash)
-        );"#
-        .into(),
-        r#"CREATE INDEX by_index_block_hash ON nakamoto_staging_blocks(index_block_hash);"#.into()
-    ];
-}
+                 -- block data
+                 data BLOB NOT NULL,
+                
+                 PRIMARY KEY(block_hash,consensus_hash)
+    );"#,
+    r#"CREATE INDEX by_index_block_hash ON nakamoto_staging_blocks(index_block_hash);"#,
+];
 
 pub struct NakamotoStagingBlocksConn(rusqlite::Connection);
 

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -636,6 +636,14 @@ pub fn test_load_store_update_nakamoto_blocks() {
     stx_transfer_tx.chain_id = 0x80000000;
     stx_transfer_tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
 
+    let mut stx_transfer_tx_3 = StacksTransaction::new(
+        TransactionVersion::Testnet,
+        TransactionAuth::from_p2pkh(&private_key).unwrap(),
+        TransactionPayload::TokenTransfer(recipient_addr.into(), 124, TokenTransferMemo([0u8; 34])),
+    );
+    stx_transfer_tx_3.chain_id = 0x80000000;
+    stx_transfer_tx_3.anchor_mode = TransactionAnchorMode::OnChainOnly;
+
     let nakamoto_txs = vec![tenure_change_tx.clone(), coinbase_tx.clone()];
     let nakamoto_tx_merkle_root = {
         let txid_vecs = nakamoto_txs
@@ -649,6 +657,16 @@ pub fn test_load_store_update_nakamoto_blocks() {
     let nakamoto_txs_2 = vec![stx_transfer_tx.clone()];
     let nakamoto_tx_merkle_root_2 = {
         let txid_vecs = nakamoto_txs_2
+            .iter()
+            .map(|tx| tx.txid().as_bytes().to_vec())
+            .collect();
+
+        MerkleTree::<Sha512Trunc256Sum>::new(&txid_vecs).root()
+    };
+
+    let nakamoto_txs_3 = vec![stx_transfer_tx_3.clone()];
+    let nakamoto_tx_merkle_root_3 = {
+        let txid_vecs = nakamoto_txs_3
             .iter()
             .map(|tx| tx.txid().as_bytes().to_vec())
             .collect();
@@ -738,6 +756,37 @@ pub fn test_load_store_update_nakamoto_blocks() {
         runtime: 204,
     };
 
+    // third nakamoto block
+    let nakamoto_header_3 = NakamotoBlockHeader {
+        version: 1,
+        chain_length: 459,
+        burn_spent: 128,
+        consensus_hash: tenure_change_payload.tenure_consensus_hash.clone(),
+        parent_block_id: nakamoto_header_2.block_id(),
+        tx_merkle_root: nakamoto_tx_merkle_root_3,
+        state_index_root: TrieHash([0x07; 32]),
+        miner_signature: MessageSignature::empty(),
+        signer_signature: ThresholdSignature::empty(),
+        signer_bitvec: BitVec::zeros(1).unwrap(),
+    };
+
+    let nakamoto_header_info_3 = StacksHeaderInfo {
+        anchored_header: StacksBlockHeaderTypes::Nakamoto(nakamoto_header_3.clone()),
+        microblock_tail: None,
+        stacks_block_height: nakamoto_header_2.chain_length,
+        index_root: TrieHash([0x67; 32]),
+        consensus_hash: nakamoto_header_2.consensus_hash.clone(),
+        burn_header_hash: BurnchainHeaderHash([0x88; 32]),
+        burn_header_height: 200,
+        burn_header_timestamp: 1001,
+        anchored_block_size: 123,
+    };
+
+    let nakamoto_block_3 = NakamotoBlock {
+        header: nakamoto_header_3.clone(),
+        txs: nakamoto_txs_3,
+    };
+
     let mut total_nakamoto_execution_cost = nakamoto_execution_cost.clone();
     total_nakamoto_execution_cost
         .add(&nakamoto_execution_cost_2)
@@ -759,7 +808,8 @@ pub fn test_load_store_update_nakamoto_blocks() {
 
     // store epoch2 and nakamoto headers
     {
-        let tx = chainstate.db_tx_begin().unwrap();
+        let (tx, staging_tx) = chainstate.headers_and_staging_tx_begin().unwrap();
+
         StacksChainState::insert_stacks_block_header(
             &tx,
             &epoch2_parent_block_id,
@@ -846,7 +896,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
             300,
         )
         .unwrap();
-        NakamotoChainState::store_block(&tx, nakamoto_block.clone(), false, false).unwrap();
+        NakamotoChainState::store_block(&staging_tx, nakamoto_block.clone(), false).unwrap();
 
         // tenure has one block
         assert_eq!(
@@ -879,7 +929,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
         )
         .unwrap();
 
-        NakamotoChainState::store_block(&tx, nakamoto_block_2.clone(), false, false).unwrap();
+        NakamotoChainState::store_block(&staging_tx, nakamoto_block_2.clone(), false).unwrap();
 
         // tenure has two blocks
         assert_eq!(
@@ -898,13 +948,18 @@ pub fn test_load_store_update_nakamoto_blocks() {
                 .unwrap(),
             epoch2_header.total_work.work + 1
         );
+
+        // store, but do not process, a block
+        NakamotoChainState::store_block(&staging_tx, nakamoto_block_3.clone(), false).unwrap();
+
+        staging_tx.commit().unwrap();
         tx.commit().unwrap();
     }
 
     // can load Nakamoto block, but only the Nakamoto block
     assert_eq!(
         NakamotoChainState::load_nakamoto_block(
-            chainstate.db(),
+            chainstate.nakamoto_blocks_db(),
             &nakamoto_header.consensus_hash,
             &nakamoto_header.block_hash()
         )
@@ -914,7 +969,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
     );
     assert_eq!(
         NakamotoChainState::load_nakamoto_block(
-            chainstate.db(),
+            chainstate.nakamoto_blocks_db(),
             &nakamoto_header_2.consensus_hash,
             &nakamoto_header_2.block_hash()
         )
@@ -924,7 +979,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
     );
     assert_eq!(
         NakamotoChainState::load_nakamoto_block(
-            chainstate.db(),
+            chainstate.nakamoto_blocks_db(),
             &epoch2_header_info.consensus_hash,
             &epoch2_header.block_hash()
         )
@@ -932,29 +987,51 @@ pub fn test_load_store_update_nakamoto_blocks() {
         None
     );
 
-    // nakamoto block should not be processed yet
+    // nakamoto block should be treated as processed because even though the processed flag is not
+    // set, the header is present (meaning that we're in-between processing the block and marking
+    // it processed in the staging DB)
     assert_eq!(
         NakamotoChainState::get_nakamoto_block_status(
+            chainstate.nakamoto_blocks_db(),
             chainstate.db(),
             &nakamoto_header.consensus_hash,
             &nakamoto_header.block_hash()
         )
         .unwrap()
         .unwrap(),
-        (false, false)
+        (true, false)
     );
+
+    // same goes for block 2
     assert_eq!(
         NakamotoChainState::get_nakamoto_block_status(
+            chainstate.nakamoto_blocks_db(),
             chainstate.db(),
             &nakamoto_header_2.consensus_hash,
             &nakamoto_header_2.block_hash()
         )
         .unwrap()
         .unwrap(),
-        (false, false)
+        (true, false)
     );
+
+    // block 3 has only been stored, but no header has been added
     assert_eq!(
         NakamotoChainState::get_nakamoto_block_status(
+            chainstate.nakamoto_blocks_db(),
+            chainstate.db(),
+            &nakamoto_header_3.consensus_hash,
+            &nakamoto_header_3.block_hash()
+        )
+        .unwrap()
+        .unwrap(),
+        (false, false)
+    );
+
+    // this method doesn't return data for epoch2
+    assert_eq!(
+        NakamotoChainState::get_nakamoto_block_status(
+            chainstate.nakamoto_blocks_db(),
             chainstate.db(),
             &epoch2_header_info.consensus_hash,
             &epoch2_header.block_hash()
@@ -965,13 +1042,15 @@ pub fn test_load_store_update_nakamoto_blocks() {
 
     // set nakamoto block processed
     {
-        let tx = chainstate.db_tx_begin().unwrap();
-        NakamotoChainState::set_block_processed(&tx, &nakamoto_header.block_id()).unwrap();
+        let (tx, staging_tx) = chainstate.headers_and_staging_tx_begin().unwrap();
+        NakamotoChainState::set_block_processed(&staging_tx, &nakamoto_header_3.block_id())
+            .unwrap();
         assert_eq!(
             NakamotoChainState::get_nakamoto_block_status(
+                staging_tx.conn(),
                 &tx,
-                &nakamoto_header.consensus_hash,
-                &nakamoto_header.block_hash()
+                &nakamoto_header_3.consensus_hash,
+                &nakamoto_header_3.block_hash()
             )
             .unwrap()
             .unwrap(),
@@ -980,10 +1059,11 @@ pub fn test_load_store_update_nakamoto_blocks() {
     }
     // set nakamoto block orphaned
     {
-        let tx = chainstate.db_tx_begin().unwrap();
-        NakamotoChainState::set_block_orphaned(&tx, &nakamoto_header.block_id()).unwrap();
+        let (tx, staging_tx) = chainstate.headers_and_staging_tx_begin().unwrap();
+        NakamotoChainState::set_block_orphaned(&staging_tx, &nakamoto_header.block_id()).unwrap();
         assert_eq!(
             NakamotoChainState::get_nakamoto_block_status(
+                staging_tx.conn(),
                 &tx,
                 &nakamoto_header.consensus_hash,
                 &nakamoto_header.block_hash()
@@ -995,10 +1075,12 @@ pub fn test_load_store_update_nakamoto_blocks() {
     }
     // orphan nakamoto block by parent
     {
-        let tx = chainstate.db_tx_begin().unwrap();
-        NakamotoChainState::set_block_orphaned(&tx, &nakamoto_header.parent_block_id).unwrap();
+        let (tx, staging_tx) = chainstate.headers_and_staging_tx_begin().unwrap();
+        NakamotoChainState::set_block_orphaned(&staging_tx, &nakamoto_header.parent_block_id)
+            .unwrap();
         assert_eq!(
             NakamotoChainState::get_nakamoto_block_status(
+                staging_tx.conn(),
                 &tx,
                 &nakamoto_header.consensus_hash,
                 &nakamoto_header.block_hash()
@@ -1181,26 +1263,32 @@ pub fn test_load_store_update_nakamoto_blocks() {
     // next ready nakamoto block is None unless both the burn block and stacks parent block have
     // been processed
     {
-        let tx = chainstate.db_tx_begin().unwrap();
+        let (tx, staging_tx) = chainstate.headers_and_staging_tx_begin().unwrap();
         assert_eq!(
-            NakamotoChainState::next_ready_nakamoto_block(&tx).unwrap(),
-            None
-        );
-
-        // set burn processed, but this isn't enough
-        NakamotoChainState::set_burn_block_processed(&tx, &nakamoto_header.consensus_hash).unwrap();
-        assert_eq!(
-            NakamotoChainState::next_ready_nakamoto_block(&tx).unwrap(),
+            NakamotoChainState::next_ready_nakamoto_block(staging_tx.conn(), &tx).unwrap(),
             None
         );
 
         // set parent epoch2 block processed
-        NakamotoChainState::set_block_processed(&tx, &epoch2_header_info.index_block_hash())
+        NakamotoChainState::set_block_processed(
+            &staging_tx,
+            &epoch2_header_info.index_block_hash(),
+        )
+        .unwrap();
+
+        // but it's not enough -- child's consensus hash needs to be burn_processable
+        assert_eq!(
+            NakamotoChainState::next_ready_nakamoto_block(staging_tx.conn(), &tx).unwrap(),
+            None
+        );
+
+        // set burn processed
+        NakamotoChainState::set_burn_block_processed(&staging_tx, &nakamoto_header.consensus_hash)
             .unwrap();
 
         // this works now
         assert_eq!(
-            NakamotoChainState::next_ready_nakamoto_block(&tx)
+            NakamotoChainState::next_ready_nakamoto_block(staging_tx.conn(), &tx)
                 .unwrap()
                 .unwrap()
                 .0,
@@ -1208,12 +1296,15 @@ pub fn test_load_store_update_nakamoto_blocks() {
         );
 
         // set parent nakamoto block processed
-        NakamotoChainState::set_block_processed(&tx, &nakamoto_header_info.index_block_hash())
-            .unwrap();
+        NakamotoChainState::set_block_processed(
+            &staging_tx,
+            &nakamoto_header_info.index_block_hash(),
+        )
+        .unwrap();
 
         // next nakamoto block
         assert_eq!(
-            NakamotoChainState::next_ready_nakamoto_block(&tx)
+            NakamotoChainState::next_ready_nakamoto_block(staging_tx.conn(), &tx)
                 .unwrap()
                 .unwrap()
                 .0,

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -730,7 +730,7 @@ impl Relayer {
             );
             return Ok(false);
         };
-        let staging_db_tx = chainstate.db_tx_begin()?;
+        let staging_db_tx = chainstate.staging_db_tx_begin()?;
         let accepted = NakamotoChainState::accept_block(
             &config,
             block,

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -730,12 +730,13 @@ impl Relayer {
             );
             return Ok(false);
         };
-        let staging_db_tx = chainstate.staging_db_tx_begin()?;
+        let (headers_conn, staging_db_tx) = chainstate.headers_conn_and_staging_tx_begin()?;
         let accepted = NakamotoChainState::accept_block(
             &config,
             block,
             sort_handle,
             &staging_db_tx,
+            headers_conn,
             &aggregate_public_key,
         )?;
         staging_db_tx.commit()?;

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -158,7 +158,7 @@ pub trait FromColumn<T> {
 
 impl FromRow<u64> for u64 {
     fn from_row<'a>(row: &'a Row) -> Result<u64, Error> {
-        let x: i64 = row.get_unwrap(0);
+        let x: i64 = row.get(0)?;
         if x < 0 {
             return Err(Error::ParseError);
         }
@@ -168,21 +168,28 @@ impl FromRow<u64> for u64 {
 
 impl FromRow<u32> for u32 {
     fn from_row<'a>(row: &'a Row) -> Result<u32, Error> {
-        let x: u32 = row.get_unwrap(0);
+        let x: u32 = row.get(0)?;
         Ok(x)
     }
 }
 
 impl FromRow<String> for String {
     fn from_row<'a>(row: &'a Row) -> Result<String, Error> {
-        let x: String = row.get_unwrap(0);
+        let x: String = row.get(0)?;
+        Ok(x)
+    }
+}
+
+impl FromRow<Vec<u8>> for Vec<u8> {
+    fn from_row<'a>(row: &'a Row) -> Result<Vec<u8>, Error> {
+        let x: Vec<u8> = row.get(0)?;
         Ok(x)
     }
 }
 
 impl FromColumn<u64> for u64 {
     fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<u64, Error> {
-        let x: i64 = row.get_unwrap(column_name);
+        let x: i64 = row.get(column_name)?;
         if x < 0 {
             return Err(Error::ParseError);
         }
@@ -192,7 +199,7 @@ impl FromColumn<u64> for u64 {
 
 impl FromRow<StacksAddress> for StacksAddress {
     fn from_row<'a>(row: &'a Row) -> Result<StacksAddress, Error> {
-        let addr_str: String = row.get_unwrap(0);
+        let addr_str: String = row.get(0)?;
         let addr = StacksAddress::from_string(&addr_str).ok_or(Error::ParseError)?;
         Ok(addr)
     }
@@ -200,7 +207,7 @@ impl FromRow<StacksAddress> for StacksAddress {
 
 impl FromColumn<Option<u64>> for u64 {
     fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<Option<u64>, Error> {
-        let x: Option<i64> = row.get_unwrap(column_name);
+        let x: Option<i64> = row.get(column_name)?;
         match x {
             Some(x) => {
                 if x < 0 {
@@ -215,14 +222,14 @@ impl FromColumn<Option<u64>> for u64 {
 
 impl FromRow<i64> for i64 {
     fn from_row<'a>(row: &'a Row) -> Result<i64, Error> {
-        let x: i64 = row.get_unwrap(0);
+        let x: i64 = row.get(0)?;
         Ok(x)
     }
 }
 
 impl FromColumn<i64> for i64 {
     fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<i64, Error> {
-        let x: i64 = row.get_unwrap(column_name);
+        let x: i64 = row.get(column_name)?;
         Ok(x)
     }
 }
@@ -232,14 +239,14 @@ impl FromColumn<QualifiedContractIdentifier> for QualifiedContractIdentifier {
         row: &'a Row,
         column_name: &str,
     ) -> Result<QualifiedContractIdentifier, Error> {
-        let value: String = row.get_unwrap(column_name);
+        let value: String = row.get(column_name)?;
         QualifiedContractIdentifier::parse(&value).map_err(|_| Error::ParseError)
     }
 }
 
 impl FromRow<bool> for bool {
     fn from_row<'a>(row: &'a Row) -> Result<bool, Error> {
-        let x: bool = row.get_unwrap(0);
+        let x: bool = row.get(0)?;
         Ok(x)
     }
 }
@@ -247,7 +254,7 @@ impl FromRow<bool> for bool {
 /// Make public keys loadable from a sqlite database
 impl FromColumn<Secp256k1PublicKey> for Secp256k1PublicKey {
     fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<Secp256k1PublicKey, Error> {
-        let pubkey_hex: String = row.get_unwrap(column_name);
+        let pubkey_hex: String = row.get(column_name)?;
         let pubkey = Secp256k1PublicKey::from_hex(&pubkey_hex).map_err(|_e| Error::ParseError)?;
         Ok(pubkey)
     }
@@ -256,7 +263,7 @@ impl FromColumn<Secp256k1PublicKey> for Secp256k1PublicKey {
 /// Make private keys loadable from a sqlite database
 impl FromColumn<Secp256k1PrivateKey> for Secp256k1PrivateKey {
     fn from_column<'a>(row: &'a Row, column_name: &str) -> Result<Secp256k1PrivateKey, Error> {
-        let privkey_hex: String = row.get_unwrap(column_name);
+        let privkey_hex: String = row.get(column_name)?;
         let privkey =
             Secp256k1PrivateKey::from_hex(&privkey_hex).map_err(|_e| Error::ParseError)?;
         Ok(privkey)
@@ -289,7 +296,7 @@ macro_rules! impl_byte_array_from_column_only {
                 row: &rusqlite::Row,
                 column_name: &str,
             ) -> Result<Self, crate::util_lib::db::Error> {
-                Ok(row.get_unwrap::<_, Self>(column_name))
+                Ok(row.get::<_, Self>(column_name)?)
             }
         }
     };
@@ -318,7 +325,7 @@ macro_rules! impl_byte_array_from_column {
                 row: &rusqlite::Row,
                 column_name: &str,
             ) -> Result<Self, crate::util_lib::db::Error> {
-                Ok(row.get_unwrap::<_, Self>(column_name))
+                Ok(row.get::<_, Self>(column_name)?)
             }
         }
 
@@ -499,7 +506,7 @@ where
         if row_data.len() > 0 {
             return Err(Error::Overflow);
         }
-        let i: i64 = row.get_unwrap(0);
+        let i: i64 = row.get(0)?;
         row_data.push(i);
     }
 
@@ -759,8 +766,8 @@ fn load_indexed(conn: &DBConn, marf_value: &MARFValue) -> Result<Option<String>,
         .map_err(Error::SqliteError)?;
     let mut value = None;
 
-    while let Some(row) = rows.next().expect("FATAL: Failed to read row from Sqlite") {
-        let value_str: String = row.get_unwrap(0);
+    while let Some(row) = rows.next()? {
+        let value_str: String = row.get(0)?;
         if value.is_some() {
             // should be impossible
             panic!(

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -1039,12 +1039,13 @@ impl MockamotoNode {
             aggregate_public_key
         };
         self.self_signer.sign_nakamoto_block(&mut block);
-        let staging_tx = self.chainstate.staging_db_tx_begin()?;
+        let (headers_conn, staging_tx) = self.chainstate.headers_conn_and_staging_tx_begin()?;
         NakamotoChainState::accept_block(
             &config,
             block,
             &mut sortition_handle,
             &staging_tx,
+            headers_conn,
             &aggregate_public_key,
         )?;
         staging_tx.commit()?;

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -404,12 +404,13 @@ impl BlockMinerThread {
                 ChainstateError::InvalidStacksBlock(format!("Invalid Nakamoto block: {e:?}"))
             })?;
         block.header.signer_signature = signature;
-        let staging_tx = chain_state.staging_db_tx_begin()?;
+        let (headers_conn, staging_tx) = chain_state.headers_conn_and_staging_tx_begin()?;
         NakamotoChainState::accept_block(
             &chainstate_config,
             block,
             &mut sortition_handle,
             &staging_tx,
+            headers_conn,
             &aggregate_public_key,
         )?;
         staging_tx.commit()?;
@@ -444,12 +445,13 @@ impl BlockMinerThread {
             aggregate_public_key
         };
 
-        let staging_tx = chain_state.staging_db_tx_begin()?;
+        let (headers_conn, staging_tx) = chain_state.headers_conn_and_staging_tx_begin()?;
         NakamotoChainState::accept_block(
             &chainstate_config,
             block,
             &mut sortition_handle,
             &staging_tx,
+            headers_conn,
             &aggregate_public_key,
         )?;
         staging_tx.commit()?;


### PR DESCRIPTION
This actually fixes https://github.com/stacks-network/stacks-core/issues/3860, which was closed prematurely since it was not addressed by PR #3992.  Doing this now because this is a blocker for the block sync system.

This PR creates a separate DB for holding Nakamoto blocks, separate from the DB that holds processed Nakamoto block headers.  The reason this is necessary is because we can expect writes to occur concurrently on both DBs -- the network stack will create transactions against the staging blocks DB to store blocks it receives, and both the miner and chains-coordinator will create transactions on the headers DB as they create / process blocks.  In Stacks today, these two data live in the same DB, and it regularly leads to DB contention since the chains-coordinator's and miner's block-processing regularly prevents the block downloader from storing downloaded blocks (which slows down IBD and block delivery).

Because latency is much more of a concern in Nakamoto, it's going to be important that the system can open both kinds of transactions concurrently.  This PR makes it possible by storing staging blocks separately from processed block headers.

The most substantial change in this PR is that the act of updating the `processed` flag on a block no longer executes within the same transaction that writes the block header.  However, this shouldn't lead to any concurrency issues because (1) only the chains coordinator thread performs these tasks, and (2) the code to query processed blocks has been updated to read from both the staging blocks DB and headers DB (this won't block ongoing writes, or be blocked by ongoing writes, since we use WAL mode in both DBs)