### PR TITLE
Fix/4793

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -85,7 +85,8 @@ jobs:
           - tests::signer::v0::block_proposal_rejection
           - tests::signer::v1::dkg
           - tests::signer::v1::sign_request_rejected
-          - tests::signer::v1::filter_bad_transactions
+          # TODO: enable these once v1 signer is fixed
+          # - tests::signer::v1::filter_bad_transactions
           - tests::signer::v1::delayed_dkg
           # TODO: enable these once v1 signer is fixed
           # - tests::signer::v1::mine_2_nakamoto_reward_cycles

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3646,8 +3646,12 @@ impl SortitionDB {
             db_error::NotFoundError
         })?;
 
+        // NOTE: the .saturating_sub(1) is necessary because the reward set is calculated in epoch
+        // 2.5 and lower at reward cycle index 1, not 0.  This correction ensures that the last
+        // block is checked against the signers who were active just before the new reward set is
+        // calculated.
         let reward_cycle_id = pox_constants
-            .block_height_to_reward_cycle(first_block_height, tip_sn.block_height)
+            .block_height_to_reward_cycle(first_block_height, tip_sn.block_height.saturating_sub(1))
             .expect("FATAL: stored snapshot with block height < first_block_height");
 
         Self::inner_get_preprocessed_reward_set_for_reward_cycle(

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4678,14 +4678,14 @@ impl SortitionDB {
         Ok(ret)
     }
 
-    /// DO NOT CALL FROM CONSENSUS CODE
+    /// DO NOT CALL during Stacks block processing (including during Clarity VM evaluation). This function returns the latest data known to the node, which may not have been at the time of original block assembly.
     pub fn index_handle_at_tip<'a>(&'a self) -> SortitionHandleConn<'a> {
         let sortition_id = SortitionDB::get_canonical_sortition_tip(self.conn()).unwrap();
         self.index_handle(&sortition_id)
     }
 
     /// Open a tx handle at the burn chain tip
-    /// DO NOT CALL FROM CONSENSUS CODE
+    /// DO NOT CALL during Stacks block processing (including during Clarity VM evaluation). This function returns the latest data known to the node, which may not have been at the time of original block assembly.
     pub fn tx_begin_at_tip<'a>(&'a mut self) -> SortitionHandleTx<'a> {
         let sortition_id = SortitionDB::get_canonical_sortition_tip(self.conn()).unwrap();
         self.tx_handle_begin(&sortition_id).unwrap()
@@ -4695,7 +4695,7 @@ impl SortitionDB {
     /// Returns Ok(Some(tip info)) on success
     /// Returns Ok(None) if there are no Nakamoto blocks in this tip
     /// Returns Err(..) on other DB error
-    /// DO NOT CALL FROM CONSENSUS CODE
+    /// DO NOT CALL during Stacks block processing (including during Clarity VM evaluation). This function returns the latest data known to the node, which may not have been at the time of original block assembly.
     pub fn get_canonical_nakamoto_tip_hash_and_height(
         conn: &Connection,
         tip: &BlockSnapshot,
@@ -4720,7 +4720,7 @@ impl SortitionDB {
     }
 
     /// Get the canonical Stacks chain tip -- this gets memoized on the canonical burn chain tip.
-    /// DO NOT CALL FROM CONSENSUS CODE
+    /// DO NOT CALL during Stacks block processing (including during Clarity VM evaluation). This function returns the latest data known to the node, which may not have been at the time of original block assembly.
     pub fn get_canonical_stacks_chain_tip_hash_and_height(
         conn: &Connection,
     ) -> Result<(ConsensusHash, BlockHeaderHash, u64), db_error> {
@@ -4748,7 +4748,7 @@ impl SortitionDB {
     }
 
     /// Get the canonical Stacks chain tip -- this gets memoized on the canonical burn chain tip.
-    /// DO NOT CALL FROM CONSENSUS CODE
+    /// DO NOT CALL during Stacks block processing (including during Clarity VM evaluation). This function returns the latest data known to the node, which may not have been at the time of original block assembly.
     pub fn get_canonical_stacks_chain_tip_hash(
         conn: &Connection,
     ) -> Result<(ConsensusHash, BlockHeaderHash), db_error> {

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -854,11 +854,11 @@ pub fn get_reward_cycle_info<U: RewardSetProvider>(
             true
         };
         if need_to_store {
-            test_debug!(
-                "Store preprocessed reward set for cycle {} (prepare start sortition {}): {:?}",
-                prev_reward_cycle,
-                &first_prepare_sn.sortition_id,
-                &reward_cycle_info
+            debug!(
+                "Store preprocessed reward set for cycle";
+                "reward_cycle" => prev_reward_cycle,
+                "prepare-start sortition" => %first_prepare_sn.sortition_id,
+                "reward_cycle_info" => format!("{:?}", &reward_cycle_info)
             );
             SortitionDB::store_preprocessed_reward_set(
                 &mut tx,

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -636,7 +636,7 @@ fn test_nakamoto_chainstate_getters() {
 
         // no tenures yet
         assert!(
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_tx.sqlite())
+            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_tx)
                 .unwrap()
                 .is_none()
         );
@@ -769,7 +769,7 @@ fn test_nakamoto_chainstate_getters() {
 
         // we now have a tenure, and it confirms the last epoch2 block
         let highest_tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_tx.sqlite())
+            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_tx)
                 .unwrap()
                 .unwrap();
         assert_eq!(highest_tenure.coinbase_height, 12);
@@ -797,7 +797,7 @@ fn test_nakamoto_chainstate_getters() {
         .is_some());
         assert!(NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
-            sort_tx.sqlite(),
+            &sort_tx,
             &blocks[0].header.consensus_hash,
             &blocks[1].header,
         )
@@ -969,7 +969,7 @@ fn test_nakamoto_chainstate_getters() {
 
         // we now have a new highest tenure
         let highest_tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_tx.sqlite())
+            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_tx)
                 .unwrap()
                 .unwrap();
         assert_eq!(highest_tenure.coinbase_height, 13);
@@ -994,14 +994,14 @@ fn test_nakamoto_chainstate_getters() {
         .is_none());
         assert!(NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
-            sort_tx.sqlite(),
+            &sort_tx,
             &new_blocks[0].header.consensus_hash,
             &new_blocks[1].header,
         )
         .unwrap());
         assert!(!NakamotoChainState::check_tenure_continuity(
             chainstate.db(),
-            sort_tx.sqlite(),
+            &sort_tx,
             &blocks[0].header.consensus_hash,
             &new_blocks[1].header,
         )
@@ -1613,7 +1613,7 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
         let sort_db = peer.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_db.conn())
+            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
                 .unwrap()
                 .unwrap();
         (tenure, tip)
@@ -1705,7 +1705,7 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
         let sort_db = peer.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_db.conn())
+            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
                 .unwrap()
                 .unwrap();
         (tenure, tip)
@@ -1800,7 +1800,7 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
         let sort_db = peer.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_db.conn())
+            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
                 .unwrap()
                 .unwrap();
         (tenure, tip)
@@ -2001,7 +2001,7 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
             let sort_db = peer.sortdb.as_mut().unwrap();
             let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
             let tenure =
-                NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_db.conn())
+                NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
                     .unwrap()
                     .unwrap();
             (tenure, tip)

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -406,7 +406,7 @@ fn replay_reward_cycle(
             block.clone(),
             None,
         )
