### PR TITLE
Check Multiple Tests' Success at Once

### DIFF
--- a/.github/workflows/atlas-tests.yml
+++ b/.github/workflows/atlas-tests.yml
@@ -54,3 +54,17 @@ jobs:
         uses: stacks-network/actions/codecov@main
         with:
           test-name: ${{ matrix.test-name }}
+
+  check-tests:
+    name: Check Tests
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - atlas-tests
+    steps:
+      - name: Check Tests Status
+        id: check_tests_status
+        uses: stacks-network/actions/check-jobs-status@main
+        with:
+          jobs: ${{ toJson(needs) }}
+          summary_print: "true"

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -94,3 +94,17 @@ jobs:
         uses: stacks-network/actions/codecov@main
         with:
           test-name: ${{ matrix.test-name }}
+
+  check-tests:
+    name: Check Tests
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - integration-tests
+    steps:
+      - name: Check Tests Status
+        id: check_tests_status
+        uses: stacks-network/actions/check-jobs-status@main
+        with:
+          jobs: ${{ toJson(needs) }}
+          summary_print: "true"

--- a/.github/workflows/epoch-tests.yml
+++ b/.github/workflows/epoch-tests.yml
@@ -78,3 +78,17 @@ jobs:
         uses: stacks-network/actions/codecov@main
         with:
           test-name: ${{ matrix.test-name }}
+
+  check-tests:
+    name: Check Tests
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - epoch-tests
+    steps:
+      - name: Check Tests Status
+        id: check_tests_status
+        uses: stacks-network/actions/check-jobs-status@main
+        with:
+          jobs: ${{ toJson(needs) }}
+          summary_print: "true"

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -56,3 +56,17 @@ jobs:
         uses: stacks-network/actions/codecov@main
         with:
           test-name: ${{ matrix.test-name }}
+
+  check-tests:
+    name: Check Tests
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - slow-tests
+    steps:
+      - name: Check Tests Status
+        id: check_tests_status
+        uses: stacks-network/actions/check-jobs-status@main
+        with:
+          jobs: ${{ toJson(needs) }}
+          summary_print: "true"

--- a/.github/workflows/stacks-core-tests.yml
+++ b/.github/workflows/stacks-core-tests.yml
@@ -180,3 +180,19 @@ jobs:
         with:
           args: test --manifest-path=./contrib/core-contract-tests/Clarinet.toml contrib/core-contract-tests/tests/bns/name_register_test.ts
 
+  check-tests:
+    name: Check Tests
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - full-genesis
+      - unit-tests
+      - open-api-validation
+      - core-contracts-clarinet-test
+    steps:
+      - name: Check Tests Status
+        id: check_tests_status
+        uses: stacks-network/actions/check-jobs-status@main
+        with:
+          jobs: ${{ toJson(needs) }}
+          summary_print: "true"

--- a/docs/ci-release.md
+++ b/docs/ci-release.md
@@ -135,6 +135,35 @@ ex:
 - `Stacks Blockchain Tests`:
   - `full-genesis`: Tests related to full genesis
 
+### Checking the result of multiple tests at once
+
+You can use the [check-jobs-status](https://github.com/stacks-network/actions/tree/main/check-jobs-status) composite action in order to check that multiple tests are successful in 1 job.
+If any of the tests given to the action (JSON string of `needs` field) fails, the step that calls the action will also fail.
+
+If you have to mark more than 1 job from the same workflow required in a ruleset, you can use this action in a separate job and only add that job as required.
+
+In the following example, `unit-tests` is a matrix job with 8 partitions (i.e. 8 jobs are running), while the others are normal jobs.
+If any of the 11 jobs are failing, the `check-tests` job will also fail.
+
+```yaml
+check-tests:
+  name: Check Tests
+  runs-on: ubuntu-latest
+  if: always()
+  needs:
+    - full-genesis
+    - unit-tests
+    - open-api-validation
+    - core-contracts-clarinet-test
+  steps:
+    - name: Check Tests Status
+      id: check_tests_status
+      uses: stacks-network/actions/check-jobs-status@main
+      with:
+        jobs: ${{ toJson(needs) }}
+        summary_print: "true"
+```
+
 ## Triggering a workflow
 
 ### PR a branch to develop


### PR DESCRIPTION
Using a composite action to check that multiple jobs which are running tests are successful. 

The called action is succeeding only if all the jobs parsed through the `jobs` input (JSON string of `needs` field) have `success` as status, otherwise it fails.

The purpose of implementing this step is to add the possibility of only making the job that calls the composite required in a ruleset check, instead of having each individual test required (i.e. each job from a matrix strategy).

Reference runs:
- Successful (no test failures): https://github.com/BowTiedDevOps/stacks-core/actions/runs/7978701647?pr=3
- Failed (4 test failures - check jobs also failing): https://github.com/BowTiedDevOps/stacks-core/actions/runs/7979062950?pr=4
- In both of these runs, `Docker Image` is failing because of a push authorization - the workflow is unchanged and only works with the secrets from `stacks-network/stacks-core` repository