### PR TITLE
Chore: Replace Hex Encoding/Decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,6 +3471,7 @@ dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
  "ed25519-dalek",
+ "faster-hex",
  "hashbrown 0.14.3",
  "lazy_static",
  "libc",

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -19,6 +19,7 @@ path = "./src/libcommon.rs"
 
 [dependencies]
 rand = { workspace = true }
+faster-hex = "0.9.0"
 serde = "1"
 serde_derive = "1"
 serde_stacker = "0.1"

--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -58,6 +58,8 @@ pub enum HexError {
     BadLength(usize),
     /// Non-hex character in string
     BadCharacter(char),
+    /// Overflow
+    Overflow,
 }
 
 impl fmt::Display for HexError {
@@ -65,6 +67,7 @@ impl fmt::Display for HexError {
         match *self {
             HexError::BadLength(n) => write!(f, "bad length {} for hex string", n),
             HexError::BadCharacter(c) => write!(f, "bad character {} for hex string", c),
+            HexError::Overflow => write!(f, "Overflow while decoding hex string"),
         }
     }
 }
@@ -77,6 +80,7 @@ impl error::Error for HexError {
         match *self {
             HexError::BadLength(_) => "hex string non-64 length",
             HexError::BadCharacter(_) => "bad hex character",
+            HexError::Overflow => "overflow while decoding hex"
         }
     }
 }


### PR DESCRIPTION
### Description

I took a look at the functions that were doing the hex encoding and decoding in the `stacks-common` package and there was an easy replacement with an external crate (`faster-hex`) in order to improve the performance. The results show a performance increase of about `1%` when processing blocks:
```sh
$ hyperfine -w 3 -r 10 "./stacks-inspect-hex-modifications replay-block ~/chainstate/ range 99990 100000" "./stacks-inspect-9385b4236 replay-block ~/chainstate/ range 99990 100000"
Benchmark 1: ./stacks-inspect-hex-modifications replay-block ~/chainstate/ range 99990 100000
  Time (mean ± σ):      7.956 s ±  0.036 s    [User: 7.571 s, System: 0.352 s]
  Range (min … max):    7.929 s …  8.052 s    10 runs
 
Benchmark 2: ./stacks-inspect-9385b4236 replay-block ~/chainstate/ range 99990 100000
  Time (mean ± σ):      8.023 s ±  0.021 s    [User: 7.610 s, System: 0.379 s]
  Range (min … max):    7.992 s …  8.061 s    10 runs
 
Summary
  ./stacks-inspect-hex-modifications replay-block ~/chainstate/ range 99990 100000 ran
    1.01 ± 0.01 times faster than ./stacks-inspect-9385b4236 replay-block ~/chainstate/ range 99990 100000
```