### PR TITLE
Fix/4735

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -704,7 +704,7 @@ impl BitcoinRegtestController {
         block_height: u64,
     ) -> Option<UTXOSet> {
         // if mock mining, do not even bother requesting UTXOs
-        if self.config.get_node_config().mock_mining {
+        if self.config.get_node_config(false).mock_mining {
             return None;
         }
 

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -65,7 +65,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 fn cli_pick_best_tip(config_path: &str, at_stacks_height: Option<u64>) -> TipCandidate {
     info!("Loading config at path {}", config_path);
     let config = match ConfigFile::from_path(config_path) {
-        Ok(config_file) => Config::from_config_file(config_file).unwrap(),
+        Ok(config_file) => Config::from_config_file(config_file, true).unwrap(),
         Err(e) => {
             warn!("Invalid config file: {}", e);
             process::exit(1);
@@ -105,7 +105,7 @@ fn cli_get_miner_spend(
 ) -> u64 {
     info!("Loading config at path {}", config_path);
     let config = match ConfigFile::from_path(&config_path) {
-        Ok(config_file) => Config::from_config_file(config_file).unwrap(),
+        Ok(config_file) => Config::from_config_file(config_file, true).unwrap(),
         Err(e) => {
             warn!("Invalid config file: {}", e);
             process::exit(1);
@@ -334,7 +334,7 @@ fn main() {
                     process::exit(1);
                 }
             };
-            match Config::from_config_file(config_file) {
+            match Config::from_config_file(config_file, true) {
                 Ok(_) => {
                     info!("Loaded config!");
                     process::exit(0);
@@ -365,9 +365,11 @@ fn main() {
             let seed = {
                 let config_path: Option<String> = args.opt_value_from_str("--config").unwrap();
                 if let Some(config_path) = config_path {
-                    let conf =
-                        Config::from_config_file(ConfigFile::from_path(&config_path).unwrap())
-                            .unwrap();
+                    let conf = Config::from_config_file(
+                        ConfigFile::from_path(&config_path).unwrap(),
+                        true,
+                    )
+                    .unwrap();
                     args.finish();
                     conf.node.seed
                 } else {
@@ -416,7 +418,7 @@ fn main() {
         }
     };
 
-    let conf = match Config::from_config_file(config_file) {
+    let conf = match Config::from_config_file(config_file, true) {
         Ok(conf) => conf,
         Err(e) => {
             warn!("Invalid config: {}", e);

--- a/testnet/stacks-node/src/nakamoto_node.rs
+++ b/testnet/stacks-node/src/nakamoto_node.rs
@@ -167,7 +167,7 @@ impl StacksNode {
         let local_peer = p2p_net.local_peer.clone();
 
         // setup initial key registration
-        let leader_key_registration_state = if config.get_node_config().mock_mining {
+        let leader_key_registration_state = if config.get_node_config(false).mock_mining {
             // mock mining, pretend to have a registered key
             let (vrf_public_key, _) = keychain.make_vrf_keypair(VRF_MOCK_MINER_KEY);
             LeaderKeyRegistrationState::Active(RegisteredKey {

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -656,7 +656,7 @@ impl BlockMinerThread {
     fn make_vrf_proof(&mut self) -> Option<VRFProof> {
         // if we're a mock miner, then make sure that the keychain has a keypair for the mocked VRF
         // key
-        let vrf_proof = if self.config.get_node_config().mock_mining {
+        let vrf_proof = if self.config.get_node_config(false).mock_mining {
             self.keychain.generate_proof(
                 VRF_MOCK_MINER_KEY,
                 self.burn_block.sortition_hash.as_bytes(),

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1712,7 +1712,7 @@ impl BlockMinerThread {
     fn make_vrf_proof(&mut self) -> Option<VRFProof> {
         // if we're a mock miner, then make sure that the keychain has a keypair for the mocked VRF
         // key
-        let vrf_proof = if self.config.get_node_config().mock_mining {
+        let vrf_proof = if self.config.get_node_config(false).mock_mining {
             self.keychain.generate_proof(
                 VRF_MOCK_MINER_KEY,
                 self.burn_block.sortition_hash.as_bytes(),
@@ -2535,7 +2535,7 @@ impl BlockMinerThread {
         let res = bitcoin_controller.submit_operation(target_epoch_id, op, &mut op_signer, attempt);
         if res.is_none() {
             self.failed_to_submit_last_attempt = true;
-            if !self.config.get_node_config().mock_mining {
+            if !self.config.get_node_config(false).mock_mining {
                 warn!("Relayer: Failed to submit Bitcoin transaction");
                 return None;
             }
@@ -3518,7 +3518,7 @@ impl RelayerThread {
             return false;
         }
 
-        if !self.config.get_node_config().mock_mining {
+        if !self.config.get_node_config(false).mock_mining {
             // mock miner can't mine microblocks yet, so don't stop it from trying multiple
             // anchored blocks
             if self.mined_stacks_block && self.config.node.mine_microblocks {
@@ -4777,7 +4777,7 @@ impl StacksNode {
         let local_peer = p2p_net.local_peer.clone();
 
         // setup initial key registration
-        let leader_key_registration_state = if config.get_node_config().mock_mining {
+        let leader_key_registration_state = if config.get_node_config(false).mock_mining {
             // mock mining, pretend to have a registered key
             let (vrf_public_key, _) = keychain.make_vrf_keypair(VRF_MOCK_MINER_KEY);
             LeaderKeyRegistrationState::Active(RegisteredKey {

--- a/testnet/stacks-node/src/run_loop/nakamoto.rs
+++ b/testnet/stacks-node/src/run_loop/nakamoto.rs
@@ -195,7 +195,7 @@ impl RunLoop {
                     return true;
                 }
             }
-            if self.config.get_node_config().mock_mining {
+            if self.config.get_node_config(false).mock_mining {
                 info!("No UTXOs found, but configured to mock mine");
                 return true;
             } else {

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -373,7 +373,7 @@ impl RunLoop {
                     return true;
                 }
             }
-            if self.config.get_node_config().mock_mining {
+            if self.config.get_node_config(false).mock_mining {
                 info!("No UTXOs found, but configured to mock mine");
                 return true;
             } else {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -149,7 +149,7 @@ fn inner_neon_integration_test_conf(seed: Option<Vec<u8>>) -> (Config, StacksAdd
         burnchain.peer_host = Some("127.0.0.1".to_string());
     }
 
-    let magic_bytes = Config::from_config_file(cfile)
+    let magic_bytes = Config::from_config_file(cfile, false)
         .unwrap()
         .burnchain
         .magic_bytes;


### PR DESCRIPTION
This fixes #4735 by making it optional to resolve bootstap nodes when loading the config.  This avoids a blocking network round-trip in the many code paths that hot-reload the config file, and removes the possibility that these network round-trips fail and trigger a node panic.