### PR TITLE
Feat/nakamoto block download API

### DIFF
--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -513,7 +513,7 @@ fn test_nakamoto_chainstate_getters() {
         assert_eq!(
             NakamotoChainState::check_sortition_exists(&mut sort_tx, &sort_tip.consensus_hash)
                 .unwrap(),
-            (sort_tip.burn_header_hash.clone(), sort_tip.block_height)
+            sort_tip
         );
     }
 

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -1791,7 +1791,7 @@ impl StacksChainState {
             .to_string();
 
         let nakamoto_staging_blocks_path =
-            StacksChainState::get_nakamoto_staging_blocks_path(path.clone())?;
+            StacksChainState::static_get_nakamoto_staging_blocks_path(path.clone())?;
         let nakamoto_staging_blocks_conn =
             StacksChainState::open_nakamoto_staging_blocks(&nakamoto_staging_blocks_path, true)?;
 

--- a/stackslib/src/net/api/getblock_v3.rs
+++ b/stackslib/src/net/api/getblock_v3.rs
@@ -1,0 +1,324 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::{fs, io};
+
+use regex::{Captures, Regex};
+use rusqlite::Connection;
+use serde::de::Error as de_Error;
+use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
+use stacks_common::types::net::PeerHost;
+use stacks_common::util::hash::to_hex;
+use {serde, serde_json};
+
+use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState, NakamotoStagingBlocksConn};
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::Error as ChainError;
+use crate::net::http::{
+    parse_bytes, Error, HttpBadRequest, HttpChunkGenerator, HttpContentType, HttpNotFound,
+    HttpRequest, HttpRequestContents, HttpRequestPreamble, HttpResponse, HttpResponseContents,
+    HttpResponsePayload, HttpResponsePreamble, HttpServerError, HttpVersion,
+};
+use crate::net::httpcore::{
+    HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp, StacksHttpRequest,
+    StacksHttpResponse,
+};
+use crate::net::{Error as NetError, StacksNodeState, TipRequest, MAX_HEADERS};
+use crate::util_lib::db::{DBConn, Error as DBError};
+
+#[derive(Clone)]
+pub struct RPCNakamotoBlockRequestHandler {
+    pub block_id: Option<StacksBlockId>,
+}
+
+impl RPCNakamotoBlockRequestHandler {
+    pub fn new() -> Self {
+        Self { block_id: None }
+    }
+}
+
+pub struct NakamotoBlockStream {
+    /// index block hash of the block to download
+    pub index_block_hash: StacksBlockId,
+    /// consensus hash of this block (identifies its tenure; used by the tenure stream)
+    pub consensus_hash: ConsensusHash,
+    /// parent index block hash of the block to download (used by the tenure stream)
+    pub parent_block_id: StacksBlockId,
+    /// offset into the blob
+    pub offset: u64,
+    /// total number of bytes read.
+    pub total_bytes: u64,
+    /// Connection to the staging DB
+    pub staging_db_conn: NakamotoStagingBlocksConn,
+    /// rowid of the block
+    pub rowid: i64,
+}
+
+impl NakamotoBlockStream {
+    pub fn new(
+        chainstate: &StacksChainState,
+        block_id: StacksBlockId,
+        consensus_hash: ConsensusHash,
+        parent_block_id: StacksBlockId,
+    ) -> Result<Self, ChainError> {
+        let staging_db_path = chainstate.get_nakamoto_staging_blocks_path()?;
+        let db_conn = StacksChainState::open_nakamoto_staging_blocks(&staging_db_path, false)?;
+        let rowid = db_conn
+            .conn()
+            .get_nakamoto_block_rowid(&block_id)?
+            .ok_or(ChainError::NoSuchBlockError)?;
+
+        Ok(NakamotoBlockStream {
+            index_block_hash: block_id,
+            consensus_hash,
+            parent_block_id,
+            offset: 0,
+            total_bytes: 0,
+            staging_db_conn: db_conn,
+            rowid,
+        })
+    }
+
+    /// reset the stream to send another block.
+    /// Does not change the DB connection or consensus hash.
+    pub fn reset(
+        &mut self,
+        block_id: StacksBlockId,
+        parent_block_id: StacksBlockId,
+    ) -> Result<(), ChainError> {
+        let rowid = self
+            .staging_db_conn
+            .conn()
+            .get_nakamoto_block_rowid(&block_id)?
+            .ok_or(ChainError::NoSuchBlockError)?;
+
+        self.index_block_hash = block_id;
+        self.parent_block_id = parent_block_id;
+        self.offset = 0;
+        self.total_bytes = 0;
+        self.rowid = rowid;
+        Ok(())
+    }
+}
+
+/// Decode the HTTP request
+impl HttpRequest for RPCNakamotoBlockRequestHandler {
+    fn verb(&self) -> &'static str {
+        "GET"
+    }
+
+    fn path_regex(&self) -> Regex {
+        Regex::new(r#"^/v3/blocks/(?P<block_id>[0-9a-f]{64})$"#).unwrap()
+    }
+
+    /// Try to decode this request.
+    /// There's nothing to load here, so just make sure the request is well-formed.
+    fn try_parse_request(
+        &mut self,
+        preamble: &HttpRequestPreamble,
+        captures: &Captures,
+        query: Option<&str>,
+        _body: &[u8],
+    ) -> Result<HttpRequestContents, Error> {
+        if preamble.get_content_length() != 0 {
+            return Err(Error::DecodeError(
+                "Invalid Http request: expected 0-length body".to_string(),
+            ));
+        }
+
+        let block_id_str = captures
+            .name("block_id")
+            .ok_or(Error::DecodeError(
+                "Failed to match path to block ID group".to_string(),
+            ))?
+            .as_str();
+
+        let block_id = StacksBlockId::from_hex(block_id_str).map_err(|_| {
+            Error::DecodeError("Invalid path: unparseable consensus hash".to_string())
+        })?;
+        self.block_id = Some(block_id);
+
+        Ok(HttpRequestContents::new().query_string(query))
+    }
+}
+
+impl RPCRequestHandler for RPCNakamotoBlockRequestHandler {
+    /// Reset internal state
+    fn restart(&mut self) {
+        self.block_id = None;
+    }
+
+    /// Make the response
+    fn try_handle_request(
+        &mut self,
+        preamble: HttpRequestPreamble,
+        _contents: HttpRequestContents,
+        node: &mut StacksNodeState,
+    ) -> Result<(HttpResponsePreamble, HttpResponseContents), NetError> {
+        let block_id = self
+            .block_id
+            .take()
+            .ok_or(NetError::SendError("Missing `block_id`".into()))?;
+
+        let stream_res =
+            node.with_node_state(|_network, _sortdb, chainstate, _mempool, _rpc_args| {
+                let Some(header) =
+                    NakamotoChainState::get_block_header_nakamoto(chainstate.db(), &block_id)?
+                else {
+                    return Err(ChainError::NoSuchBlockError);
+                };
+                let Some(nakamoto_header) = header.anchored_header.as_stacks_nakamoto() else {
+                    return Err(ChainError::NoSuchBlockError);
+                };
+                NakamotoBlockStream::new(
+                    chainstate,
+                    block_id.clone(),
+                    nakamoto_header.consensus_hash.clone(),
+                    nakamoto_header.parent_block_id.clone(),
+                )
+            });
+
+        // start loading up the block
+        let stream = match stream_res {
+            Ok(stream) => stream,
+            Err(ChainError::NoSuchBlockError) => {
+                return StacksHttpResponse::new_error(
+                    &preamble,
+                    &HttpNotFound::new(format!("No such block {:?}\n", &block_id)),
+                )
+                .try_into_contents()
+                .map_err(NetError::from)
+            }
+            Err(e) => {
+                // nope -- error trying to check
+                let msg = format!("Failed to load block {}: {:?}\n", &block_id, &e);
+                warn!("{}", &msg);
+                return StacksHttpResponse::new_error(&preamble, &HttpServerError::new(msg))
+                    .try_into_contents()
+                    .map_err(NetError::from);
+            }
+        };
+
+        let resp_preamble = HttpResponsePreamble::from_http_request_preamble(
+            &preamble,
+            200,
+            "OK",
+            None,
+            HttpContentType::Bytes,
+        );
+
+        Ok((
+            resp_preamble,
+            HttpResponseContents::from_stream(Box::new(stream)),
+        ))
+    }
+}
+
+/// Decode the HTTP response
+impl HttpResponse for RPCNakamotoBlockRequestHandler {
+    /// Decode this response from a byte stream.  This is called by the client to decode this
+    /// message
+    fn try_parse_response(
+        &self,
+        preamble: &HttpResponsePreamble,
+        body: &[u8],
+    ) -> Result<HttpResponsePayload, Error> {
+        let bytes = parse_bytes(preamble, body, MAX_MESSAGE_LEN.into())?;
+        Ok(HttpResponsePayload::Bytes(bytes))
+    }
+}
+
+/// Stream implementation for a Nakamoto block
+impl HttpChunkGenerator for NakamotoBlockStream {
+    #[cfg(test)]
+    fn hint_chunk_size(&self) -> usize {
+        // make this hurt
+        32
+    }
+
+    #[cfg(not(test))]
+    fn hint_chunk_size(&self) -> usize {
+        4096
+    }
+
+    fn generate_next_chunk(&mut self) -> Result<Vec<u8>, String> {
+        let mut blob_fd = self
+            .staging_db_conn
+            .open_nakamoto_block(self.rowid, false)
+            .map_err(|e| {
+                let msg = format!(
+                    "Failed to open Nakamoto block {}: {:?}",
+                    &self.index_block_hash, &e
+                );
+                warn!("{}", &msg);
+                msg
+            })?;
+
+        blob_fd.seek(SeekFrom::Start(self.offset)).map_err(|e| {
+            let msg = format!(
+                "Failed to read Nakamoto block {}: {:?}",
+                &self.index_block_hash, &e
+            );
+            warn!("{}", &msg);
+            msg
+        })?;
+
+        let mut buf = vec![0u8; self.hint_chunk_size()];
+        let num_read = blob_fd.read(&mut buf).map_err(|e| {
+            let msg = format!(
+                "Failed to read Nakamoto block {}: {:?}",
+                &self.index_block_hash, &e
+            );
+            warn!("{}", &msg);
+            msg
+        })?;
+
+        buf.truncate(num_read);
+
+        self.offset += num_read as u64;
+        self.total_bytes += num_read as u64;
+
+        Ok(buf)
+    }
+}
+
+impl StacksHttpRequest {
+    pub fn new_get_nakamoto_block(host: PeerHost, block_id: StacksBlockId) -> StacksHttpRequest {
+        StacksHttpRequest::new_for_peer(
+            host,
+            "GET".into(),
+            format!("/v3/blocks/{}", &block_id),
+            HttpRequestContents::new(),
+        )
+        .expect("FATAL: failed to construct request from infallible data")
+    }
+}
+
+impl StacksHttpResponse {
+    /// Decode an HTTP response into a block.
+    /// If it fails, return Self::Error(..)
+    pub fn decode_nakamoto_block(self) -> Result<NakamotoBlock, NetError> {
+        let contents = self.get_http_payload_ok()?;
+
+        // contents will be raw bytes
+        let block_bytes: Vec<u8> = contents.try_into()?;
+        let block = NakamotoBlock::consensus_deserialize(&mut &block_bytes[..])?;
+
+        Ok(block)
+    }
+}

