### PR TITLE
Add stack-aggregation-increase command

### DIFF
--- a/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
@@ -100,6 +100,7 @@ it("statefully interacts with PoX-4", async () => {
       firstLockedRewardCycle: 0,
       allowedContractCaller: "",
       callerAllowedBy: [],
+      committedRewCycleIndexes: [],
     };
   });
 

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -64,6 +64,7 @@ export type Wallet = {
   firstLockedRewardCycle: number;
   allowedContractCaller: StxAddress;
   callerAllowedBy: StxAddress[];
+  committedRewCycleIndexes: number[];
 };
 
 export type PoxCommand = fc.Command<Stub, Real>;

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -30,9 +30,9 @@ export class Stub {
   }
 
   reportCommandRuns() {
-    process.stdout.write("Command run method execution counts:");
+    console.log("Command run method execution counts:");
     this.statistics.forEach((count, commandName) => {
-      process.stdout.write(`\n${commandName}: ${count}`);
+      console.log(`${commandName}: ${count}`);
     });
   }
 }

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -12,6 +12,7 @@ export class Stub {
   readonly wallets: Map<StxAddress, Wallet>;
   readonly statistics: Map<string, number>;
   stackingMinimum: number;
+  nextRewardSetIndex: number
 
   constructor(
     wallets: Map<StxAddress, Wallet>,
@@ -20,6 +21,7 @@ export class Stub {
     this.wallets = wallets;
     this.statistics = statistics;
     this.stackingMinimum = 0;
+    this.nextRewardSetIndex = 0;
   }
 
   trackCommandRun(commandName: string) {

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -14,6 +14,7 @@ import { DelegateStackExtendCommand } from "./pox_DelegateStackExtendCommand";
 import { StackAggregationCommitAuthCommand } from "./pox_StackAggregationCommitAuthCommand";
 import { StackAggregationCommitSigCommand } from "./pox_StackAggregationCommitSigCommand";
 import { StackAggregationCommitIndexedSigCommand } from "./pox_StackAggregationCommitIndexedSigCommand";
+import { StackAggregationCommitIndexedAuthCommand } from "./pox_StackAggregationCommitIndexedAuthCommand";
 
 export function PoxCommands(
   wallets: Map<StxAddress, Wallet>,
@@ -108,6 +109,24 @@ export function PoxCommands(
       },
     ) =>
       new StackAggregationCommitSigCommand(
+        r.wallet,
+        r.authId,
+        r.currentCycle,
+      )
+    ),
+    // StackAggregationCommitIndexedAuthCommand
+    fc.record({
+      wallet: fc.constantFrom(...wallets.values()),
+      authId: fc.nat(),
+      currentCycle: fc.constant(currentCycle(network)),
+    }).map((
+      r: {
+        wallet: Wallet;
+        authId: number;
+        currentCycle: number;
+      },
+    ) =>
+      new StackAggregationCommitIndexedAuthCommand(
         r.wallet,
         r.authId,
         r.currentCycle,

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -13,6 +13,7 @@ import { DelegateStackIncreaseCommand } from "./pox_DelegateStackIncreaseCommand
 import { DelegateStackExtendCommand } from "./pox_DelegateStackExtendCommand";
 import { StackAggregationCommitAuthCommand } from "./pox_StackAggregationCommitAuthCommand";
 import { StackAggregationCommitSigCommand } from "./pox_StackAggregationCommitSigCommand";
+import { StackAggregationCommitIndexedSigCommand } from "./pox_StackAggregationCommitIndexedSigCommand";
 
 export function PoxCommands(
   wallets: Map<StxAddress, Wallet>,
@@ -107,6 +108,24 @@ export function PoxCommands(
       },
     ) =>
       new StackAggregationCommitSigCommand(
+        r.wallet,
+        r.authId,
+        r.currentCycle,
+      )
+    ),
+    // StackAggregationCommitIndexedSigCommand
+    fc.record({
+      wallet: fc.constantFrom(...wallets.values()),
+      authId: fc.nat(),
+      currentCycle: fc.constant(currentCycle(network)),
+    }).map((
+      r: {
+        wallet: Wallet;
+        authId: number;
+        currentCycle: number;
+      },
+    ) =>
+      new StackAggregationCommitIndexedSigCommand(
         r.wallet,
         r.authId,
         r.currentCycle,

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -15,6 +15,7 @@ import { StackAggregationCommitAuthCommand } from "./pox_StackAggregationCommitA
 import { StackAggregationCommitSigCommand } from "./pox_StackAggregationCommitSigCommand";
 import { StackAggregationCommitIndexedSigCommand } from "./pox_StackAggregationCommitIndexedSigCommand";
 import { StackAggregationCommitIndexedAuthCommand } from "./pox_StackAggregationCommitIndexedAuthCommand";
+import { StackAggregationIncreaseCommand } from "./pox_StackAggregationIncreaseCommand";
 
 export function PoxCommands(
   wallets: Map<StxAddress, Wallet>,
@@ -148,6 +149,33 @@ export function PoxCommands(
         r.wallet,
         r.authId,
         r.currentCycle,
+      )
+    ),
+    // StackAggregationIncreaseCommand
+    fc.record({
+      wallet: fc.constantFrom(...wallets.values()),
+      currentCycle: fc.constant(currentCycle(network)),
+    }).chain((r) => {
+      const committedRewCycleIndexesOrFallback =
+        r.wallet.committedRewCycleIndexes.length > 0
+          ? r.wallet.committedRewCycleIndexes
+          : [-1];
+      return fc.record({
+        rewardCycleIndex: fc.constantFrom(
+          ...committedRewCycleIndexesOrFallback,
+        ),
+      }).map((cycleIndex) => ({ ...r, ...cycleIndex }));
+    }).map((
+      r: {
+        wallet: Wallet;
+        currentCycle: number;
+        rewardCycleIndex: number;
+      },
+    ) =>
+      new StackAggregationIncreaseCommand(
+        r.wallet,
+        r.currentCycle,
+        r.rewardCycleIndex,
       )
     ),
     // RevokeDelegateStxCommand

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitAuthCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitAuthCommand.ts
@@ -112,6 +112,7 @@ export class StackAggregationCommitAuthCommand implements PoxCommand {
 
     const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
     operatorWallet.amountToCommit -= committedAmount;
+    operatorWallet.committedRewCycleIndexes.push(model.nextRewardSetIndex);
     model.nextRewardSetIndex++;
 
     // Log to console for debugging purposes. This is not necessary for the

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedAuthCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedAuthCommand.ts
@@ -116,6 +116,7 @@ export class StackAggregationCommitIndexedAuthCommand implements PoxCommand {
     // Update the model
     const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
     operatorWallet.amountToCommit -= committedAmount;
+    operatorWallet.committedRewCycleIndexes.push(model.nextRewardSetIndex);
     model.nextRewardSetIndex++;
 
     // Log to console for debugging purposes. This is not necessary for the

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedAuthCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedAuthCommand.ts
@@ -1,0 +1,138 @@
+import {
+  logCommand,
+  PoxCommand,
+  Real,
+  Stub,
+  Wallet,
+} from "./pox_CommandModel.ts";
+import { poxAddressToTuple } from "@stacks/stacking";
+import { expect } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+/**
+ * The `StackAggregationCommitIndexedAuthCommand` allows an operator to
+ * commit partially stacked STX & to allocate a new PoX reward address
+ * slot.
+ * This allows a stacker to lock fewer STX than the minimal threshold
+ * in multiple transactions, so long as:
+ *  1. The pox-addr is the same.
+ *  2. The "commit" transaction is called _before_ the PoX anchor block.
+ *
+ * This command calls `stack-aggregation-commit-indexed` using an
+ * `authorization`.
+ *
+ * Constraints for running this command include:
+ * - The Operator must have locked STX on behalf of at least one stacker.
+ * - The total amount previously locked by the Operator on behalf of the
+ *   stackers has to be greater than the uSTX threshold.
+ */
+export class StackAggregationCommitIndexedAuthCommand implements PoxCommand {
+  readonly operator: Wallet;
+  readonly authId: number;
+  readonly currentCycle: number;
+
+  /**
+   * Constructs a `StackAggregationCommitIndexedAuthCommand` to lock uSTX 
+   * for stacking.
+   *
+   * @param operator - Represents the `Operator`'s wallet.
+   * @param authId - Unique `auth-id` for the authorization.
+   * @param currentCycle - The current reward cycle.
+   */
+  constructor(operator: Wallet, authId: number, currentCycle: number) {
+    this.operator = operator;
+    this.authId = authId;
+    this.currentCycle = currentCycle;
+  }
+
+  check(model: Readonly<Stub>): boolean {
+    // Constraints for running this command include:
+    // - The Operator must have locked STX on behalf of at least one stacker.
+    // - The total amount previously locked by the Operator on behalf of the
+    //   stackers has to be greater than the uSTX threshold.
+
+    return (
+      this.operator.lockedAddresses.length > 0 &&
+      this.operator.amountToCommit >= model.stackingMinimum
+    );
+  }
+
+  run(model: Stub, real: Real): void {
+    model.trackCommandRun(this.constructor.name);
+
+    const committedAmount = this.operator.amountToCommit;
+
+    const { result: setSignature } = real.network.callPublicFn(
+      "ST000000000000000000002AMW42H.pox-4",
+      "set-signer-key-authorization",
+      [
+        // (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
+        poxAddressToTuple(this.operator.btcAddress),
+        // (period uint)
+        Cl.uint(1),
+        // (reward-cycle uint)
+        Cl.uint(this.currentCycle + 1),
+        // (topic (string-ascii 14))
+        Cl.stringAscii("agg-commit"),
+        // (signer-key (buff 33))
+        Cl.bufferFromHex(this.operator.signerPubKey),
+        // (allowed bool)
+        Cl.bool(true),
+        // (max-amount uint)
+        Cl.uint(committedAmount),
+        // (auth-id uint)
+        Cl.uint(this.authId),
+      ],
+      this.operator.stxAddress,
+    );
+    expect(setSignature).toBeOk(Cl.bool(true));
+
+    // Act
+    const stackAggregationCommitIndexed = real.network.callPublicFn(
+      "ST000000000000000000002AMW42H.pox-4",
+      "stack-aggregation-commit-indexed",
+      [
+        // (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
+        poxAddressToTuple(this.operator.btcAddress),
+        // (reward-cycle uint)
+        Cl.uint(this.currentCycle + 1),
+        // (signer-sig (optional (buff 65)))
+        Cl.none(),
+        // (signer-key (buff 33))
+        Cl.bufferFromHex(this.operator.signerPubKey),
+        // (max-amount uint)
+        Cl.uint(committedAmount),
+        // (auth-id uint)
+        Cl.uint(this.authId),
+      ],
+      this.operator.stxAddress,
+    );
+
+    // Assert
+    expect(stackAggregationCommitIndexed.result).toBeOk(
+      Cl.uint(model.nextRewardSetIndex),
+    );
+
+    // Update the model
+    const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
+    operatorWallet.amountToCommit -= committedAmount;
+    model.nextRewardSetIndex++;
+
+    // Log to console for debugging purposes. This is not necessary for the
+    // test to pass but it is useful for debugging and eyeballing the test.
+    logCommand(
+      `✓ ${this.operator.label}`,
+      "stack-agg-commit-indexed",
+      "amount committed",
+      committedAmount.toString(),
+      "authorization",
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.operator.label} stack-aggregation-commit-indexed auth-id ${this.authId} for reward cycle ${this.currentCycle}`;
+  }
+}

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedSigCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedSigCommand.ts
@@ -116,6 +116,7 @@ export class StackAggregationCommitIndexedSigCommand implements PoxCommand {
     // Update the model
     const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
     operatorWallet.amountToCommit -= committedAmount;
+    operatorWallet.committedRewCycleIndexes.push(model.nextRewardSetIndex);
     model.nextRewardSetIndex++;
 
     // Log to console for debugging purposes. This is not necessary for the

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedSigCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitIndexedSigCommand.ts
@@ -5,42 +5,42 @@ import {
   Stub,
   Wallet,
 } from "./pox_CommandModel.ts";
-import { poxAddressToTuple } from "@stacks/stacking";
+import { Pox4SignatureTopic, poxAddressToTuple } from "@stacks/stacking";
 import { expect } from "vitest";
 import { Cl } from "@stacks/transactions";
+import { bufferFromHex } from "@stacks/transactions/dist/cl";
 
 /**
- * The `StackAggregationCommitAuthCommand` allows an operator to commit
- * partially stacked STX & to allocate a new PoX reward address slot.
+ * The `StackAggregationCommitIndexedSigCommand` allows an operator to
+ * commit partially stacked STX & to allocate a new PoX reward address
+ * slot.
  * This allows a stacker to lock fewer STX than the minimal threshold
  * in multiple transactions, so long as:
  *  1. The pox-addr is the same.
  *  2. The "commit" transaction is called _before_ the PoX anchor block.
  *
- * This command calls stack-aggregation-commit using an `authorization`.
+ * This command calls `stack-aggregation-commit-indexed` using a
+ * `signature`.
  *
  * Constraints for running this command include:
  * - The Operator must have locked STX on behalf of at least one stacker.
  * - The total amount previously locked by the Operator on behalf of the
  *   stackers has to be greater than the uSTX threshold.
  */
-export class StackAggregationCommitAuthCommand implements PoxCommand {
+export class StackAggregationCommitIndexedSigCommand implements PoxCommand {
   readonly operator: Wallet;
   readonly authId: number;
   readonly currentCycle: number;
 
   /**
-   * Constructs a `StackAggregationCommitAuthCommand` to lock uSTX for stacking.
+   * Constructs a `StackAggregationCommitIndexedSigCommand` to lock uSTX 
+   * for stacking.
    *
    * @param operator - Represents the `Operator`'s wallet.
    * @param authId - Unique `auth-id` for the authorization.
    * @param currentCycle - The current reward cycle.
    */
-  constructor(
-    operator: Wallet,
-    authId: number,
-    currentCycle: number,
-  ) {
+  constructor(operator: Wallet, authId: number, currentCycle: number) {
     this.operator = operator;
     this.authId = authId;
     this.currentCycle = currentCycle;
@@ -52,8 +52,10 @@ export class StackAggregationCommitAuthCommand implements PoxCommand {
     // - The total amount previously locked by the Operator on behalf of the
     //   stackers has to be greater than the uSTX threshold.
 
-    return this.operator.lockedAddresses.length > 0 &&
-      this.operator.amountToCommit >= model.stackingMinimum;
+    return (
+      this.operator.lockedAddresses.length > 0 &&
+      this.operator.amountToCommit >= model.stackingMinimum
+    );
   }
 
   run(model: Stub, real: Real): void {
@@ -61,42 +63,41 @@ export class StackAggregationCommitAuthCommand implements PoxCommand {
 
     const committedAmount = this.operator.amountToCommit;
 
-    const { result: setSignature } = real.network.callPublicFn(
-      "ST000000000000000000002AMW42H.pox-4",
-      "set-signer-key-authorization",
-      [
-        // (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
-        poxAddressToTuple(this.operator.btcAddress),
-        // (period uint)
-        Cl.uint(1),
-        // (reward-cycle uint)
-        Cl.uint(this.currentCycle + 1),
-        // (topic (string-ascii 14))
-        Cl.stringAscii("agg-commit"),
-        // (signer-key (buff 33))
-        Cl.bufferFromHex(this.operator.signerPubKey),
-        // (allowed bool)
-        Cl.bool(true),
-        // (max-amount uint)
-        Cl.uint(committedAmount),
-        // (auth-id uint)
-        Cl.uint(this.authId),
-      ],
-      this.operator.stxAddress,
-    );
-    expect(setSignature).toBeOk(Cl.bool(true));
+    const signerSig = this.operator.stackingClient.signPoxSignature({
+      // The signer key being authorized.
+      signerPrivateKey: this.operator.signerPrvKey,
+      // The reward cycle for which the authorization is valid.
+      // For stack-stx and stack-extend, this refers to the reward cycle
+      // where the transaction is confirmed. For stack-aggregation-commit,
+      // this refers to the reward cycle argument in that function.
+      rewardCycle: this.currentCycle + 1,
+      // For stack-stx, this refers to lock-period. For stack-extend,
+      // this refers to extend-count. For stack-aggregation-commit, this is
+      // u1.
+      period: 1,
+      // A string representing the function where this authorization is valid.
+      // Either stack-stx, stack-extend, stack-increase or agg-commit.
+      topic: Pox4SignatureTopic.AggregateCommit,
+      // The PoX address that can be used with this signer key.
+      poxAddress: this.operator.btcAddress,
+      // The unique auth-id for this authorization.
+      authId: this.authId,
+      // The maximum amount of uSTX that can be used (per tx) with this signer
+      // key.
+      maxAmount: committedAmount,
+    });
 
     // Act
-    const stackAggregationCommit = real.network.callPublicFn(
+    const stackAggregationCommitIndexed = real.network.callPublicFn(
       "ST000000000000000000002AMW42H.pox-4",
-      "stack-aggregation-commit",
+      "stack-aggregation-commit-indexed",
       [
         // (pox-addr (tuple (version (buff 1)) (hashbytes (buff 32))))
         poxAddressToTuple(this.operator.btcAddress),
         // (reward-cycle uint)
         Cl.uint(this.currentCycle + 1),
         // (signer-sig (optional (buff 65)))
-        Cl.none(),
+        Cl.some(bufferFromHex(signerSig)),
         // (signer-key (buff 33))
         Cl.bufferFromHex(this.operator.signerPubKey),
         // (max-amount uint)
@@ -108,8 +109,11 @@ export class StackAggregationCommitAuthCommand implements PoxCommand {
     );
 
     // Assert
-    expect(stackAggregationCommit.result).toBeOk(Cl.bool(true));
+    expect(stackAggregationCommitIndexed.result).toBeOk(
+      Cl.uint(model.nextRewardSetIndex),
+    );
 
+    // Update the model
     const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
     operatorWallet.amountToCommit -= committedAmount;
     model.nextRewardSetIndex++;
@@ -118,10 +122,10 @@ export class StackAggregationCommitAuthCommand implements PoxCommand {
     // test to pass but it is useful for debugging and eyeballing the test.
     logCommand(
       `✓ ${this.operator.label}`,
-      "stack-agg-commit",
+      "stack-agg-commit-indexed",
       "amount committed",
       committedAmount.toString(),
-      "authorization",
+      "signature",
     );
   }
 
@@ -129,6 +133,6 @@ export class StackAggregationCommitAuthCommand implements PoxCommand {
     // fast-check will call toString() in case of errors, e.g. property failed.
     // It will then make a minimal counterexample, a process called 'shrinking'
     // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
-    return `${this.operator.label} stack-aggregation-commit auth-id ${this.authId} for reward cycle ${this.currentCycle}`;
+    return `${this.operator.label} stack-aggregation-commit-indexed auth-id ${this.authId} for reward cycle ${this.currentCycle}`;
   }
 }

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitSigCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitSigCommand.ts
@@ -112,6 +112,7 @@ export class StackAggregationCommitSigCommand implements PoxCommand {
 
     const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
     operatorWallet.amountToCommit -= committedAmount;
+    operatorWallet.committedRewCycleIndexes.push(model.nextRewardSetIndex);
     model.nextRewardSetIndex++;
 
     // Log to console for debugging purposes. This is not necessary for the

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitSigCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationCommitSigCommand.ts
@@ -112,6 +112,7 @@ export class StackAggregationCommitSigCommand implements PoxCommand {
 
     const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
     operatorWallet.amountToCommit -= committedAmount;
+    model.nextRewardSetIndex++;
 
     // Log to console for debugging purposes. This is not necessary for the
     // test to pass but it is useful for debugging and eyeballing the test.

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationIncreaseCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationIncreaseCommand.ts
@@ -1,0 +1,109 @@
+import {
+  logCommand,
+  PoxCommand,
+  Real,
+  Stub,
+  Wallet,
+} from "./pox_CommandModel.ts";
+import { poxAddressToTuple } from "@stacks/stacking";
+import { expect } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+/**
+ * The `StackAggregationIncreaseCommand` allows an operator to commit
+ * partially stacked STX to a PoX address which has already received
+ * some STX (more than the `stacking minimum`).
+ * This allows a delegator to lock up marginally more STX from new
+ * delegates, even if they collectively do not exceed the Stacking
+ * minimum, so long as the target PoX address already represents at
+ * least as many STX as the `stacking minimum`.
+ * This command calls stack-aggregation-increase.
+ *
+ * Constraints for running this command include:
+ * - The Operator must have locked STX on behalf of at least one stacker.
+ * - The PoX address must have partial committed STX.
+ * - The Reward Cycle Index must be positive.
+ */
+export class StackAggregationIncreaseCommand implements PoxCommand {
+  readonly operator: Wallet;
+  readonly currentCycle: number;
+  readonly rewardCycleIndex: number;
+
+  /**
+   * Constructs a `StackAggregationIncreaseCommand` to commit partially
+   * stacked STX to a PoX address which has already received some STX.
+   *
+   * @param operator - Represents the `Operator`'s wallet.
+   * @param currentCycle - The current reward cycle.
+   * @param rewardCycleIndex - The cycle index to increase the commit for.
+   */
+  constructor(
+    operator: Wallet,
+    currentCycle: number,
+    rewardCycleIndex: number,
+  ) {
+    this.operator = operator;
+    this.currentCycle = currentCycle;
+    this.rewardCycleIndex = rewardCycleIndex;
+  }
+
+  check(_model: Readonly<Stub>): boolean {
+    // Constraints for running this command include:
+    // - The Operator must have locked STX on behalf of at least one stacker.
+    // - The PoX address must have partial committed STX.
+    // - The Reward Cycle Index must be positive.
+
+    return (
+      this.operator.lockedAddresses.length > 0 &&
+      this.rewardCycleIndex >= 0 &&
+      this.operator.amountToCommit > 0
+    );
+  }
+
+  run(model: Stub, real: Real): void {
+    model.trackCommandRun(this.constructor.name);
+
+    const committedAmount = this.operator.amountToCommit;
+
+    // Act
+    const stackAggregationIncrease = real.network.callPublicFn(
+      "ST000000000000000000002AMW42H.pox-4",
+      "stack-aggregation-increase",
+      [
+        // (pox-addr { version: (buff 1), hashbytes: (buff 32) })
+        poxAddressToTuple(this.operator.btcAddress),
+        // (reward-cycle uint)
+        Cl.uint(this.currentCycle + 1),
+        // (reward-cycle-index uint))
+        Cl.uint(this.rewardCycleIndex),
+      ],
+      this.operator.stxAddress,
+    );
+
+    // Assert
+    expect(stackAggregationIncrease.result).toBeOk(Cl.bool(true));
+
+    const operatorWallet = model.wallets.get(this.operator.stxAddress)!;
+    operatorWallet.amountToCommit -= committedAmount;
+
+    // Log to console for debugging purposes. This is not necessary for the
+    // test to pass but it is useful for debugging and eyeballing the test.
+    logCommand(
+      `✓ ${this.operator.label}`,
+      "stack-agg-increase",
+      "amount committed",
+      committedAmount.toString(),
+      "cycle index",
+      this.rewardCycleIndex.toString(),
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.operator.label} stack-aggregation-increase for reward cycle ${
+      this.currentCycle + 1
+    } index ${this.rewardCycleIndex}`;
+  }
+}

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackStxCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackStxCommand.ts
@@ -162,6 +162,7 @@ export class StackStxCommand implements PoxCommand {
     wallet.amountLocked = amountUstx;
     wallet.unlockHeight = Number(unlockBurnHeight.value);
     wallet.amountUnlocked -= amountUstx;
+    model.nextRewardSetIndex++;
 
     // Log to console for debugging purposes. This is not necessary for the
     // test to pass but it is useful for debugging and eyeballing the test.


### PR DESCRIPTION
This PR adds the `stack-aggregation-commit` command, using both signature and authorization, to the stateful property testing environment. It is part of #4548 and targets `feat/pox-4-stateful-property-testing` (#4550).