-        .unwrap();
+        .unwrap_or(false);
         if accepted {
             test_debug!("Accepted Nakamoto block {block_id}");
             peer.coord.handle_new_nakamoto_stacks_block().unwrap();
@@ -1612,10 +1612,12 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
         let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
         let sort_db = peer.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-        let tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
-                .unwrap()
-                .unwrap();
+        let tenure = NakamotoChainState::get_ongoing_nakamoto_tenure(
+            chainstate.db(),
+            &sort_db.index_handle_at_tip(),
+        )
+        .unwrap()
+        .unwrap();
         (tenure, tip)
     };
     assert_eq!(highest_tenure.tenure_id_consensus_hash, tip.consensus_hash);
@@ -1704,10 +1706,12 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
         let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
         let sort_db = peer.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-        let tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
-                .unwrap()
-                .unwrap();
+        let tenure = NakamotoChainState::get_ongoing_nakamoto_tenure(
+            chainstate.db(),
+            &sort_db.index_handle_at_tip(),
+        )
+        .unwrap()
+        .unwrap();
         (tenure, tip)
     };
     assert_eq!(highest_tenure.tenure_id_consensus_hash, tip.consensus_hash);
@@ -1799,10 +1803,12 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
         let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
         let sort_db = peer.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-        let tenure =
-            NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
-                .unwrap()
-                .unwrap();
+        let tenure = NakamotoChainState::get_ongoing_nakamoto_tenure(
+            chainstate.db(),
+            &sort_db.index_handle_at_tip(),
+        )
+        .unwrap()
+        .unwrap();
         (tenure, tip)
     };
     assert_eq!(highest_tenure.tenure_id_consensus_hash, tip.consensus_hash);
@@ -2000,10 +2006,12 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
             let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
             let sort_db = peer.sortdb.as_mut().unwrap();
             let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-            let tenure =
