### PR TITLE
Move signer transaction to global location and utilize in both miner and signer

### DIFF
--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -207,15 +207,6 @@ pub(crate) mod tests {
         TcpListener::bind(config.node_host).unwrap()
     }
 
-    /// Create a mock server on the same port as the config and write a response to it
-    pub fn mock_server_from_config_and_write_response(
-        config: &GlobalConfig,
-        bytes: &[u8],
-    ) -> [u8; 1024] {
-        let mock_server = mock_server_from_config(config);
-        write_response(mock_server, bytes)
-    }
-
     /// Write a response to the mock server and return the request bytes
     pub fn write_response(mock_server: TcpListener, bytes: &[u8]) -> [u8; 1024] {
         debug!("Writing a response...");

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -483,12 +483,12 @@ impl StacksClient {
                 "Failed to convert aggregate public key to compressed data: {e}"
             ))
         })?;
-        let point = Point::try_from(&compressed_data).map_err(|e| {
+        let dkg_public_key = Point::try_from(&compressed_data).map_err(|e| {
             ClientError::MalformedClarityValue(format!(
                 "Failed to convert aggregate public key to a point: {e}"
             ))
         })?;
-        Ok(Some(point))
+        Ok(Some(dkg_public_key))
     }
 
     /// Helper function to create a stacks transaction for a modifying contract call
@@ -496,7 +496,7 @@ impl StacksClient {
         &self,
         signer_index: u32,
         round: u64,
-        point: Point,
+        dkg_public_key: Point,
         reward_cycle: u64,
         tx_fee: Option<u64>,
         nonce: u64,
@@ -507,7 +507,7 @@ impl StacksClient {
         let function_name = ClarityName::from(SIGNERS_VOTING_FUNCTION_NAME);
         let function_args = vec![
             ClarityValue::UInt(signer_index as u128),
-            ClarityValue::buff_from(point.compress().data.to_vec())?,
+            ClarityValue::buff_from(dkg_public_key.compress().data.to_vec())?,
             ClarityValue::UInt(round as u128),
             ClarityValue::UInt(reward_cycle as u128),
         ];

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -17,7 +17,9 @@ use std::net::SocketAddr;
 
 use blockstack_lib::burnchains::Txid;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
-use blockstack_lib::chainstate::stacks::boot::{RewardSet, SIGNERS_NAME, SIGNERS_VOTING_NAME};
+use blockstack_lib::chainstate::stacks::boot::{
+    RewardSet, SIGNERS_NAME, SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME,
+};
 use blockstack_lib::chainstate::stacks::{
     StacksTransaction, StacksTransactionSigner, TransactionAnchorMode, TransactionAuth,
     TransactionContractCall, TransactionPayload, TransactionPostConditionMode,
@@ -46,9 +48,6 @@ use wsts::state_machine::PublicKeys;
 
 use crate::client::{retry_with_exponential_backoff, ClientError};
 use crate::config::{GlobalConfig, RegisteredSignersInfo};
-
-/// The name of the function for casting a DKG result to signer vote contract
-pub const VOTE_FUNCTION_NAME: &str = "vote-for-aggregate-public-key";
 
 /// The Stacks signer client used to communicate with the stacks node
 #[derive(Clone, Debug)]
@@ -502,10 +501,10 @@ impl StacksClient {
         tx_fee: Option<u64>,
         nonce: u64,
     ) -> Result<StacksTransaction, ClientError> {
-        debug!("Building {VOTE_FUNCTION_NAME} transaction...");
+        debug!("Building {SIGNERS_VOTING_FUNCTION_NAME} transaction...");
         let contract_address = boot_code_addr(self.mainnet);
         let contract_name = ContractName::from(SIGNERS_VOTING_NAME);
-        let function_name = ClarityName::from(VOTE_FUNCTION_NAME);
+        let function_name = ClarityName::from(SIGNERS_VOTING_FUNCTION_NAME);
         let function_args = vec![
             ClarityValue::UInt(signer_index as u128),
             ClarityValue::buff_from(point.compress().data.to_vec())?,

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -156,6 +156,12 @@ impl RunLoop {
                     if signer.reward_cycle == prior_reward_cycle {
                         // The signers have been calculated for the next reward cycle. Update the current one
                         debug!("Signer #{}: Next reward cycle ({reward_cycle}) signer set calculated. Updating current reward cycle ({prior_reward_cycle}) signer.", signer.signer_id);
+                        signer.next_signers = new_signer_config
+                            .registered_signers
+                            .signer_ids
+                            .keys()
+                            .copied()
+                            .collect();
                         signer.next_signer_ids = new_signer_config
                             .registered_signers
                             .signer_ids
@@ -201,7 +207,7 @@ impl RunLoop {
             if signer.approved_aggregate_public_key.is_none() {
                 retry_with_exponential_backoff(|| {
                     signer
-                        .update_dkg(&self.stacks_client, current_reward_cycle)
+                        .update_dkg(&self.stacks_client)
                         .map_err(backoff::Error::transient)
                 })?;
             }

--- a/stackslib/src/chainstate/nakamoto/signer_set.rs
+++ b/stackslib/src/chainstate/nakamoto/signer_set.rs
@@ -46,7 +46,7 @@ use stacks_common::util::hash::{to_hex, Hash160, MerkleHashFunc, MerkleTree, Sha
 use stacks_common::util::retry::BoundReader;
 use stacks_common::util::secp256k1::MessageSignature;
 use stacks_common::util::vrf::{VRFProof, VRFPublicKey, VRF};
-use wsts::curve::point::Point;
+use wsts::curve::point::{Compressed, Point};
 
 use crate::burnchains::{Burnchain, PoxConstants, Txid};
 use crate::chainstate::burn::db::sortdb::{
@@ -63,7 +63,7 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::boot::{
     PoxVersions, RawRewardSetEntry, RewardSet, BOOT_TEST_POX_4_AGG_KEY_CONTRACT,
     BOOT_TEST_POX_4_AGG_KEY_FNAME, POX_4_NAME, SIGNERS_MAX_LIST_SIZE, SIGNERS_NAME, SIGNERS_PK_LEN,
-    SIGNERS_UPDATE_STATE,
+    SIGNERS_UPDATE_STATE, SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME,
 };
 use crate::chainstate::stacks::db::{
     ChainstateTx, ClarityTx, DBConfig as ChainstateConfig, MinerPaymentSchedule,
@@ -486,5 +486,85 @@ impl NakamotoSigners {
             return Err(ChainstateError::NoRegisteredSigners(reward_cycle));
         }
         Ok(signers)
+    }
+
+    /// Verify that the transaction is a valid vote for the aggregate public key
+    /// Note: it does not verify the function arguments, only that the transaction is validly formed
+    /// and has a valid nonce from an expected address
+    pub fn valid_vote_transaction(
+        account_nonces: &HashMap<StacksAddress, u64>,
+        transaction: &StacksTransaction,
+        is_mainnet: bool,
+    ) -> bool {
+        let origin_address = transaction.origin_address();
+        let origin_nonce = transaction.get_origin_nonce();
+        let Some(account_nonce) = account_nonces.get(&origin_address) else {
+            debug!("valid_vote_transaction: Unrecognized origin address ({origin_address}).",);
+            return false;
+        };
+        if transaction.is_mainnet() != is_mainnet {
+            debug!("valid_vote_transaction: Received a transaction for an unexpected network.",);
+            return false;
+        }
+        if origin_nonce < *account_nonce {
+            debug!("valid_vote_transaction: Received a transaction with an outdated nonce ({account_nonce} < {origin_nonce}).");
+            return false;
+        }
+        Self::parse_vote_for_aggregate_public_key(transaction).is_some()
+    }
+
+    pub fn parse_vote_for_aggregate_public_key(
+        transaction: &StacksTransaction,
+    ) -> Option<(u64, Point, u64, u64)> {
+        let TransactionPayload::ContractCall(payload) = &transaction.payload else {
+            // Not a contract call so not a special cased vote for aggregate public key transaction
+            return None;
+        };
+        if payload.contract_identifier()
+            != boot_code_id(SIGNERS_VOTING_NAME, transaction.is_mainnet())
+            || payload.function_name != SIGNERS_VOTING_FUNCTION_NAME.into()
+        {
+            // This is not a special cased transaction.
+            return None;
+        }
+        if payload.function_args.len() != 4 {
+            return None;
+        }
+        let signer_index_value = payload.function_args.first()?;
+        let signer_index = u64::try_from(signer_index_value.clone().expect_u128().ok()?).ok()?;
+        let point_value = payload.function_args.get(1)?;
+        let point_bytes = point_value.clone().expect_buff(33).ok()?;
+        let compressed_data = Compressed::try_from(point_bytes.as_slice()).ok()?;
+        let point = Point::try_from(&compressed_data).ok()?;
+        let round_value = payload.function_args.get(2)?;
+        let round = u64::try_from(round_value.clone().expect_u128().ok()?).ok()?;
+        let reward_cycle =
+            u64::try_from(payload.function_args.get(3)?.clone().expect_u128().ok()?).ok()?;
+        Some((signer_index, point, round, reward_cycle))
+    }
+
+    /// Update the map of filtered valid transactions, selecting one per address based first on lowest nonce, then txid
+    pub fn update_filtered_transactions(
+        filtered_transactions: &mut HashMap<StacksAddress, StacksTransaction>,
+        account_nonces: &HashMap<StacksAddress, u64>,
+        mainnet: bool,
+        transactions: Vec<StacksTransaction>,
+    ) {
+        for transaction in transactions {
+            if NakamotoSigners::valid_vote_transaction(&account_nonces, &transaction, mainnet) {
+                let origin_address = transaction.origin_address();
+                let origin_nonce = transaction.get_origin_nonce();
+                if let Some(entry) = filtered_transactions.get_mut(&origin_address) {
+                    let entry_nonce = entry.get_origin_nonce();
+                    if entry_nonce > origin_nonce
+                        || (entry_nonce == origin_nonce && entry.txid() > transaction.txid())
+                    {
+                        *entry = transaction;
+                    }
+                } else {
+                    filtered_transactions.insert(origin_address, transaction);
+                }
+            }
+        }
     }
 }

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -15,17 +15,22 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::borrow::BorrowMut;
+use std::collections::HashMap;
 use std::fs;
 
 use clarity::types::chainstate::{PoxId, SortitionId, StacksBlockId};
 use clarity::vm::clarity::ClarityConnection;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::types::StacksAddressExtensions;
+use clarity::vm::Value;
+use rand::{thread_rng, RngCore};
 use rusqlite::Connection;
 use stacks_common::address::AddressHashMode;
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
-use stacks_common::consts::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH};
+use stacks_common::consts::{
+    CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH,
+};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, StacksAddress, StacksPrivateKey,
     StacksPublicKey, StacksWorkScore, TrieHash, VRFSeed,
@@ -37,6 +42,8 @@ use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PublicKey};
 use stacks_common::util::vrf::{VRFPrivateKey, VRFProof, VRFPublicKey, VRF};
 use stdext::prelude::Integer;
 use stx_genesis::GenesisData;
+use wsts::curve::point::Point;
+use wsts::curve::scalar::Scalar;
 
 use crate::burnchains::{BurnchainSigner, PoxConstants, Txid};
 use crate::chainstate::burn::db::sortdb::tests::make_fork_run;
@@ -52,13 +59,16 @@ use crate::chainstate::coordinator::tests::{
 };
 use crate::chainstate::nakamoto::coordinator::tests::boot_nakamoto;
 use crate::chainstate::nakamoto::miner::NakamotoBlockBuilder;
+use crate::chainstate::nakamoto::signer_set::NakamotoSigners;
 use crate::chainstate::nakamoto::tenure::NakamotoTenure;
 use crate::chainstate::nakamoto::test_signers::TestSigners;
 use crate::chainstate::nakamoto::tests::node::TestStacker;
 use crate::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, SortitionHandle, FIRST_STACKS_BLOCK_ID,
 };
-use crate::chainstate::stacks::boot::MINERS_NAME;
+use crate::chainstate::stacks::boot::{
+    MINERS_NAME, SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME,
+};
 use crate::chainstate::stacks::db::{
     ChainStateBootData, ChainstateAccountBalance, ChainstateAccountLockup, ChainstateBNSName,
     ChainstateBNSNamespace, StacksAccount, StacksBlockHeaderTypes, StacksChainState,
@@ -67,13 +77,15 @@ use crate::chainstate::stacks::db::{
 use crate::chainstate::stacks::{
     CoinbasePayload, StacksBlock, StacksBlockHeader, StacksTransaction, StacksTransactionSigner,
     TenureChangeCause, TenureChangePayload, ThresholdSignature, TokenTransferMemo,
-    TransactionAnchorMode, TransactionAuth, TransactionPayload, TransactionVersion,
+    TransactionAnchorMode, TransactionAuth, TransactionContractCall, TransactionPayload,
+    TransactionPostConditionMode, TransactionSmartContract, TransactionVersion,
 };
 use crate::core;
 use crate::core::{StacksEpochExtension, STACKS_EPOCH_3_0_MARKER};
 use crate::net::codec::test::check_codec_and_corruption;
 use crate::util_lib::boot::boot_code_id;
 use crate::util_lib::db::Error as db_error;
+use crate::util_lib::strings::StacksString;
 
 /// Get an address's account
 pub fn get_account(
@@ -2067,4 +2079,745 @@ fn test_make_miners_stackerdb_config() {
 
     assert_eq!(miner_hashbytes[8].1, miner_hash160s[8]);
     assert_eq!(miner_hashbytes[9].1, miner_hash160s[8]);
+}
+
+#[test]
+fn parse_vote_for_aggregate_public_key_valid() {
+    let signer_private_key = StacksPrivateKey::new();
+    let mainnet = false;
+    let chainid = CHAIN_ID_TESTNET;
+    let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
+    let contract_addr = vote_contract_id.issuer.into();
+    let contract_name = vote_contract_id.name.clone();
+
+    let signer_index = thread_rng().next_u64();
+    let signer_index_arg = Value::UInt(signer_index as u128);
+
+    let point = Point::from(Scalar::random(&mut thread_rng()));
+    let point_arg =
+        Value::buff_from(point.compress().data.to_vec()).expect("Failed to create buff");
+    let round = thread_rng().next_u64();
+    let round_arg = Value::UInt(round as u128);
+
+    let reward_cycle = thread_rng().next_u64();
+    let reward_cycle_arg = Value::UInt(reward_cycle as u128);
+
+    let valid_function_args = vec![
+        signer_index_arg.clone(),
+        point_arg.clone(),
+        round_arg.clone(),
+        reward_cycle_arg.clone(),
+    ];
+    let valid_tx = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr,
+            contract_name,
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args,
+        }),
+    };
+    let (res_signer_index, res_point, res_round, res_reward_cycle) =
+        NakamotoSigners::parse_vote_for_aggregate_public_key(&valid_tx).unwrap();
+    assert_eq!(res_signer_index, signer_index);
+    assert_eq!(res_point, point);
+    assert_eq!(res_round, round);
+    assert_eq!(res_reward_cycle, reward_cycle);
+}
+
+#[test]
+fn parse_vote_for_aggregate_public_key_invalid() {
+    let signer_private_key = StacksPrivateKey::new();
+    let mainnet = false;
+    let chainid = CHAIN_ID_TESTNET;
+    let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
+    let contract_addr: StacksAddress = vote_contract_id.issuer.into();
+    let contract_name = vote_contract_id.name.clone();
+
+    let signer_index = thread_rng().next_u32();
+    let signer_index_arg = Value::UInt(signer_index as u128);
+
+    let point = Point::from(Scalar::random(&mut thread_rng()));
+    let point_arg =
+        Value::buff_from(point.compress().data.to_vec()).expect("Failed to create buff");
+    let round = thread_rng().next_u64();
+    let round_arg = Value::UInt(round as u128);
+
+    let reward_cycle = thread_rng().next_u64();
+    let reward_cycle_arg = Value::UInt(reward_cycle as u128);
+
+    let valid_function_args = vec![
+        signer_index_arg.clone(),
+        point_arg.clone(),
+        round_arg.clone(),
+        reward_cycle_arg.clone(),
+    ];
+
+    let mut invalid_contract_address = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: StacksAddress::p2pkh(
+                false,
+                &StacksPublicKey::from_private(&signer_private_key),
+            ),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_contract_address.set_origin_nonce(1);
+
+    let mut invalid_contract_name = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: "bad-signers-contract-name".into(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_contract_name.set_origin_nonce(1);
+
+    let mut invalid_signers_vote_function = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: "some-other-function".into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_signers_vote_function.set_origin_nonce(1);
+
+    let mut invalid_function_arg_signer_index = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                point_arg.clone(),
+                point_arg.clone(),
+                round_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_signer_index.set_origin_nonce(1);
+
+    let mut invalid_function_arg_key = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                signer_index_arg.clone(),
+                signer_index_arg.clone(),
+                round_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_key.set_origin_nonce(1);
+
+    let mut invalid_function_arg_round = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                signer_index_arg.clone(),
+                point_arg.clone(),
+                point_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_round.set_origin_nonce(1);
+
+    let mut invalid_function_arg_reward_cycle = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                signer_index_arg.clone(),
+                point_arg.clone(),
+                round_arg.clone(),
+                point_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_reward_cycle.set_origin_nonce(1);
+
+    let mut account_nonces = std::collections::HashMap::new();
+    account_nonces.insert(invalid_contract_name.origin_address(), 1);
+    for (i, tx) in vec![
+        invalid_contract_address,
+        invalid_contract_name,
+        invalid_signers_vote_function,
+        invalid_function_arg_signer_index,
+        invalid_function_arg_key,
+        invalid_function_arg_round,
+        invalid_function_arg_reward_cycle,
+    ]
+    .iter()
+    .enumerate()
+    {
+        assert!(
+            NakamotoSigners::parse_vote_for_aggregate_public_key(&tx).is_none(),
+            "{}",
+            format!("parsed the {i}th transaction: {tx:?}")
+        );
+    }
+}
+
+#[test]
+fn valid_vote_transaction() {
+    let signer_private_key = StacksPrivateKey::new();
+    let mainnet = false;
+    let chainid = CHAIN_ID_TESTNET;
+    let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
+    let contract_addr = vote_contract_id.issuer.into();
+    let contract_name = vote_contract_id.name.clone();
+
+    let signer_index = thread_rng().next_u32();
+    let signer_index_arg = Value::UInt(signer_index as u128);
+
+    let point = Point::from(Scalar::random(&mut thread_rng()));
+    let point_arg =
+        Value::buff_from(point.compress().data.to_vec()).expect("Failed to create buff");
+    let round = thread_rng().next_u64();
+    let round_arg = Value::UInt(round as u128);
+
+    let reward_cycle = thread_rng().next_u64();
+    let reward_cycle_arg = Value::UInt(reward_cycle as u128);
+
+    let valid_function_args = vec![
+        signer_index_arg.clone(),
+        point_arg.clone(),
+        round_arg.clone(),
+        reward_cycle_arg.clone(),
+    ];
+    let mut valid_tx = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr,
+            contract_name: contract_name,
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args,
+        }),
+    };
+    valid_tx.set_origin_nonce(1);
+    let mut account_nonces = std::collections::HashMap::new();
+    account_nonces.insert(valid_tx.origin_address(), 1);
+    assert!(NakamotoSigners::valid_vote_transaction(
+        &account_nonces,
+        &valid_tx,
+        mainnet
+    ));
+}
+
+#[test]
+fn valid_vote_transaction_malformed_transactions() {
+    let signer_private_key = StacksPrivateKey::new();
+    let mainnet = false;
+    let chainid = CHAIN_ID_TESTNET;
+    let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
+    let contract_addr: StacksAddress = vote_contract_id.issuer.into();
+    let contract_name = vote_contract_id.name.clone();
+
+    let signer_index = thread_rng().next_u32();
+    let signer_index_arg = Value::UInt(signer_index as u128);
+
+    let point = Point::from(Scalar::random(&mut thread_rng()));
+    let point_arg =
+        Value::buff_from(point.compress().data.to_vec()).expect("Failed to create buff");
+    let round = thread_rng().next_u64();
+    let round_arg = Value::UInt(round as u128);
+
+    let reward_cycle = thread_rng().next_u64();
+    let reward_cycle_arg = Value::UInt(reward_cycle as u128);
+
+    let valid_function_args = vec![
+        signer_index_arg.clone(),
+        point_arg.clone(),
+        round_arg.clone(),
+        reward_cycle_arg.clone(),
+    ];
+    // Create a invalid transaction that is not a contract call
+    let mut invalid_not_contract_call = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::SmartContract(
+            TransactionSmartContract {
+                name: "test-contract".into(),
+                code_body: StacksString::from_str("(/ 1 0)").unwrap(),
+            },
+            None,
+        ),
+    };
+    invalid_not_contract_call.set_origin_nonce(1);
+
+    let mut invalid_contract_address = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: StacksAddress::p2pkh(
+                mainnet,
+                &StacksPublicKey::from_private(&signer_private_key),
+            ),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_contract_address.set_origin_nonce(1);
+
+    let mut invalid_contract_name = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: "bad-signers-contract-name".into(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_contract_name.set_origin_nonce(1);
+
+    let mut invalid_network = StacksTransaction {
+        version: TransactionVersion::Mainnet,
+        chain_id: CHAIN_ID_MAINNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_network.set_origin_nonce(1);
+
+    let mut invalid_signers_vote_function = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: "some-other-function".into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_signers_vote_function.set_origin_nonce(1);
+
+    let mut invalid_function_arg_signer_index = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                point_arg.clone(),
+                point_arg.clone(),
+                round_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_signer_index.set_origin_nonce(1);
+
+    let mut invalid_function_arg_key = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                signer_index_arg.clone(),
+                signer_index_arg.clone(),
+                round_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_key.set_origin_nonce(1);
+
+    let mut invalid_function_arg_round = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                signer_index_arg.clone(),
+                point_arg.clone(),
+                point_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_round.set_origin_nonce(1);
+
+    let mut invalid_function_arg_reward_cycle = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: vec![
+                signer_index_arg.clone(),
+                point_arg.clone(),
+                round_arg.clone(),
+                point_arg.clone(),
+            ],
+        }),
+    };
+    invalid_function_arg_reward_cycle.set_origin_nonce(1);
+
+    let mut invalid_nonce = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: valid_function_args.clone(),
+        }),
+    };
+    invalid_nonce.set_origin_nonce(0); // old nonce
+
+    let mut account_nonces = std::collections::HashMap::new();
+    account_nonces.insert(invalid_not_contract_call.origin_address(), 1);
+    for tx in vec![
+        invalid_not_contract_call,
+        invalid_contract_address,
+        invalid_contract_name,
+        invalid_signers_vote_function,
+        invalid_function_arg_signer_index,
+        invalid_function_arg_key,
+        invalid_function_arg_round,
+        invalid_function_arg_reward_cycle,
+        invalid_nonce,
+        invalid_network,
+    ] {
+        assert!(!NakamotoSigners::valid_vote_transaction(
+            &account_nonces,
+            &tx,
+            mainnet
+        ));
+    }
+}
+
+#[test]
+fn filter_one_transaction_per_signer_multiple_addresses() {
+    let signer_private_key_1 = StacksPrivateKey::new();
+    let signer_private_key_2 = StacksPrivateKey::new();
+    let mainnet = false;
+    let chainid = CHAIN_ID_TESTNET;
+    let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
+    let contract_addr: StacksAddress = vote_contract_id.issuer.into();
+    let contract_name = vote_contract_id.name.clone();
+
+    let signer_index = thread_rng().next_u32();
+    let signer_index_arg = Value::UInt(signer_index as u128);
+
+    let point = Point::from(Scalar::random(&mut thread_rng()));
+    let point_arg =
+        Value::buff_from(point.compress().data.to_vec()).expect("Failed to create buff");
+    let round = thread_rng().next_u64();
+    let round_arg = Value::UInt(round as u128);
+
+    let reward_cycle = thread_rng().next_u64();
+    let reward_cycle_arg = Value::UInt(reward_cycle as u128);
+
+    let function_args = vec![
+        signer_index_arg.clone(),
+        point_arg.clone(),
+        round_arg.clone(),
+        reward_cycle_arg.clone(),
+    ];
+
+    let mut valid_tx_1_address_1 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key_1).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: function_args.clone(),
+        }),
+    };
+    valid_tx_1_address_1.set_origin_nonce(1);
+
+    let mut valid_tx_2_address_1 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key_1).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: function_args.clone(),
+        }),
+    };
+    valid_tx_2_address_1.set_origin_nonce(2);
+
+    let mut valid_tx_3_address_1 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key_1).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: function_args.clone(),
+        }),
+    };
+    valid_tx_3_address_1.set_origin_nonce(3);
+
+    let mut valid_tx_1_address_2 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key_2).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: function_args.clone(),
+        }),
+    };
+    valid_tx_1_address_2.set_origin_nonce(1);
+
+    let mut valid_tx_2_address_2 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key_2).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr,
+            contract_name,
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args,
+        }),
+    };
+    valid_tx_2_address_2.set_origin_nonce(2);
+    let mut filtered_transactions = HashMap::new();
+    let mut account_nonces = std::collections::HashMap::new();
+    account_nonces.insert(valid_tx_1_address_1.origin_address(), 1);
+    account_nonces.insert(valid_tx_1_address_2.origin_address(), 1);
+    NakamotoSigners::update_filtered_transactions(
+        &mut filtered_transactions,
+        &account_nonces,
+        false,
+        vec![
+            valid_tx_1_address_1.clone(),
+            valid_tx_3_address_1,
+            valid_tx_1_address_2.clone(),
+            valid_tx_2_address_2,
+            valid_tx_2_address_1,
+        ],
+    );
+    let txs: Vec<_> = filtered_transactions.into_values().collect();
+    assert_eq!(txs.len(), 2);
+    assert!(txs.contains(&valid_tx_1_address_1));
+    assert!(txs.contains(&valid_tx_1_address_2));
+}
+
+#[test]
+fn filter_one_transaction_per_signer_duplicate_nonces() {
+    let signer_private_key = StacksPrivateKey::new();
+    let mainnet = false;
+    let chainid = CHAIN_ID_TESTNET;
+    let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
+    let contract_addr: StacksAddress = vote_contract_id.issuer.into();
+    let contract_name = vote_contract_id.name.clone();
+
+    let signer_index = thread_rng().next_u32();
+    let signer_index_arg = Value::UInt(signer_index as u128);
+
+    let point = Point::from(Scalar::random(&mut thread_rng()));
+    let point_arg =
+        Value::buff_from(point.compress().data.to_vec()).expect("Failed to create buff");
+    let round = thread_rng().next_u64();
+    let round_arg = Value::UInt(round as u128);
+
+    let reward_cycle = thread_rng().next_u64();
+    let reward_cycle_arg = Value::UInt(reward_cycle as u128);
+
+    let function_args = vec![
+        signer_index_arg.clone(),
+        point_arg.clone(),
+        round_arg.clone(),
+        reward_cycle_arg.clone(),
+    ];
+
+    let mut valid_tx_1 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: function_args.clone(),
+        }),
+    };
+    valid_tx_1.set_origin_nonce(0);
+
+    let mut valid_tx_2 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr.clone(),
+            contract_name: contract_name.clone(),
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args: function_args.clone(),
+        }),
+    };
+    valid_tx_2.set_origin_nonce(0);
+
+    let mut valid_tx_3 = StacksTransaction {
+        version: TransactionVersion::Testnet,
+        chain_id: CHAIN_ID_TESTNET,
+        auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+        anchor_mode: TransactionAnchorMode::Any,
+        post_condition_mode: TransactionPostConditionMode::Allow,
+        post_conditions: vec![],
+        payload: TransactionPayload::ContractCall(TransactionContractCall {
+            address: contract_addr,
+            contract_name,
+            function_name: SIGNERS_VOTING_FUNCTION_NAME.into(),
+            function_args,
+        }),
+    };
+    valid_tx_3.set_origin_nonce(0);
+
+    let mut account_nonces = std::collections::HashMap::new();
+    account_nonces.insert(valid_tx_1.origin_address(), 0);
+    let mut txs = vec![valid_tx_2, valid_tx_1, valid_tx_3];
+    let mut filtered_transactions = HashMap::new();
+    NakamotoSigners::update_filtered_transactions(
+        &mut filtered_transactions,
+        &account_nonces,
+        false,
+        txs.clone(),
+    );
+    let filtered_txs: Vec<_> = filtered_transactions.into_values().collect();
+    txs.sort_by(|a, b| a.txid().cmp(&b.txid()));
+    assert_eq!(filtered_txs.len(), 1);
+    assert!(filtered_txs.contains(&txs.first().expect("failed to get first tx")));
 }

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -2122,12 +2122,11 @@ fn parse_vote_for_aggregate_public_key_valid() {
             function_args: valid_function_args,
         }),
     };
