### PR TITLE
Fix/4734

### DIFF
--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -1142,7 +1142,7 @@ impl PeerDB {
     }
 
     /// Set a peer as an initial peer
-    fn set_initial_peer(
+    pub fn set_initial_peer(
         tx: &Transaction,
         network_id: u32,
         peer_addr: &PeerAddress,

--- a/stackslib/src/net/inv/epoch2x.rs
+++ b/stackslib/src/net/inv/epoch2x.rs
@@ -1753,7 +1753,7 @@ impl PeerNetwork {
     }
 
     /// Determine at which reward cycle to begin scanning inventories
-    fn get_block_scan_start(&self, sortdb: &SortitionDB) -> u64 {
+    pub(crate) fn get_block_scan_start(&self, sortdb: &SortitionDB) -> u64 {
         // see if the stacks tip affirmation map and heaviest affirmation map diverge.  If so, then
         // start scaning at the reward cycle just before that.
         let am_rescan_rc = self
@@ -1786,10 +1786,12 @@ impl PeerNetwork {
         let rescan_rc = cmp::min(am_rescan_rc, start_reward_cycle);
 
         test_debug!(
-            "begin blocks inv scan at {} = min({},{})",
+            "begin blocks inv scan at {} = min({},{}) stacks_tip_am={} heaviest_am={}",
             rescan_rc,
-            stacks_tip_rc,
-            am_rescan_rc
+            am_rescan_rc,
+            start_reward_cycle,
+            &self.stacks_tip_affirmation_map,
+            &self.heaviest_affirmation_map
         );
         rescan_rc
     }

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -1954,6 +1954,7 @@ fn test_nakamoto_download_run_2_peers() {
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
+            false,
         );
         TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
     }
@@ -2140,6 +2141,7 @@ fn test_nakamoto_unconfirmed_download_run_2_peers() {
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
+            false,
         );
         TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
     }

--- a/stackslib/src/net/tests/inv/epoch2x.rs
+++ b/stackslib/src/net/tests/inv/epoch2x.rs
@@ -1248,11 +1248,14 @@ fn test_sync_inv_2_peers_plain() {
         let mut peer_1_config = TestPeerConfig::new(function_name!(), 0, 0);
         let mut peer_2_config = TestPeerConfig::new(function_name!(), 0, 0);
 
-        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_1_config.connection_opts.inv_reward_cycles = 10;
+        peer_2_config.connection_opts.inv_reward_cycles = 10;
 
         let mut peer_1 = TestPeer::new(peer_1_config);
         let mut peer_2 = TestPeer::new(peer_2_config);
+
+        peer_1.add_neighbor(&mut peer_2.to_neighbor(), None, true);
+        peer_2.add_neighbor(&mut peer_1.to_neighbor(), None, true);
 
         let num_blocks = (GETPOXINV_MAX_BITLEN * 2) as u64;
         let first_stacks_block_height = {
@@ -1422,11 +1425,14 @@ fn test_sync_inv_2_peers_stale() {
         let mut peer_1_config = TestPeerConfig::new(function_name!(), 0, 0);
         let mut peer_2_config = TestPeerConfig::new(function_name!(), 0, 0);
 
-        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_1_config.connection_opts.inv_reward_cycles = 10;
+        peer_2_config.connection_opts.inv_reward_cycles = 10;
 
         let mut peer_1 = TestPeer::new(peer_1_config);
         let mut peer_2 = TestPeer::new(peer_2_config);
+
+        peer_1.add_neighbor(&mut peer_2.to_neighbor(), None, true);
+        peer_2.add_neighbor(&mut peer_1.to_neighbor(), None, true);
 
         let num_blocks = (GETPOXINV_MAX_BITLEN * 2) as u64;
         let first_stacks_block_height = {
@@ -1525,13 +1531,16 @@ fn test_sync_inv_2_peers_unstable() {
         let mut peer_1_config = TestPeerConfig::new(function_name!(), 0, 0);
         let mut peer_2_config = TestPeerConfig::new(function_name!(), 0, 0);
 
-        let stable_confs = peer_1_config.burnchain.stable_confirmations as u64;
+        peer_1_config.connection_opts.inv_reward_cycles = 10;
+        peer_2_config.connection_opts.inv_reward_cycles = 10;
 
-        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        let stable_confs = peer_1_config.burnchain.stable_confirmations as u64;
 
         let mut peer_1 = TestPeer::new(peer_1_config);
         let mut peer_2 = TestPeer::new(peer_2_config);
+
+        peer_1.add_neighbor(&mut peer_2.to_neighbor(), None, true);
+        peer_2.add_neighbor(&mut peer_1.to_neighbor(), None, true);
 
         let num_blocks = (GETPOXINV_MAX_BITLEN * 2) as u64;
 
@@ -1559,7 +1568,7 @@ fn test_sync_inv_2_peers_unstable() {
             } else {
                 // peer 1 diverges
                 test_debug!("Peer 1 diverges at {}", i + first_stacks_block_height);
-                peer_1.next_burnchain_block(vec![]);
+                peer_1.next_burnchain_block_diverge(vec![burn_ops[0].clone()]);
             }
         }
 
@@ -1734,14 +1743,17 @@ fn test_sync_inv_2_peers_different_pox_vectors() {
         let mut peer_1_config = TestPeerConfig::new(function_name!(), 0, 0);
         let mut peer_2_config = TestPeerConfig::new(function_name!(), 0, 0);
 
-        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_1_config.connection_opts.inv_reward_cycles = 10;
+        peer_2_config.connection_opts.inv_reward_cycles = 10;
 
         let reward_cycle_length = peer_1_config.burnchain.pox_constants.reward_cycle_length as u64;
         assert_eq!(reward_cycle_length, 5);
 
         let mut peer_1 = TestPeer::new(peer_1_config);
         let mut peer_2 = TestPeer::new(peer_2_config);
+
+        peer_1.add_neighbor(&mut peer_2.to_neighbor(), None, true);
+        peer_2.add_neighbor(&mut peer_1.to_neighbor(), None, true);
 
         let num_blocks = (GETPOXINV_MAX_BITLEN * 3) as u64;
 


### PR DESCRIPTION
This fixes #4734 by ensuring that all inventory synchronizations happen starting from the reward cycle that is `connection_opts.inv_reward_cycles` ago, instead of 0.