### PR TITLE
Feat/signers subscribe to burn blocks

### DIFF
--- a/libsigner/src/events.rs
+++ b/libsigner/src/events.rs
@@ -73,6 +73,8 @@ pub enum SignerEvent {
     BlockValidationResponse(BlockValidateResponse),
     /// Status endpoint request
     StatusCheck,
+    /// A new burn block event was received
+    NewBurnBlock,
 }
 
 impl StacksMessageCodec for BlockProposalSigners {
@@ -281,6 +283,8 @@ impl EventReceiver for SignerEventReceiver {
                 process_stackerdb_event(event_receiver.local_addr, request, is_mainnet)
             } else if request.url() == "/proposal_response" {
                 process_proposal_response(request)
+            } else if request.url() == "/new_burn_block" {
+                process_new_burn_block_event(request)
             } else {
                 let url = request.url().to_string();
 
@@ -436,6 +440,16 @@ fn process_proposal_response(mut request: HttpRequest) -> Result<SignerEvent, Ev
     }
 
     Ok(SignerEvent::BlockValidationResponse(event))
+}
+
+/// Process a new burn block event from the node
+fn process_new_burn_block_event(mut request: HttpRequest) -> Result<SignerEvent, EventError> {
+    debug!("Got burn_block event");
+    let event = SignerEvent::NewBurnBlock;
+    if let Err(e) = request.respond(HttpResponse::empty(200u16)) {
+        error!("Failed to respond to request: {:?}", &e);
+    }
+    Ok(event)
 }
 
 fn get_signers_db_signer_set_message_id(name: &str) -> Option<(u32, u32)> {

--- a/libsigner/src/events.rs
+++ b/libsigner/src/events.rs
@@ -31,6 +31,7 @@ use blockstack_lib::util_lib::boot::boot_code_id;
 use clarity::vm::types::serialization::SerializationError;
 use clarity::vm::types::QualifiedContractIdentifier;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use stacks_common::codec::{
     read_next, read_next_at_most, read_next_exact, write_next, Error as CodecError,
     StacksMessageCodec,
@@ -73,8 +74,18 @@ pub enum SignerEvent {
     BlockValidationResponse(BlockValidateResponse),
     /// Status endpoint request
     StatusCheck,
-    /// A new burn block event was received
-    NewBurnBlock,
+    /// A new burn block event was received with the given burnchain block height
+    NewBurnBlock(u64),
+}
+
+/// A struct to aid in deserializing the new burn block event
+#[derive(Debug, Deserialize)]
+struct TempBurnBlockEvent {
+    burn_block_hash: String,
+    burn_block_height: u64,
+    reward_recipients: Vec<serde_json::Value>,
+    reward_slot_holders: Vec<String>,
+    burn_amount: u64,
 }
 
 impl StacksMessageCodec for BlockProposalSigners {
@@ -445,7 +456,22 @@ fn process_proposal_response(mut request: HttpRequest) -> Result<SignerEvent, Ev
 /// Process a new burn block event from the node
 fn process_new_burn_block_event(mut request: HttpRequest) -> Result<SignerEvent, EventError> {
     debug!("Got burn_block event");
-    let event = SignerEvent::NewBurnBlock;
+    let mut body = String::new();
+    if let Err(e) = request.as_reader().read_to_string(&mut body) {
+        error!("Failed to read body: {:?}", &e);
+
+        if let Err(e) = request.respond(HttpResponse::empty(200u16)) {
+            error!("Failed to respond to request: {:?}", &e);
+        }
+        return Err(EventError::MalformedRequest(format!(
+            "Failed to read body: {:?}",
+            &e
+        )));
+    }
+
+    let temp: TempBurnBlockEvent = serde_json::from_slice(body.as_bytes())
+        .map_err(|e| EventError::Deserialize(format!("Could not decode body to JSON: {:?}", &e)))?;
+    let event = SignerEvent::NewBurnBlock(temp.burn_block_height);
     if let Err(e) = request.respond(HttpResponse::empty(200u16)) {
         error!("Failed to respond to request: {:?}", &e);
     }

--- a/libsigner/src/events.rs
+++ b/libsigner/src/events.rs
@@ -78,16 +78,6 @@ pub enum SignerEvent {
     NewBurnBlock(u64),
 }
 
-/// A struct to aid in deserializing the new burn block event
-#[derive(Debug, Deserialize)]
-struct TempBurnBlockEvent {
-    burn_block_hash: String,
-    burn_block_height: u64,
-    reward_recipients: Vec<serde_json::Value>,
-    reward_slot_holders: Vec<String>,
-    burn_amount: u64,
-}
-
 impl StacksMessageCodec for BlockProposalSigners {
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError> {
         self.block.consensus_serialize(fd)?;
@@ -468,7 +458,14 @@ fn process_new_burn_block_event(mut request: HttpRequest) -> Result<SignerEvent,
             &e
         )));
     }
-
+    #[derive(Debug, Deserialize)]
+    struct TempBurnBlockEvent {
+        burn_block_hash: String,
+        burn_block_height: u64,
+        reward_recipients: Vec<serde_json::Value>,
+        reward_slot_holders: Vec<String>,
+        burn_amount: u64,
+    }
     let temp: TempBurnBlockEvent = serde_json::from_slice(body.as_bytes())
         .map_err(|e| EventError::Deserialize(format!("Could not decode body to JSON: {:?}", &e)))?;
     let event = SignerEvent::NewBurnBlock(temp.burn_block_height);

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -23,7 +23,6 @@ use std::time::Duration;
 
 use clarity::vm::errors::Error as ClarityError;
 use clarity::vm::types::serialization::SerializationError;
-use libsigner::RPCError;
 use libstackerdb::Error as StackerDBError;
 use slog::slog_debug;
 pub use stackerdb::*;
@@ -48,9 +47,6 @@ pub enum ClientError {
     /// Failed to sign stacker-db chunk
     #[error("Failed to sign stacker-db chunk: {0}")]
     FailToSign(#[from] StackerDBError),
-    /// Failed to write to stacker-db due to RPC error
-    #[error("Failed to write to stacker-db instance: {0}")]
-    PutChunkFailed(#[from] RPCError),
     /// Stacker-db instance rejected the chunk
     #[error("Stacker-db rejected the chunk. Reason: {0}")]
     PutChunkRejected(String),
@@ -72,33 +68,18 @@ pub enum ClientError {
     /// Failed to parse a Clarity value
     #[error("Received a malformed clarity value: {0}")]
     MalformedClarityValue(String),
-    /// Invalid Clarity Name
-    #[error("Invalid Clarity Name: {0}")]
-    InvalidClarityName(String),
     /// Backoff retry timeout
     #[error("Backoff retry timeout occurred. Stacks node may be down.")]
     RetryTimeout,
     /// Not connected
     #[error("Not connected")]
     NotConnected,
-    /// Invalid signing key
-    #[error("Signing key not represented in the list of signers")]
-    InvalidSigningKey,
     /// Clarity interpreter error
     #[error("Clarity interpreter error: {0}")]
     ClarityError(#[from] ClarityError),
-    /// Our stacks address does not belong to a registered signer
-    #[error("Our stacks address does not belong to a registered signer")]
-    NotRegistered,
-    /// Reward set not yet calculated for the given reward cycle
-    #[error("Reward set not yet calculated for reward cycle: {0}")]
-    RewardSetNotYetCalculated(u64),
     /// Malformed reward set
     #[error("Malformed contract data: {0}")]
     MalformedContractData(String),
-    /// No reward set exists for the given reward cycle
-    #[error("No reward set exists for reward cycle {0}")]
-    NoRewardSet(u64),
     /// Stacks node does not support a feature we need
     #[error("Stacks node does not support a required feature: {0}")]
     UnsupportedStacksFeature(String),

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -169,7 +169,7 @@ impl StackerDB {
                             warn!("Failed to send message to stackerdb due to wrong version number. Attempted {}. Expected {}. Retrying...", slot_version, slot_metadata.slot_version);
                             slot_version = slot_metadata.slot_version;
                         } else {
-                            warn!("Failed to send message to stackerdb due to wrong version number. Attempted {}. Expected unkown version number. Incrementing and retrying...", slot_version);
+                            warn!("Failed to send message to stackerdb due to wrong version number. Attempted {}. Expected unknown version number. Incrementing and retrying...", slot_version);
                         }
                         if let Some(versions) = self.slot_versions.get_mut(&msg_id) {
                             // NOTE: per the above, this is always executed

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -46,6 +46,7 @@ use wsts::curve::point::{Compressed, Point};
 
 use crate::client::{retry_with_exponential_backoff, ClientError};
 use crate::config::GlobalConfig;
+use crate::runloop::RewardCycleInfo;
 
 /// The Stacks signer client used to communicate with the stacks node
 #[derive(Clone, Debug)]
@@ -363,16 +364,23 @@ impl StacksClient {
         Ok(peer_info.burn_block_height)
     }
 
-    /// Get the current reward cycle from the stacks node
-    pub fn get_current_reward_cycle(&self) -> Result<u64, ClientError> {
+    /// Get the current reward cycle info from the stacks node
+    pub fn get_current_reward_cycle_info(&self) -> Result<RewardCycleInfo, ClientError> {
         let pox_data = self.get_pox_data()?;
         let blocks_mined = pox_data
             .current_burnchain_block_height
             .saturating_sub(pox_data.first_burnchain_block_height);
-        let reward_cycle_length = pox_data
+        let reward_phase_block_length = pox_data
             .reward_phase_block_length
             .saturating_add(pox_data.prepare_phase_block_length);
-        Ok(blocks_mined / reward_cycle_length)
+        let reward_cycle = blocks_mined / reward_phase_block_length;
+        Ok(RewardCycleInfo {
+            reward_cycle,
+            reward_phase_block_length,
+            prepare_phase_block_length: pox_data.prepare_phase_block_length,
+            first_burnchain_block_height: pox_data.first_burnchain_block_height,
+            last_burnchain_block_height: pox_data.current_burnchain_block_height,
+        })
     }
 
     /// Helper function to retrieve the account info from the stacks node for a specific address
@@ -735,9 +743,9 @@ mod tests {
     fn valid_reward_cycle_should_succeed() {
         let mock = MockServerClient::new();
         let (pox_data_response, pox_data) = build_get_pox_data_response(None, None, None, None);
-        let h = spawn(move || mock.client.get_current_reward_cycle());
+        let h = spawn(move || mock.client.get_current_reward_cycle_info());
         write_response(mock.server, pox_data_response.as_bytes());
-        let current_cycle_id = h.join().unwrap().unwrap();
+        let current_cycle_info = h.join().unwrap().unwrap();
         let blocks_mined = pox_data
             .current_burnchain_block_height
             .saturating_sub(pox_data.first_burnchain_block_height);
@@ -745,13 +753,13 @@ mod tests {
             .reward_phase_block_length
             .saturating_add(pox_data.prepare_phase_block_length);
         let id = blocks_mined / reward_cycle_length;
-        assert_eq!(current_cycle_id, id);
+        assert_eq!(current_cycle_info.reward_cycle, id);
     }
 
     #[test]
     fn invalid_reward_cycle_should_fail() {
         let mock = MockServerClient::new();
-        let h = spawn(move || mock.client.get_current_reward_cycle());
+        let h = spawn(move || mock.client.get_current_reward_cycle_info());
         write_response(
             mock.server,
             b"HTTP/1.1 200 Ok\n\n{\"current_cycle\":{\"id\":\"fake id\", \"is_pox_active\":false}}",

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -202,7 +202,8 @@ impl SignerTest {
         let current_block_height = self
             .running_nodes
             .btc_regtest_controller
-            .get_headers_height();
+            .get_headers_height()
+            .saturating_sub(1); // Must subtract 1 since get_headers_height returns current block height + 1
         let curr_reward_cycle = self.get_current_reward_cycle();
         let next_reward_cycle = curr_reward_cycle.saturating_add(1);
         let next_reward_cycle_height = self
@@ -221,15 +222,14 @@ impl SignerTest {
         let current_block_height = self
             .running_nodes
             .btc_regtest_controller
-            .get_headers_height();
+            .get_headers_height()
+            .saturating_sub(1); // Must subtract 1 since get_headers_height returns current block height + 1
         let reward_cycle_height = self
             .running_nodes
             .btc_regtest_controller
             .get_burnchain()
             .reward_cycle_to_block_height(reward_cycle);
-        reward_cycle_height
-            .saturating_sub(current_block_height)
-            .saturating_sub(1)
+        reward_cycle_height.saturating_sub(current_block_height)
     }
 
     // Only call after already past the epoch 3.0 boundary
@@ -245,23 +245,26 @@ impl SignerTest {
             .running_nodes
             .btc_regtest_controller
             .get_headers_height()
+            .saturating_sub(1) // Must subtract 1 since get_headers_height returns current block height + 1
             .saturating_add(nmb_blocks_to_mine_to_dkg);
+        let mut point = None;
         info!("Mining {nmb_blocks_to_mine_to_dkg} Nakamoto block(s) to reach DKG calculation at block height {end_block_height}");
         for i in 1..=nmb_blocks_to_mine_to_dkg {
             info!("Mining Nakamoto block #{i} of {nmb_blocks_to_mine_to_dkg}");
             self.mine_nakamoto_block(timeout);
             let hash = self.wait_for_validate_ok_response(timeout);
-            let signatures = self.wait_for_frost_signatures(timeout);
+            let (signatures, points) = if i != nmb_blocks_to_mine_to_dkg {
+                (self.wait_for_frost_signatures(timeout), vec![])
+            } else {
+                self.wait_for_dkg_and_frost_signatures(timeout)
+            };
             // Verify the signers accepted the proposed block and are using the new DKG to sign it
             for signature in &signatures {
                 assert!(signature.verify(&set_dkg, hash.0.as_slice()));
             }
+            point = points.last().copied();
         }
-        if nmb_blocks_to_mine_to_dkg == 0 {
-            None
-        } else {
-            Some(self.wait_for_dkg(timeout))
-        }
+        point
     }
 
     // Only call after already past the epoch 3.0 boundary
@@ -292,7 +295,13 @@ impl SignerTest {
                 )
             }
             if total_nmb_blocks_to_mine >= nmb_blocks_to_reward_cycle {
-                debug!("Mining {nmb_blocks_to_reward_cycle} Nakamoto block(s) to reach the next reward cycle boundary.");
+                let end_block_height = self
+                    .running_nodes
+                    .btc_regtest_controller
+                    .get_headers_height()
+                    .saturating_sub(1) // Must subtract 1 since get_headers_height returns current block height + 1
+                    .saturating_add(nmb_blocks_to_reward_cycle);
+                debug!("Mining {nmb_blocks_to_reward_cycle} Nakamoto block(s) to reach the next reward cycle boundary at {end_block_height}.");
                 for i in 1..=nmb_blocks_to_reward_cycle {
                     debug!("Mining Nakamoto block #{i} of {nmb_blocks_to_reward_cycle}");
                     let curr_reward_cycle = self.get_current_reward_cycle();
@@ -314,7 +323,8 @@ impl SignerTest {
                 blocks_to_dkg = self.nmb_blocks_to_reward_set_calculation();
             }
         }
-        for _ in 1..=total_nmb_blocks_to_mine {
+        for i in 1..=total_nmb_blocks_to_mine {
+            info!("Mining Nakamoto block #{i} of {total_nmb_blocks_to_mine} to reach {burnchain_height}");
             let curr_reward_cycle = self.get_current_reward_cycle();
             let set_dkg = self
                 .stacks_client
@@ -419,6 +429,61 @@ impl SignerTest {
         }
         debug!("Finished waiting for DKG!");
         key
+    }
+
+    fn wait_for_dkg_and_frost_signatures(
+        &mut self,
+        timeout: Duration,
+    ) -> (Vec<Signature>, Vec<Point>) {
+        debug!("Waiting for DKG and frost signatures...");
+        let mut sigs = Vec::new();
+        let mut keys = Vec::new();
+        let sign_now = Instant::now();
+        for recv in self.result_receivers.iter() {
+            let mut frost_signature = None;
+            let mut aggregate_public_key = None;
+            loop {
+                let results = recv
+                    .recv_timeout(timeout)
+                    .expect("failed to recv dkg and signature results");
+                for result in results {
+                    match result {
+                        OperationResult::Sign(sig) => {
+                            info!("Received Signature ({},{})", &sig.R, &sig.z);
+                            frost_signature = Some(sig);
+                        }
+                        OperationResult::SignTaproot(proof) => {
+                            panic!("Received SchnorrProof ({},{})", &proof.r, &proof.s);
+                        }
+                        OperationResult::DkgError(dkg_error) => {
+                            panic!("Received DkgError {:?}", dkg_error);
+                        }
+                        OperationResult::SignError(sign_error) => {
+                            panic!("Received SignError {}", sign_error);
+                        }
+                        OperationResult::Dkg(point) => {
+                            info!("Received aggregate_group_key {point}");
+                            aggregate_public_key = Some(point);
+                        }
+                    }
+                }
+                if (frost_signature.is_some() && aggregate_public_key.is_some())
+                    || sign_now.elapsed() > timeout
+                {
+                    break;
+                }
+            }
+
+            let frost_signature = frost_signature
+                .expect(&format!("Failed to get frost signature within {timeout:?}"));
+            let key = aggregate_public_key.expect(&format!(
+                "Failed to get aggregate public key within {timeout:?}"
+            ));
+            sigs.push(frost_signature);
+            keys.push(key);
+        }
+        debug!("Finished waiting for DKG and frost signatures!");
+        (sigs, keys)
     }
 
     fn wait_for_frost_signatures(&mut self, timeout: Duration) -> Vec<Signature> {

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -804,7 +804,11 @@ fn setup_stx_btc_node(
 
         naka_conf.events_observers.insert(EventObserverConfig {
             endpoint: format!("{}", signer_config.endpoint),
-            events_keys: vec![EventKeyType::StackerDBChunks, EventKeyType::BlockProposal],
+            events_keys: vec![
+                EventKeyType::StackerDBChunks,
+                EventKeyType::BlockProposal,
+                EventKeyType::BurnchainBlocks,
+            ],
         });
     }
 


### PR DESCRIPTION
- Subscribes to burn block events
- Store current reward cycle on the side. Only refresh reward cycle when a new burn block event arrives (prevents spamming the node needlessly)
- Only attempt to initialize/refresh the current reward cycle signer if initializing the runloop
- Only attempt to refresh a signer config for the NEXT reward cycle if in the prepare phase during runloop initialization OR have received a new burn block in the prepare phase and have still not been registered
- Removes unused ClientErrors
- This uncovered a bug in poststackerdbchunk error codes. Cleaned up as part of this PR

Closes: https://github.com/stacks-network/stacks-core/issues/4504