### PR TITLE
2.5: PoX missed-slot updates

### DIFF
--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -92,6 +92,16 @@ impl StacksEpochId {
             StacksEpochId::Epoch24 | StacksEpochId::Epoch25 | StacksEpochId::Epoch30 => true,
         }
     }
+
+    /// Does this epoch support unlocking PoX contributors that miss a slot?
+    ///
+    /// Epoch 2.0 - 2.05 didn't support this feature, but they weren't epoch-guarded on it. Instead,
+    ///  the behavior never activates in those epochs because the Pox1 contract does not provide
+    ///  `contibuted_stackers` information. This check maintains that exact semantics by returning
+    ///  true for all epochs before 2.5. For 2.5 and after, this returns false.
+    pub fn supports_pox_missed_slot_unlocks(&self) -> bool {
+        self < &StacksEpochId::Epoch25
+    }
 }
 
 impl std::fmt::Display for StacksEpochId {

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -432,7 +432,7 @@ impl StacksChainState {
         cycle_number: u64,
         cycle_info: Option<PoxStartCycleInfo>,
     ) -> Result<Vec<StacksTransactionEvent>, Error> {
-        Self::handle_pox_cycle_start(clarity, cycle_number, cycle_info, POX_2_NAME)
+        Self::handle_pox_cycle_missed_unlocks(clarity, cycle_number, cycle_info, &PoxVersions::Pox2)
     }
 
     /// Do all the necessary Clarity operations at the start of a PoX reward cycle.
@@ -444,7 +444,7 @@ impl StacksChainState {
         cycle_number: u64,
         cycle_info: Option<PoxStartCycleInfo>,
     ) -> Result<Vec<StacksTransactionEvent>, Error> {
-        Self::handle_pox_cycle_start(clarity, cycle_number, cycle_info, POX_3_NAME)
+        Self::handle_pox_cycle_missed_unlocks(clarity, cycle_number, cycle_info, &PoxVersions::Pox3)
     }
 
     /// Do all the necessary Clarity operations at the start of a PoX reward cycle.
@@ -452,29 +452,36 @@ impl StacksChainState {
     ///
     /// This should only be called for PoX v4 cycles.
     pub fn handle_pox_cycle_start_pox_4(
-        clarity: &mut ClarityTransactionConnection,
-        cycle_number: u64,
-        cycle_info: Option<PoxStartCycleInfo>,
+        _clarity: &mut ClarityTransactionConnection,
+        _cycle_number: u64,
+        _cycle_info: Option<PoxStartCycleInfo>,
     ) -> Result<Vec<StacksTransactionEvent>, Error> {
-        Self::handle_pox_cycle_start(clarity, cycle_number, cycle_info, POX_4_NAME)
+        // PASS
+        Ok(vec![])
     }
 
     /// Do all the necessary Clarity operations at the start of a PoX reward cycle.
     /// Currently, this just means applying any auto-unlocks to Stackers who qualified.
     ///
-    fn handle_pox_cycle_start(
+    fn handle_pox_cycle_missed_unlocks(
         clarity: &mut ClarityTransactionConnection,
         cycle_number: u64,
         cycle_info: Option<PoxStartCycleInfo>,
-        pox_contract_name: &str,
+        pox_contract_ver: &PoxVersions,
     ) -> Result<Vec<StacksTransactionEvent>, Error> {
         clarity.with_clarity_db(|db| Ok(Self::mark_pox_cycle_handled(db, cycle_number)))??;
+
+        if !matches!(pox_contract_ver, PoxVersions::Pox2 | PoxVersions::Pox3) {
+            return Err(Error::InvalidStacksBlock(format!(
+                "Attempted to invoke missed unlocks handling on invalid PoX version ({pox_contract_ver})"
+            )));
+        }
 
         debug!(
             "Handling PoX reward cycle start";
             "reward_cycle" => cycle_number,
             "cycle_active" => cycle_info.is_some(),
-            "pox_contract" => pox_contract_name
+            "pox_contract" => %pox_contract_ver,
         );
 
         let cycle_info = match cycle_info {
@@ -483,7 +490,8 @@ impl StacksChainState {
         };
 
         let sender_addr = PrincipalData::from(boot::boot_code_addr(clarity.is_mainnet()));
-        let pox_contract = boot::boot_code_id(pox_contract_name, clarity.is_mainnet());
+        let pox_contract =
+            boot::boot_code_id(pox_contract_ver.get_name_str(), clarity.is_mainnet());
 
         let mut total_events = vec![];
         for (principal, amount_locked) in cycle_info.missed_reward_slots.iter() {
@@ -509,7 +517,8 @@ impl StacksChainState {
             }).expect("FATAL: failed to accelerate PoX unlock");
 
             // query the stacking state for this user before deleting it
-            let user_data = Self::get_user_stacking_state(clarity, principal, pox_contract_name);
+            let user_data =
+                Self::get_user_stacking_state(clarity, principal, pox_contract_ver.get_name_str());
 
             // perform the unlock
             let (result, _, mut events, _) = clarity
@@ -814,12 +823,19 @@ impl StacksChainState {
             //   pointer set by the PoX contract, then add them to auto-unlock list
             if slots_taken == 0 && !contributed_stackers.is_empty() {
                 info!(
-                    "Stacker missed reward slot, added to unlock list";
-                    //                    "stackers" => %VecDisplay(&contributed_stackers),
+                    "{}",
+                    if epoch_id.supports_pox_missed_slot_unlocks() {
+                        "Stacker missed reward slot, added to unlock list"
+                    } else {
+                        "Stacker missed reward slot"
+                    };
                     "reward_address" => %address.clone().to_b58(),
                     "threshold" => threshold,
                     "stacked_amount" => stacked_amt
                 );
+                if !epoch_id.supports_pox_missed_slot_unlocks() {
+                    continue;
+                }
                 contributed_stackers
                     .sort_by_cached_key(|(stacker, ..)| to_hex(&stacker.serialize_to_vec()));
                 while let Some((contributor, amt)) = contributed_stackers.pop() {
@@ -838,6 +854,9 @@ impl StacksChainState {
                     missed_slots.push((contributor, total_amount));
                 }
             }
+        }
+        if !epoch_id.supports_pox_missed_slot_unlocks() {
+            missed_slots.clear();
         }
         info!("Reward set calculated"; "slots_occuppied" => reward_set.len());
         RewardSet {

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -356,63 +356,6 @@
 (define-read-only (get-reward-set-pox-address (reward-cycle uint) (index uint))
     (map-get? reward-cycle-pox-address-list { reward-cycle: reward-cycle, index: index }))
 
-(define-private (fold-unlock-reward-cycle (set-index uint)
-                                          (data-res (response { cycle: uint,
-                                                      first-unlocked-cycle: uint,
-                                                      stacker: principal
-                                                    } int)))
-    (let ((data (try! data-res))
-          (cycle (get cycle data))
-          (first-unlocked-cycle (get first-unlocked-cycle data)))
-         ;; if current-cycle hasn't reached first-unlocked-cycle, just continue to next iter
-         (asserts! (>= cycle first-unlocked-cycle) (ok (merge data { cycle: (+ u1 cycle) })))
-         (let ((cycle-entry (unwrap-panic (map-get? reward-cycle-pox-address-list { reward-cycle: cycle, index: set-index })))
-               (cycle-entry-u (get stacker cycle-entry))
-               (cycle-entry-total-ustx (get total-ustx cycle-entry))
-               (cycle-last-entry-ix (- (get len (unwrap-panic (map-get? reward-cycle-pox-address-list-len { reward-cycle: cycle }))) u1)))
-            (asserts! (is-eq cycle-entry-u (some (get stacker data))) (err ERR_STACKING_CORRUPTED_STATE))
-            (if (not (is-eq cycle-last-entry-ix set-index))
-                ;; do a "move" if the entry to remove isn't last
-                (let ((move-entry (unwrap-panic (map-get? reward-cycle-pox-address-list { reward-cycle: cycle, index: cycle-last-entry-ix }))))
-                    (map-set reward-cycle-pox-address-list
-                             { reward-cycle: cycle, index: set-index }
-                             move-entry)
-                    (match (get stacker move-entry) moved-stacker
-                     ;; if the moved entry had an associated stacker, update its state
-                     (let ((moved-state (unwrap-panic (map-get? stacking-state { stacker: moved-stacker })))
-                           ;; calculate the index into the reward-set-indexes that `cycle` is at
-                           (moved-cycle-index (- cycle (get first-reward-cycle moved-state)))
-                           (moved-reward-list (get reward-set-indexes moved-state))
-                           ;; reward-set-indexes[moved-cycle-index] = set-index via slice?, append, concat.
-                           (update-list (unwrap-panic (replace-at? moved-reward-list moved-cycle-index set-index))))
-                          (map-set stacking-state { stacker: moved-stacker }
-                                   (merge moved-state { reward-set-indexes: update-list })))
-                     ;; otherwise, we don't need to update stacking-state after move
-                     true))
-                ;; if not moving, just noop
-                true)
-            ;; in all cases, we now need to delete the last list entry
-            (map-delete reward-cycle-pox-address-list { reward-cycle: cycle, index: cycle-last-entry-ix })
-            (map-set reward-cycle-pox-address-list-len { reward-cycle: cycle } { len: cycle-last-entry-ix })
-            ;; finally, update `reward-cycle-total-stacked`
-            (map-set reward-cycle-total-stacked { reward-cycle: cycle }
-                { total-ustx: (- (get total-ustx (unwrap-panic (map-get? reward-cycle-total-stacked { reward-cycle: cycle })))
-                                 cycle-entry-total-ustx) })
-            (ok (merge data { cycle: (+ u1 cycle)} )))))
-
-;; This method is called by the Stacks block processor directly in order to handle the contract state mutations
-;;  associated with an early unlock. This can only be invoked by the block processor: it is private, and no methods
-;;  from this contract invoke it.
-(define-private (handle-unlock (user principal) (amount-locked uint) (cycle-to-unlock uint))
-    (let ((user-stacking-state (unwrap-panic (map-get? stacking-state { stacker: user })))
-          (first-cycle-locked (get first-reward-cycle user-stacking-state))
-          (reward-set-indexes (get reward-set-indexes user-stacking-state)))
-        ;; iterate over each reward set the user is a member of, and remove them from the sets. only apply to reward sets after cycle-to-unlock.
-        (try! (fold fold-unlock-reward-cycle reward-set-indexes (ok { cycle: first-cycle-locked, first-unlocked-cycle: cycle-to-unlock, stacker: user })))
-        ;; Now that we've cleaned up all the reward set entries for the user, delete the user's stacking-state
-        (map-delete stacking-state { stacker: user })
-        (ok true)))
-
 ;; Add a PoX address to the `cycle-index`-th reward cycle, if `cycle-index` is between 0 and the given num-cycles (exclusive).
 ;; Arguments are given as a tuple, so this function can be (folded ..)'ed onto a list of its arguments.
 ;; Used by add-pox-addr-to-reward-cycles.

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -1867,6 +1867,7 @@ pub mod test {
         pub winner_txid: Txid,
         pub matured_rewards: Vec<MinerReward>,
         pub matured_rewards_info: Option<MinerRewardInfo>,
+        pub reward_set_data: Option<RewardSetData>,
     }
 
     pub struct TestEventObserver {
@@ -1912,6 +1913,7 @@ pub mod test {
                 winner_txid,
                 matured_rewards: matured_rewards.to_owned(),
                 matured_rewards_info: matured_rewards_info.map(|info| info.clone()),
+                reward_set_data: reward_set_data.clone(),
             })
         }
 


### PR DESCRIPTION
### Description

This PR removes the unlock behavior of PoX-4 when solo stackers miss a reward slot. This behavior was broken `next`: missed reward slot unlocks have consequences for signer set calculation, which has to be addressed. This PR addresses it by removing the unlock behavior.

This PR also adds a test that covers the case of a 2.5 reward cycle having participation but no slots. Such a cycle should still allow the system to make forward progress in 2.5.
