### PR TITLE
Feat/mock mining hot swap

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -704,7 +704,7 @@ impl BitcoinRegtestController {
         block_height: u64,
     ) -> Option<UTXOSet> {
         // if mock mining, do not even both requesting UTXOs
-        if self.config.node.mock_mining {
+        if self.config.get_node_config().mock_mining {
             return None;
         }
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -703,7 +703,7 @@ impl BitcoinRegtestController {
         utxos_to_exclude: Option<UTXOSet>,
         block_height: u64,
     ) -> Option<UTXOSet> {
-        // if mock mining, do not even both requesting UTXOs
+        // if mock mining, do not even bother requesting UTXOs
         if self.config.get_node_config().mock_mining {
             return None;
         }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -558,6 +558,19 @@ impl Config {
         return config.miner;
     }
 
+    pub fn get_node_config(&self) -> NodeConfig {
+        let Some(path) = &self.config_path else {
+            return self.node.clone();
+        };
+        let Ok(config_file) = ConfigFile::from_path(path.as_str()) else {
+            return self.node.clone();
+        };
+        let Ok(config) = Config::from_config_file(config_file) else {
+            return self.node.clone();
+        };
+        return config.node;
+    }
+
     /// Apply any test settings to this burnchain config struct
     #[cfg_attr(test, mutants::skip)]
     fn apply_test_settings(&self, burnchain: &mut Burnchain) {

--- a/testnet/stacks-node/src/nakamoto_node.rs
+++ b/testnet/stacks-node/src/nakamoto_node.rs
@@ -167,7 +167,7 @@ impl StacksNode {
         let local_peer = p2p_net.local_peer.clone();
 
         // setup initial key registration
-        let leader_key_registration_state = if config.node.mock_mining {
+        let leader_key_registration_state = if config.get_node_config().mock_mining {
             // mock mining, pretend to have a registered key
             let (vrf_public_key, _) = keychain.make_vrf_keypair(VRF_MOCK_MINER_KEY);
             LeaderKeyRegistrationState::Active(RegisteredKey {

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -656,7 +656,7 @@ impl BlockMinerThread {
     fn make_vrf_proof(&mut self) -> Option<VRFProof> {
         // if we're a mock miner, then make sure that the keychain has a keypair for the mocked VRF
         // key
-        let vrf_proof = if self.config.node.mock_mining {
+        let vrf_proof = if self.config.get_node_config().mock_mining {
             self.keychain.generate_proof(
                 VRF_MOCK_MINER_KEY,
                 self.burn_block.sortition_hash.as_bytes(),

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1712,7 +1712,7 @@ impl BlockMinerThread {
     fn make_vrf_proof(&mut self) -> Option<VRFProof> {
         // if we're a mock miner, then make sure that the keychain has a keypair for the mocked VRF
         // key
-        let vrf_proof = if self.config.node.mock_mining {
+        let vrf_proof = if self.config.get_node_config().mock_mining {
             self.keychain.generate_proof(
                 VRF_MOCK_MINER_KEY,
                 self.burn_block.sortition_hash.as_bytes(),
@@ -2535,7 +2535,7 @@ impl BlockMinerThread {
         let res = bitcoin_controller.submit_operation(target_epoch_id, op, &mut op_signer, attempt);
         if res.is_none() {
             self.failed_to_submit_last_attempt = true;
-            if !self.config.node.mock_mining {
+            if !self.config.get_node_config().mock_mining {
                 warn!("Relayer: Failed to submit Bitcoin transaction");
                 return None;
             }
@@ -3518,7 +3518,7 @@ impl RelayerThread {
             return false;
         }
 
-        if !self.config.node.mock_mining {
+        if !self.config.get_node_config().mock_mining {
             // mock miner can't mine microblocks yet, so don't stop it from trying multiple
             // anchored blocks
             if self.mined_stacks_block && self.config.node.mine_microblocks {
@@ -4777,7 +4777,7 @@ impl StacksNode {
         let local_peer = p2p_net.local_peer.clone();
 
         // setup initial key registration
-        let leader_key_registration_state = if config.node.mock_mining {
+        let leader_key_registration_state = if config.get_node_config().mock_mining {
             // mock mining, pretend to have a registered key
             let (vrf_public_key, _) = keychain.make_vrf_keypair(VRF_MOCK_MINER_KEY);
             LeaderKeyRegistrationState::Active(RegisteredKey {

--- a/testnet/stacks-node/src/run_loop/nakamoto.rs
+++ b/testnet/stacks-node/src/run_loop/nakamoto.rs
@@ -195,7 +195,7 @@ impl RunLoop {
                     return true;
                 }
             }
-            if self.config.node.mock_mining {
+            if self.config.get_node_config().mock_mining {
                 info!("No UTXOs found, but configured to mock mine");
                 return true;
             } else {

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -373,7 +373,7 @@ impl RunLoop {
                     return true;
                 }
             }
-            if self.config.node.mock_mining {
+            if self.config.get_node_config().mock_mining {
                 info!("No UTXOs found, but configured to mock mine");
                 return true;
             } else {


### PR DESCRIPTION
Fixes https://github.com/stacks-network/stacks-core/issues/4705

I went through all the hot-swappable fields and wrote this to follow the architecture implemented for burnchain hot-swappable fields from the config.

### How I tested this using clarinet for devnet and regtest nodes:
Moved my testing commits to this [external branch ](https://github.com/ASuciuX/stacks-core/commits/test/mock-mining-hot-swap/).
1. Have my updated code + the 2 commits from Hugo.
2. Build a custom docker image using the last commit from this source branch using this commit `214ae48c0a2c2bac6cd593039210cc21ac3e5e0b`.
3. Custom clarinet devnet start:
  a. Use the built docker image for `stacks_node_image_url = "localhost:5001/stacks-node:mock-miner"` 
  b. Disable automatically bitcoin mining to check balances `bitcoin_controller_automining_disabled = true`. This is performed as we expect the stacks-mock-miner not to spend bitcoin, while the stacks-miner spends for mining.
4. Get into stacks-node docker container > files > src>stacks-node>Stacks.toml and add `mock_mining=true`.
5. Results on the image below - when the mock-miner was true, there were no stacks-blocks created, in that frame 4 bitcoin blocks were mined and 0 stacks blocks. After switching back the config to not have mock-miner, it mined stacks blocks again.

![image](https://github.com/stacks-network/stacks-core/assets/151519329/070fad4d-f9cc-4e63-808d-3554ce8a68d1)
 
  