### PR TITLE
Add disallow-contract-caller command

### DIFF
--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -16,6 +16,7 @@ import { StackAggregationCommitSigCommand } from "./pox_StackAggregationCommitSi
 import { StackAggregationCommitIndexedSigCommand } from "./pox_StackAggregationCommitIndexedSigCommand";
 import { StackAggregationCommitIndexedAuthCommand } from "./pox_StackAggregationCommitIndexedAuthCommand";
 import { StackAggregationIncreaseCommand } from "./pox_StackAggregationIncreaseCommand";
+import { DisallowContractCallerCommand } from "./pox_DisallowContractCallerCommand";
 
 export function PoxCommands(
   wallets: Map<StxAddress, Wallet>,
@@ -326,6 +327,20 @@ export function PoxCommands(
             r.alllowUntilBurnHt,
           ),
       ),
+    // DisallowContractCallerCommand
+    fc.record({
+      stacker: fc.constantFrom(...wallets.values()),
+      callerToDisallow: fc.constantFrom(...wallets.values()),
+    }).map(
+      (r: {
+        stacker: Wallet;
+        callerToDisallow: Wallet;
+      }) =>
+        new DisallowContractCallerCommand(
+          r.stacker,
+          r.callerToDisallow,
+        ),
+    ),
     // GetStxAccountCommand
     fc.record({
       wallet: fc.constantFrom(...wallets.values()),

--- a/contrib/core-contract-tests/tests/pox-4/pox_DisallowContractCallerCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_DisallowContractCallerCommand.ts
@@ -1,0 +1,98 @@
+import {
+  logCommand,
+  PoxCommand,
+  Real,
+  Stub,
+  Wallet,
+} from "./pox_CommandModel.ts";
+import { expect } from "vitest";
+import { boolCV, Cl } from "@stacks/transactions";
+
+/**
+ * The `DisallowContractCallerComand` revokes a `contract-caller`'s
+ * authorization to call stacking methods.
+ *
+ * Constraints for running this command include:
+ * - The Caller to be disallowed must have been previously
+ *   allowed by the Operator.
+ */
+export class DisallowContractCallerCommand implements PoxCommand {
+  readonly stacker: Wallet;
+  readonly callerToDisallow: Wallet;
+
+  /**
+   * Constructs a `DisallowContractCallerComand` to revoke authorization
+   * for calling stacking methods.
+   *
+   * @param stacker - Represents the `Stacker`'s wallet.
+   * @param callerToDisallow - The `contract-caller` to be revoked.
+   */
+
+  constructor(stacker: Wallet, callerToDisallow: Wallet) {
+    this.stacker = stacker;
+    this.callerToDisallow = callerToDisallow;
+  }
+
+  check(_model: Readonly<Stub>): boolean {
+    // Constraints for running this command include:
+    // - The Caller to be disallowed must have been previously
+    //   allowed by the Operator.
+
+    return (
+      this.stacker.allowedContractCaller === this.callerToDisallow.stxAddress &&
+      this.callerToDisallow.callerAllowedBy.includes(this.stacker.stxAddress) ===
+        true
+    );
+  }
+
+  run(model: Stub, real: Real): void {
+    model.trackCommandRun(this.constructor.name);
+
+    // Act
+    const disallowContractCaller = real.network.callPublicFn(
+      "ST000000000000000000002AMW42H.pox-4",
+      "disallow-contract-caller",
+      [
+        // (caller principal)
+        Cl.principal(this.callerToDisallow.stxAddress),
+      ],
+      this.stacker.stxAddress,
+    );
+
+    // Assert
+    expect(disallowContractCaller.result).toBeOk(boolCV(true));
+
+    // Get the wallet to be revoked stacking rights from the model and 
+    // update it with the new state.
+    const callerToDisallow = model.wallets.get(
+      this.callerToDisallow.stxAddress,
+    )!;
+
+    // Update model so that we know that the stacker has revoked stacking 
+    // allowance.
+    this.stacker.allowedContractCaller = "";
+
+    // Remove the operator from the caller to disallow's allowance list.
+    const walletIndexAllowedByList = callerToDisallow.callerAllowedBy.indexOf(
+      this.stacker.stxAddress,
+    );
+
+    expect(walletIndexAllowedByList).toBeGreaterThan(-1);
+    callerToDisallow.callerAllowedBy.splice(walletIndexAllowedByList, 1);
+
+    // Log to console for debugging purposes. This is not necessary for the
+    // test to pass but it is useful for debugging and eyeballing the test.
+    logCommand(
+      `✓ ${this.stacker.label}`,
+      "disallow-contract-caller",
+      this.callerToDisallow.label,
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.stacker.label} disallow-contract-caller ${this.callerToDisallow.label}`;
+  }
+}


### PR DESCRIPTION
This PR adds the `disallow-contract-caller` command to the stateful property testing environment. It is part of #4548 and targets `feat/pox-4-stateful-property-testing` (#4550).