-    let (res_signer_index, res_point, res_round, res_reward_cycle) =
-        NakamotoSigners::parse_vote_for_aggregate_public_key(&valid_tx).unwrap();
-    assert_eq!(res_signer_index, signer_index);
-    assert_eq!(res_point, point);
-    assert_eq!(res_round, round);
-    assert_eq!(res_reward_cycle, reward_cycle);
+    let params = NakamotoSigners::parse_vote_for_aggregate_public_key(&valid_tx).unwrap();
+    assert_eq!(params.signer_index, signer_index);
+    assert_eq!(params.aggregate_key, point);
+    assert_eq!(params.voting_round, round);
+    assert_eq!(params.reward_cycle, reward_cycle);
 }
 
 #[test]

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -78,6 +78,7 @@ pub const POX_3_NAME: &'static str = "pox-3";
 pub const POX_4_NAME: &'static str = "pox-4";
 pub const SIGNERS_NAME: &'static str = "signers";
 pub const SIGNERS_VOTING_NAME: &'static str = "signers-voting";
+pub const SIGNERS_VOTING_FUNCTION_NAME: &str = "vote-for-aggregate-public-key";
 /// This is the name of a variable in the `.signers` contract which tracks the most recently updated
 /// reward cycle number.
 pub const SIGNERS_UPDATE_STATE: &'static str = "last-set-cycle";
