### PR TITLE
Fixes for clarity-wasm map-type functions

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1211,7 +1211,7 @@ fn write_to_wasm(
                 // `offset`.
                 let offset_buffer = (in_mem_offset as i32).to_le_bytes();
                 memory
-                    .write(&mut store, (offset) as usize, &offset_buffer)
+                    .write(&mut store, offset as usize, &offset_buffer)
                     .map_err(|e| Error::Wasm(WasmError::UnableToWriteMemory(e.into())))?;
                 written += 4;
                 let len_buffer = (in_mem_written as i32).to_le_bytes();

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -4355,8 +4355,8 @@ fn link_map_get_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32,
+             mut key_offset: i32,
+             mut key_length: i32,
              return_offset: i32,
              _return_length: i32| {
                 // Get the memory from the caller
@@ -4382,6 +4382,10 @@ fn link_map_get_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,
@@ -4444,10 +4448,10 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32,
-             value_offset: i32,
-             value_length: i32| {
+             mut key_offset: i32,
+             mut key_length: i32,
+             mut value_offset: i32,
+             mut value_length: i32| {
                 if caller.data().global_context.is_read_only() {
                     return Err(CheckErrors::WriteAttemptedInReadOnly.into());
                 }
@@ -4477,6 +4481,10 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,
@@ -4487,6 +4495,10 @@ fn link_map_set_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Error>
                 )?;
 
                 // Read in the value from the Wasm memory
+                if is_in_memory_type(&data_types.value_type) {
+                    (value_offset, value_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, value_offset)?;
+                }
                 let value = read_from_wasm(
                     memory,
                     &mut caller,
@@ -4546,10 +4558,10 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32,
-             value_offset: i32,
-             value_length: i32| {
+             mut key_offset: i32,
+             mut key_length: i32,
+             mut value_offset: i32,
+             mut value_length: i32| {
                 if caller.data().global_context.is_read_only() {
                     return Err(CheckErrors::WriteAttemptedInReadOnly.into());
                 }
@@ -4579,6 +4591,10 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,
@@ -4589,6 +4605,10 @@ fn link_map_insert_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                 )?;
 
                 // Read in the value from the Wasm memory
+                if is_in_memory_type(&data_types.value_type) {
+                    (value_offset, value_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, value_offset)?;
+                }
                 let value = read_from_wasm(
                     memory,
                     &mut caller,
@@ -4648,8 +4668,8 @@ fn link_map_delete_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
             |mut caller: Caller<'_, ClarityWasmContext>,
              name_offset: i32,
              name_length: i32,
-             key_offset: i32,
-             key_length: i32| {
+             mut key_offset: i32,
+             mut key_length: i32| {
                 if caller.data().global_context.is_read_only() {
                     return Err(CheckErrors::WriteAttemptedInReadOnly.into());
                 }
@@ -4678,6 +4698,10 @@ fn link_map_delete_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Err
                     .clone();
 
                 // Read in the key from the Wasm memory
+                if is_in_memory_type(&data_types.key_type) {
+                    (key_offset, key_length) =
+                        read_indirect_offset_and_length(memory, &mut caller, key_offset)?;
+                }
                 let key = read_from_wasm(
                     memory,
                     &mut caller,

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -658,15 +658,19 @@ pub fn get_type_in_memory_size(ty: &TypeSignature, include_repr: bool) -> i32 {
         }
         TypeSignature::OptionalType(inner) => 4 + get_type_in_memory_size(inner, true),
         TypeSignature::SequenceType(SequenceSubtype::ListType(list_data)) => {
-            let mut size =
-                list_data.get_max_len() as i32 * get_type_size(list_data.get_list_item_type());
+            let mut size = list_data.get_max_len() as i32
+                * get_type_in_memory_size(list_data.get_list_item_type(), true);
             if include_repr {
                 size += 8; // offset + length
             }
             size
         }
         TypeSignature::SequenceType(SequenceSubtype::BufferType(length)) => {
-            u32::from(length) as i32
+            let mut size = u32::from(length) as i32;
+            if include_repr {
+                size += 8; // offset + length
+            }
+            size
         }
         TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(length))) => {
             let mut size = u32::from(length) as i32 * 4;


### PR DESCRIPTION
The clarity type `Map` had a mistake in all its related functions: the key/values read from memory in the linked functions should be able to dereference them or not. This PR adds this capability.

Tests on those fixes also showed a bug while writing the values into the Wasm memory. It seems we had a few mistakes in the computation of the type sizes for lists and buffers. This PR also adds this fix.

As usual for PRs related to clarity-wasm, the tests are in the clarity-wasm repo.