### PR TITLE
feat: add a parity check and filter events sent to the signer instances

### DIFF
--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -447,7 +447,9 @@ impl SignerTest {
                             panic!("Received SignError {}", sign_error);
                         }
                         OperationResult::Dkg(point) => {
-                            panic!("Received aggregate_group_key {point}");
+                            // should not panic, because DKG may have just run for the
+                            //   next reward cycle.
+                            info!("Received aggregate_group_key {point}");
                         }
                     }
                 }


### PR DESCRIPTION
This adds a reward-set parity check to the signer run loop so that it only sends relevant events to the signer instances.