### PR TITLE
Fix/StackerDB Audit

### DIFF
--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2540,6 +2540,7 @@ pub mod test {
                     &mut stacks_node.chainstate,
                     &sortdb,
                     old_stackerdb_configs,
+                    config.connection_opts.num_neighbors,
                 )
                 .expect("Failed to refresh stackerdb configs");
 

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -5363,6 +5363,7 @@ impl PeerNetwork {
             chainstate,
             sortdb,
             stacker_db_configs,
+            self.connection_opts.num_neighbors,
         )?;
         Ok(())
     }

--- a/stackslib/src/net/stackerdb/config.rs
+++ b/stackslib/src/net/stackerdb/config.rs
@@ -292,6 +292,7 @@ impl StackerDBConfig {
         contract_id: &QualifiedContractIdentifier,
         tip: &StacksBlockId,
         signers: Vec<(StacksAddress, u32)>,
+        local_max_neighbors: u64,
     ) -> Result<StackerDBConfig, NetError> {
         let value =
             chainstate.eval_read_only(burn_dbconn, tip, contract_id, "(stackerdb-get-config)")?;
@@ -365,11 +366,12 @@ impl StackerDBConfig {
             ));
         }
 
-        let max_neighbors = config_tuple
+        let mut max_neighbors = config_tuple
             .get("max-neighbors")
             .expect("FATAL: missing 'max-neighbors'")
             .clone()
             .expect_u128()?;
+
         if max_neighbors > usize::MAX as u128 {
             let reason = format!(
                 "Contract {} stipulates a maximum number of neighbors beyond usize::MAX",
@@ -380,6 +382,16 @@ impl StackerDBConfig {
                 contract_id.clone(),
                 reason,
             ));
+        }
+
+        if max_neighbors > u128::from(local_max_neighbors) {
+            warn!(
+                "Contract {} stipulates a maximum number of neighbors ({}) beyond locally-configured maximum {}; defaulting to locally-configured maximum",
+                contract_id,
+                max_neighbors,
+                local_max_neighbors,
+            );
+            max_neighbors = u128::from(local_max_neighbors);
         }
 
         let hint_replicas_list = config_tuple
@@ -435,7 +447,7 @@ impl StackerDBConfig {
                 ));
             }
 
