### PR TITLE
Remove unnecessary retries throughout code

### DIFF
--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -100,7 +100,7 @@ impl StackerDB {
     }
 
     /// Sends message (as a raw msg ID and bytes) to the .signers stacker-db with an
-    ///  exponential backoff retry
+    /// exponential backoff retry
     pub fn send_message_bytes_with_retry(
         &mut self,
         msg_id: &MessageSlotID,
@@ -224,9 +224,7 @@ impl StackerDB {
     }
 
     /// Get this signer's latest transactions from stackerdb
-    pub fn get_current_transactions_with_retry(
-        &mut self,
-    ) -> Result<Vec<StacksTransaction>, ClientError> {
+    pub fn get_current_transactions(&mut self) -> Result<Vec<StacksTransaction>, ClientError> {
         let Some(transactions_session) = self
             .signers_message_stackerdb_sessions
             .get_mut(&MessageSlotID::Transactions)
@@ -237,7 +235,7 @@ impl StackerDB {
     }
 
     /// Get the latest signer transactions from signer ids for the next reward cycle
-    pub fn get_next_transactions_with_retry(
+    pub fn get_next_transactions(
         &mut self,
         signer_ids: &[SignerSlotID],
     ) -> Result<Vec<StacksTransaction>, ClientError> {
@@ -272,7 +270,7 @@ mod tests {
     use crate::config::GlobalConfig;
 
     #[test]
-    fn get_signer_transactions_with_retry_should_succeed() {
+    fn get_signer_transactions_should_succeed() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
         let signer_config = generate_signer_config(&config, 5, 20);
         let mut stackerdb = StackerDB::from(&signer_config);
@@ -297,7 +295,7 @@ mod tests {
         let message = signer_message.serialize_to_vec();
 
         let signer_slot_ids = vec![SignerSlotID(0), SignerSlotID(1)];
-        let h = spawn(move || stackerdb.get_next_transactions_with_retry(&signer_slot_ids));
+        let h = spawn(move || stackerdb.get_next_transactions(&signer_slot_ids));
         let mut response_bytes = b"HTTP/1.1 200 OK\n\n".to_vec();
         response_bytes.extend(message);
         let mock_server = mock_server_from_config(&config);
@@ -315,7 +313,7 @@ mod tests {
     }
 
     #[test]
-    fn send_signer_message_with_retry_should_succeed() {
+    fn send_signer_message_should_succeed() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-1.toml").unwrap();
         let signer_config = generate_signer_config(&config, 5, 20);
         let mut stackerdb = StackerDB::from(&signer_config);

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -198,7 +198,7 @@ impl StacksClient {
 
     /// Determine the stacks node current epoch
     pub fn get_node_epoch(&self) -> Result<StacksEpochId, ClientError> {
-        let pox_info = self.get_pox_data_with_retry()?;
+        let pox_info = self.get_pox_data()?;
         let burn_block_height = self.get_burn_block_height()?;
 
         let epoch_25 = pox_info
@@ -227,10 +227,7 @@ impl StacksClient {
     }
 
     /// Submit the block proposal to the stacks node. The block will be validated and returned via the HTTP endpoint for Block events.
-    pub fn submit_block_for_validation_with_retry(
-        &self,
-        block: NakamotoBlock,
-    ) -> Result<(), ClientError> {
+    pub fn submit_block_for_validation(&self, block: NakamotoBlock) -> Result<(), ClientError> {
         let block_proposal = NakamotoBlockProposal {
             block,
             chain_id: self.chain_id,
@@ -276,12 +273,11 @@ impl StacksClient {
 
     /// Retrieve the current account nonce for the provided address
     pub fn get_account_nonce(&self, address: &StacksAddress) -> Result<u64, ClientError> {
-        let account_entry = self.get_account_entry_with_retry(address)?;
-        Ok(account_entry.nonce)
+        self.get_account_entry(address).map(|entry| entry.nonce)
     }
 
     /// Get the current peer info data from the stacks node
-    pub fn get_peer_info_with_retry(&self) -> Result<RPCPeerInfoData, ClientError> {
+    pub fn get_peer_info(&self) -> Result<RPCPeerInfoData, ClientError> {
         debug!("Getting stacks node info...");
         let send_request = || {
             self.stacks_node_client
@@ -325,7 +321,7 @@ impl StacksClient {
     }
 
     /// Get the reward set signers from the stacks node for the given reward cycle
-    pub fn get_reward_set_signers_with_retry(
+    pub fn get_reward_set_signers(
         &self,
         reward_cycle: u64,
     ) -> Result<Option<Vec<NakamotoSignerEntry>>, ClientError> {
@@ -345,7 +341,7 @@ impl StacksClient {
     }
 
     /// Retreive the current pox data from the stacks node
-    pub fn get_pox_data_with_retry(&self) -> Result<RPCPoxInfoData, ClientError> {
+    pub fn get_pox_data(&self) -> Result<RPCPoxInfoData, ClientError> {
         debug!("Getting pox data...");
         let send_request = || {
             self.stacks_node_client
@@ -363,13 +359,12 @@ impl StacksClient {
 
     /// Helper function to retrieve the burn tip height from the stacks node
     fn get_burn_block_height(&self) -> Result<u64, ClientError> {
-        let peer_info = self.get_peer_info_with_retry()?;
-        Ok(peer_info.burn_block_height)
+        self.get_peer_info().map(|info| info.burn_block_height)
     }
 
     /// Get the current reward cycle info from the stacks node
     pub fn get_current_reward_cycle_info(&self) -> Result<RewardCycleInfo, ClientError> {
-        let pox_data = self.get_pox_data_with_retry()?;
+        let pox_data = self.get_pox_data()?;
         let blocks_mined = pox_data
             .current_burnchain_block_height
             .saturating_sub(pox_data.first_burnchain_block_height);
@@ -387,7 +382,7 @@ impl StacksClient {
     }
 
     /// Helper function to retrieve the account info from the stacks node for a specific address
-    fn get_account_entry_with_retry(
+    fn get_account_entry(
         &self,
         address: &StacksAddress,
     ) -> Result<AccountEntryResponse, ClientError> {
@@ -464,10 +459,7 @@ impl StacksClient {
     }
 
     /// Helper function to submit a transaction to the Stacks mempool
-    pub fn submit_transaction_with_retry(
-        &self,
-        tx: &StacksTransaction,
-    ) -> Result<Txid, ClientError> {
+    pub fn submit_transaction(&self, tx: &StacksTransaction) -> Result<Txid, ClientError> {
         let txid = tx.txid();
         let tx = tx.serialize_to_vec();
         let send_request = || {
@@ -510,12 +502,15 @@ impl StacksClient {
         let body =
             json!({"sender": self.stacks_address.to_string(), "arguments": args}).to_string();
         let path = self.read_only_path(contract_addr, contract_name, function_name);
-        let response = self
-            .stacks_node_client
-            .post(path.clone())
-            .header("Content-Type", "application/json")
-            .body(body.clone())
-            .send()?;
+        let send_request = || {
+            self.stacks_node_client
+                .post(path.clone())
+                .header("Content-Type", "application/json")
+                .body(body.clone())
+                .send()
+                .map_err(backoff::Error::transient)
+        };
+        let response = retry_with_exponential_backoff(send_request)?;
         if !response.status().is_success() {
             return Err(ClientError::RequestFailure(response.status()));
         }
@@ -848,7 +843,7 @@ mod tests {
             + 1;
 
         let tx_clone = tx.clone();
-        let h = spawn(move || mock.client.submit_transaction_with_retry(&tx_clone));
+        let h = spawn(move || mock.client.submit_transaction(&tx_clone));
 
         let request_bytes = write_response(
             mock.server,
@@ -911,7 +906,7 @@ mod tests {
                     nonce,
                 )
                 .unwrap();
-            mock.client.submit_transaction_with_retry(&tx)
+            mock.client.submit_transaction(&tx)
         });
         let mock = MockServerClient::from_config(mock.config);
         write_response(
@@ -1092,7 +1087,7 @@ mod tests {
             header,
             txs: vec![],
         };
-        let h = spawn(move || mock.client.submit_block_for_validation_with_retry(block));
+        let h = spawn(move || mock.client.submit_block_for_validation(block));
         write_response(mock.server, b"HTTP/1.1 200 OK\n\n");
         assert!(h.join().unwrap().is_ok());
     }
@@ -1116,7 +1111,7 @@ mod tests {
             header,
             txs: vec![],
         };
-        let h = spawn(move || mock.client.submit_block_for_validation_with_retry(block));
+        let h = spawn(move || mock.client.submit_block_for_validation(block));
         write_response(mock.server, b"HTTP/1.1 404 Not Found\n\n");
         assert!(h.join().unwrap().is_err());
     }
@@ -1125,7 +1120,7 @@ mod tests {
     fn get_peer_info_should_succeed() {
         let mock = MockServerClient::new();
         let (response, peer_info) = build_get_peer_info_response(None, None);
-        let h = spawn(move || mock.client.get_peer_info_with_retry());
+        let h = spawn(move || mock.client.get_peer_info());
         write_response(mock.server, response.as_bytes());
         assert_eq!(h.join().unwrap().unwrap(), peer_info);
     }
@@ -1166,7 +1161,7 @@ mod tests {
         let stackers_response_json = serde_json::to_string(&stackers_response)
             .expect("Failed to serialize get stacker response");
         let response = format!("HTTP/1.1 200 OK\n\n{stackers_response_json}");
-        let h = spawn(move || mock.client.get_reward_set_signers_with_retry(0));
+        let h = spawn(move || mock.client.get_reward_set_signers(0));
         write_response(mock.server, response.as_bytes());
         assert_eq!(h.join().unwrap().unwrap(), stacker_set.signers);
     }

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -128,10 +128,7 @@ impl RunLoop {
         reward_cycle: u64,
     ) -> Result<Option<SignerEntries>, ClientError> {
         debug!("Getting registered signers for reward cycle {reward_cycle}...");
-        let Some(signers) = self
-            .stacks_client
-            .get_reward_set_signers_with_retry(reward_cycle)?
-        else {
+        let Some(signers) = self.stacks_client.get_reward_set_signers(reward_cycle)? else {
             warn!("No reward set signers found for reward cycle {reward_cycle}.");
             return Ok(None);
         };
@@ -390,11 +387,7 @@ impl SignerRunLoop<Vec<OperationResult>, RunLoopCommand> for RunLoop {
             }
 
             if signer.approved_aggregate_public_key.is_none() {
-                if let Err(e) = retry_with_exponential_backoff(|| {
-                    signer
-                        .update_dkg(&self.stacks_client, current_reward_cycle)
-                        .map_err(backoff::Error::transient)
-                }) {
+                if let Err(e) = signer.update_dkg(&self.stacks_client, current_reward_cycle) {
                     error!("{signer}: failed to update DKG: {e}");
                 }
             }

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -48,7 +48,7 @@ use wsts::state_machine::signer::Signer as WSTSSigner;
 use wsts::state_machine::{OperationResult, SignError};
 use wsts::v2;
 
-use crate::client::{retry_with_exponential_backoff, ClientError, StackerDB, StacksClient};
+use crate::client::{ClientError, StackerDB, StacksClient};
 use crate::config::SignerConfig;
 use crate::coordinator::CoordinatorSelector;
 use crate::signerdb::SignerDb;
@@ -331,11 +331,7 @@ impl Signer {
                     debug!("Reward cycle #{} Signer #{}: Already have an aggregate key. Ignoring DKG command.", self.reward_cycle, self.signer_id);
                     return;
                 }
-                let vote_round = match retry_with_exponential_backoff(|| {
-                    stacks_client
-                        .get_last_round(self.reward_cycle)
-                        .map_err(backoff::Error::transient)
-                }) {
+                let vote_round = match stacks_client.get_last_round(self.reward_cycle) {
                     Ok(last_round) => last_round,
                     Err(e) => {
                         error!("{self}: Unable to perform DKG. Failed to get last round from stacks node: {e:?}");
@@ -614,7 +610,7 @@ impl Signer {
                         });
                     // Submit the block for validation
                     stacks_client
-                        .submit_block_for_validation_with_retry(proposal.block.clone())
+                        .submit_block_for_validation(proposal.block.clone())
                         .unwrap_or_else(|e| {
                             warn!("{self}: Failed to submit block for validation: {e:?}");
                         });
@@ -753,7 +749,7 @@ impl Signer {
             );
             let block_info = BlockInfo::new_with_request(block.clone(), nonce_request.clone());
             stacks_client
-                .submit_block_for_validation_with_retry(block)
+                .submit_block_for_validation(block)
                 .unwrap_or_else(|e| {
                     warn!("{self}: Failed to submit block for validation: {e:?}",);
                 });
@@ -840,7 +836,7 @@ impl Signer {
     ) -> Result<Vec<StacksTransaction>, ClientError> {
         let transactions: Vec<_> = self
             .stackerdb
-            .get_current_transactions_with_retry()?
+            .get_current_transactions()?
             .into_iter()
             .filter_map(|tx| {
                 if !NakamotoSigners::valid_vote_transaction(nonces, &tx, self.mainnet) {
@@ -865,7 +861,7 @@ impl Signer {
         let account_nonces = self.get_account_nonces(stacks_client, &self.next_signer_addresses);
         let transactions: Vec<_> = self
             .stackerdb
-            .get_next_transactions_with_retry(&self.next_signer_slot_ids)?;
+            .get_next_transactions(&self.next_signer_slot_ids)?;
         let mut filtered_transactions = std::collections::HashMap::new();
         NakamotoSigners::update_filtered_transactions(
             &mut filtered_transactions,
@@ -995,37 +991,31 @@ impl Signer {
                        "error" => %e);
             }
         }
-
-        let epoch = retry_with_exponential_backoff(|| {
-            stacks_client
-                .get_node_epoch()
-                .map_err(backoff::Error::transient)
-        })
-        .unwrap_or(StacksEpochId::Epoch24);
+        // Get our current nonce from the stacks node and compare it against what we have sitting in the stackerdb instance
+        let signer_address = stacks_client.get_signer_address();
+        // Retreieve ALL account nonces as we may have transactions from other signers in our stackerdb slot that we care about
+        let account_nonces = self.get_account_nonces(stacks_client, &self.signer_addresses);
+        let account_nonce = account_nonces.get(signer_address).unwrap_or(&0);
+        let signer_transactions = self
+            .get_signer_transactions(&account_nonces)
+            .map_err(|e| {
+                error!("{self}: Unable to get signer transactions: {e:?}.");
+            })
+            .unwrap_or_default();
+        // If we have a transaction in the stackerdb slot, we need to increment the nonce hence the +1, else should use the account nonce
+        let next_nonce = signer_transactions
+            .first()
+            .map(|tx| tx.get_origin_nonce().wrapping_add(1))
+            .unwrap_or(*account_nonce);
+        let epoch = stacks_client
+            .get_node_epoch()
+            .unwrap_or(StacksEpochId::Epoch24);
         let tx_fee = if epoch < StacksEpochId::Epoch30 {
             debug!("{self}: in pre Epoch 3.0 cycles, must set a transaction fee for the DKG vote.");
             Some(self.tx_fee_ustx)
         } else {
             None
         };
-        // Get our current nonce from the stacks node and compare it against what we have sitting in the stackerdb instance
-        let signer_address = stacks_client.get_signer_address();
-        // Retreieve ALL account nonces as we may have transactions from other signers in our stackerdb slot that we care about
-        let account_nonces = self.get_account_nonces(stacks_client, &self.signer_addresses);
-        let account_nonce = account_nonces.get(signer_address).unwrap_or(&0);
-        let signer_transactions = retry_with_exponential_backoff(|| {
-            self.get_signer_transactions(&account_nonces)
-                .map_err(backoff::Error::transient)
-        })
-        .map_err(|e| {
-            warn!("{self}: Unable to get signer transactions: {e:?}");
-        })
-        .unwrap_or_default();
-        // If we have a transaction in the stackerdb slot, we need to increment the nonce hence the +1, else should use the account nonce
-        let next_nonce = signer_transactions
-            .first()
-            .map(|tx| tx.get_origin_nonce().wrapping_add(1))
-            .unwrap_or(*account_nonce);
         match stacks_client.build_vote_for_aggregate_public_key(
             self.stackerdb.get_signer_slot_id().0,
             self.coordinator.current_dkg_id,
@@ -1091,7 +1081,7 @@ impl Signer {
             debug!("{self}: Received a DKG result while in epoch 3.0. Broadcast the transaction only to stackerDB.");
         } else if epoch == StacksEpochId::Epoch25 {
             debug!("{self}: Received a DKG result while in epoch 2.5. Broadcast the transaction to the mempool.");
-            stacks_client.submit_transaction_with_retry(&new_transaction)?;
+            stacks_client.submit_transaction(&new_transaction)?;
             info!("{self}: Submitted DKG vote transaction ({txid:?}) to the mempool");
         } else {
             debug!("{self}: Received a DKG result, but are in an unsupported epoch. Do not broadcast the transaction ({}).", new_transaction.txid());


### PR DESCRIPTION
Was having a hard time following the retry logic throughout the stacks-signer. Have made it more explicit. Removing any outer retry calls unless trying to initialize/refresh the signer as a signer may be started before a node boots.