### PR TITLE
Fix callable type issue (DO NOT MERGE)

### DIFF
--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -769,6 +769,21 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                 )?;
             }
         }
+        (
+            TypeSignature::CallableType(CallableSubtype::Principal(_)),
+            TypeSignature::ListUnionType(types),
+        ) => {
+            // If all types in the union are callable principals, then the principal
+            // is compatible with the union (the actual type is just principal).
+            for subtype in types {
+                if let CallableSubtype::Principal(_) = subtype {
+                    continue;
+                }
+                return Err(
+                    CheckErrors::TypeError(expected_type.clone(), actual_type.clone()).into(),
+                );
+            }
+        }
         (TypeSignature::NoType, _) => (),
         (_, _) => {
             if !expected_type.admits_type(&StacksEpochId::Epoch21, actual_type)? {

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
@@ -3658,3 +3658,61 @@ fn test_principal_admits() {
         assert!(res.is_err());
     }
 }
+
+#[test]
+fn test_replace_at_callable() {
+    let contract = "(replace-at?
+        (list
+          'SK1655DMX0A8VKB0W7R2EN6B29MS98G1HTZV2XW41.CKPAbAeaxopNIumug
+          'ST3Z7C6C0Q0VWBM06788X4P386517JNEAYTN1SRB7.euEUmoKftalFLQpCsmeswgNWQQcRelTgmVVSY
+          'S12R7Q5M2WN8PYVPNH9RXHMHV1GDX1PCT9XQFZ1VF.zQurKADWgvZWXBvpAb
+        )
+        u1
+        'SK1655DMX0A8VKB0W7R2EN6B29MS98G1HTZV2XW41.CKPAbAeaxopNIumug
+      )";
+
+    assert!(mem_type_check(contract).is_ok());
+}
+
+#[test]
+fn test_replace_at_option_callable() {
+    let contract = "(replace-at?
+        (list
+          (some 'SK1655DMX0A8VKB0W7R2EN6B29MS98G1HTZV2XW41.CKPAbAeaxopNIumug)
+          none
+          none
+          none
+          (some 'ST3Z7C6C0Q0VWBM06788X4P386517JNEAYTN1SRB7.euEUmoKftalFLQpCsmeswgNWQQcRelTgmVVSY)
+          (some 'S12R7Q5M2WN8PYVPNH9RXHMHV1GDX1PCT9XQFZ1VF.zQurKADWgvZWXBvpAb)
+          none
+        )
+        u4
+        (some 'SK1655DMX0A8VKB0W7R2EN6B29MS98G1HTZV2XW41.CKPAbAeaxopNIumug)
+      )";
+
+    assert!(mem_type_check(contract).is_ok());
+}
+
+#[test]
+fn test_replace_at_callable_workaround() {
+    let contract = "
+(define-private (replace-optional-callable (l (list 8 (optional principal))) (index uint) (element (optional principal)))
+  (replace-at? l index element)
+)
+(replace-optional-callable
+  (list
+    (some 'SK1655DMX0A8VKB0W7R2EN6B29MS98G1HTZV2XW41.CKPAbAeaxopNIumug)
+    none
+    none
+    none
+    (some 'ST3Z7C6C0Q0VWBM06788X4P386517JNEAYTN1SRB7.euEUmoKftalFLQpCsmeswgNWQQcRelTgmVVSY)
+    (some 'S12R7Q5M2WN8PYVPNH9RXHMHV1GDX1PCT9XQFZ1VF.zQurKADWgvZWXBvpAb)
+    none
+  )
+  u4
+  (some 'SK1655DMX0A8VKB0W7R2EN6B29MS98G1HTZV2XW41.CKPAbAeaxopNIumug)
+)
+";
+
+    assert!(mem_type_check(contract).is_ok());
+}


### PR DESCRIPTION
### Description
This fixes the issue described in #4622. This is still a work in progress, as I am not sure yet if this is the appropriate fix or if there is a call to `concretize` on the type missing somewhere. 

**It also needs to be gated on an epoch or on a new version of Clarity.**

### Applicable issues

- fixes #4622 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
