### PR TITLE
Fix: validate epochs must special case 2.5

### DIFF
--- a/stackslib/src/core/mod.rs
+++ b/stackslib/src/core/mod.rs
@@ -1431,10 +1431,14 @@ impl StacksEpochExtension for StacksEpoch {
             .iter()
             .max()
             .expect("FATAL: expect at least one epoch");
-        assert!(
-            max_epoch.network_epoch as u32 <= PEER_NETWORK_EPOCH,
-            "stacks-blockchain static network epoch should be greater than or equal to the max epoch's"
-        );
+        if max_epoch.epoch_id == StacksEpochId::Epoch30 {
+            assert!(PEER_NETWORK_EPOCH >= u32::from(PEER_VERSION_EPOCH_2_5));
+        } else {
+            assert!(
+                max_epoch.network_epoch as u32 <= PEER_NETWORK_EPOCH,
+                "stacks-blockchain static network epoch should be greater than or equal to the max epoch's"
+            );
+        }
 
         assert!(
             StacksEpochId::latest() >= max_epoch.epoch_id,


### PR DESCRIPTION
The 2.5 node defines Epoch 3.0, but it does not use its network version byte, which means validate_epochs must special case 2.5 and 3.0.