### PR TITLE
chore(stacks-common): Improvements to `Vec` allocation and operations

### DIFF
--- a/stacks-common/src/address/c32.rs
+++ b/stacks-common/src/address/c32.rs
@@ -180,7 +180,9 @@ const C32_CHARACTERS_MAP: [Option<u8>; 128] = [
 ];
 
 fn c32_encode(input_bytes: &[u8]) -> String {
-    let mut result = vec![];
+    // c32-encoded size is 160%  that of ASCII
+    let size = input_bytes.len().saturating_mul(8).div_ceil(5);
+    let mut result = Vec::with_capacity(size);
     let mut carry = 0;
     let mut carry_bits = 0;
 
@@ -234,10 +236,6 @@ fn c32_decode(input_str: &str) -> Result<Vec<u8>, Error> {
 }
 
 fn c32_decode_ascii(input_str: &str) -> Result<Vec<u8>, Error> {
-    let mut result = vec![];
-    let mut carry: u16 = 0;
-    let mut carry_bits = 0; // can be up to 5
-
     let mut iter_c32_digits = Vec::<u8>::with_capacity(input_str.len());
 
     for x in input_str.as_bytes().iter().rev() {
@@ -250,6 +248,12 @@ fn c32_decode_ascii(input_str: &str) -> Result<Vec<u8>, Error> {
         // at least one char was None
         return Err(Error::InvalidCrockford32);
     }
+
+    // ASCII size is 62.5%  that of c32-encoded
+    let size = iter_c32_digits.len().saturating_mul(5).div_ceil(8);
+    let mut result = Vec::with_capacity(size);
+    let mut carry: u16 = 0;
+    let mut carry_bits = 0; // can be up to 5
 
     for current_5bit in &iter_c32_digits {
         carry += (*current_5bit as u16) << carry_bits;

--- a/stacks-common/src/address/c32.rs
+++ b/stacks-common/src/address/c32.rs
@@ -180,7 +180,8 @@ const C32_CHARACTERS_MAP: [Option<u8>; 128] = [
 ];
 
 fn c32_encode(input_bytes: &[u8]) -> String {
-    // c32-encoded size is 160%  that of ASCII
+    // ASCII characters are 8-bits and c32-encoding encodes 5-bits per
+    // character, so the c32-encoded size should be ceil((ascii size) * 8 / 5)
     let size = input_bytes.len().saturating_mul(8).div_ceil(5);
     let mut result = Vec::with_capacity(size);
     let mut carry = 0;
@@ -249,7 +250,9 @@ fn c32_decode_ascii(input_str: &str) -> Result<Vec<u8>, Error> {
         return Err(Error::InvalidCrockford32);
     }
 
-    // ASCII size is 62.5%  that of c32-encoded
+    // c32-encoding encodes 5 bits into each character, while ASCII encodes
+    // 8-bits into each character. So, the ASCII-encoded size should be
+    // ceil((c32 size) * 5 / 8)
     let size = iter_c32_digits.len().saturating_mul(5).div_ceil(8);
     let mut result = Vec::with_capacity(size);
     let mut carry: u16 = 0;

--- a/stacks-common/src/deps_common/bech32/mod.rs
+++ b/stacks-common/src/deps_common/bech32/mod.rs
@@ -599,7 +599,8 @@ fn verify_checksum(hrp: &[u8], data: &[u5]) -> Option<Variant> {
 }
 
 fn hrp_expand(hrp: &[u8]) -> Vec<u5> {
-    let mut v: Vec<u5> = Vec::new();
+    let size = (hrp.len() * 2) + 1;
+    let mut v: Vec<u5> = Vec::with_capacity(size);
     for b in hrp {
         v.push(u5::try_from_u8(*b >> 5).expect("can't be out of range, max. 7"));
     }

--- a/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
@@ -203,7 +203,7 @@ fn build_scriptint(n: i64) -> Vec<u8> {
     let neg = n < 0;
 
     let mut abs = n.abs() as usize;
-    let mut v = Vec::with_capacity(size_of::<usize>() / 8);
+    let mut v = Vec::with_capacity(size_of::<usize>() + 2);
     while abs > 0xFF {
         v.push((abs & 0xFF) as u8);
         abs >>= 8;

--- a/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
@@ -25,6 +25,7 @@
 //!
 
 use std::default::Default;
+use std::mem::size_of;
 use std::{error, fmt};
 
 use serde;
@@ -201,8 +202,8 @@ fn build_scriptint(n: i64) -> Vec<u8> {
 
     let neg = n < 0;
 
-    let mut abs = if neg { -n } else { n } as usize;
-    let mut v = vec![];
+    let mut abs = n.abs() as usize;
+    let mut v = Vec::with_capacity(size_of::<usize>() / 8);
     while abs > 0xFF {
         v.push((abs & 0xFF) as u8);
         abs >>= 8;

--- a/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
@@ -203,7 +203,7 @@ fn build_scriptint(n: i64) -> Vec<u8> {
     let neg = n < 0;
 
     let mut abs = n.abs() as usize;
-    let mut v = Vec::with_capacity(size_of::<usize>() + 2);
+    let mut v = Vec::with_capacity(size_of::<usize>() + 1);
     while abs > 0xFF {
         v.push((abs & 0xFF) as u8);
         abs >>= 8;

--- a/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
@@ -291,16 +291,12 @@ impl Transaction {
         } else {
             // sha256d of the concatenation of the previous outpoints, which are each the concatenation
             // of the previous txid and output index
-            let raw_vec = self
-                .input
-                .iter()
-                .flat_map(|inp| {
-                    serialize(&inp.previous_output)
-                        .expect("FATAL: failed to encode previous output")
-                        .into_iter()
-                })
-                .collect::<Vec<_>>();
-
+            let mut raw_vec = vec![];
+            for inp in self.input.iter() {
+                let mut prev_output_bytes = serialize(&inp.previous_output)
+                    .expect("FATAL: failed to encode previous output");
+                raw_vec.append(&mut prev_output_bytes);
+            }
             Sha256dHash::from_data(&raw_vec)
         }
     }
@@ -315,11 +311,10 @@ impl Transaction {
             Sha256dHash([0u8; 32])
         } else {
             // sha256d of the concatenation of the nSequences
-            let raw_vec = self
-                .input
-                .iter()
-                .flat_map(|inp| inp.sequence.to_le_bytes())
-                .collect::<Vec<_>>();
+            let mut raw_vec = vec![];
+            for inp in self.input.iter() {
+                raw_vec.extend_from_slice(&inp.sequence.to_le_bytes());
+            }
             Sha256dHash::from_data(&raw_vec)
         }
     }

--- a/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
@@ -291,12 +291,16 @@ impl Transaction {
         } else {
             // sha256d of the concatenation of the previous outpoints, which are each the concatenation
             // of the previous txid and output index
-            let mut raw_vec = vec![];
-            for inp in self.input.iter() {
-                let mut prev_output_bytes = serialize(&inp.previous_output)
-                    .expect("FATAL: failed to encode previous output");
-                raw_vec.append(&mut prev_output_bytes);
-            }
+            let raw_vec = self
+                .input
+                .iter()
+                .flat_map(|inp| {
+                    serialize(&inp.previous_output)
+                        .expect("FATAL: failed to encode previous output")
+                        .into_iter()
+                })
+                .collect::<Vec<_>>();
+
             Sha256dHash::from_data(&raw_vec)
         }
     }

--- a/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
@@ -315,10 +315,11 @@ impl Transaction {
             Sha256dHash([0u8; 32])
         } else {
             // sha256d of the concatenation of the nSequences
-            let mut raw_vec = vec![];
-            for inp in self.input.iter() {
-                raw_vec.append(&mut inp.sequence.to_le_bytes().to_vec());
-            }
+            let raw_vec = self
+                .input
+                .iter()
+                .flat_map(|inp| inp.sequence.to_le_bytes())
+                .collect::<Vec<_>>();
             Sha256dHash::from_data(&raw_vec)
         }
     }
@@ -327,26 +328,27 @@ impl Transaction {
     /// does not work for codeseparator
     fn segwit_script_pubkey_bytes(&self, script: &Script) -> Vec<u8> {
         // bizarrely, if this is a p2wpkh, we have to convert it into a p2pkh
-        let script_bytes = script.clone().into_bytes();
+        let script_bytes = script.as_bytes();
         if script_bytes.len() == 22 && script_bytes[0..2] == [0x00, 0x14] {
             // p2wpkh --> length-prefixed p2pkh
-            let mut converted_script_bytes = vec![];
-            converted_script_bytes.append(&mut vec![0x19, 0x76, 0xa9, 0x14]);
-            converted_script_bytes.append(&mut script_bytes[2..22].to_vec());
-            converted_script_bytes.append(&mut vec![0x88, 0xac]);
+            let mut converted_script_bytes = Vec::with_capacity(26);
+            converted_script_bytes.extend_from_slice(&[0x19, 0x76, 0xa9, 0x14]);
+            converted_script_bytes.extend_from_slice(&script_bytes[2..22]);
+            converted_script_bytes.extend_from_slice(&[0x88, 0xac]);
             converted_script_bytes
         } else {
             // p2wsh or p2tr
             // codeseparator is not supported
             // prefix the script bytes with a varint length
-            let mut length_script = vec![];
-            let mut script_bytes = script.clone().into_bytes();
-            let script_len = VarInt(script_bytes.len() as u64);
+            let script_bytes_len = script_bytes.len();
+            let script_len = VarInt(script_bytes_len as u64);
+            let mut length_script =
+                Vec::with_capacity(script_len.encoded_length() as usize + script_bytes_len);
 
             let mut script_len_bytes =
                 serialize(&script_len).expect("FATAL: failed to encode varint");
             length_script.append(&mut script_len_bytes);
-            length_script.append(&mut script_bytes);
+            length_script.extend_from_slice(&script_bytes);
             length_script
         }
     }
@@ -357,28 +359,31 @@ impl Transaction {
             // hash of all output amounts and scriptpubkeys
             let mut raw_vec = vec![];
             for outp in self.output.iter() {
-                raw_vec.append(&mut outp.value.to_le_bytes().to_vec());
+                raw_vec.extend_from_slice(&outp.value.to_le_bytes());
 
-                let mut script_bytes = outp.script_pubkey.clone().into_bytes();
+                let script_bytes = outp.script_pubkey.as_bytes();
                 let script_len = VarInt(script_bytes.len() as u64);
 
                 let mut script_len_bytes =
                     serialize(&script_len).expect("FATAL: failed to encode varint");
                 raw_vec.append(&mut script_len_bytes);
-                raw_vec.append(&mut script_bytes);
+                raw_vec.extend_from_slice(&script_bytes);
             }
             Sha256dHash::from_data(&raw_vec)
         } else if sighash_type == SigHashType::Single && input_index < self.output.len() {
             // hash of just the output indexed by the input index
-            let mut raw_vec = vec![];
 
-            let mut script_bytes = self.output[input_index].script_pubkey.clone().into_bytes();
-            let script_len = VarInt(script_bytes.len() as u64);
+            let script_bytes = self.output[input_index].script_pubkey.as_bytes();
+            let script_bytes_len = script_bytes.len();
+            let script_len = VarInt(script_bytes_len as u64);
+
+            let mut raw_vec =
+                Vec::with_capacity(script_len.encoded_length() as usize + script_bytes_len);
 
             let mut script_len_bytes =
                 serialize(&script_len).expect("FATAL: failed to encode varint");
             raw_vec.append(&mut script_len_bytes);
-            raw_vec.append(&mut script_bytes);
+            raw_vec.extend_from_slice(script_bytes);
             Sha256dHash::from_data(&raw_vec)
         } else {
             Sha256dHash([0u8; 32])
@@ -410,15 +415,15 @@ impl Transaction {
             SigHashType::from_u32(sighash_u32).split_anyonecanpay_flag();
 
         // nVersion
-        raw_vec.append(&mut self.version.to_le_bytes().to_vec());
+        raw_vec.extend_from_slice(&self.version.to_le_bytes());
 
         // hashPrevouts
         let prevouts_hash = self.segwit_prevouts_hash(anyone_can_pay);
-        raw_vec.append(&mut prevouts_hash.as_bytes().to_vec());
+        raw_vec.extend_from_slice(prevouts_hash.as_bytes());
 
         // hashSequence
         let hash_sequence = self.segwit_sequence_hash(sighash, anyone_can_pay);
-        raw_vec.append(&mut hash_sequence.as_bytes().to_vec());
+        raw_vec.extend_from_slice(hash_sequence.as_bytes());
 
         // outpoint in question
         let mut outpoint_to_sign = serialize(&self.input[input_index].previous_output)
@@ -430,20 +435,20 @@ impl Transaction {
         raw_vec.append(&mut script_code);
 
         // value sent
-        raw_vec.append(&mut amount.to_le_bytes().to_vec());
+        raw_vec.extend_from_slice(&amount.to_le_bytes());
 
         // input sequence
-        raw_vec.append(&mut self.input[input_index].sequence.to_le_bytes().to_vec());
+        raw_vec.extend_from_slice(&self.input[input_index].sequence.to_le_bytes());
 
         // hashed outputs
         let outputs_hash = self.segwit_outputs_hash(input_index, sighash);
-        raw_vec.append(&mut outputs_hash.as_bytes().to_vec());
+        raw_vec.extend_from_slice(outputs_hash.as_bytes());
 
         // locktime
-        raw_vec.append(&mut self.lock_time.to_le_bytes().to_vec());
+        raw_vec.extend_from_slice(&self.lock_time.to_le_bytes());
 
         // sighash
-        raw_vec.append(&mut sighash_u32.to_le_bytes().to_vec());
+        raw_vec.extend_from_slice(&sighash_u32.to_le_bytes());
 
         Sha256dHash::from_data(&raw_vec)
     }

--- a/stacks-common/src/deps_common/bitcoin/util/hash.rs
+++ b/stacks-common/src/deps_common/bitcoin/util/hash.rs
@@ -419,8 +419,9 @@ pub fn bitcoin_merkle_root(data: Vec<Sha256dHash>) -> Sha256dHash {
         return data[0];
     }
     // Recursion
-    let mut next = vec![];
-    for idx in 0..((data.len() + 1) / 2) {
+    let iterations = (data.len() + 1) / 2;
+    let mut next = Vec::with_capacity(iterations);
+    for idx in 0..iterations {
         let idx1 = 2 * idx;
         let idx2 = min(idx1 + 1, data.len() - 1);
         let mut encoder = RawEncoder::new(Cursor::new(vec![]));

--- a/stacks-common/src/types/chainstate.rs
+++ b/stacks-common/src/types/chainstate.rs
@@ -361,9 +361,7 @@ impl BlockHeaderHash {
 
     pub fn from_serialized_header(buf: &[u8]) -> BlockHeaderHash {
         let h = Sha512Trunc256Sum::from_data(buf);
-        let mut b = [0u8; 32];
-        b.copy_from_slice(h.as_bytes());
-        BlockHeaderHash(b)
+        BlockHeaderHash(h.to_bytes())
     }
 }
 
@@ -377,8 +375,7 @@ impl BurnchainHeaderHash {
     }
 
     pub fn to_bitcoin_hash(&self) -> Sha256dHash {
-        let mut bytes = self.0.to_vec();
-        bytes.reverse();
+        let bytes = self.0.iter().rev().copied().collect::<Vec<_>>();
         let mut buf = [0u8; 32];
         buf.copy_from_slice(&bytes[0..32]);
         Sha256dHash(buf)
@@ -399,10 +396,7 @@ impl BurnchainHeaderHash {
         bytes.extend_from_slice(index_root.as_bytes());
         bytes.extend_from_slice(&noise.to_be_bytes());
         let h = DoubleSha256::from_data(&bytes[..]);
-        let mut hb = [0u8; 32];
-        hb.copy_from_slice(h.as_bytes());
-
-        BurnchainHeaderHash(hb)
+        BurnchainHeaderHash(h.to_bytes())
     }
 }
 

--- a/stacks-common/src/types/chainstate.rs
+++ b/stacks-common/src/types/chainstate.rs
@@ -190,14 +190,12 @@ impl PoxId {
 impl FromStr for PoxId {
     type Err = &'static str;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut result = vec![];
-        for i in s.chars() {
-            if i == '1' {
-                result.push(true);
-            } else if i == '0' {
-                result.push(false);
-            } else {
-                return Err("Unexpected character in PoX ID serialization");
+        let mut result = Vec::with_capacity(s.len());
+        for c in s.chars() {
+            match c {
+                '0' => result.push(false),
+                '1' => result.push(true),
+                _ => return Err("Unexpected character in PoX ID serialization"),
             }
         }
         Ok(PoxId::new(result))

--- a/stacks-common/src/util/hash.rs
+++ b/stacks-common/src/util/hash.rs
@@ -451,12 +451,10 @@ where
 
     /// Get a non-leaf hash
     pub fn get_node_hash(left: &H, right: &H) -> H {
-        let left_bits = left.bits();
-        let right_bits = right.bits();
-        let mut buf = Vec::with_capacity(left_bits.len() + right_bits.len());
-        buf.extend_from_slice(left_bits);
-        buf.extend_from_slice(right_bits);
-        H::from_tagged_data(MERKLE_PATH_NODE_TAG, &buf[..])
+        let iter = left.bits().iter();
+        let iter = iter.chain(right.bits().iter());
+        let buf = iter.copied().collect::<Vec<_>>();
+        H::from_tagged_data(MERKLE_PATH_NODE_TAG, &buf)
     }
 
     /// Find a given hash in a merkle tree row

--- a/stacks-common/src/util/hash.rs
+++ b/stacks-common/src/util/hash.rs
@@ -451,9 +451,11 @@ where
 
     /// Get a non-leaf hash
     pub fn get_node_hash(left: &H, right: &H) -> H {
-        let mut buf = vec![];
-        buf.extend_from_slice(left.bits());
-        buf.extend_from_slice(right.bits());
+        let left_bits = left.bits();
+        let right_bits = right.bits();
+        let mut buf = Vec::with_capacity(left_bits.len() + right_bits.len());
+        buf.extend_from_slice(left_bits);
+        buf.extend_from_slice(right_bits);
         H::from_tagged_data(MERKLE_PATH_NODE_TAG, &buf[..])
     }
 


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Similar to #4408, but for `./stacks-common`. This PR also removes unnecessary intermediate `Vec`s used by `Vec::append()` by using `Vec::extend_from_slice()` instead

This gives a significant improvement of around **5%**

```console
❯ hyperfine -w 3 -r 10 "stacks-core/target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000" "stacks-core/target/release/stacks-inspect.vec-allocation-stacks-common replay-block /home/jbencin/data/next/ range 99990 100000"
Benchmark 1: stacks-core/target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000
  Time (mean ± σ):      9.044 s ±  0.020 s    [User: 8.556 s, System: 0.442 s]
  Range (min … max):    9.022 s …  9.074 s    10 runs
 
Benchmark 2: stacks-core/target/release/stacks-inspect.vec-allocation-stacks-common replay-block /home/jbencin/data/next/ range 99990 100000
  Time (mean ± σ):      8.649 s ±  0.040 s    [User: 8.157 s, System: 0.441 s]
  Range (min … max):    8.597 s …  8.724 s    10 runs
 
Summary
  stacks-core/target/release/stacks-inspect.vec-allocation-stacks-common replay-block /home/jbencin/data/next/ range 99990 100000 ran
    1.05 ± 0.01 times faster than stacks-core/target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000
```

### Applicable issues

- #4316

### Additional info (benefits, drawbacks, caveats)

Same as #4408

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
