### PR TITLE
Fix/4826

### DIFF
--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -151,6 +151,24 @@ impl StacksEpochId {
             StacksEpochId::Epoch30 => MINING_COMMITMENT_FREQUENCY_NAKAMOTO,
         }
     }
+
+    /// Does this epoch use the nakamoto reward set, or the epoch2 reward set?
+    /// We use the epoch2 reward set in all pre-3.0 epochs.
+    /// We also use the epoch2 reward set in the first 3.0 reward cycle.
+    /// After that, we use the nakamoto reward set.
+    pub fn uses_nakamoto_reward_set(&self, cur_reward_cycle: u64, first_epoch30_reward_cycle: u64) -> bool {
+        match self {
+            StacksEpochId::Epoch10
+            | StacksEpochId::Epoch20
+            | StacksEpochId::Epoch2_05
+            | StacksEpochId::Epoch21
+            | StacksEpochId::Epoch22
+            | StacksEpochId::Epoch23
+            | StacksEpochId::Epoch24
+            | StacksEpochId::Epoch25 => false,
+            StacksEpochId::Epoch30 => cur_reward_cycle > first_epoch30_reward_cycle
+        }
+    }
 }
 
 impl std::fmt::Display for StacksEpochId {

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -156,7 +156,11 @@ impl StacksEpochId {
     /// We use the epoch2 reward set in all pre-3.0 epochs.
     /// We also use the epoch2 reward set in the first 3.0 reward cycle.
     /// After that, we use the nakamoto reward set.
-    pub fn uses_nakamoto_reward_set(&self, cur_reward_cycle: u64, first_epoch30_reward_cycle: u64) -> bool {
+    pub fn uses_nakamoto_reward_set(
+        &self,
+        cur_reward_cycle: u64,
+        first_epoch30_reward_cycle: u64,
+    ) -> bool {
         match self {
             StacksEpochId::Epoch10
             | StacksEpochId::Epoch20
@@ -166,7 +170,7 @@ impl StacksEpochId {
             | StacksEpochId::Epoch23
             | StacksEpochId::Epoch24
             | StacksEpochId::Epoch25 => false,
-            StacksEpochId::Epoch30 => cur_reward_cycle > first_epoch30_reward_cycle
+            StacksEpochId::Epoch30 => cur_reward_cycle > first_epoch30_reward_cycle,
         }
     }
 }

--- a/stackslib/src/burnchains/burnchain.rs
+++ b/stackslib/src/burnchains/burnchain.rs
@@ -551,16 +551,18 @@ impl Burnchain {
             .reward_cycle_to_block_height(self.first_block_height, reward_cycle)
     }
 
-    pub fn next_reward_cycle(&self, block_height: u64) -> Option<u64> {
+    /// Compute the reward cycle ID of the PoX reward set which is active as of this burn_height.
+    /// The reward set is calculated at reward cycle index 1, so if this block height is at or after
+    /// reward cycle index 1, then this behaves like `block_height_to_reward_cycle()`.  However,
+    /// if it's reward cycle index is 0, then it belongs to the previous reward cycle.
+    pub fn pox_reward_cycle(&self, block_height: u64) -> Option<u64> {
         let cycle = self.block_height_to_reward_cycle(block_height)?;
         let effective_height = block_height.checked_sub(self.first_block_height)?;
-        let next_bump = if effective_height % u64::from(self.pox_constants.reward_cycle_length) == 0
-        {
-            0
+        if effective_height % u64::from(self.pox_constants.reward_cycle_length) == 0 {
+            Some(cycle.saturating_sub(1))
         } else {
-            1
-        };
-        Some(cycle + next_bump)
+            Some(cycle)
+        }
     }
 
     pub fn block_height_to_reward_cycle(&self, block_height: u64) -> Option<u64> {

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3457,8 +3457,10 @@ impl SortitionDB {
         Ok(())
     }
 
-    /// Wrapper around SortitionDBConn::get_prepare_phase_end_sortition_id_for_reward_cycle().
-    /// See that method for details.
+    /// Get the prepare phase end sortition ID of a reward cycle.  This is the last prepare
+    /// phase sortition for the prepare phase that began this reward cycle (i.e. the returned
+    /// sortition will be in the preceding reward cycle)
+    /// Wrapper around SortitionDBConn::get_prepare_phase_end_sortition_id_for_reward_ccyle()
     pub fn get_prepare_phase_end_sortition_id_for_reward_cycle(
         &self,
         tip: &SortitionId,
@@ -3473,8 +3475,10 @@ impl SortitionDB {
             )
     }
 
+    /// Get the prepare phase start sortition ID of a reward cycle.  This is the first prepare
+    /// phase sortition for the prepare phase that began this reward cycle (i.e. the returned
+    /// sortition will be in the preceding reward cycle)
     /// Wrapper around SortitionDBConn::get_prepare_phase_start_sortition_id_for_reward_cycle().
-    /// See that method for details.
     pub fn get_prepare_phase_start_sortition_id_for_reward_cycle(
         &self,
         tip: &SortitionId,
@@ -3489,8 +3493,11 @@ impl SortitionDB {
             )
     }
 
+    /// Figure out the reward cycle for `tip` and lookup the preprocessed
+    /// reward set (if it exists) for the active reward cycle during `tip`.
+    /// Returns the reward cycle info on success.
+    /// Returns Error on DB errors, as well as if the reward set is not yet processed.
     /// Wrapper around SortitionDBConn::get_preprocessed_reward_set_for_reward_cycle().
-    /// See that method for details.
     pub fn get_preprocessed_reward_set_for_reward_cycle(
         &self,
         tip: &SortitionId,
@@ -3505,8 +3512,11 @@ impl SortitionDB {
             )
     }
 
+    /// Figure out the reward cycle for `tip` and lookup the preprocessed
+    /// reward set (if it exists) for the active reward cycle during `tip`.
+    /// Returns the reward cycle info on success.
+    /// Returns Error on DB errors, as well as if the reward set is not yet processed.
     /// Wrapper around SortitionDBConn::get_preprocessed_reward_set_of().
-    /// See that method for details.
     pub fn get_preprocessed_reward_set_of(
         &self,
         tip: &SortitionId,

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -662,7 +662,7 @@ impl LeaderBlockCommitOp {
                         check_recipients.sort();
                         let mut commit_outs = self.commit_outs.clone();
                         commit_outs.sort();
-                        for (expected_commit, found_commit) in
+                        for (found_commit, expected_commit) in
                             commit_outs.iter().zip(check_recipients)
                         {
                             if expected_commit.to_burnchain_repr()

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -830,7 +830,8 @@ pub fn get_reward_cycle_info<U: RewardSetProvider>(
     };
 
     // cache the reward cycle info as of the first sortition in the prepare phase, so that
-    // the Nakamoto epoch can go find it later
+    // the first Nakamoto epoch can go find it later.  Subsequent Nakamoto epochs will use the
+    // reward set stored to the Nakamoto chain state.
     let ic = sort_db.index_handle(sortition_tip);
     let prev_reward_cycle = burnchain
         .block_height_to_reward_cycle(burn_height)

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -752,6 +752,7 @@ pub fn get_reward_cycle_info<U: RewardSetProvider>(
 ) -> Result<Option<RewardCycleInfo>, Error> {
     let epoch_at_height = SortitionDB::get_stacks_epoch(sort_db.conn(), burn_height)?
         .unwrap_or_else(|| panic!("FATAL: no epoch defined for burn height {}", burn_height));
+
     if !burnchain.is_reward_cycle_start(burn_height) {
         return Ok(None);
     }
@@ -3531,6 +3532,7 @@ impl SortitionDBMigrator {
             .pox_constants
             .reward_cycle_to_block_height(sort_db.first_block_height, reward_cycle)
             .saturating_sub(1);
+
         let sort_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn())?;
 
         let ancestor_sn = {

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -400,6 +400,7 @@ fn replay_reward_cycle(
         info!("Process Nakamoto block {} ({:?}", &block_id, &block.header);
 
         let accepted = Relayer::process_new_nakamoto_block(
+            &peer.config.burnchain,
             &sortdb,
             &mut sort_handle,
             &mut node.chainstate,

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2704,6 +2704,12 @@ impl NakamotoChainState {
                 &mut clarity_tx,
                 vote_for_agg_key_ops.clone(),
             ));
+
+            if signer_set_calc.is_some() {
+                debug!("Setup block: computed reward set for the next reward cycle";
+                       "anchor_block_height" => coinbase_height,
+                       "burn_header_height" => burn_header_height);
+            }
         } else {
             signer_set_calc = None;
         }

--- a/stackslib/src/chainstate/nakamoto/signer_set.rs
+++ b/stackslib/src/chainstate/nakamoto/signer_set.rs
@@ -217,6 +217,8 @@ impl NakamotoSigners {
         Ok(slots)
     }
 
+    /// Compute the reward set for the next reward cycle, store it, and write it to the .signers
+    /// contract.  `reward_cycle` is the _current_ reward cycle.
     pub fn handle_signer_stackerdb_update(
         clarity: &mut ClarityTransactionConnection,
         pox_constants: &PoxConstants,
@@ -351,6 +353,11 @@ impl NakamotoSigners {
         Ok(SignerCalculation { events, reward_set })
     }
 
+    /// If this block is mined in the prepare phase, based on its tenure's `burn_tip_height`.  If
+    /// so, and if we haven't done so yet, then compute the PoX reward set, store it, and update
+    /// the .signers contract.  The stored PoX reward set is the reward set for the next reward
+    /// cycle, and will be used by the Nakamoto chains coordinator to validate its block-commits
+    /// and block signatures.
     pub fn check_and_handle_prepare_phase_start(
         clarity_tx: &mut ClarityTx,
         first_block_height: u64,

--- a/stackslib/src/chainstate/nakamoto/test_signers.rs
+++ b/stackslib/src/chainstate/nakamoto/test_signers.rs
@@ -50,7 +50,6 @@ use crate::chainstate::burn::*;
 use crate::chainstate::coordinator::{
     ChainsCoordinator, Error as CoordinatorError, OnChainRewardSetProvider,
 };
-use crate::chainstate::nakamoto::coordinator::get_nakamoto_next_recipients;
 use crate::chainstate::nakamoto::miner::NakamotoBlockBuilder;
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader, NakamotoChainState};
 use crate::chainstate::stacks::address::PoxAddress;

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -585,7 +585,10 @@ impl TestStacksNode {
             // Get the reward set
             let sort_tip_sn = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
             let reward_set = load_nakamoto_reward_set(
-                miner.burnchain.pox_reward_cycle(sort_tip_sn.block_height).expect("FATAL: no reward cycle for sortition"),
+                miner
+                    .burnchain
+                    .pox_reward_cycle(sort_tip_sn.block_height)
+                    .expect("FATAL: no reward cycle for sortition"),
                 &sort_tip_sn.sortition_id,
                 &miner.burnchain,
                 chainstate,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -585,7 +585,7 @@ impl TestStacksNode {
             // Get the reward set
             let sort_tip_sn = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
             let reward_set = load_nakamoto_reward_set(
-                sort_tip_sn.block_height,
+                miner.burnchain.pox_reward_cycle(sort_tip_sn.block_height).expect("FATAL: no reward cycle for sortition"),
                 &sort_tip_sn.sortition_id,
                 &miner.burnchain,
                 chainstate,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -386,11 +386,12 @@ impl TestStacksNode {
                 .unwrap();
 
                 test_debug!(
-                    "Work in {} {} for Nakamoto parent: {},{}",
+                    "Work in {} {} for Nakamoto parent: {},{}. Last tenure ID is {}",
                     burn_block.block_height,
                     burn_block.parent_snapshot.burn_header_hash,
                     parent_sortition.total_burn,
                     last_parent.header.chain_length + 1,
+                    &parent_tenure_id,
                 );
 
                 (parent_tenure_id, parent_sortition)
@@ -420,11 +421,12 @@ impl TestStacksNode {
                 let parent_tenure_id = parent_chain_tip.index_block_hash();
 
                 test_debug!(
-                    "Work in {} {} for Stacks 2.x parent: {},{}",
+                    "Work in {} {} for Stacks 2.x parent: {},{}. Last tenure ID is {}",
                     burn_block.block_height,
                     burn_block.parent_snapshot.burn_header_hash,
                     parent_stacks_block_snapshot.total_burn,
                     parent_chain_tip.anchored_header.height(),
+                    &parent_tenure_id,
                 );
 
                 (parent_tenure_id, parent_stacks_block_snapshot)

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -63,7 +63,7 @@ use crate::net::inv::epoch2x::InvState;
 use crate::net::inv::nakamoto::{NakamotoInvStateMachine, NakamotoTenureInv};
 use crate::net::neighbors::rpc::NeighborRPC;
 use crate::net::neighbors::NeighborComms;
-use crate::net::p2p::PeerNetwork;
+use crate::net::p2p::{CurrentRewardSet, PeerNetwork};
 use crate::net::server::HttpPeer;
 use crate::net::{Error as NetError, Neighbor, NeighborAddress, NeighborKey};
 use crate::util_lib::db::{DBConn, Error as DBError};
@@ -1155,7 +1155,7 @@ impl NakamotoDownloadStateMachine {
     fn update_tenure_downloaders(
         &mut self,
         count: usize,
-        current_reward_sets: &BTreeMap<u64, RewardCycleInfo>,
+        current_reward_sets: &BTreeMap<u64, CurrentRewardSet>,
     ) {
         self.tenure_downloads.make_tenure_downloaders(
             &mut self.tenure_download_schedule,

--- a/stackslib/src/net/download/nakamoto/tenure_downloader.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader.rs
@@ -57,7 +57,7 @@ use crate::net::inv::epoch2x::InvState;
 use crate::net::inv::nakamoto::{NakamotoInvStateMachine, NakamotoTenureInv};
 use crate::net::neighbors::rpc::NeighborRPC;
 use crate::net::neighbors::NeighborComms;
-use crate::net::p2p::PeerNetwork;
+use crate::net::p2p::{CurrentRewardSet, PeerNetwork};
 use crate::net::server::HttpPeer;
 use crate::net::{Error as NetError, Neighbor, NeighborAddress, NeighborKey};
 use crate::util_lib::db::{DBConn, Error as DBError};

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -62,7 +62,7 @@ use crate::net::inv::epoch2x::InvState;
 use crate::net::inv::nakamoto::{NakamotoInvStateMachine, NakamotoTenureInv};
 use crate::net::neighbors::rpc::NeighborRPC;
 use crate::net::neighbors::NeighborComms;
-use crate::net::p2p::PeerNetwork;
+use crate::net::p2p::{CurrentRewardSet, PeerNetwork};
 use crate::net::server::HttpPeer;
 use crate::net::{Error as NetError, Neighbor, NeighborAddress, NeighborKey};
 use crate::util_lib::db::{DBConn, Error as DBError};
@@ -419,7 +419,7 @@ impl NakamotoTenureDownloaderSet {
         available: &mut HashMap<ConsensusHash, Vec<NeighborAddress>>,
         tenure_block_ids: &HashMap<NeighborAddress, AvailableTenures>,
         count: usize,
-        current_reward_cycles: &BTreeMap<u64, RewardCycleInfo>,
+        current_reward_cycles: &BTreeMap<u64, CurrentRewardSet>,
     ) {
         test_debug!("schedule: {:?}", schedule);
         test_debug!("available: {:?}", &available);
@@ -482,7 +482,7 @@ impl NakamotoTenureDownloaderSet {
             };
             let Some(Some(start_reward_set)) = current_reward_cycles
                 .get(&tenure_info.start_reward_cycle)
-                .map(|cycle_info| cycle_info.known_selected_anchor_block())
+                .map(|cycle_info| cycle_info.reward_set())
             else {
                 test_debug!(
                     "Cannot fetch tenure-start block due to no known start reward set for cycle {}: {:?}",
@@ -494,7 +494,7 @@ impl NakamotoTenureDownloaderSet {
             };
             let Some(Some(end_reward_set)) = current_reward_cycles
                 .get(&tenure_info.end_reward_cycle)
-                .map(|cycle_info| cycle_info.known_selected_anchor_block())
+                .map(|cycle_info| cycle_info.reward_set())
             else {
                 test_debug!(
                     "Cannot fetch tenure-end block due to no known end reward set for cycle {}: {:?}",

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2756,6 +2756,7 @@ pub mod test {
             let receipts_res = self.relayer.process_network_result(
                 self.network.get_local_peer(),
                 &mut net_result,
+                &self.network.burnchain,
                 &mut sortdb,
                 &mut stacks_node.chainstate,
                 &mut mempool,
@@ -3884,29 +3885,12 @@ pub mod test {
         }
 
         /// Verify that the sortition DB migration into Nakamoto worked correctly.
-        /// For now, it's sufficient to check that the `get_last_processed_reward_cycle()` calculation
-        /// works the same across both the original and migration-compatible implementations.
         pub fn check_nakamoto_migration(&mut self) {
             let mut sortdb = self.sortdb.take().unwrap();
             let mut node = self.stacks_node.take().unwrap();
             let chainstate = &mut node.chainstate;
 
             let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
-            for height in 0..=tip.block_height {
-                let sns =
-                    SortitionDB::get_all_snapshots_by_burn_height(sortdb.conn(), height).unwrap();
-                for sn in sns {
-                    let ih = sortdb.index_handle(&sn.sortition_id);
-                    let highest_processed_rc = ih.get_last_processed_reward_cycle().unwrap();
-                    let expected_highest_processed_rc =
-                        ih.legacy_get_last_processed_reward_cycle().unwrap();
-                    assert_eq!(
-                        highest_processed_rc, expected_highest_processed_rc,
-                        "BUG: at burn height {} the highest-processed reward cycles diverge",
-                        height
-                    );
-                }
-            }
             let epochs = SortitionDB::get_stacks_epochs(sortdb.conn()).unwrap();
             let epoch_3_idx =
                 StacksEpoch::find_epoch_by_id(&epochs, StacksEpochId::Epoch30).unwrap();

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -40,13 +40,14 @@ use {mio, url};
 
 use crate::burnchains::db::{BurnchainDB, BurnchainHeaderReader};
 use crate::burnchains::{Address, Burnchain, BurnchainView, PublicKey};
-use crate::chainstate::burn::db::sortdb::{BlockHeaderCache, SortitionDB};
+use crate::chainstate::burn::db::sortdb::{get_ancestor_sort_id, BlockHeaderCache, SortitionDB};
 use crate::chainstate::burn::BlockSnapshot;
 use crate::chainstate::coordinator::{
     static_get_canonical_affirmation_map, static_get_heaviest_affirmation_map,
-    static_get_stacks_tip_affirmation_map, RewardCycleInfo,
+    static_get_stacks_tip_affirmation_map, OnChainRewardSetProvider, RewardCycleInfo,
 };
-use crate::chainstate::stacks::boot::MINERS_NAME;
+use crate::chainstate::nakamoto::coordinator::load_nakamoto_reward_set;
+use crate::chainstate::stacks::boot::{RewardSet, MINERS_NAME};
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::{StacksBlockHeader, MAX_BLOCK_LEN, MAX_TRANSACTION_LEN};
 use crate::core::StacksEpoch;
@@ -232,6 +233,24 @@ impl ConnectingPeer {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct CurrentRewardSet {
+    pub reward_cycle: u64,
+    pub reward_cycle_info: RewardCycleInfo,
+    pub anchor_block_consensus_hash: ConsensusHash,
+    pub anchor_block_hash: BlockHeaderHash,
+}
+
+impl CurrentRewardSet {
+    pub fn reward_set(&self) -> Option<&RewardSet> {
+        self.reward_cycle_info.known_selected_anchor_block()
+    }
+
+    pub fn anchor_block_id(&self) -> StacksBlockId {
+        StacksBlockId::new(&self.anchor_block_consensus_hash, &self.anchor_block_hash)
+    }
+}
+
 pub struct PeerNetwork {
     // constants
     pub peer_version: u32,
@@ -258,16 +277,9 @@ pub struct PeerNetwork {
     /// In epoch 2.x, this is the same as the tip block ID
     /// In nakamoto, this is the block ID of the first block in the current tenure
     pub tenure_start_block_id: StacksBlockId,
-    /// The reward sets of the current and past reward cycle.
+    /// The reward sets of the past three reward cycles.
     /// Needed to validate blocks, which are signed by a threshold of stackers
-    pub current_reward_sets: BTreeMap<u64, RewardCycleInfo>,
-    /// The sortition IDs that began the prepare-phases for given reward cycles.  This is used to
-    /// determine whether or not the reward cycle info in `current_reward_sets` is still valid -- a
-    /// burnchain fork may invalidate them, so the code must check that the sortition ID for the
-    /// start of the prepare-phase is still canonical.
-    /// This needs to be in 1-to-1 correspondence with `current_reward_sets` -- the sortition IDs
-    /// that make up the values need to correspond to the reward sets computed as of the sortition.
-    pub current_reward_set_ids: BTreeMap<u64, SortitionId>,
+    pub current_reward_sets: BTreeMap<u64, CurrentRewardSet>,
 
     // information about the state of the network's anchor blocks
     pub heaviest_affirmation_map: AffirmationMap,
@@ -479,7 +491,6 @@ impl PeerNetwork {
             parent_stacks_tip: (ConsensusHash([0x00; 20]), BlockHeaderHash([0x00; 32]), 0),
             tenure_start_block_id: StacksBlockId([0x00; 32]),
             current_reward_sets: BTreeMap::new(),
-            current_reward_set_ids: BTreeMap::new(),
 
             peerdb: peerdb,
             atlasdb: atlasdb,
@@ -5434,38 +5445,10 @@ impl PeerNetwork {
     }
 
     /// Clear out old reward cycles
-    fn free_old_reward_cycles(
-        &mut self,
-        sortdb: &SortitionDB,
-        tip_sortition_id: &SortitionId,
-        prev_rc: u64,
-    ) {
+    fn free_old_reward_cycles(&mut self, rc: u64) {
         if self.current_reward_sets.len() > 3 {
             self.current_reward_sets.retain(|old_rc, _| {
-                if (*old_rc).saturating_add(1) < prev_rc {
-                    self.current_reward_set_ids.remove(old_rc);
-                    test_debug!("Drop reward cycle info for cycle {}", old_rc);
-                    return false;
-                }
-                let Some(old_sortition_id) = self.current_reward_set_ids.get(old_rc) else {
-                    // shouldn't happen
-                    self.current_reward_set_ids.remove(old_rc);
-                    test_debug!("Drop reward cycle info for cycle {}", old_rc);
-                    return false;
-                };
-                let Ok(prepare_phase_sort_id) = sortdb
-                    .get_prepare_phase_start_sortition_id_for_reward_cycle(
-                        &tip_sortition_id,
-                        *old_rc,
-                    )
-                else {
-                    self.current_reward_set_ids.remove(old_rc);
-                    test_debug!("Drop reward cycle info for cycle {}", old_rc);
-                    return false;
-                };
-                if prepare_phase_sort_id != *old_sortition_id {
-                    // non-canonical reward cycle info
-                    self.current_reward_set_ids.remove(old_rc);
+                if (*old_rc).saturating_add(2) < rc {
                     test_debug!("Drop reward cycle info for cycle {}", old_rc);
                     return false;
                 }
@@ -5474,10 +5457,11 @@ impl PeerNetwork {
         }
     }
 
-    /// Refresh our view of the last two reward cycles
+    /// Refresh our view of the last three reward cycles
     fn refresh_reward_cycles(
         &mut self,
         sortdb: &SortitionDB,
+        chainstate: &mut StacksChainState,
         tip_sn: &BlockSnapshot,
     ) -> Result<(), net_error> {
         let cur_rc = self
@@ -5486,57 +5470,58 @@ impl PeerNetwork {
             .expect("FATAL: sortition from before system start");
 
         let prev_rc = cur_rc.saturating_sub(1);
+        let prev_prev_rc = prev_rc.saturating_sub(1);
+        let ih = sortdb.index_handle(&tip_sn.sortition_id);
 
-        // keyed by both rc and sortition ID in case there's a bitcoin fork -- we'd want the
-        // canonical reward set to be loaded
-        let cur_rc_sortition_id = sortdb
-            .get_prepare_phase_start_sortition_id_for_reward_cycle(&tip_sn.sortition_id, cur_rc)?;
-        let prev_rc_sortition_id = sortdb
-            .get_prepare_phase_start_sortition_id_for_reward_cycle(&tip_sn.sortition_id, prev_rc)?;
-
-        for (rc, sortition_id) in [
-            (prev_rc, prev_rc_sortition_id),
-            (cur_rc, cur_rc_sortition_id),
-        ]
-        .into_iter()
-        {
-            if let Some(sort_id) = self.current_reward_set_ids.get(&rc) {
-                if sort_id == &sortition_id {
-                    continue;
-                }
-            }
-            let Ok((reward_cycle_info, reward_cycle_sort_id)) = sortdb
-                .get_preprocessed_reward_set_for_reward_cycle(&tip_sn.sortition_id, rc)
-                .map_err(|e| {
-                    warn!(
-                        "Failed to load reward set for cycle {} ({}): {:?}",
-                        rc, &sortition_id, &e
-                    );
-                    e
-                })
+        for rc in [cur_rc, prev_rc, prev_prev_rc] {
+            let rc_start_height = self.burnchain.reward_cycle_to_block_height(rc) + 1;
+            let Some(ancestor_sort_id) =
+                get_ancestor_sort_id(&ih, rc_start_height, &tip_sn.sortition_id)?
             else {
-                // NOTE: this should never be reached
-                error!("Unreachable code (but not panicking): no reward cycle info for reward cycle {}", rc);
+                // reward cycle is too far back for there to be an ancestor
                 continue;
             };
-            if !reward_cycle_info.is_reward_info_known() {
-                // haven't yet processed the anchor block, so don't store
-                debug!("Reward cycle info for cycle {} at sortition {} expects the PoX anchor block, so will not cache", rc, &reward_cycle_sort_id);
-                continue;
+            let ancestor_ih = sortdb.index_handle(&ancestor_sort_id);
+            let anchor_hash_opt = ancestor_ih.get_last_anchor_block_hash()?;
+
+            if let Some(cached_rc_info) = self.current_reward_sets.get(&rc) {
+                if let Some(anchor_hash) = anchor_hash_opt.as_ref() {
+                    if cached_rc_info.anchor_block_hash == *anchor_hash {
+                        // cached reward set data is still valid
+                        continue;
+                    }
+                }
             }
 
-            test_debug!(
-                "Reward cycle info for cycle {} at sortition {} is {:?}",
+            let Some((reward_set_info, anchor_block_header)) = load_nakamoto_reward_set(
                 rc,
-                &reward_cycle_sort_id,
-                &reward_cycle_info
-            );
-            self.current_reward_sets.insert(rc, reward_cycle_info);
-            self.current_reward_set_ids.insert(rc, reward_cycle_sort_id);
-        }
+                &tip_sn.sortition_id,
+                &self.burnchain,
+                chainstate,
+                sortdb,
+                &OnChainRewardSetProvider::new(),
+            )
+            .map_err(|e| {
+                warn!(
+                    "Failed to load reward cycle info for cycle {}: {:?}",
+                    rc, &e
+                );
+                e
+            })
+            .unwrap_or(None) else {
+                continue;
+            };
 
-        // free memory
-        self.free_old_reward_cycles(sortdb, &tip_sn.sortition_id, prev_rc);
+            let rc_info = CurrentRewardSet {
+                reward_cycle: rc,
+                reward_cycle_info: reward_set_info,
+                anchor_block_consensus_hash: anchor_block_header.consensus_hash,
+                anchor_block_hash: anchor_block_header.anchored_header.block_hash(),
+            };
+
+            self.current_reward_sets.insert(rc, rc_info);
+        }
+        self.free_old_reward_cycles(cur_rc);
         Ok(())
     }
 
@@ -5560,7 +5545,9 @@ impl PeerNetwork {
             SortitionDB::get_canonical_stacks_chain_tip_hash_and_height(sortdb.conn())?;
 
         let burnchain_tip_changed = canonical_sn.block_height != self.chain_view.burn_block_height
-            || self.num_state_machine_passes == 0;
+            || self.num_state_machine_passes == 0
+            || canonical_sn.sortition_id != self.burnchain_tip.sortition_id;
+
         let stacks_tip_changed = self.stacks_tip != stacks_tip;
         let new_stacks_tip_block_id = StacksBlockId::new(&stacks_tip.0, &stacks_tip.1);
         let need_stackerdb_refresh = canonical_sn.canonical_stacks_tip_consensus_hash
@@ -5568,8 +5555,8 @@ impl PeerNetwork {
             || burnchain_tip_changed
             || stacks_tip_changed;
 
-        if stacks_tip_changed || burnchain_tip_changed {
-            self.refresh_reward_cycles(sortdb, &canonical_sn)?;
+        if burnchain_tip_changed || stacks_tip_changed {
+            self.refresh_reward_cycles(sortdb, chainstate, &canonical_sn)?;
         }
 
         let mut ret: HashMap<NeighborKey, Vec<StacksMessage>> = HashMap::new();
@@ -6789,11 +6776,13 @@ mod test {
         while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
             if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
+                let burnchain = peer_1.network.burnchain.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,
@@ -6807,11 +6796,13 @@ mod test {
 
             if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
+                let burnchain = peer_2.network.burnchain.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,
@@ -6976,11 +6967,13 @@ mod test {
         while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
             if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
+                let burnchain = peer_1.network.burnchain.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,
@@ -6994,11 +6987,13 @@ mod test {
 
             if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
+                let burnchain = peer_2.network.burnchain.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,
@@ -7180,11 +7175,13 @@ mod test {
         while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs / 2 {
             if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
+                let burnchain = peer_1.network.burnchain.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,
@@ -7198,11 +7195,13 @@ mod test {
 
             if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
+                let burnchain = peer_2.network.burnchain.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,
@@ -7364,11 +7363,13 @@ mod test {
         while peer_1_mempool_txs < num_txs || peer_2.network.mempool_sync_txs < (num_txs as u64) {
             if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
+                let burnchain = peer_1.network.burnchain.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,
@@ -7382,11 +7383,13 @@ mod test {
 
             if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
+                let burnchain = peer_2.network.burnchain.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
                         relayer.process_network_result(
                             &lp,
                             &mut result,
+                            &burnchain,
                             sortdb,
                             chainstate,
                             mempool,

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -5499,7 +5499,7 @@ impl PeerNetwork {
             }
 
             let Some((reward_set_info, anchor_block_header)) = load_nakamoto_reward_set(
-                rc_start_height,
+                rc,
                 &tip_sn.sortition_id,
                 &self.burnchain,
                 chainstate,

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -730,7 +730,7 @@ impl Relayer {
         let tip = block_sn.sortition_id;
 
         let reward_info = match load_nakamoto_reward_set(
-            block_sn.block_height,
+            burnchain.pox_reward_cycle(block_sn.block_height).expect("FATAL: block snapshot has no reward cycle"),
             &tip,
             burnchain,
             chainstate,

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -730,7 +730,9 @@ impl Relayer {
         let tip = block_sn.sortition_id;
 
         let reward_info = match load_nakamoto_reward_set(
-            burnchain.pox_reward_cycle(block_sn.block_height).expect("FATAL: block snapshot has no reward cycle"),
+            burnchain
+                .pox_reward_cycle(block_sn.block_height)
+                .expect("FATAL: block snapshot has no reward cycle"),
             &tip,
             burnchain,
             chainstate,

--- a/stackslib/src/net/tests/download/epoch2x.rs
+++ b/stackslib/src/net/tests/download/epoch2x.rs
@@ -329,10 +329,12 @@ where
             let mut result = peer.step_dns(&mut dns_clients[i]).unwrap();
 
             let lp = peer.network.local_peer.clone();
+            let burnchain = peer.network.burnchain.clone();
             peer.with_db_state(|sortdb, chainstate, relayer, mempool| {
                 relayer.process_network_result(
                     &lp,
                     &mut result,
+                    &burnchain,
                     sortdb,
                     chainstate,
                     mempool,

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -448,6 +448,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -456,6 +457,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -523,6 +525,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -531,6 +534,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -624,6 +628,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -632,6 +637,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -724,6 +730,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -732,6 +739,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -803,6 +811,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -811,6 +820,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -930,6 +930,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );
@@ -938,6 +939,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
                 .get(&tip_rc)
                 .cloned()
                 .unwrap()
+                .reward_cycle_info
                 .known_selected_anchor_block_owned()
                 .unwrap(),
         );

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -230,6 +230,7 @@ impl NakamotoBootPlan {
             for block in blocks {
                 let block_id = block.block_id();
                 let accepted = Relayer::process_new_nakamoto_block(
+                    &peer.network.burnchain,
                     &sortdb,
                     &mut sort_handle,
                     &mut node.chainstate,

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -300,7 +300,9 @@ impl BlockMinerThread {
             })?;
 
         let reward_info = match load_nakamoto_reward_set(
-            tip.block_height,
+            self.burnchain
+                .pox_reward_cycle(tip.block_height.saturating_add(1))
+                .expect("FATAL: no reward cycle for sortition"),
             &tip.sortition_id,
             &self.burnchain,
             &mut chain_state,
@@ -402,7 +404,9 @@ impl BlockMinerThread {
             })?;
 
         let reward_info = match load_nakamoto_reward_set(
-            tip.block_height,
+            self.burnchain
+                .pox_reward_cycle(tip.block_height.saturating_add(1))
+                .expect("FATAL: no reward cycle for sortition"),
             &tip.sortition_id,
             &self.burnchain,
             &mut chain_state,
@@ -883,7 +887,9 @@ impl BlockMinerThread {
             .map_err(|e| NakamotoNodeError::MiningFailure(ChainstateError::DBError(e)))?;
 
         let reward_info = match load_nakamoto_reward_set(
-            tip.block_height,
+            self.burnchain
+                .pox_reward_cycle(tip.block_height.saturating_add(1))
+                .expect("FATAL: no reward cycle defined for sortition tip"),
             &tip.sortition_id,
             &self.burnchain,
             &mut chain_state,

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -258,6 +258,7 @@ impl RelayerThread {
             .process_network_result(
                 &self.local_peer,
                 &mut net_result,
+                &self.burnchain,
                 &mut self.sortdb,
                 &mut self.chainstate,
                 &mut self.mempool,
@@ -416,11 +417,16 @@ impl RelayerThread {
                 .unwrap_or_else(|| VRFProof::empty());
 
         // let's figure out the recipient set!
-        let recipients = get_nakamoto_next_recipients(&sort_tip, &mut self.sortdb, &self.burnchain)
-            .map_err(|e| {
-                error!("Relayer: Failure fetching recipient set: {:?}", e);
-                NakamotoNodeError::SnapshotNotFoundForChainTip
-            })?;
+        let recipients = get_nakamoto_next_recipients(
+            &sort_tip,
+            &mut self.sortdb,
+            &mut self.chainstate,
+            &self.burnchain,
+        )
+        .map_err(|e| {
+            error!("Relayer: Failure fetching recipient set: {:?}", e);
+            NakamotoNodeError::SnapshotNotFoundForChainTip
+        })?;
 
         let block_header =
             NakamotoChainState::get_block_header_by_consensus_hash(self.chainstate.db(), target_ch)

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -202,7 +202,11 @@ impl SignCoordinator {
     ) -> Result<Self, ChainstateError> {
         let is_mainnet = config.is_mainnet();
         let Some(ref reward_set_signers) = reward_set.signers else {
-            error!("Could not initialize WSTS coordinator for reward set without signer");
+            error!("Could not initialize signing coordinator for reward set without signer");
+            debug!(
+                "reward_cycle: {}, reward set: {:?}",
+                reward_cycle, &reward_set
+            );
             return Err(ChainstateError::NoRegisteredSigners(0));
         };
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -2727,6 +2727,7 @@ impl RelayerThread {
                 .process_network_result(
                     &relayer_thread.local_peer,
                     &mut net_result,
+                    &relayer_thread.burnchain,
                     sortdb,
                     chainstate,
                     mempool,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -375,7 +375,9 @@ pub fn read_and_sign_block_proposal(
     let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
 
     let reward_set = load_nakamoto_reward_set(
-        tip.block_height,
+        burnchain
+            .pox_reward_cycle(tip.block_height.saturating_add(1))
+            .unwrap(),
         &tip.sortition_id,
         &burnchain,
         &mut chainstate,


### PR DESCRIPTION
This fixes #4826 by consolidating the way in which the code loads a Nakamoto-epoch reward set.  It now will load it from the Nakamoto chain state, where it is keyed to the PoX anchor block selected in the given burnchain fork, with one exception:  the first-ever Nakamoto reward set must be loaded from the sortition DB, since that'll be the only place where it is available.