### PR TITLE
fix: Rewrite URLs for metrics to reduce number of unique strings

### DIFF
--- a/stackslib/src/monitoring/mod.rs
+++ b/stackslib/src/monitoring/mod.rs
@@ -56,7 +56,7 @@ where
     increment_rpc_calls_counter();
 
     #[cfg(feature = "monitoring_prom")]
-    let timer = prometheus::new_rpc_call_timer(req.request_path());
+    let timer = prometheus::new_rpc_call_timer(req.get_metrics_identifier());
 
     let res = handler(req);
 

--- a/stackslib/src/net/api/getaccount.rs
+++ b/stackslib/src/net/api/getaccount.rs
@@ -68,6 +68,14 @@ impl RPCGetAccountRequestHandler {
     pub fn new() -> Self {
         Self { account: None }
     }
+
+    pub fn path_regex() -> Regex {
+        Regex::new(&format!(
+            "^/v2/accounts/(?P<principal>{})$",
+            *PRINCIPAL_DATA_REGEX_STRING
+        ))
+        .unwrap()
+    }
 }
 
 /// Decode the HTTP request
@@ -77,11 +85,7 @@ impl HttpRequest for RPCGetAccountRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(&format!(
-            "^/v2/accounts/(?P<principal>{})$",
-            *PRINCIPAL_DATA_REGEX_STRING
-        ))
-        .unwrap()
+        Self::path_regex()
     }
 
     /// Try to decode this request.

--- a/stackslib/src/net/api/getattachment.rs
+++ b/stackslib/src/net/api/getattachment.rs
@@ -47,6 +47,10 @@ impl RPCGetAttachmentRequestHandler {
             attachment_hash: None,
         }
     }
+
+    pub fn path_regex() -> Regex {
+        Regex::new(r#"^/v2/attachments/(?P<attachment_hash>[0-9a-f]{40})$"#).unwrap()
+    }
 }
 
 /// Decode the HTTP request
@@ -56,7 +60,7 @@ impl HttpRequest for RPCGetAttachmentRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(r#"^/v2/attachments/(?P<attachment_hash>[0-9a-f]{40})$"#).unwrap()
+        Self::path_regex()
     }
 
     /// Try to decode this request.

--- a/stackslib/src/net/api/getblock.rs
+++ b/stackslib/src/net/api/getblock.rs
@@ -49,6 +49,10 @@ impl RPCBlocksRequestHandler {
     pub fn new() -> Self {
         Self { block_id: None }
     }
+
+    pub fn path_regex() -> Regex {
+        Regex::new(r#"^/v2/blocks/(?P<block_id>[0-9a-f]{64})$"#).unwrap()
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -87,7 +91,7 @@ impl HttpRequest for RPCBlocksRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(r#"^/v2/blocks/(?P<block_id>[0-9a-f]{64})$"#).unwrap()
+        Self::path_regex()
     }
 
     /// Try to decode this request.

--- a/stackslib/src/net/api/getheaders.rs
+++ b/stackslib/src/net/api/getheaders.rs
@@ -46,6 +46,10 @@ impl RPCHeadersRequestHandler {
     pub fn new() -> Self {
         Self { quantity: None }
     }
+
+    pub fn path_regex() -> Regex {
+        Regex::new(r#"^/v2/headers/(?P<quantity>[0-9]+)$"#).unwrap()
+    }
 }
 
 #[derive(Debug)]
@@ -106,7 +110,7 @@ impl HttpRequest for RPCHeadersRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(r#"^/v2/headers/(?P<quantity>[0-9]+)$"#).unwrap()
+        Self::path_regex()
     }
 
     /// Try to decode this request.

--- a/stackslib/src/net/api/postblock.rs
+++ b/stackslib/src/net/api/postblock.rs
@@ -83,6 +83,10 @@ impl RPCPostBlockRequestHandler {
         })?;
         Ok(block)
     }
+
+    pub fn path_regex() -> Regex {
+        Regex::new(r#"^/v2/blocks/upload/(?P<consensus_hash>[0-9a-f]{40})$"#).unwrap()
+    }
 }
 
 /// Decode the HTTP request
@@ -92,7 +96,7 @@ impl HttpRequest for RPCPostBlockRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(r#"^/v2/blocks/upload/(?P<consensus_hash>[0-9a-f]{40})$"#).unwrap()
+        Self::path_regex()
     }
 
     /// Try to decode this request.


### PR DESCRIPTION
### Description

When sending metrics data to Prometheus, replace unique identifiers used in requests such as `/v2/attachments/` with fixed strings. This will reduce the number of unique strings the server has to keep track of. As an example, it might rewrite:

```
/v2/attachments/012c8195f4381d0b0eadc2daee6e2c5b8243f4ff
```

to

```
/v2/attachments/:hash
```

### Applicable issues

- fixes #4574

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
