### PR TITLE
Refine the next cycle state refresh function

### DIFF
--- a/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox-4.stateful-prop.test.ts
@@ -117,6 +117,7 @@ it("statefully interacts with PoX-4", async () => {
     new Map(wallets.map((wallet) => [wallet.stxAddress, {
       ustxBalance: 100_000_000_000_000,
       isStacking: false,
+      isStackingSolo: false,
       hasDelegated: false,
       lockedAddresses: [],
       amountToCommit: 0,

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -117,7 +117,7 @@ export class Stub {
 
         // For each pool stacker that no longer have partially commited STX for
         // the next reward cycle, decrement the operator's amountToCommit
-        // (partial-stacked) by the stacker's amountLocked
+        // (partial-stacked) by the stacker's amountLocked.
         stackersToRemoveAmountToCommit.forEach((expStacker) => {
           const expStackerWallet = this.stackers.get(expStacker)!;
           wallet.amountToCommit -= expStackerWallet.amountLocked;

--- a/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_CommandModel.ts
@@ -133,7 +133,8 @@ export class Stub {
           wallet.amountLocked = 0;
           wallet.unlockHeight = 0;
           wallet.firstLockedRewardCycle = 0;
-        } // If the wallet is solo stacking and its stack won't expire in the
+        } 
+        // If the wallet is solo stacking and its stack won't expire in the
         // next reward cycle, increment the model's nextRewardSetIndex (the
         // next empty reward slot)
         else if (

--- a/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_Commands.ts
@@ -349,7 +349,7 @@ export function PoxCommands(
 
   // More on size: https://github.com/dubzzz/fast-check/discussions/2978
   // More on cmds: https://github.com/dubzzz/fast-check/discussions/3026
-  return fc.commands(cmds, { size: "small" });
+  return fc.commands(cmds, { size: "xsmall" });
 }
 
 export const REWARD_CYCLE_LENGTH = 1050;

--- a/contrib/core-contract-tests/tests/pox-4/pox_StackStxCommand.ts
+++ b/contrib/core-contract-tests/tests/pox-4/pox_StackStxCommand.ts
@@ -168,6 +168,7 @@ export class StackStxCommand implements PoxCommand {
     // in order to prevent the test from stacking multiple times with the same
     // address.
     wallet.isStacking = true;
+    wallet.isStackingSolo = true;
     // Update locked, unlocked, and unlock-height fields in the model.
     wallet.amountLocked = amountUstx;
     wallet.unlockHeight = Number(unlockBurnHeight.value);


### PR DESCRIPTION
This PR updates the state refreshing function for new cycles and targets `feat/pox-4-stateful-property-testing` (#4550).