### PR TITLE
Downgrade transaction warnings

### DIFF
--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -970,14 +970,14 @@ impl StacksChainState {
                 // Their presence in this variant makes the transaction invalid.
                 if tx.post_conditions.len() > 0 {
                     let msg = format!("Invalid Stacks transaction: TokenTransfer transactions do not support post-conditions");
-                    warn!("{}", &msg);
+                    info!("{}", &msg);
 
                     return Err(Error::InvalidStacksTransaction(msg, false));
                 }
 
                 if *addr == origin_account.principal {
                     let msg = format!("Invalid TokenTransfer: address tried to send to itself");
-                    warn!("{}", &msg);
+                    info!("{}", &msg);
                     return Err(Error::InvalidStacksTransaction(msg, false));
                 }
 
@@ -1088,7 +1088,7 @@ impl StacksChainState {
                             if epoch_id >= StacksEpochId::Epoch21 {
                                 // in 2.1 and later, this is a permitted runtime error.  take the
                                 // fee from the payer and keep the tx.
-                                warn!("Contract-call encountered an analysis error at runtime";
+                                info!("Contract-call encountered an analysis error at runtime";
                                       "txid" => %tx.txid(),
                                       "origin" => %origin_account.principal,
                                       "origin_nonce" => %origin_account.nonce,
@@ -1163,7 +1163,7 @@ impl StacksChainState {
                 // (because this can be checked statically by the miner before mining the block).
                 if StacksChainState::get_contract(clarity_tx, &contract_id)?.is_some() {
                     let msg = format!("Duplicate contract '{}'", &contract_id);
-                    warn!("{}", &msg);
+                    info!("{}", &msg);
 
                     return Err(Error::InvalidStacksTransaction(msg, false));
                 }
@@ -1225,7 +1225,7 @@ impl StacksChainState {
                                     .sub(&cost_before)
                                     .expect("BUG: total block cost decreased");
 
-                                warn!(
+                                info!(
                                     "Runtime error in contract analysis for {}: {:?}",
                                     &contract_id, &other_error;
                                     "txid" => %tx.txid(),
@@ -1329,7 +1329,7 @@ impl StacksChainState {
                             if epoch_id >= StacksEpochId::Epoch21 {
                                 // in 2.1 and later, this is a permitted runtime error.  take the
                                 // fee from the payer and keep the tx.
-                                warn!("Smart-contract encountered an analysis error at runtime";
+                                info!("Smart-contract encountered an analysis error at runtime";
                                       "txid" => %tx.txid(),
                                       "contract" => %contract_id,
                                       "code" => %contract_code_str,
@@ -1380,7 +1380,7 @@ impl StacksChainState {
                 // Their presence in this variant makes the transaction invalid.
                 if tx.post_conditions.len() > 0 {
                     let msg = format!("Invalid Stacks transaction: PoisonMicroblock transactions do not support post-conditions");
-                    warn!("{}", &msg);
+                    info!("{}", &msg);
 
                     return Err(Error::InvalidStacksTransaction(msg, false));
                 }
@@ -1412,7 +1412,7 @@ impl StacksChainState {
                 // Their presence in this variant makes the transaction invalid.
                 if tx.post_conditions.len() > 0 {
                     let msg = format!("Invalid Stacks transaction: TenureChange transactions do not support post-conditions");
-                    warn!("{msg}");
+                    info!("{msg}");
 
                     return Err(Error::InvalidStacksTransaction(msg, false));
                 }
@@ -1475,7 +1475,7 @@ impl StacksChainState {
             // requires 2.1 and higher
             if clarity_block.get_epoch() < StacksEpochId::Epoch21 {
                 let msg = format!("Invalid transaction {}: asks for Clarity2, but not in Stacks epoch 2.1 or later", tx.txid());
-                warn!("{}", &msg);
+                info!("{}", &msg);
                 return Err(Error::InvalidStacksTransaction(msg, false));
             }
         }

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -2332,7 +2332,7 @@ impl StacksBlockBuilder {
                                         // if we have an invalid transaction that was quietly ignored, don't warn here either
                                     }
                                     e => {
-                                        warn!("Failed to apply tx {}: {:?}", &txinfo.tx.txid(), &e);
+                                        info!("Failed to apply tx {}: {:?}", &txinfo.tx.txid(), &e);
                                         return Ok(Some(result_event));
                                     }
                                 }

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -5850,7 +5850,7 @@ impl PeerNetwork {
             &stacks_epoch.block_limit,
             &stacks_epoch.epoch_id,
         ) {
-            warn!("Transaction rejected from mempool, {}", &e.into_json(&txid));
+            info!("Transaction rejected from mempool, {}", &e.into_json(&txid));
             return false;
         }
 


### PR DESCRIPTION
### Description

These problems with transactions are normal and should not be warnings in the stacks-node logs. They are flooding the logs with warnings, making it easier to miss real warnings.

### Applicable issues

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
