### PR TITLE
Signers-Voting Chore(s): Round Up & Round-Data Getter

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -58,8 +58,8 @@
 (define-read-only (get-vote (reward-cycle uint) (round uint) (signer principal))
     (map-get? votes {reward-cycle: reward-cycle, round: round, signer: signer}))
 
-(define-read-only (get-current-round-info)
-    (map-get? round-data {reward-cycle: (current-reward-cycle), round: (default-to u0 (get-last-round (current-reward-cycle)))}))
+(define-read-only (get-round-info (reward-cycle uint) (round uint))
+    (map-get? round-data {reward-cycle: reward-cycle, round: round}))
 
 (define-read-only (get-candidate-info (reward-cycle uint) (round uint) (candidate (buff 33)))
     {candidate-weight: (default-to u0 (map-get? tally {reward-cycle: reward-cycle, round: round, aggregate-public-key: candidate})),
@@ -92,10 +92,6 @@
 (define-read-only (get-threshold-weight (reward-cycle uint))
     (let  ((total-weight (default-to u0 (map-get? cycle-total-weight reward-cycle))))
         (/ (+ (* total-weight threshold-consensus) u99) u100)))
-
-;; get the voting data for specific reward cycle and round
-(define-private (get-voting-data (reward-cycle uint) (round uint))
-    (map-get? round-data {reward-cycle: reward-cycle, round: round}))
 
 (define-private (is-in-voting-window (height uint) (reward-cycle uint))
     (let ((last-cycle (unwrap-panic (contract-call? .signers get-last-set-cycle))))

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -84,9 +84,7 @@
 ;; get the weight required for consensus threshold
 (define-private (get-threshold-weight (reward-cycle uint))
     (let  ((total-weight (try! (get-and-cache-total-weight reward-cycle))))
-        (ok (/ (+ (* total-weight threshold-consensus) u99) u100))
-    )
-)
+        (ok (/ (+ (* total-weight threshold-consensus) u99) u100))))
 
 (define-private (is-in-voting-window (height uint) (reward-cycle uint))
     (let ((last-cycle (unwrap-panic (contract-call? .signers get-last-set-cycle))))

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -25,8 +25,8 @@
 (define-constant pox-info
     (unwrap-panic (contract-call? .pox-4 get-pox-info)))
 
-;; Threshold consensus, expressed as parts-per-thousand to allow for integer
-;; division with higher precision (e.g. 700 for 70%).
+;; Threshold consensus, expressed as parts-per-hundred to allow for integer
+;; division with higher precision (e.g. 70 for 70%).
 (define-constant threshold-consensus u70)
 
 ;; Maps reward-cycle ids to last round

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -89,9 +89,14 @@
     (map-get? aggregate-public-keys reward-cycle))
 
 ;; get the weight required for consensus threshold
-(define-public (get-threshold-weight (reward-cycle uint))
+(define-private (get-threshold-weight (reward-cycle uint))
     (let  ((total-weight (try! (get-and-cache-total-weight reward-cycle))))
         (ok (/ (+ (* total-weight threshold-consensus) u99) u100))))
+
+;; get the weight required for consensus threshold (read-only)
+(define-read-only (get-threshold-weight-read-only (reward-cycle uint))
+    (let  ((total-weight (default-to u0 (map-get? cycle-total-weight reward-cycle))))
+        (/ (+ (* total-weight threshold-consensus) u99) u100)))
 
 (define-private (is-in-voting-window (height uint) (reward-cycle uint))
     (let ((last-cycle (unwrap-panic (contract-call? .signers get-last-set-cycle))))

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -26,7 +26,7 @@
 
 ;; Threshold consensus, expressed as parts-per-thousand to allow for integer
 ;; division with higher precision (e.g. 700 for 70%).
-(define-constant threshold-consensus u700)
+(define-constant threshold-consensus u70)
 
 ;; Maps reward-cycle ids to last round
 (define-map rounds uint uint)
@@ -84,7 +84,7 @@
 ;; get the weight required for consensus threshold
 (define-private (get-threshold-weight (reward-cycle uint))
     (let  ((total-weight (try! (get-and-cache-total-weight reward-cycle))))
-        (ok (/ (+ (* total-weight threshold-consensus) u999) u1000))
+        (ok (/ (+ (* total-weight threshold-consensus) u99) u100))
     )
 )
 

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -95,7 +95,7 @@
 
 ;; get the voting data for specific reward cycle and round
 (define-private (get-voting-data (reward-cycle uint) (round uint))
-    (unwrap-panic (map-get? round-data {reward-cycle: reward-cycle, round: round})))
+    (map-get? round-data {reward-cycle: reward-cycle, round: round}))
 
 (define-private (is-in-voting-window (height uint) (reward-cycle uint))
     (let ((last-cycle (unwrap-panic (contract-call? .signers get-last-set-cycle))))

--- a/stackslib/src/chainstate/stacks/boot/signers-voting.clar
+++ b/stackslib/src/chainstate/stacks/boot/signers-voting.clar
@@ -20,7 +20,6 @@
 (define-constant ERR_DUPLICATE_VOTE u15)
 (define-constant ERR_FAILED_TO_RETRIEVE_SIGNERS u16)
 (define-constant ERR_INVALID_ROUND u17)
-(define-constant ERR_GET_SIGNER_WEIGHT u18)
 
 (define-constant pox-info
     (unwrap-panic (contract-call? .pox-4 get-pox-info)))
@@ -144,7 +143,7 @@
 (define-public (vote-for-aggregate-public-key (signer-index uint) (key (buff 33)) (round uint) (reward-cycle uint))
     (let ((tally-key {reward-cycle: reward-cycle, round: round, aggregate-public-key: key})
             ;; vote by signer weight
-            (signer-weight (unwrap! (get-signer-weight signer-index reward-cycle) (err ERR_GET_SIGNER_WEIGHT)))
+            (signer-weight (try! (get-signer-weight signer-index reward-cycle)))
             (new-total (+ signer-weight (default-to u0 (map-get? tally tally-key))))
             (cached-weight (try! (get-and-cache-total-weight reward-cycle)))
             (threshold-weight (get-threshold-weight reward-cycle))

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -546,15 +546,16 @@ pub fn get_round_info(
     peer: &mut TestPeer<'_>,
     latest_block_id: StacksBlockId,
     reward_cycle: u128,
-    round: u128) -> Option<Value> {
-        let round_tuple = readonly_call(
-            peer,
-            &latest_block_id,
-            "signers-voting".into(),
-            "get-round-info".into(),
-            vec![Value::UInt(reward_cycle), Value::UInt(round)],
-        )
-        .expect_optional()
-        .unwrap();
+    round: u128,
+) -> Option<Value> {
+    let round_tuple = readonly_call(
+        peer,
+        &latest_block_id,
+        "signers-voting".into(),
+        "get-round-info".into(),
+        vec![Value::UInt(reward_cycle), Value::UInt(round)],
+    )
+    .expect_optional()
+    .unwrap();
     round_tuple
 }

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -541,3 +541,20 @@ pub fn get_signer_index(
         })
         .expect("signer not found") as u128
 }
+
+pub fn get_round_info(
+    peer: &mut TestPeer<'_>,
+    latest_block_id: StacksBlockId,
+    reward_cycle: u128,
+    round: u128) -> Option<Value> {
+        let round_tuple = readonly_call(
+            peer,
+            &latest_block_id,
+            "signers-voting".into(),
+            "get-round-info".into(),
+            vec![Value::UInt(reward_cycle), Value::UInt(round)],
+        )
+        .expect_optional()
+        .unwrap();
+    round_tuple
+}

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -541,21 +541,3 @@ pub fn get_signer_index(
         })
         .expect("signer not found") as u128
 }
-
-pub fn get_round_info(
-    peer: &mut TestPeer<'_>,
-    latest_block_id: StacksBlockId,
-    reward_cycle: u128,
-    round: u128,
-) -> Option<Value> {
-    let round_tuple = readonly_call(
-        peer,
-        &latest_block_id,
-        "signers-voting".into(),
-        "get-round-info".into(),
-        vec![Value::UInt(reward_cycle), Value::UInt(round)],
-    )
-    .expect_optional()
-    .unwrap();
-    round_tuple
-}

--- a/stackslib/src/chainstate/stacks/boot/signers_voting_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_voting_tests.rs
@@ -64,7 +64,7 @@ use crate::chainstate::stacks::boot::pox_2_tests::{
 use crate::chainstate::stacks::boot::pox_4_tests::{
     assert_latest_was_burn, get_last_block_sender_transactions, get_tip, make_test_epochs_pox,
 };
-use crate::chainstate::stacks::boot::signers_tests::{get_signer_index, prepare_signers_test};
+use crate::chainstate::stacks::boot::signers_tests::{get_signer_index, prepare_signers_test, get_round_info};
 use crate::chainstate::stacks::boot::{
     BOOT_CODE_COST_VOTING_TESTNET as BOOT_CODE_COST_VOTING, BOOT_CODE_POX_TESTNET, SIGNERS_NAME,
     SIGNERS_VOTING_NAME,
@@ -2046,6 +2046,91 @@ fn vote_for_aggregate_public_key_mixed_rounds() {
     let alice_vote_tx = &receipts[3];
     assert_eq!(alice_vote_tx.result, Value::err_uint(12)); // ERR_OUT_OF_VOTING_WINDOW
     assert_eq!(alice_vote_tx.events.len(), 0);
+}
+
+// In this test case, Alice & Bob vote & we test the new getter
+#[test]
+fn test_get_round_info() {
+     // Test setup
+     let alice = TestStacker::from_seed(&[3, 4]);
+     let bob = TestStacker::from_seed(&[5, 6]);
+     let observer = TestEventObserver::new();
+ 
+     // Alice - Signer 1
+     let alice_key = &alice.signer_private_key;
+     let alice_address = key_to_stacks_addr(alice_key);
+     let alice_principal = PrincipalData::from(alice_address);
+ 
+     // Bob - Signer 2
+     let bob_key = &bob.signer_private_key;
+     let bob_address = key_to_stacks_addr(bob_key);
+     let bob_principal = PrincipalData::from(bob_address);
+ 
+     let (mut peer, mut test_signers, latest_block_id, current_reward_cycle) = prepare_signers_test(
+         function_name!(),
+         vec![
+             (alice_principal.clone(), 1000),
+             (bob_principal.clone(), 1000),
+         ],
+         &[alice.clone(), bob.clone()],
+         Some(&observer),
+     );
+ 
+     // Alice and Bob will each have voted once while booting to Nakamoto
+     let alice_nonce = 1;
+     let bob_nonce = 1;
+ 
+     let cycle_id = current_reward_cycle;
+ 
+     // create vote txs
+     let alice_index = get_signer_index(&mut peer, latest_block_id, alice_address, cycle_id);
+     let bob_index = get_signer_index(&mut peer, latest_block_id, bob_address, cycle_id);
+ 
+     let mut signers = TestSigners::default();
+     let aggregate_key = signers.generate_aggregate_key(cycle_id as u64 + 1);
+     let aggregate_public_key = Value::buff_from(aggregate_key.compress().data.to_vec())
+         .expect("Failed to serialize aggregate public key");
+ 
+     let aggregate_public_key_ill_formed = Value::buff_from_byte(0x00);
+ 
+     let txs = vec![
+         // Alice casts vote correctly
+         make_signers_vote_for_aggregate_public_key_value(
+             alice_key,
+             alice_nonce,
+             alice_index,
+             aggregate_public_key.clone(),
+             0,
+             cycle_id + 1,
+         ),
+         // Bob casts a vote correctly
+         make_signers_vote_for_aggregate_public_key_value(
+             bob_key,
+             bob_nonce,
+             bob_index,
+             aggregate_public_key.clone(),
+             0,
+             cycle_id + 1,
+         ),
+     ];
+ 
+     //
+     // vote in the first burn block of prepare phase
+     //
+     let blocks_and_sizes = nakamoto_tenure(&mut peer, &mut test_signers, vec![txs]);
+
+    // Proceed to the next prepare phase
+    let _ = nakamoto_tenure(&mut peer, &mut test_signers, Vec::new());
+    let _ = nakamoto_tenure(&mut peer, &mut test_signers, Vec::new());
+    let _ = nakamoto_tenure(&mut peer, &mut test_signers, Vec::new());
+    let _ = nakamoto_tenure(&mut peer, &mut test_signers, Vec::new());
+    let _ = nakamoto_tenure(&mut peer, &mut test_signers, Vec::new());
+    let _ = nakamoto_tenure(&mut peer, &mut test_signers, Vec::new());
+
+     let round_info = get_round_info(&mut peer, latest_block_id, cycle_id, 0);
+
+     println!("Round Info: {:?}", round_info);
+ 
 }
 
 fn nakamoto_tenure(


### PR DESCRIPTION
### Description
This is a small PR that addresses two small issues found in the .Signers-Voting.clar Clarity contract. In draft as is it's still missing relevant tests.

### Applicable issues
#4457 
#4487 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