@@ -1933,7 +1934,7 @@ pub mod test {
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
             SIGNERS_VOTING_NAME,
-            "vote-for-aggregate-public-key",
+            SIGNERS_VOTING_FUNCTION_NAME,
             vec![
                 Value::UInt(signer_index),
                 aggregate_public_key,

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -46,7 +46,9 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::boot::test::{
     key_to_stacks_addr, make_pox_4_lockup, make_signer_key_signature, with_sortdb,
 };
-use crate::chainstate::stacks::boot::MINERS_NAME;
+use crate::chainstate::stacks::boot::{
+    MINERS_NAME, SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME,
+};
 use crate::chainstate::stacks::db::{MinerPaymentTxFees, StacksAccount, StacksChainState};
 use crate::chainstate::stacks::events::TransactionOrigin;
 use crate::chainstate::stacks::{
@@ -185,9 +187,9 @@ impl NakamotoBootPlan {
                         function_name,
                         ..
                     }) => {
-                        if contract_name.as_str() == "signers-voting"
+                        if contract_name.as_str() == SIGNERS_VOTING_NAME
                             && address.is_burn()
-                            && function_name.as_str() == "vote-for-aggregate-public-key"
+                            && function_name.as_str() == SIGNERS_VOTING_FUNCTION_NAME
                         {
                             false
                         } else {

--- a/testnet/stacks-node/src/mockamoto.rs
+++ b/testnet/stacks-node/src/mockamoto.rs
@@ -49,7 +49,7 @@ use stacks::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, SetupBlockResult,
 };
 use stacks::chainstate::stacks::address::PoxAddress;
-use stacks::chainstate::stacks::boot::SIGNERS_VOTING_NAME;
+use stacks::chainstate::stacks::boot::{SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME};
 use stacks::chainstate::stacks::db::{ChainStateBootData, ClarityTx, StacksChainState};
 use stacks::chainstate::stacks::miner::{
     BlockBuilder, BlockBuilderSettings, BlockLimitFunction, MinerStatus, TransactionResult,
@@ -934,7 +934,7 @@ impl MockamotoNode {
         let vote_payload = TransactionPayload::new_contract_call(
             boot_code_addr(false),
             SIGNERS_VOTING_NAME,
-            "vote-for-aggregate-public-key",
+            SIGNERS_VOTING_FUNCTION_NAME,
             vec![
                 ClarityValue::UInt(0),
                 aggregate_public_key_val,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -30,7 +30,9 @@ use stacks::chainstate::nakamoto::miner::NakamotoBlockBuilder;
 use stacks::chainstate::nakamoto::test_signers::TestSigners;
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use stacks::chainstate::stacks::address::PoxAddress;
-use stacks::chainstate::stacks::boot::{MINERS_NAME, SIGNERS_VOTING_NAME};
+use stacks::chainstate::stacks::boot::{
+    MINERS_NAME, SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME,
+};
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks::chainstate::stacks::miner::{BlockBuilder, BlockLimitFunction, TransactionResult};
 use stacks::chainstate::stacks::{StacksTransaction, ThresholdSignature, TransactionPayload};
@@ -455,7 +457,7 @@ pub fn boot_to_epoch_3(
                 300,
                 &StacksAddress::burn_address(false),
                 SIGNERS_VOTING_NAME,
-                "vote-for-aggregate-public-key",
+                SIGNERS_VOTING_FUNCTION_NAME,
                 &[
                     clarity::vm::Value::UInt(i as u128),
                     aggregate_public_key.clone(),
@@ -564,7 +566,7 @@ fn signer_vote_if_needed(
                     300,
                     &StacksAddress::burn_address(false),
                     SIGNERS_VOTING_NAME,
-                    "vote-for-aggregate-public-key",
+                    SIGNERS_VOTING_FUNCTION_NAME,
                     &[
                         clarity::vm::Value::UInt(i as u128),
                         aggregate_public_key.clone(),

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -7,23 +7,35 @@ use std::time::{Duration, Instant};
 use std::{env, thread};
 
 use clarity::boot_util::boot_code_id;
+use clarity::vm::Value;
 use libsigner::{
     BlockResponse, RejectCode, RunningSigner, Signer, SignerEventReceiver, SignerMessage,
     BLOCK_MSG_ID,
 };
+use rand::thread_rng;
+use rand_core::RngCore;
 use stacks::burnchains::Txid;
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::nakamoto::signer_set::NakamotoSigners;
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader, NakamotoBlockVote};
-use stacks::chainstate::stacks::boot::SIGNERS_NAME;
+use stacks::chainstate::stacks::boot::{
+    SIGNERS_NAME, SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME,
+};
 use stacks::chainstate::stacks::miner::TransactionEvent;
-use stacks::chainstate::stacks::{StacksPrivateKey, StacksTransaction, ThresholdSignature};
+use stacks::chainstate::stacks::{
+    StacksPrivateKey, StacksTransaction, ThresholdSignature, TransactionAnchorMode,
+    TransactionAuth, TransactionPayload, TransactionPostConditionMode, TransactionSmartContract,
+    TransactionVersion,
+};
 use stacks::core::StacksEpoch;
 use stacks::net::api::postblock_proposal::BlockValidateResponse;
+use stacks::util_lib::strings::StacksString;
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::{read_next, StacksMessageCodec};
-use stacks_common::consts::SIGNER_SLOTS_PER_USER;
-use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId, TrieHash};
+use stacks_common::consts::{CHAIN_ID_TESTNET, SIGNER_SLOTS_PER_USER};
+use stacks_common::types::chainstate::{
+    ConsensusHash, StacksAddress, StacksBlockId, StacksPublicKey, TrieHash,
+};
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::{MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::MessageSignature;
@@ -545,38 +557,190 @@ impl SignerTest {
             .unwrap();
         // Get the signer indices
         let reward_cycle = self.get_current_reward_cycle();
-        let valid_signer_index = self.get_signer_index(reward_cycle);
-        let round = self
-            .stacks_client
-            .get_last_round(reward_cycle)
-            .expect("FATAL: failed to get round")
-            .unwrap_or(0)
-            .saturating_add(1);
-        let point = Point::from(Scalar::random(&mut rand::thread_rng()));
-        let invalid_nonce_tx = self
-            .stacks_client
-            .build_vote_for_aggregate_public_key(
-                valid_signer_index,
-                round,
-                point,
-                reward_cycle,
+
+        let signer_private_key = self.signer_stacks_private_keys[0];
+
+        let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, false);
+        let contract_addr = vote_contract_id.issuer.into();
+        let contract_name = vote_contract_id.name.clone();
+
+        let signer_index = thread_rng().next_u64();
+        let signer_index_arg = Value::UInt(signer_index as u128);
+
+        let point = Point::from(Scalar::random(&mut thread_rng()));
+        let point_arg =
+            Value::buff_from(point.compress().data.to_vec()).expect("Failed to create buff");
+
+        let round = thread_rng().next_u64();
+        let round_arg = Value::UInt(round as u128);
+
+        let reward_cycle_arg = Value::UInt(reward_cycle as u128);
+        let valid_function_args = vec![
+            signer_index_arg.clone(),
+            point_arg.clone(),
+            round_arg.clone(),
+            reward_cycle_arg.clone(),
+        ];
+
+        // Create a invalid transaction that is not a contract call
+        let invalid_not_contract_call = StacksTransaction {
+            version: TransactionVersion::Testnet,
+            chain_id: CHAIN_ID_TESTNET,
+            auth: TransactionAuth::from_p2pkh(&signer_private_key).unwrap(),
+            anchor_mode: TransactionAnchorMode::Any,
+            post_condition_mode: TransactionPostConditionMode::Allow,
+            post_conditions: vec![],
+            payload: TransactionPayload::SmartContract(
+                TransactionSmartContract {
+                    name: "test-contract".into(),
+                    code_body: StacksString::from_str("(/ 1 0)").unwrap(),
+                },
                 None,
-                0, // Old nonce
+            ),
+        };
+        let invalid_contract_address = StacksClient::build_signed_contract_call_transaction(
+            &StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&signer_private_key)),
+            contract_name.clone(),
+            SIGNERS_VOTING_FUNCTION_NAME.into(),
+            &valid_function_args,
+            &signer_private_key,
+            TransactionVersion::Testnet,
+            CHAIN_ID_TESTNET,
+            1,
+            10,
+        )
+        .unwrap();
+
+        let invalid_contract_name = StacksClient::build_signed_contract_call_transaction(
+            &contract_addr,
+            "bad-signers-contract-name".into(),
+            SIGNERS_VOTING_FUNCTION_NAME.into(),
+            &valid_function_args,
+            &signer_private_key,
+            TransactionVersion::Testnet,
+            CHAIN_ID_TESTNET,
+            1,
+            10,
+        )
+        .unwrap();
+
+        let invalid_signers_vote_function = StacksClient::build_signed_contract_call_transaction(
+            &contract_addr,
+            contract_name.clone(),
+            "some-other-function".into(),
+            &valid_function_args,
+            &signer_private_key,
+            TransactionVersion::Testnet,
+            CHAIN_ID_TESTNET,
+            1,
+            10,
+        )
+        .unwrap();
+
+        let invalid_function_arg_signer_index =
+            StacksClient::build_signed_contract_call_transaction(
+                &contract_addr,
+                contract_name.clone(),
+                SIGNERS_VOTING_FUNCTION_NAME.into(),
+                &[
+                    point_arg.clone(),
+                    point_arg.clone(),
+                    round_arg.clone(),
+                    reward_cycle_arg.clone(),
+                ],
+                &signer_private_key,
+                TransactionVersion::Testnet,
+                CHAIN_ID_TESTNET,
+                1,
+                10,
             )
-            .expect("FATAL: failed to build vote for aggregate public key");
+            .unwrap();
+
+        let invalid_function_arg_key = StacksClient::build_signed_contract_call_transaction(
+            &contract_addr,
+            contract_name.clone(),
+            SIGNERS_VOTING_FUNCTION_NAME.into(),
+            &[
+                signer_index_arg.clone(),
+                signer_index_arg.clone(),
+                round_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+            &signer_private_key,
+            TransactionVersion::Testnet,
+            CHAIN_ID_TESTNET,
+            1,
+            10,
+        )
+        .unwrap();
+
+        let invalid_function_arg_round = StacksClient::build_signed_contract_call_transaction(
+            &contract_addr,
+            contract_name.clone(),
+            SIGNERS_VOTING_FUNCTION_NAME.into(),
+            &[
+                signer_index_arg.clone(),
+                point_arg.clone(),
+                point_arg.clone(),
+                reward_cycle_arg.clone(),
+            ],
+            &signer_private_key,
+            TransactionVersion::Testnet,
+            CHAIN_ID_TESTNET,
+            1,
+            10,
+        )
+        .unwrap();
+
+        let invalid_function_arg_reward_cycle =
+            StacksClient::build_signed_contract_call_transaction(
+                &contract_addr,
+                contract_name.clone(),
+                SIGNERS_VOTING_FUNCTION_NAME.into(),
+                &[
+                    signer_index_arg.clone(),
+                    point_arg.clone(),
+                    round_arg.clone(),
+                    point_arg.clone(),
+                ],
+                &signer_private_key,
+                TransactionVersion::Testnet,
+                CHAIN_ID_TESTNET,
+                1,
+                10,
+            )
+            .unwrap();
+
+        let invalid_nonce = StacksClient::build_signed_contract_call_transaction(
+            &contract_addr,
+            contract_name.clone(),
+            SIGNERS_VOTING_FUNCTION_NAME.into(),
+            &valid_function_args,
+            &signer_private_key,
+            TransactionVersion::Testnet,
+            CHAIN_ID_TESTNET,
+            0, // Old nonce
+            10,
+        )
+        .unwrap();
+
         let invalid_stacks_client = StacksClient::new(StacksPrivateKey::new(), host, false);
         let invalid_signer_tx = invalid_stacks_client
-            .build_vote_for_aggregate_public_key(
-                valid_signer_index,
-                round,
-                point,
-                reward_cycle,
-                None,
-                0,
-            )
+            .build_vote_for_aggregate_public_key(0, round, point, reward_cycle, None, 0)
             .expect("FATAL: failed to build vote for aggregate public key");
-        // TODO: add invalid contract calls (one with non 'vote-for-aggregate-public-key' function call and one with invalid function args)
-        vec![invalid_nonce_tx, invalid_signer_tx]
+
+        vec![
+            invalid_nonce,
+            invalid_not_contract_call,
+            invalid_contract_name,
+            invalid_contract_address,
+            invalid_signers_vote_function,
+            invalid_function_arg_key,
+            invalid_function_arg_reward_cycle,
+            invalid_function_arg_round,
+            invalid_function_arg_signer_index,
+            invalid_signer_tx,
+        ]
     }
 
     fn shutdown(self) {


### PR DESCRIPTION
I simplified the transaction logic and made it the same between signers and miners. It simply filters invalidly formed transactions from the list of signer transactions, i.e. non vote for aggregate public key transactions, and invalidly formed vote for aggregate public key transactions. It no longer asserts that the actual values of the function args are as expected, leaving it up to the clarity contract to reject them. Additionally, it asserts that only one transaction is allowed per signer per block, sorting proposed transactions based first upon nonce, secondly upon txid if the nonce is the same. 

### Applicable issues

- Closes #https://github.com/stacks-network/stacks-core/issues/4387
