### PR TITLE
test: Timing of Nakamoto miner block production

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -82,6 +82,7 @@ jobs:
           - tests::nakamoto_integrations::vote_for_aggregate_key_burn_op
           - tests::nakamoto_integrations::follower_bootup
           - tests::nakamoto_integrations::forked_tenure_is_ignored
+          - tests::nakamoto_integrations::nakamoto_attempt_time
           - tests::signer::v0::block_proposal_rejection
           - tests::signer::v1::dkg
           - tests::signer::v1::sign_request_rejected

--- a/docs/mining.md
+++ b/docs/mining.md
@@ -26,7 +26,7 @@ subsequent_attempt_time_ms = 60000
 # Time to spend mining a microblock, in milliseconds.
 microblock_attempt_time_ms = 30000
 # Time to spend mining a Nakamoto block, in milliseconds.
-nakamoto_attempt_time_ms = 10000
+nakamoto_attempt_time_ms = 20000
 ```
 
 You can verify that your node is operating as a miner by checking its log output

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -2320,7 +2320,7 @@ impl Default for MinerConfig {
             first_attempt_time_ms: 10,
             subsequent_attempt_time_ms: 120_000,
             microblock_attempt_time_ms: 30_000,
-            nakamoto_attempt_time_ms: 10_000,
+            nakamoto_attempt_time_ms: 20_000,
             probability_pick_no_estimate_tx: 25,
             block_reward_recipient: None,
             segwit: false,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -3902,7 +3902,7 @@ fn check_block_heights() {
 /// Test config parameter `nakamoto_attempt_time_ms`
 #[test]
 #[ignore]
-fn test_nakamoto_attempt_time() {
+fn nakamoto_attempt_time() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
     }

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -45,7 +45,10 @@ use stacks::chainstate::stacks::boot::{
 };
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks::chainstate::stacks::miner::{BlockBuilder, BlockLimitFunction, TransactionResult};
-use stacks::chainstate::stacks::{StacksTransaction, ThresholdSignature, TransactionPayload};
+use stacks::chainstate::stacks::{
+    StacksTransaction, ThresholdSignature, TransactionPayload, MAX_BLOCK_LEN,
+};
+use stacks::core::mempool::MAXIMUM_MEMPOOL_TX_CHAINING;
 use stacks::core::{
     StacksEpoch, StacksEpochId, BLOCK_LIMIT_MAINNET_10, HELIUM_BLOCK_LIMIT_20,
     PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05,
@@ -3887,6 +3890,302 @@ fn check_block_heights() {
         "Should have mined (1 + interim_blocks_per_tenure) * tenure_count nakamoto blocks"
     );
 
+    coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    run_loop_stopper.store(false, Ordering::SeqCst);
+
+    run_loop_thread.join().unwrap();
+}
+
+/// Test config parameter `nakamoto_attempt_time_ms`
+#[test]
+#[ignore]
+fn test_nakamoto_attempt_time() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let signers = TestSigners::default();
+    let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
+    let password = "12345".to_string();
+    naka_conf.connection_options.block_proposal_token = Some(password.clone());
+    // Use fixed timing params for this test
+    let nakamoto_attempt_time_ms = 20_000;
+    naka_conf.miner.nakamoto_attempt_time_ms = nakamoto_attempt_time_ms;
+    let stacker_sk = setup_stacker(&mut naka_conf);
+
+    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_addr = tests::to_addr(&sender_sk);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        1_000_000_000,
+    );
+
+    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_addr = tests::to_addr(&sender_signer_sk);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100_000,
+    );
+
+    let recipient = PrincipalData::from(StacksAddress::burn_address(false));
+    let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
+
+    // We'll need a lot of accounts for one subtest to avoid MAXIMUM_MEMPOOL_TX_CHAINING
+    struct Account {
+        nonce: u64,
+        privk: Secp256k1PrivateKey,
+        _address: StacksAddress,
+    }
+    let num_accounts = 1_000;
+    let init_account_balance = 1_000_000_000;
+    let account_keys = add_initial_balances(&mut naka_conf, num_accounts, init_account_balance);
+    let mut account = account_keys
+        .into_iter()
+        .map(|privk| {
+            let _address = tests::to_addr(&privk);
+            Account {
+                nonce: 0,
+                privk,
+                _address,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // only subscribe to the block proposal events
+    test_observer::spawn();
+    let observer_port = test_observer::EVENT_OBSERVER_PORT;
+    naka_conf.events_observers.insert(EventObserverConfig {
+        endpoint: format!("localhost:{observer_port}"),
+        events_keys: vec![EventKeyType::BlockProposal],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(naka_conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .expect("Failed starting bitcoind");
+    let mut btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
+    btc_regtest_controller.bootstrap_chain(201);
+
+    let mut run_loop = boot_nakamoto::BootRunLoop::new(naka_conf.clone()).unwrap();
+    let run_loop_stopper = run_loop.get_termination_switch();
+    let Counters {
+        blocks_processed,
+        naka_submitted_vrfs: vrfs_submitted,
+        naka_submitted_commits: commits_submitted,
+        naka_proposed_blocks: proposals_submitted,
+        ..
+    } = run_loop.counters();
+
+    let coord_channel = run_loop.coordinator_channels();
+
+    let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
+    wait_for_runloop(&blocks_processed);
+    boot_to_epoch_3(
+        &naka_conf,
+        &blocks_processed,
+        &[stacker_sk],
+        &[sender_signer_sk],
+        Some(&signers),
+        &mut btc_regtest_controller,
+    );
+
+    info!("Bootstrapped to Epoch-3.0 boundary, starting nakamoto miner");
+    blind_signer(&naka_conf, &signers, proposals_submitted);
+
+    let burnchain = naka_conf.get_burnchain();
+    let sortdb = burnchain.open_sortition_db(true).unwrap();
+    let (chainstate, _) = StacksChainState::open(
+        naka_conf.is_mainnet(),
+        naka_conf.burnchain.chain_id,
+        &naka_conf.get_chainstate_path_str(),
+        None,
+    )
+    .unwrap();
+
+    let _block_height_pre_3_0 =
+        NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+            .unwrap()
+            .unwrap()
+            .stacks_block_height;
+
+    info!("Nakamoto miner started...");
+
+    // first block wakes up the run loop, wait until a key registration has been submitted.
+    next_block_and(&mut btc_regtest_controller, 60, || {
+        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
+        Ok(vrf_count >= 1)
+    })
+    .unwrap();
+
+    // second block should confirm the VRF register, wait until a block commit is submitted
+    next_block_and(&mut btc_regtest_controller, 60, || {
+        let commits_count = commits_submitted.load(Ordering::SeqCst);
+        Ok(commits_count >= 1)
+    })
+    .unwrap();
+
+    // Mine 3 nakamoto tenures
+    for _ in 0..3 {
+        next_block_and_mine_commit(
+            &mut btc_regtest_controller,
+            60,
+            &coord_channel,
+            &commits_submitted,
+        )
+        .unwrap();
+    }
+
+    // TODO (hack) instantiate the sortdb in the burnchain
+    _ = btc_regtest_controller.sortdb_mut();
+
+    // ----- Setup boilerplate finished, test block proposal API endpoint -----
+
+    let mut sender_nonce = 0;
+    let tenure_count = 3;
+    let inter_blocks_per_tenure = 10;
+
+    // Subtest 1
+    // Mine nakamoto tenures with a few transactions
+    // Blocks should be produced at least every 20 seconds
+    for _ in 0..tenure_count {
+        let commits_before = commits_submitted.load(Ordering::SeqCst);
+        next_block_and_process_new_stacks_block(&mut btc_regtest_controller, 60, &coord_channel)
+            .unwrap();
+
+        let mut last_tip = BlockHeaderHash([0x00; 32]);
+        let mut last_tip_height = 0;
+
+        // mine the interim blocks
+        for _ in 0..inter_blocks_per_tenure {
+            let blocks_processed_before = coord_channel
+                .lock()
+                .expect("Mutex poisoned")
+                .get_stacks_blocks_processed();
+
+            let txs_per_block = 3;
+            let tx_fee = 500;
+            let amount = 500;
+
+            for _ in 0..txs_per_block {
+                let transfer_tx =
+                    make_stacks_transfer(&sender_sk, sender_nonce, tx_fee, &recipient, amount);
+                sender_nonce += 1;
+                submit_tx(&http_origin, &transfer_tx);
+            }
+
+            // Sleep a bit longer than what our max block time should be
+            thread::sleep(Duration::from_millis(nakamoto_attempt_time_ms + 100));
+
+            // Miner should have made a new block by now
+            let blocks_processed = coord_channel
+                .lock()
+                .expect("Mutex poisoned")
+                .get_stacks_blocks_processed();
+
+            assert!(blocks_processed > blocks_processed_before);
+
+            let info = get_chain_info_result(&naka_conf).unwrap();
+            assert_ne!(info.stacks_tip, last_tip);
+            assert_ne!(info.stacks_tip_height, last_tip_height);
+
+            last_tip = info.stacks_tip;
+            last_tip_height = info.stacks_tip_height;
+        }
+
+        let start_time = Instant::now();
+        while commits_submitted.load(Ordering::SeqCst) <= commits_before {
+            if start_time.elapsed() >= Duration::from_secs(20) {
+                panic!("Timed out waiting for block-commit");
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    // Subtest 2
+    // Confirm that no blocks are mined if there are no transactions
+    for _ in 0..2 {
+        let blocks_processed_before = coord_channel
+            .lock()
+            .expect("Mutex poisoned")
+            .get_stacks_blocks_processed();
+
+        let info_before = get_chain_info_result(&naka_conf).unwrap();
+
+        // Wait long enough for a block to be mined
+        thread::sleep(Duration::from_millis(nakamoto_attempt_time_ms * 2));
+
+        let blocks_processed = coord_channel
+            .lock()
+            .expect("Mutex poisoned")
+            .get_stacks_blocks_processed();
+
+        let info = get_chain_info_result(&naka_conf).unwrap();
+
+        // Assert that no block was mined while waiting
+        assert_eq!(blocks_processed, blocks_processed_before);
+        assert_eq!(info.stacks_tip, info_before.stacks_tip);
+        assert_eq!(info.stacks_tip_height, info_before.stacks_tip_height);
+    }
+
+    // Subtest 3
+    // Add more than `nakamoto_attempt_time_ms` worth of transactions into mempool
+    // Multiple blocks should be mined
+    for _ in 0..tenure_count {
+        let info_before = get_chain_info_result(&naka_conf).unwrap();
+
+        let blocks_processed_before = coord_channel
+            .lock()
+            .expect("Mutex poisoned")
+            .get_stacks_blocks_processed();
+
+        let tx_limit = 10000;
+        let tx_fee = 500;
+        let amount = 500;
+        let mut tx_total_size = 0;
+        let mut tx_count = 0;
+        let mut acct_idx = 0;
+
+        // Submit max # of txs from each account to reach tx_limit
+        'submit_txs: loop {
+            let acct = &mut account[acct_idx];
+            for _ in 0..MAXIMUM_MEMPOOL_TX_CHAINING {
+                let transfer_tx =
+                    make_stacks_transfer(&acct.privk, acct.nonce, tx_fee, &recipient, amount);
+                submit_tx(&http_origin, &transfer_tx);
+                tx_total_size += transfer_tx.len();
+                tx_count += 1;
+                acct.nonce += 1;
+                if tx_count >= tx_limit {
+                    break 'submit_txs;
+                }
+            }
+            acct_idx += 1;
+        }
+
+        // Make sure that these transactions *could* fit into a single block
+        assert!(tx_total_size < MAX_BLOCK_LEN as usize);
+
+        // Wait long enough for 2 blocks to be made
+        thread::sleep(Duration::from_millis(nakamoto_attempt_time_ms * 2 + 100));
+
+        // Check that 2 blocks were made
+        let blocks_processed = coord_channel
+            .lock()
+            .expect("Mutex poisoned")
+            .get_stacks_blocks_processed();
+
+        let blocks_mined = blocks_processed - blocks_processed_before;
+        assert!(blocks_mined > 2);
+
+        let info = get_chain_info_result(&naka_conf).unwrap();
+        assert_ne!(info.stacks_tip, info_before.stacks_tip);
+        assert_ne!(info.stacks_tip_height, info_before.stacks_tip_height);
+    }
+
+    // ----- Clean up -----
     coord_channel
         .lock()
         .expect("Mutex poisoned")


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This PR changes the default value for `nakamoto_attempt_time_ms` to 20 seconds and adds an integration test, `test_nakamoto_attempt_time`, to check that this value works as expected. Specifically, it checks the following:

- No blocks are produced if no transactions are submitted
- If there is a small number of transactions, blocks will be produced at the rate of `nakamoto_attempt_time_ms`
- If there are many transactions in the mempool, where it would take longer than `nakamoto_attempt_time_ms` to include them all in a single block, blocks will still be produced at the rate of `nakamoto_attempt_time_ms`

### Applicable issues

- #4711

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
