### PR TITLE
fix: update prepare offset of start-end cycle ids

### DIFF
--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -113,8 +113,11 @@ fn create_event_info_data_code(
 ) -> String {
     // If a given burn block height is in a prepare phase, then the stacker will be in the _next_ reward cycle, so bump the cycle by 1
     // `prepare_offset` is 1 or 0, depending on whether current execution is in a prepare phase or not
-    let prepare_offset = r#"
-        (prepare-offset (if (<
+    //
+    // "is-in-next-pox-set" == effective-height <= (reward-length - prepare-length)
+    // "<=" since the txs of the first block of the prepare phase are considered in the pox-set
+    let pox_set_offset = r#"
+        (pox-set-offset (if (<=
             (mod (- %height% (var-get first-burnchain-block-height)) (var-get pox-reward-cycle-length))
             (- (var-get pox-reward-cycle-length) (var-get pox-prepare-cycle-length))
         ) u0 u1))
@@ -126,7 +129,7 @@ fn create_event_info_data_code(
                 r#"
                 (let (
                     (unlock-burn-height (reward-cycle-to-burn-height (+ (current-pox-reward-cycle) u1 {lock_period})))
-                    {prepare_offset}
+                    {pox_set_offset}
                 )
                 {{
                     data: {{
@@ -156,7 +159,7 @@ fn create_event_info_data_code(
                         ;; Get end cycle ID
                         end-cycle-id: (some (burn-height-to-reward-cycle unlock-burn-height)),
                         ;; Get start cycle ID
-                        start-cycle-id: (+ (current-pox-reward-cycle) u1 prepare-offset),
+                        start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
                 }})
                 "#,
@@ -168,7 +171,7 @@ fn create_event_info_data_code(
                 signer_key = &args.get(5).unwrap_or(&Value::none()),
                 max_amount = &args.get(6).unwrap_or(&Value::none()),
                 auth_id = &args.get(7).unwrap_or(&Value::none()),
-                prepare_offset = prepare_offset.replace("%height%", "burn-block-height"),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "delegate-stack-stx" => {
@@ -176,7 +179,7 @@ fn create_event_info_data_code(
                 r#"
                 (let (
                     (unlock-burn-height (reward-cycle-to-burn-height (+ (current-pox-reward-cycle) u1 {lock_period})))
-                    {prepare_offset}
+                    {pox_set_offset}
                 )
                 {{
                     data: {{
@@ -203,7 +206,7 @@ fn create_event_info_data_code(
                         ;; Get end cycle ID
                         end-cycle-id: (some (burn-height-to-reward-cycle unlock-burn-height)),
                         ;; Get start cycle ID
-                        start-cycle-id: (+ (current-pox-reward-cycle) u1 prepare-offset),
+                        start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
                 }})
                 "#,
@@ -212,7 +215,7 @@ fn create_event_info_data_code(
                 pox_addr = &args[2],
                 start_burn_height = &args[3],
                 lock_period = &args[4],
-                prepare_offset = prepare_offset.replace("%height%", "burn-block-height"),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "stack-increase" => {
@@ -220,7 +223,7 @@ fn create_event_info_data_code(
                 r#"
                 (let (
                     (unlock-height (get unlock-height (stx-account tx-sender)))
-                    {prepare_offset}
+                    {pox_set_offset}
                 )
                 {{
                     data: {{
@@ -244,7 +247,7 @@ fn create_event_info_data_code(
                         ;; Get end cycle ID
                         end-cycle-id: (some (burn-height-to-reward-cycle unlock-height)),
                         ;; Get start cycle ID
-                        start-cycle-id: (+ (current-pox-reward-cycle) u1 prepare-offset),
+                        start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
                 }})
                 "#,
@@ -253,7 +256,7 @@ fn create_event_info_data_code(
                 signer_key = &args.get(2).unwrap_or(&Value::none()),
                 max_amount = &args.get(3).unwrap_or(&Value::none()),
                 auth_id = &args.get(4).unwrap_or(&Value::none()),
-                prepare_offset = prepare_offset.replace("%height%", "burn-block-height"),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "delegate-stack-increase" => {
@@ -261,7 +264,7 @@ fn create_event_info_data_code(
                 r#"
                 (let (
                     (unlock-height (get unlock-height (stx-account '{stacker})))
-                    {prepare_offset}
+                    {pox_set_offset}
                 )
                 {{
                     data: {{
@@ -283,14 +286,14 @@ fn create_event_info_data_code(
                         ;; Get end cycle ID
                         end-cycle-id: (some (burn-height-to-reward-cycle unlock-height)),
                         ;; Get start cycle ID
-                        start-cycle-id: (+ (current-pox-reward-cycle) u1 prepare-offset),
+                        start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
                 }}
                 "#,
                 stacker = &args[0],
                 pox_addr = &args[1],
                 increase_by = &args[2],
-                prepare_offset = prepare_offset.replace("%height%", "burn-block-height"),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "stack-extend" => {
@@ -307,7 +310,7 @@ fn create_event_info_data_code(
                             unlock-in-cycle))
                     (last-extend-cycle  (- (+ first-extend-cycle {extend_count}) u1))
                     (new-unlock-ht (reward-cycle-to-burn-height (+ u1 last-extend-cycle)))
-                    {prepare_offset}
+                    {pox_set_offset}
                 )
                 {{
                     data: {{
@@ -330,7 +333,7 @@ fn create_event_info_data_code(
                         ;; Get end cycle ID
                         end-cycle-id: (some (burn-height-to-reward-cycle new-unlock-ht)),
                         ;; Get start cycle ID
-                        start-cycle-id: (+ (current-pox-reward-cycle) u1 prepare-offset),
+                        start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
                 }})
                 "#,
@@ -340,7 +343,7 @@ fn create_event_info_data_code(
                 signer_key = &args.get(3).map_or("none".to_string(), |v| v.to_string()),
                 max_amount = &args.get(4).unwrap_or(&Value::none()),
                 auth_id = &args.get(5).unwrap_or(&Value::none()),
-                prepare_offset = prepare_offset.replace("%height%", "burn-block-height"),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "delegate-stack-extend" => {
@@ -356,7 +359,7 @@ fn create_event_info_data_code(
                             unlock-in-cycle))
                     (last-extend-cycle  (- (+ first-extend-cycle {extend_count}) u1))
                     (new-unlock-ht (reward-cycle-to-burn-height (+ u1 last-extend-cycle)))
-                    {prepare_offset}
+                    {pox_set_offset}
                 )
                 {{
                     data: {{
@@ -376,19 +379,26 @@ fn create_event_info_data_code(
                         ;; Get end cycle ID
                         end-cycle-id: (some (burn-height-to-reward-cycle new-unlock-ht)),
                         ;; Get start cycle ID
-                        start-cycle-id: (+ (current-pox-reward-cycle) u1 prepare-offset),
+                        start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
                 }})
                 "#,
                 stacker = &args[0],
                 pox_addr = &args[1],
                 extend_count = &args[2],
-                prepare_offset = prepare_offset.replace("%height%", "burn-block-height"),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "stack-aggregation-commit" | "stack-aggregation-commit-indexed" => {
             format!(
                 r#"
+                (let (
+                    (next-cycle (+ (current-pox-reward-cycle) u1))
+                    {pox_set_offset}
+                    (start-cycle (if (is-eq {reward_cycle} next-cycle)
+                        (+ {reward_cycle} pox-set-offset)
+                        {reward_cycle}))
+                )
                 {{
                     data: {{
                         ;; pox addr locked up
@@ -412,11 +422,11 @@ fn create_event_info_data_code(
                         ;; equal to args[5]
                         auth-id: {auth_id},
                         ;; Get end cycle ID
-                        end-cycle-id: (some {reward_cycle}),
+                        end-cycle-id: (some (+ {reward_cycle} u1)),
                         ;; Get start cycle ID
-                        start-cycle-id: {reward_cycle},
+                        start-cycle-id: start-cycle,
                     }}
-                }}
+                }})
                 "#,
                 pox_addr = &args[0],
                 reward_cycle = &args[1],
@@ -424,11 +434,19 @@ fn create_event_info_data_code(
                 signer_key = &args.get(3).unwrap_or(&Value::none()),
                 max_amount = &args.get(4).unwrap_or(&Value::none()),
                 auth_id = &args.get(5).unwrap_or(&Value::none()),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "stack-aggregation-increase" => {
             format!(
                 r#"
+                (let (
+                    (next-cycle (+ (current-pox-reward-cycle) u1))
+                    {pox_set_offset}
+                    (start-cycle (if (is-eq {reward_cycle} next-cycle)
+                        (+ {reward_cycle} pox-set-offset)
+                        {reward_cycle}))
+                )
                 {{
                     data: {{
                         ;; pox addr locked up
@@ -446,22 +464,23 @@ fn create_event_info_data_code(
                         ;; equal to args[2]
                         reward-cycle-index: {reward_cycle_index},
                         ;; Get end cycle ID
-                        end-cycle-id: (some {reward_cycle}),
+                        end-cycle-id: (some (+ {reward_cycle} u1)),
                         ;; Get start cycle ID
-                        start-cycle-id: {reward_cycle},
+                        start-cycle-id: start-cycle,
                     }}
-                }}
+                }})
                 "#,
                 pox_addr = &args[0],
                 reward_cycle = &args[1],
                 reward_cycle_index = &args.get(2).unwrap_or(&Value::none()),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "delegate-stx" => {
             format!(
                 r#"
                 (let (
-                    {prepare_offset}
+                    {pox_set_offset}
                 )
                 {{
                     data: {{
@@ -483,7 +502,7 @@ fn create_event_info_data_code(
                             none
                         ),
                         ;; Get start cycle ID
-                        start-cycle-id: (+ (current-pox-reward-cycle) u1 prepare-offset),
+                        start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
                 }})
                 "#,
@@ -491,7 +510,7 @@ fn create_event_info_data_code(
                 delegate_to = &args[1],
                 until_burn_height = &args[2],
                 pox_addr = &args[3],
-                prepare_offset = prepare_offset.replace("%height%", "burn-block-height"),
+                pox_set_offset = pox_set_offset.replace("%height%", "burn-block-height"),
             )
         }
         "revoke-delegate-stx" => {

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1332,13 +1332,13 @@ fn pox_3_unlocks() {
     }
 }
 
-// This tests calls most pox-4 Clarity functions to check the existence of `start-cycle-id` and `end-cycle-id`
+// This test calls most pox-4 Clarity functions to check the existence of `start-cycle-id` and `end-cycle-id`
 // in emitted pox events.
 // In this set up, Steph is a solo stacker and invokes `stack-stx`, `stack-increase` and `stack-extend` functions
 // Alice delegates to Bob via `delegate-stx`
-// And Bob as the delegate, invokes 'delegate-stack-stx' and 'stack-aggregation-commit-indexed'
+// Bob as the delegate, invokes 'delegate-stack-stx' and 'stack-aggregation-commit-indexed'
 #[test]
-fn pox_4_check_cycle_id_range_in_print_events() {
+fn pox_4_check_cycle_id_range_in_print_events_pool() {
     // Config for this test
     let (epochs, pox_constants) = make_test_epochs_pox();
 
@@ -1704,7 +1704,7 @@ fn pox_4_check_cycle_id_range_in_print_events() {
         ("start-cycle-id", Value::UInt(next_reward_cycle)),
         (
             "end-cycle-id",
-            Value::some(Value::UInt(next_reward_cycle)).unwrap(),
+            Value::some(Value::UInt(next_reward_cycle + 1)).unwrap(),
         ),
     ]);
     let common_data = PoxPrintFields {
@@ -1721,8 +1721,761 @@ fn pox_4_check_cycle_id_range_in_print_events() {
     );
 }
 
-// This tests calls some pox-4 Clarity functions to check the existence of `start-cycle-id` and `end-cycle-id`
-// in emitted pox events.
+// This test calls most pox-4 Clarity functions to check the existence of `start-cycle-id` and `end-cycle-id`
+// in emitted pox events. This tests for the correct offset in the prepare phase.
+// In this set up, Steph is a solo stacker and invokes `stack-stx`, `stack-increase` and `stack-extend` functions
+// Alice delegates to Bob via `delegate-stx`
+// Bob as the delegate, invokes 'delegate-stack-stx' and 'stack-aggregation-commit-indexed'
+#[test]
+fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
+    // Config for this test
+    let (epochs, pox_constants) = make_test_epochs_pox();
+
+    let mut burnchain = Burnchain::default_unittest(
+        0,
+        &BurnchainHeaderHash::from_hex(BITCOIN_REGTEST_FIRST_BLOCK_HASH).unwrap(),
+    );
+    burnchain.pox_constants = pox_constants.clone();
+
+    let observer = TestEventObserver::new();
+
+    let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
+        &burnchain,
+        function_name!(),
+        Some(epochs.clone()),
+        Some(&observer),
+    );
+
+    assert_eq!(burnchain.pox_constants.reward_slots(), 6);
+    let mut coinbase_nonce = 0;
+    let mut latest_block = None;
+
+    // alice
+    let alice = keys.pop().unwrap();
+    let alice_address = key_to_stacks_addr(&alice);
+    let alice_principal = PrincipalData::from(alice_address.clone());
+    let alice_pox_addr = pox_addr_from(&alice);
+
+    // bob
+    let bob = keys.pop().unwrap();
+    let bob_address = key_to_stacks_addr(&bob);
+    let bob_principal = PrincipalData::from(bob_address.clone());
+    let bob_pox_addr = pox_addr_from(&bob);
+    let bob_signing_key = Secp256k1PublicKey::from_private(&bob);
+    let bob_pox_addr_val = Value::Tuple(bob_pox_addr.as_clarity_tuple().unwrap());
+
+    // steph the solo stacker stacks stx so nakamoto signer set stays stacking.
+    let steph_key = keys.pop().unwrap();
+    let steph_address = key_to_stacks_addr(&steph_key);
+    let steph_principal = PrincipalData::from(steph_address.clone());
+    let steph_pox_addr_val =
+        make_pox_addr(AddressHashMode::SerializeP2PKH, steph_address.bytes.clone());
+    let steph_pox_addr = pox_addr_from(&steph_key);
+    let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
+    let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
+
+    let mut alice_nonce = 0;
+    let mut steph_nonce = 0;
+    let mut bob_nonce = 0;
+
+    // Advance into pox4
+    let target_height = burnchain.pox_constants.pox_4_activation_height;
+    // produce blocks until the first reward phase that everyone should be in
+    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+        latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
+    }
+    // produce blocks until the we're in the prepare phase (first block of prepare-phase was mined, i.e. pox-set for next cycle determined)
+    while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height) {
+        latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
+    }
+
+    let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
+    let next_reward_cycle = reward_cycle + 1;
+
+    info!(
+        "Block height: {}",
+        get_tip(peer.sortdb.as_ref()).block_height,
+    );
+
+    let lock_period = 1;
+    let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap());
+
+    // stack-stx
+    let steph_stack_stx_nonce = steph_nonce;
+    let signature = make_signer_key_signature(
+        &steph_pox_addr,
+        &steph_key,
+        reward_cycle,
+        &Pox4SignatureTopic::StackStx,
+        lock_period,
+        u128::MAX,
+        1,
+    );
+    let steph_stacking = make_pox_4_lockup(
+        &steph_key,
+        steph_stack_stx_nonce,
+        min_ustx,
+        &steph_pox_addr.clone(),
+        lock_period,
+        &steph_signing_key,
+        block_height,
+        Some(signature),
+        u128::MAX,
+        1,
+    );
+    steph_nonce += 1;
+
+    // stack-increase
+    let steph_stack_increase_nonce = steph_nonce;
+    let signature = make_signer_key_signature(
+        &steph_pox_addr,
+        &steph_key,
+        reward_cycle,
+        &Pox4SignatureTopic::StackIncrease,
+        lock_period,
+        u128::MAX,
+        1,
+    );
+    let steph_stack_increase = make_pox_4_stack_increase(
+        &steph_key,
+        steph_stack_increase_nonce,
+        100,
+        &steph_signing_key,
+        Some(signature),
+        u128::MAX,
+        1,
+    );
+    steph_nonce += 1;
+
+    // stack-extend
+    let steph_stack_extend_nonce = steph_nonce;
+    let stack_extend_signature = make_signer_key_signature(
+        &steph_pox_addr,
+        &steph_key,
+        reward_cycle,
+        &Pox4SignatureTopic::StackExtend,
+        1_u128,
+        u128::MAX,
+        1,
+    );
+    let steph_stack_extend = make_pox_4_extend(
+        &steph_key,
+        steph_stack_extend_nonce,
+        steph_pox_addr,
+        lock_period,
+        steph_signing_key,
+        Some(stack_extend_signature),
+        u128::MAX,
+        1,
+    );
+    steph_nonce += 1;
+
+    // alice delegates STX to bob
+    let target_height = get_tip(peer.sortdb.as_ref()).block_height
+        + (3 * pox_constants.reward_cycle_length as u64) // 3 cycles (next cycle + 2)
+        + 1; // additional few blocks shouldn't matter to unlock-cycle
+    let alice_delegate = make_pox_4_delegate_stx(
+        &alice,
+        alice_nonce,
+        min_ustx,
+        bob_principal.clone(),
+        Some(target_height as u128),
+        Some(bob_pox_addr.clone()),
+    );
+    let alice_delegate_nonce = alice_nonce;
+    alice_nonce += 1;
+
+    let curr_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let bob_delegate_stack_nonce = bob_nonce;
+    let bob_delegate_stack = make_pox_4_delegate_stack_stx(
+        &bob,
+        bob_nonce,
+        alice_principal.clone(),
+        min_ustx,
+        bob_pox_addr.clone(),
+        curr_height as u128,
+        lock_period,
+    );
+    bob_nonce += 1;
+
+    let bob_aggregation_commit_nonce = bob_nonce;
+    let signature = make_signer_key_signature(
+        &bob_pox_addr,
+        &bob,
+        next_reward_cycle,
+        &Pox4SignatureTopic::AggregationCommit,
+        lock_period,
+        u128::MAX,
+        1,
+    );
+    let bob_aggregation_commit = make_pox_4_aggregation_commit_indexed(
+        &bob,
+        bob_aggregation_commit_nonce,
+        &bob_pox_addr,
+        next_reward_cycle,
+        Some(signature),
+        &bob_signing_key,
+        u128::MAX,
+        1,
+    );
+    bob_nonce += 1;
+
+    latest_block = Some(peer.tenure_with_txs(
+        &[
+            steph_stacking,
+            steph_stack_increase,
+            steph_stack_extend,
+            alice_delegate,
+            bob_delegate_stack,
+            bob_aggregation_commit,
+        ],
+        &mut coinbase_nonce,
+    ));
+
+    let tip = get_tip(peer.sortdb.as_ref());
+    let tipId = StacksBlockId::new(&tip.consensus_hash, &tip.canonical_stacks_tip_hash);
+    assert_eq!(tipId, latest_block.unwrap());
+
+    let in_prepare_phase = burnchain.is_in_prepare_phase(tip.block_height);
+    assert_eq!(in_prepare_phase, true);
+
+    let blocks = observer.get_blocks();
+    let mut steph_txs = HashMap::new();
+    let mut alice_txs = HashMap::new();
+    let mut bob_txs = HashMap::new();
+
+    for b in blocks.into_iter() {
+        for r in b.receipts.into_iter() {
+            if let TransactionOrigin::Stacks(ref t) = r.transaction {
+                let addr = t.auth.origin().address_testnet();
+                if addr == steph_address {
+                    steph_txs.insert(t.auth.get_origin_nonce(), r);
+                } else if addr == alice_address {
+                    alice_txs.insert(t.auth.get_origin_nonce(), r);
+                } else if addr == bob_address {
+                    bob_txs.insert(t.auth.get_origin_nonce(), r);
+                }
+            }
+        }
+    }
+
+    assert_eq!(steph_txs.len() as u64, 3);
+    assert_eq!(alice_txs.len() as u64, 1);
+    assert_eq!(bob_txs.len() as u64, 2);
+
+    let steph_stack_stx_tx = &steph_txs.get(&steph_stack_stx_nonce);
+    let steph_stack_extend_tx = &steph_txs.get(&steph_stack_extend_nonce);
+    let steph_stack_increase_tx = &steph_txs.get(&steph_stack_increase_nonce);
+    let bob_delegate_stack_stx_tx = &bob_txs.get(&bob_delegate_stack_nonce);
+    let bob_aggregation_commit_tx = &bob_txs.get(&bob_aggregation_commit_nonce);
+    let alice_delegate_tx = &alice_txs.get(&alice_delegate_nonce);
+
+    // Check event for stack-stx tx
+    let steph_stacking_tx_events = &steph_stack_stx_tx.unwrap().clone().events;
+    assert_eq!(steph_stacking_tx_events.len() as u64, 2);
+    let steph_stacking_tx_event = &steph_stacking_tx_events[0];
+    let steph_stacking_op_data = HashMap::from([
+        // +1, since we're in a prepare phase
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(next_reward_cycle + lock_period)).unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "stack-stx".to_string(),
+        stacker: steph_principal.clone().into(),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(steph_stacking_tx_event, common_data, steph_stacking_op_data);
+
+    // Check event for stack-increase tx
+    let steph_stack_increase_tx_events = &steph_stack_increase_tx.unwrap().clone().events;
+    assert_eq!(steph_stack_increase_tx_events.len() as u64, 2);
+    let steph_stack_increase_tx_event = &steph_stack_increase_tx_events[0];
+    let steph_stack_increase_op_data = HashMap::from([
+        // `stack-increase` is in the same block as `stack-stx`, so we essentially want to be able to override the first event
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(next_reward_cycle + lock_period)).unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "stack-increase".to_string(),
+        stacker: steph_principal.clone().into(),
+        balance: Value::UInt(10234866000000),
+        locked: Value::UInt(5134000000),
+        burnchain_unlock_height: Value::UInt(120),
+    };
+    check_pox_print_event(
+        steph_stack_increase_tx_event,
+        common_data,
+        steph_stack_increase_op_data,
+    );
+
+    // Check event for stack-extend tx
+    let steph_stack_extend_tx_events = &steph_stack_extend_tx.unwrap().clone().events;
+    assert_eq!(steph_stack_extend_tx_events.len() as u64, 2);
+    let steph_stack_extend_tx_event = &steph_stack_extend_tx_events[0];
+    let steph_stacking_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(next_reward_cycle + lock_period + 1)).unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "stack-extend".to_string(),
+        stacker: steph_principal.clone().into(),
+        balance: Value::UInt(10234865999900),
+        locked: Value::UInt(5134000100),
+        burnchain_unlock_height: Value::UInt(120),
+    };
+    check_pox_print_event(
+        steph_stack_extend_tx_event,
+        common_data,
+        steph_stacking_op_data,
+    );
+
+    // Check event for delegate-stx tx
+    let alice_delegation_tx_events = &alice_delegate_tx.unwrap().clone().events;
+    assert_eq!(alice_delegation_tx_events.len() as u64, 1);
+    let alice_delegation_tx_event = &alice_delegation_tx_events[0];
+    let alice_delegate_stx_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(
+                burnchain
+                    .block_height_to_reward_cycle(target_height)
+                    .unwrap() as u128,
+            ))
+            .unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "delegate-stx".to_string(),
+        stacker: alice_principal.clone().into(),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(
+        alice_delegation_tx_event,
+        common_data,
+        alice_delegate_stx_op_data,
+    );
+
+    // Check event for delegate-stack-stx tx
+    let bob_delegate_stack_stx_tx_events = &bob_delegate_stack_stx_tx.unwrap().clone().events;
+    assert_eq!(bob_delegate_stack_stx_tx_events.len() as u64, 2);
+    let bob_delegate_stack_stx_tx_event = &bob_delegate_stack_stx_tx_events[0];
+    let bob_delegate_stack_stx_tx_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(next_reward_cycle + lock_period)).unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "delegate-stack-stx".to_string(),
+        stacker: alice_principal.clone().into(),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(
+        bob_delegate_stack_stx_tx_event,
+        common_data,
+        bob_delegate_stack_stx_tx_op_data,
+    );
+
+    // Check event for aggregation_commit tx
+    let bob_aggregation_commit_tx_events = &bob_aggregation_commit_tx.unwrap().clone().events;
+    assert_eq!(bob_aggregation_commit_tx_events.len() as u64, 1);
+    let bob_aggregation_commit_tx_event = &bob_aggregation_commit_tx_events[0];
+    let bob_aggregation_commit_tx_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(next_reward_cycle + 1)).unwrap(), // end is same as start, which means this missed the pox-set
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "stack-aggregation-commit-indexed".to_string(),
+        stacker: bob_principal.clone().into(),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(
+        bob_aggregation_commit_tx_event,
+        common_data,
+        bob_aggregation_commit_tx_op_data,
+    );
+}
+
+// This test calls most pox-4 Clarity functions to check the existence of `start-cycle-id` and `end-cycle-id`
+// in emitted pox events. This tests for the correct offset in the prepare phase, when skipping a cycle for commit.
+// In this set up, Alice delegates to Bob via `delegate-stx`
+// Bob as the delegate, invokes 'delegate-stack-stx' and 'stack-aggregation-commit-indexed'
+// for one after the next cycle, so there should be no prepare-offset in the commit start.
+#[test]
+fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase_skip_cycle() {
+    // Config for this test
+    let (epochs, pox_constants) = make_test_epochs_pox();
+
+    let mut burnchain = Burnchain::default_unittest(
+        0,
+        &BurnchainHeaderHash::from_hex(BITCOIN_REGTEST_FIRST_BLOCK_HASH).unwrap(),
+    );
+    burnchain.pox_constants = pox_constants.clone();
+
+    let observer = TestEventObserver::new();
+
+    let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
+        &burnchain,
+        function_name!(),
+        Some(epochs.clone()),
+        Some(&observer),
+    );
+
+    assert_eq!(burnchain.pox_constants.reward_slots(), 6);
+    let mut coinbase_nonce = 0;
+    let mut latest_block = None;
+
+    // alice
+    let alice = keys.pop().unwrap();
+    let alice_address = key_to_stacks_addr(&alice);
+    let alice_principal = PrincipalData::from(alice_address.clone());
+    let alice_pox_addr = pox_addr_from(&alice);
+
+    // bob
+    let bob = keys.pop().unwrap();
+    let bob_address = key_to_stacks_addr(&bob);
+    let bob_principal = PrincipalData::from(bob_address.clone());
+    let bob_pox_addr = pox_addr_from(&bob);
+    let bob_signing_key = Secp256k1PublicKey::from_private(&bob);
+    let bob_pox_addr_val = Value::Tuple(bob_pox_addr.as_clarity_tuple().unwrap());
+
+    let mut alice_nonce = 0;
+    let mut bob_nonce = 0;
+
+    // Advance into pox4
+    let target_height = burnchain.pox_constants.pox_4_activation_height;
+    // produce blocks until the first reward phase that everyone should be in
+    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+        latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
+    }
+    // produce blocks until the we're in the prepare phase (first block of prepare-phase was mined, i.e. pox-set for next cycle determined)
+    while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height) {
+        latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
+    }
+
+    let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
+    let next_reward_cycle = reward_cycle + 1;
+
+    info!(
+        "Block height: {}",
+        get_tip(peer.sortdb.as_ref()).block_height
+    );
+
+    let lock_period = 2;
+    let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap());
+
+    // alice delegates STX to bob
+    let target_height = get_tip(peer.sortdb.as_ref()).block_height
+        + (3 * pox_constants.reward_cycle_length as u64) // 3 cycles (next cycle + 2)
+        + 1; // additional few blocks shouldn't matter to unlock-cycle
+    let alice_delegate = make_pox_4_delegate_stx(
+        &alice,
+        alice_nonce,
+        min_ustx,
+        bob_principal.clone(),
+        Some(target_height as u128),
+        Some(bob_pox_addr.clone()),
+    );
+    let alice_delegate_nonce = alice_nonce;
+    alice_nonce += 1;
+
+    let curr_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let bob_delegate_stack_nonce = bob_nonce;
+    let bob_delegate_stack = make_pox_4_delegate_stack_stx(
+        &bob,
+        bob_nonce,
+        alice_principal.clone(),
+        min_ustx,
+        bob_pox_addr.clone(),
+        curr_height as u128,
+        lock_period,
+    );
+    bob_nonce += 1;
+
+    let target_cycle = next_reward_cycle + 1;
+    let bob_aggregation_commit_nonce = bob_nonce;
+    let signature = make_signer_key_signature(
+        &bob_pox_addr,
+        &bob,
+        target_cycle,
+        &Pox4SignatureTopic::AggregationCommit,
+        1,
+        u128::MAX,
+        1,
+    );
+    let bob_aggregation_commit = make_pox_4_aggregation_commit_indexed(
+        &bob,
+        bob_aggregation_commit_nonce,
+        &bob_pox_addr,
+        target_cycle,
+        Some(signature),
+        &bob_signing_key,
+        u128::MAX,
+        1,
+    );
+    bob_nonce += 1;
+
+    latest_block = Some(peer.tenure_with_txs(
+        &[alice_delegate, bob_delegate_stack, bob_aggregation_commit],
+        &mut coinbase_nonce,
+    ));
+
+    let tip = get_tip(peer.sortdb.as_ref());
+    let tipId = StacksBlockId::new(&tip.consensus_hash, &tip.canonical_stacks_tip_hash);
+    assert_eq!(tipId, latest_block.unwrap());
+
+    let in_prepare_phase = burnchain.is_in_prepare_phase(tip.block_height);
+    assert_eq!(in_prepare_phase, true);
+
+    let blocks = observer.get_blocks();
+    let mut alice_txs = HashMap::new();
+    let mut bob_txs = HashMap::new();
+
+    for b in blocks.into_iter() {
+        for r in b.receipts.into_iter() {
+            if let TransactionOrigin::Stacks(ref t) = r.transaction {
+                let addr = t.auth.origin().address_testnet();
+                if addr == alice_address {
+                    alice_txs.insert(t.auth.get_origin_nonce(), r);
+                } else if addr == bob_address {
+                    bob_txs.insert(t.auth.get_origin_nonce(), r);
+                }
+            }
+        }
+    }
+
+    assert_eq!(alice_txs.len() as u64, 1);
+    assert_eq!(bob_txs.len() as u64, 2);
+
+    let bob_delegate_stack_stx_tx = &bob_txs.get(&bob_delegate_stack_nonce);
+    let bob_aggregation_commit_tx = &bob_txs.get(&bob_aggregation_commit_nonce);
+    let alice_delegate_tx = &alice_txs.get(&alice_delegate_nonce);
+
+    // Check event for delegate-stx tx
+    let alice_delegation_tx_events = &alice_delegate_tx.unwrap().clone().events;
+    assert_eq!(alice_delegation_tx_events.len() as u64, 1);
+    let alice_delegation_tx_event = &alice_delegation_tx_events[0];
+    let alice_delegate_stx_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(
+                burnchain
+                    .block_height_to_reward_cycle(target_height)
+                    .unwrap() as u128,
+            ))
+            .unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "delegate-stx".to_string(),
+        stacker: alice_principal.clone().into(),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(
+        alice_delegation_tx_event,
+        common_data,
+        alice_delegate_stx_op_data,
+    );
+
+    // Check event for delegate-stack-stx tx
+    let bob_delegate_stack_stx_tx_events = &bob_delegate_stack_stx_tx.unwrap().clone().events;
+    assert_eq!(bob_delegate_stack_stx_tx_events.len() as u64, 2);
+    let bob_delegate_stack_stx_tx_event = &bob_delegate_stack_stx_tx_events[0];
+    let bob_delegate_stack_stx_tx_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(next_reward_cycle + 1)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(next_reward_cycle + lock_period)).unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "delegate-stack-stx".to_string(),
+        stacker: alice_principal.clone().into(),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(
+        bob_delegate_stack_stx_tx_event,
+        common_data,
+        bob_delegate_stack_stx_tx_op_data,
+    );
+
+    // Check event for aggregation_commit tx
+    let bob_aggregation_commit_tx_events = &bob_aggregation_commit_tx.unwrap().clone().events;
+    assert_eq!(bob_aggregation_commit_tx_events.len() as u64, 1);
+    let bob_aggregation_commit_tx_event = &bob_aggregation_commit_tx_events[0];
+    let bob_aggregation_commit_tx_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(target_cycle)), // no prepare-offset, since target is not next cycle
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(target_cycle + 1)).unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "stack-aggregation-commit-indexed".to_string(),
+        stacker: bob_principal.clone().into(),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(
+        bob_aggregation_commit_tx_event,
+        common_data,
+        bob_aggregation_commit_tx_op_data,
+    );
+}
+
+// This test calls some pox-4 Clarity functions to check the existence of `start-cycle-id` and `end-cycle-id`
+// in emitted pox events. This test checks that the prepare-offset isn't used before its time.
+// In this setup, Steph solo stacks in the prepare phase
+#[test]
+fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
+    // Config for this test
+    let (epochs, pox_constants) = make_test_epochs_pox();
+
+    let mut burnchain = Burnchain::default_unittest(
+        0,
+        &BurnchainHeaderHash::from_hex(BITCOIN_REGTEST_FIRST_BLOCK_HASH).unwrap(),
+    );
+    burnchain.pox_constants = pox_constants.clone();
+
+    let observer = TestEventObserver::new();
+
+    let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
+        &burnchain,
+        function_name!(),
+        Some(epochs.clone()),
+        Some(&observer),
+    );
+
+    assert_eq!(burnchain.pox_constants.reward_slots(), 6);
+    let mut coinbase_nonce = 0;
+    let mut latest_block = None;
+
+    let steph_key = keys.pop().unwrap();
+    let steph_address = key_to_stacks_addr(&steph_key);
+    let steph_principal = PrincipalData::from(steph_address.clone());
+    let steph_pox_addr_val =
+        make_pox_addr(AddressHashMode::SerializeP2PKH, steph_address.bytes.clone());
+    let steph_pox_addr = pox_addr_from(&steph_key);
+    let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
+    let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
+
+    let mut steph_nonce = 0;
+
+    // Advance into pox4
+    let target_height = burnchain.pox_constants.pox_4_activation_height;
+    // produce blocks until the first reward phase that everyone should be in
+    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+        latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
+    }
+    // produce blocks until the we're 1 before the prepare phase (first block of prepare-phase not yet mined)
+    while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height + 1) {
+        latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
+    }
+
+    let steph_balance = get_balance(&mut peer, &steph_principal);
+
+    info!(
+        "Block height: {}",
+        get_tip(peer.sortdb.as_ref()).block_height
+    );
+
+    let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap()) * 120 / 100; // * 1.2
+
+    // stack-stx
+    let steph_lock_period = 2;
+    let current_cycle = get_current_reward_cycle(&peer, &burnchain);
+    let next_cycle = current_cycle + 1;
+    let signature = make_signer_key_signature(
+        &steph_pox_addr,
+        &steph_key,
+        current_cycle,
+        &Pox4SignatureTopic::StackStx,
+        steph_lock_period,
+        u128::MAX,
+        1,
+    );
+    let steph_stacking = make_pox_4_lockup(
+        &steph_key,
+        steph_nonce,
+        min_ustx,
+        &steph_pox_addr.clone(),
+        steph_lock_period,
+        &steph_signing_key,
+        get_tip(peer.sortdb.as_ref()).block_height,
+        Some(signature),
+        u128::MAX,
+        1,
+    );
+    steph_nonce += 1;
+
+    latest_block = Some(peer.tenure_with_txs(&[steph_stacking.clone()], &mut coinbase_nonce));
+
+    let txs: HashMap<_, _> = observer
+        .get_blocks()
+        .into_iter()
+        .flat_map(|b| b.receipts)
+        .filter_map(|r| match r.transaction {
+            TransactionOrigin::Stacks(ref t) => Some((t.txid(), r.clone())),
+            _ => None,
+        })
+        .collect();
+
+    // Check event for stack-stx tx
+    let steph_stacking_receipt = txs.get(&steph_stacking.txid()).unwrap().clone();
+    assert_eq!(steph_stacking_receipt.events.len(), 2);
+    let steph_stacking_op_data = HashMap::from([
+        ("start-cycle-id", Value::UInt(next_cycle)),
+        (
+            "end-cycle-id",
+            Value::some(Value::UInt(next_cycle + steph_lock_period)).unwrap(),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "stack-stx".to_string(),
+        stacker: steph_principal.clone().into(),
+        balance: Value::UInt(steph_balance),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(
+        &steph_stacking_receipt.events[0],
+        common_data,
+        steph_stacking_op_data,
+    );
+}
+
+// This test calls some pox-4 Clarity functions to check the existence of `start-cycle-id` and `end-cycle-id`
+// in emitted pox events. This test checks that the prepare-offset is used for the pox-anchor-block.
 // In this setup, Steph solo stacks in the prepare phase
 #[test]
 fn pox_4_check_cycle_id_range_in_print_events_in_prepare_phase() {
@@ -1765,7 +2518,7 @@ fn pox_4_check_cycle_id_range_in_print_events_in_prepare_phase() {
     while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
-    // produce blocks until the we're in the prepare phase
+    // produce blocks until the we're in the prepare phase (first block of prepare-phase was mined, i.e. pox-set for next cycle determined)
     while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }


### PR DESCRIPTION
- update `prepare_offset` to more fitting `pox_set_offset`
- this fixes an off-by-one error in the check for which pox txs could still be considered in the next cycle.

* adds more tests along the prepare phase border
* non consensus critical, but will output different event values

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`

---

~_I wanted to add checks to the end of the tests to check whether the addresses are actually in (or not in) the pox-set (reward_addresses), but I couldn't get the Rust to work 🙈 If somebody has ideas on how to best do that from a TestPeer._~ thx Brice