--- a/stackslib/src/net/api/gettenure.rs
+++ b/stackslib/src/net/api/gettenure.rs
@@ -1,0 +1,324 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::{fs, io};
+
+use regex::{Captures, Regex};
+use serde::de::Error as de_Error;
+use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
+use stacks_common::types::net::PeerHost;
+use stacks_common::util::hash::to_hex;
+use {serde, serde_json};
+
+use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState, NakamotoStagingBlocksConn};
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::Error as ChainError;
+use crate::net::api::getblock_v3::NakamotoBlockStream;
+use crate::net::http::{
+    parse_bytes, Error, HttpBadRequest, HttpChunkGenerator, HttpContentType, HttpNotFound,
+    HttpRequest, HttpRequestContents, HttpRequestPreamble, HttpResponse, HttpResponseContents,
+    HttpResponsePayload, HttpResponsePreamble, HttpServerError, HttpVersion,
+};
+use crate::net::httpcore::{
+    HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp, StacksHttpRequest,
+    StacksHttpResponse,
+};
+use crate::net::{Error as NetError, StacksNodeState, TipRequest, MAX_HEADERS};
+use crate::util_lib::db::{DBConn, Error as DBError};
+
+#[derive(Clone)]
+pub struct RPCNakamotoTenureRequestHandler {
+    /// Block to start streaming from. It and its ancestors will be incrementally streamed until one of
+    /// hte following happens:
+    /// * we reach the first block in the tenure
+    /// * we would exceed MAX_MESSAGE_LEN bytes transmitted if we started sending the next block
+    pub block_id: Option<StacksBlockId>,
+}
+
+impl RPCNakamotoTenureRequestHandler {
+    pub fn new() -> Self {
+        Self { block_id: None }
+    }
+}
+
+pub struct NakamotoTenureStream {
+    /// stream for the current block
+    pub block_stream: NakamotoBlockStream,
+    /// connection to the headers DB
+    pub headers_conn: DBConn,
+    /// total bytess sent so far
+    pub total_sent: u64,
+}
+
+impl NakamotoTenureStream {
+    pub fn new(
+        chainstate: &StacksChainState,
+        block_id: StacksBlockId,
+        consensus_hash: ConsensusHash,
+        parent_block_id: StacksBlockId,
+    ) -> Result<Self, ChainError> {
+        let block_stream =
+            NakamotoBlockStream::new(chainstate, block_id, consensus_hash, parent_block_id)?;
+        let headers_conn = chainstate.reopen_db()?;
+        Ok(NakamotoTenureStream {
+            block_stream,
+            headers_conn,
+            total_sent: 0,
+        })
+    }
+
+    /// Start streaming the next block (i.e. the parent of the block we last streamed).
+    /// Return Ok(true) if we can fit the block into the stream.
+    /// Return Ok(false) if not. The caller will need to call this RPC method again with the block
+    /// ID of the last block it received.
+    /// Return Err(..) on DB error
+    pub fn next_block(&mut self) -> Result<bool, ChainError> {
+        let parent_header = NakamotoChainState::get_block_header_nakamoto(
+            &self.headers_conn,
+            &self.block_stream.parent_block_id,
+        )?
+        .ok_or(ChainError::NoSuchBlockError)?;
+
+        // stop sending if the parent is an epoch2 block
+        let Some(parent_nakamoto_header) = parent_header.anchored_header.as_stacks_nakamoto()
+        else {
+            return Ok(false);
+        };
+
+        // stop sending if the parent is in a different tenure
+        if parent_nakamoto_header.consensus_hash != self.block_stream.consensus_hash {
+            return Ok(false);
+        }
+
+        let parent_size = self
+            .block_stream
+            .staging_db_conn
+            .conn()
+            .get_nakamoto_block_size(&self.block_stream.parent_block_id)?
+            .ok_or(ChainError::NoSuchBlockError)?;
+
+        self.total_sent = self
+            .total_sent
+            .saturating_add(self.block_stream.total_bytes);
+        if self.total_sent.saturating_add(parent_size) > MAX_MESSAGE_LEN.into() {
+            // out of space to send this
+            return Ok(false);
+        }
+
+        self.block_stream.reset(
+            parent_nakamoto_header.block_id(),
+            parent_nakamoto_header.parent_block_id.clone(),
+        )?;
+        Ok(true)
+    }
+}
+
+/// Decode the HTTP request
+impl HttpRequest for RPCNakamotoTenureRequestHandler {
+    fn verb(&self) -> &'static str {
+        "GET"
+    }
+
+    fn path_regex(&self) -> Regex {
+        Regex::new(r#"^/v3/tenures/(?P<block_id>[0-9a-f]{64})$"#).unwrap()
+    }
+
+    /// Try to decode this request.
+    /// There's nothing to load here, so just make sure the request is well-formed.
+    fn try_parse_request(
+        &mut self,
+        preamble: &HttpRequestPreamble,
+        captures: &Captures,
+        query: Option<&str>,
+        _body: &[u8],
+    ) -> Result<HttpRequestContents, Error> {
+        if preamble.get_content_length() != 0 {
+            return Err(Error::DecodeError(
+                "Invalid Http request: expected 0-length body".to_string(),
+            ));
+        }
+
+        let block_id_str = captures
+            .name("block_id")
+            .ok_or(Error::DecodeError(
+                "Failed to match path to block ID group".to_string(),
+            ))?
+            .as_str();
+
+        let block_id = StacksBlockId::from_hex(block_id_str).map_err(|_| {
+            Error::DecodeError("Invalid path: unparseable consensus hash".to_string())
+        })?;
+        self.block_id = Some(block_id);
+
+        Ok(HttpRequestContents::new().query_string(query))
+    }
+}
+
+impl RPCRequestHandler for RPCNakamotoTenureRequestHandler {
+    /// Reset internal state
+    fn restart(&mut self) {
+        self.block_id = None;
+    }
+
+    /// Make the response
+    fn try_handle_request(
+        &mut self,
+        preamble: HttpRequestPreamble,
+        _contents: HttpRequestContents,
+        node: &mut StacksNodeState,
+    ) -> Result<(HttpResponsePreamble, HttpResponseContents), NetError> {
+        let block_id = self
+            .block_id
+            .take()
+            .ok_or(NetError::SendError("Missing `block_id`".into()))?;
+
+        let stream_res =
+            node.with_node_state(|_network, _sortdb, chainstate, _mempool, _rpc_args| {
+                let Some(header) =
+                    NakamotoChainState::get_block_header_nakamoto(chainstate.db(), &block_id)?
+                else {
+                    return Err(ChainError::NoSuchBlockError);
+                };
+                let Some(nakamoto_header) = header.anchored_header.as_stacks_nakamoto() else {
+                    return Err(ChainError::NoSuchBlockError);
+                };
+                NakamotoTenureStream::new(
+                    chainstate,
+                    block_id,
+                    nakamoto_header.consensus_hash.clone(),
+                    nakamoto_header.parent_block_id.clone(),
+                )
+            });
+
+        // start loading up the block
+        let stream = match stream_res {
+            Ok(stream) => stream,
+            Err(ChainError::NoSuchBlockError) => {
+                return StacksHttpResponse::new_error(
+                    &preamble,
+                    &HttpNotFound::new(format!("No such block {:?}\n", &block_id)),
+                )
+                .try_into_contents()
+                .map_err(NetError::from)
+            }
+            Err(e) => {
+                // nope -- error trying to check
+                let msg = format!("Failed to load block {}: {:?}\n", &block_id, &e);
+                warn!("{}", &msg);
+                return StacksHttpResponse::new_error(&preamble, &HttpServerError::new(msg))
+                    .try_into_contents()
+                    .map_err(NetError::from);
+            }
+        };
+
+        let resp_preamble = HttpResponsePreamble::from_http_request_preamble(
+            &preamble,
+            200,
+            "OK",
+            None,
+            HttpContentType::Bytes,
+        );
+
+        Ok((
+            resp_preamble,
+            HttpResponseContents::from_stream(Box::new(stream)),
+        ))
+    }
+}
+
+/// Decode the HTTP response
+impl HttpResponse for RPCNakamotoTenureRequestHandler {
+    /// Decode this response from a byte stream.  This is called by the client to decode this
+    /// message
+    fn try_parse_response(
+        &self,
+        preamble: &HttpResponsePreamble,
+        body: &[u8],
+    ) -> Result<HttpResponsePayload, Error> {
+        let bytes = parse_bytes(preamble, body, MAX_MESSAGE_LEN.into())?;
+        Ok(HttpResponsePayload::Bytes(bytes))
+    }
+}
+
+/// Stream implementation for a Nakamoto block
+impl HttpChunkGenerator for NakamotoTenureStream {
+    #[cfg(test)]
+    fn hint_chunk_size(&self) -> usize {
+        // make this hurt
+        32
+    }
+
+    #[cfg(not(test))]
+    fn hint_chunk_size(&self) -> usize {
+        4096
+    }
+
+    fn generate_next_chunk(&mut self) -> Result<Vec<u8>, String> {
+        let next_block_chunk = self.block_stream.generate_next_chunk()?;
+        if next_block_chunk.len() > 0 {
+            // have block data to send
+            return Ok(next_block_chunk);
+        }
+
+        // load up next block
+        let send_more = self.next_block().map_err(|e| {
+            let msg = format!("Failed to load next block in this tenure: {:?}", &e);
+            warn!("{}", &msg);
+            msg
+        })?;
+
+        if !send_more {
+            return Ok(vec![]);
+        }
+
+        self.block_stream.generate_next_chunk()
+    }
+}
+
+impl StacksHttpRequest {
+    pub fn new_get_nakamoto_tenure(host: PeerHost, block_id: StacksBlockId) -> StacksHttpRequest {
+        StacksHttpRequest::new_for_peer(
+            host,
+            "GET".into(),
+            format!("/v3/tenures/{}", &block_id),
+            HttpRequestContents::new(),
+        )
+        .expect("FATAL: failed to construct request from infallible data")
+    }
+}
+
+impl StacksHttpResponse {
+    /// Decode an HTTP response into a tenure.
+    /// The bytes are a concatenation of Nakamoto blocks, with no length prefix.
+    /// If it fails, return Self::Error(..)
+    pub fn decode_nakamoto_tenure(self) -> Result<Vec<NakamotoBlock>, NetError> {
+        let contents = self.get_http_payload_ok()?;
+
+        // contents will be raw bytes
+        let tenure_bytes: Vec<u8> = contents.try_into()?;
+        let ptr = &mut tenure_bytes.as_slice();
+
+        let mut blocks = vec![];
+        while ptr.len() > 0 {
+            let block = NakamotoBlock::consensus_deserialize(ptr)?;
+            blocks.push(block);
+        }
+
+        Ok(blocks)
+    }
+}

