### PR TITLE
fix: try not deleting accepted blocks from signerDB

### DIFF
--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -73,7 +73,7 @@ pub struct BlockInfo {
     /// The associated packet nonce request if we have one
     nonce_request: Option<NonceRequest>,
     /// Whether this block is already being signed over
-    signed_over: bool,
+    pub signed_over: bool,
 }
 
 impl BlockInfo {
@@ -992,10 +992,12 @@ impl Signer {
             return;
         };
 
-        // TODO: proper garbage collection...This is currently our only cleanup of blocks
-        self.signer_db
-            .remove_block(&block_vote.signer_signature_hash)
-            .expect(&format!("{self}: Failed to remove block from to signer DB"));
+        // WIP: try not deleting a block from signerDB until we have a better garbage collection strategy.
+        // This causes issues when we have to reprocess a block and we have already deleted it from the signerDB
+        // // TODO: proper garbage collection...This is currently our only cleanup of blocks
+        // self.signer_db
+        //     .remove_block(&block_vote.signer_signature_hash)
+        //     .expect(&format!("{self}: Failed to remove block from to signer DB"));
 
         let block_submission = if block_vote.rejected {
             // We signed a rejection message. Return a rejection message

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -91,8 +91,10 @@ impl SignerDb {
         let block_json =
             serde_json::to_string(&block_info).expect("Unable to serialize block info");
         let hash = &block_info.signer_signature_hash();
+        let block_id = &block_info.block.block_id();
+        let signed_over = &block_info.signed_over;
         debug!(
-            "Inserting block_info: sighash = {hash}, vote = {:?}",
+            "Inserting block_info: sighash = {hash}, block_id = {block_id}, signed = {signed_over} vote = {:?}",
             block_info.vote.as_ref().map(|v| {
                 if v.rejected {
                     "REJECT"
@@ -117,6 +119,7 @@ impl SignerDb {
 
     /// Remove a block
     pub fn remove_block(&mut self, hash: &Sha512Trunc256Sum) -> Result<(), DBError> {
+        debug!("Deleting block_info: sighash = {hash}");
         self.db.execute(
             "DELETE FROM blocks WHERE signer_signature_hash = ?",
             &[format!("{}", hash)],


### PR DESCRIPTION
In looking at testnet logs, I've seen that we hit scenarios where a block is saved as "accepted", which deletes the block from SignerDB, and then shortly later the signer tries to process the block, but the signer has no about the block (because it's deleted).

<img width="1328" alt="image" src="https://github.com/stacks-network/stacks-core/assets/1109058/a4b73262-7ab4-40e4-a4e4-cddc442afb61">
