### PR TITLE
Feat/wasm global variable error

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -518,7 +518,7 @@ pub fn call_function<'a, 'b, 'c, 'hooks>(
     // Access the global stack pointer from the instance
     let stack_pointer = instance
         .get_global(&mut store, "stack-pointer")
-        .ok_or(Error::Wasm(WasmError::StackPointerNotFound))?;
+        .ok_or(Error::Wasm(WasmError::GlobalNotFound("stack-pointer".to_string())))?;
     let mut offset = stack_pointer
         .get(&mut store)
         .i32()

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -518,7 +518,9 @@ pub fn call_function<'a, 'b, 'c, 'hooks>(
     // Access the global stack pointer from the instance
     let stack_pointer = instance
         .get_global(&mut store, "stack-pointer")
-        .ok_or(Error::Wasm(WasmError::GlobalNotFound("stack-pointer".to_string())))?;
+        .ok_or(Error::Wasm(WasmError::GlobalNotFound(
+            "stack-pointer".to_string(),
+        )))?;
     let mut offset = stack_pointer
         .get(&mut store)
         .i32()

--- a/clarity/src/vm/errors.rs
+++ b/clarity/src/vm/errors.rs
@@ -135,7 +135,6 @@ pub enum WasmError {
     UnableToReadIdentifier(FromUtf8Error),
     UnableToRetrieveIdentifier(i32),
     InvalidClarityName(String),
-    StackPointerNotFound,
     #[cfg(feature = "canonical")]
     UnableToWriteStackPointer(wasmtime::Error),
     #[cfg(feature = "canonical")]
@@ -174,7 +173,6 @@ impl fmt::Display for WasmError {
                 write!(f, "Unable to retrieve identifier: {id}")
             }
             WasmError::InvalidClarityName(name) => write!(f, "Invalid Clarity name: {name}"),
-            WasmError::StackPointerNotFound => write!(f, "Stack pointer not found"),
             #[cfg(feature = "canonical")]
             WasmError::UnableToWriteStackPointer(e) => {
                 write!(f, "Unable to write stack pointer: {e}")

--- a/clarity/src/vm/errors.rs
+++ b/clarity/src/vm/errors.rs
@@ -125,6 +125,7 @@ pub enum WasmError {
     DefinesNotFound,
     TopLevelNotFound,
     MemoryNotFound,
+    GlobalNotFound(String),
     #[cfg(feature = "canonical")]
     WasmCompileFailed(wasmtime::Error),
     #[cfg(feature = "canonical")]
@@ -159,6 +160,7 @@ impl fmt::Display for WasmError {
             WasmError::DefinesNotFound => write!(f, "Defines function not found"),
             WasmError::TopLevelNotFound => write!(f, "Top level function not found"),
             WasmError::MemoryNotFound => write!(f, "Memory not found"),
+            WasmError::GlobalNotFound(e) => write!(f, "Global variable not found: {e}"),
             #[cfg(feature = "canonical")]
             WasmError::WasmCompileFailed(e) => write!(f, "Wasm compile failed: {e}"),
             #[cfg(feature = "canonical")]


### PR DESCRIPTION
This PR adds a generic wasm error for globals on clarity-wasm standard library.

New global variables will be added to the `Standard.wat` WebAssembly file. For instance, a new variable to handle runtime errors is under validation on this [PR](https://github.com/stacks-network/clarity-wasm/pull/379/files#diff-0dbeb8ed9c7228c4c202b84da52fadf9f0aa8985b4c27617f5763c744c9f87b2R3426).

Thus, it makes sense to have a generic WASM error to avoid creating a new error type for each global added to the WebAssembly.