--- a/stackslib/src/net/api/gettenureinfo.rs
+++ b/stackslib/src/net/api/gettenureinfo.rs
@@ -1,0 +1,158 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::{fs, io};
+
+use regex::{Captures, Regex};
+use serde::de::Error as de_Error;
+use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
+use stacks_common::types::net::PeerHost;
+use stacks_common::util::hash::to_hex;
+use {serde, serde_json};
+
+use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState, NakamotoStagingBlocksConn};
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::Error as ChainError;
+use crate::net::api::getblock_v3::NakamotoBlockStream;
+use crate::net::http::{
+    parse_bytes, parse_json, Error, HttpBadRequest, HttpChunkGenerator, HttpContentType,
+    HttpNotFound, HttpRequest, HttpRequestContents, HttpRequestPreamble, HttpResponse,
+    HttpResponseContents, HttpResponsePayload, HttpResponsePreamble, HttpServerError, HttpVersion,
+};
+use crate::net::httpcore::{
+    HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp, StacksHttpRequest,
+    StacksHttpResponse,
+};
+use crate::net::{Error as NetError, StacksNodeState, TipRequest, MAX_HEADERS};
+use crate::util_lib::db::{DBConn, Error as DBError};
+
+#[derive(Clone)]
+pub struct RPCNakamotoTenureInfoRequestHandler {}
+
+impl RPCNakamotoTenureInfoRequestHandler {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// The view of this node's current tenure.
+/// All of this information can be found from the PeerNetwork struct, so loading this up should
+/// incur zero disk I/O.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct RPCGetTenureInfo {
+    /// The highest known consensus hash (identifies the current tenure)
+    pub consensus_hash: ConsensusHash,
+    /// The highest Stacks block ID
+    pub tip_block_id: StacksBlockId,
+    /// The height of this tip
+    pub tip_height: u64,
+    /// Which reward cycle we're in
+    pub reward_cycle: u64,
+}
+
+/// Decode the HTTP request
+impl HttpRequest for RPCNakamotoTenureInfoRequestHandler {
+    fn verb(&self) -> &'static str {
+        "GET"
+    }
+
+    fn path_regex(&self) -> Regex {
+        Regex::new(r#"^/v3/tenures/info"#).unwrap()
+    }
+
+    /// Try to decode this request.
+    /// There's nothing to load here, so just make sure the request is well-formed.
+    fn try_parse_request(
+        &mut self,
+        preamble: &HttpRequestPreamble,
+        _captures: &Captures,
+        query: Option<&str>,
+        _body: &[u8],
+    ) -> Result<HttpRequestContents, Error> {
+        if preamble.get_content_length() != 0 {
+            return Err(Error::DecodeError(
+                "Invalid Http request: expected 0-length body".to_string(),
+            ));
+        }
+        Ok(HttpRequestContents::new().query_string(query))
+    }
+}
+
+impl RPCRequestHandler for RPCNakamotoTenureInfoRequestHandler {
+    /// Reset internal state
+    fn restart(&mut self) {}
+
+    /// Make the response
+    fn try_handle_request(
+        &mut self,
+        preamble: HttpRequestPreamble,
+        _contents: HttpRequestContents,
+        node: &mut StacksNodeState,
+    ) -> Result<(HttpResponsePreamble, HttpResponseContents), NetError> {
+        let info = node.with_node_state(|network, _sortdb, _chainstate, _mempool, _rpc_args| {
+            RPCGetTenureInfo {
+                consensus_hash: network.stacks_tip.0.clone(),
+                tip_block_id: StacksBlockId::new(&network.stacks_tip.0, &network.stacks_tip.1),
+                tip_height: network.stacks_tip.2,
+                reward_cycle: network
+                    .burnchain
+                    .block_height_to_reward_cycle(network.burnchain_tip.block_height)
+                    .expect("FATAL: burnchain tip before system start"),
+            }
+        });
+
+        let preamble = HttpResponsePreamble::ok_json(&preamble);
+        let body = HttpResponseContents::try_from_json(&info)?;
+        Ok((preamble, body))
+    }
+}
+
+/// Decode the HTTP response
+impl HttpResponse for RPCNakamotoTenureInfoRequestHandler {
+    fn try_parse_response(
+        &self,
+        preamble: &HttpResponsePreamble,
+        body: &[u8],
+    ) -> Result<HttpResponsePayload, Error> {
+        let peer_info: RPCGetTenureInfo = parse_json(preamble, body)?;
+        Ok(HttpResponsePayload::try_from_json(peer_info)?)
+    }
+}
+
+impl StacksHttpRequest {
+    /// Make a new getinfo request to this endpoint
+    pub fn new_get_nakamoto_tenure_info(host: PeerHost) -> StacksHttpRequest {
+        StacksHttpRequest::new_for_peer(
+            host,
+            "GET".into(),
+            "/v3/tenures/info".into(),
+            HttpRequestContents::new(),
+        )
+        .expect("FATAL: failed to construct request from infallible data")
+    }
+}
+
+impl StacksHttpResponse {
+    pub fn decode_nakamoto_tenure_info(self) -> Result<RPCGetTenureInfo, NetError> {
+        let contents = self.get_http_payload_ok()?;
+        let response_json: serde_json::Value = contents.try_into()?;
+        let tenure_info: RPCGetTenureInfo = serde_json::from_value(response_json)
+            .map_err(|_e| Error::DecodeError("Failed to decode JSON".to_string()))?;
+        Ok(tenure_info)
+    }
+}

