### PR TITLE
remove portable flag

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,6 +2,11 @@
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 
+# Uncomment to improve performance slightly, at the cost of portability
+#   * Note that native binaries may not run on CPUs that are different from the build machine
+# [build]
+# rustflags = ["-Ctarget-cpu=native"]
+
 # Needed by perf to generate flamegraphs.
 #[target.x86_64-unknown-linux-gnu]
 #linker = "/usr/bin/clang"

--- a/.cargo/config
+++ b/.cargo/config
@@ -2,13 +2,6 @@
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 
-# Default to `native`
-# This makes it slightly faster for running tests and locally built binaries.
-# This can cause trouble when building "portable" binaries, such as for docker,
-# so disable it with the "portable" feature.
-[target.'cfg(not(feature = "portable"))']
-rustflags = ["-Ctarget-cpu=native"]
-
 # Needed by perf to generate flamegraphs.
 #[target.x86_64-unknown-linux-gnu]
 #linker = "/usr/bin/clang"

--- a/.github/actions/dockerfiles/Dockerfile.debian-source
+++ b/.github/actions/dockerfiles/Dockerfile.debian-source
@@ -19,7 +19,7 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && rustup component add rustfmt \
-    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache musl-dev
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json,portable --release
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
 
 RUN cp target/release/stacks-node /out
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -10,7 +10,7 @@ COPY . .
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json,portable --release
+RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
 
 RUN cp target/release/stacks-node /out
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ cargo build --release
 cargo build --profile release-lite
 ```
 
+_Note on building_: you may set `RUSTFLAGS` to build binaries for your native cpu:
+
+```
+RUSTFLAGS="-Ctarget-cpu=native"
+```
+
+or uncomment these lines in `./cargo/config`:
+
+```
+# [build]
+# rustflags = ["-Ctarget-cpu=native"]
+```
+
 ## Testing
 
 **Run the tests:**

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -60,6 +60,3 @@ features = ["arbitrary_precision", "unbounded_depth"]
 [dependencies.secp256k1]
 version = "0.24.3"
 features = ["serde", "recovery"]
-
-[features]
-portable = []

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -65,5 +65,4 @@ path = "src/stacks_events.rs"
 monitoring_prom = ["stacks/monitoring_prom"]
 slog_json = ["stacks/slog_json", "stacks-common/slog_json", "clarity/slog_json"]
 prod-genesis-chainstate = []
-portable = []
 default = []


### PR DESCRIPTION
ref: #4638 

the options in .cargo/config are not being applied, this PR removes them entirely and adds some text in the README on how to enable building for `native-cpu`. 

removing the portable flag will have some downstream effects to the release build process that we'll need to address once merged (basically removing the portable feature flag, and re-enabling macos-arm64 stacks-signer binary builds). 