### PR TITLE
feat: add startup logging with config to signer

### DIFF
--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -64,6 +64,8 @@ pub enum Command {
     GenerateFiles(GenerateFilesArgs),
     /// Generate a signature for Stacking transactions
     GenerateStackingSignature(GenerateStackingSignatureArgs),
+    /// Check a configuration file and output config information
+    CheckConfig(RunSignerArgs),
 }
 
 /// Basic arguments for all cyrptographic and stacker-db functionality

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt::Display;
 use std::fs;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
@@ -329,6 +330,39 @@ impl GlobalConfig {
     pub fn load_from_file(path: &str) -> Result<Self, ConfigError> {
         Self::try_from(&PathBuf::from(path))
     }
+
+    /// Return a string with non-sensitive configuration
+    /// information for logging purposes
+    pub fn config_to_log_string(&self) -> String {
+        let tx_fee = match self.tx_fee_ustx {
+            0 => "default".to_string(),
+            _ => (self.tx_fee_ustx as f64 / 1_000_000.0).to_string(),
+        };
+        format!(
+            r#"
+Stacks node host: {node_host}
+Signer endpoint: {endpoint}
+Stacks address: {stacks_address}
+Public key: {public_key}
+Network: {network}
+Database path: {db_path}
+DKG transaction fee: {tx_fee} uSTX
+"#,
+            node_host = self.node_host,
+            endpoint = self.endpoint,
+            stacks_address = self.stacks_address.to_string(),
+            public_key = StacksPublicKey::from_private(&self.stacks_private_key).to_hex(),
+            network = self.network,
+            db_path = self.db_path.to_str().unwrap_or_default(),
+            tx_fee = tx_fee
+        )
+    }
+}
+
+impl Display for GlobalConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.config_to_log_string())
+    }
 }
 
 /// Helper function for building a signer config for each provided signer private key
@@ -411,5 +445,25 @@ mod tests {
             RawConfigFile::load_from_str(&config_tomls[0]).expect("Failed to parse config file");
 
         assert_eq!(config.auth_password, "melon");
+    }
+
+    #[test]
+    fn test_config_to_string() {
+        let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
+        let config_str = config.config_to_log_string();
+        assert_eq!(
+            config_str,
+            format!(
+                r#"
+Stacks node host: 127.0.0.1:20443
+Signer endpoint: [::1]:30000
+Stacks address: ST3FPN8KBZ3YPBP0ZJGAAHTVFMQDTJCR5QPS7VTNJ
+Public key: 03bc489f27da3701d9f9e577c88de5567cf4023111b7577042d55cde4d823a3505
+Network: testnet
+Database path: :memory:
+DKG transaction fee: 0.01 uSTX
+"#
+            )
+        );
     }
 }

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -350,6 +350,11 @@ fn handle_generate_stacking_signature(
     signature
 }
 
+fn handle_check_config(args: RunSignerArgs) {
+    let config = GlobalConfig::try_from(&args.config).unwrap();
+    println!("Config: {}", config);
+}
+
 /// Helper function for writing the given contents to filename in the given directory
 fn write_file(dir: &Path, filename: &str, contents: &str) {
     let file_path = dir.join(filename);
@@ -397,6 +402,9 @@ fn main() {
         }
         Command::GenerateStackingSignature(args) => {
             handle_generate_stacking_signature(args, true);
+        }
+        Command::CheckConfig(args) => {
+            handle_check_config(args);
         }
     }
 }

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -38,12 +38,12 @@ use clap::Parser;
 use clarity::vm::types::QualifiedContractIdentifier;
 use libsigner::{RunningSigner, Signer, SignerEventReceiver, SignerSession, StackerDBSession};
 use libstackerdb::StackerDBChunkData;
-use slog::{slog_debug, slog_error};
+use slog::{slog_debug, slog_error, slog_info};
 use stacks_common::codec::read_next;
 use stacks_common::types::chainstate::StacksPrivateKey;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PublicKey};
-use stacks_common::{debug, error};
+use stacks_common::{debug, error, info};
 use stacks_signer::cli::{
     Cli, Command, GenerateFilesArgs, GenerateStackingSignatureArgs, GetChunkArgs,
     GetLatestChunkArgs, PutChunkArgs, RunDkgArgs, RunSignerArgs, SignArgs, StackerDBArgs,
@@ -85,6 +85,7 @@ fn write_chunk_to_stdout(chunk_opt: Option<Vec<u8>>) {
 fn spawn_running_signer(path: &PathBuf) -> SpawnedSigner {
     let config = GlobalConfig::try_from(path).unwrap();
     let endpoint = config.endpoint;
+    info!("Starting signer with config: {}", config);
     let (cmd_send, cmd_recv) = channel();
     let (res_send, res_recv) = channel();
     let ev = SignerEventReceiver::new(config.network.is_mainnet());


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/4602

This adds a simple log when the signer is started with the signer's configuration information. The goal is just to help signers ensure their signer is configured as expected. It also provides the signer's STX address and public key.

I've also added a `check-config` command which validates a config file and outputs the same startup logging information.