### PR TITLE
Broadcast `/new_pox_set` events to observers registered to `any` event

### DIFF
--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -940,7 +940,7 @@ impl EventDispatcher {
         cycle_number: u64,
     ) {
         let interested_observers =
-            self.filter_observers(&self.pox_stacker_set_observers_lookup, false);
+            self.filter_observers(&self.pox_stacker_set_observers_lookup, true);
 
         if interested_observers.is_empty() {
             return;


### PR DESCRIPTION
The `/new_pox_set` event was not broadcasted to observers who subscribed to the `*` any event.