### PR TITLE
fix: handle a race condition between the signer and the /v2/pox endpoint

### DIFF
--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -83,6 +83,9 @@ pub enum ClientError {
     /// Stacks node does not support a feature we need
     #[error("Stacks node does not support a required feature: {0}")]
     UnsupportedStacksFeature(String),
+    /// Invalid response from the stacks node
+    #[error("Invalid response from the stacks node: {0}")]
+    InvalidResponse(String),
 }
 
 /// Retry a function F with an exponential backoff and notification on transient failure

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -297,8 +297,9 @@ impl RunLoop {
                 if info.reward_cycle != block_reward_cycle {
                     // If the stacks-node is still processing the burn block, the /v2/pox endpoint
                     // may return the previous reward cycle. In this case, we should retry.
-                    return Err(backoff::Error::transient(err_msg!(
-                        "Received reward cycle info is not the new block's expected reward cycle. Try again."
+                    return Err(backoff::Error::transient(ClientError::InvalidResponse(
+                        "Received reward cycle info does not match the current burn block height."
+                            .to_string(),
                     )));
                 }
                 Ok(info)

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -300,8 +300,11 @@ impl RunLoop {
                     // If the stacks-node is still processing the burn block, the /v2/pox endpoint
                     // may return the previous reward cycle. In this case, we should retry.
                     return Err(backoff::Error::transient(ClientError::InvalidResponse(
-                        "Received reward cycle info does not match the current burn block height."
-                            .to_string(),
+                        format!("Received reward cycle ({}) does not match the expected reward cycle ({}) for block {}.",
+                            info.reward_cycle,
+                            block_reward_cycle,
+                            current_burn_block_height
+                        ),
                     )));
                 }
                 Ok(info)

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -296,7 +296,7 @@ impl RunLoop {
                     .stacks_client
                     .get_current_reward_cycle_info()
                     .map_err(backoff::Error::transient)?;
-                if info.reward_cycle != block_reward_cycle {
+                if info.reward_cycle < block_reward_cycle {
                     // If the stacks-node is still processing the burn block, the /v2/pox endpoint
                     // may return the previous reward cycle. In this case, we should retry.
                     return Err(backoff::Error::transient(ClientError::InvalidResponse(

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -89,6 +89,14 @@ impl RewardCycleInfo {
             burnchain_block_height,
         )
     }
+
+    /// Check if the provided burnchain block height is in the prepare phase of the next cycle
+    pub fn is_in_next_prepare_phase(&self, burnchain_block_height: u64) -> bool {
+        let next_reward_cycle = self.reward_cycle.saturating_add(1);
+
+        self.is_in_prepare_phase(burnchain_block_height)
+            && self.get_reward_cycle(burnchain_block_height) == next_reward_cycle
+    }
 }
 
 /// The runloop for the stacks signer
@@ -299,7 +307,7 @@ impl RunLoop {
         }
         let current_reward_cycle = reward_cycle_info.reward_cycle;
         // We should only attempt to refresh the signer if we are not configured for the next reward cycle yet and we received a new burn block for its prepare phase
-        if reward_cycle_info.is_in_prepare_phase(current_burn_block_height) {
+        if reward_cycle_info.is_in_next_prepare_phase(current_burn_block_height) {
             let next_reward_cycle = current_reward_cycle.saturating_add(1);
             if self
                 .stacks_signers


### PR DESCRIPTION
When the signer is processing a new burn block, it may hit the /v2/pox endpoint before it has been updated with the latest block. This change will check for this case and retry until it receives the expected cycle.

This also fixes a problem with refreshing the signer too early. It should only attempt to refresh the signer during the next prepare phase. This handles the case where for the first block in a cycle (height % cycle_length == 0), it will report that it is in cycle N, but it will also report that it is in the prepare phase. This was resulting in refreshing the signer config too early. For example, with a cycle length of 20, at block 160, we would see a log:

```
Received a new burnchain block height (160) in the prepare phase of the next reward cycle (9). Checking for signer registration...
```
    
This is incorrect, because block 160 is not in the prepare phase for cycle 9.