### PR TITLE
Fix: manually calculate current reward cycle ID in /v2/pox_info

### DIFF
--- a/stackslib/src/net/api/getpoxinfo.rs
+++ b/stackslib/src/net/api/getpoxinfo.rs
@@ -286,6 +286,9 @@ impl RPCPoxInfoData {
             return Err(NetError::DBError(DBError::Corruption));
         }
 
+        // Manually calculate `reward_cycle_id` so that clients don't get an "off by one" view at
+        //  reward cycle boundaries (because if the reward cycle is loaded from clarity, its
+        //  evaluated in the last mined Stacks block, not the most recent burn block).
         let reward_cycle_id = burnchain
             .block_height_to_reward_cycle(burnchain_tip.block_height)
             .ok_or_else(|| {

--- a/stackslib/src/net/api/getpoxinfo.rs
+++ b/stackslib/src/net/api/getpoxinfo.rs
@@ -226,12 +226,6 @@ impl RPCPoxInfoData {
             .to_owned()
             .expect_u128()? as u64;
 
-        let reward_cycle_id = res
-            .get("reward-cycle-id")
-            .unwrap_or_else(|_| panic!("FATAL: no 'reward-cycle-id'"))
-            .to_owned()
-            .expect_u128()? as u64;
-
         let reward_cycle_length = res
             .get("reward-cycle-length")
             .unwrap_or_else(|_| panic!("FATAL: no 'reward-cycle-length'"))
@@ -292,7 +286,13 @@ impl RPCPoxInfoData {
             return Err(NetError::DBError(DBError::Corruption));
         }
 
+        let reward_cycle_id = burnchain
+            .block_height_to_reward_cycle(burnchain_tip.block_height)
+            .ok_or_else(|| {
+                NetError::ChainstateError("Current burn block height is before stacks start".into())
+            })?;
         let effective_height = burnchain_tip.block_height - first_burnchain_block_height;
+
         let next_reward_cycle_in = reward_cycle_length - (effective_height % reward_cycle_length);
 
         let next_rewards_start = burnchain_tip.block_height + next_reward_cycle_in;


### PR DESCRIPTION
### Description

`/v2/pox` invokes `get-pox-info` in the current PoX contract to obtain information about the current cycle. However, the burn view of this invocation is _always_ one block behind the current chain tip: 2.x Stacks blocks are evaluated with a burnchain view equal to their parent (because the Stacks blocks must be assembled before the burn block in which they are committed).

This leads to an "off by one" situation at reward cycle boundaries. This isn't a huge problem for Stacks 2.x nodes, because the information returned from this endpoint isn't really critical during the reward cycle change-overs. For signers in Nakamoto, though, this is problematic: they must know that the reward cycle has changed because they are now responsible for signing any new blocks _at the time of the change-over_.

This PR addresses this problem by manually computing the current reward-cycle ID.