### PR TITLE
feat: initialize BitVec with correct length and track next BitVec

### DIFF
--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3515,15 +3515,14 @@ impl SortitionDB {
         let Some(reward_set) = reward_info.known_selected_anchor_block() else {
             return None;
         };
-        Some(
-            reward_set
-                .signers
-                .clone()
-                .map(|x| x.len())
-                .unwrap_or(0)
-                .try_into()
-                .expect("FATAL: size of reward set is larger than u16"),
-        )
+
+        reward_set
+            .signers
+            .clone()
+            .map(|x| x.len())
+            .unwrap_or(0)
+            .try_into()
+            .ok()
     }
 }
 

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3507,6 +3507,24 @@ impl SortitionDB {
 
         Ok(rc_info)
     }
+
+    pub fn get_preprocessed_reward_set_size(&self, tip: &SortitionId) -> Option<u16> {
+        let Ok(Some(reward_info)) = &self.get_preprocessed_reward_set_of(&tip) else {
+            return None;
+        };
+        let Some(reward_set) = reward_info.known_selected_anchor_block() else {
+            return None;
+        };
+        Some(
+            reward_set
+                .signers
+                .clone()
+                .map(|x| x.len())
+                .unwrap_or(0)
+                .try_into()
+                .expect("FATAL: size of reward set is larger than u16"),
+        )
+    }
 }
 
 impl<'a> SortitionDBTx<'a> {

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -176,6 +176,7 @@ impl NakamotoBlockBuilder {
         total_burn: u64,
         tenure_change: Option<&StacksTransaction>,
         coinbase: Option<&StacksTransaction>,
+        bitvec_len: u16,
     ) -> Result<NakamotoBlockBuilder, Error> {
         let next_height = parent_stacks_header
             .anchored_header
@@ -208,6 +209,7 @@ impl NakamotoBlockBuilder {
                 total_burn,
                 tenure_id_consensus_hash.clone(),
                 parent_stacks_header.index_block_hash(),
+                bitvec_len,
             ),
         })
     }
