### PR TITLE
fix: `target-cpu=native` flag working again

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,12 +2,11 @@
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 
-# For x86_64 CPUs, default to `native` and override in CI for release builds
-# This makes it slightly faster for users running locally built binaries.
+# Default to `native`
+# This makes it slightly faster for running tests and locally built binaries.
 # This can cause trouble when building "portable" binaries, such as for docker,
 # so disable it with the "portable" feature.
-# TODO: Same for other targets?
-[target.'cfg(all(target_arch = "x86_64", not(feature = portable))']
+[target.'cfg(not(feature = "portable"))']
 rustflags = ["-Ctarget-cpu=native"]
 
 # Needed by perf to generate flamegraphs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache musl-dev
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json,portable --release
 
 RUN cp target/release/stacks-node /out
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -10,7 +10,7 @@ COPY . .
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json,portable --release
 
 RUN cp target/release/stacks-node /out
 


### PR DESCRIPTION
### Description

Pass the flag `target-cpu=native` to `rustc` for local builds and tests for improved performance

**This PR also require stacks-network/actions#31 to be approved and merged**

### Applicable issues

- #4316 
- #4364: Original commit enabling this flag
- #4489: Broke flag being passed to `rustc` (not sure why)