-            if port < 1024 || port > ((u16::MAX - 1) as u128) {
+            if port < 1024 || port > u128::from(u16::MAX - 1) {
                 let reason = format!(
                     "Contract {} stipulates a port lower than 1024 or above u16::MAX - 1",
                     contract_id
@@ -446,11 +458,20 @@ impl StackerDBConfig {
                     reason,
                 ));
             }
+            // NOTE: port is now known to be in range [1024, 65535]
 
             let mut pubkey_hash_slice = [0u8; 20];
             pubkey_hash_slice.copy_from_slice(&pubkey_hash_bytes[0..20]);
 
             let peer_addr = PeerAddress::from_slice(&addr_bytes).expect("FATAL: not 16 bytes");
+            if peer_addr.is_in_private_range() {
+                debug!(
+                    "Ignoring private IP address '{}' in hint-replias",
+                    &peer_addr.to_socketaddr(port as u16)
+                );
+                continue;
+            }
+
             let naddr = NeighborAddress {
                 addrbytes: peer_addr,
                 port: port as u16,
@@ -475,6 +496,7 @@ impl StackerDBConfig {
         chainstate: &mut StacksChainState,
         sortition_db: &SortitionDB,
         contract_id: &QualifiedContractIdentifier,
+        max_neighbors: u64,
     ) -> Result<StackerDBConfig, NetError> {
         let chain_tip =
             NakamotoChainState::get_canonical_block_header(chainstate.db(), sortition_db)?
@@ -542,7 +564,14 @@ impl StackerDBConfig {
 
         // evaluate the contract for these two functions
         let signers = Self::eval_signer_slots(chainstate, &dbconn, contract_id, &chain_tip_hash)?;
-        let config = Self::eval_config(chainstate, &dbconn, contract_id, &chain_tip_hash, signers)?;
+        let config = Self::eval_config(
+            chainstate,
+            &dbconn,
+            contract_id,
+            &chain_tip_hash,
+            signers,
+            max_neighbors,
+        )?;
         Ok(config)
     }
 }

--- a/stackslib/src/net/stackerdb/config.rs
+++ b/stackslib/src/net/stackerdb/config.rs
@@ -466,7 +466,7 @@ impl StackerDBConfig {
             let peer_addr = PeerAddress::from_slice(&addr_bytes).expect("FATAL: not 16 bytes");
             if peer_addr.is_in_private_range() {
                 debug!(
-                    "Ignoring private IP address '{}' in hint-replias",
+                    "Ignoring private IP address '{}' in hint-replicas",
                     &peer_addr.to_socketaddr(port as u16)
                 );
                 continue;

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -267,6 +267,7 @@ impl StackerDBs {
         chainstate: &mut StacksChainState,
         sortdb: &SortitionDB,
         stacker_db_configs: HashMap<QualifiedContractIdentifier, StackerDBConfig>,
+        num_neighbors: u64,
     ) -> Result<HashMap<QualifiedContractIdentifier, StackerDBConfig>, net_error> {
         let existing_contract_ids = self.get_stackerdb_contract_ids()?;
         let mut new_stackerdb_configs = HashMap::new();
@@ -288,15 +289,20 @@ impl StackerDBs {
                 })
             } else {
                 // attempt to load the config from the contract itself
-                StackerDBConfig::from_smart_contract(chainstate, &sortdb, &stackerdb_contract_id)
-                    .unwrap_or_else(|e| {
-                        warn!(
-                            "Failed to load StackerDB config";
-                            "contract" => %stackerdb_contract_id,
-                            "err" => ?e,
-                        );
-                        StackerDBConfig::noop()
-                    })
+                StackerDBConfig::from_smart_contract(
+                    chainstate,
+                    &sortdb,
+                    &stackerdb_contract_id,
+                    num_neighbors,
+                )
+                .unwrap_or_else(|e| {
+                    warn!(
+                        "Failed to load StackerDB config";
+                        "contract" => %stackerdb_contract_id,
+                        "err" => ?e,
+                    );
+                    StackerDBConfig::noop()
+                })
             };
             // Create the StackerDB replica if it does not exist already
             if !existing_contract_ids.contains(&stackerdb_contract_id) {

--- a/stackslib/src/net/stackerdb/tests/config.rs
+++ b/stackslib/src/net/stackerdb/tests/config.rs
@@ -133,7 +133,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -152,7 +152,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                 write_freq: 4,
                 max_writes: 56,
                 hint_replicas: vec![NeighborAddress {
-                    addrbytes: PeerAddress::from_ipv4(127, 0, 0, 1),
+                    addrbytes: PeerAddress::from_ipv4(142, 150, 80, 100),
                     port: 8901,
                     public_key_hash: Hash160::from_hex("0123456789abcdef0123456789abcdef01234567")
                         .unwrap(),
@@ -174,7 +174,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -193,7 +193,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                 write_freq: 4,
                 max_writes: 56,
                 hint_replicas: vec![NeighborAddress {
-                    addrbytes: PeerAddress::from_ipv4(127, 0, 0, 1),
+                    addrbytes: PeerAddress::from_ipv4(142, 150, 80, 100),
                     port: 8901,
                     public_key_hash: Hash160::from_hex("0123456789abcdef0123456789abcdef01234567")
                         .unwrap(),
@@ -212,7 +212,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -234,7 +234,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -256,7 +256,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -278,7 +278,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -300,7 +300,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -322,7 +322,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -344,7 +344,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -366,7 +366,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -388,7 +388,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u18446744073709551617,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u8901,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -432,7 +432,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u1,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
@@ -454,13 +454,51 @@ fn test_valid_and_invalid_stackerdb_configs() {
                     max-neighbors: u7,
                     hint-replicas: (list
                         {
-                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u142 u150 u80 u100),
                             port: u65537,
                             public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
                         })
                 }))
             "#,
             None,
+        ),
+        (
+            // valid, but private IP and absurd max neighbors are both handled
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u1024,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u192 u168 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            Some(StackerDBConfig {
+                chunk_size: 123,
+                signers: vec![(
+                    StacksAddress {
+                        version: 26,
+                        bytes: Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b")
+                            .unwrap(),
+                    },
+                    3,
+                )],
+                write_freq: 4,
+                max_writes: 56,
+                // no neighbors
+                hint_replicas: vec![],
+                // max neighbors is truncated
+                max_neighbors: 32,
+            }),
         ),
     ];
 
@@ -490,7 +528,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
             ContractName::try_from(format!("test-{}", i)).unwrap(),
         );
         peer.with_db_state(|sortdb, chainstate, _, _| {
-            match StackerDBConfig::from_smart_contract(chainstate, sortdb, &contract_id) {
+            match StackerDBConfig::from_smart_contract(chainstate, sortdb, &contract_id, 32) {
                 Ok(config) => {
                     let expected = result
                         .clone()

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -4610,7 +4610,12 @@ impl StacksNode {
             stackerdb_configs.insert(contract.clone(), StackerDBConfig::noop());
         }
         let stackerdb_configs = stackerdbs
-            .create_or_reconfigure_stackerdbs(&mut chainstate, &sortdb, stackerdb_configs)
+            .create_or_reconfigure_stackerdbs(
+                &mut chainstate,
+                &sortdb,
+                stackerdb_configs,
+                config.connection_options.num_neighbors,
+            )
             .unwrap();
 
         let stackerdb_contract_ids: Vec<QualifiedContractIdentifier> =


### PR DESCRIPTION
This addresses all of the points brought forth by a StackerDB audit.  None of them are security risks or pose a serious problem to the system's operation, so it's safe to just open it against `develop` for now without doing a hotfix.

The fixes are:

* Don't accept a private IP address from `hint-replicas` in the StackerDB config contract
* Limit the upper value of `max-neighbors` to the locally-configured `num_neighbors` in `ConnectionOptions`