### PR TITLE
Fix: only report codecov status after ci

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,22 @@
+# https://docs.codecov.com/docs/codecovyml-reference
+codecov:
+  require_ci_to_pass: false
+  notify:
+    wait_for_ci: true
 coverage:
+  range: 60..79
+  round: down
+  precision: 2
   status:
-    patch: off
-
+    changes: false
+    patch: false
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+comment:
+  layout: "condensed_header, diff, files, footer"
+  hide_project_coverage: false
+  after_n_builds: 35
 github_checks:
   annotations: false


### PR DESCRIPTION
This is an opinionated change - feedback/changes are welcome. 

the current `codecov.yml` reports coverage too early in the process, and is misleading in reporting low coverage.
the changes in this commit aim to defer that status update until most of the tests have completed. 

some notes:
- codecov documentation is infuriating
- a coverage percentage of 80 is set (with a change in 1% being allowed) - this is only relevant if we also enable codecov as a required status check (similar to how we require rustfmt to pass). 
- for the codecov dash, i'm setting anything > 79 as being fully covered, with a range of 60-79 in a "warn" state. this is only relevant for UI coloring, it has no material effect on the coverage detection
- CI is not required to pass to report on coverage (in the case of a flaky test/timeout etc)
- notify is set to only show *after* ci has completed (this seems to have zero effect if you also use `after_n_builds` which use for the PR comment, but removing it seems to break reporting for some reason). 

for the comment itself - i kept the details as relevant as i could based on the options available. the confounding setting is `after_n_builds`. each PR uploads 58 codecov reports (i've counted). however, using a value of 58 here means no PR comment is displayed. i've tuned this down to a value that has been reliable at `35`. 
`37` seems to be the correct number to use to wait until all ci tests have completed. 



i've tested this both with codecov as a required status check and without - in either case, it will be displayed as a status check with a  percentage that is updated as more reports are received. this can be disabled by setting:
```yaml
  status:
    changes: false
    patch: false
    project: false
```

if we leave the change as-is with this commit, there wil be a failed status check unless coverage cross the 80% threshhold. 

<img width="926" alt="Screenshot 2024-02-21 at 13 55 51" src="https://github.com/stacks-network/stacks-core/assets/2847772/43546f87-1b7b-4e46-a36d-81ae74cbc3c1">

<img width="917" alt="Screenshot 2024-02-21 at 13 58 03" src="https://github.com/stacks-network/stacks-core/assets/2847772/2ad2dfd5-bb8b-47ce-891f-002b8bd37acd">


<img width="962" alt="Screenshot 2024-02-21 at 13 56 32" src="https://github.com/stacks-network/stacks-core/assets/2847772/65314f4e-4b4a-44aa-9808-b47515f499a5">

<img width="995" alt="Screenshot 2024-02-21 at 13 56 45" src="https://github.com/stacks-network/stacks-core/assets/2847772/bb9a8ded-9bfe-4d51-af19-efb74e09f407">

