### PR TITLE
Clarity-wasm: fix computation of in-memory size

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -656,14 +656,15 @@ pub fn get_type_in_memory_size(ty: &TypeSignature, include_repr: bool) -> i32 {
             }
             size
         }
-        TypeSignature::OptionalType(inner) => 4 + get_type_in_memory_size(inner, true),
+        TypeSignature::OptionalType(inner) => 4 + get_type_in_memory_size(inner, include_repr),
         TypeSignature::SequenceType(SequenceSubtype::ListType(list_data)) => {
-            let mut size = list_data.get_max_len() as i32
-                * get_type_in_memory_size(list_data.get_list_item_type(), true);
             if include_repr {
-                size += 8; // offset + length
+                8 // offset + length
+                 + list_data.get_max_len() as i32
+                    * get_type_in_memory_size(list_data.get_list_item_type(), true)
+            } else {
+                list_data.get_max_len() as i32 * get_type_size(list_data.get_list_item_type())
             }
-            size
         }
         TypeSignature::SequenceType(SequenceSubtype::BufferType(length)) => {
             let mut size = u32::from(length) as i32;
@@ -684,14 +685,14 @@ pub fn get_type_in_memory_size(ty: &TypeSignature, include_repr: bool) -> i32 {
         TypeSignature::TupleType(tuple_ty) => {
             let mut size = 0;
             for inner_type in tuple_ty.get_type_map().values() {
-                size += get_type_in_memory_size(inner_type, true);
+                size += get_type_in_memory_size(inner_type, include_repr);
             }
             size
         }
         TypeSignature::ResponseType(res_types) => {
             // indicator: i32, ok_val: inner_types.0, err_val: inner_types.1
-            4 + get_type_in_memory_size(&res_types.0, true)
-                + get_type_in_memory_size(&res_types.1, true)
+            4 + get_type_in_memory_size(&res_types.0, include_repr)
+                + get_type_in_memory_size(&res_types.1, include_repr)
         }
         TypeSignature::ListUnionType(_) => unreachable!("not a value type"),
     }


### PR DESCRIPTION
Here is another fix for `get_type_in_memory_size`.

At first, it did not account for the actual value of an in-memory type, causing issues when returning complex types from linked functions.
Then, it accounted for it all the time, requiring too much space when sometimes not needed and breaking the function `append`.

Here is a fix that takes the best of both worlds.

This passes 500 iterations of each proptests in clarity-wasm, where the tests are.