### PR TITLE
fix: ignore timing out runloop test

### DIFF
--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -1511,6 +1511,7 @@ mod tests {
 
     #[test]
     #[serial]
+    #[ignore]
     fn verify_transactions_valid() {
         let config = Config::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
         let mut runloop: RunLoop<FireCoordinator<v2::Aggregator>> = RunLoop::from(&config);


### PR DESCRIPTION
Currently, the `next` branch [fails CI](https://github.com/stacks-network/stacks-core/actions/runs/7974981548/job/21772737936?pr=4377) due to this test timing out. The test is vastly revamped in #4287 , so we can ignore it for now. We'll want to make sure @jferrant removes the `#[ignore]` flag in her PR