### PR TITLE
Remove redundant block proposal message and fix tests

### DIFF
--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -32,11 +32,13 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::Duration;
 
-use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::util_lib::signed_structured_data::pox4::make_pox_4_signer_key_signature;
 use clap::Parser;
 use clarity::vm::types::QualifiedContractIdentifier;
-use libsigner::{RunningSigner, Signer, SignerEventReceiver, SignerSession, StackerDBSession};
+use libsigner::{
+    BlockProposalSigners, RunningSigner, Signer, SignerEventReceiver, SignerSession,
+    StackerDBSession,
+};
 use libstackerdb::StackerDBChunkData;
 use slog::{slog_debug, slog_error, slog_info};
 use stacks_common::codec::read_next;
@@ -208,15 +210,16 @@ fn handle_dkg(args: RunDkgArgs) {
 fn handle_sign(args: SignArgs) {
     debug!("Signing message...");
     let spawned_signer = spawn_running_signer(&args.config);
-    let Some(block) = read_next::<NakamotoBlock, _>(&mut &args.data[..]).ok() else {
-        error!("Unable to parse provided message as a NakamotoBlock.");
+    let Some(block_proposal) = read_next::<BlockProposalSigners, _>(&mut &args.data[..]).ok()
+    else {
+        error!("Unable to parse provided message as a BlockProposalSigners.");
         spawned_signer.running_signer.stop();
         return;
     };
     let sign_command = RunLoopCommand {
         reward_cycle: args.reward_cycle,
         command: SignerCommand::Sign {
-            block,
+            block_proposal,
             is_taproot: false,
             merkle_root: None,
         },
@@ -230,8 +233,9 @@ fn handle_sign(args: SignArgs) {
 fn handle_dkg_sign(args: SignArgs) {
     debug!("Running DKG and signing message...");
     let spawned_signer = spawn_running_signer(&args.config);
-    let Some(block) = read_next::<NakamotoBlock, _>(&mut &args.data[..]).ok() else {
-        error!("Unable to parse provided message as a NakamotoBlock.");
+    let Some(block_proposal) = read_next::<BlockProposalSigners, _>(&mut &args.data[..]).ok()
+    else {
+        error!("Unable to parse provided message as a BlockProposalSigners.");
         spawned_signer.running_signer.stop();
         return;
     };
@@ -242,7 +246,7 @@ fn handle_dkg_sign(args: SignArgs) {
     let sign_command = RunLoopCommand {
         reward_cycle: args.reward_cycle,
         command: SignerCommand::Sign {
-            block,
+            block_proposal,
             is_taproot: false,
             merkle_root: None,
         },

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -507,43 +507,6 @@ impl NakamotoBlockBuilder {
     pub fn get_bytes_so_far(&self) -> u64 {
         self.bytes_so_far
     }
-
-    /// Make a StackerDB chunk message containing a proposed block.
-    /// Sign it with the miner's private key.
-    /// Automatically determine which StackerDB slot and version number to use.
-    /// Returns Some(chunk) if the given key corresponds to one of the expected miner slots
-    /// Returns None if not
-    /// Returns an error on signing or DB error
-    pub fn make_stackerdb_block_proposal<T: StacksMessageCodec>(
-        sortdb: &SortitionDB,
-        tip: &BlockSnapshot,
-        stackerdbs: &StackerDBs,
-        block: &T,
-        miner_privkey: &StacksPrivateKey,
-        miners_contract_id: &QualifiedContractIdentifier,
-    ) -> Result<Option<StackerDBChunkData>, Error> {
-        let miner_pubkey = StacksPublicKey::from_private(&miner_privkey);
-        let Some(slot_range) = NakamotoChainState::get_miner_slot(sortdb, tip, &miner_pubkey)?
-        else {
-            // No slot exists for this miner
-            return Ok(None);
-        };
-        // proposal slot is the first slot.
-        let slot_id = slot_range.start;
-        // Get the LAST slot version number written to the DB. If not found, use 0.
-        // Add 1 to get the NEXT version number
-        // Note: we already check above for the slot's existence
-        let slot_version = stackerdbs
-            .get_slot_version(&miners_contract_id, slot_id)?
-            .unwrap_or(0)
-            .saturating_add(1);
-        let block_bytes = block.serialize_to_vec();
-        let mut chunk = StackerDBChunkData::new(slot_id, slot_version, block_bytes);
-        chunk
-            .sign(miner_privkey)
-            .map_err(|_| net_error::SigningError("Failed to sign StackerDB chunk".into()))?;
-        Ok(Some(chunk))
-    }
 }
 
 impl BlockBuilder for NakamotoBlockBuilder {

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -23,6 +23,7 @@ use clarity::vm::clarity::ClarityConnection;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::types::StacksAddressExtensions;
 use clarity::vm::Value;
+use libstackerdb::StackerDBChunkData;
 use rand::{thread_rng, RngCore};
 use rusqlite::{Connection, ToSql};
 use stacks_common::address::AddressHashMode;
@@ -2019,31 +2020,26 @@ fn test_make_miners_stackerdb_config() {
             txs: vec![],
         };
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+        let miner_privkey = &miner_keys[i];
+        let miner_pubkey = StacksPublicKey::from_private(miner_privkey);
+        let slot_id = NakamotoChainState::get_miner_slot(&sort_db, &tip, &miner_pubkey)
+            .expect("Failed to get miner slot");
         if sortition {
-            let chunk = NakamotoBlockBuilder::make_stackerdb_block_proposal(
-                &sort_db,
-                &tip,
-                &stackerdbs,
-                &block,
-                &miner_keys[i],
-                &miners_contract_id,
-            )
-            .unwrap()
-            .unwrap();
+            let slot_id = slot_id.expect("No miner slot exists for this miner").start;
+            let slot_version = stackerdbs
+                .get_slot_version(&miners_contract_id, slot_id)
+                .expect("Failed to get slot version")
+                .unwrap_or(0)
+                .saturating_add(1);
+            let block_bytes = block.serialize_to_vec();
+            let mut chunk = StackerDBChunkData::new(slot_id, slot_version, block_bytes);
+            chunk.sign(&miner_keys[i]).expect("Failed to sign chunk");
             assert_eq!(chunk.slot_version, 1);
             assert_eq!(chunk.data, block.serialize_to_vec());
             stackerdb_chunks.push(chunk);
         } else {
-            assert!(NakamotoBlockBuilder::make_stackerdb_block_proposal(
-                &sort_db,
-                &tip,
-                &stackerdbs,
-                &block,
-                &miner_keys[i],
-                &miners_contract_id,
-            )
-            .unwrap()
-            .is_none());
+            // We are not a miner anymore and should not have any slot
+            assert!(slot_id.is_none());
         }
     }
     // miners are "stable" across snapshots

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -151,7 +151,7 @@ pub const STACKERDB_MAX_PAGE_COUNT: u32 = 2;
 
 pub const STACKERDB_SLOTS_FUNCTION: &str = "stackerdb-get-signer-slots";
 pub const STACKERDB_CONFIG_FUNCTION: &str = "stackerdb-get-config";
-pub const MINER_SLOT_COUNT: u32 = 2;
+pub const MINER_SLOT_COUNT: u32 = 1;
 
 /// Final result of synchronizing state with a remote set of DB replicas
 pub struct StackerDBSyncResult {

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -18,20 +18,16 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use clarity::boot_util::boot_code_id;
 use clarity::vm::clarity::ClarityConnection;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use hashbrown::HashSet;
-use libsigner::{
-    BlockProposalSigners, MessageSlotID, SignerMessage, SignerSession, StackerDBSession,
-};
+use libsigner::{MessageSlotID, SignerMessage};
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::{BlockSnapshot, ConsensusHash};
 use stacks::chainstate::nakamoto::miner::{NakamotoBlockBuilder, NakamotoTenureInfo};
 use stacks::chainstate::nakamoto::signer_set::NakamotoSigners;
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
-use stacks::chainstate::stacks::boot::MINERS_NAME;
 use stacks::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
 use stacks::chainstate::stacks::{
     CoinbasePayload, Error as ChainstateError, StacksTransaction, StacksTransactionSigner,
@@ -179,13 +175,9 @@ impl BlockMinerThread {
             };
 
             if let Some(mut new_block) = new_block {
-                if let Err(e) = self.propose_block(&new_block, &stackerdbs) {
-                    error!("Unrecoverable error while proposing block to signer set: {e:?}. Ending tenure.");
-                    return;
-                }
-
                 let (aggregate_public_key, signers_signature) = match self.coordinate_signature(
                     &new_block,
+                    self.burn_block.block_height,
                     &mut stackerdbs,
                     &mut attempts,
                 ) {
@@ -239,6 +231,7 @@ impl BlockMinerThread {
     fn coordinate_signature(
         &mut self,
         new_block: &NakamotoBlock,
+        burn_block_height: u64,
         stackerdbs: &mut StackerDBs,
         attempts: &mut u64,
     ) -> Result<(Point, ThresholdSignature), NakamotoNodeError> {
@@ -302,18 +295,6 @@ impl BlockMinerThread {
             ));
         };
 
-        #[cfg(test)]
-        {
-            // In test mode, short-circuit spinning up the SignCoordinator if the TEST_SIGNING
-            //  channel has been created. This allows integration tests for the stacks-node
-            //  independent of the stacks-signer.
-            if let Some(signature) =
-                crate::tests::nakamoto_integrations::TestSigningChannel::get_signature()
-            {
-                return Ok((aggregate_public_key, signature));
-            }
-        }
-
         let miner_privkey_as_scalar = Scalar::from(miner_privkey.as_slice().clone());
         let mut coordinator = SignCoordinator::new(
             &reward_set,
@@ -332,95 +313,16 @@ impl BlockMinerThread {
         *attempts += 1;
         let signature = coordinator.begin_sign(
             new_block,
+            burn_block_height,
             *attempts,
             &tip,
             &self.burnchain,
             &sort_db,
             &stackerdbs,
+            &self.globals.counters,
         )?;
 
         Ok((aggregate_public_key, signature))
-    }
-
-    fn propose_block(
-        &mut self,
-        new_block: &NakamotoBlock,
-        stackerdbs: &StackerDBs,
-    ) -> Result<(), NakamotoNodeError> {
-        let rpc_socket = self.config.node.get_rpc_loopback().ok_or_else(|| {
-            NakamotoNodeError::MinerConfigurationFailed("Could not parse RPC bind")
-        })?;
-        let miners_contract_id = boot_code_id(MINERS_NAME, self.config.is_mainnet());
-        let mut miners_session =
-            StackerDBSession::new(&rpc_socket.to_string(), miners_contract_id.clone());
-        let Some(miner_privkey) = self.config.miner.mining_key else {
-            return Err(NakamotoNodeError::MinerConfigurationFailed(
-                "No mining key configured, cannot mine",
-            ));
-        };
-        let sort_db = SortitionDB::open(
-            &self.config.get_burn_db_file_path(),
-            true,
-            self.burnchain.pox_constants.clone(),
-        )
-        .expect("FATAL: could not open sortition DB");
-        let tip = SortitionDB::get_block_snapshot_consensus(
-            sort_db.conn(),
-            &new_block.header.consensus_hash,
-        )
-        .expect("FATAL: could not retrieve chain tip")
-        .expect("FATAL: could not retrieve chain tip");
-        let reward_cycle = self
-            .burnchain
-            .pox_constants
-            .block_height_to_reward_cycle(
-                self.burnchain.first_block_height,
-                self.burn_block.block_height,
-            )
-            .expect("FATAL: building on a burn block that is before the first burn block");
-
-        let proposal_msg = BlockProposalSigners {
-            block: new_block.clone(),
-            burn_height: self.burn_block.block_height,
-            reward_cycle,
-        };
-        let proposal = match NakamotoBlockBuilder::make_stackerdb_block_proposal(
-            &sort_db,
-            &tip,
-            &stackerdbs,
-            &proposal_msg,
-            &miner_privkey,
-            &miners_contract_id,
-        ) {
-            Ok(Some(chunk)) => chunk,
-            Ok(None) => {
-                warn!("Failed to propose block to stackerdb: no slot available");
-                return Ok(());
-            }
-            Err(e) => {
-                warn!("Failed to propose block to stackerdb: {e:?}");
-                return Ok(());
-            }
-        };
-
-        // Propose the block to the observing signers through the .miners stackerdb instance
-        match miners_session.put_chunk(&proposal) {
-            Ok(ack) => {
-                info!(
-                    "Proposed block to stackerdb";
-                    "signer_sighash" => %new_block.header.signer_signature_hash(),
-                    "ack_msg" => ?ack,
-                );
-            }
-            Err(e) => {
-                return Err(NakamotoNodeError::SigningCoordinatorFailure(format!(
-                    "Failed to propose block to stackerdb {e:?}"
-                )));
-            }
-        }
-
-        self.globals.counters.bump_naka_proposed_blocks();
-        Ok(())
     }
 
     fn get_stackerdb_contract_and_slots(

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -9,8 +9,8 @@ use std::{env, thread};
 use clarity::boot_util::boot_code_id;
 use clarity::vm::Value;
 use libsigner::{
-    BlockResponse, MessageSlotID, RejectCode, RunningSigner, Signer, SignerEventReceiver,
-    SignerMessage,
+    BlockProposalSigners, BlockResponse, MessageSlotID, RejectCode, RunningSigner, Signer,
+    SignerEventReceiver, SignerMessage,
 };
 use rand::thread_rng;
 use rand_core::RngCore;
@@ -1037,13 +1037,23 @@ fn stackerdb_sign() {
 
     info!("------------------------- Test Sign -------------------------");
     let reward_cycle = signer_test.get_current_reward_cycle();
+    let block_proposal_1 = BlockProposalSigners {
+        block: block1.clone(),
+        burn_height: 0,
+        reward_cycle,
+    };
+    let block_proposal_2 = BlockProposalSigners {
+        block: block2.clone(),
+        burn_height: 0,
+        reward_cycle,
+    };
     // Determine the coordinator of the current node height
     info!("signer_runloop: spawn send commands to do sign");
     let sign_now = Instant::now();
     let sign_command = RunLoopCommand {
         reward_cycle,
         command: SignerCommand::Sign {
-            block: block1,
+            block_proposal: block_proposal_1,
             is_taproot: false,
             merkle_root: None,
         },
@@ -1051,7 +1061,7 @@ fn stackerdb_sign() {
     let sign_taproot_command = RunLoopCommand {
         reward_cycle,
         command: SignerCommand::Sign {
-            block: block2,
+            block_proposal: block_proposal_2,
             is_taproot: true,
             merkle_root: None,
         },


### PR DESCRIPTION
This is a cleanup of the miner block proposal process. Since the miner immediately follows up a block proposal with a sign request over the same block, it would be better to make the sign request also the block proposal message. Removes some extra logic and the extra block slot. 