### PR TITLE
Adding 2.5.0.0.4 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,30 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ### Added
 
-- Added support for Clarity 3, with new keywords, `tenure-height` and `stacks-block-height`, and removal of `block-height`
+- Adds the solo stacking scenarios to the stateful property-based testing strategy for PoX-4 (#4725)
+- Add signer-key to synthetic stack-aggregation-increase event (#4728)
+- Implement the assumed total commit with carry-over (ATC-C) strategy for denying opportunistic Bitcoin miners from mining Stacks at a discount (#4733)
+- Adding support for stacks-block-height and tenure-height in Clarity 3 (#4745)
+- Preserve PeerNetwork struct when transitioning to 3.0 (#4767)
+- Implement singer monitor server error (#4773)
+- Pull current stacks signer out into v1 implementation and create placeholder v0 mod (#4778)
+- Create new block signature message type for v0 signer (#4787)
+- Isolate the rusqlite dependency in stacks-common and clarity behind a cargo feature (#4791)
+- Add next_initiative_delay config option to control how frequently the miner checks if a new burnchain block has been processed (#4795)
+- Various performance improvements and cleanup
 
 ### Changed
 
 - Downgraded log messages about transactions from warning to info (#4697)
+- Fix race condition between the signer binary and the /v2/pox endpoint (#4738)
+- Make node config mock_miner item hot-swappable (#4743)
+- Mandates that a burnchain block header be resolved by a BurnchainHeaderReader, which will resolve a block height to at most one burnchain header (#4748)
+- Optional config option to resolve DNS of bootstrap nodes (#4749)
+- Limit inventory syncs with new peers (#4750)
+- Update /v2/fees/transfer to report the median transaction fee estimate for a STX-transfer of 180 bytes (#4754)
+- Reduce connection spamming in stackerdb (#4759)
+- Remove deprecated signer cli commands (#4772)
+
 
 ## [2.5.0.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## Unreleased
+## [2.5.0.0.4]
 
 ### Added
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache musl-dev
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
+RUN cargo build --features monitoring_prom,slog_json --release
 
 RUN cp target/release/stacks-node /out
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -10,7 +10,7 @@ COPY . .
 
 RUN mkdir /out
 
-RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
+RUN cargo build --features monitoring_prom,slog_json --release
 
 RUN cp target/release/stacks-node /out
 


### PR DESCRIPTION
Prepping for the 2.5.0.0.4 release, this PR simply adds the changelog entry. 

Secondary - i noticed a small issue with the Dockerfiles in the repo root, which were still set to use the old build command. that change is also added here, but is trivial and inconsequential. 
```
RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
```
is now
```
RUN cargo build --features monitoring_prom,slog_json --release
```

