### PR TITLE
Round up thresholds 

### DIFF
--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -156,9 +156,8 @@ impl From<SignerConfig> for Signer {
             .expect("FATAL: Too many registered signers to fit in a u32");
         let num_keys = u32::try_from(signer_config.registered_signers.public_keys.key_ids.len())
             .expect("FATAL: Too many key ids to fit in a u32");
-        // Always add +0.9 to force any remainder to round up to the next integer
-        let threshold = (num_keys * 7 + 9) / 10;
-        let dkg_threshold = (num_keys * 9 + 9) / 10;
+        let threshold = (num_keys as f64 * 7_f64 / 10_f64).ceil() as u32;
+        let dkg_threshold = (num_keys as f64 * 9_f64 / 10_f64).ceil() as u32;
 
         let coordinator_config = CoordinatorConfig {
             threshold,

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -156,8 +156,9 @@ impl From<SignerConfig> for Signer {
             .expect("FATAL: Too many registered signers to fit in a u32");
         let num_keys = u32::try_from(signer_config.registered_signers.public_keys.key_ids.len())
             .expect("FATAL: Too many key ids to fit in a u32");
-        let threshold = num_keys * 7 / 10;
-        let dkg_threshold = num_keys * 9 / 10;
+        // Always add +0.9 to force any remainder to round up to the next integer
+        let threshold = (num_keys * 7 + 9) / 10;
+        let dkg_threshold = (num_keys * 9 + 9) / 10;
 
         let coordinator_config = CoordinatorConfig {
             threshold,

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -391,8 +391,7 @@ impl BlockMinerThread {
         let slot_ids = slot_ids_addresses.keys().cloned().collect::<Vec<_>>();
         // If more than a threshold percentage of the signers reject the block, we should not wait any further
         let weights: u64 = signer_weights.values().sum();
-        // Always add +0.9 to force any remainder to round up to the next integer
-        let rejection_threshold = (weights * 7 + 9) / 10;
+        let rejection_threshold: u64 = (weights as f64 * 7_f64 / 10_f64).ceil() as u64;
         let mut rejections = HashSet::new();
         let mut rejections_weight: u64 = 0;
         let now = Instant::now();

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -391,7 +391,8 @@ impl BlockMinerThread {
         let slot_ids = slot_ids_addresses.keys().cloned().collect::<Vec<_>>();
         // If more than a threshold percentage of the signers reject the block, we should not wait any further
         let weights: u64 = signer_weights.values().sum();
-        let rejection_threshold = weights / 10 * 7;
+        // Always add +0.9 to force any remainder to round up to the next integer
+        let rejection_threshold = (weights * 7 + 9) / 10;
         let mut rejections = HashSet::new();
         let mut rejections_weight: u64 = 0;
         let now = Instant::now();


### PR DESCRIPTION
@hstove found a bug when operating a single signer with a single key. Essentially the threshold became 0 which causes wsts to panic as it should due to an invalid threshold being provided. @xoloki subsequently pointed out that we actually had a bug in our threshold calculation due to integer arithmatic forcing us to always calculate a threshold "under" our desired amount whenever we had any remainder. This pr forces us to "round up" by adding 0.9 to the result. If any remainder exists, it will force our result over into the next integer amount (note that due to integer math and the nature of dividing by 10, the remainder will always be minimum 0.1 or more hence why adding 0.9 guarantees pushing it over to the next integer if remainder is present).

Due to Joey's suggestion, I have converted all integers involved to floating points instead to use the ceil function.