### PR TITLE
fix: `stacked_amt: u128` should serialize as string

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -213,10 +213,30 @@ fn hex_deserialize<'de, D: serde::Deserializer<'de>>(
     Ok(bytes)
 }
 
+fn serialize_u128_as_string<S>(value: &u128, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+fn deserialize_u128_from_string<'de, D>(deserializer: D) -> Result<u128, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use std::str::FromStr;
+    let s = String::deserialize(deserializer)?;
+    u128::from_str(&s).map_err(serde::de::Error::custom)
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct NakamotoSignerEntry {
     #[serde(serialize_with = "hex_serialize", deserialize_with = "hex_deserialize")]
     pub signing_key: [u8; 33],
+    #[serde(
+        serialize_with = "serialize_u128_as_string",
+        deserialize_with = "deserialize_u128_from_string"
+    )]
     pub stacked_amt: u128,
     pub weight: u32,
 }


### PR DESCRIPTION
The `stacked_amt: u128` reward set property in `/new_block` event was being serialized as a json number which is unsafe for the majority of applications which treat these as 64-bit floating point. This PR fixes the issue by serializing the large integer as a string like we do in other places. 

Note: most other json serialization for u128 values in the codebase are manually constructed rather than going directly from a rust struct, so a new serialize/deserialize helper was added for this case.