### PR TITLE
Chore: Remove `Box`ing of `SymbolicExpression`s

### DIFF
--- a/clarity/src/vm/ast/parser/v1.rs
+++ b/clarity/src/vm/ast/parser/v1.rs
@@ -525,7 +525,7 @@ pub fn parse_lexed(input: Vec<(LexItem, u32, u32)>) -> ParseResult<Vec<PreSymbol
                 if let Some((list, start_line, start_column, parse_context)) = parse_stack.pop() {
                     match parse_context {
                         ParseContext::CollectList => {
-                            let checked_list: ParseResult<Box<[PreSymbolicExpression]>> = list
+                            let checked_list: ParseResult<Vec<PreSymbolicExpression>> = list
                                 .into_iter()
                                 .map(|i| match i {
                                     ParseStackItem::Expression(e) => Ok(e),
@@ -601,8 +601,7 @@ pub fn parse_lexed(input: Vec<(LexItem, u32, u32)>) -> ParseResult<Vec<PreSymbol
                                     _ => unreachable!("More than four modulos of four."),
                                 }?;
                             }
-                            let mut pre_expr =
-                                PreSymbolicExpression::tuple(checked_list.into_boxed_slice());
+                            let mut pre_expr = PreSymbolicExpression::tuple(checked_list);
                             pre_expr.set_span(start_line, start_column, line_pos, column_pos);
                             handle_expression(&mut parse_stack, &mut output_list, pre_expr);
                         }
@@ -772,7 +771,7 @@ mod test {
         start_column: u32,
         end_line: u32,
         end_column: u32,
-        x: Box<[PreSymbolicExpression]>,
+        x: Vec<PreSymbolicExpression>,
     ) -> PreSymbolicExpression {
         let mut e = PreSymbolicExpression::list(x);
         e.set_span(start_line, start_column, end_line, end_column);
@@ -784,7 +783,7 @@ mod test {
         start_column: u32,
         end_line: u32,
         end_column: u32,
-        x: Box<[PreSymbolicExpression]>,
+        x: Vec<PreSymbolicExpression>,
     ) -> PreSymbolicExpression {
         let mut e = PreSymbolicExpression::tuple(x);
         e.set_span(start_line, start_column, end_line, end_column);
@@ -808,42 +807,42 @@ mod test {
                 3,
                 6,
                 11,
-                Box::new([
+                vec![
                     make_atom("let", 1, 4, 1, 6),
                     make_list(
                         1,
                         8,
                         1,
                         20,
-                        Box::new([
+                        vec![
                             make_list(
                                 1,
                                 9,
                                 1,
                                 13,
-                                Box::new([
+                                vec![
                                     make_atom("x", 1, 10, 1, 10),
                                     make_atom_value(Value::Int(1), 1, 12, 1, 12),
-                                ]),
+                                ],
                             ),
                             make_list(
                                 1,
                                 15,
                                 1,
                                 19,
-                                Box::new([
+                                vec![
                                     make_atom("y", 1, 16, 1, 16),
                                     make_atom_value(Value::Int(2), 1, 18, 1, 18),
-                                ]),
+                                ],
                             ),
-                        ]),
+                        ],
                     ),
                     make_list(
                         2,
                         5,
                         6,
                         10,
-                        Box::new([
+                        vec![
                             make_atom("+", 2, 6, 2, 6),
                             make_atom("x", 2, 8, 2, 8),
                             make_list(
@@ -851,41 +850,41 @@ mod test {
                                 9,
                                 5,
                                 16,
-                                Box::new([
+                                vec![
                                     make_atom("let", 4, 10, 4, 12),
                                     make_list(
                                         4,
                                         14,
                                         4,
                                         20,
-                                        Box::new([make_list(
+                                        vec![make_list(
                                             4,
                                             15,
                                             4,
                                             19,
-                                            Box::new([
+                                            vec![
                                                 make_atom("x", 4, 16, 4, 16),
                                                 make_atom_value(Value::Int(3), 4, 18, 4, 18),
-                                            ]),
-                                        )]),
+                                            ],
+                                        )],
                                     ),
                                     make_list(
                                         5,
                                         9,
                                         5,
                                         15,
-                                        Box::new([
+                                        vec![
                                             make_atom("+", 5, 10, 5, 10),
                                             make_atom("x", 5, 12, 5, 12),
                                             make_atom("y", 5, 14, 5, 14),
-                                        ]),
+                                        ],
                                     ),
-                                ]),
+                                ],
                             ),
                             make_atom("x", 6, 9, 6, 9),
-                        ]),
+                        ],
                     ),
-                ]),
+                ],
             ),
             make_atom("x", 6, 13, 6, 13),
             make_atom("y", 6, 15, 6, 15),
@@ -907,11 +906,11 @@ mod test {
                 9,
                 2,
                 17,
-                Box::new([
+                vec![
                     make_atom("-", 2, 10, 2, 10),
                     make_atom_value(Value::Int(12), 2, 12, 2, 13),
                     make_atom_value(Value::Int(34), 2, 15, 2, 16),
-                ]),
+                ],
             ),
         ];
 
@@ -931,10 +930,10 @@ mod test {
             1,
             1,
             11,
-            Box::new([
+            vec![
                 make_atom("id", 1, 2, 1, 3),
                 make_atom_value(Value::Int(1337), 1, 6, 1, 9),
-            ]),
+            ],
         )];
         let parsed = ast::parser::v1::parse(input);
         assert_eq!(Ok(program), parsed, "Should match expected tuple literal");

--- a/clarity/src/vm/ast/parser/v2/mod.rs
+++ b/clarity/src/vm/ast/parser/v2/mod.rs
@@ -236,7 +236,7 @@ impl<'a> Parser<'a> {
                             span.end_line = token.span.end_line;
                             span.end_column = token.span.end_column;
                             let out_nodes: Vec<_> = std::mem::take(nodes);
-                            let mut e = PreSymbolicExpression::list(out_nodes.into_boxed_slice());
+                            let mut e = PreSymbolicExpression::list(out_nodes);
                             e.copy_span(span);
                             Ok(Some(e))
                         }
@@ -253,7 +253,7 @@ impl<'a> Parser<'a> {
                             span.end_line = token.span.end_line;
                             span.end_column = token.span.end_column;
                             let out_nodes: Vec<_> = std::mem::take(nodes);
-                            let mut e = PreSymbolicExpression::list(out_nodes.into_boxed_slice());
+                            let mut e = PreSymbolicExpression::list(out_nodes);
                             e.copy_span(span);
                             Ok(Some(e))
                         }
@@ -301,8 +301,7 @@ impl<'a> Parser<'a> {
                                     open_tuple.span.clone(),
                                 )?;
                                 let out_nodes: Vec<_> = open_tuple.nodes.drain(..).collect();
-                                let mut e =
-                                    PreSymbolicExpression::tuple(out_nodes.into_boxed_slice());
+                                let mut e = PreSymbolicExpression::tuple(out_nodes);
                                 let span_before_eof = &self.tokens[self.tokens.len() - 2].span;
                                 open_tuple.span.end_line = span_before_eof.end_line;
                                 open_tuple.span.end_column = span_before_eof.end_column;
@@ -341,7 +340,7 @@ impl<'a> Parser<'a> {
                         placeholder.copy_span(&token.span);
                         open_tuple.nodes.push(placeholder); // Placeholder value
                         let out_nodes: Vec<_> = open_tuple.nodes.drain(..).collect();
-                        let mut e = PreSymbolicExpression::tuple(out_nodes.into_boxed_slice());
+                        let mut e = PreSymbolicExpression::tuple(out_nodes);
                         let span_before_eof = &self.tokens[self.tokens.len() - 2].span;
                         open_tuple.span.end_line = span_before_eof.end_line;
                         open_tuple.span.end_column = span_before_eof.end_column;
@@ -386,8 +385,7 @@ impl<'a> Parser<'a> {
                                 placeholder.copy_span(&eof_span);
                                 open_tuple.nodes.push(placeholder); // Placeholder value
                                 let out_nodes: Vec<_> = open_tuple.nodes.drain(..).collect();
-                                let mut e =
-                                    PreSymbolicExpression::tuple(out_nodes.into_boxed_slice());
+                                let mut e = PreSymbolicExpression::tuple(out_nodes);
                                 open_tuple.span.end_line =
                                     open_tuple.diagnostic_token.span.end_line;
                                 open_tuple.span.end_column =
@@ -422,7 +420,7 @@ impl<'a> Parser<'a> {
                         open_tuple.span.end_column = token.span.end_column;
                         self.next_token();
                         let out_nodes: Vec<_> = open_tuple.nodes.drain(..).collect();
-                        let mut e = PreSymbolicExpression::tuple(out_nodes.into_boxed_slice());
+                        let mut e = PreSymbolicExpression::tuple(out_nodes);
                         e.copy_span(&open_tuple.span);
                         return Ok(Some(e));
                     }
@@ -440,7 +438,7 @@ impl<'a> Parser<'a> {
                     open_tuple.span.end_column = token.span.end_column;
                     self.next_token();
                     let out_nodes: Vec<_> = open_tuple.nodes.drain(..).collect();
-                    let mut e = PreSymbolicExpression::tuple(out_nodes.into_boxed_slice());
+                    let mut e = PreSymbolicExpression::tuple(out_nodes);
                     e.copy_span(&open_tuple.span);
                     return Ok(Some(e));
                 }
@@ -479,7 +477,7 @@ impl<'a> Parser<'a> {
                 open_tuple.span.end_column = token.span.end_column;
                 self.next_token();
                 let out_nodes: Vec<_> = open_tuple.nodes.drain(..).collect();
-                let mut e = PreSymbolicExpression::tuple(out_nodes.into_boxed_slice());
+                let mut e = PreSymbolicExpression::tuple(out_nodes);
                 e.copy_span(&open_tuple.span);
                 return Ok(SetupTupleResult::Closed(e));
             }
@@ -496,7 +494,7 @@ impl<'a> Parser<'a> {
             open_tuple.span.end_column = token.span.end_column;
             self.next_token();
             let out_nodes: Vec<_> = open_tuple.nodes.drain(..).collect();
-            let mut e = PreSymbolicExpression::tuple(out_nodes.into_boxed_slice());
+            let mut e = PreSymbolicExpression::tuple(out_nodes);
             e.copy_span(&open_tuple.span);
             return Ok(SetupTupleResult::Closed(e));
         }

--- a/clarity/src/vm/ast/sugar_expander/mod.rs
+++ b/clarity/src/vm/ast/sugar_expander/mod.rs
@@ -205,7 +205,7 @@ mod test {
         start_column: u32,
         end_line: u32,
         end_column: u32,
-        x: Box<[PreSymbolicExpression]>,
+        x: Vec<PreSymbolicExpression>,
     ) -> PreSymbolicExpression {
         let mut e = PreSymbolicExpression::list(x);
         e.set_span(start_line, start_column, end_line, end_column);
@@ -217,7 +217,7 @@ mod test {
         start_column: u32,
         end_line: u32,
         end_column: u32,
-        x: Box<[PreSymbolicExpression]>,
+        x: Vec<PreSymbolicExpression>,
     ) -> PreSymbolicExpression {
         let mut e = PreSymbolicExpression::tuple(x);
         e.set_span(start_line, start_column, end_line, end_column);
@@ -305,42 +305,42 @@ mod test {
                 3,
                 6,
                 11,
-                Box::new([
+                vec![
                     make_pre_atom("let", 1, 4, 1, 6),
                     make_pre_list(
                         1,
                         8,
                         1,
                         20,
-                        Box::new([
+                        vec![
                             make_pre_list(
                                 1,
                                 9,
                                 1,
                                 13,
-                                Box::new([
+                                vec![
                                     make_pre_atom("x", 1, 10, 1, 10),
                                     make_pre_atom_value(Value::Int(1), 1, 12, 1, 12),
-                                ]),
+                                ],
                             ),
                             make_pre_list(
                                 1,
                                 15,
                                 1,
                                 19,
-                                Box::new([
+                                vec![
                                     make_pre_atom("y", 1, 16, 1, 16),
                                     make_pre_atom_value(Value::Int(2), 1, 18, 1, 18),
-                                ]),
+                                ],
                             ),
-                        ]),
+                        ],
                     ),
                     make_pre_list(
                         2,
                         5,
                         6,
                         10,
-                        Box::new([
+                        vec![
                             make_pre_atom("+", 2, 6, 2, 6),
                             make_pre_atom("x", 2, 8, 2, 8),
                             make_pre_list(
@@ -348,41 +348,41 @@ mod test {
                                 9,
                                 5,
                                 16,
-                                Box::new([
+                                vec![
                                     make_pre_atom("let", 4, 10, 4, 12),
                                     make_pre_list(
                                         4,
                                         14,
                                         4,
                                         20,
-                                        Box::new([make_pre_list(
+                                        vec![make_pre_list(
                                             4,
                                             15,
                                             4,
                                             19,
-                                            Box::new([
+                                            vec![
                                                 make_pre_atom("x", 4, 16, 4, 16),
                                                 make_pre_atom_value(Value::Int(3), 4, 18, 4, 18),
-                                            ]),
-                                        )]),
+                                            ],
+                                        )],
                                     ),
                                     make_pre_list(
                                         5,
                                         9,
                                         5,
                                         15,
-                                        Box::new([
+                                        vec![
                                             make_pre_atom("+", 5, 10, 5, 10),
                                             make_pre_atom("x", 5, 12, 5, 12),
                                             make_pre_atom("y", 5, 14, 5, 14),
-                                        ]),
+                                        ],
                                     ),
-                                ]),
+                                ],
                             ),
                             make_pre_atom("x", 6, 9, 6, 9),
-                        ]),
+                        ],
                     ),
-                ]),
+                ],
             ),
             make_pre_atom("x", 6, 13, 6, 13),
             make_pre_atom("y", 6, 15, 6, 15),
@@ -498,10 +498,10 @@ mod test {
             1,
             1,
             9,
-            Box::new([
+            vec![
                 make_pre_atom("id", 1, 2, 1, 3),
                 make_pre_atom_value(Value::Int(1337), 1, 5, 1, 8),
-            ]),
+            ],
         )];
         let ast = vec![make_list(
             1,
@@ -848,7 +848,7 @@ mod test {
         // )
         let pre_foo = make_pre_atom("foo", 2, 4, 2, 6);
         let pre_comment = make_pre_comment("this is a comment".to_string(), 3, 4, 3, 20);
-        let pre_ast = vec![make_pre_list(1, 1, 4, 1, Box::new([pre_foo, pre_comment]))];
+        let pre_ast = vec![make_pre_list(1, 1, 4, 1, vec![pre_foo, pre_comment])];
         let mut foo = make_atom("foo", 2, 4, 2, 6);
         foo.post_comments = vec![(
             "this is a comment".to_string(),

--- a/clarity/src/vm/ast/sugar_expander/mod.rs
+++ b/clarity/src/vm/ast/sugar_expander/mod.rs
@@ -77,14 +77,14 @@ impl SugarExpander {
                 PreSymbolicExpressionType::List(pre_exprs) => {
                     let drain = PreExpressionsDrain::new(pre_exprs.to_vec().drain(..), None);
                     let expression = self.transform(drain, contract_ast)?;
-                    SymbolicExpression::list(expression.into_boxed_slice())
+                    SymbolicExpression::list(expression)
                 }
                 PreSymbolicExpressionType::Tuple(pre_exprs) => {
                     let drain = PreExpressionsDrain::new(pre_exprs.to_vec().drain(..), None);
                     let expression = self.transform(drain, contract_ast)?;
                     let mut pairs = expression
                         .chunks(2)
-                        .map(|pair| pair.to_vec().into_boxed_slice())
+                        .map(|pair| pair.to_vec())
                         .map(SymbolicExpression::list)
                         .collect::<Vec<_>>();
                     pairs.insert(
@@ -96,7 +96,7 @@ impl SugarExpander {
                                 .map_err(|_| ParseErrors::InterpreterFailure)?,
                         ),
                     );
-                    SymbolicExpression::list(pairs.into_boxed_slice())
+                    SymbolicExpression::list(pairs)
                 }
                 PreSymbolicExpressionType::SugaredContractIdentifier(contract_name) => {
                     let contract_identifier =
@@ -277,7 +277,7 @@ mod test {
         start_column: u32,
         end_line: u32,
         end_column: u32,
-        x: Box<[SymbolicExpression]>,
+        x: Vec<SymbolicExpression>,
     ) -> SymbolicExpression {
         let mut e = SymbolicExpression::list(x);
         e.set_span(start_line, start_column, end_line, end_column);
@@ -395,42 +395,42 @@ mod test {
                 3,
                 6,
                 11,
-                Box::new([
+                vec![
                     make_atom("let", 1, 4, 1, 6),
                     make_list(
                         1,
                         8,
                         1,
                         20,
-                        Box::new([
+                        vec![
                             make_list(
                                 1,
                                 9,
                                 1,
                                 13,
-                                Box::new([
+                                vec![
                                     make_atom("x", 1, 10, 1, 10),
                                     make_literal_value(Value::Int(1), 1, 12, 1, 12),
-                                ]),
+                                ],
                             ),
                             make_list(
                                 1,
                                 15,
                                 1,
                                 19,
-                                Box::new([
+                                vec![
                                     make_atom("y", 1, 16, 1, 16),
                                     make_literal_value(Value::Int(2), 1, 18, 1, 18),
-                                ]),
+                                ],
                             ),
-                        ]),
+                        ],
                     ),
                     make_list(
                         2,
                         5,
                         6,
                         10,
-                        Box::new([
+                        vec![
                             make_atom("+", 2, 6, 2, 6),
                             make_atom("x", 2, 8, 2, 8),
                             make_list(
@@ -438,41 +438,41 @@ mod test {
                                 9,
                                 5,
                                 16,
-                                Box::new([
+                                vec![
                                     make_atom("let", 4, 10, 4, 12),
                                     make_list(
                                         4,
                                         14,
                                         4,
                                         20,
-                                        Box::new([make_list(
+                                        vec![make_list(
                                             4,
                                             15,
                                             4,
                                             19,
-                                            Box::new([
+                                            vec![
                                                 make_atom("x", 4, 16, 4, 16),
                                                 make_literal_value(Value::Int(3), 4, 18, 4, 18),
-                                            ]),
-                                        )]),
+                                            ],
+                                        )],
                                     ),
                                     make_list(
                                         5,
                                         9,
                                         5,
                                         15,
-                                        Box::new([
+                                        vec![
                                             make_atom("+", 5, 10, 5, 10),
                                             make_atom("x", 5, 12, 5, 12),
                                             make_atom("y", 5, 14, 5, 14),
-                                        ]),
+                                        ],
                                     ),
-                                ]),
+                                ],
                             ),
                             make_atom("x", 6, 9, 6, 9),
-                        ]),
+                        ],
                     ),
-                ]),
+                ],
             ),
             make_atom("x", 6, 13, 6, 13),
             make_atom("y", 6, 15, 6, 15),
@@ -508,19 +508,19 @@ mod test {
             1,
             1,
             9,
-            Box::new([
+            vec![
                 make_atom("tuple", 0, 0, 0, 0),
                 make_list(
                     0,
                     0,
                     0,
                     0,
-                    Box::new([
+                    vec![
                         make_atom("id", 1, 2, 1, 3),
                         make_literal_value(Value::Int(1337), 1, 5, 1, 8),
-                    ]),
+                    ],
                 ),
-            ]),
+            ],
         )];
         let contract_id = QualifiedContractIdentifier::parse(
             "S1G2081040G2081040G2081040G208105NK8PE5.contract-a",
@@ -859,7 +859,7 @@ mod test {
                 end_column: 20,
             },
         )];
-        let list = make_list(1, 1, 4, 1, Box::new([foo]));
+        let list = make_list(1, 1, 4, 1, vec![foo]);
         let ast = vec![list];
 
         let contract_id = QualifiedContractIdentifier::parse(

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -991,7 +991,7 @@ fn compute_cost(
         )));
     }
 
-    let function_invocation = [SymbolicExpression::list(program.into_boxed_slice())];
+    let function_invocation = [SymbolicExpression::list(program)];
 
     let eval_result = eval_all(
         &function_invocation,

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -609,16 +609,16 @@ mod test {
         //  (define a 59)
         //  (do_work a)
         //
-        let content = [SymbolicExpression::list(Box::new([
+        let content = [SymbolicExpression::list(vec![
             SymbolicExpression::atom("do_work".into()),
             SymbolicExpression::atom("a".into()),
-        ]))];
+        ])];
 
-        let func_body = SymbolicExpression::list(Box::new([
+        let func_body = SymbolicExpression::list(vec![
             SymbolicExpression::atom("+".into()),
             SymbolicExpression::atom_value(Value::Int(5)),
             SymbolicExpression::atom("x".into()),
-        ]));
+        ]);
 
         let func_args = vec![("x".into(), TypeSignature::IntType)];
         let user_function = DefinedFunction::new(

--- a/clarity/src/vm/representations.rs
+++ b/clarity/src/vm/representations.rs
@@ -170,8 +170,8 @@ impl StacksMessageCodec for ContractName {
 pub enum PreSymbolicExpressionType {
     AtomValue(Value),
     Atom(ClarityName),
-    List(Box<[PreSymbolicExpression]>),
-    Tuple(Box<[PreSymbolicExpression]>),
+    List(Vec<PreSymbolicExpression>),
+    Tuple(Vec<PreSymbolicExpression>),
     SugaredContractIdentifier(ContractName),
     SugaredFieldIdentifier(ContractName, ClarityName),
     FieldIdentifier(TraitIdentifier),
@@ -323,14 +323,14 @@ impl PreSymbolicExpression {
         }
     }
 
-    pub fn list(val: Box<[PreSymbolicExpression]>) -> PreSymbolicExpression {
+    pub fn list(val: Vec<PreSymbolicExpression>) -> PreSymbolicExpression {
         PreSymbolicExpression {
             pre_expr: PreSymbolicExpressionType::List(val),
             ..PreSymbolicExpression::cons()
         }
     }
 
-    pub fn tuple(val: Box<[PreSymbolicExpression]>) -> PreSymbolicExpression {
+    pub fn tuple(val: Vec<PreSymbolicExpression>) -> PreSymbolicExpression {
         PreSymbolicExpression {
             pre_expr: PreSymbolicExpressionType::Tuple(val),
             ..PreSymbolicExpression::cons()

--- a/clarity/src/vm/representations.rs
+++ b/clarity/src/vm/representations.rs
@@ -412,7 +412,7 @@ impl PreSymbolicExpression {
 pub enum SymbolicExpressionType {
     AtomValue(Value),
     Atom(ClarityName),
-    List(Box<[SymbolicExpression]>),
+    List(Vec<SymbolicExpression>),
     LiteralValue(Value),
     Field(TraitIdentifier),
     TraitReference(ClarityName, TraitDefinition),
@@ -544,7 +544,7 @@ impl SymbolicExpression {
         }
     }
 
-    pub fn list(val: Box<[SymbolicExpression]>) -> SymbolicExpression {
+    pub fn list(val: Vec<SymbolicExpression>) -> SymbolicExpression {
         SymbolicExpression {
             expr: SymbolicExpressionType::List(val),
             ..SymbolicExpression::cons()


### PR DESCRIPTION
### Description
`SymbolicExpression`s and `PreSymbolicExpression`s are unnecessarily `Box`ed in a few places in the `clarity` crate when used in `Vec`s. As `Vec`s are already on the heap, a `Box` is not necessary.

Closes #4445 