### PR TITLE
feat: add flag to output signer key signature in JSON

### DIFF
--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 
 use blockstack_lib::chainstate::stacks::address::PoxAddress;
 use blockstack_lib::util_lib::signed_structured_data::pox4::Pox4SignatureTopic;
-use clap::{Parser, ValueEnum};
+use clap::{ArgAction, Parser, ValueEnum};
 use clarity::vm::types::QualifiedContractIdentifier;
 use stacks_common::address::b58;
 use stacks_common::types::chainstate::StacksPrivateKey;
@@ -234,13 +234,14 @@ pub struct GenerateStackingSignatureArgs {
     /// BTC address used to receive rewards
     #[arg(short, long, value_parser = parse_pox_addr)]
     pub pox_address: PoxAddress,
-    /// The reward cycle to be used in the signature's message hash
+    /// The reward cycle during which this signature
+    /// can be used
     #[arg(short, long)]
     pub reward_cycle: u64,
-    /// Path to config file
+    /// Path to signer config file
     #[arg(long, short, value_name = "FILE")]
     pub config: PathBuf,
-    /// Topic for signature
+    /// Stacking method that can be used
     #[arg(long)]
     pub method: StackingSignatureMethod,
     /// Number of cycles used as a lock period.
@@ -253,6 +254,9 @@ pub struct GenerateStackingSignatureArgs {
     /// A unique identifier to prevent re-using this authorization
     #[arg(long)]
     pub auth_id: u128,
+    /// Output information in JSON format
+    #[arg(long, action=ArgAction::SetTrue, required=false)]
+    pub json: bool,
 }
 
 /// Parse the contract ID

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -320,12 +320,27 @@ fn handle_generate_stacking_signature(
     )
     .expect("Failed to generate signature");
 
-    if do_print {
-        println!(
-            "\nSigner Public Key: 0x{}\nSigner Key Signature: 0x{}\n\n",
+    let output_str = if args.json {
+        serde_json::to_string_pretty(&serde_json::json!({
+            "signerKey": to_hex(&public_key.to_bytes_compressed()),
+            "signerSignature": to_hex(signature.to_rsv().as_slice()),
+            "authId": format!("{}", args.auth_id),
+            "rewardCycle": args.reward_cycle,
+            "maxAmount": format!("{}", args.max_amount),
+            "period": args.period,
+            "poxAddress": args.pox_address.to_b58(),
+        }))
+        .expect("Failed to serialize JSON")
+    } else {
+        format!(
+            "Signer Public Key: 0x{}\nSigner Key Signature: 0x{}\n\n",
             to_hex(&public_key.to_bytes_compressed()),
             to_hex(signature.to_rsv().as_slice()) // RSV is needed for Clarity
-        );
+        )
+    };
+
+    if do_print {
+        println!("{}", output_str);
     }
 
     signature
@@ -446,6 +461,7 @@ pub mod tests {
             period: 12,
             max_amount: u128::MAX,
             auth_id: 1,
+            json: false,
         };
 
         let signature = handle_generate_stacking_signature(args.clone(), false);
@@ -500,6 +516,7 @@ pub mod tests {
             period: 12,
             max_amount: u128::MAX,
             auth_id: 1,
+            json: false,
         };
 
         let signature = handle_generate_stacking_signature(args.clone(), false);


### PR DESCRIPTION
This PR adds a new (optional) flag, `--json`, to the `generate-stacking-signature` command in `stacks-signer`. If specified, the CLI will output all the relevant information in JSON form.

The utility of this JSON is that Stacking apps can add a simple "paste JSON" field, which then auto-fills the relevant fields. Because there is a lot of information that must be shared between the signer and stacker, providing this "standard" can help reduce mistakes.

This "paste JSON" functionality is also already implemented in a beta version of Lockstacks:

<img width="586" alt="image" src="https://github.com/stacks-network/stacks-core/assets/1109058/bd9d4035-8708-4780-a9fc-275e1f51ef0f">
