### PR TITLE
Track nmb of invalid signers and their key ids to treat them as non responsive

### DIFF
--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -279,7 +279,7 @@ mod tests {
     #[serial]
     fn get_signer_transactions_with_retry_should_succeed() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
-        let signer_config = generate_signer_config(&config, 5, 20);
+        let signer_config = generate_signer_config(&config, 5, 0, 4);
         let mut stackerdb = StackerDB::from(&signer_config);
         let sk = StacksPrivateKey::new();
         let tx = StacksTransaction {
@@ -323,7 +323,7 @@ mod tests {
     #[serial]
     fn send_signer_message_with_retry_should_succeed() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
-        let signer_config = generate_signer_config(&config, 5, 20);
+        let signer_config = generate_signer_config(&config, 5, 0, 4);
         let mut stackerdb = StackerDB::from(&signer_config);
 
         let sk = StacksPrivateKey::new();

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -126,6 +126,10 @@ pub struct ParsedSignerEntries {
     /// The signer ids mapped to a hash set of key ids
     /// The wsts coordinator uses a hash set for each signer since it needs to do lots of lookups
     pub coordinator_key_ids: HashMap<u32, HashSet<u32>>,
+    /// The number of invalid key ids
+    pub num_invalid_key_ids: u32,
+    /// The number of invalid signers
+    pub num_invalid_signers: u32,
 }
 
 /// The Configuration info needed for an individual signer per reward cycle

--- a/stacks-signer/src/coordinator.rs
+++ b/stacks-signer/src/coordinator.rs
@@ -173,7 +173,7 @@ mod tests {
     fn calculate_coordinator_different_consensus_hashes_produces_unique_results() {
         let number_of_tests = 5;
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
-        let public_keys = generate_signer_config(&config, 10, 4000)
+        let public_keys = generate_signer_config(&config, 10, 0, 4000)
             .signer_entries
             .public_keys;
         let mut results = Vec::new();
@@ -196,7 +196,7 @@ mod tests {
         count: usize,
     ) -> Vec<Vec<u32>> {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
-        let public_keys = generate_signer_config(&config, 10, 4000)
+        let public_keys = generate_signer_config(&config, 10, 0, 4000)
             .signer_entries
             .public_keys;
         let mut results = Vec::new();

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -161,9 +161,11 @@ impl From<SignerConfig> for Signer {
         let stackerdb = StackerDB::from(&signer_config);
 
         let num_signers = u32::try_from(signer_config.signer_entries.public_keys.signers.len())
-            .expect("FATAL: Too many registered signers to fit in a u32");
+            .expect("FATAL: Too many registered signers to fit in a u32")
+            .saturating_add(signer_config.signer_entries.num_invalid_signers);
         let num_keys = u32::try_from(signer_config.signer_entries.public_keys.key_ids.len())
-            .expect("FATAL: Too many key ids to fit in a u32");
+            .expect("FATAL: Too many key ids to fit in a u32")
+            .saturating_add(signer_config.signer_entries.num_invalid_key_ids);
         let threshold = num_keys * 7 / 10;
         let dkg_threshold = num_keys * 9 / 10;
 


### PR DESCRIPTION
See https://github.com/Trust-Machines/wsts/pull/56 for test to ensure that key ids that are included without a public key are treated as non responsive signers.

