### PR TITLE
fix: fix delegate stack increase events

### DIFF
--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -288,7 +288,7 @@ fn create_event_info_data_code(
                         ;; Get start cycle ID
                         start-cycle-id: (+ (current-pox-reward-cycle) u1 pox-set-offset),
                     }}
-                }}
+                }})
                 "#,
                 stacker = &args[0],
                 pox_addr = &args[1],


### PR DESCRIPTION
- missing `)` in injected code was causing an event to not emit

> not consensus critical, but very important for the api
