### PR TITLE
Update wsts workspace dependency to v8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4646,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06eee6f3bb38f8c8dca03053572130be2e5006a31dc7e5d8c62e375952b2ff38"
+checksum = "467aa8e40ed0277d19922fd0e7357c16552cb900e5138f61a48ac23c4b7878e0"
 dependencies = [
  "aes-gcm 0.10.3",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 
 # Dependencies we want to keep the same between workspace members
 [workspace.dependencies]  
-wsts = { version = "8.0", default-features = false }
+wsts = { version = "8.1", default-features = false }
 ed25519-dalek = { version = "2.1.1", features = ["serde", "rand_core"] } 
 rand_core = "0.6"
 rand = "0.8"


### PR DESCRIPTION
### Description
Update the `wsts` workspace dependency to version `8.1`.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
