### PR TITLE
fix: Use finite set of strings for HTTP metrics

### DIFF
--- a/stackslib/src/monitoring/mod.rs
+++ b/stackslib/src/monitoring/mod.rs
@@ -28,7 +28,8 @@ use stacks_common::util::uint::{Uint256, Uint512};
 
 use crate::burnchains::{BurnchainSigner, Txid};
 use crate::core::MemPoolDB;
-use crate::net::httpcore::{StacksHttpRequest, StacksHttpResponse};
+use crate::net::httpcore::{StacksHttp, StacksHttpRequest, StacksHttpResponse};
+use crate::net::rpc::ConversationHttp;
 use crate::net::Error as net_error;
 use crate::util_lib::db::{sqlite_open, tx_busy_handler, DBConn, Error as DatabaseError};
 
@@ -46,19 +47,20 @@ pub fn increment_rpc_calls_counter() {
 }
 
 pub fn instrument_http_request_handler<F, R>(
+    conv_http: &mut ConversationHttp,
     req: StacksHttpRequest,
     handler: F,
 ) -> Result<R, net_error>
 where
-    F: FnOnce(StacksHttpRequest) -> Result<R, net_error>,
+    F: FnOnce(&mut ConversationHttp, StacksHttpRequest) -> Result<R, net_error>,
 {
     #[cfg(feature = "monitoring_prom")]
     increment_rpc_calls_counter();
 
     #[cfg(feature = "monitoring_prom")]
-    let timer = prometheus::new_rpc_call_timer(req.request_path());
+    let timer = prometheus::new_rpc_call_timer(conv_http.metrics_identifier(&req));
 
-    let res = handler(req);
+    let res = handler(conv_http, req);
 
     #[cfg(feature = "monitoring_prom")]
     timer.stop_and_record();

--- a/stackslib/src/monitoring/mod.rs
+++ b/stackslib/src/monitoring/mod.rs
@@ -28,7 +28,7 @@ use stacks_common::util::uint::{Uint256, Uint512};
 
 use crate::burnchains::{BurnchainSigner, Txid};
 use crate::core::MemPoolDB;
-use crate::net::httpcore::{StacksHttp, StacksHttpRequest, StacksHttpResponse};
+use crate::net::httpcore::{StacksHttpRequest, StacksHttpResponse};
 use crate::net::rpc::ConversationHttp;
 use crate::net::Error as net_error;
 use crate::util_lib::db::{sqlite_open, tx_busy_handler, DBConn, Error as DatabaseError};
@@ -48,7 +48,7 @@ pub fn increment_rpc_calls_counter() {
 
 pub fn instrument_http_request_handler<F, R>(
     conv_http: &mut ConversationHttp,
-    req: StacksHttpRequest,
+    mut req: StacksHttpRequest,
     handler: F,
 ) -> Result<R, net_error>
 where
@@ -58,7 +58,7 @@ where
     increment_rpc_calls_counter();
 
     #[cfg(feature = "monitoring_prom")]
-    let timer = prometheus::new_rpc_call_timer(conv_http.metrics_identifier(&req));
+    let timer = prometheus::new_rpc_call_timer(conv_http.metrics_identifier(&mut req));
 
     let res = handler(conv_http, req);
 

--- a/stackslib/src/net/api/callreadonly.rs
+++ b/stackslib/src/net/api/callreadonly.rs
@@ -116,6 +116,10 @@ impl HttpRequest for RPCCallReadOnlyRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/contracts/call-read/:principal/:contract_name/:func_name"
+    }
+
     /// Try to decode this request.
     fn try_parse_request(
         &mut self,

--- a/stackslib/src/net/api/getaccount.rs
+++ b/stackslib/src/net/api/getaccount.rs
@@ -84,6 +84,10 @@ impl HttpRequest for RPCGetAccountRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/accounts/:principal"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getattachment.rs
+++ b/stackslib/src/net/api/getattachment.rs
@@ -59,6 +59,10 @@ impl HttpRequest for RPCGetAttachmentRequestHandler {
         Regex::new(r#"^/v2/attachments/(?P<attachment_hash>[0-9a-f]{40})$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/attachments/:hash"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getattachmentsinv.rs
+++ b/stackslib/src/net/api/getattachmentsinv.rs
@@ -61,6 +61,10 @@ impl HttpRequest for RPCGetAttachmentsInvRequestHandler {
         Regex::new("^/v2/attachments/inv$").unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/attachments/inv"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getblock.rs
+++ b/stackslib/src/net/api/getblock.rs
@@ -90,6 +90,10 @@ impl HttpRequest for RPCBlocksRequestHandler {
         Regex::new(r#"^/v2/blocks/(?P<block_id>[0-9a-f]{64})$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/blocks/:hash"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getconstantval.rs
+++ b/stackslib/src/net/api/getconstantval.rs
@@ -83,6 +83,10 @@ impl HttpRequest for RPCGetConstantValRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/constant_val/:principal/:contract_name/:const_name"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getcontractabi.rs
+++ b/stackslib/src/net/api/getcontractabi.rs
@@ -78,6 +78,10 @@ impl HttpRequest for RPCGetContractAbiRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/contracts/interface/:principal/:contract_name"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getcontractsrc.rs
+++ b/stackslib/src/net/api/getcontractsrc.rs
@@ -86,6 +86,10 @@ impl HttpRequest for RPCGetContractSrcRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/contracts/source/:principal/:contract_name"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getdatavar.rs
+++ b/stackslib/src/net/api/getdatavar.rs
@@ -86,6 +86,10 @@ impl HttpRequest for RPCGetDataVarRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/data_var/:principal/:contract_name/:var_name"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getheaders.rs
+++ b/stackslib/src/net/api/getheaders.rs
@@ -109,6 +109,10 @@ impl HttpRequest for RPCHeadersRequestHandler {
         Regex::new(r#"^/v2/headers/(?P<quantity>[0-9]+)$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/headers/:height"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getinfo.rs
+++ b/stackslib/src/net/api/getinfo.rs
@@ -182,6 +182,10 @@ impl HttpRequest for RPCPeerInfoRequestHandler {
         Regex::new(r#"^/v2/info$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/info"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getistraitimplemented.rs
+++ b/stackslib/src/net/api/getistraitimplemented.rs
@@ -86,6 +86,10 @@ impl HttpRequest for RPCGetIsTraitImplementedRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/traits/:principal/:contract_name"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getmapentry.rs
+++ b/stackslib/src/net/api/getmapentry.rs
@@ -92,6 +92,10 @@ impl HttpRequest for RPCGetMapEntryRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/map_entry/:principal/:contract_name/:map_name"
+    }
+
     /// Try to decode this request.
     /// The body must be a hex string, encoded as a JSON string.
     /// So, something like `"123abc"`.  It encodes the map key as a serialized Clarity value.

--- a/stackslib/src/net/api/getmicroblocks_confirmed.rs
+++ b/stackslib/src/net/api/getmicroblocks_confirmed.rs
@@ -79,6 +79,10 @@ impl HttpRequest for RPCMicroblocksConfirmedRequestHandler {
         Regex::new(r#"^/v2/microblocks/confirmed/(?P<block_id>[0-9a-f]{64})$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/microblocks/confirmed/:hash"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getmicroblocks_indexed.rs
+++ b/stackslib/src/net/api/getmicroblocks_indexed.rs
@@ -112,6 +112,10 @@ impl HttpRequest for RPCMicroblocksIndexedRequestHandler {
         Regex::new(r#"^/v2/microblocks/(?P<tail_microblock_id>[0-9a-f]{64})$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/microblocks/:hash"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getmicroblocks_unconfirmed.rs
+++ b/stackslib/src/net/api/getmicroblocks_unconfirmed.rs
@@ -106,6 +106,10 @@ impl HttpRequest for RPCMicroblocksUnconfirmedRequestHandler {
         Regex::new(r#"^/v2/microblocks/unconfirmed/(?P<parent_block_id>[0-9a-f]{64})/(?P<start_sequence>[0-9]{1,6})$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/microblocks/unconfirmed/:hash/:seq"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getneighbors.rs
+++ b/stackslib/src/net/api/getneighbors.rs
@@ -179,6 +179,10 @@ impl HttpRequest for RPCNeighborsRequestHandler {
         Regex::new(r#"^/v2/neighbors$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/neighbors"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getpoxinfo.rs
+++ b/stackslib/src/net/api/getpoxinfo.rs
@@ -380,6 +380,10 @@ impl HttpRequest for RPCPoxInfoRequestHandler {
         Regex::new(r#"^/v2/pox$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/pox"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getstackerdbchunk.rs
+++ b/stackslib/src/net/api/getstackerdbchunk.rs
@@ -77,6 +77,10 @@ impl HttpRequest for RPCGetStackerDBChunkRequestHandler {
         )).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/stackerdb/:principal/:contract_name/:slot_id/:slot_version"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getstackerdbmetadata.rs
+++ b/stackslib/src/net/api/getstackerdbmetadata.rs
@@ -73,6 +73,10 @@ impl HttpRequest for RPCGetStackerDBMetadataRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/stackerdb/:principal/:contract_name"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/getstxtransfercost.rs
+++ b/stackslib/src/net/api/getstxtransfercost.rs
@@ -59,6 +59,10 @@ impl HttpRequest for RPCGetStxTransferCostRequestHandler {
         Regex::new(r#"^/v2/fees/transfer$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/fees/transfer"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/gettransaction_unconfirmed.rs
+++ b/stackslib/src/net/api/gettransaction_unconfirmed.rs
@@ -75,6 +75,10 @@ impl HttpRequest for RPCGetTransactionUnconfirmedRequestHandler {
         Regex::new(r#"^/v2/transactions/unconfirmed/(?P<txid>[0-9a-f]{64})$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/transactions/unconfirmed/:txid"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/liststackerdbreplicas.rs
+++ b/stackslib/src/net/api/liststackerdbreplicas.rs
@@ -77,6 +77,10 @@ impl HttpRequest for RPCListStackerDBReplicasRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/stackedb/:principal/:contract_name/replicas"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/postblock.rs
+++ b/stackslib/src/net/api/postblock.rs
@@ -95,6 +95,10 @@ impl HttpRequest for RPCPostBlockRequestHandler {
         Regex::new(r#"^/v2/blocks/upload/(?P<consensus_hash>[0-9a-f]{40})$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/blocks/upload/:block"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/postfeerate.rs
+++ b/stackslib/src/net/api/postfeerate.rs
@@ -111,6 +111,10 @@ impl HttpRequest for RPCPostFeeRateRequestHandler {
         Regex::new(r#"^/v2/fees/transaction$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/fees/transaction"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/postmempoolquery.rs
+++ b/stackslib/src/net/api/postmempoolquery.rs
@@ -222,6 +222,10 @@ impl HttpRequest for RPCMempoolQueryRequestHandler {
         Regex::new(r#"^/v2/mempool/query$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/mempool/query"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/postmicroblock.rs
+++ b/stackslib/src/net/api/postmicroblock.rs
@@ -85,6 +85,10 @@ impl HttpRequest for RPCPostMicroblockRequestHandler {
         Regex::new(r#"^/v2/microblocks$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/microblocks"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/poststackerdbchunk.rs
+++ b/stackslib/src/net/api/poststackerdbchunk.rs
@@ -81,6 +81,10 @@ impl HttpRequest for RPCPostStackerDBChunkRequestHandler {
         .unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/block_proposal/:principal/:contract_name/chunks"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/api/posttransaction.rs
+++ b/stackslib/src/net/api/posttransaction.rs
@@ -120,6 +120,10 @@ impl HttpRequest for RPCPostTransactionRequestHandler {
         Regex::new(r#"^/v2/transactions$"#).unwrap()
     }
 
+    fn metrics_identifier(&self) -> &str {
+        "/v2/transactions"
+    }
+
     /// Try to decode this request.
     /// There's nothing to load here, so just make sure the request is well-formed.
     fn try_parse_request(

--- a/stackslib/src/net/http/request.rs
+++ b/stackslib/src/net/http/request.rs
@@ -696,4 +696,6 @@ pub trait HttpRequest: Send + HttpRequestClone {
         query_str: Option<&str>,
         body: &[u8],
     ) -> Result<HttpRequestContents, Error>;
+    /// Get identifier from finite set to be used in metrics
+    fn metrics_identifier(&self) -> &str;
 }

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -1085,7 +1085,10 @@ impl StacksHttp {
         node: &mut StacksNodeState,
     ) -> Result<(HttpResponsePreamble, HttpResponseContents), NetError> {
         let (decoded_path, _) = decode_request_path(&request.preamble().path_and_query_str)?;
-        let Some(response_handler_index) = request.response_handler_index.or_else(|| self.find_response_handler(&request.preamble().verb, &decoded_path)) else {
+        let Some(response_handler_index) = request
+            .response_handler_index
+            .or_else(|| self.find_response_handler(&request.preamble().verb, &decoded_path))
+        else {
             // method not found
             return StacksHttpResponse::new_error(
                 &request.preamble,
@@ -1248,7 +1251,8 @@ impl StacksHttp {
             return "<err-url-decode>";
         };
 
-        let Some(response_handler_index) = req.response_handler_index
+        let Some(response_handler_index) = req
+            .response_handler_index
             .or_else(|| self.find_response_handler(&req.preamble().verb, &decoded_path))
         else {
             return "<err-handler-not-found>";

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -552,6 +552,11 @@ impl StacksHttpRequest {
         self.send(&mut ret)?;
         Ok(ret)
     }
+
+    #[cfg(test)]
+    pub fn get_response_handler_index(&self) -> Option<usize> {
+        self.response_handler_index
+    }
 }
 
 /// A received HTTP response (fully decoded in RAM)

--- a/stackslib/src/net/rpc.rs
+++ b/stackslib/src/net/rpc.rs
@@ -534,11 +534,8 @@ impl ConversationHttp {
         test_debug!("{:?}: {} HTTP requests pending", &self, num_inbound);
 
         for _i in 0..num_inbound {
-            let msg = match self.connection.next_inbox_message() {
-                None => {
-                    continue;
-                }
-                Some(m) => m,
+            let Some(msg) = self.connection.next_inbox_message() else {
+                continue;
             };
 
             match msg {
@@ -661,7 +658,7 @@ impl ConversationHttp {
         self.peer_host.clone()
     }
 
-    pub fn metrics_identifier(&self, req: &StacksHttpRequest) -> &str {
+    pub fn metrics_identifier(&self, req: &mut StacksHttpRequest) -> &str {
         self.connection.protocol.metrics_identifier(req)
     }
 }

--- a/stackslib/src/net/rpc.rs
+++ b/stackslib/src/net/rpc.rs
@@ -158,12 +158,12 @@ impl ConversationHttp {
         let stacks_http = StacksHttp::new(peer_addr.clone(), conn_opts);
         ConversationHttp {
             connection: ConnectionHttp::new(stacks_http, conn_opts, None),
-            conn_id: conn_id,
+            conn_id,
             timeout: conn_opts.timeout,
             reply_streams: VecDeque::new(),
-            peer_addr: peer_addr,
-            outbound_url: outbound_url,
-            peer_host: peer_host,
+            peer_addr,
+            outbound_url,
+            peer_host,
             canonical_stacks_tip_height: None,
             pending_request: None,
             pending_response: None,
@@ -550,9 +550,11 @@ impl ConversationHttp {
                     let start_time = Instant::now();
                     let verb = req.verb().to_string();
                     let request_path = req.request_path().to_string();
-                    let msg_opt = monitoring::instrument_http_request_handler(req, |req| {
-                        self.handle_request(req, node)
-                    })?;
+                    let msg_opt = monitoring::instrument_http_request_handler(
+                        self,
+                        req,
+                        |conv_http, req| conv_http.handle_request(req, node),
+                    )?;
 
                     info!("Handled StacksHTTPRequest";
                            "verb" => %verb,
@@ -657,5 +659,9 @@ impl ConversationHttp {
 
     pub fn get_peer_host(&self) -> PeerHost {
         self.peer_host.clone()
+    }
+
+    pub fn metrics_identifier(&self, req: &StacksHttpRequest) -> &str {
+        self.connection.protocol.metrics_identifier(req)
     }
 }

--- a/stackslib/src/net/tests/httpcore.rs
+++ b/stackslib/src/net/tests/httpcore.rs
@@ -1095,7 +1095,7 @@ fn test_metrics_identifiers() {
     for (input, output) in fixtures {
         // Destructure fixture data
         let (verb, path_and_query_string) = input;
-        let (metrics_identifier_expected, should_have_hadler) = output;
+        let (metrics_identifier_expected, should_have_handler) = output;
 
         // Create request from data
         let preamble = HttpRequestPreamble::new(
@@ -1114,6 +1114,6 @@ fn test_metrics_identifiers() {
 
         // Check that we get expected metrics identifier and request handler
         assert_eq!(metrics_identifier, metrics_identifier_expected);
-        assert_eq!(response_handler_index.is_some(), should_have_hadler);
+        assert_eq!(response_handler_index.is_some(), should_have_handler);
     }
 }

--- a/stackslib/src/net/tests/httpcore.rs
+++ b/stackslib/src/net/tests/httpcore.rs
@@ -1050,3 +1050,70 @@ fn test_http_parse_proof_request_query() {
         .get_with_proof();
     assert!(proof_req);
 }
+
+#[test]
+fn test_metrics_identifiers() {
+    let convo = ConversationHttp::new(
+        "127.0.0.1:12345".parse().unwrap(),
+        None,
+        PeerHost::DNS("localhost".to_string(), 12345),
+        &ConnectionOptions::default(),
+        100,
+        32,
+    );
+
+    let fixtures = vec![
+        // Valid requests
+        (("GET", "/v2/info"), ("/v2/info", true)),
+        (
+            ("GET", "/v2/info?param1=value&param2=other_value"),
+            ("/v2/info", true),
+        ),
+        (
+            (
+                "GET",
+                "/v2/blocks/d8bd3c7e7cf7a9d783560a71356d3d9dbc84dc2f0c1a0001be8b141927c9d7ab",
+            ),
+            ("/v2/blocks/:hash", true),
+        ),
+        // Invalid requests
+        (("POST", "/v2/info"), ("<err-handler-not-found>", false)),
+        (("GET", "!@#%&^$#!&^(@&+++"), ("<err-url-decode>", false)),
+        (
+            ("GET", "/some/nonexistent/endpoint"),
+            ("<err-handler-not-found>", false),
+        ),
+        (
+            (
+                "GET",
+                "/v2/blocks/dsviawevasigngawuqajauharpqjumzkalfuwgfkwpdhtbefgxkdhdfduskafdgh",
+            ),
+            ("<err-handler-not-found>", false),
+        ),
+    ];
+
+    for (input, output) in fixtures {
+        // Destructure fixture data
+        let (verb, path_and_query_string) = input;
+        let (metrics_identifier_expected, should_have_hadler) = output;
+
+        // Create request from data
+        let preamble = HttpRequestPreamble::new(
+            HttpVersion::Http11,
+            verb.to_string(),
+            path_and_query_string.to_string(),
+            "localhost".to_string(),
+            12345,
+            true,
+        );
+
+        let mut request = StacksHttpRequest::new(preamble, HttpRequestContents::new());
+
+        let metrics_identifier = convo.metrics_identifier(&mut request);
+        let response_handler_index = request.get_response_handler_index();
+
+        // Check that we get expected metrics identifier and request handler
+        assert_eq!(metrics_identifier, metrics_identifier_expected);
+        assert_eq!(response_handler_index.is_some(), should_have_hadler);
+    }
+}


### PR DESCRIPTION
### Description

When sending metrics data to Prometheus, map URLs to a finite set of strings. This will reduce the number of unique strings the server has to keep track of. As an example, it might rewrite:

```
/v2/attachments/012c8195f4381d0b0eadc2daee6e2c5b8243f4ff
```

to

```
/v2/attachments/:hash
```

### Applicable issues

- fixes #4574

### Additional info (benefits, drawbacks, caveats)

**NOTE:** The test `net::stackerdb::tests::sync::test_stackerdb_replica_2_neighbors_1_chunk` is currently failing, but also fails in `master`, meaning it was not broken by this PR

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