--- a/stackslib/src/net/api/mod.rs
+++ b/stackslib/src/net/api/mod.rs
@@ -38,6 +38,7 @@ pub mod getaccount;
 pub mod getattachment;
 pub mod getattachmentsinv;
 pub mod getblock;
+pub mod getblock_v3;
 pub mod getconstantval;
 pub mod getcontractabi;
 pub mod getcontractsrc;
@@ -55,6 +56,8 @@ pub mod getstackerdbchunk;
 pub mod getstackerdbmetadata;
 pub mod getstackers;
 pub mod getstxtransfercost;
+pub mod gettenure;
+pub mod gettenureinfo;
 pub mod gettransaction_unconfirmed;
 pub mod liststackerdbreplicas;
 pub mod postblock;
@@ -80,6 +83,7 @@ impl StacksHttp {
         self.register_rpc_endpoint(getattachment::RPCGetAttachmentRequestHandler::new());
         self.register_rpc_endpoint(getattachmentsinv::RPCGetAttachmentsInvRequestHandler::new());
         self.register_rpc_endpoint(getblock::RPCBlocksRequestHandler::new());
+        self.register_rpc_endpoint(getblock_v3::RPCNakamotoBlockRequestHandler::new());
         self.register_rpc_endpoint(getconstantval::RPCGetConstantValRequestHandler::new());
         self.register_rpc_endpoint(getcontractabi::RPCGetContractAbiRequestHandler::new());
         self.register_rpc_endpoint(getcontractsrc::RPCGetContractSrcRequestHandler::new());
@@ -107,6 +111,8 @@ impl StacksHttp {
             getstackerdbmetadata::RPCGetStackerDBMetadataRequestHandler::new(),
         );
         self.register_rpc_endpoint(getstackers::GetStackersRequestHandler::default());
+        self.register_rpc_endpoint(gettenure::RPCNakamotoTenureRequestHandler::new());
+        self.register_rpc_endpoint(gettenureinfo::RPCNakamotoTenureInfoRequestHandler::new());
         self.register_rpc_endpoint(
             gettransaction_unconfirmed::RPCGetTransactionUnconfirmedRequestHandler::new(),
         );

--- a/stackslib/src/net/api/tests/getblock_v3.rs
+++ b/stackslib/src/net/api/tests/getblock_v3.rs
@@ -1,0 +1,188 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use clarity::vm::types::{QualifiedContractIdentifier, StacksAddressExtensions};
+use clarity::vm::{ClarityName, ContractName};
+use stacks_common::codec::StacksMessageCodec;
+use stacks_common::types::chainstate::{
+    ConsensusHash, StacksAddress, StacksBlockId, StacksPrivateKey,
+};
+use stacks_common::types::net::PeerHost;
+use stacks_common::types::Address;
+
+use super::TestRPC;
+use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
+use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
+use crate::chainstate::stacks::db::blocks::test::*;
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::{
+    Error as chainstate_error, StacksBlock, StacksBlockHeader, StacksMicroblock,
+};
+use crate::net::api::getblock_v3::NakamotoBlockStream;
+use crate::net::api::*;
+use crate::net::connection::ConnectionOptions;
+use crate::net::http::HttpChunkGenerator;
+use crate::net::httpcore::{
+    HttpPreambleExtensions, HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp,
+    StacksHttpRequest,
+};
+use crate::net::test::TestEventObserver;
+use crate::net::tests::inv::nakamoto::make_nakamoto_peer_from_invs;
+use crate::net::{ProtocolFamily, TipRequest};
+use crate::util_lib::db::DBConn;
+
+#[test]
+fn test_try_parse_request() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+    let mut http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
+
+    let request = StacksHttpRequest::new_get_nakamoto_block(addr.into(), StacksBlockId([0x11; 32]));
+    let bytes = request.try_serialize().unwrap();
+
+    debug!("Request:\n{}\n", std::str::from_utf8(&bytes).unwrap());
+
+    let (parsed_preamble, offset) = http.read_preamble(&bytes).unwrap();
+    let mut handler = getblock_v3::RPCNakamotoBlockRequestHandler::new();
+    let mut parsed_request = http
+        .handle_try_parse_request(
+            &mut handler,
+            &parsed_preamble.expect_request(),
+            &bytes[offset..],
+        )
+        .unwrap();
+
+    // parsed request consumes headers that would not be in a constructed reqeuest
+    parsed_request.clear_headers();
+    let (preamble, contents) = parsed_request.destruct();
+
+    // consumed path args
+    assert_eq!(handler.block_id, Some(StacksBlockId([0x11; 32])));
+
+    assert_eq!(&preamble, request.preamble());
+
+    handler.restart();
+    assert!(handler.block_id.is_none());
+}
+
+#[test]
+fn test_try_make_response() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+
+    let test_observer = TestEventObserver::new();
+    let rpc_test = TestRPC::setup_nakamoto(function_name!(), &test_observer);
+
+    let nakamoto_chain_tip = rpc_test.canonical_tip.clone();
+    let consensus_hash = rpc_test.consensus_hash.clone();
+
+    let mut requests = vec![];
+
+    // query existing block
+    let request =
+        StacksHttpRequest::new_get_nakamoto_block(addr.into(), nakamoto_chain_tip.clone());
+    requests.push(request);
+
+    // query non-existant block
+    let request = StacksHttpRequest::new_get_nakamoto_block(addr.into(), StacksBlockId([0x11; 32]));
+    requests.push(request);
+
+    let mut responses = rpc_test.run(requests);
+
+    // got the block
+    let response = responses.remove(0);
+    let resp = response.decode_nakamoto_block().unwrap();
+
+    assert_eq!(
+        StacksBlockHeader::make_index_block_hash(&consensus_hash, &resp.header.block_hash()),
+        nakamoto_chain_tip
+    );
+
+    // no block
+    let response = responses.remove(0);
+    let (preamble, body) = response.destruct();
+
+    assert_eq!(preamble.status_code, 404);
+}
+
+#[test]
+fn test_stream_nakamoto_blocks() {
+    let test_observer = TestEventObserver::new();
+    let bitvecs = vec![vec![
+        true, true, true, true, true, true, true, true, true, true,
+    ]];
+
+    let mut peer =
+        make_nakamoto_peer_from_invs(function_name!(), &test_observer, 10, 3, bitvecs.clone());
+
+    // can't stream a nonexistant block
+    assert!(NakamotoBlockStream::new(
+        peer.chainstate(),
+        StacksBlockId([0x11; 32]),
+        ConsensusHash([0x22; 20]),
+        StacksBlockId([0x33; 32])
+    )
+    .is_err());
+
+    let nakamoto_tip = {
+        let sortdb = peer.sortdb.take().unwrap();
+        let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+        let ih = sortdb.index_handle(&tip.sortition_id);
+        let nakamoto_tip = ih.get_nakamoto_tip().unwrap().unwrap();
+        peer.sortdb = Some(sortdb);
+        nakamoto_tip
+    };
+
+    let nakamoto_tip_block_id = StacksBlockId::new(&nakamoto_tip.0, &nakamoto_tip.1);
+    let nakamoto_header = {
+        let header_info = NakamotoChainState::get_block_header_nakamoto(
+            peer.chainstate().db(),
+            &nakamoto_tip_block_id,
+        )
+        .unwrap()
+        .unwrap();
+        header_info
+            .anchored_header
+            .as_stacks_nakamoto()
+            .cloned()
+            .unwrap()
+    };
+
+    let mut stream = NakamotoBlockStream::new(
+        peer.chainstate(),
+        nakamoto_tip_block_id,
+        nakamoto_tip.0.clone(),
+        nakamoto_header.parent_block_id.clone(),
+    )
+    .unwrap();
+    let mut all_block_bytes = vec![];
+
+    loop {
+        let mut next_bytes = stream.generate_next_chunk().unwrap();
+        if next_bytes.is_empty() {
+            break;
+        }
+        test_debug!(
+            "Got {} more bytes from staging; add to {} total",
+            next_bytes.len(),
+            all_block_bytes.len()
+        );
+        all_block_bytes.append(&mut next_bytes);
+    }
+
+    let staging_block = NakamotoBlock::consensus_deserialize(&mut &all_block_bytes[..]).unwrap();
+    assert_eq!(staging_block.header.block_id(), nakamoto_tip_block_id);
+}