@@ -406,6 +408,7 @@ impl NakamotoBlockBuilder {
         settings: BlockBuilderSettings,
         event_observer: Option<&dyn MemPoolEventDispatcher>,
         signer_transactions: Vec<StacksTransaction>,
+        signer_bitvec_len: u16,
     ) -> Result<(NakamotoBlock, ExecutionCost, u64, Vec<TransactionEvent>), Error> {
         let (tip_consensus_hash, tip_block_hash, tip_height) = (
             parent_stacks_header.consensus_hash.clone(),
@@ -426,6 +429,7 @@ impl NakamotoBlockBuilder {
             total_burn,
             tenure_info.tenure_change_tx(),
             tenure_info.coinbase_tx(),
+            signer_bitvec_len,
         )?;
 
         let ts_start = get_epoch_time_ms();

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -503,6 +503,7 @@ impl NakamotoBlockHeader {
         burn_spent: u64,
         consensus_hash: ConsensusHash,
         parent_block_id: StacksBlockId,
+        bitvec_len: u16,
     ) -> NakamotoBlockHeader {
         NakamotoBlockHeader {
             version: NAKAMOTO_BLOCK_VERSION,
@@ -514,7 +515,8 @@ impl NakamotoBlockHeader {
             state_index_root: TrieHash([0u8; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: ThresholdSignature::empty(),
-            signer_bitvec: BitVec::zeros(1).expect("BUG: bitvec of length-1 failed to construct"),
+            signer_bitvec: BitVec::ones(bitvec_len)
+                .expect("BUG: bitvec of length-1 failed to construct"),
         }
     }
 

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -547,6 +547,7 @@ impl TestStacksNode {
                     } else {
                         None
                     },
+                    1,
                 )
                 .unwrap()
             } else {

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -257,6 +257,7 @@ impl NakamotoBlockProposal {
             self.block.header.burn_spent,
             tenure_change,
             coinbase,
+            self.block.header.signer_bitvec.len(),
         )?;
 
         let mut miner_tenure_info =

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -830,7 +830,7 @@ impl BlockMinerThread {
             //  correct signer_sighash for `process_mined_nakamoto_block_event`
             Some(&self.event_dispatcher),
             signer_transactions,
-            signer_bitvec_len.unwrap_or(1),
+            signer_bitvec_len.unwrap_or(0),
         )
         .map_err(|e| {
             if !matches!(

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -30,6 +30,7 @@ use stacks::chainstate::stacks::{Error as ChainstateError, ThresholdSignature};
 use stacks::libstackerdb::StackerDBChunkData;
 use stacks::net::stackerdb::StackerDBs;
 use stacks::util_lib::boot::boot_code_id;
+use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{StacksPrivateKey, StacksPublicKey};
 use wsts::common::PolyCommitment;
@@ -62,6 +63,7 @@ pub struct SignCoordinator {
     is_mainnet: bool,
     miners_session: StackerDBSession,
     signing_round_timeout: Duration,
+    pub next_signer_bitvec: BitVec<4000>,
 }
 
 pub struct NakamotoSigningParams {
@@ -209,6 +211,15 @@ impl SignCoordinator {
         let miners_contract_id = boot_code_id(MINERS_NAME, is_mainnet);
         let miners_session = StackerDBSession::new(&rpc_socket.to_string(), miners_contract_id);
 
+        let next_signer_bitvec: BitVec<4000> = BitVec::zeros(
+            reward_set_signers
+                .clone()
+                .len()
+                .try_into()
+                .expect("FATAL: signer set length greater than u16"),
+        )
+        .expect("FATAL: unable to construct initial bitvec for signer set");
+
         let NakamotoSigningParams {
             num_signers,
             num_keys,
@@ -264,6 +275,7 @@ impl SignCoordinator {
             is_mainnet,
             miners_session,
             signing_round_timeout: config.miner.wait_on_signers.clone(),
+            next_signer_bitvec,
         })
     }
 
@@ -386,6 +398,22 @@ impl SignCoordinator {
                 debug!("Ignoring StackerDB event for non-signer contract"; "contract" => %event.contract_id);
                 continue;
             }
+            let modified_slots = &event.modified_slots;
+
+            // Update `next_signers_bitvec` with the slots that were modified in the event
+            modified_slots.iter().for_each(|chunk| {
+                if let Ok(slot_id) = chunk.slot_id.try_into() {
+                    match &self.next_signer_bitvec.set(slot_id, true) {
+                        Err(e) => {
+                            warn!("Failed to set bitvec for next signer: {e:?}");
+                        }
+                        _ => (),
+                    };
+                } else {
+                    error!("FATAL: slot_id greater than u16, which should never happen.");
+                }
+            });
+
             let Ok(signer_event) = SignerEvent::try_from(event).map_err(|e| {
                 warn!("Failure parsing StackerDB event into signer event. Ignoring message."; "err" => ?e);
             }) else {
@@ -456,6 +484,10 @@ impl SignCoordinator {
                                 "Signature failed to validate over the expected block".into(),
                             ));
                         } else {
+                            info!(
+                                "SignCoordinator: Generated a valid signature for the block";
+                                "next_signer_bitvec" => self.next_signer_bitvec.binary_str(),
+                            );
                             return Ok(signature);
                         }
                     }

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -1354,7 +1354,8 @@ fn stackerdb_sign_after_signer_reboot() {
         .init();
 
     info!("------------------------- Test Setup -------------------------");
-    let mut signer_test = SignerTest::new(3);
+    let num_signers = 3;
+    let mut signer_test = SignerTest::new(num_signers);
     let timeout = Duration::from_secs(200);
     let short_timeout = Duration::from_secs(30);
 
@@ -1383,10 +1384,19 @@ fn stackerdb_sign_after_signer_reboot() {
 
     info!("------------------------- Test Mine Block after restart -------------------------");
 
-    signer_test.mine_nakamoto_block(timeout);
+    let last_block = signer_test.mine_nakamoto_block(timeout);
     let proposed_signer_signature_hash = signer_test.wait_for_validate_ok_response(short_timeout);
     let frost_signature =
         signer_test.wait_for_confirmed_block(&proposed_signer_signature_hash, short_timeout);
+
+    // Check that the latest block's bitvec is all 1's
+    assert_eq!(
+        last_block.signer_bitvec,
+        serde_json::to_value(BitVec::<4000>::ones(num_signers as u16).unwrap())
+            .expect("Failed to serialize BitVec")
+            .as_str()
+            .expect("Failed to serialize BitVec")
+    );
 
     assert!(
         frost_signature.verify(&key, proposed_signer_signature_hash.0.as_slice()),


### PR DESCRIPTION
This PR extends off of #4627, but is setup against the `develop` branch. My understanding is that this should be a develop-based PR now, because it's not consensus critical.

This PR adds two things:

- When a new Nakamoto block is formed by a miner, it starts with a BitVec of 1's with the length of the signer set.
- In the miner's coordinator thread, a `next_signer_bitvec` property is added. After a miner has collected all block responses from the signers, it updates this BitVec to match the signers who gave a response.

Note that, from a functional perspective, all this changes is that the length of the BitVec will match the signer's length. However, the BitVec will be all 1's, even if not all signers respond. Future work is required to construct a new block in the case that a block is rejected, and in that work we can use this `next_signer_bitvec` in that new block.

- Closes https://github.com/stacks-network/stacks-core/issues/4558