### PR TITLE
Fix/nakamoto downloader audit

### DIFF
--- a/stackslib/src/net/api/gettenure.rs
+++ b/stackslib/src/net/api/gettenure.rs
@@ -19,7 +19,7 @@ use std::{fs, io};
 
 use regex::{Captures, Regex};
 use serde::de::Error as de_Error;
-use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::codec::{StacksMessageCodec, MAX_PAYLOAD_LEN};
 use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
 use stacks_common::types::net::PeerHost;
 use stacks_common::util::hash::to_hex;
@@ -46,7 +46,7 @@ pub struct RPCNakamotoTenureRequestHandler {
     /// Block to start streaming from. It and its ancestors will be incrementally streamed until one of
     /// hte following happens:
     /// * we reach the first block in the tenure
-    /// * we would exceed MAX_MESSAGE_LEN bytes transmitted if we started sending the next block
+    /// * we would exceed MAX_PAYLOAD_LEN bytes transmitted if we started sending the next block
     pub block_id: Option<StacksBlockId>,
     /// What's the final block ID to stream from?
     /// Passed as `stop=` query parameter
@@ -132,7 +132,7 @@ impl NakamotoTenureStream {
         self.total_sent = self
             .total_sent
             .saturating_add(self.block_stream.total_bytes);
-        if self.total_sent.saturating_add(parent_size) > MAX_MESSAGE_LEN.into() {
+        if self.total_sent.saturating_add(parent_size) > MAX_PAYLOAD_LEN.into() {
             // out of space to send this
             return Ok(false);
         }
@@ -284,7 +284,7 @@ impl HttpResponse for RPCNakamotoTenureRequestHandler {
         preamble: &HttpResponsePreamble,
         body: &[u8],
     ) -> Result<HttpResponsePayload, Error> {
-        let bytes = parse_bytes(preamble, body, MAX_MESSAGE_LEN.into())?;
+        let bytes = parse_bytes(preamble, body, MAX_PAYLOAD_LEN.into())?;
         Ok(HttpResponsePayload::Bytes(bytes))
     }
 }

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -431,8 +431,8 @@ impl NakamotoTenureDownloaderSet {
             self.num_scheduled_downloaders()
         );
 
-        self.clear_available_peers();
         self.clear_finished_downloaders();
+        self.clear_available_peers();
         self.try_transition_fetch_tenure_end_blocks(tenure_block_ids);
         while self.inflight() < count {
             let Some(ch) = schedule.front() else {

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -247,8 +247,6 @@ impl InvGenerator {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct NakamotoTenureInv {
-    /// What state is the machine in?
-    pub state: NakamotoInvState,
     /// Bitmap of which tenures a peer has.
     /// Maps reward cycle to bitmap.
     pub tenures_inv: BTreeMap<u64, BitVec<2100>>,
@@ -279,7 +277,6 @@ impl NakamotoTenureInv {
         neighbor_address: NeighborAddress,
     ) -> Self {
         Self {
-            state: NakamotoInvState::GetNakamotoInvBegin,
             tenures_inv: BTreeMap::new(),
             last_updated_at: 0,
             first_block_height,
@@ -335,7 +332,8 @@ impl NakamotoTenureInv {
 
     /// Add in a newly-discovered inventory.
     /// NOTE: inventories are supposed to be aligned to the reward cycle
-    /// Returns true if we learned about at least one new tenure-start block
+    /// Returns true if the tenure bitvec has changed -- we either learned about a new tenure-start
+    /// block, or the remote peer "un-learned" it (e.g. due to a reorg).
     /// Returns false if not.
     pub fn merge_tenure_inv(&mut self, tenure_inv: BitVec<2100>, reward_cycle: u64) -> bool {
         // populate the tenures bitmap to we can fit this tenures inv
@@ -367,7 +365,6 @@ impl NakamotoTenureInv {
             && (self.cur_reward_cycle >= cur_rc || !self.online)
         {
             test_debug!("Reset inv comms for {}", &self.neighbor_address);
-            self.state = NakamotoInvState::GetNakamotoInvBegin;
             self.online = true;
             self.start_sync_time = now;
             self.cur_reward_cycle = start_rc;
@@ -472,13 +469,6 @@ impl NakamotoTenureInv {
             }
         }
     }
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum NakamotoInvState {
-    GetNakamotoInvBegin,
-    GetNakamotoInvFinish,
-    Done,
 }
 
 /// Nakamoto inventory state machine


### PR DESCRIPTION
This fixes all issues that were discovered in the Nakamoto download state machine audit.

The two severe ones were:

* It was possible that the download state machine could get stuck in an infinite loop while creating new tenure downloaders
* The unconfirmed tenure downloader would accept blocks it didn't validate

Test coverage has been expanded to verify that neither of the above happen.