--- a/stackslib/src/net/api/tests/gettenure.rs
+++ b/stackslib/src/net/api/tests/gettenure.rs
@@ -1,0 +1,203 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use clarity::vm::types::{QualifiedContractIdentifier, StacksAddressExtensions};
+use clarity::vm::{ClarityName, ContractName};
+use stacks_common::codec::StacksMessageCodec;
+use stacks_common::types::chainstate::{
+    ConsensusHash, StacksAddress, StacksBlockId, StacksPrivateKey,
+};
+use stacks_common::types::net::PeerHost;
+use stacks_common::types::Address;
+
+use super::TestRPC;
+use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
+use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
+use crate::chainstate::stacks::db::blocks::test::*;
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::{
+    Error as chainstate_error, StacksBlock, StacksBlockHeader, StacksMicroblock,
+};
+use crate::net::api::gettenure::NakamotoTenureStream;
+use crate::net::api::*;
+use crate::net::connection::ConnectionOptions;
+use crate::net::http::HttpChunkGenerator;
+use crate::net::httpcore::{
+    HttpPreambleExtensions, HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp,
+    StacksHttpRequest,
+};
+use crate::net::test::TestEventObserver;
+use crate::net::tests::inv::nakamoto::make_nakamoto_peer_from_invs;
+use crate::net::{ProtocolFamily, TipRequest};
+use crate::util_lib::db::DBConn;
+
+#[test]
+fn test_try_parse_request() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+    let mut http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
+
+    let request =
+        StacksHttpRequest::new_get_nakamoto_tenure(addr.into(), StacksBlockId([0x11; 32]));
+    let bytes = request.try_serialize().unwrap();
+
+    debug!("Request:\n{}\n", std::str::from_utf8(&bytes).unwrap());
+
+    let (parsed_preamble, offset) = http.read_preamble(&bytes).unwrap();
+    let mut handler = gettenure::RPCNakamotoTenureRequestHandler::new();
+    let mut parsed_request = http
+        .handle_try_parse_request(
+            &mut handler,
+            &parsed_preamble.expect_request(),
+            &bytes[offset..],
+        )
+        .unwrap();
+
+    // parsed request consumes headers that would not be in a constructed reqeuest
+    parsed_request.clear_headers();
+    let (preamble, contents) = parsed_request.destruct();
+
+    // consumed path args
+    assert_eq!(handler.block_id, Some(StacksBlockId([0x11; 32])));
+
+    assert_eq!(&preamble, request.preamble());
+
+    handler.restart();
+    assert!(handler.block_id.is_none());
+}
+
+#[test]
+fn test_try_make_response() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+
+    let test_observer = TestEventObserver::new();
+    let rpc_test = TestRPC::setup_nakamoto(function_name!(), &test_observer);
+
+    let nakamoto_chain_tip = rpc_test.canonical_tip.clone();
+    let consensus_hash = rpc_test.consensus_hash.clone();
+
+    let mut requests = vec![];
+
+    // query existing tenure
+    let request =
+        StacksHttpRequest::new_get_nakamoto_tenure(addr.into(), nakamoto_chain_tip.clone());
+    requests.push(request);
+
+    // TODO: mid-tenure?
+    // TODO: just the start of the tenure?
+
+    // query non-existant block
+    let request =
+        StacksHttpRequest::new_get_nakamoto_tenure(addr.into(), StacksBlockId([0x11; 32]));
+    requests.push(request);
+
+    let mut responses = rpc_test.run(requests);
+
+    // got the block
+    let response = responses.remove(0);
+    let resp = response.decode_nakamoto_tenure().unwrap();
+
+    info!("response: {:?}", &resp);
+    assert_eq!(resp.len(), 10);
+    assert_eq!(resp.first().unwrap().header.block_id(), nakamoto_chain_tip);
+
+    // no block
+    let response = responses.remove(0);
+    let (preamble, body) = response.destruct();
+
+    assert_eq!(preamble.status_code, 404);
+}
+
+#[test]
+fn test_stream_nakamoto_tenure() {
+    let test_observer = TestEventObserver::new();
+    let bitvecs = vec![vec![
+        true, true, true, true, true, true, true, true, true, true,
+    ]];
+
+    let mut peer =
+        make_nakamoto_peer_from_invs(function_name!(), &test_observer, 10, 3, bitvecs.clone());
+
+    // can't stream a nonexistant tenure
+    assert!(NakamotoTenureStream::new(
+        peer.chainstate(),
+        StacksBlockId([0x11; 32]),
+        ConsensusHash([0x22; 20]),
+        StacksBlockId([0x33; 32])
+    )
+    .is_err());
+
+    let nakamoto_tip = {
+        let sortdb = peer.sortdb.take().unwrap();
+        let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+        let ih = sortdb.index_handle(&tip.sortition_id);
+        let nakamoto_tip = ih.get_nakamoto_tip().unwrap().unwrap();
+        peer.sortdb = Some(sortdb);
+        nakamoto_tip
+    };
+
+    let nakamoto_tip_block_id = StacksBlockId::new(&nakamoto_tip.0, &nakamoto_tip.1);
+    let nakamoto_header = {
+        let header_info = NakamotoChainState::get_block_header_nakamoto(
+            peer.chainstate().db(),
+            &nakamoto_tip_block_id,
+        )
+        .unwrap()
+        .unwrap();
+        header_info
+            .anchored_header
+            .as_stacks_nakamoto()
+            .cloned()
+            .unwrap()
+    };
+
+    let mut stream = NakamotoTenureStream::new(
+        peer.chainstate(),
+        nakamoto_tip_block_id.clone(),
+        nakamoto_header.consensus_hash.clone(),
+        nakamoto_header.parent_block_id.clone(),
+    )
+    .unwrap();
+    let mut all_block_bytes = vec![];
+
+    loop {
+        let mut next_bytes = stream.generate_next_chunk().unwrap();
+        if next_bytes.is_empty() {
+            break;
+        }
+        test_debug!(
+            "Got {} more bytes from staging; add to {} total",
+            next_bytes.len(),
+            all_block_bytes.len()
+        );
+        all_block_bytes.append(&mut next_bytes);
+    }
+
+    let ptr = &mut all_block_bytes.as_slice();
+    let mut blocks = vec![];
+    while ptr.len() > 0 {
+        let block = NakamotoBlock::consensus_deserialize(ptr).unwrap();
+        blocks.push(block);
+    }
+
+    info!("blocks = {:?}", &blocks);
+    assert_eq!(blocks.len(), 10);
+    assert_eq!(
+        blocks.first().unwrap().header.block_id(),
+        nakamoto_tip_block_id
+    );
+}

