### PR TITLE
fix: allow `nakamoto-neon` mode

### DIFF
--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -469,8 +469,8 @@ impl PoxConstants {
     pub fn regtest_default() -> PoxConstants {
         PoxConstants::new(
             5,
-            1,
-            1,
+            3,
+            2,
             3333333333333333,
             1,
             BITCOIN_REGTEST_FIRST_BLOCK_HEIGHT + POX_SUNSET_START,

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1299,6 +1299,8 @@ mod tests {
         });
 
         let mut burnchain = Burnchain::regtest("nope");
+        burnchain.pox_constants.prepare_length = 1;
+        burnchain.pox_constants.anchor_threshold = 1;
         burnchain.pox_constants.sunset_start = 16843019;
         burnchain.pox_constants.sunset_end = 16843020;
 
@@ -1351,6 +1353,8 @@ mod tests {
         });
 
         let mut burnchain = Burnchain::regtest("nope");
+        burnchain.pox_constants.prepare_length = 1;
+        burnchain.pox_constants.anchor_threshold = 1;
         burnchain.pox_constants.sunset_start = 16843019;
         burnchain.pox_constants.sunset_end = 16843020;
 
@@ -1426,6 +1430,8 @@ mod tests {
         });
 
         let mut burnchain = Burnchain::regtest("nope");
+        burnchain.pox_constants.prepare_length = 1;
+        burnchain.pox_constants.anchor_threshold = 1;
         burnchain.pox_constants.sunset_start = 16843019;
         burnchain.pox_constants.sunset_end = 16843020;
 
@@ -1468,6 +1474,8 @@ mod tests {
         });
 
         let mut burnchain = Burnchain::regtest("nope");
+        burnchain.pox_constants.prepare_length = 1;
+        burnchain.pox_constants.anchor_threshold = 1;
         burnchain.pox_constants.sunset_start = 16843019;
         burnchain.pox_constants.sunset_end = 16843020;
 
@@ -1519,6 +1527,8 @@ mod tests {
         });
 
         let mut burnchain = Burnchain::regtest("nope");
+        burnchain.pox_constants.prepare_length = 1;
+        burnchain.pox_constants.anchor_threshold = 1;
         burnchain.pox_constants.sunset_start = 16843019;
         burnchain.pox_constants.sunset_end = 16843020;
 
@@ -1594,6 +1604,8 @@ mod tests {
         });
 
         let mut burnchain = Burnchain::regtest("nope");
+        burnchain.pox_constants.prepare_length = 1;
+        burnchain.pox_constants.anchor_threshold = 1;
         burnchain.pox_constants.sunset_start = 16843019;
         burnchain.pox_constants.sunset_end = 16843020;
 
@@ -1711,6 +1723,8 @@ mod tests {
             );
 
             let mut burnchain = Burnchain::regtest("nope");
+            burnchain.pox_constants.prepare_length = 1;
+            burnchain.pox_constants.anchor_threshold = 1;
             burnchain.pox_constants.sunset_start = block_height;
             burnchain.pox_constants.sunset_end = block_height + 1;
 

--- a/stackslib/src/core/mod.rs
+++ b/stackslib/src/core/mod.rs
@@ -443,13 +443,13 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch25,
             start_height: 6000,
-            end_height: 7000,
+            end_height: 7001,
             block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_5
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch30,
-            start_height: 7000,
+            start_height: 7001,
             end_height: STACKS_EPOCH_MAX,
             block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
             network_epoch: PEER_VERSION_EPOCH_3_0

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -437,6 +437,7 @@ fn main() {
             return;
         }
     } else if conf.burnchain.mode == "neon"
+        || conf.burnchain.mode == "nakamoto-neon"
         || conf.burnchain.mode == "xenon"
         || conf.burnchain.mode == "krypton"
         || conf.burnchain.mode == "mainnet"


### PR DESCRIPTION
PR #4577 removed `nakamoto-neon` mode, in order to make nakamoto the default, but did not remove `nakamoto-neon` everywhere. This change re-adds support for "nakamoto-neon" mode, but also leaves nakamoto mode as the default for xenon and mainnet modes. 

Some integration tests failed in #4577, but the PR was merged anyway because it seems that the "Bitcoin Tests / Check Tests" check is not required. @wileyj can we make that check required now?