### PR TITLE
trigger ci workflow when merge queue requests it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 name: CI
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - master


### PR DESCRIPTION
per github docs on merge queus, adds the following to the ci.yml workflow:
```yaml
on:
  merge_group:
    types:
      - checks_requested
```
per: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

this is a required change before we can enable merge queues for the `next` branch. 

