### PR TITLE
CI: do not fail CI if the codecov upload fails

### DIFF
--- a/.github/workflows/stacks-core-tests.yml
+++ b/.github/workflows/stacks-core-tests.yml
@@ -160,7 +160,8 @@ jobs:
         id: codecov
         uses: stacks-network/actions/codecov@main
         with:
-          fail_ci_if_error: true
+          # We'd like to uncomment the below line once the codecov upload is working
+          # fail_ci_if_error: true
           test-name: ${{ matrix.test-name }}
           upload-only: true
           filename: ./contrib/core-contract-tests/lcov.info


### PR DESCRIPTION
This is currently causing CI failures in all PRs, so it needs to be disabled for now.