### PR TITLE
fix: use testnet consts when generating xenon config

### DIFF
--- a/stackslib/src/core/mod.rs
+++ b/stackslib/src/core/mod.rs
@@ -374,14 +374,14 @@ lazy_static! {
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch25,
-            start_height: BITCOIN_MAINNET_STACKS_25_BURN_HEIGHT,
-            end_height: BITCOIN_MAINNET_STACKS_30_BURN_HEIGHT,
+            start_height: BITCOIN_TESTNET_STACKS_25_BURN_HEIGHT,
+            end_height: BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT,
             block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_5
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch30,
-            start_height: BITCOIN_MAINNET_STACKS_30_BURN_HEIGHT,
+            start_height: BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT,
             end_height: STACKS_EPOCH_MAX,
             block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
             network_epoch: PEER_VERSION_EPOCH_3_0


### PR DESCRIPTION
I was playing around with running a xenon node off of the `next` branch (which I know won't work), and I caught a startup error that originates from validation of burnchain epochs. Looking in to the code, I caught that we were using mainnet consts instead of testnet consts.

I know these consts will definitely change, but I'd still like to get this merged, because I'm trying to help signers get their infra setup. Even if their node doesn't sync any Stacks blocks, it would be helpful to not have a startup crash.