### PR TITLE
fix: use default serialization for new RewardSet property in order to…

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -277,7 +277,8 @@ pub struct RewardSet {
     pub signers: Option<Vec<NakamotoSignerEntry>>,
     #[serde(
         serialize_with = "serialize_optional_u128_as_string",
-        deserialize_with = "deserialize_optional_u128_from_string"
+        deserialize_with = "deserialize_optional_u128_from_string",
+        default
     )]
     pub pox_ustx_threshold: Option<u128>,
 }


### PR DESCRIPTION
PR https://github.com/stacks-network/stacks-core/pull/4524 introduced a possible issue with db migrations, because it added a new and required property to a struct which may be already stored in a db. This PR makes the struct deserialize correctly in that situation.