### PR TITLE
Fix `get-vote` response type

### DIFF
--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -332,6 +332,20 @@ pub(crate) mod tests {
     /// Build a response for the get_approved_aggregate_key request
     pub fn build_get_approved_aggregate_key_response(point: Option<Point>) -> String {
         let clarity_value = if let Some(point) = point {
+            ClarityValue::some(
+                ClarityValue::buff_from(point.compress().as_bytes().to_vec())
+                    .expect("BUG: Failed to create clarity value from point"),
+            )
+            .expect("BUG: Failed to create clarity value from point")
+        } else {
+            ClarityValue::none()
+        };
+        build_read_only_response(&clarity_value)
+    }
+
+    /// Build a response for the get_approved_aggregate_key request
+    pub fn build_get_vote_for_aggregate_key_response(point: Option<Point>) -> String {
+        let clarity_value = if let Some(point) = point {
             ClarityValue::some(ClarityValue::Tuple(
                 TupleData::from_data(vec![
                     (

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -137,6 +137,7 @@ pub(crate) mod tests {
     };
     use blockstack_lib::util_lib::boot::boot_code_id;
     use clarity::vm::costs::ExecutionCost;
+    use clarity::vm::types::TupleData;
     use clarity::vm::Value as ClarityValue;
     use hashbrown::{HashMap, HashSet};
     use rand::distributions::Standard;
@@ -331,11 +332,18 @@ pub(crate) mod tests {
     /// Build a response for the get_approved_aggregate_key request
     pub fn build_get_approved_aggregate_key_response(point: Option<Point>) -> String {
         let clarity_value = if let Some(point) = point {
-            ClarityValue::some(
-                ClarityValue::buff_from(point.compress().as_bytes().to_vec())
-                    .expect("BUG: Failed to create clarity value from point"),
-            )
-            .expect("BUG: Failed to create clarity value from point")
+            ClarityValue::some(ClarityValue::Tuple(
+                TupleData::from_data(vec![
+                    (
+                        "aggregate-public-key".into(),
+                        ClarityValue::buff_from(point.compress().as_bytes().to_vec())
+                            .expect("BUG: Failed to create clarity value from point"),
+                    ),
+                    ("signer-weight".into(), ClarityValue::UInt(1)), // fixed for testing purposes
+                ])
+                .expect("BUG: Failed to create clarity value from tuple data"),
+            ))
+            .expect("BUG: Failed to create clarity value from tuple data")
         } else {
             ClarityValue::none()
         };

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -619,7 +619,8 @@ mod tests {
     use crate::client::tests::{
         build_account_nonce_response, build_get_approved_aggregate_key_response,
         build_get_last_round_response, build_get_peer_info_response, build_get_pox_data_response,
-        build_read_only_response, write_response, MockServerClient,
+        build_get_vote_for_aggregate_key_response, build_read_only_response, write_response,
+        MockServerClient,
     };
 
     #[test]
@@ -1149,7 +1150,7 @@ mod tests {
         let mock = MockServerClient::new();
         let point = Point::from(Scalar::random(&mut rand::thread_rng()));
         let stacks_address = mock.client.stacks_address;
-        let key_response = build_get_approved_aggregate_key_response(Some(point));
+        let key_response = build_get_vote_for_aggregate_key_response(Some(point));
         let h = spawn(move || {
             mock.client
                 .get_vote_for_aggregate_public_key(0, 0, stacks_address)
@@ -1159,7 +1160,7 @@ mod tests {
 
         let mock = MockServerClient::new();
         let stacks_address = mock.client.stacks_address;
-        let key_response = build_get_approved_aggregate_key_response(None);
+        let key_response = build_get_vote_for_aggregate_key_response(None);
         let h = spawn(move || {
             mock.client
                 .get_vote_for_aggregate_public_key(0, 0, stacks_address)


### PR DESCRIPTION
It now returns a tuple including the weight, instead of just the key.

```clarity
(option { aggregate-public-key: (buff 33), signer-weight: uint })
```
