### PR TITLE
Move Checksum Generation to Composite

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -59,12 +59,7 @@ jobs:
       ## Generate a checksums file to be added to the release page
       - name: Generate Checksums
         id: generate_checksum
-        uses: jmgilman/actions-generate-checksum@24a35957fba81c6cbaefeb1e3d59ee56e3db5077 # v1.0.0
-        with:
-          method: sha512
-          output: CHECKSUMS.txt
-          patterns: |
-            release/*.zip
+        uses: stacks-network/actions/generate-checksum@main
 
       ## Upload the release archives with the checksums file
       - name: Upload Release


### PR DESCRIPTION
The action used to generate a checksum for the github release flow (https://github.com/stacks-network/stacks-core/blob/develop/.github/workflows/github-release.yml#L59-L67) had to be updated to a newer version due to an error causing the step to fail. After this issue arose, a quick fix in order to make the action work was merging a PR to the `master` branch (https://github.com/stacks-network/stacks-core/pull/4374). 

The goal of this PR is to move the generation of checksums to composite actions for easier fixes if they are necessary, and do it with bash instead of a predefined action for consistency and significantly lower chances of unexpected failures.

This PR should be merged after the one in `actions` repository is: https://github.com/stacks-network/actions/pull/24

Reference issue: https://github.com/stacks-network/stacks-core/issues/4375
Reference action run: https://github.com/BowTiedDevOps/stacks-core/actions/runs/7920897073/job/21625430204#step:3:57