### PR TITLE
Fix invalid nonce log in valid_vote_transaction and flush stackerdb transactions that are outdated

### DIFF
--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -272,7 +272,7 @@ mod tests {
     use crate::config::GlobalConfig;
 
     #[test]
-    fn get_signer_transactions_with_retry_should_succeed() {
+    fn get_filtered_signer_transactions_with_retry_should_succeed() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
         let signer_config = generate_signer_config(&config, 5, 20);
         let mut stackerdb = StackerDB::from(&signer_config);

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -398,6 +398,9 @@ impl SignerRunLoop<Vec<OperationResult>, RunLoopCommand> for RunLoop {
                     error!("{signer}: failed to update DKG: {e}");
                 }
             }
+            if let Err(e) = signer.refresh_stackerdb_transactions(&self.stacks_client) {
+                error!("{signer}: failed to refresh stackerdb transactions: {e}");
+            }
             signer.refresh_coordinator();
             if let Err(e) = signer.process_event(
                 &self.stacks_client,

--- a/stackslib/src/chainstate/nakamoto/signer_set.rs
+++ b/stackslib/src/chainstate/nakamoto/signer_set.rs
@@ -514,7 +514,7 @@ impl NakamotoSigners {
             return false;
         }
         if origin_nonce < *account_nonce {
-            debug!("valid_vote_transaction: Received a transaction with an outdated nonce ({account_nonce} < {origin_nonce}).");
+            debug!("valid_vote_transaction: Received a transaction with an outdated nonce ({origin_nonce} < {account_nonce}).");
             return false;
         }
         Self::parse_vote_for_aggregate_public_key(transaction).is_some()

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -459,7 +459,7 @@ impl BlockMinerThread {
         Ok((signers_contract_id, slot_ids_addresses))
     }
 
-    fn get_signer_transactions(
+    fn get_filtered_signer_transactions(
         &self,
         chainstate: &mut StacksChainState,
         sortdb: &SortitionDB,
@@ -807,7 +807,7 @@ impl BlockMinerThread {
             .saturating_add(1);
 
         let signer_transactions =
-            self.get_signer_transactions(&mut chain_state, &burn_db, &stackerdbs)?;
+            self.get_filtered_signer_transactions(&mut chain_state, &burn_db, &stackerdbs)?;
 
         // build the block itself
         let (mut block, consumed, size, tx_events) = NakamotoBlockBuilder::build_nakamoto_block(


### PR DESCRIPTION
This is not the most efficient thing ever as we will be polling the node quite frequently. might be better to do this every x number of stacks blocks for example. however, currently we never refresh stackerdb which spams the node with lots of "outdated nonce" logs as confirmed vote transactions are never flushed. 