### PR TITLE
fix: dont log "couldn't connect to miner" in 2.5

### DIFF
--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -240,6 +240,16 @@ impl StacksClient {
         let pox_info = self.get_pox_data()?;
         let burn_block_height = self.get_burn_block_height()?;
 
+        self.get_node_epoch_from_pox_data(&pox_info, burn_block_height)
+    }
+
+    /// Determine the stacks node current epoch based on the provided
+    /// pox data and burn block height
+    pub fn get_node_epoch_from_pox_data(
+        &self,
+        pox_info: &RPCPoxInfoData,
+        burn_block_height: u64,
+    ) -> Result<StacksEpochId, ClientError> {
         let epoch_25 = pox_info
             .epochs
             .iter()
@@ -466,12 +476,15 @@ impl StacksClient {
             .reward_phase_block_length
             .saturating_add(pox_data.prepare_phase_block_length);
         let reward_cycle = blocks_mined / reward_cycle_length;
+        let epoch =
+            self.get_node_epoch_from_pox_data(&pox_data, pox_data.current_burnchain_block_height)?;
         Ok(RewardCycleInfo {
             reward_cycle,
             reward_cycle_length,
             prepare_phase_block_length: pox_data.prepare_phase_block_length,
             first_burnchain_block_height: pox_data.first_burnchain_block_height,
             last_burnchain_block_height: pox_data.current_burnchain_block_height,
+            epoch,
         })
     }
 


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/4757

When the signer looks up the current coordinator during an active reward cycle, it assumes the miner should be the coordinator. In 2.5, this isn't the case. When DKG doesn't complete before the active reward cycle, the signer continues to lookup the coordinator, but it still outputs this error log.

TLDR: the signer's coordinator logic is fine, as it already falls back to the DKG coordinator, but it shouldn't log this error in 2.5.

To implement this, I've extended the `RewardCycleInfo` struct to include the current epoch, and I pass around this struct instead of just `current_reward_cycle` in a few places.