### PR TITLE
feat: return any value type from `execute_contract_allow_private`

### DIFF
--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -55,4 +55,4 @@ default = []
 developer-mode = []
 slog_json = ["stacks_common/slog_json"]
 testing = []
-
+devtools = []

--- a/clarity/src/vm/callables.rs
+++ b/clarity/src/vm/callables.rs
@@ -340,8 +340,8 @@ impl DefinedFunction {
     pub fn apply(&self, args: &[Value], env: &mut Environment) -> Result<Value> {
         match self.define_type {
             DefineType::Private => self.execute_apply(args, env),
-            DefineType::Public => env.execute_function_as_transaction(self, args, None),
-            DefineType::ReadOnly => env.execute_function_as_transaction(self, args, None),
+            DefineType::Public => env.execute_function_as_transaction(self, args, None, false),
+            DefineType::ReadOnly => env.execute_function_as_transaction(self, args, None, false),
         }
     }
 

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1739,7 +1739,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
                     self.roll_back()?;
                 }
                 Ok(Value::Response(data))
-            } else if allow_private {
+            } else if allow_private && cfg!(feature = "developer-mode") {
                 self.commit()?;
                 Ok(result)
             } else {

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1726,6 +1726,9 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
         self.database.roll_back()
     }
 
+    // the allow_private parameter allows private functions calls to return any Clarity type
+    // and not just Response. It only has effect is the devtools feature is enabled. eg:
+    // clarity = { version = "*", features = ["devtools"] }
     pub fn handle_tx_result(
         &mut self,
         result: Result<Value>,

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1739,7 +1739,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
                     self.roll_back()?;
                 }
                 Ok(Value::Response(data))
-            } else if allow_private && cfg!(feature = "developer-mode") {
+            } else if allow_private && cfg!(feature = "devtools") {
                 self.commit()?;
                 Ok(result)
             } else {


### PR DESCRIPTION
The helper `execute_contract_allow_private` does not allow the private function to return any type and can throw `PublicFunctionMustReturnResponse` if the private function return a non-Response value.

On Clarinet, we get recurrent requests from the community and internal teams to add the ability to call private function in unit tests 

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- N/A Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- N/A New clarity functions have corresponding PR in `clarity-benchmarking` repo
- N/A New integration test(s) added to `bitcoin-tests.yml`
