### PR TITLE
chore(clarity): Allocate `HashMap`s with capacity when possible

### DIFF
--- a/clarity/src/vm/ast/traits_resolver/mod.rs
+++ b/clarity/src/vm/ast/traits_resolver/mod.rs
@@ -46,14 +46,12 @@ impl TraitsResolver {
     }
 
     pub fn run(&mut self, contract_ast: &mut ContractAST) -> ParseResult<()> {
-        let exprs = contract_ast.pre_expressions[..].to_vec();
         let mut referenced_traits = HashMap::new();
 
-        for exp in exprs.iter() {
+        for exp in contract_ast.pre_expressions.iter() {
             // Top-level comment nodes have been filtered from `args` by `try_parse_pre_expr`.
-            let (define_type, args) = match self.try_parse_pre_expr(exp) {
-                Some(x) => x,
-                None => continue,
+            let Some((define_type, args)) = self.try_parse_pre_expr(exp) else {
+                continue;
             };
 
             match define_type {

--- a/clarity/src/vm/ast/types.rs
+++ b/clarity/src/vm/ast/types.rs
@@ -79,10 +79,7 @@ pub struct PreExpressionsDrain {
 
 impl PreExpressionsDrain {
     pub fn new(pre_exprs_drain: Drain<PreSymbolicExpression>, sorting: Option<Vec<usize>>) -> Self {
-        let mut pre_expressions = HashMap::new();
-        for (index, pre_expr) in pre_exprs_drain.enumerate() {
-            pre_expressions.insert(index, pre_expr);
-        }
+        let pre_expressions: HashMap<_, _> = pre_exprs_drain.enumerate().collect();
 
         let sorting = match sorting {
             Some(sorting) if !sorting.is_empty() => Some(sorting),

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -306,10 +306,7 @@ impl AssetMap {
         asset: AssetIdentifier,
         transfered: Value,
     ) {
-        let principal_map = self
-            .asset_map
-            .entry(principal.clone())
-            .or_insert_with(|| HashMap::new());
+        let principal_map = self.asset_map.entry(principal.clone()).or_default();
 
         if let Some(map_entry) = principal_map.get_mut(&asset) {
             map_entry.push(transfered);
@@ -326,10 +323,7 @@ impl AssetMap {
     ) -> Result<()> {
         let next_amount = self.get_next_amount(principal, &asset, amount)?;
 
-        let principal_map = self
-            .token_map
-            .entry(principal.clone())
-            .or_insert_with(|| HashMap::new());
+        let principal_map = self.token_map.entry(principal.clone()).or_default();
         principal_map.insert(asset, next_amount);
 
         Ok(())
@@ -362,10 +356,7 @@ impl AssetMap {
         // After this point, this function will not fail.
         for (principal, mut principal_map) in other.asset_map.drain() {
             for (asset, mut transfers) in principal_map.drain() {
-                let landing_map = self
-                    .asset_map
-                    .entry(principal.clone())
-                    .or_insert_with(|| HashMap::new());
+                let landing_map = self.asset_map.entry(principal.clone()).or_default();
                 if let Some(landing_vec) = landing_map.get_mut(&asset) {
                     landing_vec.append(&mut transfers);
                 } else {
@@ -383,10 +374,7 @@ impl AssetMap {
         }
 
         for (principal, asset, amount) in to_add.into_iter() {
-            let principal_map = self
-                .token_map
-                .entry(principal)
-                .or_insert_with(|| HashMap::new());
+            let principal_map = self.token_map.entry(principal).or_default();
             principal_map.insert(asset, amount);
         }
 
@@ -394,9 +382,9 @@ impl AssetMap {
     }
 
     pub fn to_table(mut self) -> HashMap<PrincipalData, HashMap<AssetIdentifier, AssetMapEntry>> {
-        let mut map = HashMap::new();
+        let mut map = HashMap::with_capacity(self.token_map.len());
         for (principal, mut principal_map) in self.token_map.drain() {
-            let mut output_map = HashMap::new();
+            let mut output_map = HashMap::with_capacity(principal_map.len());
             for (asset, amount) in principal_map.drain() {
                 output_map.insert(asset, AssetMapEntry::Token(amount));
             }
@@ -404,9 +392,7 @@ impl AssetMap {
         }
 
         for (principal, stx_amount) in self.stx_map.drain() {
-            let output_map = map
-                .entry(principal.clone())
-                .or_insert_with(|| HashMap::new());
+            let output_map = map.entry(principal.clone()).or_default();
             output_map.insert(
                 AssetIdentifier::STX(),
                 AssetMapEntry::STX(stx_amount as u128),
@@ -414,9 +400,7 @@ impl AssetMap {
         }
 
         for (principal, stx_burned_amount) in self.burn_map.drain() {
-            let output_map = map
-                .entry(principal.clone())
-                .or_insert_with(|| HashMap::new());
+            let output_map = map.entry(principal.clone()).or_default();
             output_map.insert(
                 AssetIdentifier::STX_burned(),
                 AssetMapEntry::Burn(stx_burned_amount as u128),
@@ -424,9 +408,7 @@ impl AssetMap {
         }
 
         for (principal, mut principal_map) in self.asset_map.drain() {
-            let output_map = map
-                .entry(principal.clone())
-                .or_insert_with(|| HashMap::new());
+            let output_map = map.entry(principal.clone()).or_default();
             for (asset, transfers) in principal_map.drain() {
                 output_map.insert(asset, AssetMapEntry::Asset(transfers));
             }
@@ -436,17 +418,11 @@ impl AssetMap {
     }
 
     pub fn get_stx(&self, principal: &PrincipalData) -> Option<u128> {
-        match self.stx_map.get(principal) {
-            Some(value) => Some(*value),
-            None => None,
-        }
+        self.stx_map.get(principal).copied()
     }
 
     pub fn get_stx_burned(&self, principal: &PrincipalData) -> Option<u128> {
-        match self.burn_map.get(principal) {
-            Some(value) => Some(*value),
-            None => None,
-        }
+        self.burn_map.get(principal).copied()
     }
 
     pub fn get_stx_burned_total(&self) -> Result<u128> {

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -811,9 +811,10 @@ impl TrackerData {
 
         self.contract_call_circuits = contract_call_circuits;
 
-        let mut cost_contracts = HashMap::new();
-        let mut m = HashMap::new();
-        for f in ClarityCostFunction::ALL.iter() {
+        let iter = ClarityCostFunction::ALL.iter();
+        let mut cost_contracts = HashMap::with_capacity(iter.len());
+        let mut m = HashMap::with_capacity(iter.len());
+        for f in iter {
             let cost_function_ref = cost_function_references.remove(f).unwrap_or_else(|| {
                 ClarityCostFunctionReference::new(boot_costs_id.clone(), f.get_name())
             });

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -812,8 +812,9 @@ impl TrackerData {
         self.contract_call_circuits = contract_call_circuits;
 
         let iter = ClarityCostFunction::ALL.iter();
-        let mut cost_contracts = HashMap::with_capacity(iter.len());
-        let mut m = HashMap::with_capacity(iter.len());
+        let iter_len = iter.len();
+        let mut cost_contracts = HashMap::with_capacity(iter_len);
+        let mut m = HashMap::with_capacity(iter_len);
         for f in iter {
             let cost_function_ref = cost_function_references.remove(f).unwrap_or_else(|| {
                 ClarityCostFunctionReference::new(boot_costs_id.clone(), f.get_name())

--- a/clarity/src/vm/coverage.rs
+++ b/clarity/src/vm/coverage.rs
@@ -72,8 +72,9 @@ impl CoverageReporter {
 
     pub fn to_file<P: AsRef<std::path::Path> + Copy>(&self, filename: P) -> std::io::Result<()> {
         let f = File::create(filename)?;
-        let mut coverage = HashMap::new();
-        for (contract, execution_map) in self.executed_lines.iter() {
+        let iter = self.executed_lines.iter();
+        let mut coverage = HashMap::with_capacity(iter.len());
+        for (contract, execution_map) in iter {
             let mut executed_lines = execution_map
                 .iter()
                 .map(|(line, count)| (*line, *count))


### PR DESCRIPTION
### Description

Like `Vec`, `HashMap` can also be initialized using `with_capacity()`. I made this change where it was possible in `./clarity` and saw around a **2%** performance gain:

```console
❯ hyperfine -w 3 -r 10 "target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000" "target/release/stacks-inspect.hashmap-alloc replay-block /home/jbencin/data/next/ range 99990 100000"
Benchmark 1: target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000
  Time (mean ± σ):      8.682 s ±  0.019 s    [User: 8.200 s, System: 0.435 s]
  Range (min … max):    8.651 s …  8.710 s    10 runs
 
Benchmark 2: target/release/stacks-inspect.hashmap-alloc replay-block /home/jbencin/data/next/ range 99990 100000
  Time (mean ± σ):      8.552 s ±  0.026 s    [User: 8.082 s, System: 0.425 s]
  Range (min … max):    8.510 s …  8.586 s    10 runs
 
Summary
  target/release/stacks-inspect.hashmap-alloc replay-block /home/jbencin/data/next/ range 99990 100000 ran
    1.02 ± 0.00 times faster than target/release/stacks-inspect.next replay-block /home/jbencin/data/next/ range 99990 100000
```

### Applicable issues

- #4316 

