### PR TITLE
feat: limit length of chunks when signer reads from stackerdb

### DIFF
--- a/libsigner/src/session.rs
+++ b/libsigner/src/session.rs
@@ -218,7 +218,8 @@ impl SignerSession for StackerDBSession {
         let limit = if self.stackerdb_contract_id.name.starts_with("signer") {
             SIGNERS_STACKERDB_CHUNK_SIZE
         } else {
-            STACKERDB_MAX_CHUNK_SIZE as usize
+            usize::try_from(STACKERDB_MAX_CHUNK_SIZE)
+                .expect("infallible: StackerDB chunk size exceeds usize::MAX")
         };
         for slot_id in slot_ids.iter() {
             let path = stackerdb_get_chunk_path(self.stackerdb_contract_id.clone(), *slot_id, None);

--- a/libsigner/src/session.rs
+++ b/libsigner/src/session.rs
@@ -17,11 +17,11 @@
 use std::net::{SocketAddr, TcpStream};
 use std::str;
 
-use blockstack_lib::net::stackerdb::SIGNERS_STACKERDB_CHUNK_SIZE;
 use clarity::vm::types::QualifiedContractIdentifier;
 use libstackerdb::{
     stackerdb_get_chunk_path, stackerdb_get_metadata_path, stackerdb_post_chunk_path, SlotMetadata,
-    StackerDBChunkAckData, StackerDBChunkData,
+    StackerDBChunkAckData, StackerDBChunkData, SIGNERS_STACKERDB_CHUNK_SIZE,
+    STACKERDB_MAX_CHUNK_SIZE,
 };
 use stacks_common::codec::StacksMessageCodec;
 
@@ -215,14 +215,17 @@ impl SignerSession for StackerDBSession {
     /// query the replica for zero or more latest chunks
     fn get_latest_chunks(&mut self, slot_ids: &[u32]) -> Result<Vec<Option<Vec<u8>>>, RPCError> {
         let mut payloads = vec![];
+        let limit = if self.stackerdb_contract_id.name.starts_with("signer") {
+            SIGNERS_STACKERDB_CHUNK_SIZE
+        } else {
+            STACKERDB_MAX_CHUNK_SIZE as usize
+        };
         for slot_id in slot_ids.iter() {
             let path = stackerdb_get_chunk_path(self.stackerdb_contract_id.clone(), *slot_id, None);
             let chunk = match self.rpc_request("GET", &path, None, &[]) {
                 Ok(body_bytes) => {
                     // Verify that the chunk is not too large
-                    if body_bytes.len() > u32::MAX as usize {
-                        None
-                    } else if body_bytes.len() as u32 > SIGNERS_STACKERDB_CHUNK_SIZE {
+                    if body_bytes.len() > limit {
                         None
                     } else {
                         Some(body_bytes)

--- a/libstackerdb/src/libstackerdb.rs
+++ b/libstackerdb/src/libstackerdb.rs
@@ -35,6 +35,8 @@ use stacks_common::util::secp256k1::MessageSignature;
 
 /// maximum chunk size (16 MB; same as MAX_PAYLOAD_SIZE)
 pub const STACKERDB_MAX_CHUNK_SIZE: u32 = 16 * 1024 * 1024;
+/// CHUNK_SIZE constant for signers StackerDBs (2MB)
+pub const SIGNERS_STACKERDB_CHUNK_SIZE: usize = 2 * 1024 * 1024; // 2MB
 
 #[cfg(test)]
 mod tests;

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -148,8 +148,6 @@ pub const STACKERDB_INV_MAX: u32 = 4096;
 pub const STACKERDB_PAGE_LIST_MAX: u32 = 4096;
 /// maximum number of pages that can be used in a StackerDB contract
 pub const STACKERDB_MAX_PAGE_COUNT: u32 = 2;
-/// CHUNK_SIZE constant for signers StackerDBs
-pub const SIGNERS_STACKERDB_CHUNK_SIZE: u32 = 2 * 1024 * 1024; // 2MB
 
 pub const STACKERDB_SLOTS_FUNCTION: &str = "stackerdb-get-signer-slots";
 pub const STACKERDB_CONFIG_FUNCTION: &str = "stackerdb-get-config";

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -148,6 +148,8 @@ pub const STACKERDB_INV_MAX: u32 = 4096;
 pub const STACKERDB_PAGE_LIST_MAX: u32 = 4096;
 /// maximum number of pages that can be used in a StackerDB contract
 pub const STACKERDB_MAX_PAGE_COUNT: u32 = 2;
+/// CHUNK_SIZE constant for signers StackerDBs
+pub const SIGNERS_STACKERDB_CHUNK_SIZE: u32 = 2 * 1024 * 1024; // 2MB
 
 pub const STACKERDB_SLOTS_FUNCTION: &str = "stackerdb-get-signer-slots";
 pub const STACKERDB_CONFIG_FUNCTION: &str = "stackerdb-get-config";


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/4648

This uses the `CHUNK_SIZE` constant, which is set in `signers.clar` and used as part of its StackerDB config, when reading chunks from the `stacks-signer`. This maximum chunk length is already enforced on the node, but this PR adds a some redundancy on that maximum length check.