### PR TITLE
[pox-4]  Stack Aggregation Increase Update

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -2185,6 +2185,40 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
+    pub fn make_pox_4_aggregation_increase(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        pox_addr: &PoxAddress,
+        reward_cycle: u128,
+        reward_cycle_index: u128,
+        signature_opt: Option<Vec<u8>>,
+        signer_key: &Secp256k1PublicKey,
+        max_amount: u128,
+        auth_id: u128,
+    ) -> StacksTransaction {
+        let addr_tuple = Value::Tuple(pox_addr.as_clarity_tuple().unwrap());
+        let signature = signature_opt
+            .map(|sig| Value::some(Value::buff_from(sig).unwrap()).unwrap())
+            .unwrap_or_else(|| Value::none());
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_4_NAME,
+            "stack-aggregation-increase",
+            vec![
+                addr_tuple,
+                Value::UInt(reward_cycle),
+                Value::UInt(reward_cycle_index),
+                signature,
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
+                Value::UInt(max_amount),
+                Value::UInt(auth_id),
+            ],
+        )
+        .unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
     pub fn make_pox_4_stack_increase(
         key: &StacksPrivateKey,
         nonce: u64,

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -901,10 +901,10 @@
           (total-ustx (+ (get total-ustx existing-total) amount-ustx)))
 
           ;; must be stackable
-          (try! (minimal-can-stack-stx pox-addr total-ustx reward-cycle u1))
+          (try! (minimal-can-stack-stx pox-addr increased-ustx reward-cycle u1))
 
           ;; new total must exceed the stacking minimum
-          (asserts! (<= (get-stacking-minimum) total-ustx)
+          (asserts! (<= (get-stacking-minimum) increased-ustx)
                     (err ERR_STACKING_THRESHOLD_NOT_MET))
 
           ;; there must *not* be a stacker entry (since this is a delegator)

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -664,6 +664,10 @@
                 (err ERR_STACKING_INVALID_POX_ADDRESS))
          true)
 
+      ;; address hashbytes must be valid for the version
+      (asserts! (check-pox-addr-hashbytes (get version pox-addr) (get hashbytes pox-addr))
+                (err ERR_STACKING_INVALID_POX_ADDRESS))
+
       ;; tx-sender must not be delegating
       (asserts! (is-none (get-check-delegation tx-sender))
         (err ERR_STACKING_ALREADY_DELEGATED))
@@ -919,6 +923,7 @@
           (asserts! (>= max-amount increased-ustx) (err ERR_SIGNER_AUTH_AMOUNT_TOO_HIGH))
 
           ;; Verify signature from delegate that allows this sender for this cycle
+          ;; 'lock-period' param set to one period, same as aggregation-commit-indexed
           (try! (consume-signer-key-authorization pox-addr reward-cycle "agg-increase" u1 signer-sig signer-key increased-ustx max-amount auth-id))
 
           ;; update the pox-address list -- bump the total-ustx

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -316,7 +316,6 @@
           (some delegation-info))))
 
 ;; Get the size of the reward set for a reward cycle.
-;; Note that this does _not_ return duplicate PoX addresses.
 ;; Note that this also _will_ return PoX addresses that are beneath
 ;; the minimum threshold -- i.e. the threshold can increase after insertion.
 ;; Used internally by the Stacks node, which filters out the entries
@@ -1169,9 +1168,6 @@
 
     ;; Verify signature from delegate that allows this sender for this cycle
     (try! (consume-signer-key-authorization pox-addr cur-cycle "stack-extend" extend-count signer-sig signer-key u0 max-amount auth-id))
