### PR TITLE
adding missing flag to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8"
 rand_chacha = "0.3.1"
 tikv-jemallocator = "0.5.4"
 # wsts = { version = "8.1", default-features = false }
-wsts = { git = "https://github.com/stacks-network/wsts.git", branch = "feat/public-sign-ids" }
+wsts = { git = "https://github.com/stacks-network/wsts.git", branch = "feat/public-sign-ids", default-features = false }
 
 # Use a bit more than default optimization for
 #  dev builds to speed up test execution


### PR DESCRIPTION
#4331 added the ability to build for multiple arches and OSes. 

this was changed in https://github.com/stacks-network/stacks-core/commit/207cb690fe8cb25cba6734ec4492f077108cc30b resulting in only glibc based sytems building as part of the ci workflows. 

this change brings back the flag added in #4331 