### PR TITLE
Run the v0 signer by default instead of v1

### DIFF
--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -43,7 +43,7 @@ use stacks_signer::cli::{
     RunSignerArgs, StackerDBArgs,
 };
 use stacks_signer::config::GlobalConfig;
-use stacks_signer::v1::SpawnedSigner;
+use stacks_signer::v0::SpawnedSigner;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 


### PR DESCRIPTION
If we later want to make this an argument we can, but for now we default run v0 signer as v1 is broken as is anyway.