-
-    ;; TODO: add more assertions to sanity check the `stacker-info` values with
-    ;;       the `stacker-state` values
 
     (let ((last-extend-cycle  (- (+ first-extend-cycle extend-count) u1))
           (lock-period (+ u1 (- last-extend-cycle first-reward-cycle)))

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -1437,6 +1437,9 @@
                                              (max-amount uint)
                                              (auth-id uint))
   (begin
+    ;; must be called directly by the tx-sender or by an allowed contract-caller
+    (asserts! (check-caller-allowed)
+      (err ERR_NOT_ALLOWED))
     ;; Validate that `tx-sender` has the same pubkey hash as `signer-key`
     (asserts! (is-eq
       (unwrap! (principal-construct? (if is-in-mainnet STACKS_ADDR_VERSION_MAINNET STACKS_ADDR_VERSION_TESTNET) (hash160 signer-key)) (err ERR_INVALID_SIGNER_KEY))

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -664,9 +664,11 @@
                 (err ERR_STACKING_INVALID_POX_ADDRESS))
          true)
 
-      ;; address hashbytes must be valid for the version
-      (asserts! (check-pox-addr-hashbytes (get version pox-addr) (get hashbytes pox-addr))
+      (match pox-addr
+         pox-tuple
+            (asserts! (check-pox-addr-hashbytes (get version pox-tuple) (get hashbytes pox-tuple))
                 (err ERR_STACKING_INVALID_POX_ADDRESS))
+         true)
 
       ;; tx-sender must not be delegating
       (asserts! (is-none (get-check-delegation tx-sender))
@@ -897,12 +899,12 @@
     (let ((partial-amount-ustx (get stacked-amount partial-stacked))
           ;; reward-cycle must point to an existing record in reward-cycle-total-stacked
           ;; infallible; getting something from partial-stacked-by-cycle succeeded so this must succeed
-          (existing-cycle-total (unwrap-panic (map-get? reward-cycle-total-stacked { reward-cycle: reward-cycle })))
+          (existing-cycle (unwrap-panic (map-get? reward-cycle-total-stacked { reward-cycle: reward-cycle })))
           ;; reward-cycle and reward-cycle-index must point to an existing record in reward-cycle-pox-address-list
-          (existing-entry-total (unwrap! (map-get? reward-cycle-pox-address-list { reward-cycle: reward-cycle, index: reward-cycle-index })
+          (existing-entry (unwrap! (map-get? reward-cycle-pox-address-list { reward-cycle: reward-cycle, index: reward-cycle-index })
                           (err ERR_DELEGATION_NO_REWARD_SLOT)))
-          (increased-entry-total (+ (get total-ustx existing-entry-total) partial-amount-ustx))
-          (increased-cycle-total (+ (get total-ustx existing-cycle-total) partial-amount-ustx)))
+          (increased-entry-total (+ (get total-ustx existing-entry) partial-amount-ustx))
+          (increased-cycle-total (+ (get total-ustx existing-cycle) partial-amount-ustx)))
 
           ;; must be stackable
           (try! (minimal-can-stack-stx pox-addr increased-entry-total reward-cycle u1))

--- a/stackslib/src/chainstate/stacks/boot/pox-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-4.clar
@@ -904,7 +904,8 @@
           (existing-entry (unwrap! (map-get? reward-cycle-pox-address-list { reward-cycle: reward-cycle, index: reward-cycle-index })
                           (err ERR_DELEGATION_NO_REWARD_SLOT)))
           (increased-entry-total (+ (get total-ustx existing-entry) partial-amount-ustx))
-          (increased-cycle-total (+ (get total-ustx existing-cycle) partial-amount-ustx)))
+          (increased-cycle-total (+ (get total-ustx existing-cycle) partial-amount-ustx))
+          (existing-signer-key (get signer existing-entry)))
 
           ;; must be stackable
           (try! (minimal-can-stack-stx pox-addr increased-entry-total reward-cycle u1))
@@ -923,6 +924,9 @@
 
           ;; Validate that amount is less than or equal to `max-amount`
           (asserts! (>= max-amount increased-entry-total) (err ERR_SIGNER_AUTH_AMOUNT_TOO_HIGH))
+
+          ;; Validate that signer-key matches the existing signer-key
+          (asserts! (is-eq existing-signer-key signer-key) (err ERR_INVALID_SIGNER_KEY))
 
           ;; Verify signature from delegate that allows this sender for this cycle
           ;; 'lock-period' param set to one period, same as aggregation-commit-indexed

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -3340,7 +3340,8 @@ fn advance_to_block_height(
 }
 
 #[test]
-/// Tests for verifying signatures in `stack-aggregation-commit`
+/// Test for verifying that the stacker aggregation works as expected
+///   with new signature parameters.
 fn stack_agg_increase() {
     // Alice service signer setup
     let mut alice = StackerSignerInfo::new();

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -3345,7 +3345,7 @@ fn advance_to_block_height(
 ///   delegate for pool 1, Frank is a delegate for pool 2, & Grace is a delegate for pool 2.
 fn stack_agg_increase() {
     // Alice service signer setup
-    let mut alice = StackerSignerInfo::new();
+    let alice = StackerSignerInfo::new();
     // Bob pool operator
     let mut bob = StackerSignerInfo::new();
     // Carl pool 1 delegate
@@ -3411,10 +3411,8 @@ fn stack_agg_increase() {
     // Produce blocks until the first reward phase that everyone should be in
     while peer.get_burn_block_height() < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut peer_nonce));
-        observer.get_blocks();
     }
     let latest_block = latest_block.expect("Failed to get tip");
-    //let latest_block = peer.tenure_with_txs(&[], &mut peer_nonce);
     // Current reward cycle: 5 (starts at burn block 101)
     let reward_cycle = get_current_reward_cycle(&peer, &peer.config.burnchain);
     let next_reward_cycle = reward_cycle.wrapping_add(1);

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -3665,7 +3665,7 @@ fn stack_agg_increase() {
         &alice.public_key,
         u128::MAX,
         2,
-    );  
+    );
     bob.nonce += 1;
 
     let txs = vec![

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -3545,7 +3545,7 @@ fn stack_agg_increase() {
         Some(bob.pox_address.clone()),
     );
     eve.nonce += 1;
-    // Bob pool operator calling delegate-stack-stx on behalf of Dave
+    // Bob pool operator calling delegate-stack-stx on behalf of Eve
     let bob_delegate_stack_stx_for_eve_tx = make_pox_4_delegate_stack_stx(
         &bob.private_key,
         bob.nonce,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -43,7 +43,6 @@ use stacks_common::types::{Address, PrivateKey};
 use stacks_common::util::hash::{hex_bytes, to_hex, Sha256Sum, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use stdext::num::integer::Integer;
-use wsts::curve::field::P;
 use wsts::curve::point::{Compressed, Point};
 
 use super::test::*;

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -3374,10 +3374,6 @@ fn stack_agg_increase() {
     )
     .unwrap();
 
-    // reward cycles are 5 blocks long
-    // first 25 blocks are boot-up
-    // reward cycle 6 instantiates pox-3
-    // we stack in reward cycle 7 so pox-3 is evaluated to find reward set participation
     peer_config.aggregate_public_key = Some(aggregate_public_key.clone());
     peer_config
         .stacker_dbs

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -83,6 +83,7 @@ pub mod pox4 {
     define_named_enum!(Pox4SignatureTopic {
         StackStx("stack-stx"),
         AggregationCommit("agg-commit"),
+        AggregationIncrease("agg-increase"),
         StackExtend("stack-extend"),
         StackIncrease("stack-increase"),
     });


### PR DESCRIPTION
### Description
Initial draft of a solution to address #4643 found by @janniks. Keeping the logic in parallel with solo 'stack-increase', we opted to adding a required signature | set approval to the existing 'stack-aggregation-increase' function. 

This PR also includes minimal testing setup seen in #4586 as well (which will likely be rebased once this is first merged in). Also includes some comment clean up.

### Applicable issues
#4643

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
