### PR TITLE
chore: Use `hashbrown` in most workspace members

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ name = "clarity"
 version = "0.0.1"
 dependencies = [
  "assert-json-diff",
+ "hashbrown 0.14.3",
  "integer-sqrt",
  "lazy_static",
  "rand 0.8.5",
@@ -2756,6 +2757,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "relay-server"
 version = "0.0.1"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "reqwest"
@@ -3452,6 +3456,7 @@ dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
  "ed25519-dalek",
+ "hashbrown 0.14.3",
  "lazy_static",
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ members = [
 
 # Dependencies we want to keep the same between workspace members
 [workspace.dependencies]  
-wsts = { version = "8.1", default-features = false }
 ed25519-dalek = { version = "2.1.1", features = ["serde", "rand_core"] } 
+hashbrown = "0.14.3"
 rand_core = "0.6"
 rand = "0.8"
 rand_chacha = "0.3.1"
+wsts = { version = "8.1", default-features = false }
 
 # Use a bit more than default optimization for
 #  dev builds to speed up test execution

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -30,6 +30,7 @@ slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 stacks_common = { package = "stacks-common", path = "../stacks-common" }
 rstest = "0.17.0"
 rstest_reuse = "0.5.0"
+hashbrown = { workspace = true }
 
 [dependencies.serde_json]
 version = "1.0"

--- a/clarity/src/vm/analysis/analysis_db.rs
+++ b/clarity/src/vm/analysis/analysis_db.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use stacks_common::types::StacksEpochId;
 

--- a/clarity/src/vm/analysis/arithmetic_checker/mod.rs
+++ b/clarity/src/vm/analysis/arithmetic_checker/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 pub use super::errors::{
     check_argument_count, check_arguments_at_least, CheckError, CheckErrors, CheckResult,

--- a/clarity/src/vm/analysis/read_only_checker/mod.rs
+++ b/clarity/src/vm/analysis/read_only_checker/mod.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
-
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 
 pub use super::errors::{

--- a/clarity/src/vm/analysis/trait_checker/mod.rs
+++ b/clarity/src/vm/analysis/trait_checker/mod.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
-
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 
 use crate::vm::analysis::errors::{CheckError, CheckErrors, CheckResult};

--- a/clarity/src/vm/analysis/type_checker/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/contexts.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
-
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 
 use crate::vm::analysis::errors::{CheckError, CheckErrors, CheckResult};

--- a/clarity/src/vm/analysis/type_checker/v2_05/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/contexts.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
+
+use hashbrown::{HashMap, HashSet};
 
 use crate::vm::analysis::errors::{CheckError, CheckErrors, CheckResult};
 use crate::vm::analysis::types::ContractAnalysis;

--- a/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
@@ -18,9 +18,10 @@ pub mod contexts;
 //mod maps;
 pub mod natives;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 
 use self::contexts::ContractContext;

--- a/clarity/src/vm/analysis/type_checker/v2_1/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/contexts.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
+
+use hashbrown::{HashMap, HashSet};
 
 use crate::vm::analysis::errors::{CheckError, CheckErrors, CheckResult};
 use crate::vm::analysis::types::ContractAnalysis;

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -17,9 +17,10 @@
 pub mod contexts;
 pub mod natives;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 
 use self::contexts::ContractContext;

--- a/clarity/src/vm/analysis/types.rs
+++ b/clarity/src/vm/analysis/types.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 
 use crate::vm::analysis::analysis_db::AnalysisDatabase;

--- a/clarity/src/vm/ast/definition_sorter/mod.rs
+++ b/clarity/src/vm/ast/definition_sorter/mod.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
+
+use hashbrown::{HashMap, HashSet};
 
 use crate::vm::ast::errors::{ParseError, ParseErrors, ParseResult};
 use crate::vm::ast::types::{BuildASTPass, ContractAST};

--- a/clarity/src/vm/ast/mod.rs
+++ b/clarity/src/vm/ast/mod.rs
@@ -319,8 +319,7 @@ pub fn build_ast<T: CostTracker>(
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
+    use hashbrown::HashMap;
     use stacks_common::types::StacksEpochId;
 
     use crate::vm::ast::errors::ParseErrors;

--- a/clarity/src/vm/ast/sugar_expander/mod.rs
+++ b/clarity/src/vm/ast/sugar_expander/mod.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
+
+use hashbrown::{HashMap, HashSet};
 
 use crate::vm::ast::errors::{ParseError, ParseErrors, ParseResult};
 use crate::vm::ast::types::{BuildASTPass, ContractAST, PreExpressionsDrain};

--- a/clarity/src/vm/ast/traits_resolver/mod.rs
+++ b/clarity/src/vm/ast/traits_resolver/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet};
 
 use crate::vm::analysis::AnalysisDatabase;
 use crate::vm::ast::errors::{ParseError, ParseErrors, ParseResult};

--- a/clarity/src/vm/ast/types.rs
+++ b/clarity/src/vm/ast/types.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
 use std::vec::Drain;
+
+use hashbrown::{HashMap, HashSet};
 
 use crate::vm::ast::errors::ParseResult;
 use crate::vm::representations::{PreSymbolicExpression, SymbolicExpression, TraitDefinition};

--- a/clarity/src/vm/callables.rs
+++ b/clarity/src/vm/callables.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fmt;
 use std::iter::FromIterator;

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 use std::fmt;
 use std::mem::replace;
 
+use hashbrown::{HashMap, HashSet};
 use serde::Serialize;
 use serde_json::json;
 use stacks_common::consts::CHAIN_ID_TESTNET;
@@ -277,7 +278,7 @@ impl AssetMap {
         amount: u128,
     ) -> Result<u128> {
         let current_amount = match self.token_map.get(principal) {
-            Some(principal_map) => *principal_map.get(&asset).unwrap_or(&0),
+            Some(principal_map) => *principal_map.get(asset).unwrap_or(&0),
             None => 0,
         };
 
@@ -1948,7 +1949,7 @@ impl CallStack {
                 )
                 .into());
             }
-            if tracked && !self.set.remove(&function) {
+            if tracked && !self.set.remove(function) {
                 return Err(InterpreterError::InterpreterError(
                     "Tried to remove tracked function from call stack, but could not find in current context.".into()
                 )

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::{cmp, fmt};
 
+use hashbrown::HashMap;
 use lazy_static::lazy_static;
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use serde::{Deserialize, Serialize};
@@ -814,7 +815,7 @@ impl TrackerData {
         let mut cost_contracts = HashMap::new();
         let mut m = HashMap::new();
         for f in ClarityCostFunction::ALL.iter() {
-            let cost_function_ref = cost_function_references.remove(&f).unwrap_or_else(|| {
+            let cost_function_ref = cost_function_references.remove(f).unwrap_or_else(|| {
                 ClarityCostFunctionReference::new(boot_costs_id.clone(), f.get_name())
             });
             if !cost_contracts.contains_key(&cost_function_ref.contract_id) {

--- a/clarity/src/vm/coverage.rs
+++ b/clarity/src/vm/coverage.rs
@@ -1,7 +1,8 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Write;
 
+use hashbrown::{HashMap, HashSet};
 use serde_json::Value as JsonValue;
 
 use super::functions::define::DefineFunctionsParsed;

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, VecDeque};
 use std::convert::{TryFrom, TryInto};
 
 use serde_json;

--- a/clarity/src/vm/database/key_value_wrapper.rs
+++ b/clarity/src/vm/database/key_value_wrapper.rs
@@ -16,9 +16,9 @@
 
 use std::clone::Clone;
 use std::cmp::Eq;
-use std::collections::HashMap;
 use std::hash::Hash;
 
+use hashbrown::HashMap;
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::Sha512Trunc256Sum;

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 pub use self::clarity_db::{
     BurnStateDB, ClarityDatabase, HeadersDB, StoreType, NULL_BURN_STATE_DB, NULL_HEADER_DB,

--- a/clarity/src/vm/docs/contracts.rs
+++ b/clarity/src/vm/docs/contracts.rs
@@ -1,6 +1,7 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
+use hashbrown::{HashMap, HashSet};
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::StacksEpochId;
 

--- a/clarity/src/vm/functions/define.rs
+++ b/clarity/src/vm/functions/define.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use crate::vm::callables::{DefineType, DefinedFunction};
 use crate::vm::contexts::{ContractContext, Environment, LocalContext};

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -587,8 +587,7 @@ pub fn execute_v2(program: &str) -> Result<Option<Value>> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
+    use hashbrown::HashMap;
     use stacks_common::consts::CHAIN_ID_TESTNET;
     use stacks_common::types::StacksEpochId;
 

--- a/clarity/src/vm/tests/assets.rs
+++ b/clarity/src/vm/tests/assets.rs
@@ -440,7 +440,7 @@ fn test_native_stx_ops(epoch: StacksEpochId, mut env_factory: TopLevelMemoryEnvi
 
     let table = asset_map.to_table();
 
-    let contract_principal = token_contract_id.clone().into();
+    let contract_principal = PrincipalData::from(token_contract_id.clone());
 
     assert_eq!(
         table[&contract_principal][&AssetIdentifier::STX()],

--- a/clarity/src/vm/tests/principals.rs
+++ b/clarity/src/vm/tests/principals.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::hex_bytes;
 

--- a/clarity/src/vm/types/serialization.rs
+++ b/clarity/src/vm/types/serialization.rs
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::io::{Read, Write};
 use std::{cmp, error, fmt, str};
 
+use hashbrown::HashMap;
 use lazy_static::lazy_static;
 use serde_json::Value as JSONValue;
 use stacks_common::codec::{Error as codec_error, StacksMessageCodec};

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -15,12 +15,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::btree_map::Entry;
-// TypeSignatures
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 use std::{cmp, fmt};
 
+// TypeSignatures
+use hashbrown::HashSet;
 use lazy_static::lazy_static;
 use stacks_common::address::c32;
 use stacks_common::types::StacksEpochId;

--- a/contrib/tools/relay-server/Cargo.toml
+++ b/contrib/tools/relay-server/Cargo.toml
@@ -8,3 +8,4 @@ name = "relay-server"
 path = "src/main.rs"
 
 [dependencies]
+hashbrown = { workspace = true }

--- a/contrib/tools/relay-server/src/http.rs
+++ b/contrib/tools/relay-server/src/http.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
 use std::io::{Error, Read};
+
+use hashbrown::HashMap;
 
 use crate::to_io_result::ToIoResult;
 

--- a/contrib/tools/relay-server/src/state.rs
+++ b/contrib/tools/relay-server/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 #[derive(Default)]
 pub struct State {

--- a/contrib/tools/relay-server/src/url.rs
+++ b/contrib/tools/relay-server/src/url.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 pub trait QueryEx {
     fn url_query(&self) -> HashMap<&str, &str>;

--- a/libsigner/Cargo.toml
+++ b/libsigner/Cargo.toml
@@ -17,7 +17,7 @@ path = "./src/libsigner.rs"
 
 [dependencies]
 clarity = { path = "../clarity" }
-hashbrown = "0.14"
+hashbrown = { workspace = true }
 libc = "0.2"
 libstackerdb = { path = "../libstackerdb" }
 serde = "1"

--- a/libsigner/src/http.rs
+++ b/libsigner/src/http.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
 use std::io;
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 
+use hashbrown::HashMap;
 use stacks_common::codec::MAX_MESSAGE_LEN;
 use stacks_common::deps_common::httparse;
 use stacks_common::util::chunked_encoding::*;

--- a/libsigner/src/tests/http.rs
+++ b/libsigner/src/tests/http.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::{io, str};
 
+use hashbrown::HashMap;
 use stacks_common::util::chunked_encoding::*;
 
 use crate::error::{EventError, RPCError};

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -32,6 +32,7 @@ slog-json = { version = "2.3.0", optional = true }
 chrono = "0.4.19"
 libc = "0.2.82"
 wsts = { workspace = true }
+hashbrown = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"

--- a/stacks-common/src/deps_common/bitcoin/network/encodable.rs
+++ b/stacks-common/src/deps_common/bitcoin/network/encodable.rs
@@ -29,9 +29,10 @@
 //! big-endian decimals, etc.)
 //!
 
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::{mem, u32};
+
+use hashbrown::HashMap;
 
 use crate::deps_common::bitcoin::network::serialize::{self, SimpleDecoder, SimpleEncoder};
 use crate::deps_common::bitcoin::util::hash::Sha256dHash;

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 backoff = "0.4"
 clarity = { path = "../clarity" }
 clap = { version = "4.1.1", features = ["derive", "env"] }
-hashbrown = "0.14"
+hashbrown = { workspace = true }
 libsigner = { path = "../libsigner" }
 libstackerdb = { path = "../libstackerdb" }
 rand_core = "0.6"

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -56,8 +56,8 @@ stacks-common = { path = "../stacks-common" }
 pox-locking = { path = "../pox-locking" }
 libstackerdb = { path = "../libstackerdb" }
 siphasher = "0.3.7"
-wsts = {workspace = true}
-hashbrown = "0.14"
+wsts = { workspace = true }
+hashbrown = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"

--- a/stackslib/src/chainstate/stacks/boot/docs.rs
+++ b/stackslib/src/chainstate/stacks/boot/docs.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
 use clarity::vm::docs::contracts::{produce_docs_refs, ContractSupportDocs};
+use hashbrown::{HashMap, HashSet};
 
 use super::STACKS_BOOT_CODE_MAINNET;
 

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -30,7 +30,7 @@ libsigner = { path = "../../libsigner" }
 wsts = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
-hashbrown = "0.14"
+hashbrown = { workspace = true }
 
 [dev-dependencies]
 ring = "0.16.19"


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This PR replaces `std::collections::{HashMap, HashSet}` with the `hashbrown` equivalents in most of the workspace members (excluding `stackslib` and `stacks-node`). By doing this, we are able to validate blocks around **3%** faster:

```console
❯ hyperfine -w 3 -r 20 "stacks-core/target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000" "stacks-core/target/release/stacks-inspect.hashbrown replay-block /home/jbencin/data/next/ range 99990 100000"
Benchmark 1: stacks-core/target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000
  Time (mean ± σ):     11.102 s ±  0.021 s    [User: 10.591 s, System: 0.460 s]
  Range (min … max):   11.066 s … 11.147 s    20 runs
 
Benchmark 2: stacks-core/target/release/stacks-inspect.hashbrown replay-block /home/jbencin/data/next/ range 99990 100000
  Time (mean ± σ):     10.738 s ±  0.023 s    [User: 10.223 s, System: 0.464 s]
  Range (min … max):   10.709 s … 10.796 s    20 runs
 
Summary
  stacks-core/target/release/stacks-inspect.hashbrown replay-block /home/jbencin/data/next/ range 99990 100000 ran
    1.03 ± 0.00 times faster than stacks-core/target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000
```

Thanks @cylewitruk for the suggestion!

### Applicable issues

- #4316

### Additional info (benefits, drawbacks, caveats)

- From the Hashbrown [README](https://github.com/rust-lang/hashbrown), not sure if this matters in the locations that it is used:
  > Uses [AHash](https://github.com/tkaitchuck/aHash) as the default hasher, which is much faster than SipHash. However, AHash does not provide the same level of HashDoS resistance as SipHash, so if that is important to you, you might want to consider using a different hasher

- `hashbrown` is not *quite* a drop in replacement for the `std::collections` equivalents. It uses different trait bounds on certain functions, which breaks type inference in some places, and this is why I've skipped making this change in `stackslib` and `stacks-node` for now

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
