### PR TITLE
feat: Preserve `PeerNetwork` during Epoch 3.0 transition

### DIFF
--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -646,6 +646,24 @@ impl PeerNetwork {
         Ok(())
     }
 
+    /// Call `bind()` only if not already bound
+    /// Returns:
+    /// - `Ok(true)` if `bind()` call was successful
+    /// - `Ok(false)` if `bind()` call was skipped
+    /// - `Err()` if `bind()`` failed
+    #[cfg_attr(test, mutants::skip)]
+    pub fn try_bind(
+        &mut self,
+        my_addr: &SocketAddr,
+        http_addr: &SocketAddr,
+    ) -> Result<bool, net_error> {
+        if self.network.is_some() {
+            // Already bound
+            return Ok(false);
+        }
+        self.bind(my_addr, http_addr).map(|()| true)
+    }
+
     /// Get bound neighbor key. This is how this PeerNetwork appears to other nodes.
     pub fn bound_neighbor_key(&self) -> &NeighborKey {
         &self.bind_nk

--- a/testnet/stacks-node/src/nakamoto_node.rs
+++ b/testnet/stacks-node/src/nakamoto_node.rs
@@ -25,6 +25,7 @@ use stacks::chainstate::stacks::Error as ChainstateError;
 use stacks::monitoring;
 use stacks::monitoring::update_active_miners_count_gauge;
 use stacks::net::atlas::AtlasConfig;
+use stacks::net::p2p::PeerNetwork;
 use stacks::net::relay::Relayer;
 use stacks::net::stackerdb::StackerDBs;
 use stacks_common::types::chainstate::SortitionId;
@@ -132,6 +133,7 @@ impl StacksNode {
         globals: Globals,
         // relay receiver endpoint for the p2p thread, so the relayer can feed it data to push
         relay_recv: Receiver<RelayerDirective>,
+        peer_network: Option<PeerNetwork>,
     ) -> StacksNode {
         let config = runloop.config().clone();
         let is_miner = runloop.is_miner();
@@ -157,7 +159,8 @@ impl StacksNode {
             .connect_mempool_db()
             .expect("FATAL: database failure opening mempool");
 
-        let mut p2p_net = NeonNode::setup_peer_network(&config, &atlas_config, burnchain);
+        let mut p2p_net = peer_network
+            .unwrap_or_else(|| NeonNode::setup_peer_network(&config, &atlas_config, burnchain));
 
         let stackerdbs = StackerDBs::connect(&config.get_stacker_db_file_path(), true)
             .expect("FATAL: failed to connect to stacker DB");

--- a/testnet/stacks-node/src/nakamoto_node/peer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/peer.rs
@@ -182,8 +182,13 @@ impl PeerThread {
             .parse()
             .unwrap_or_else(|_| panic!("Failed to parse socket: {}", &config.node.rpc_bind));
 
-        net.bind(&p2p_sock, &rpc_sock)
-            .expect("BUG: PeerNetwork could not bind or is already bound");
+        let did_bind = net
+            .try_bind(&p2p_sock, &rpc_sock)
+            .expect("BUG: PeerNetwork could not bind");
+
+        if !did_bind {
+            info!("`PeerNetwork::bind()` skipped, already bound");
+        }
 
         let poll_timeout = cmp::min(5000, config.miner.first_attempt_time_ms / 2);
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -298,7 +298,7 @@ pub struct StacksNode {
     /// True if we're a miner
     is_miner: bool,
     /// handle to the p2p thread
-    pub p2p_thread_handle: JoinHandle<()>,
+    pub p2p_thread_handle: JoinHandle<Option<PeerNetwork>>,
     /// handle to the relayer thread
     pub relayer_thread_handle: JoinHandle<()>,
 }
@@ -4655,7 +4655,10 @@ impl StacksNode {
     /// Main loop of the p2p thread.
     /// Runs in a separate thread.
     /// Continuously receives, until told otherwise.
-    pub fn p2p_main(mut p2p_thread: PeerThread, event_dispatcher: EventDispatcher) {
+    pub fn p2p_main(
+        mut p2p_thread: PeerThread,
+        event_dispatcher: EventDispatcher,
+    ) -> Option<PeerNetwork> {
         let should_keep_running = p2p_thread.globals.should_keep_running.clone();
         let (mut dns_resolver, mut dns_client) = DNSResolver::new(10);
 
@@ -4718,6 +4721,7 @@ impl StacksNode {
             thread::sleep(Duration::from_secs(5));
         }
         info!("P2P thread exit!");
+        p2p_thread.net
     }
 
     /// This function sets the global var `GLOBAL_BURNCHAIN_SIGNER`.
@@ -4814,7 +4818,7 @@ impl StacksNode {
             ))
             .spawn(move || {
                 debug!("p2p thread ID is {:?}", thread::current().id());
-                Self::p2p_main(p2p_thread, p2p_event_dispatcher);
+                Self::p2p_main(p2p_thread, p2p_event_dispatcher)
             })
             .expect("FATAL: failed to start p2p thread");
 
@@ -5017,8 +5021,8 @@ impl StacksNode {
     }
 
     /// Join all inner threads
-    pub fn join(self) {
+    pub fn join(self) -> Option<PeerNetwork> {
         self.relayer_thread_handle.join().unwrap();
-        self.p2p_thread_handle.join().unwrap();
+        self.p2p_thread_handle.join().unwrap()
     }
 }

--- a/testnet/stacks-node/src/run_loop/boot_nakamoto.rs
+++ b/testnet/stacks-node/src/run_loop/boot_nakamoto.rs
@@ -108,7 +108,7 @@ impl BootRunLoop {
         let InnerLoops::Epoch3(ref mut naka_loop) = self.active_loop else {
             panic!("FATAL: unexpectedly invoked start_from_naka when active loop wasn't nakamoto");
         };
-        naka_loop.start(burnchain_opt, mine_start)
+        naka_loop.start(burnchain_opt, mine_start, None)
     }
 
     fn start_from_neon(&mut self, burnchain_opt: Option<Burnchain>, mine_start: u64) {
@@ -120,7 +120,7 @@ impl BootRunLoop {
 
         let boot_thread = Self::spawn_stopper(&self.config, neon_loop)
             .expect("FATAL: failed to spawn epoch-2/3-boot thread");
-        neon_loop.start(burnchain_opt.clone(), mine_start);
+        let peer_network = neon_loop.start(burnchain_opt.clone(), mine_start);
 
         let monitoring_thread = neon_loop.take_monitoring_thread();
         // did we exit because of the epoch-3.0 transition, or some other reason?
@@ -150,7 +150,7 @@ impl BootRunLoop {
         let InnerLoops::Epoch3(ref mut naka_loop) = self.active_loop else {
             panic!("FATAL: unexpectedly found epoch2 loop after setting epoch3 active");
         };
-        naka_loop.start(burnchain_opt, mine_start)
+        naka_loop.start(burnchain_opt, mine_start, peer_network)
     }
 
     fn spawn_stopper(

--- a/testnet/stacks-node/src/run_loop/nakamoto.rs
+++ b/testnet/stacks-node/src/run_loop/nakamoto.rs
@@ -31,6 +31,7 @@ use stacks::chainstate::stacks::db::{ChainStateBootData, StacksChainState};
 use stacks::chainstate::stacks::miner::{signal_mining_blocked, signal_mining_ready, MinerStatus};
 use stacks::core::StacksEpochId;
 use stacks::net::atlas::{AtlasConfig, AtlasDB, Attachment};
+use stacks::net::p2p::PeerNetwork;
 use stacks_common::types::PublicKey;
 use stacks_common::util::hash::Hash160;
 use stx_genesis::GenesisData;
@@ -392,7 +393,12 @@ impl RunLoop {
     /// It will start the burnchain (separate thread), set-up a channel in
     /// charge of coordinating the new blocks coming from the burnchain and
     /// the nodes, taking turns on tenures.  
-    pub fn start(&mut self, burnchain_opt: Option<Burnchain>, mut mine_start: u64) {
+    pub fn start(
+        &mut self,
+        burnchain_opt: Option<Burnchain>,
+        mut mine_start: u64,
+        peer_network: Option<PeerNetwork>,
+    ) {
         let (coordinator_receivers, coordinator_senders) = self
             .coordinator_channels
             .take()
@@ -475,7 +481,7 @@ impl RunLoop {
 
         // Boot up the p2p network and relayer, and figure out how many sortitions we have so far
         // (it could be non-zero if the node is resuming from chainstate)
-        let mut node = StacksNode::spawn(self, globals.clone(), relay_recv);
+        let mut node = StacksNode::spawn(self, globals.clone(), relay_recv, peer_network);
 
         // Wait for all pending sortitions to process
         let burnchain_db = burnchain_config

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -21,6 +21,7 @@ use stacks::chainstate::stacks::db::{ChainStateBootData, StacksChainState};
 use stacks::chainstate::stacks::miner::{signal_mining_blocked, signal_mining_ready, MinerStatus};
 use stacks::core::StacksEpochId;
 use stacks::net::atlas::{AtlasConfig, AtlasDB, Attachment};
+use stacks::net::p2p::PeerNetwork;
 use stacks::util_lib::db::Error as db_error;
 use stacks_common::deps_common::ctrlc as termination;
 use stacks_common::deps_common::ctrlc::SignalId;
@@ -999,7 +1000,11 @@ impl RunLoop {
     /// It will start the burnchain (separate thread), set-up a channel in
     /// charge of coordinating the new blocks coming from the burnchain and
     /// the nodes, taking turns on tenures.  
-    pub fn start(&mut self, burnchain_opt: Option<Burnchain>, mut mine_start: u64) {
+    pub fn start(
+        &mut self,
+        burnchain_opt: Option<Burnchain>,
+        mut mine_start: u64,
+    ) -> Option<PeerNetwork> {
         let (coordinator_receivers, coordinator_senders) = self
             .coordinator_channels
             .take()
@@ -1018,12 +1023,12 @@ impl RunLoop {
             Ok(burnchain_controller) => burnchain_controller,
             Err(burnchain_error::ShutdownInitiated) => {
                 info!("Exiting stacks-node");
-                return;
+                return None;
             }
             Err(e) => {
                 error!("Error initializing burnchain: {}", e);
                 info!("Exiting stacks-node");
-                return;
+                return None;
             }
         };
 
@@ -1142,11 +1147,11 @@ impl RunLoop {
 
                 globals.coord().stop_chains_coordinator();
                 coordinator_thread_handle.join().unwrap();
-                node.join();
+                let peer_network = node.join();
                 liveness_thread.join().unwrap();
 
                 info!("Exiting stacks-node");
-                break;
+                break peer_network;
             }
 
             let remote_chain_height = burnchain.get_headers_height() - 1;
@@ -1269,7 +1274,7 @@ impl RunLoop {
                         if !node.relayer_sortition_notify() {
                             // relayer hung up, exit.
                             error!("Runloop: Block relayer and miner hung up, exiting.");
-                            return;
+                            return None;
                         }
                     }
 
@@ -1343,7 +1348,7 @@ impl RunLoop {
                     if !node.relayer_issue_tenure(ibd) {
                         // relayer hung up, exit.
                         error!("Runloop: Block relayer and miner hung up, exiting.");
-                        break;
+                        break None;
                     }
                 }
             }


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Preserve `PeerNetwork` struct from Neon node and pass to Nakamoto node during Epoch 3.0 transition to maintain network connections

### Applicable issues

- fixes #4355
- fixes #4547

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
