### PR TITLE
feat: Add `nakamoto_attempt_time_ms` to control Nakamoto miner

### DIFF
--- a/docs/mining.md
+++ b/docs/mining.md
@@ -3,7 +3,7 @@
 Stacks tokens (STX) are mined by transferring BTC via PoX. To run as a miner,
 you should make sure to add the following config fields to your config file:
 
-```
+```toml
 [node]
 # Run as a miner
 miner = True
@@ -25,6 +25,8 @@ first_attempt_time_ms = 1000
 subsequent_attempt_time_ms = 60000
 # Time to spend mining a microblock, in milliseconds.
 microblock_attempt_time_ms = 30000
+# Time to spend mining a Nakamoto block, in milliseconds.
+nakamoto_attempt_time_ms = 10000
 ```
 
 You can verify that your node is operating as a miner by checking its log output
@@ -40,7 +42,7 @@ INFO [1630127492.062652] [testnet/stacks-node/src/run_loop/neon.rs:164] [main] U
 
 Fee and cost estimators can be configured via the config section `[fee_estimation]`:
 
-```
+```toml
 [fee_estimation]
 cost_estimator = naive_pessimistic
 fee_estimator = fuzzed_weighted_median_fee_rate

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -802,10 +802,6 @@ impl BlockMinerThread {
 
         parent_block_info.stacks_parent_header.microblock_tail = None;
 
-        let block_num = u64::try_from(self.mined_blocks.len())
-            .map_err(|_| NakamotoNodeError::UnexpectedChainState)?
-            .saturating_add(1);
-
         let signer_transactions =
             self.get_signer_transactions(&mut chain_state, &burn_db, &stackerdbs)?;
 
@@ -818,11 +814,8 @@ impl BlockMinerThread {
             &self.burn_block.consensus_hash,
             self.burn_block.total_burn,
             tenure_start_info,
-            self.config.make_block_builder_settings(
-                block_num,
-                false,
-                self.globals.get_miner_status(),
-            ),
+            self.config
+                .make_nakamoto_block_builder_settings(self.globals.get_miner_status()),
             // we'll invoke the event dispatcher ourselves so that it calculates the
             //  correct signer_sighash for `process_mined_nakamoto_block_event`
             Some(&self.event_dispatcher),


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Add new config parameter `nakamoto_attempt_time_ms` to control Nakamoto miner separately from existing (pre-Nakamoto) miner config

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