--- a/stackslib/src/net/api/tests/gettenureinfo.rs
+++ b/stackslib/src/net/api/tests/gettenureinfo.rs
@@ -1,0 +1,89 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use clarity::vm::types::{QualifiedContractIdentifier, StacksAddressExtensions};
+use clarity::vm::{ClarityName, ContractName};
+use serde_json;
+use stacks_common::codec::StacksMessageCodec;
+use stacks_common::types::chainstate::StacksAddress;
+use stacks_common::types::net::PeerHost;
+use stacks_common::types::Address;
+
+use super::test_rpc;
+use crate::net::api::getinfo::RPCPeerInfoData;
+use crate::net::api::tests::TestRPC;
+use crate::net::api::*;
+use crate::net::connection::ConnectionOptions;
+use crate::net::httpcore::{
+    HttpPreambleExtensions, HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp,
+    StacksHttpRequest,
+};
+use crate::net::test::TestEventObserver;
+use crate::net::{ProtocolFamily, TipRequest};
+
+#[test]
+fn test_try_parse_request() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+    let mut http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
+
+    let request = StacksHttpRequest::new_get_nakamoto_tenure_info(addr.into());
+
+    let bytes = request.try_serialize().unwrap();
+
+    debug!("Request:\n{}\n", std::str::from_utf8(&bytes).unwrap());
+
+    let (parsed_preamble, offset) = http.read_preamble(&bytes).unwrap();
+    let mut parsed_request = http
+        .try_parse_request(&parsed_preamble.expect_request(), &bytes[offset..])
+        .unwrap();
+
+    // parsed request consumes headers that would not be in a constructed reqeuest
+    parsed_request.clear_headers();
+    let (preamble, contents) = parsed_request.destruct();
+
+    assert_eq!(&preamble, request.preamble());
+}
+
+#[test]
+fn test_try_make_response() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+
+    let test_observer = TestEventObserver::new();
+    let rpc_test = TestRPC::setup_nakamoto(function_name!(), &test_observer);
+
+    let nakamoto_chain_tip = rpc_test.canonical_tip.clone();
+    let consensus_hash = rpc_test.consensus_hash.clone();
+
+    let mut requests = vec![];
+
+    // query existing account
+    let request = StacksHttpRequest::new_get_nakamoto_tenure_info(addr.into());
+    requests.push(request);
+
+    let mut responses = rpc_test.run(requests);
+
+    let response = responses.remove(0);
+    debug!(
+        "Response:\n{}\n",
+        std::str::from_utf8(&response.try_serialize().unwrap()).unwrap()
+    );
+
+    let resp = response.decode_nakamoto_tenure_info().unwrap();
+    assert_eq!(resp.consensus_hash, consensus_hash);
+    assert_eq!(resp.tip_block_id, nakamoto_chain_tip);
+}

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -31,6 +31,7 @@ use stacks_common::util::pipe::Pipe;
 use crate::burnchains::bitcoin::indexer::BitcoinIndexer;
 use crate::burnchains::Txid;
 use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::nakamoto::NakamotoChainState;
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::miner::{BlockBuilderSettings, StacksMicroblockBuilder};
 use crate::chainstate::stacks::{
@@ -43,7 +44,8 @@ use crate::net::db::PeerDB;
 use crate::net::httpcore::{StacksHttpRequest, StacksHttpResponse};
 use crate::net::relay::Relayer;
 use crate::net::rpc::ConversationHttp;
-use crate::net::test::{TestPeer, TestPeerConfig};
+use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
+use crate::net::tests::inv::nakamoto::make_nakamoto_peers_from_invs;
 use crate::net::{
     Attachment, AttachmentInstance, RPCHandlerArgs, StackerDBConfig, StacksNodeState, UrlString,
 };
@@ -53,6 +55,7 @@ mod getaccount;
 mod getattachment;
 mod getattachmentsinv;
 mod getblock;
+mod getblock_v3;
 mod getconstantval;
 mod getcontractabi;
 mod getcontractsrc;
@@ -69,6 +72,8 @@ mod getpoxinfo;
 mod getstackerdbchunk;
 mod getstackerdbmetadata;
 mod getstxtransfercost;
+mod gettenure;
+mod gettenureinfo;
 mod gettransaction_unconfirmed;
 mod liststackerdbreplicas;
 mod postblock;
@@ -194,11 +199,13 @@ pub struct TestRPC<'a> {
     /// list of microblock transactions
     pub microblock_txids: Vec<Txid>,
     /// next block to post, and its consensus hash
-    pub next_block: (ConsensusHash, StacksBlock),
+    pub next_block: Option<(ConsensusHash, StacksBlock)>,
     /// next microblock to post (may already be posted)
-    pub next_microblock: StacksMicroblock,
+    pub next_microblock: Option<StacksMicroblock>,
     /// transactions that can be posted to the mempool
     pub sendable_txs: Vec<StacksTransaction>,
+    /// whether or not to maintain unconfirmed microblocks (e.g. this is false for nakamoto)
+    pub unconfirmed_state: bool,
 }
 
 impl<'a> TestRPC<'a> {
@@ -803,9 +810,96 @@ impl<'a> TestRPC<'a> {
             microblock_tip_hash: microblock.block_hash(),
             mempool_txids,
             microblock_txids,
-            next_block: (next_consensus_hash, next_stacks_block),
-            next_microblock: microblock,
+            next_block: Some((next_consensus_hash, next_stacks_block)),
+            next_microblock: Some(microblock),
             sendable_txs,
+            unconfirmed_state: true,
+        }
+    }
+
+    /// Set up the peers as Nakamoto nodes
+    pub fn setup_nakamoto(test_name: &str, observer: &'a TestEventObserver) -> TestRPC<'a> {
+        let bitvecs = vec![vec![
+            true, true, true, true, true, true, true, true, true, true,
+        ]];
+
+        let (mut peer, mut other_peers) =
+            make_nakamoto_peers_from_invs(function_name!(), observer, 10, 3, bitvecs.clone(), 1);
+        let mut other_peer = other_peers.pop().unwrap();
+
+        let peer_1_indexer = BitcoinIndexer::new_unit_test(&peer.config.burnchain.working_dir);
+        let peer_2_indexer =
+            BitcoinIndexer::new_unit_test(&other_peer.config.burnchain.working_dir);
+
+        let convo_1 = ConversationHttp::new(
+            format!("127.0.0.1:{}", peer.config.http_port)
+                .parse::<SocketAddr>()
+                .unwrap(),
+            Some(UrlString::try_from(format!("http://peer1.com")).unwrap()),
+            peer.to_peer_host(),
+            &peer.config.connection_opts,
+            0,
+            32,
+        );
+
+        let convo_2 = ConversationHttp::new(
+            format!("127.0.0.1:{}", other_peer.config.http_port)
+                .parse::<SocketAddr>()
+                .unwrap(),
+            Some(UrlString::try_from(format!("http://peer2.com")).unwrap()),
+            other_peer.to_peer_host(),
+            &other_peer.config.connection_opts,
+            1,
+            32,
+        );
+
+        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb().conn()).unwrap();
+        let nakamoto_tip = {
+            let sortdb = peer.sortdb.take().unwrap();
+            let tip =
+                NakamotoChainState::get_canonical_block_header(peer.chainstate().db(), &sortdb)
+                    .unwrap()
+                    .unwrap();
+            peer.sortdb = Some(sortdb);
+            tip
+        };
+
+        // sanity check
+        let other_tip =
+            SortitionDB::get_canonical_burn_chain_tip(other_peer.sortdb().conn()).unwrap();
+        let other_nakamoto_tip = {
+            let sortdb = other_peer.sortdb.take().unwrap();
+            let tip = NakamotoChainState::get_canonical_block_header(
+                other_peer.chainstate().db(),
+                &sortdb,
+            )
+            .unwrap()
+            .unwrap();
+            other_peer.sortdb = Some(sortdb);
+            tip
+        };
+
+        assert_eq!(tip, other_tip);
+        assert_eq!(nakamoto_tip, other_nakamoto_tip);
+
+        TestRPC {
+            privk1: peer.config.private_key.clone(),
+            privk2: other_peer.config.private_key.clone(),
+            peer_1: peer,
+            peer_2: other_peer,
+            peer_1_indexer,
+            peer_2_indexer,
+            convo_1,
+            convo_2,
+            canonical_tip: nakamoto_tip.index_block_hash(),
+            consensus_hash: nakamoto_tip.consensus_hash.clone(),
+            microblock_tip_hash: BlockHeaderHash([0x00; 32]),
+            mempool_txids: vec![],
+            microblock_txids: vec![],
+            next_block: None,
+            next_microblock: None,
+            sendable_txs: vec![],
+            unconfirmed_state: false,
         }
     }
 