-                NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
-                    .unwrap()
-                    .unwrap();
+            let tenure = NakamotoChainState::get_ongoing_nakamoto_tenure(
+                chainstate.db(),
+                &sort_db.index_handle_at_tip(),
+            )
+            .unwrap()
+            .unwrap();
             (tenure, tip)
         };
 

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2826,7 +2826,7 @@ impl NakamotoChainState {
                 // this block is mined in the ongoing tenure.
                 if !Self::check_tenure_continuity(
                     chainstate_tx,
-                    burn_dbconn.sqlite(),
+                    burn_dbconn,
                     &parent_ch,
                     &block.header,
                 )? {

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2009,7 +2009,7 @@ impl NakamotoChainState {
     }
 
     /// Load the canonical Stacks block header (either epoch-2 rules or Nakamoto)
-    /// DO NOT CALL FROM CONSENSUS CODE
+    /// DO NOT CALL during Stacks block processing (including during Clarity VM evaluation). This function returns the latest data known to the node, which may not have been at the time of original block assembly.
     pub fn get_canonical_block_header(
         chainstate_conn: &Connection,
         sortdb: &SortitionDB,

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -496,16 +496,6 @@ impl NakamotoBlockHeader {
         Ok(())
     }
 
-    /// Verify the block header against an aggregate public key
-    pub fn verify_threshold_signer(
-        &self,
-        signer_aggregate: &Point,
-        signature: &ThresholdSignature,
-    ) -> bool {
-        let message = self.signer_signature_hash().0;
-        signature.verify(signer_aggregate, &message)
-    }
-
     /// Verify the block header against the list of signer signatures
     ///
     /// Validate against:
@@ -1799,7 +1789,6 @@ impl NakamotoChainState {
         db_handle: &mut SortitionHandleConn,
         staging_db_tx: &NakamotoStagingBlocksTx,
         headers_conn: &Connection,
-        _aggregate_public_key: Option<&Point>,
         reward_set: RewardSet,
     ) -> Result<bool, ChainstateError> {
         test_debug!("Consider Nakamoto block {}", &block.block_id());
@@ -1847,21 +1836,6 @@ impl NakamotoChainState {
             return Ok(false);
         };
 
-        // TODO: epoch gate to verify aggregate signature
-        // let schnorr_signature = &block.header.signer_signature.0;
-        // if !db_handle.expects_signer_signature(
-        //     &block.header.consensus_hash,
-        //     schnorr_signature,
-        //     &block.header.signer_signature_hash().0,
-        //     aggregate_public_key,
-        // )? {
-        //     let msg = format!(
-        //         "Received block, but the signer signature does not match the active stacking cycle"
-        //     );
-        //     warn!("{}", msg; "aggregate_key" => %aggregate_public_key);
-        //     return Err(ChainstateError::InvalidStacksBlock(msg));
-        // }
-
         if let Err(e) = block.header.verify_signer_signatures(&reward_set) {
             warn!("Received block, but the signer signatures are invalid";
                   "block_id" => %block.block_id(),
@@ -1879,83 +1853,6 @@ impl NakamotoChainState {
         Self::store_block(staging_db_tx, block, burn_attachable)?;
         test_debug!("Stored Nakamoto block {}", &_block_id);
         Ok(true)
-    }
-
-    /// Get the aggregate public key for the given block from the signers-voting contract
-    pub(crate) fn load_aggregate_public_key<SH: SortitionHandle>(
-        sortdb: &SortitionDB,
-        sort_handle: &SH,
-        chainstate: &mut StacksChainState,
-        for_burn_block_height: u64,
-        at_block_id: &StacksBlockId,
-        warn_if_not_found: bool,
-    ) -> Result<Point, ChainstateError> {
-        // Get the current reward cycle
-        let Some(rc) = sort_handle.pox_constants().block_height_to_reward_cycle(
-            sort_handle.first_burn_block_height(),
-            for_burn_block_height,
-        ) else {
-            // This should be unreachable, but we'll return an error just in case.
-            let msg = format!(
-                "BUG: Failed to determine reward cycle of burn block height: {}.",
-                for_burn_block_height
-            );
-            warn!("{msg}");
-            return Err(ChainstateError::InvalidStacksBlock(msg));
-        };
-
-        test_debug!(
-            "get-approved-aggregate-key at block {}, cycle {}",
-            at_block_id,
-            rc
-        );
-        match chainstate.get_aggregate_public_key_pox_4(sortdb, at_block_id, rc)? {
-            Some(key) => Ok(key),
-            None => {
-                // this can happen for a whole host of reasons
-                if warn_if_not_found {
-                    warn!(
-                        "Failed to get aggregate public key";
-                        "block_id" => %at_block_id,
-                        "reward_cycle" => rc,
-                    );
-                }
-                Err(ChainstateError::InvalidStacksBlock(
-                    "Failed to get aggregate public key".into(),
-                ))
-            }
-        }
-    }
-
-    /// Get the aggregate public key for a block.
-    /// TODO: The block at which the aggregate public key is queried needs to be better defined.
-    /// See https://github.com/stacks-network/stacks-core/issues/4109
-    pub fn get_aggregate_public_key<SH: SortitionHandle>(
-        chainstate: &mut StacksChainState,
-        sortdb: &SortitionDB,
-        sort_handle: &SH,
-        block: &NakamotoBlock,
-    ) -> Result<Point, ChainstateError> {
-        let block_sn =
-            SortitionDB::get_block_snapshot_consensus(sortdb.conn(), &block.header.consensus_hash)?
-                .ok_or(ChainstateError::DBError(DBError::NotFoundError))?;
-        let aggregate_key_block_header =
-            Self::get_canonical_block_header(chainstate.db(), sortdb)?.unwrap();
-        let epoch_id = SortitionDB::get_stacks_epoch(sortdb.conn(), block_sn.block_height)?
-            .ok_or(ChainstateError::InvalidStacksBlock(
-                "Failed to get epoch ID".into(),
-            ))?
-            .epoch_id;
-
-        let aggregate_public_key = Self::load_aggregate_public_key(
-            sortdb,
-            sort_handle,
-            chainstate,
-            block_sn.block_height,
-            &aggregate_key_block_header.index_block_hash(),
-            epoch_id >= StacksEpochId::Epoch30,
-        )?;
-        Ok(aggregate_public_key)
     }
 
     /// Return the total ExecutionCost consumed during the tenure up to and including
@@ -2112,6 +2009,7 @@ impl NakamotoChainState {
     }
 
     /// Load the canonical Stacks block header (either epoch-2 rules or Nakamoto)
+    /// DO NOT CALL FROM CONSENSUS CODE
     pub fn get_canonical_block_header(
         chainstate_conn: &Connection,
         sortdb: &SortitionDB,

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -1844,10 +1844,12 @@ pub fn test_get_highest_nakamoto_tenure() {
         "stacks tip = {},{},{}",
         &stacks_ch, &stacks_bhh, stacks_height
     );
-    let highest_tenure =
-        NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
-            .unwrap()
-            .unwrap();
+    let highest_tenure = NakamotoChainState::get_highest_nakamoto_tenure(
+        chainstate.db(),
+        &sort_db.index_handle_at_tip(),
+    )
+    .unwrap()
+    .unwrap();
 
     let last_tenure_change = last_tenure_change.unwrap();
     let last_header = last_header.unwrap();
@@ -1882,10 +1884,12 @@ pub fn test_get_highest_nakamoto_tenure() {
     );
 
     // new tip doesn't include the last two tenures
-    let highest_tenure =
-        NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
-            .unwrap()
-            .unwrap();
+    let highest_tenure = NakamotoChainState::get_highest_nakamoto_tenure(
+        chainstate.db(),
+        &sort_db.index_handle_at_tip(),
+    )
+    .unwrap()
+    .unwrap();
     let last_tenure_change = &all_tenure_changes[2];
     let last_header = &all_headers[2];
     assert_eq!(

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -583,7 +583,6 @@ impl TestStacksNode {
             let reward_set = sortdb
                 .get_preprocessed_reward_set_of(&sort_tip)
                 .expect("Failed to get reward cycle info")
-                .expect("Failed to get reward cycle info")
                 .known_selected_anchor_block_owned()
                 .expect("Expected a reward set");
 

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -40,7 +40,9 @@ use serde::Deserialize;
 use stacks_common::address::AddressHashMode;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types;
-use stacks_common::types::chainstate::{BlockHeaderHash, StacksAddress, StacksBlockId};
+use stacks_common::types::chainstate::{
+    BlockHeaderHash, StacksAddress, StacksBlockId, StacksPublicKey,
+};
 use stacks_common::util::hash::{hex_bytes, to_hex, Hash160};
 use wsts::curve::point::{Compressed, Point};
 use wsts::curve::scalar::Scalar;

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -1628,7 +1628,7 @@ impl ConversationP2P {
             .map_err(|e| net_error::from(e))?;
 
         if cfg!(test) {
-            // make *sure* the behavior stays the same
+            // make *sure* the behavior stays the same in epoch 2
             let original_blocks_inv_data: BlocksInvData =
                 chainstate.get_blocks_inventory(&block_hashes)?;
 

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -38,9 +38,11 @@ use crate::chainstate::burn::db::sortdb::{
     BlockHeaderCache, SortitionDB, SortitionDBConn, SortitionHandleConn,
 };
 use crate::chainstate::burn::BlockSnapshot;
+use crate::chainstate::coordinator::RewardCycleInfo;
 use crate::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, NakamotoStagingBlocksConnRef,
 };
+use crate::chainstate::stacks::boot::RewardSet;
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::{
     Error as chainstate_error, StacksBlockHeader, TenureChangePayload,
@@ -861,6 +863,7 @@ impl NakamotoDownloadStateMachine {
                     "Peer {} has no inventory for reward cycle {}",
                     naddr, reward_cycle
                 );
+                test_debug!("Peer {} has the following inventory data: {:?}", naddr, inv);
                 continue;
             };
             for (i, wt) in wanted_tenures.iter().enumerate() {
@@ -1152,14 +1155,14 @@ impl NakamotoDownloadStateMachine {
     fn update_tenure_downloaders(
         &mut self,
         count: usize,
-        agg_public_keys: &BTreeMap<u64, Option<Point>>,
+        current_reward_sets: &BTreeMap<u64, RewardCycleInfo>,
     ) {
         self.tenure_downloads.make_tenure_downloaders(
             &mut self.tenure_download_schedule,
             &mut self.available_tenures,
             &mut self.tenure_block_ids,
             count,
-            agg_public_keys,
+            current_reward_sets,
         )
     }
 
@@ -1435,7 +1438,7 @@ impl NakamotoDownloadStateMachine {
                 sortdb,
                 sort_tip,
                 chainstate,
-                &network.aggregate_public_keys,
+                &network.current_reward_sets,
             ) else {
                 neighbor_rpc.add_dead(network, &naddr);
                 continue;
@@ -1500,7 +1503,7 @@ impl NakamotoDownloadStateMachine {
         max_count: usize,
     ) -> HashMap<ConsensusHash, Vec<NakamotoBlock>> {
         // queue up more downloaders
-        self.update_tenure_downloaders(max_count, &network.aggregate_public_keys);
+        self.update_tenure_downloaders(max_count, &network.current_reward_sets);
 
         // run all downloaders
         let new_blocks = self.tenure_downloads.run(network, &mut self.neighbor_rpc);

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -31,16 +31,17 @@ use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use stacks_common::util::{get_epoch_time_ms, get_epoch_time_secs, log};
-use wsts::curve::point::Point;
 
 use crate::burnchains::{Burnchain, BurnchainView, PoxConstants};
 use crate::chainstate::burn::db::sortdb::{
     BlockHeaderCache, SortitionDB, SortitionDBConn, SortitionHandleConn,
 };
 use crate::chainstate::burn::BlockSnapshot;
+use crate::chainstate::coordinator::{PoxAnchorBlockStatus, RewardCycleInfo};
 use crate::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, NakamotoStagingBlocksConnRef,
 };
+use crate::chainstate::stacks::boot::RewardSet;
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::{
     Error as chainstate_error, StacksBlockHeader, TenureChangePayload,
@@ -418,7 +419,7 @@ impl NakamotoTenureDownloaderSet {
         available: &mut HashMap<ConsensusHash, Vec<NeighborAddress>>,
         tenure_block_ids: &HashMap<NeighborAddress, AvailableTenures>,
         count: usize,
-        agg_public_keys: &BTreeMap<u64, Option<Point>>,
+        current_reward_cycles: &BTreeMap<u64, RewardCycleInfo>,
     ) {
         test_debug!("schedule: {:?}", schedule);
         test_debug!("available: {:?}", &available);
@@ -479,19 +480,25 @@ impl NakamotoTenureDownloaderSet {
                 test_debug!("Neighbor {} does not serve tenure {}", &naddr, ch);
                 continue;
             };
-            let Some(Some(start_agg_pubkey)) = agg_public_keys.get(&tenure_info.start_reward_cycle)
+            let Some(Some(start_reward_set)) = current_reward_cycles
+                .get(&tenure_info.start_reward_cycle)
+                .map(|cycle_info| cycle_info.known_selected_anchor_block())
             else {
                 test_debug!(
-                    "Cannot fetch tenure-start block due to no known aggregate public key: {:?}",
+                    "Cannot fetch tenure-start block due to no known start reward set for cycle {}: {:?}",
+                    tenure_info.start_reward_cycle,
                     &tenure_info
                 );
                 schedule.pop_front();
                 continue;
             };
-            let Some(Some(end_agg_pubkey)) = agg_public_keys.get(&tenure_info.end_reward_cycle)
+            let Some(Some(end_reward_set)) = current_reward_cycles
+                .get(&tenure_info.end_reward_cycle)
+                .map(|cycle_info| cycle_info.known_selected_anchor_block())
             else {
                 test_debug!(
-                    "Cannot fetch tenure-end block due to no known aggregate public key: {:?}",
+                    "Cannot fetch tenure-end block due to no known end reward set for cycle {}: {:?}",
+                    tenure_info.end_reward_cycle,
                     &tenure_info
                 );
                 schedule.pop_front();
@@ -499,12 +506,10 @@ impl NakamotoTenureDownloaderSet {
             };
 
             test_debug!(
-                "Download tenure {} (start={}, end={}) with aggregate keys {}, {} (rc {},{})",
+                "Download tenure {} (start={}, end={}) (rc {},{})",
                 &ch,
                 &tenure_info.start_block_id,
                 &tenure_info.end_block_id,
-                &start_agg_pubkey,
-                &end_agg_pubkey,
                 tenure_info.start_reward_cycle,
                 tenure_info.end_reward_cycle
             );
@@ -513,8 +518,8 @@ impl NakamotoTenureDownloaderSet {
                 tenure_info.start_block_id.clone(),
                 tenure_info.end_block_id.clone(),
                 naddr.clone(),
-                start_agg_pubkey.clone(),
-                end_agg_pubkey.clone(),
+                start_reward_set.clone(),
+                end_reward_set.clone(),
             );
 
             test_debug!("Request tenure {} from neighbor {}", ch, &naddr);

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_unconfirmed.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_unconfirmed.rs
@@ -31,16 +31,17 @@ use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use stacks_common::util::{get_epoch_time_ms, get_epoch_time_secs, log};
-use wsts::curve::point::Point;
 
 use crate::burnchains::{Burnchain, BurnchainView, PoxConstants};
 use crate::chainstate::burn::db::sortdb::{
     BlockHeaderCache, SortitionDB, SortitionDBConn, SortitionHandleConn,
 };
 use crate::chainstate::burn::BlockSnapshot;
+use crate::chainstate::coordinator::RewardCycleInfo;
 use crate::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, NakamotoStagingBlocksConnRef,
 };
+use crate::chainstate::stacks::boot::RewardSet;
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::{
     Error as chainstate_error, StacksBlockHeader, TenureChangePayload,
@@ -107,10 +108,10 @@ pub struct NakamotoUnconfirmedTenureDownloader {
     pub state: NakamotoUnconfirmedDownloadState,
     /// Address of who we're asking
     pub naddr: NeighborAddress,
-    /// Aggregate public key of the highest confirmed tenure
-    pub confirmed_aggregate_public_key: Option<Point>,
-    /// Aggregate public key of the unconfirmed (ongoing) tenure
-    pub unconfirmed_aggregate_public_key: Option<Point>,
+    /// reward set of the highest confirmed tenure
+    pub confirmed_signer_keys: Option<RewardSet>,
+    /// reward set of the unconfirmed (ongoing) tenure
+    pub unconfirmed_signer_keys: Option<RewardSet>,
     /// Block ID of this node's highest-processed block.
     /// We will not download any blocks lower than this, if it's set.
     pub highest_processed_block_id: Option<StacksBlockId>,
@@ -133,8 +134,8 @@ impl NakamotoUnconfirmedTenureDownloader {
         Self {
             state: NakamotoUnconfirmedDownloadState::GetTenureInfo,
             naddr,
-            confirmed_aggregate_public_key: None,
-            unconfirmed_aggregate_public_key: None,
+            confirmed_signer_keys: None,
+            unconfirmed_signer_keys: None,
             highest_processed_block_id,
             highest_processed_block_height: None,
             tenure_tip: None,
@@ -185,7 +186,7 @@ impl NakamotoUnconfirmedTenureDownloader {
         local_sort_tip: &BlockSnapshot,
         chainstate: &StacksChainState,
         remote_tenure_tip: RPCGetTenureInfo,
-        agg_pubkeys: &BTreeMap<u64, Option<Point>>,
+        current_reward_sets: &BTreeMap<u64, RewardCycleInfo>,
     ) -> Result<(), NetError> {
         if self.state != NakamotoUnconfirmedDownloadState::GetTenureInfo {
             return Err(NetError::InvalidState);
@@ -297,21 +298,24 @@ impl NakamotoUnconfirmedTenureDownloader {
             )
             .expect("FATAL: sortition from before system start");
 
-        // get aggregate public keys for the unconfirmed tenure and highest-complete tenure sortitions
-        let Some(Some(confirmed_aggregate_public_key)) =
-            agg_pubkeys.get(&parent_tenure_rc).cloned()
+        // get reward set info for the unconfirmed tenure and highest-complete tenure sortitions
+        let Some(Some(confirmed_reward_set)) = current_reward_sets
+            .get(&parent_tenure_rc)
+            .map(|cycle_info| cycle_info.known_selected_anchor_block())
         else {
             warn!(
-                "No aggregate public key for confirmed tenure {} (rc {})",
+                "No signer public keys for confirmed tenure {} (rc {})",
                 &parent_local_tenure_sn.consensus_hash, parent_tenure_rc
             );
             return Err(NetError::InvalidState);
         };
 
-        let Some(Some(unconfirmed_aggregate_public_key)) = agg_pubkeys.get(&tenure_rc).cloned()
+        let Some(Some(unconfirmed_reward_set)) = current_reward_sets
+            .get(&tenure_rc)
+            .map(|cycle_info| cycle_info.known_selected_anchor_block())
         else {
             warn!(
-                "No aggregate public key for confirmed tenure {} (rc {})",
+                "No signer public keys for unconfirmed tenure {} (rc {})",
                 &local_tenure_sn.consensus_hash, tenure_rc
             );
             return Err(NetError::InvalidState);
@@ -339,14 +343,12 @@ impl NakamotoUnconfirmedTenureDownloader {
         }
 
         test_debug!(
-            "Will validate unconfirmed blocks with ({},{}) and ({},{})",
-            &confirmed_aggregate_public_key,
+            "Will validate unconfirmed blocks with reward sets in ({},{})",
             parent_tenure_rc,
-            &unconfirmed_aggregate_public_key,
             tenure_rc
         );
-        self.confirmed_aggregate_public_key = Some(confirmed_aggregate_public_key);
-        self.unconfirmed_aggregate_public_key = Some(unconfirmed_aggregate_public_key);
+        self.confirmed_signer_keys = Some(confirmed_reward_set.clone());
+        self.unconfirmed_signer_keys = Some(unconfirmed_reward_set.clone());
         self.tenure_tip = Some(remote_tenure_tip);
 
         Ok(())
@@ -370,25 +372,22 @@ impl NakamotoUnconfirmedTenureDownloader {
             return Err(NetError::InvalidState);
         };
 
-        // TODO: epoch-gated loading of aggregate key
-        // let Some(unconfirmed_aggregate_public_key) = self.unconfirmed_aggregate_public_key.as_ref()
-        // else {
-        //     return Err(NetError::InvalidState);
-        // };
+        let Some(unconfirmed_signer_keys) = self.unconfirmed_signer_keys.as_ref() else {
+            return Err(NetError::InvalidState);
+        };
 
-        // stacker signature has to match the current aggregate public key
-        // TODO: epoch-gated verify threshold or vec of signatures
-        // if !unconfirmed_tenure_start_block
-        //     .header
-        //     .verify_threshold_signer(unconfirmed_aggregate_public_key)
-        // {
-        //     warn!("Invalid tenure-start block: bad signer signature";
-        //           "tenure_start_block.header.consensus_hash" => %unconfirmed_tenure_start_block.header.consensus_hash,
-        //           "tenure_start_block.header.block_id" => %unconfirmed_tenure_start_block.header.block_id(),
-        //           "unconfirmed_aggregate_public_key" => %unconfirmed_aggregate_public_key,
-        //           "state" => %self.state);
-        //     return Err(NetError::InvalidMessage);
-        // }
+        // stacker signature has to match the current reward set
+        if let Err(e) = unconfirmed_tenure_start_block
+            .header
+            .verify_signer_signatures(unconfirmed_signer_keys)
+        {
+            warn!("Invalid tenure-start block: bad signer signature";
+                  "tenure_start_block.header.consensus_hash" => %unconfirmed_tenure_start_block.header.consensus_hash,
+                  "tenure_start_block.header.block_id" => %unconfirmed_tenure_start_block.header.block_id(),
+                  "state" => %self.state,
+                  "error" => %e);
+            return Err(NetError::InvalidMessage);
+        }
 
         // block has to match the expected hash
         if tenure_start_block_id != &unconfirmed_tenure_start_block.header.block_id() {
@@ -437,11 +436,9 @@ impl NakamotoUnconfirmedTenureDownloader {
             return Err(NetError::InvalidState);
         };
 
-        // TODO: epoch-gated load aggregate key
-        // let Some(unconfirmed_aggregate_public_key) = self.unconfirmed_aggregate_public_key.as_ref()
-        // else {
-        //     return Err(NetError::InvalidState);
-        // };
+        let Some(unconfirmed_signer_keys) = self.unconfirmed_signer_keys.as_ref() else {
+            return Err(NetError::InvalidState);
+        };
 
         if tenure_blocks.is_empty() {
             // nothing to do
@@ -459,18 +456,17 @@ impl NakamotoUnconfirmedTenureDownloader {
                       "block_id" => %block.header.block_id());
                 return Err(NetError::InvalidMessage);
             }
-            // TODO: epoch-gated verify threshold or vec of signatures
-            // if !block
-            //     .header
-            //     .verify_threshold_signer(unconfirmed_aggregate_public_key)
-            // {
-            //     warn!("Invalid block: bad signer signature";
-            //           "tenure_id" => %tenure_tip.consensus_hash,
-            //           "block.header.block_id" => %block.header.block_id(),
-            //           "unconfirmed_aggregate_public_key" => %unconfirmed_aggregate_public_key,
-            //           "state" => %self.state);
-            //     return Err(NetError::InvalidMessage);
-            // }
+            if let Err(e) = block
+                .header
+                .verify_signer_signatures(unconfirmed_signer_keys)
+            {
+                warn!("Invalid block: bad signer signature";
+                      "tenure_id" => %tenure_tip.consensus_hash,
+                      "block.header.block_id" => %block.header.block_id(),
+                      "state" => %self.state,
+                      "error" => %e);
+                return Err(NetError::InvalidMessage);
+            }
 
             // we may or may not need the tenure-start block for the unconfirmed tenure.  But if we
             // do, make sure it's valid, and it's the last block we receive.
@@ -616,12 +612,10 @@ impl NakamotoUnconfirmedTenureDownloader {
         else {
             return Err(NetError::InvalidState);
         };
-        let Some(confirmed_aggregate_public_key) = self.confirmed_aggregate_public_key.as_ref()
-        else {
+        let Some(confirmed_signer_keys) = self.confirmed_signer_keys.as_ref() else {
             return Err(NetError::InvalidState);
         };
-        let Some(unconfirmed_aggregate_public_key) = self.unconfirmed_aggregate_public_key.as_ref()
-        else {
+        let Some(unconfirmed_signer_keys) = self.unconfirmed_signer_keys.as_ref() else {
             return Err(NetError::InvalidState);
         };
 
@@ -634,8 +628,8 @@ impl NakamotoUnconfirmedTenureDownloader {
             unconfirmed_tenure.winning_block_id.clone(),
             unconfirmed_tenure_start_block.header.block_id(),
             self.naddr.clone(),
-            confirmed_aggregate_public_key.clone(),
-            unconfirmed_aggregate_public_key.clone(),
+            confirmed_signer_keys.clone(),
+            unconfirmed_signer_keys.clone(),
         )
         .with_tenure_end_block(unconfirmed_tenure_start_block.clone());
 
@@ -723,7 +717,7 @@ impl NakamotoUnconfirmedTenureDownloader {
         sortdb: &SortitionDB,
         local_sort_tip: &BlockSnapshot,
         chainstate: &StacksChainState,
-        agg_pubkeys: &BTreeMap<u64, Option<Point>>,
+        current_reward_sets: &BTreeMap<u64, RewardCycleInfo>,
     ) -> Result<Option<Vec<NakamotoBlock>>, NetError> {
         match &self.state {
             NakamotoUnconfirmedDownloadState::GetTenureInfo => {
@@ -735,7 +729,7 @@ impl NakamotoUnconfirmedTenureDownloader {
                     local_sort_tip,
                     chainstate,
                     remote_tenure_info,
-                    agg_pubkeys,
+                    current_reward_sets,
                 )?;
                 Ok(None)
             }

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -72,7 +72,8 @@ pub(crate) struct InvTenureInfo {
 
 impl InvTenureInfo {
     /// Load up cacheable tenure state for a given tenure-ID consensus hash.
-    /// This only returns Ok(Some(..)) if there was a tenure-change tx for this consensus hash.
+    /// This only returns Ok(Some(..)) if there was a tenure-change tx for this consensus hash
+    /// (i.e. it was a BlockFound tenure, not an Extension tenure)
     pub fn load(
         chainstate: &StacksChainState,
         consensus_hash: &ConsensusHash,

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2021,6 +2021,7 @@ pub mod test {
         /// What services should this peer support?
         pub services: u16,
         /// aggregate public key to use
+        /// (NOTE: will be used post-Nakamoto)
         pub aggregate_public_key: Option<Point>,
         pub test_stackers: Option<Vec<TestStacker>>,
         pub test_signers: Option<TestSigners>,

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -265,6 +265,8 @@ pub struct PeerNetwork {
     /// determine whether or not the reward cycle info in `current_reward_sets` is still valid -- a
     /// burnchain fork may invalidate them, so the code must check that the sortition ID for the
     /// start of the prepare-phase is still canonical.
+    /// This needs to be in 1-to-1 correspondence with `current_reward_sets` -- the sortition IDs
+    /// that make up the values need to correspond to the reward sets computed as of the sortition.
     pub current_reward_set_ids: BTreeMap<u64, SortitionId>,
 
     // information about the state of the network's anchor blocks

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -736,7 +736,7 @@ impl NakamotoBootPlan {
             let sort_db = peer.sortdb.as_mut().unwrap();
             let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
             let tenure =
-                NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), sort_db.conn())
+                NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
                     .unwrap()
                     .unwrap();
             (tenure, tip)
@@ -811,7 +811,7 @@ impl NakamotoBootPlan {
                 let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
                 let tenure = NakamotoChainState::get_highest_nakamoto_tenure(
                     chainstate.db(),
-                    sort_db.conn(),
+                    &sort_db.index_handle_at_tip(),
                 )
                 .unwrap()
                 .unwrap();

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -735,10 +735,12 @@ impl NakamotoBootPlan {
             let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
             let sort_db = peer.sortdb.as_mut().unwrap();
             let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-            let tenure =
-                NakamotoChainState::get_highest_nakamoto_tenure(chainstate.db(), &sort_db.index_handle_at_tip())
-                    .unwrap()
-                    .unwrap();
+            let tenure = NakamotoChainState::get_highest_nakamoto_tenure(
+                chainstate.db(),
+                &sort_db.index_handle_at_tip(),
+            )
+            .unwrap()
+            .unwrap();
             (tenure, tip)
         };
 

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -42,8 +42,7 @@ use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
 use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::hash::Hash160;
 use stacks_common::util::vrf::VRFProof;
-use wsts::curve::ecdsa;
-use wsts::curve::point::{Compressed, Point};
+use wsts::curve::point::Point;
 use wsts::curve::scalar::Scalar;
 
 use super::relayer::RelayerThread;
@@ -288,16 +287,7 @@ impl BlockMinerThread {
         };
 
         // NOTE: this is a placeholder until the API can be fixed
-        let aggregate_public_key = {
-            let key_bytes = [
-                0x03, 0xd3, 0xe1, 0x5a, 0x36, 0xf3, 0x2a, 0x9e, 0x71, 0x31, 0x7f, 0xcb, 0x4a, 0x20,
-                0x1b, 0x0c, 0x08, 0xb3, 0xbc, 0xfb, 0xdc, 0x8a, 0xee, 0x2e, 0xe4, 0xd2, 0x69, 0x23,
-                0x00, 0x06, 0xb1, 0xa0, 0xcb,
-            ];
-            let ecdsa_pk = ecdsa::PublicKey::try_from(key_bytes.as_slice()).unwrap();
-            Point::try_from(&Compressed::from(ecdsa_pk.to_bytes())).unwrap()
-        };
-
+        let aggregate_public_key = Point::new();
         let miner_privkey_as_scalar = Scalar::from(miner_privkey.as_slice().clone());
         let mut coordinator = SignCoordinator::new(
             &reward_set,

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -287,9 +287,6 @@ impl BlockMinerThread {
             ));
         };
 
-        let chain_state = neon_node::open_chainstate_with_faults(&self.config)
-            .expect("FATAL: could not open chainstate DB");
-
         // NOTE: this is a placeholder until the API can be fixed
         let aggregate_public_key = {
             let key_bytes = [

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -367,7 +367,6 @@ pub fn read_and_sign_block_proposal(
     let reward_set = sortdb
         .get_preprocessed_reward_set_of(&tip.sortition_id)
         .expect("Failed to get reward cycle info")
-        .expect("Failed to get reward cycle info")
         .known_selected_anchor_block_owned()
         .expect("Expected a reward set");
 


### PR DESCRIPTION
This PR updates the Nakamoto chainstate and networking stack to use the reward cycle's signers instead of the aggregate public key to authenticate Nakamoto blocks (#4793).  In order to do this, this PR also fixes #4813.

Note that the fix for #4813 does _not_ need a schema migration for nodes today which have erroneously stored a `SelectedAndUnknown` reward set, because the impact of doing so is nonexistent.  This would only have required a schema migration if the last reward 2.5 cycle was erroneously set to `SelectedAndUnknown`.