### PR TITLE
Add missing stacks-signer binary to release docker images

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.alpine-binary
+++ b/.github/actions/dockerfiles/Dockerfile.alpine-binary
@@ -23,5 +23,5 @@ RUN case ${TARGETPLATFORM} in \
     && unzip ${BIN_ARCH}.zip -d /out
 
 FROM --platform=${TARGETPLATFORM} alpine
-COPY --from=builder /out/stacks-node /bin/
+COPY --from=builder /out/stacks-node /out/stacks-signer /bin/
 CMD ["stacks-node", "mainnet"]

--- a/.github/actions/dockerfiles/Dockerfile.debian-binary
+++ b/.github/actions/dockerfiles/Dockerfile.debian-binary
@@ -23,5 +23,5 @@ RUN case ${TARGETPLATFORM} in \
     && unzip ${BIN_ARCH}.zip -d /out
 
 FROM --platform=${TARGETPLATFORM} debian:bookworm
-COPY --from=builder /out/stacks-node /bin/
+COPY --from=builder /out/stacks-node /out/stacks-signer /bin/
 CMD ["stacks-node", "mainnet"]


### PR DESCRIPTION
cc @friedger 

Reported that the stacks-signer binary was missing in the rc4 docker release image. 
this changes the current dockerfile to also add `stacks-signer` along with `stacks-node` to the release docker image. 

More binaries can be added at the expense of image size, but i think these 2 are the bare minimum. 