### PR TITLE
2.5: Tuple performance improvements

### DIFF
--- a/clarity/src/vm/analysis/contract_interface_builder/mod.rs
+++ b/clarity/src/vm/analysis/contract_interface_builder/mod.rs
@@ -171,14 +171,16 @@ impl ContractInterfaceAtomType {
     pub fn vec_from_tuple_type(
         tuple_type: &TupleTypeSignature,
     ) -> Vec<ContractInterfaceTupleEntryType> {
-        tuple_type
+        let mut out: Vec<_> = tuple_type
             .get_type_map()
             .iter()
             .map(|(name, sig)| ContractInterfaceTupleEntryType {
                 name: name.to_string(),
                 type_f: Self::from_type_signature(sig),
             })
-            .collect()
+            .collect();
+        out.sort_unstable_by(|ty1, ty2| ty1.name.cmp(&ty2.name));
+        out
     }
 
     pub fn from_type_signature(sig: &TypeSignature) -> ContractInterfaceAtomType {

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -71,6 +71,7 @@ pub fn mem_type_check(
         cost_tracker,
         epoch,
         version,
+        true,
     ) {
         Ok(x) => {
             // return the first type result of the type checker
@@ -78,7 +79,7 @@ pub fn mem_type_check(
                 .type_map
                 .as_ref()
                 .ok_or_else(|| CheckErrors::Expects("Should be non-empty".into()))?
-                .get_type(
+                .get_type_expected(
                     x.expressions
                         .last()
                         .ok_or_else(|| CheckErrors::Expects("Should be non-empty".into()))?,
@@ -111,6 +112,7 @@ pub fn type_check(
         LimitedCostTracker::new_free(),
         *epoch,
         *version,
+        true,
     )
     .map_err(|(e, _cost_tracker)| e)
 }
@@ -123,6 +125,7 @@ pub fn run_analysis(
     cost_tracker: LimitedCostTracker,
     epoch: StacksEpochId,
     version: ClarityVersion,
+    build_type_map: bool,
 ) -> Result<ContractAnalysis, (CheckError, LimitedCostTracker)> {
     let mut contract_analysis = ContractAnalysis::new(
         contract_identifier.clone(),
@@ -135,7 +138,7 @@ pub fn run_analysis(
         ReadOnlyChecker::run_pass(&epoch, &mut contract_analysis, db)?;
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
-                TypeChecker2_05::run_pass(&epoch, &mut contract_analysis, db)
+                TypeChecker2_05::run_pass(&epoch, &mut contract_analysis, db, build_type_map)
             }
             StacksEpochId::Epoch21
             | StacksEpochId::Epoch22
@@ -143,7 +146,7 @@ pub fn run_analysis(
             | StacksEpochId::Epoch24
             | StacksEpochId::Epoch25
             | StacksEpochId::Epoch30 => {
-                TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db)
+                TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db, build_type_map)
             }
             StacksEpochId::Epoch10 => {
                 return Err(CheckErrors::Expects(

--- a/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
@@ -111,14 +111,15 @@ impl CostTracker for TypeChecker<'_, '_> {
     }
 }
 
-impl AnalysisPass for TypeChecker<'_, '_> {
-    fn run_pass(
+impl TypeChecker<'_, '_> {
+    pub fn run_pass(
         _epoch: &StacksEpochId,
         contract_analysis: &mut ContractAnalysis,
         analysis_db: &mut AnalysisDatabase,
+        build_type_map: bool,
     ) -> CheckResult<()> {
         let cost_track = contract_analysis.take_contract_cost_tracker();
-        let mut command = TypeChecker::new(analysis_db, cost_track);
+        let mut command = TypeChecker::new(analysis_db, cost_track, build_type_map);
         // run the analysis, and replace the cost tracker whether or not the
         //   analysis succeeded.
         match command.run(contract_analysis) {
@@ -343,13 +344,14 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
     fn new(
         db: &'a mut AnalysisDatabase<'b>,
         cost_track: LimitedCostTracker,
+        build_type_map: bool,
     ) -> TypeChecker<'a, 'b> {
         Self {
             db,
             cost_track,
             contract_context: ContractContext::new(),
             function_return_tracker: None,
-            type_map: TypeMap::new(),
+            type_map: TypeMap::new(build_type_map),
         }
     }
 

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -75,6 +75,7 @@ Is illegally typed in our language.
 */
 
 pub struct TypeChecker<'a, 'b> {
+    epoch: StacksEpochId,
     pub type_map: TypeMap,
     contract_context: ContractContext,
     function_return_tracker: Option<Option<TypeSignature>>,
@@ -115,18 +116,21 @@ impl CostTracker for TypeChecker<'_, '_> {
     }
 }
 
-impl AnalysisPass for TypeChecker<'_, '_> {
-    fn run_pass(
-        _epoch: &StacksEpochId,
+impl TypeChecker<'_, '_> {
+    pub fn run_pass(
+        epoch: &StacksEpochId,
         contract_analysis: &mut ContractAnalysis,
         analysis_db: &mut AnalysisDatabase,
+        build_type_map: bool,
     ) -> CheckResult<()> {
         let cost_track = contract_analysis.take_contract_cost_tracker();
         let mut command = TypeChecker::new(
+            epoch,
             analysis_db,
             cost_track,
             &contract_analysis.contract_identifier,
             &contract_analysis.clarity_version,
+            build_type_map,
         );
         // run the analysis, and replace the cost tracker whether or not the
         //   analysis succeeded.
@@ -876,17 +880,20 @@ pub fn no_type() -> TypeSignature {
 
 impl<'a, 'b> TypeChecker<'a, 'b> {
     fn new(
+        epoch: &StacksEpochId,
         db: &'a mut AnalysisDatabase<'b>,
         cost_track: LimitedCostTracker,
         contract_identifier: &QualifiedContractIdentifier,
         clarity_version: &ClarityVersion,
+        build_type_map: bool,
     ) -> TypeChecker<'a, 'b> {
         Self {
+            epoch: epoch.clone(),
             db,
             cost_track,
             contract_context: ContractContext::new(contract_identifier.clone(), *clarity_version),
             function_return_tracker: None,
-            type_map: TypeMap::new(),
+            type_map: TypeMap::new(build_type_map),
             clarity_version: *clarity_version,
         }
     }
@@ -1076,8 +1083,19 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         }
 
         let mut function_context = context.extend()?;
+        let mut tracked_mem = 0u64;
         for (arg_name, arg_type) in args.iter() {
             self.contract_context.check_name_used(arg_name)?;
+
+            if self.epoch.analysis_memory() {
+                let added_memory = u64::from(arg_name.len())
+                    .checked_add(arg_type.type_size()?.into())
+                    .ok_or_else(|| CostErrors::CostOverflow)?;
+                self.add_memory(added_memory)?;
+                tracked_mem = tracked_mem
+                    .checked_add(added_memory)
+                    .ok_or_else(|| CostErrors::CostOverflow)?;
+            }
 
             match arg_type {
                 TypeSignature::CallableType(CallableSubtype::Trait(trait_id)) => {
@@ -1094,6 +1112,9 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         self.function_return_tracker = Some(None);
 
         let return_result = self.type_check(body, &function_context);
+
+        drop(function_context);
+        self.drop_memory(tracked_mem)?;
 
         match return_result {
             Err(e) => {
@@ -1435,6 +1456,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         v_type.type_size()?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(v_name.len().into())?;
+                        self.add_memory(v_type.type_size()?.into())?;
+                    }
                     self.contract_context.add_variable_type(v_name, v_type)?;
                 }
                 DefineFunctionsParsed::PrivateFunction { signature, body } => {
@@ -1446,6 +1471,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         f_type.total_type_size()?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(f_name.len().into())?;
+                        self.add_memory(f_type.total_type_size()?)?;
+                    }
                     self.contract_context
                         .add_private_function_type(f_name, FunctionType::Fixed(f_type))?;
                 }
@@ -1457,7 +1486,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         f_type.total_type_size()?,
                     )?;
-
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(f_name.len().into())?;
+                        self.add_memory(f_type.total_type_size()?)?;
+                    }
                     if f_type.returns.is_response_type() {
                         self.contract_context
                             .add_public_function_type(f_name, FunctionType::Fixed(f_type))?;
@@ -1476,6 +1508,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         f_type.total_type_size()?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(f_name.len().into())?;
+                        self.add_memory(f_type.total_type_size()?)?;
+                    }
                     self.contract_context
                         .add_read_only_function_type(f_name, FunctionType::Fixed(f_type))?;
                 }
@@ -1489,6 +1525,11 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                     let total_type_size = u64::from(map_type.0.type_size()?)
                         .cost_overflow_add(u64::from(map_type.1.type_size()?))?;
                     runtime_cost(ClarityCostFunction::AnalysisBindName, self, total_type_size)?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(f_name.len().into())?;
+                        self.add_memory(map_type.0.type_size()?.into())?;
+                        self.add_memory(map_type.1.type_size()?.into())?;
+                    }
                     self.contract_context.add_map_type(f_name, map_type)?;
                 }
                 DefineFunctionsParsed::PersistedVariable {
@@ -1503,6 +1544,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         v_type.type_size()?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(v_name.len().into())?;
+                        self.add_memory(v_type.type_size()?.into())?;
+                    }
                     self.contract_context
                         .add_persisted_variable_type(v_name, v_type)?;
                 }
@@ -1513,6 +1558,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         TypeSignature::UIntType.type_size()?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(token_name.len().into())?;
+                        self.add_memory(TypeSignature::UIntType.type_size()?.into())?;
+                    }
                     self.contract_context.add_ft(token_name)?;
                 }
                 DefineFunctionsParsed::UnboundedFungibleToken { name } => {
@@ -1522,6 +1571,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         TypeSignature::UIntType.type_size()?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(token_name.len().into())?;
+                        self.add_memory(TypeSignature::UIntType.type_size()?.into())?;
+                    }
                     self.contract_context.add_ft(token_name)?;
                 }
                 DefineFunctionsParsed::NonFungibleToken { name, nft_type } => {
@@ -1532,6 +1585,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         token_type.type_size()?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(token_name.len().into())?;
+                        self.add_memory(token_type.type_size()?.into())?;
+                    }
                     self.contract_context.add_nft(token_name, token_type)?;
                 }
                 DefineFunctionsParsed::Trait { name, functions } => {
@@ -1542,6 +1599,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                         self,
                         trait_type_size(&trait_signature)?,
                     )?;
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(trait_name.len().into())?;
+                        self.add_memory(trait_type_size(&trait_signature)?)?;
+                    }
                     self.contract_context
                         .add_defined_trait(trait_name, trait_signature)?;
                 }
@@ -1563,6 +1624,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                                 type_size,
                             )?;
                             runtime_cost(ClarityCostFunction::AnalysisBindName, self, type_size)?;
+                            if self.epoch.analysis_memory() {
+                                self.add_memory(trait_identifier.name.len().into())?;
+                                self.add_memory(type_size)?;
+                            }
                             self.contract_context.add_used_trait(
                                 name.clone(),
                                 trait_identifier.clone(),
@@ -1577,6 +1642,9 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                     }
                 }
                 DefineFunctionsParsed::ImplTrait { trait_identifier } => {
+                    if self.epoch.analysis_memory() {
+                        self.add_memory(trait_identifier.name.len().into())?;
+                    }
                     self.contract_context
                         .add_implemented_trait(trait_identifier.clone())?;
                 }

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -81,6 +81,7 @@ pub fn type_check_version(
         LimitedCostTracker::new_free(),
         epoch,
         version,
+        false,
     )
     .map_err(|(e, _)| e)
 }

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -210,6 +210,7 @@ pub trait TransactionConnection: ClarityConnection {
                 cost_track,
                 epoch_id,
                 clarity_version,
+                false,
             );
 
             match result {

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2917,7 +2917,7 @@ mod test {
                     .type_map
                     .as_ref()
                     .unwrap()
-                    .get_type(&analysis.expressions.last().unwrap())
+                    .get_type_expected(&analysis.expressions.last().unwrap())
                     .cloned(),
             );
         }

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -80,6 +80,21 @@ impl StacksEpochId {
     }
 
     /// Returns whether or not this Epoch should perform
+    ///  memory checks during analysis
+    pub fn analysis_memory(&self) -> bool {
+        match self {
+            StacksEpochId::Epoch10
+            | StacksEpochId::Epoch20
+            | StacksEpochId::Epoch2_05
+            | StacksEpochId::Epoch21
+            | StacksEpochId::Epoch22
+            | StacksEpochId::Epoch23
+            | StacksEpochId::Epoch24 => false,
+            StacksEpochId::Epoch25 | StacksEpochId::Epoch30 => true,
+        }
+    }
+
+    /// Returns whether or not this Epoch should perform
     ///  Clarity value sanitization
     pub fn value_sanitizing(&self) -> bool {
         match self {

--- a/stackslib/src/clarity_cli.rs
+++ b/stackslib/src/clarity_cli.rs
@@ -144,7 +144,7 @@ fn friendly_expect_opt<A>(input: Option<A>, msg: &str) -> A {
     })
 }
 
-pub const DEFAULT_CLI_EPOCH: StacksEpochId = StacksEpochId::Epoch21;
+pub const DEFAULT_CLI_EPOCH: StacksEpochId = StacksEpochId::Epoch25;
 
 struct EvalInput {
     marf_kv: MarfedKV,
@@ -221,6 +221,8 @@ fn run_analysis_free<C: ClarityStorage>(
         LimitedCostTracker::new_free(),
         DEFAULT_CLI_EPOCH,
         clarity_version,
+        // no type map data is used in the clarity_cli
+        false,
     )
 }
 
@@ -253,6 +255,8 @@ fn run_analysis<C: ClarityStorage>(
         cost_track,
         DEFAULT_CLI_EPOCH,
         clarity_version,
+        // no type map data is used in the clarity_cli
+        false,
     )
 }
 


### PR DESCRIPTION
### Description

This PR replaces the BTreeMap in tuple type signatures with a more efficient hashmap, and also improves the analysis performance by simplifying the type map struct to a hash set (only when possible: the type map's values are required in testing and docs generation).