### PR TITLE
Feat: add affirmation map overrides to xenon default config for epoch 2.5

### DIFF
--- a/stackslib/src/core/mod.rs
+++ b/stackslib/src/core/mod.rs
@@ -137,6 +137,11 @@ pub const BITCOIN_TESTNET_STACKS_24_BURN_HEIGHT: u64 = 2_432_545;
 pub const BITCOIN_TESTNET_STACKS_25_BURN_HEIGHT: u64 = 2_583_893;
 pub const BITCOIN_TESTNET_STACKS_30_BURN_HEIGHT: u64 = 30_000_000;
 
+/// This constant sets the approximate testnet bitcoin height at which 2.5 Xenon
+///  was reorged back to 2.5 instantiation. This is only used to calculate the
+///  expected affirmation maps (so it only must be accurate to the reward cycle).
+pub const BITCOIN_TESTNET_STACKS_25_REORGED_HEIGHT: u64 = 2_586_000;
+
 pub const BITCOIN_REGTEST_FIRST_BLOCK_HEIGHT: u64 = 0;
 pub const BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP: u32 = 0;
 pub const BITCOIN_REGTEST_FIRST_BLOCK_HASH: &str =


### PR DESCRIPTION
This adds default overrides for the affirmation maps in Epoch 2.5 on the Xenon testnet. This is necessary because the 2.5 release version contains a different pox-4 contract than the one instantiated in Xenon testnet initially. This is similar to the reorg required during Epoch 2.4 on Xenon Testnet (see: https://github.com/stacks-network/stacks-core/pull/4560).

