### PR TITLE
update release workflow to tag the correct commit

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -70,6 +70,8 @@ jobs:
           draft: false
           prerelease: true
           fail_on_unmatched_files: true
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
           files: |
             release/*.zip
             CHECKSUMS.txt


### PR DESCRIPTION
adds:
```
          target_commitish: ${{ github.sha }}
          generate_release_notes: true
```
to the github release workflow so the correct tag is used when not building from the default branch. 
https://github.com/softprops/action-gh-release?tab=readme-ov-file#-customizing

sample workflow: https://github.com/wileyj/stacks-blockchain/actions/runs/8634094479
and tag produced from the forked `release/2.5.0.0.0` branch (with the same commit): https://github.com/wileyj/stacks-blockchain/releases/tag/2.5.0.0.0-rc5