### PR TITLE
Debug/dkg results

### DIFF
--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -388,14 +388,9 @@ impl SignerRunLoop<Vec<OperationResult>, RunLoopCommand> for RunLoop {
             if event_parity == Some(other_signer_parity) {
                 continue;
             }
-
             if signer.approved_aggregate_public_key.is_none() {
-                if let Err(e) = retry_with_exponential_backoff(|| {
-                    signer
-                        .update_dkg(&self.stacks_client, current_reward_cycle)
-                        .map_err(backoff::Error::transient)
-                }) {
-                    error!("{signer}: failed to update DKG: {e}");
+                if let Err(e) = signer.refresh_dkg(&self.stacks_client) {
+                    error!("{signer}: failed to refresh DKG: {e}");
                 }
             }
             signer.refresh_coordinator();

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -996,6 +996,10 @@ impl Signer {
     /// Process a dkg result by broadcasting a vote to the stacks node
     fn process_dkg(&mut self, stacks_client: &StacksClient, dkg_public_key: &Point) {
         let mut dkg_results_bytes = vec![];
+        debug!(
+            "{self}: Received DKG result. Broadcasting vote to the stacks node...";
+            "dkg_public_key" => %dkg_public_key
+        );
         if let Err(e) = SignerMessage::serialize_dkg_result(
             &mut dkg_results_bytes,
             dkg_public_key,

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -1292,15 +1292,13 @@ impl Signer {
                     self.approved_aggregate_public_key
                 );
             }
-            if matches!(self.state, State::OperationInProgress(Operation::Dkg)) {
+            if let State::OperationInProgress(Operation::Dkg) = self.state {
                 debug!(
-                    "{self}: DKG has already been set. Aborting DKG operation {}.",
-                    self.coordinator.current_dkg_id
+                    "{self}: DKG has already been set. Aborting DKG operation {self.coordinator.current_dkg_id}."
                 );
                 self.finish_operation();
             }
         } else if should_queue {
-            info!("{self} is the current coordinator and must trigger DKG. Queuing DKG command...");
             if self.commands.front() != Some(&Command::Dkg) {
                 info!("{self} is the current coordinator and must trigger DKG. Queuing DKG command...");
                 self.commands.push_front(Command::Dkg);

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -1321,11 +1321,21 @@ impl Signer {
                 );
                 return Ok(());
             }
-            debug!("{self}: Vote for DKG failed. Triggering a DKG round.";
+
+            // Try again to get the approved key, in case it has reached the threshold weight
+            // after we last checked.
+            self.approved_aggregate_public_key =
+                stacks_client.get_approved_aggregate_key(self.reward_cycle)?;
+            if self.approved_aggregate_public_key.is_some() {
+                self.coordinator
+                    .set_aggregate_public_key(self.approved_aggregate_public_key);
+                return Ok(false);
+            }
+            debug!("{self}: Vote for DKG failed.";
                 "voting_round" => self.coordinator.current_dkg_id,
                 "aggregate_key" => %aggregate_key,
                 "round_weight" => round_weight,
-                "threshold_weight" => threshold_weight
+                "threshold_weight" => threshold_weight,
             );
         } else {
             debug!("{self}: Triggering a DKG round.");

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -1273,7 +1273,10 @@ impl Signer {
     pub fn refresh_dkg(&mut self, stacks_client: &StacksClient) -> Result<(), ClientError> {
         // First check if we should queue DKG based on contract vote state and stackerdb transactions
         let should_queue = self.should_queue_dkg(stacks_client)?;
-        // Before queueing the command, check one last time if DKG has been approved (could have happend in the meantime)
+        // Before queueing the command, check one last time if DKG has been
+        // approved. It could have happened after the last call to
+        // `get_approved_aggregate_key` but before the theshold check in
+        // `should_queue_dkg`.
         let old_dkg = self.approved_aggregate_public_key;
         self.approved_aggregate_public_key =
             stacks_client.get_approved_aggregate_key(self.reward_cycle)?;


### PR DESCRIPTION
We needlessly were triggering DKG rounds due to a timing issue between our first check to see if a key was approved and the later threshold check being exceeded. 
Now if we have not locally stored an approved key, we will always attempt the DKG queue checks. It will always follow this check by a final loading of whatever is set in the contract. Not bothering to queue a command if it finds an approved key. This should mitigate needless triggering of DKG for the obvious case. 

However, we still need the later update to retrieve DKG shares based on round ID in https://github.com/stacks-network/stacks-core/issues/4654 as we can never be sure that our view of the contract is correct at the time of triggering a DKG round. (we could be milliseconds off when checking the approved key is set still). 


