### PR TITLE
Add allow-contract-caller command

### DIFF
--- a/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
@@ -28,6 +28,7 @@ describe("PoX-4 invariant tests", () => {
     const model: Stub = {
       stackingMinimum: 0,
       wallets: new Map<StxAddress, Wallet>(),
+      network: sut.network
     };
 
     const wallets = [

--- a/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
@@ -71,6 +71,8 @@ describe("PoX-4 invariant tests", () => {
         amountLocked: 0,
         amountUnlocked: initialUstxBalance,
         unlockHeight: 0,
+        allowedContractCaller: '',
+        callerAllowedBy: []
       };
     });
 

--- a/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
@@ -28,7 +28,6 @@ describe("PoX-4 invariant tests", () => {
     const model: Stub = {
       stackingMinimum: 0,
       wallets: new Map<StxAddress, Wallet>(),
-      network: sut.network
     };
 
     const wallets = [

--- a/contrib/core-contract-tests/tests/pox-4/pox_AllowContractCallerCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_AllowContractCallerCommand.ts
@@ -1,0 +1,97 @@
+import { PoxCommand, Real, Stub, Wallet } from "./pox_CommandModel.ts";
+import { expect } from "vitest";
+import { boolCV, Cl } from "@stacks/transactions";
+
+/**
+ * The `AllowContractCallerComand` gives a `contract-caller` authorization to call stacking methods.
+ * Normally, stacking methods may only be invoked by direct transactions (i.e., the tx-sender
+ * issues a direct contract-call to the stacking methods).
+ * By issuing an allowance, the tx-sender may call stacking methods through the allowed contract.
+ *
+ * There are no constraints for running this command.
+ */
+export class AllowContractCallerCommand implements PoxCommand {
+  readonly wallet: Wallet;
+  readonly allowanceTo: Wallet;
+  readonly allowUntilBurnHt: number | undefined;
+
+  /**
+   * Constructs an `AllowContractCallerComand` that authorizes a `contract-caller` to call
+   * stacking methods.
+   *
+   * @param wallet - Represents the Stacker's wallet.
+   * @param allowanceTo - Represents the authorized `contract-caller` (i.e. a stacking pool)
+   * @param alllowUntilBurnHt - The burn block height until the authorization is valid.
+   */
+
+  constructor(
+    wallet: Wallet,
+    allowanceTo: Wallet,
+    allowUntilBurnHt: number | undefined,
+  ) {
+    this.wallet = wallet;
+    this.allowanceTo = allowanceTo;
+    this.allowUntilBurnHt = allowUntilBurnHt;
+  }
+
+  check(): boolean {
+    // There are no constraints for running this command.
+    return true;
+  }
+
+  run(model: Stub, real: Real): void {
+    // Arrange
+    const untilBurnHtOptionalCv = this.allowUntilBurnHt === undefined
+      ? Cl.none()
+      : Cl.some(Cl.uint(this.allowUntilBurnHt));
+
+    // Act
+    const allowContractCaller = real.network.callPublicFn(
+      "ST000000000000000000002AMW42H.pox-4",
+      "allow-contract-caller",
+      [
+        // (caller principal)
+        Cl.principal(this.allowanceTo.stxAddress),
+        // (until-burn-ht (optional uint))
+        untilBurnHtOptionalCv,
+      ],
+      this.wallet.stxAddress,
+    );
+
+    // Assert
+    expect(allowContractCaller.result).toBeOk(boolCV(true));
+
+    // Get the wallets involved from the model and update it with the new state.
+    const wallet = model.wallets.get(this.wallet.stxAddress)!;
+    const callerToAllow = model.wallets.get(this.allowanceTo.stxAddress)!;
+    // Update model so that we know this wallet has authorized a contract-caller. 
+
+    wallet.allowedContractCaller = this.allowanceTo.stxAddress;
+    callerToAllow.callerAllowedBy.push(wallet.stxAddress);
+
+    // Log to console for debugging purposes. This is not necessary for the
+    // test to pass but it is useful for debugging and eyeballing the test.
+    console.info(
+      `✓ ${
+        this.wallet.label.padStart(
+          8,
+          " ",
+        )
+      } ${
+        "allow-contract-caller".padStart(
+          34,
+          " ",
+        )
+      } ${this.allowanceTo.label.padStart(12, " ")} ${"until".padStart(53)} ${
+        (this.allowUntilBurnHt || "none").toString().padStart(17)
+      }`,
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.wallet.stxAddress} allow-contract-caller ${this.allowanceTo.stxAddress} until burn ht ${this.allowUntilBurnHt}`;
+  }
+}

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -32,6 +32,8 @@ export type Wallet = {
   amountLocked: number;
   amountUnlocked: number;
   unlockHeight: number;
+  allowedContractCaller: StxAddress;
+  callerAllowedBy: StxAddress[];
 };
 
 export type PoxCommand = fc.Command<Stub, Real>;

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -9,7 +9,6 @@ export type StxAddress = string;
 export type Stub = {
   stackingMinimum: number;
   wallets: Map<StxAddress, Wallet>;
-  network: Simnet;
 };
 
 export type Real = {

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -9,6 +9,7 @@ export type StxAddress = string;
 export type Stub = {
   stackingMinimum: number;
   wallets: Map<StxAddress, Wallet>;
+  network: Simnet;
 };
 
 export type Real = {

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -71,15 +71,9 @@ export function PoxCommands(
     // RevokeDelegateStxCommand
     fc.record({
       wallet: fc.constantFrom(...wallets.values()),
-      delegateTo: fc.constantFrom(...wallets.values()),
-      untilBurnHt: fc.integer({ min: 1 }),
-      amount: fc.bigInt({ min:0n, max: 100_000_000_000_000n }),
     }).map((
       r: {
         wallet: Wallet;
-        delegateTo: Wallet;
-        untilBurnHt: number;
-        amount: bigint;
       },
     ) =>
       new RevokeDelegateStxCommand(

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -154,7 +154,7 @@ const currentCycle = (network: Simnet) =>
     ).result,
   ));
 
-const currentCycleFirstBlock = (network: Simnet) =>
+export const currentCycleFirstBlock = (network: Simnet) =>
   Number(cvToValue(
     network.callReadOnlyFn(
       "ST000000000000000000002AMW42H.pox-4",

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -6,7 +6,7 @@ import { StackStxCommand } from "./pox_StackStxCommand";
 import { DelegateStxCommand } from "./pox_DelegateStxCommand";
 import { DelegateStackStxCommand } from "./pox_DelegateStackStxCommand";
 import { Simnet } from "@hirosystems/clarinet-sdk";
-import { Cl, cvToValue } from "@stacks/transactions";
+import { Cl, cvToValue, OptionalCV, UIntCV } from "@stacks/transactions";
 import { RevokeDelegateStxCommand } from "./pox_RevokeDelegateStxCommand";
 import { AllowContractCallerCommand } from "./pox_AllowContractCallerCommand";
 
@@ -111,13 +111,16 @@ export function PoxCommands(
     fc.record({
       wallet: fc.constantFrom(...wallets.values()),
       allowanceTo: fc.constantFrom(...wallets.values()),
-      alllowUntilBurnHt: fc.option(fc.integer({ min: 1 }), {nil: undefined}),
+      alllowUntilBurnHt: fc.oneof(
+        fc.constant(Cl.none()),
+        fc.integer({ min: 1 }).map((value) => Cl.some(Cl.uint(value))),
+      ),
     })
       .map(
         (r: {
           wallet: Wallet;
           allowanceTo: Wallet;
-          alllowUntilBurnHt: number | undefined;
+          alllowUntilBurnHt: OptionalCV<UIntCV>;
         }) =>
           new AllowContractCallerCommand(
             r.wallet,

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -8,6 +8,7 @@ import { DelegateStackStxCommand } from "./pox_DelegateStackStxCommand";
 import { Simnet } from "@hirosystems/clarinet-sdk";
 import { Cl, cvToValue } from "@stacks/transactions";
 import { RevokeDelegateStxCommand } from "./pox_RevokeDelegateStxCommand";
+import { AllowContractCallerCommand } from "./pox_AllowContractCallerCommand";
 
 export function PoxCommands(
   wallets: Map<StxAddress, Wallet>, network: Simnet,
@@ -112,6 +113,24 @@ export function PoxCommands(
         r.amount
       )
     ),
+    // AllowContractCallerCommand
+    fc.record({
+      wallet: fc.constantFrom(...wallets.values()),
+      allowanceTo: fc.constantFrom(...wallets.values()),
+      alllowUntilBurnHt: fc.option(fc.integer({ min: 1 }), {nil: undefined}),
+    })
+      .map(
+        (r: {
+          wallet: Wallet;
+          allowanceTo: Wallet;
+          alllowUntilBurnHt: number | undefined;
+        }) =>
+          new AllowContractCallerCommand(
+            r.wallet,
+            r.allowanceTo,
+            r.alllowUntilBurnHt,
+          ),
+      ),
     // GetStxAccountCommand
     fc.record({
       wallet: fc.constantFrom(...wallets.values()),

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -90,21 +90,23 @@ export function PoxCommands(
       }),
       period: fc.integer({ min: 1, max: 12 }),
       amount: fc.bigInt({ min:0n, max: 100_000_000_000_000n }),
-    }).map((
-      r: {
-        operator: Wallet;
-        stacker: Wallet;
-        startBurnHt: number;
-        period: number;
-        amount: bigint;
-      },
-    ) =>
+    }).chain((r) =>
+      fc.record({
+        unlockBurnHt: fc.constant(
+          currentCycleFirstBlock(network) + 1050 * (r.period + 1),
+        ),
+      }).map((unlockBurnHtRecord) => ({
+        ...r,
+        ...unlockBurnHtRecord,
+      }))
+    ).map((r) =>
       new DelegateStackStxCommand(
         r.operator,
         r.stacker,
         r.startBurnHt,
         r.period,
-        r.amount
+        r.amount,
+        r.unlockBurnHt,
       )
     ),
     // AllowContractCallerCommand


### PR DESCRIPTION
This PR adds the `allow-contract-caller` command to the stateful property testing environment. It is part of #4548 and targets `feat/pox-4-stateful-property-testing` (#4550).