### PR TITLE
[CI] fix error in release step that generates checksums

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -59,7 +59,7 @@ jobs:
       ## Generate a checksums file to be added to the release page
       - name: Generate Checksums
         id: generate_checksum
-        uses: jmgilman/actions-generate-checksum@24a35957fba81c6cbaefeb1e3d59ee56e3db5077 # v1.0.0
+        uses: jmgilman/actions-generate-checksum@3ea6dc9bf8eecf28e2ecc982fab683484a1a8561 # v1.0.1
         with:
           method: sha512
           output: CHECKSUMS.txt


### PR DESCRIPTION
During workflow testing a release in a downstream fork, an unexpected error kept surfacing:
```
Poetry could not find a pyproject.toml file in /github/workspace or its parents
```
https://github.com/wileyj/stacks-blockchain/actions/runs/7878083852/job/21495965471#step:4:11

updating this specific action's commit to the latest release v1.0.1 resolves the immediate issue. 
we'll be moving this workflow out of this repo (possibly refactoring it using bash or something, since it's a simple task that really shouldn't fail due to a python dependency). 

