### PR TITLE
fix: add reward cycle to signerdb

### DIFF
--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -317,7 +317,7 @@ impl Signer {
                 let signer_signature_hash = block.header.signer_signature_hash();
                 let mut block_info = self
                     .signer_db
-                    .block_lookup(&signer_signature_hash)
+                    .block_lookup(self.reward_cycle, &signer_signature_hash)
                     .unwrap_or_else(|_| Some(BlockInfo::new(block.clone())))
                     .unwrap_or_else(|| BlockInfo::new(block.clone()));
                 if block_info.signed_over {
@@ -339,7 +339,7 @@ impl Signer {
                         debug!("{self}: ACK: {ack:?}",);
                         block_info.signed_over = true;
                         self.signer_db
-                            .insert_block(&block_info)
+                            .insert_block(self.reward_cycle, &block_info)
                             .unwrap_or_else(|e| {
                                 error!("{self}: Failed to insert block in DB: {e:?}");
                             });
@@ -392,7 +392,10 @@ impl Signer {
             BlockValidateResponse::Ok(block_validate_ok) => {
                 let signer_signature_hash = block_validate_ok.signer_signature_hash;
                 // For mutability reasons, we need to take the block_info out of the map and add it back after processing
-                let mut block_info = match self.signer_db.block_lookup(&signer_signature_hash) {
+                let mut block_info = match self
+                    .signer_db
+                    .block_lookup(self.reward_cycle, &signer_signature_hash)
+                {
                     Ok(Some(block_info)) => block_info,
                     Ok(None) => {
                         // We have not seen this block before. Why are we getting a response for it?
@@ -407,7 +410,7 @@ impl Signer {
                 let is_valid = self.verify_block_transactions(stacks_client, &block_info.block);
                 block_info.valid = Some(is_valid);
                 self.signer_db
-                    .insert_block(&block_info)
+                    .insert_block(self.reward_cycle, &block_info)
                     .expect(&format!("{self}: Failed to insert block in DB"));
                 info!(
                     "{self}: Treating block validation for block {} as valid: {:?}",
@@ -418,7 +421,10 @@ impl Signer {
             }
             BlockValidateResponse::Reject(block_validate_reject) => {
                 let signer_signature_hash = block_validate_reject.signer_signature_hash;
-                let mut block_info = match self.signer_db.block_lookup(&signer_signature_hash) {
+                let mut block_info = match self
+                    .signer_db
+                    .block_lookup(self.reward_cycle, &signer_signature_hash)
+                {
                     Ok(Some(block_info)) => block_info,
                     Ok(None) => {
                         // We have not seen this block before. Why are we getting a response for it?
@@ -481,7 +487,7 @@ impl Signer {
             }
         }
         self.signer_db
-            .insert_block(&block_info)
+            .insert_block(self.reward_cycle, &block_info)
             .expect(&format!("{self}: Failed to insert block in DB"));
     }
 
@@ -522,7 +528,7 @@ impl Signer {
                 continue;
             }
             let sig_hash = proposal.block.header.signer_signature_hash();
-            match self.signer_db.block_lookup(&sig_hash) {
+            match self.signer_db.block_lookup(self.reward_cycle, &sig_hash) {
                 Ok(Some(block)) => {
                     debug!(
                         "{self}: Received proposal for block already known, ignoring new proposal.";
@@ -542,7 +548,7 @@ impl Signer {
                 Ok(None) => {
                     // Store the block in our cache
                     self.signer_db
-                        .insert_block(&BlockInfo::new(proposal.block.clone()))
+                        .insert_block(self.reward_cycle, &BlockInfo::new(proposal.block.clone()))
                         .unwrap_or_else(|e| {
                             error!("{self}: Failed to insert block in DB: {e:?}");
                         });
@@ -617,7 +623,7 @@ impl Signer {
 
         match self
             .signer_db
-            .block_lookup(&block_vote.signer_signature_hash)
+            .block_lookup(self.reward_cycle, &block_vote.signer_signature_hash)
             .expect(&format!("{self}: Failed to connect to DB"))
             .map(|b| b.vote)
         {
@@ -671,7 +677,7 @@ impl Signer {
         let signer_signature_hash = block.header.signer_signature_hash();
         let mut block_info = match self
             .signer_db
-            .block_lookup(&signer_signature_hash)
+            .block_lookup(self.reward_cycle, &signer_signature_hash)
             .expect("Failed to connect to signer DB")
         {
             Some(block_info) => block_info,
@@ -679,7 +685,7 @@ impl Signer {
                 debug!("{self}: We have received a block sign request for a block we have not seen before. Cache the nonce request and submit the block for validation...");
                 let block_info = BlockInfo::new_with_request(block.clone(), nonce_request.clone());
                 self.signer_db
-                    .insert_block(&block_info)
+                    .insert_block(self.reward_cycle, &block_info)
                     .expect(&format!("{self}: Failed to insert block in DB"));
                 stacks_client
                     .submit_block_for_validation(block)
@@ -699,7 +705,7 @@ impl Signer {
 
         self.determine_vote(&mut block_info, nonce_request);
         self.signer_db
-            .insert_block(&block_info)
+            .insert_block(self.reward_cycle, &block_info)
             .expect(&format!("{self}: Failed to insert block in DB"));
         true
     }
@@ -1066,7 +1072,7 @@ impl Signer {
             };
             let Some(block_info) = self
                 .signer_db
-                .block_lookup(&block_vote.signer_signature_hash)
+                .block_lookup(self.reward_cycle, &block_vote.signer_signature_hash)
                 .expect(&format!("{self}: Failed to connect to signer DB"))
             else {
                 debug!(

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -34,8 +34,10 @@ pub struct SignerDb {
 
 const CREATE_BLOCKS_TABLE: &'static str = "
 CREATE TABLE IF NOT EXISTS blocks (
-    signer_signature_hash TEXT PRIMARY KEY,
-    block_info TEXT NOT NULL
+    reward_cycle INTEGER NOT NULL,
+    signer_signature_hash TEXT NOT NULL,
+    block_info TEXT NOT NULL,
+    PRIMARY KEY (reward_cycle, signer_signature_hash)
 )";
 
 impl SignerDb {
@@ -70,11 +72,15 @@ impl SignerDb {
 
     /// Fetch a block from the database using the block's
     /// `signer_signature_hash`
-    pub fn block_lookup(&self, hash: &Sha512Trunc256Sum) -> Result<Option<BlockInfo>, DBError> {
+    pub fn block_lookup(
+        &self,
+        reward_cycle: u64,
+        hash: &Sha512Trunc256Sum,
+    ) -> Result<Option<BlockInfo>, DBError> {
         let result: Option<String> = query_row(
             &self.db,
-            "SELECT block_info FROM blocks WHERE signer_signature_hash = ?",
-            &[format!("{}", hash)],
+            "SELECT block_info FROM blocks WHERE reward_cycle = ? AND signer_signature_hash = ?",
+            &[&reward_cycle.to_string(), &format!("{}", hash)],
         )?;
         if let Some(block_info) = result {
             let block_info: BlockInfo =
@@ -87,14 +93,18 @@ impl SignerDb {
 
     /// Insert a block into the database.
     /// `hash` is the `signer_signature_hash` of the block.
-    pub fn insert_block(&mut self, block_info: &BlockInfo) -> Result<(), DBError> {
+    pub fn insert_block(
+        &mut self,
+        reward_cycle: u64,
+        block_info: &BlockInfo,
+    ) -> Result<(), DBError> {
         let block_json =
             serde_json::to_string(&block_info).expect("Unable to serialize block info");
         let hash = &block_info.signer_signature_hash();
         let block_id = &block_info.block.block_id();
         let signed_over = &block_info.signed_over;
         debug!(
-            "Inserting block_info: sighash = {hash}, block_id = {block_id}, signed = {signed_over} vote = {:?}",
+            "Inserting block_info: reward_cycle = {reward_cycle}, sighash = {hash}, block_id = {block_id}, signed = {signed_over} vote = {:?}",
             block_info.vote.as_ref().map(|v| {
                 if v.rejected {
                     "REJECT"
@@ -105,8 +115,8 @@ impl SignerDb {
         );
         self.db
             .execute(
-                "INSERT OR REPLACE INTO blocks (signer_signature_hash, block_info) VALUES (?1, ?2)",
-                &[format!("{}", hash), block_json],
+                "INSERT OR REPLACE INTO blocks (reward_cycle, signer_signature_hash, block_info) VALUES (?1, ?2, ?3)",
+                &[reward_cycle.to_string(), format!("{}", hash), block_json],
             )
             .map_err(|e| {
                 return DBError::Other(format!(
@@ -118,11 +128,15 @@ impl SignerDb {
     }
 
     /// Remove a block
-    pub fn remove_block(&mut self, hash: &Sha512Trunc256Sum) -> Result<(), DBError> {
+    pub fn remove_block(
+        &mut self,
+        reward_cycle: u64,
+        hash: &Sha512Trunc256Sum,
+    ) -> Result<(), DBError> {
         debug!("Deleting block_info: sighash = {hash}");
         self.db.execute(
-            "DELETE FROM blocks WHERE signer_signature_hash = ?",
-            &[format!("{}", hash)],
+            "DELETE FROM blocks WHERE reward_cycle = ? AND signer_signature_hash = ?",
+            &[reward_cycle.to_string(), format!("{}", hash)],
         )?;
 
         Ok(())
@@ -193,16 +207,23 @@ mod tests {
 
     fn test_basic_signer_db_with_path(db_path: impl AsRef<Path>) {
         let mut db = SignerDb::new(db_path).expect("Failed to create signer db");
+        let reward_cycle = 1;
         let (block_info, block) = create_block();
-        db.insert_block(&block_info)
+        db.insert_block(reward_cycle, &block_info)
             .expect("Unable to insert block into db");
 
         let block_info = db
-            .block_lookup(&block.header.signer_signature_hash())
+            .block_lookup(reward_cycle, &block.header.signer_signature_hash())
             .unwrap()
             .expect("Unable to get block from db");
 
         assert_eq!(BlockInfo::new(block.clone()), block_info);
+
+        // Test looking up a block from a different reward cycle
+        let block_info = db
+            .block_lookup(reward_cycle + 1, &block.header.signer_signature_hash())
+            .unwrap();
+        assert!(block_info.is_none());
     }
 
     #[test]
@@ -220,12 +241,13 @@ mod tests {
     fn test_update_block() {
         let db_path = tmp_db_path();
         let mut db = SignerDb::new(db_path).expect("Failed to create signer db");
+        let reward_cycle = 42;
         let (block_info, block) = create_block();
-        db.insert_block(&block_info)
+        db.insert_block(reward_cycle, &block_info)
             .expect("Unable to insert block into db");
 
         let block_info = db
-            .block_lookup(&block.header.signer_signature_hash())
+            .block_lookup(reward_cycle, &block.header.signer_signature_hash())
             .unwrap()
             .expect("Unable to get block from db");
 
@@ -246,11 +268,11 @@ mod tests {
             rejected: false,
         };
         block_info.vote = Some(vote.clone());
-        db.insert_block(&block_info)
+        db.insert_block(reward_cycle, &block_info)
             .expect("Unable to insert block into db");
 
         let block_info = db
-            .block_lookup(&block.header.signer_signature_hash())
+            .block_lookup(reward_cycle, &block.header.signer_signature_hash())
             .unwrap()
             .expect("Unable to get block from db");
 


### PR DESCRIPTION
The blocks should always be associated with a specific reward cycle so that the signers do not take actions on blocks from the previous cycle. This should prevent a halt like the one that we saw this morning.