### PR TITLE
Update stack-aggregation-increase command to use a signature

### DIFF
--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -156,6 +156,7 @@ export function PoxCommands(
     fc.record({
       wallet: fc.constantFrom(...wallets.values()),
       currentCycle: fc.constant(currentCycle(network)),
+      authId: fc.nat(),
     }).chain((r) => {
       const committedRewCycleIndexesOrFallback =
         r.wallet.committedRewCycleIndexes.length > 0
@@ -171,12 +172,14 @@ export function PoxCommands(
         wallet: Wallet;
         currentCycle: number;
         rewardCycleIndex: number;
+        authId: number;
       },
     ) =>
       new StackAggregationIncreaseCommand(
         r.wallet,
         r.currentCycle,
         r.rewardCycleIndex,
+        r.authId,
       )
     ),
     // RevokeDelegateStxCommand

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationIncreaseCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackAggregationIncreaseCommand.ts
@@ -7,7 +7,8 @@ import {
 } from "./pox_CommandModel.ts";
 import { poxAddressToTuple } from "@stacks/stacking";
 import { expect } from "vitest";
-import { Cl } from "@stacks/transactions";
+import { Cl, cvToJSON } from "@stacks/transactions";
+import { bufferFromHex } from "@stacks/transactions/dist/cl";
 
 /**
  * The `StackAggregationIncreaseCommand` allows an operator to commit
@@ -28,6 +29,7 @@ export class StackAggregationIncreaseCommand implements PoxCommand {
   readonly operator: Wallet;
   readonly currentCycle: number;
   readonly rewardCycleIndex: number;
+  readonly authId: number;
 
   /**
    * Constructs a `StackAggregationIncreaseCommand` to commit partially
@@ -41,10 +43,12 @@ export class StackAggregationIncreaseCommand implements PoxCommand {
     operator: Wallet,
     currentCycle: number,
     rewardCycleIndex: number,
+    authId: number,
   ) {
     this.operator = operator;
     this.currentCycle = currentCycle;
     this.rewardCycleIndex = rewardCycleIndex;
+    this.authId = authId;
   }
 
   check(_model: Readonly<Stub>): boolean {
@@ -64,6 +68,42 @@ export class StackAggregationIncreaseCommand implements PoxCommand {
     model.trackCommandRun(this.constructor.name);
 
     const committedAmount = this.operator.amountToCommit;
+    const existingEntryCV = real.network.getMapEntry(
+      "ST000000000000000000002AMW42H.pox-4",
+      "reward-cycle-pox-address-list",
+      Cl.tuple({
+        "index": Cl.uint(this.rewardCycleIndex),
+        "reward-cycle": Cl.uint(this.currentCycle + 1),
+      }),
+    );
+
+    const totalStackedBefore =
+      cvToJSON(existingEntryCV).value.value["total-ustx"].value;
+    const maxAmount = committedAmount + Number(totalStackedBefore);
+
+    const signerSig = this.operator.stackingClient.signPoxSignature({
+      // The signer key being authorized.
+      signerPrivateKey: this.operator.signerPrvKey,
+      // The reward cycle for which the authorization is valid.
+      // For stack-stx and stack-extend, this refers to the reward cycle
+      // where the transaction is confirmed. For stack-aggregation-commit,
+      // this refers to the reward cycle argument in that function.
+      rewardCycle: this.currentCycle + 1,
+      // For stack-stx, this refers to lock-period. For stack-extend,
+      // this refers to extend-count. For stack-aggregation-commit, this is
+      // u1.
+      period: 1,
+      // A string representing the function where this authorization is valid.
+      // Either stack-stx, stack-extend, stack-increase, agg-commit or agg-increase.
+      topic: "agg-increase",
+      // The PoX address that can be used with this signer key.
+      poxAddress: this.operator.btcAddress,
+      // The unique auth-id for this authorization.
+      authId: this.authId,
+      // The maximum amount of uSTX that can be used (per tx) with this signer
+      // key.
+      maxAmount: maxAmount,
+    });
 
     // Act
     const stackAggregationIncrease = real.network.callPublicFn(
@@ -76,6 +116,14 @@ export class StackAggregationIncreaseCommand implements PoxCommand {
         Cl.uint(this.currentCycle + 1),
         // (reward-cycle-index uint))
         Cl.uint(this.rewardCycleIndex),
+        // (signer-sig (optional (buff 65)))
+        Cl.some(bufferFromHex(signerSig)),
+        // (signer-key (buff 33))
+        Cl.bufferFromHex(this.operator.signerPubKey),
+        // (max-amount uint)
+        Cl.uint(maxAmount),
+        // (auth-id uint)
+        Cl.uint(this.authId),
       ],
       this.operator.stxAddress,
     );


### PR DESCRIPTION
This PR updates the `stack-aggregation-increase` command to use a signature. It targets `feat/pox-4-stateful-property-testing` (#4550).