### PR TITLE
Reward cycle length was being incorrectly stored as reward phase length

### DIFF
--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -413,13 +413,13 @@ impl StacksClient {
         let blocks_mined = pox_data
             .current_burnchain_block_height
             .saturating_sub(pox_data.first_burnchain_block_height);
-        let reward_phase_block_length = pox_data
+        let reward_cycle_length = pox_data
             .reward_phase_block_length
             .saturating_add(pox_data.prepare_phase_block_length);
-        let reward_cycle = blocks_mined / reward_phase_block_length;
+        let reward_cycle = blocks_mined / reward_cycle_length;
         Ok(RewardCycleInfo {
             reward_cycle,
-            reward_phase_block_length,
+            reward_cycle_length,
             prepare_phase_block_length: pox_data.prepare_phase_block_length,
             first_burnchain_block_height: pox_data.first_burnchain_block_height,
             last_burnchain_block_height: pox_data.current_burnchain_block_height,

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -56,8 +56,8 @@ pub enum State {
 pub struct RewardCycleInfo {
     /// The current reward cycle
     pub reward_cycle: u64,
-    /// The reward phase cycle length
-    pub reward_phase_block_length: u64,
+    /// The total reward cycle length
+    pub reward_cycle_length: u64,
     /// The prepare phase length
     pub prepare_phase_block_length: u64,
     /// The first burn block height
@@ -70,10 +70,7 @@ impl RewardCycleInfo {
     /// Check if the provided burnchain block height is part of the reward cycle
     pub const fn is_in_reward_cycle(&self, burnchain_block_height: u64) -> bool {
         let blocks_mined = burnchain_block_height.saturating_sub(self.first_burnchain_block_height);
-        let reward_cycle_length = self
-            .reward_phase_block_length
-            .saturating_add(self.prepare_phase_block_length);
-        let reward_cycle = blocks_mined / reward_cycle_length;
+        let reward_cycle = blocks_mined / self.reward_cycle_length;
         self.reward_cycle == reward_cycle
     }
 
@@ -81,7 +78,7 @@ impl RewardCycleInfo {
     pub fn is_in_prepare_phase(&self, burnchain_block_height: u64) -> bool {
         PoxConstants::static_is_in_prepare_phase(
             self.first_burnchain_block_height,
-            self.reward_phase_block_length,
+            self.reward_cycle_length,
             self.prepare_phase_block_length,
             burnchain_block_height,
         )


### PR DESCRIPTION
Sometimes regtest would stall on boot with the following messages:
	
2024-04-02, 05:32:20.104 PM	
[signer_runloop] Received a new burnchain block height (117) in the prepare phase of the next reward cycle (6). Checking for signer registration...
2024-04-02, 05:32:20.057 PM	
[signer_runloop] Received a new burnchain block height (117) in the prepare phase of the next reward cycle (5). Checking for signer registration.

This made me realize something was up with the reward cycle info or prepare phase calculation. Was accidentally storing the full reward cycle length but calling it the reward phase length and then adding and subtracting the prepare phase length again. This should fix the problem. 

Fixes https://github.com/stacks-network/stacks-core/issues/4630