### PR TITLE
Bugfix/do not unconditionally attempt block post submit failure

### DIFF
--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -516,6 +516,8 @@ pub(crate) struct BlockMinerThread {
     burn_block: BlockSnapshot,
     /// Handle to the node's event dispatcher
     event_dispatcher: EventDispatcher,
+    /// Failed to submit last attempted block
+    failed_to_submit_last_attempt: bool,
 }
 
 /// State representing the microblock miner.
@@ -1020,6 +1022,7 @@ impl BlockMinerThread {
             registered_key,
             burn_block,
             event_dispatcher: rt.event_dispatcher.clone(),
+            failed_to_submit_last_attempt: false,
         }
     }
 
@@ -1543,7 +1546,9 @@ impl BlockMinerThread {
             Self::find_inflight_mined_blocks(self.burn_block.block_height, &self.last_mined_blocks);
 
         // has the tip changed from our previously-mined block for this epoch?
-        let (attempt, max_txs) = if last_mined_blocks.len() <= 1 {
+        let should_unconditionally_mine = last_mined_blocks.is_empty()
+            || (last_mined_blocks.len() == 1 && self.failed_to_submit_last_attempt);
+        let (attempt, max_txs) = if should_unconditionally_mine {
             // always mine if we've not mined a block for this epoch yet, or
             // if we've mined just one attempt, unconditionally try again (so we
             // can use `subsequent_miner_time_ms` in this attempt)
@@ -2482,12 +2487,14 @@ impl BlockMinerThread {
 
         let res = bitcoin_controller.submit_operation(target_epoch_id, op, &mut op_signer, attempt);
         if res.is_none() {
+            self.failed_to_submit_last_attempt = true;
             if !self.config.node.mock_mining {
                 warn!("Relayer: Failed to submit Bitcoin transaction");
                 return None;
-            } else {
-                debug!("Relayer: Mock-mining enabled; not sending Bitcoin transaction");
             }
+            debug!("Relayer: Mock-mining enabled; not sending Bitcoin transaction");
+        } else {
+            self.failed_to_submit_last_attempt = false;
         }
 
         Some(MinerThreadResult::Block(


### PR DESCRIPTION
This is to quiet the logs which were unconditionally reattempting block submissions with the exact same info post failure due to an attempt to handle the case where the first attempted block was much smaller than subsequent attempts would be. @kantai gave me a diff...
Closes https://github.com/stacks-network/stacks-core/issues/4484
