### PR TITLE
feat: add a next_initiative_delay config

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1781,6 +1781,7 @@ pub struct NodeConfig {
     pub max_microblocks: u64,
     pub wait_time_for_microblocks: u64,
     pub wait_time_for_blocks: u64,
+    pub next_initiative_delay: u64,
     pub prometheus_bind: Option<String>,
     pub marf_cache_strategy: Option<String>,
     pub marf_defer_hashing: bool,
@@ -2066,6 +2067,7 @@ impl Default for NodeConfig {
             max_microblocks: u16::MAX as u64,
             wait_time_for_microblocks: 30_000,
             wait_time_for_blocks: 30_000,
+            next_initiative_delay: 10_000,
             prometheus_bind: None,
             marf_cache_strategy: None,
             marf_defer_hashing: true,
@@ -2516,6 +2518,7 @@ pub struct NodeConfigFile {
     pub max_microblocks: Option<u64>,
     pub wait_time_for_microblocks: Option<u64>,
     pub wait_time_for_blocks: Option<u64>,
+    pub next_initiative_delay: Option<u64>,
     pub prometheus_bind: Option<String>,
     pub marf_cache_strategy: Option<String>,
     pub marf_defer_hashing: Option<bool>,
@@ -2576,6 +2579,9 @@ impl NodeConfigFile {
             wait_time_for_blocks: self
                 .wait_time_for_blocks
                 .unwrap_or(default_node_config.wait_time_for_blocks),
+            next_initiative_delay: self
+                .next_initiative_delay
+                .unwrap_or(default_node_config.next_initiative_delay),
             prometheus_bind: self.prometheus_bind,
             marf_cache_strategy: self.marf_cache_strategy,
             marf_defer_hashing: self

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1781,6 +1781,12 @@ pub struct NodeConfig {
     pub max_microblocks: u64,
     pub wait_time_for_microblocks: u64,
     pub wait_time_for_blocks: u64,
+    /// Controls how frequently, in milliseconds, the nakamoto miner's relay thread acts on its own initiative
+    /// (as opposed to responding to an event from the networking thread, etc.). This is roughly
+    /// how frequently the miner checks if a new burnchain block has been processed.
+    ///
+    /// Default value of 10 seconds is reasonable in mainnet (where bitcoin blocks are ~10 minutes),
+    /// but environments where burn blocks are more frequent may want to decrease this value.
     pub next_initiative_delay: u64,
     pub prometheus_bind: Option<String>,
     pub marf_cache_strategy: Option<String>,

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -190,8 +190,10 @@ impl RelayerThread {
 
         let bitcoin_controller = BitcoinRegtestController::new_dummy(config.clone());
 
+        let next_initiative_delay = config.node.next_initiative_delay;
+
         RelayerThread {
-            config: config,
+            config,
             sortdb,
             chainstate,
             mempool,
@@ -215,7 +217,7 @@ impl RelayerThread {
 
             miner_thread: None,
             is_miner,
-            next_initiative: Instant::now() + Duration::from_secs(10),
+            next_initiative: Instant::now() + Duration::from_millis(next_initiative_delay),
             last_committed: None,
         }
     }
@@ -819,10 +821,12 @@ impl RelayerThread {
     pub fn main(mut self, relay_rcv: Receiver<RelayerDirective>) {
         debug!("relayer thread ID is {:?}", std::thread::current().id());
 
-        self.next_initiative = Instant::now() + Duration::from_secs(10);
+        self.next_initiative =
+            Instant::now() + Duration::from_millis(self.config.node.next_initiative_delay);
         while self.globals.keep_running() {
             let directive = if Instant::now() >= self.next_initiative {
-                self.next_initiative = Instant::now() + Duration::from_secs(10);
+                self.next_initiative =
+                    Instant::now() + Duration::from_millis(self.config.node.next_initiative_delay);
                 self.initiative()
             } else {
                 None


### PR DESCRIPTION
### Description

The `next_initiative` is hard coded in 3 different places, with this PR, the default value is only set once.
By making it configurable, other environments can set it to a lower delay (in the Devnet, the bitcoin block production can be faster than 10sec)

### Applicable issues
/

### Additional info (benefits, drawbacks, caveats)
/

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
