### PR TITLE
Additional 'set-signer-key-authorization' Checks

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -32,6 +32,7 @@
 (define-constant ERR_DELEGATION_ALREADY_REVOKED 34)
 (define-constant ERR_INVALID_SIGNATURE_PUBKEY 35)
 (define-constant ERR_INVALID_SIGNATURE_RECOVER 36)
+(define-constant ERR_INVALID_REWARD_CYCLE 37)
 
 ;; Valid values for burnchain address versions.
 ;; These first four correspond to address hash modes in Stacks 2.1,
@@ -1368,6 +1369,10 @@
     (asserts! (is-eq
       (unwrap! (principal-construct? (if is-in-mainnet STACKS_ADDR_VERSION_MAINNET STACKS_ADDR_VERSION_TESTNET) (hash160 signer-key)) (err ERR_INVALID_SIGNER_KEY))
       tx-sender) (err ERR_NOT_ALLOWED))
+    ;; Must be called with positive period
+    (asserts! (>= period u1) (err ERR_STACKING_INVALID_LOCK_PERIOD))
+    ;; Must be current or future reward cycle
+    (asserts! (>= reward-cycle (current-pox-reward-cycle)) (err ERR_INVALID_REWARD_CYCLE))
     (map-set signer-key-authorizations { pox-addr: pox-addr, period: period, reward-cycle: reward-cycle, topic: topic, signer-key: signer-key } allowed)
     (ok allowed)))
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -2646,6 +2646,8 @@ fn test_set_signer_key_auth() {
     let signer_addr = key_to_stacks_addr(&signer_key);
     let pox_addr = pox_addr_from(&signer_key);
 
+    let current_reward_cycle = get_current_reward_cycle(&peer, &burnchain);
+
     // Only the address associated with `signer-key` can enable auth for that key
     let invalid_enable_nonce = alice_nonce;
     let invalid_enable_tx = make_pox_4_set_signer_key_auth(
@@ -2659,29 +2661,39 @@ fn test_set_signer_key_auth() {
         Some(&alice_key),
     );
 
-    let current_cycle = get_current_reward_cycle(&peer, &burnchain);
-    println!("Current cycle: {}", current_cycle);
-
     // Test that period is at least u1
-    let invalid_auth_tx_period: StacksTransaction = make_pox_4_set_signer_key_auth(
+    let signer_invalid_period_nonce = signer_nonce;
+    signer_nonce += 1;
+    let invalid_tx_period: StacksTransaction = make_pox_4_set_signer_key_auth(
         &pox_addr,
         &signer_key,
-        22,
+        current_reward_cycle,
         &Pox4SignatureTopic::StackStx,
         0,
         false,
-        signer_nonce,
+        signer_invalid_period_nonce,
         Some(&signer_key),
     );
 
+    let signer_invalid_cycle_nonce = signer_nonce;
+    signer_nonce += 1;
     // Test that confirmed reward cycle is at least current reward cycle
+    let invalid_tx_cycle: StacksTransaction = make_pox_4_set_signer_key_auth(
+        &pox_addr, 
+        &signer_key, 
+        1, 
+        &Pox4SignatureTopic::StackStx,
+        1,
+        false,
+        signer_invalid_cycle_nonce,
+        Some(&signer_key),
+    );
 
     // Disable auth for `signer-key`
-    signer_nonce += 1;
     let disable_auth_tx: StacksTransaction = make_pox_4_set_signer_key_auth(
         &pox_addr,
         &signer_key,
-        22,
+        current_reward_cycle,
         &Pox4SignatureTopic::StackStx,
         lock_period,
         false,
@@ -2690,7 +2702,7 @@ fn test_set_signer_key_auth() {
     );
 
     let latest_block =
-        peer.tenure_with_txs(&[invalid_enable_tx, invalid_auth_tx_period, disable_auth_tx], &mut coinbase_nonce);
+        peer.tenure_with_txs(&[invalid_enable_tx, invalid_tx_period, invalid_tx_cycle, disable_auth_tx], &mut coinbase_nonce);
 
     let alice_txs = get_last_block_sender_transactions(&observer, alice_addr);
     let invalid_enable_tx_result = alice_txs
@@ -2703,16 +2715,29 @@ fn test_set_signer_key_auth() {
 
     let signer_txs = get_last_block_sender_transactions(&observer, signer_addr);
 
-    // // Print all signer transaction receipts
-    println!("signer_txs: {:?}", signer_txs);
-    for tx in signer_txs {
-        println!("txs in signer_tx? {:?}", tx.result);
-    }
+    let invalid_tx_period_result = signer_txs.clone()
+        .get(signer_invalid_period_nonce as usize)
+        .unwrap()
+        .result
+        .clone();
+
+    // Check for invalid lock period err
+    assert_eq!(invalid_tx_period_result, Value::error(Value::Int(2)).unwrap());
+
+    let invalid_tx_cycle_result = signer_txs.clone()
+        .get(signer_invalid_cycle_nonce as usize)
+        .unwrap()
+        .result
+        .clone();
+
+    // Check for invalid cycle err
+    assert_eq!(invalid_tx_cycle_result, Value::error(Value::Int(37)).unwrap());
+
     let signer_key_enabled = get_signer_key_authorization_pox_4(
         &mut peer,
         &latest_block,
         &pox_addr,
-        22,
+        current_reward_cycle.clone() as u64,
         &Pox4SignatureTopic::StackStx,
         lock_period.try_into().unwrap(),
         &signer_public_key,
@@ -2726,7 +2751,7 @@ fn test_set_signer_key_auth() {
     let enable_auth_tx = make_pox_4_set_signer_key_auth(
         &pox_addr,
         &signer_key,
-        22,
+        current_reward_cycle,
         &Pox4SignatureTopic::StackStx,
         lock_period,
         true,
@@ -2740,7 +2765,7 @@ fn test_set_signer_key_auth() {
         &mut peer,
         &latest_block,
         &pox_addr,
-        22,
+        current_reward_cycle.clone() as u64,
         &Pox4SignatureTopic::StackStx,
         lock_period.try_into().unwrap(),
         &signer_public_key,
@@ -2754,7 +2779,7 @@ fn test_set_signer_key_auth() {
     let disable_auth_tx = make_pox_4_set_signer_key_auth(
         &pox_addr,
         &signer_key,
-        22,
+        current_reward_cycle,
         &Pox4SignatureTopic::StackStx,
         lock_period,
         false,
@@ -2768,7 +2793,7 @@ fn test_set_signer_key_auth() {
         &mut peer,
         &latest_block,
         &pox_addr,
-        22,
+        current_reward_cycle.clone() as u64,
         &Pox4SignatureTopic::StackStx,
         lock_period.try_into().unwrap(),
         &signer_public_key,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -2643,6 +2643,7 @@ fn test_set_signer_key_auth() {
     let mut signer_nonce = 0;
     let signer_key = &keys[1];
     let signer_public_key = StacksPublicKey::from_private(signer_key);
+    let signer_addr = key_to_stacks_addr(&signer_key);
     let pox_addr = pox_addr_from(&signer_key);
 
     // Only the address associated with `signer-key` can enable auth for that key
@@ -2658,21 +2659,38 @@ fn test_set_signer_key_auth() {
         Some(&alice_key),
     );
 
+    let current_cycle = get_current_reward_cycle(&peer, &burnchain);
+    println!("Current cycle: {}", current_cycle);
+
+    // Test that period is at least u1
+    let invalid_auth_tx_period: StacksTransaction = make_pox_4_set_signer_key_auth(
+        &pox_addr,
+        &signer_key,
+        22,
+        &Pox4SignatureTopic::StackStx,
+        0,
+        false,
+        signer_nonce,
+        Some(&signer_key),
+    );
+
+    // Test that confirmed reward cycle is at least current reward cycle
+
     // Disable auth for `signer-key`
-    let disable_auth_nonce = signer_nonce;
+    signer_nonce += 1;
     let disable_auth_tx: StacksTransaction = make_pox_4_set_signer_key_auth(
         &pox_addr,
         &signer_key,
-        1,
+        22,
         &Pox4SignatureTopic::StackStx,
         lock_period,
         false,
-        disable_auth_nonce,
+        signer_nonce,
         None,
     );
 
     let latest_block =
-        peer.tenure_with_txs(&[invalid_enable_tx, disable_auth_tx], &mut coinbase_nonce);
+        peer.tenure_with_txs(&[invalid_enable_tx, invalid_auth_tx_period, disable_auth_tx], &mut coinbase_nonce);
 
     let alice_txs = get_last_block_sender_transactions(&observer, alice_addr);
     let invalid_enable_tx_result = alice_txs
@@ -2683,11 +2701,18 @@ fn test_set_signer_key_auth() {
     let expected_error = Value::error(Value::Int(19)).unwrap();
     assert_eq!(invalid_enable_tx_result, expected_error);
 
+    let signer_txs = get_last_block_sender_transactions(&observer, signer_addr);
+
+    // // Print all signer transaction receipts
+    println!("signer_txs: {:?}", signer_txs);
+    for tx in signer_txs {
+        println!("txs in signer_tx? {:?}", tx.result);
+    }
     let signer_key_enabled = get_signer_key_authorization_pox_4(
         &mut peer,
         &latest_block,
         &pox_addr,
-        1,
+        22,
         &Pox4SignatureTopic::StackStx,
         lock_period.try_into().unwrap(),
         &signer_public_key,
@@ -2701,7 +2726,7 @@ fn test_set_signer_key_auth() {
     let enable_auth_tx = make_pox_4_set_signer_key_auth(
         &pox_addr,
         &signer_key,
-        1,
+        22,
         &Pox4SignatureTopic::StackStx,
         lock_period,
         true,
@@ -2715,7 +2740,7 @@ fn test_set_signer_key_auth() {
         &mut peer,
         &latest_block,
         &pox_addr,
-        1,
+        22,
         &Pox4SignatureTopic::StackStx,
         lock_period.try_into().unwrap(),
         &signer_public_key,
@@ -2729,7 +2754,7 @@ fn test_set_signer_key_auth() {
     let disable_auth_tx = make_pox_4_set_signer_key_auth(
         &pox_addr,
         &signer_key,
-        1,
+        22,
         &Pox4SignatureTopic::StackStx,
         lock_period,
         false,
@@ -2743,7 +2768,7 @@ fn test_set_signer_key_auth() {
         &mut peer,
         &latest_block,
         &pox_addr,
-        1,
+        22,
         &Pox4SignatureTopic::StackStx,
         lock_period.try_into().unwrap(),
         &signer_public_key,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -2679,9 +2679,9 @@ fn test_set_signer_key_auth() {
     signer_nonce += 1;
     // Test that confirmed reward cycle is at least current reward cycle
     let invalid_tx_cycle: StacksTransaction = make_pox_4_set_signer_key_auth(
-        &pox_addr, 
-        &signer_key, 
-        1, 
+        &pox_addr,
+        &signer_key,
+        1,
         &Pox4SignatureTopic::StackStx,
         1,
         false,
@@ -2701,8 +2701,15 @@ fn test_set_signer_key_auth() {
         None,
     );
 
-    let latest_block =
-        peer.tenure_with_txs(&[invalid_enable_tx, invalid_tx_period, invalid_tx_cycle, disable_auth_tx], &mut coinbase_nonce);
+    let latest_block = peer.tenure_with_txs(
+        &[
+            invalid_enable_tx,
+            invalid_tx_period,
+            invalid_tx_cycle,
+            disable_auth_tx,
+        ],
+        &mut coinbase_nonce,
+    );
 
     let alice_txs = get_last_block_sender_transactions(&observer, alice_addr);
     let invalid_enable_tx_result = alice_txs
@@ -2715,23 +2722,31 @@ fn test_set_signer_key_auth() {
 
     let signer_txs = get_last_block_sender_transactions(&observer, signer_addr);
 
-    let invalid_tx_period_result = signer_txs.clone()
+    let invalid_tx_period_result = signer_txs
+        .clone()
         .get(signer_invalid_period_nonce as usize)
         .unwrap()
         .result
         .clone();
 
     // Check for invalid lock period err
-    assert_eq!(invalid_tx_period_result, Value::error(Value::Int(2)).unwrap());
+    assert_eq!(
+        invalid_tx_period_result,
+        Value::error(Value::Int(2)).unwrap()
+    );
 
-    let invalid_tx_cycle_result = signer_txs.clone()
+    let invalid_tx_cycle_result = signer_txs
+        .clone()
         .get(signer_invalid_cycle_nonce as usize)
         .unwrap()
         .result
         .clone();
 
     // Check for invalid cycle err
-    assert_eq!(invalid_tx_cycle_result, Value::error(Value::Int(37)).unwrap());
+    assert_eq!(
+        invalid_tx_cycle_result,
+        Value::error(Value::Int(37)).unwrap()
+    );
 
     let signer_key_enabled = get_signer_key_authorization_pox_4(
         &mut peer,


### PR DESCRIPTION
### Description
While writing up the testing document for PoX-4/Boot contracts I believe I stumbled upon two checks that should be added to the 'set-signer-key-authorization' function recently added to PoX-4.clar.

The point of this authorization is for stackers to not have to provide the optional signature. However, the way it's currently written, it's possible for the signer to create malformed/invalid authorizations that would result in a seemingly-valid authorization but would later fail when stackers attempt to use it. 

Specifically, a 'period' of length 0 can be passed in; additionally, a previous reward-cycle can be submitted.

Still need input from @hstove before removing 'draft' status.

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`