### PR TITLE
Fix race condition in stacks signer client tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,19 +989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if 1.0.0",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,16 +1977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,29 +2254,6 @@ name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -3068,12 +3022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3222,31 +3170,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -3536,7 +3459,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_stacker",
- "serial_test",
  "slog",
  "slog-json",
  "slog-term",

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -44,7 +44,6 @@ wsts = { workspace = true }
 rand = { workspace = true }
 
 [dev-dependencies]
-serial_test = "3.0.0"
 clarity = { path = "../clarity", features = ["testing"] }
 
 [dependencies.serde_json]

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -269,14 +269,12 @@ mod tests {
         TransactionSmartContract, TransactionVersion,
     };
     use blockstack_lib::util_lib::strings::StacksString;
-    use serial_test::serial;
 
     use super::*;
     use crate::client::tests::{generate_signer_config, mock_server_from_config, write_response};
     use crate::config::GlobalConfig;
 
     #[test]
-    #[serial]
     fn get_signer_transactions_with_retry_should_succeed() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
         let signer_config = generate_signer_config(&config, 5, 20);
@@ -320,9 +318,8 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn send_signer_message_with_retry_should_succeed() {
-        let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
+        let config = GlobalConfig::load_from_file("./src/tests/conf/signer-1.toml").unwrap();
         let signer_config = generate_signer_config(&config, 5, 20);
         let mut stackerdb = StackerDB::from(&signer_config);
 

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -596,7 +596,6 @@ mod tests {
     use blockstack_lib::chainstate::stacks::ThresholdSignature;
     use rand::thread_rng;
     use rand_core::RngCore;
-    use serial_test::serial;
     use stacks_common::bitvec::BitVec;
     use stacks_common::consts::{CHAIN_ID_TESTNET, SIGNER_SLOTS_PER_USER};
     use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId, TrieHash};
@@ -837,7 +836,6 @@ mod tests {
 
     #[ignore]
     #[test]
-    #[serial]
     fn build_vote_for_aggregate_public_key_should_succeed() {
         let mock = MockServerClient::new();
         let point = Point::from(Scalar::random(&mut rand::thread_rng()));
@@ -861,7 +859,6 @@ mod tests {
 
     #[ignore]
     #[test]
-    #[serial]
     fn broadcast_vote_for_aggregate_public_key_should_succeed() {
         let mock = MockServerClient::new();
         let point = Point::from(Scalar::random(&mut rand::thread_rng()));

--- a/stacks-signer/src/tests/conf/signer-0.toml
+++ b/stacks-signer/src/tests/conf/signer-0.toml
@@ -1,4 +1,3 @@
-
 stacks_private_key = "6a1fc1a3183018c6d79a4e11e154d2bdad2d89ac8bc1b0a021de8b4d28774fbb01"
 node_host = "127.0.0.1:20443"
 endpoint = "localhost:30000"

--- a/stacks-signer/src/tests/conf/signer-1.toml
+++ b/stacks-signer/src/tests/conf/signer-1.toml
@@ -1,5 +1,4 @@
-
 stacks_private_key = "126e916e77359ccf521e168feea1fcb9626c59dc375cae00c7464303381c7dff01"
-node_host = "127.0.0.1:20443"
+node_host = "127.0.0.1:20444"
 endpoint = "localhost:30001"
 network = "testnet"

--- a/stacks-signer/src/tests/conf/signer-2.toml
+++ b/stacks-signer/src/tests/conf/signer-2.toml
@@ -1,5 +1,0 @@
-
-stacks_private_key = "b169d0d1408f66d16beb321857f525f9014dfc289f1aeedbcf96e78afeb8eb4001"
-node_host = "127.0.0.1:20443"
-endpoint = "localhost:30002"
-network = "testnet"

--- a/stacks-signer/src/tests/conf/signer-3.toml
+++ b/stacks-signer/src/tests/conf/signer-3.toml
@@ -1,5 +1,0 @@
-
-stacks_private_key = "63cef3cd8880969b7f2450ca13b9ca57fd3cd3f7ee57ec6ed7654a84d39181e401"
-node_host = "127.0.0.1:20443"
-endpoint = "localhost:30003"
-network = "testnet"


### PR DESCRIPTION
### Description
This PR eliminates a race condition between tests and improves the test isolation in `client::stackerdb::tests` by ensuring the tests have different node hosts in their signer configs.

In addition, the dev-dependency `serial_test` is no longer needed and therefore removed. 

### Applicable issues

- fixes #4472
