### PR TITLE
[CI] 4746 - Avoid extraneous CI runs (develop)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    paths-ignore:
-      - "**.md"
-      - "**.yml"
-    ## might be better to use inclusive v exclusive paths here, ex:
-    # paths:
-    #   - "**.rs"
-    #   - "**.clar"
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-i## The main Github Actions workflow
+## The main Github Actions workflow
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-## The main Github Actions workflow
+i## The main Github Actions workflow
 name: CI
 
 on:
@@ -31,9 +31,6 @@ on:
     # paths:
     #   - "**.rs"
     #   - "**.clar"
-  pull_request_review:
-    types:
-      - submitted
 
 defaults:
   run:
@@ -55,15 +52,6 @@ jobs:
   ##     - PR review comment
   ##     - PR change is requested
   rustfmt:
-    if: |
-      !(
-        github.event_name == 'pull_request_review' && 
-        github.event.action == 'submitted' && 
-        (
-          github.event.review.state == 'commented' ||
-          github.event.review.state == 'changes_requested'
-        )
-      )
     name: Rust Format
     runs-on: ubuntu-latest
     steps:
@@ -104,22 +92,9 @@ jobs:
   ##
   ## Runs when:
   ##   - tag is not provided
-  ##   and the following are not true:
-  ##     - PR review submitted (not approved)
-  ##     and any of:
-  ##       - PR review comment
-  ##       - PR change is requested
   docker-image:
     if: |
-      inputs.tag == '' &&
-      !(
-        github.event_name == 'pull_request_review' &&
-        github.event.action == 'submitted' &&
-        (
-          github.event.review.state == 'commented' ||
-          github.event.review.state == 'changes_requested'
-        )
-      )
+      inputs.tag == ''
     name: Docker Image (Source)
     uses: ./.github/workflows/image-build-source.yml
     needs:
@@ -133,7 +108,6 @@ jobs:
   ##   or:
   ##     - no tag provided
   ##       and any of:
-  ##         - PR is approved (any approval will trigger)
   ##         - this workflow is called manually
   ##         - PR is opened
   ##         - commit to either (development, master) branch
@@ -141,11 +115,6 @@ jobs:
     if: |
       inputs.tag != '' || (
         inputs.tag == '' && (
-          (
-            github.event_name == 'pull_request_review' &&
-            github.event.action == 'submitted' &&
-            github.event.review.state == 'approved'
-          ) ||
           github.event_name == 'workflow_dispatch' ||
           github.event_name == 'pull_request' ||
           github.event_name == 'merge_group' ||
@@ -168,16 +137,28 @@ jobs:
   ##
   ## Runs when:
   ##   - tag is provided
-  ##   either or of the following:
-  ##     - tag is not provided
-  ##     - PR is approved
+  ##   or:
+  ##     - no tag provided
+  ##       and any of:
+  ##         - this workflow is called manually
+  ##         - PR is opened
+  ##         - PR added to merge queue
+  ##         - commit to either (development, next, master) branch
   stacks-core-tests:
     if: |
       inputs.tag != '' || (
-        inputs.tag == '' || (
-          github.event_name == 'pull_request_review' &&
-          github.event.action == 'submitted' &&
-          github.event.review.state == 'approved'
+        inputs.tag == '' && (
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'pull_request' ||
+          github.event_name == 'merge_group' ||
+          (
+            contains('
+              refs/heads/master
+              refs/heads/develop
+              refs/heads/next
+            ', github.event.pull_request.head.ref) &&
+            github.event_name == 'push'
+          )
         )
       )
     name: Stacks Core Tests
@@ -189,10 +170,18 @@ jobs:
   bitcoin-tests:
     if: |
       inputs.tag != '' || (
-        inputs.tag == '' || (
-          github.event_name == 'pull_request_review' &&
-          github.event.action == 'submitted' &&
-          github.event.review.state == 'approved'
+        inputs.tag == '' && (
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'pull_request' ||
+          github.event_name == 'merge_group' ||
+          (
+            contains('
+              refs/heads/master
+              refs/heads/develop
+              refs/heads/next
+            ', github.event.pull_request.head.ref) &&
+            github.event_name == 'push'
+          )
         )
       )
     name: Bitcoin Tests
@@ -228,3 +217,4 @@ jobs:
       - rustfmt
       - create-cache
     uses: ./.github/workflows/slow-tests.yml
+


### PR DESCRIPTION
Small change to the ci workflow to reduce the frequency of when CI is triggered. 
previously, various workflows would trigger:
- open a PR
- new commits to a PR
- PR approvals
- add PR to merge group
- would not trigger if only change is yml/md


This change does the following:
- workflow triggers when a PR:
  - is opened
  - is changed
  - only updated files are md/yml (this will be addressed in a future PR - today the required status checks would make this problematic)
- workflow no longer runs:
  - when PR is approved