@@ -818,9 +912,13 @@ impl<'a> TestRPC<'a> {
         let peer_2_indexer = self.peer_2_indexer;
         let mut convo_1 = self.convo_1;
         let mut convo_2 = self.convo_2;
+        let unconfirmed_state = self.unconfirmed_state;
 
         let mut responses = vec![];
         for request in requests.into_iter() {
+            peer_1.refresh_burnchain_view();
+            peer_2.refresh_burnchain_view();
+
             convo_1.send_request(request.clone()).unwrap();
             let mut peer_1_mempool = peer_1.mempool.take().unwrap();
             let peer_2_mempool = peer_2.mempool.take().unwrap();
@@ -832,8 +930,13 @@ impl<'a> TestRPC<'a> {
             let peer_1_sortdb = peer_1.sortdb.take().unwrap();
             let mut peer_1_stacks_node = peer_1.stacks_node.take().unwrap();
 
-            Relayer::setup_unconfirmed_state(&mut peer_1_stacks_node.chainstate, &peer_1_sortdb)
+            if unconfirmed_state {
+                Relayer::setup_unconfirmed_state(
+                    &mut peer_1_stacks_node.chainstate,
+                    &peer_1_sortdb,
+                )
                 .unwrap();
+            }
 
             {
                 let rpc_args = RPCHandlerArgs::default();
@@ -869,8 +972,13 @@ impl<'a> TestRPC<'a> {
                 )
                 .unwrap();
 
-            Relayer::setup_unconfirmed_state(&mut peer_2_stacks_node.chainstate, &peer_2_sortdb)
+            if unconfirmed_state {
+                Relayer::setup_unconfirmed_state(
+                    &mut peer_2_stacks_node.chainstate,
+                    &peer_2_sortdb,
+                )
                 .unwrap();
+            }
 
             {
                 let rpc_args = RPCHandlerArgs::default();
@@ -910,8 +1018,13 @@ impl<'a> TestRPC<'a> {
                 )
                 .unwrap();
 
-            Relayer::setup_unconfirmed_state(&mut peer_1_stacks_node.chainstate, &peer_1_sortdb)
+            if unconfirmed_state {
+                Relayer::setup_unconfirmed_state(
+                    &mut peer_1_stacks_node.chainstate,
+                    &peer_1_sortdb,
+                )
                 .unwrap();
+            }
 
             {
                 let rpc_args = RPCHandlerArgs::default();

--- a/stackslib/src/net/api/tests/postblock.rs
+++ b/stackslib/src/net/api/tests/postblock.rs
@@ -96,33 +96,26 @@ fn test_try_make_response() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
 
     let rpc_test = TestRPC::setup(function_name!());
-    let stacks_block_id = StacksBlockHeader::make_index_block_hash(
-        &rpc_test.next_block.0,
-        &rpc_test.next_block.1.block_hash(),
-    );
+    let next_block = rpc_test.next_block.clone().unwrap();
+    let stacks_block_id =
+        StacksBlockHeader::make_index_block_hash(&next_block.0, &next_block.1.block_hash());
     let mut requests = vec![];
 
     // post the block
-    let request = StacksHttpRequest::new_post_block(
-        addr.into(),
-        rpc_test.next_block.0.clone(),
-        rpc_test.next_block.1.clone(),
-    );
+    let request =
+        StacksHttpRequest::new_post_block(addr.into(), next_block.0.clone(), next_block.1.clone());
     requests.push(request);
 
     // idempotent
-    let request = StacksHttpRequest::new_post_block(
-        addr.into(),
-        rpc_test.next_block.0.clone(),
-        rpc_test.next_block.1.clone(),
-    );
+    let request =
+        StacksHttpRequest::new_post_block(addr.into(), next_block.0.clone(), next_block.1.clone());
     requests.push(request);
 
     // fails if the consensus hash is not recognized
     let request = StacksHttpRequest::new_post_block(
         addr.into(),
         ConsensusHash([0x11; 20]),
-        rpc_test.next_block.1.clone(),
+        next_block.1.clone(),
     );
     requests.push(request);
 

--- a/stackslib/src/net/api/tests/postmicroblock.rs
+++ b/stackslib/src/net/api/tests/postmicroblock.rs
@@ -103,7 +103,7 @@ fn test_try_make_response() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
 
     let test_rpc = TestRPC::setup_ex(function_name!(), false);
-    let mblock = test_rpc.next_microblock.clone();
+    let mblock = test_rpc.next_microblock.clone().unwrap();
 
     let mut requests = vec![];
 

--- a/stackslib/src/net/http/request.rs
+++ b/stackslib/src/net/http/request.rs
@@ -266,7 +266,7 @@ impl StacksMessageCodec for HttpRequestPreamble {
         }
 
         // "User-Agent: $agent\r\nHost: $host\r\n"
-        fd.write_all("User-Agent: stacks/2.0\r\nHost: ".as_bytes())
+        fd.write_all("User-Agent: stacks/3.0\r\nHost: ".as_bytes())
             .map_err(CodecError::WriteError)?;
         fd.write_all(format!("{}", self.host).as_bytes())
             .map_err(CodecError::WriteError)?;

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2679,6 +2679,18 @@ pub mod test {
             ret
         }
 
+        pub fn refresh_burnchain_view(&mut self) {
+            let sortdb = self.sortdb.take().unwrap();
+            let mut stacks_node = self.stacks_node.take().unwrap();
+            let indexer = BitcoinIndexer::new_unit_test(&self.config.burnchain.working_dir);
+            self.network
+                .refresh_burnchain_view(&indexer, &sortdb, &mut stacks_node.chainstate, false)
+                .unwrap();
+
+            self.sortdb = Some(sortdb);
+            self.stacks_node = Some(stacks_node);
+        }
+
         pub fn for_each_convo_p2p<F, R>(&mut self, mut f: F) -> Vec<Result<R, net_error>>
         where
             F: FnMut(usize, &mut ConversationP2P) -> Result<R, net_error>,

--- a/stackslib/src/net/tests/inv/nakamoto.rs
+++ b/stackslib/src/net/tests/inv/nakamoto.rs
@@ -325,7 +325,7 @@ fn test_nakamoto_inv_10_extended_tenures_10_sortitions() {
 
 /// NOTE: The second return value does _not_ need `<'a>`, since `observer` is never installed into
 /// the peers here.  However, it appears unavoidable to the borrow-checker.
-fn make_nakamoto_peers_from_invs<'a>(
+pub fn make_nakamoto_peers_from_invs<'a>(
     test_name: &str,
     observer: &'a TestEventObserver,
     rc_len: u32,
@@ -399,6 +399,8 @@ fn make_nakamoto_peers_from_invs<'a>(
                     NakamotoBootStep::TenureExtend(vec![next_stx_transfer()]),
                     NakamotoBootStep::Block(vec![next_stx_transfer()]),
                     NakamotoBootStep::TenureExtend(vec![next_stx_transfer()]),
+                    NakamotoBootStep::Block(vec![next_stx_transfer()]),
+                    NakamotoBootStep::TenureExtend(vec![next_stx_transfer()]),
                 ]));
             }
         }
@@ -414,7 +416,7 @@ fn make_nakamoto_peers_from_invs<'a>(
     (peer, other_peers)
 }
 
-fn make_nakamoto_peer_from_invs<'a>(
+pub fn make_nakamoto_peer_from_invs<'a>(
     test_name: &str,
     observer: &'a TestEventObserver,
     rc_len: u32,


### PR DESCRIPTION
This PR adds three new endpoints:

* `/v3/tenures/info`:  this returns metadata about the highest-known tenure.  It will be used by the block-downloader state machine to identify peers with newer block data and fetch them.

* `/v3/tenures/{block-id}`:  this returns all blocks in a tenure ending with `block-id`, all the way back to either the first block in the tenure or the last 2 MB of block data (whichever is reached sooner).  This endpoint will be used to page through tenure data by the block downloader state machine.

* `/v3/blocks/{block-id}`: this returns a specific Nakamoto block.  This endpoint will be used by the block-downloader to fetch the tenure-start blocks, which will allow it to fetch and authenticate the tenures that span them.

In addition, this PR fixes a consensus bug of omission in `next` -- it ensures that a tenure-start Nakamoto block's block-commit commits to the parent tenure's tenure-start block.