### PR TITLE
feat: include signer bitvec in nakamoto block event

### DIFF
--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -102,6 +102,7 @@ pub struct MinedNakamotoBlockEvent {
     pub block_size: u64,
     pub cost: ExecutionCost,
     pub tx_events: Vec<TransactionEvent>,
+    pub signer_bitvec: String,
 }
 
 impl EventObserver {
@@ -1023,6 +1024,8 @@ impl EventDispatcher {
             return;
         }
 
+        let signer_bitvec = bytes_to_hex(block.header.signer_bitvec.serialize_to_vec().as_slice());
+
         let payload = serde_json::to_value(MinedNakamotoBlockEvent {
             target_burn_height,
             block_hash: block.header.block_hash().to_string(),
@@ -1031,6 +1034,7 @@ impl EventDispatcher {
             block_size: block_size_bytes,
             cost: consumed.clone(),
             tx_events,
+            signer_bitvec,
         })
         .unwrap();
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -52,11 +52,13 @@ use stacks::net::api::getstackers::GetStackersResponse;
 use stacks::net::api::postblock_proposal::{
     BlockValidateReject, BlockValidateResponse, NakamotoBlockProposal, ValidateRejectCode,
 };
+use stacks::util::hash::hex_bytes;
 use stacks::util_lib::boot::boot_code_id;
 use stacks::util_lib::signed_structured_data::pox4::{
     make_pox_4_signer_key_signature, Pox4SignatureTopic,
 };
 use stacks_common::address::AddressHashMode;
+use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::consts::{CHAIN_ID_TESTNET, STACKS_EPOCH_MAX};
 use stacks_common::types::chainstate::{
@@ -2142,6 +2144,13 @@ fn miner_writes_proposed_block_to_stackerdb() {
         "proposed_zero_block_hash" => &proposed_zero_block_hash,
         "proposed_block_hash" => &proposed_block_hash,
     );
+
+    let signer_bitvec_str = observed_block.signer_bitvec.clone();
+    let signer_bitvec_bytes = hex_bytes(&signer_bitvec_str).unwrap();
+    let signer_bitvec = BitVec::<4000>::consensus_deserialize(&mut signer_bitvec_bytes.as_slice())
+        .expect("Failed to deserialize signer bitvec");
+
+    assert_eq!(signer_bitvec.len(), 1);
 
     assert_eq!(
         format!("0x{}", observed_block.block_hash),


### PR DESCRIPTION
This includes the `signer_bitvec` in the `/mined_nakamoto_block` event.

- Closes #4257 

This property is formatted as a hex string, using the [`consensus_serialize` implementation of BitVec](https://github.com/stacks-network/stacks-core/blob/25fba11b99006cd2ef792f909148f2bcb41d68b0/stacks-common/src/bitvec.rs#L55). The first bytes are the length of the bitvec, encoded as a `u16`. Then the rest of the string is the bitvec data.