### PR TITLE
fix: core contract tests corrupted package.json

### DIFF
--- a/.github/workflows/stacks-core-tests.yml
+++ b/.github/workflows/stacks-core-tests.yml
@@ -153,7 +153,7 @@ jobs:
           node-version: 18.x
           cache: "npm"
           cache-dependency-path: "./contrib/core-contract-tests/package-lock.json"
-      - run: npm ci -f # need to force the update as long as we are using a beta version of the clarinet-sdk
+      - run: npm ci
       - run: npm test
       ## Upload code coverage file
       - name: Code Coverage

--- a/contrib/core-contract-tests/package-lock.json
+++ b/contrib/core-contract-tests/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@hirosystems/clarinet-sdk": "^2.4.0-beta4",
+        "@hirosystems/clarinet-sdk": "^2.4.1",
         "@stacks/clarunit": "0.0.1",
         "@stacks/transactions": "^6.12.0",
         "chokidar-cli": "^3.0.0",
@@ -426,11 +426,11 @@
       }
     },
     "node_modules/@hirosystems/clarinet-sdk": {
-      "version": "2.4.0-beta4",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk/-/clarinet-sdk-2.4.0-beta4.tgz",
-      "integrity": "sha512-BBhPN0vEtNBG7gSR1CzAfbJED836damTgeKwAnNMUMVasIxzvclyFMRYyt2UOpjxuN7daPcObLZlHye0Ob70oQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk/-/clarinet-sdk-2.4.1.tgz",
+      "integrity": "sha512-gFwU9Ljgmbe9/mLcco3yB9AIY02WT/Nk+BlSAAvFz0kh36FZWwwIqvAs/10LEU1vYwxs6oFh33dTLzNuKUbHdw==",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.4.0-beta3",
+        "@hirosystems/clarinet-sdk-wasm": "^2.4.0",
         "@stacks/encryption": "^6.12.0",
         "@stacks/network": "^6.11.3",
         "@stacks/stacking": "^6.11.4-pr.36558cf.0",
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.4.0-beta3",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.4.0-beta3.tgz",
-      "integrity": "sha512-m4PHoE38F+YzH5WDwK5CuRs3/RZWGstIPx4bq2vX6ut1ETE2S9LkS8q91RFF4FnZHnI5f8LwxflTbaxE+RSNrA=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.4.0.tgz",
+      "integrity": "sha512-qApXWsnWRtQcj5BsqoKd+AsEtDURA5CJQcRxgCAVjyRSjkbGJXxNgrW9oRnIkfIIKJ6D5mV7JGrr8CQ8BSJ/tg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1103,11 +1103,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@stacks/clarunit/node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.3.2.tgz",
-      "integrity": "sha512-Uz5RX06hRB05S6JPyS5j1F7HOPmmRArqR8c+61IUlOarPwYxum2MmLW7DnmsKWuC/m6wD8zbxUN22xRpHLFJWA=="
     },
     "node_modules/@stacks/clarunit/node_modules/esbuild": {
       "version": "0.18.20",

--- a/contrib/core-contract-tests/package.json
+++ b/contrib/core-contract-tests/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@hirosystems/clarinet-sdk": "^2.4.0-beta4",
+    "@hirosystems/clarinet-sdk": "^2.4.1",
     "@stacks/clarunit": "0.0.1",
     "@stacks/transactions": "^6.12.0",
     "chokidar-cli": "^3.0.0",


### PR DESCRIPTION
### Description

- Fix broken CI
- Because the clarinet-sdk 2.4.0 was release as stable, the `-f` isn't needed anymore
I'll try to see how the lock file got corrupted in the first place

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
