### PR TITLE
fix: remove `--reward-cycle` from `stacks-signer run`

### DIFF
--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -55,7 +55,7 @@ pub enum Command {
     /// Run a DKG round through the stacker-db instance
     Dkg(RunDkgArgs),
     /// Run the signer, waiting for events from the stacker-db instance
-    Run(RunDkgArgs),
+    Run(RunSignerArgs),
     /// Generate necessary files for running a collection of signers
     GenerateFiles(GenerateFilesArgs),
     /// Generate a signature for Stacking transactions
@@ -124,7 +124,7 @@ pub struct PutChunkArgs {
 /// Arguments for the dkg-sign and sign command
 pub struct SignArgs {
     /// Path to config file
-    #[arg(long, value_name = "FILE")]
+    #[arg(long, short, value_name = "FILE")]
     pub config: PathBuf,
     /// The reward cycle the signer is registered for and wants to sign for
     /// Note: this must be the current reward cycle of the node
@@ -138,14 +138,22 @@ pub struct SignArgs {
 }
 
 #[derive(Parser, Debug, Clone)]
-/// Arguments for the Run and Dkg commands
+/// Arguments for the Dkg command
 pub struct RunDkgArgs {
     /// Path to config file
-    #[arg(long, value_name = "FILE")]
+    #[arg(long, short, value_name = "FILE")]
     pub config: PathBuf,
     /// The reward cycle the signer is registered for and wants to peform DKG for
     #[arg(long, short)]
     pub reward_cycle: u64,
+}
+
+#[derive(Parser, Debug, Clone)]
+/// Arguments for the Run command
+pub struct RunSignerArgs {
+    /// Path to config file
+    #[arg(long, short, value_name = "FILE")]
+    pub config: PathBuf,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -230,7 +238,7 @@ pub struct GenerateStackingSignatureArgs {
     #[arg(short, long)]
     pub reward_cycle: u64,
     /// Path to config file
-    #[arg(long, value_name = "FILE")]
+    #[arg(long, short, value_name = "FILE")]
     pub config: PathBuf,
     /// Topic for signature
     #[arg(long)]

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -46,7 +46,7 @@ use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PublicKey};
 use stacks_common::{debug, error};
 use stacks_signer::cli::{
     Cli, Command, GenerateFilesArgs, GenerateStackingSignatureArgs, GetChunkArgs,
-    GetLatestChunkArgs, PutChunkArgs, RunDkgArgs, SignArgs, StackerDBArgs,
+    GetLatestChunkArgs, PutChunkArgs, RunDkgArgs, RunSignerArgs, SignArgs, StackerDBArgs,
 };
 use stacks_signer::config::{build_signer_config_tomls, GlobalConfig};
 use stacks_signer::runloop::{RunLoop, RunLoopCommand};
@@ -252,7 +252,7 @@ fn handle_dkg_sign(args: SignArgs) {
     spawned_signer.running_signer.stop();
 }
 
-fn handle_run(args: RunDkgArgs) {
+fn handle_run(args: RunSignerArgs) {
     debug!("Running signer...");
     let spawned_signer = spawn_running_signer(&args.config);
     println!("Signer spawned successfully. Waiting for messages to process...");


### PR DESCRIPTION
Right now, when running `stacks-signer run ...`, you need to include a `--reward-cycle` argument. This is actually now longer used, but it's still required, so all of our docs/infra just use `--reward-cycle 1`.

This PR separates the args for `run` and `dkg`, so that you no longer need to pass `--reward-cycle` to `run`.

I've also added the `short` macro to all `--config` args, so you can optionally use `-c`.

NB: this will break existing infra as well as some of our docs, so we need to be mindful of updating them once this is merged.