### PR TITLE
Feat: PoX punish/reward via bitvec

### DIFF
--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -121,6 +121,22 @@ impl StacksEpochId {
         }
     }
 
+    /// Whether or not this epoch supports the punishment of PoX reward
+    /// recipients using the bitvec scheme
+    pub fn allows_pox_punishment(&self) -> bool {
+        match self {
+            StacksEpochId::Epoch10
+            | StacksEpochId::Epoch20
+            | StacksEpochId::Epoch2_05
+            | StacksEpochId::Epoch21
+            | StacksEpochId::Epoch22
+            | StacksEpochId::Epoch23
+            | StacksEpochId::Epoch24
+            | StacksEpochId::Epoch25 => false,
+            StacksEpochId::Epoch30 => true,
+        }
+    }
+
     /// Does this epoch support unlocking PoX contributors that miss a slot?
     ///
     /// Epoch 2.0 - 2.05 didn't support this feature, but they weren't epoch-guarded on it. Instead,

--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -113,7 +113,7 @@ impl SortitionsView {
         block: &NakamotoBlock,
         block_pk: &StacksPublicKey,
     ) -> Result<bool, ClientError> {
-        let bitvec_all_1s = block.header.signer_bitvec.iter().all(|entry| entry);
+        let bitvec_all_1s = block.header.pox_treatment.iter().all(|entry| entry);
         if !bitvec_all_1s {
             warn!(
                 "Miner block proposal has bitvec field which punishes in disagreement with signer. Considering invalid.";

--- a/stacks-signer/src/tests/chainstate.rs
+++ b/stacks-signer/src/tests/chainstate.rs
@@ -95,7 +95,7 @@ fn setup_test_environment(
             state_index_root: TrieHash([0; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: vec![],
-            signer_bitvec: BitVec::zeros(1).unwrap(),
+            pox_treatment: BitVec::zeros(1).unwrap(),
         },
         txs: vec![],
     };

--- a/stacks-signer/src/tests/chainstate.rs
+++ b/stacks-signer/src/tests/chainstate.rs
@@ -95,7 +95,7 @@ fn setup_test_environment(
             state_index_root: TrieHash([0; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: vec![],
-            pox_treatment: BitVec::zeros(1).unwrap(),
+            pox_treatment: BitVec::ones(1).unwrap(),
         },
         txs: vec![],
     };

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -693,6 +693,8 @@ pub enum Error {
     CoordinatorClosed,
     /// Graceful shutdown error
     ShutdownInitiated,
+    /// No epoch defined at that height
+    NoStacksEpoch,
 }
 
 impl fmt::Display for Error {
@@ -718,6 +720,10 @@ impl fmt::Display for Error {
             ),
             Error::CoordinatorClosed => write!(f, "ChainsCoordinator channel hung up"),
             Error::ShutdownInitiated => write!(f, "Graceful shutdown was initiated"),
+            Error::NoStacksEpoch => write!(
+                f,
+                "No Stacks epoch is defined at the height being evaluated"
+            ),
         }
     }
 }
@@ -741,6 +747,7 @@ impl error::Error for Error {
             Error::NonCanonicalPoxId(_, _) => None,
             Error::CoordinatorClosed => None,
             Error::ShutdownInitiated => None,
+            Error::NoStacksEpoch => None,
         }
     }
 }

--- a/stackslib/src/burnchains/tests/burnchain.rs
+++ b/stackslib/src/burnchains/tests/burnchain.rs
@@ -153,7 +153,7 @@ fn test_process_block_ops() {
 
     let block_commit_1 = LeaderBlockCommitOp {
         sunset_burn: 0,
-        punished: vec![],
+        treatment: vec![],
         commit_outs: vec![],
         block_header_hash: BlockHeaderHash::from_bytes(
             &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222").unwrap(),
@@ -192,7 +192,7 @@ fn test_process_block_ops() {
 
     let block_commit_2 = LeaderBlockCommitOp {
         sunset_burn: 0,
-        punished: vec![],
+        treatment: vec![],
         commit_outs: vec![],
         block_header_hash: BlockHeaderHash::from_bytes(
             &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223").unwrap(),
@@ -231,7 +231,7 @@ fn test_process_block_ops() {
 
     let block_commit_3 = LeaderBlockCommitOp {
         sunset_burn: 0,
-        punished: vec![],
+        treatment: vec![],
         commit_outs: vec![],
         block_header_hash: BlockHeaderHash::from_bytes(
             &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224").unwrap(),
@@ -781,7 +781,7 @@ fn test_burn_snapshot_sequence() {
         if i > 0 {
             let next_block_commit = LeaderBlockCommitOp {
                 sunset_burn: 0,
-                punished: vec![],
+                treatment: vec![],
                 commit_outs: vec![],
                 block_header_hash: BlockHeaderHash::from_bytes(&vec![
                     i, i, i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/stackslib/src/burnchains/tests/burnchain.rs
+++ b/stackslib/src/burnchains/tests/burnchain.rs
@@ -153,6 +153,7 @@ fn test_process_block_ops() {
 
     let block_commit_1 = LeaderBlockCommitOp {
         sunset_burn: 0,
+        punished: vec![],
         commit_outs: vec![],
         block_header_hash: BlockHeaderHash::from_bytes(
             &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222").unwrap(),
@@ -191,6 +192,7 @@ fn test_process_block_ops() {
 
     let block_commit_2 = LeaderBlockCommitOp {
         sunset_burn: 0,
+        punished: vec![],
         commit_outs: vec![],
         block_header_hash: BlockHeaderHash::from_bytes(
             &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223").unwrap(),
@@ -229,6 +231,7 @@ fn test_process_block_ops() {
 
     let block_commit_3 = LeaderBlockCommitOp {
         sunset_burn: 0,
+        punished: vec![],
         commit_outs: vec![],
         block_header_hash: BlockHeaderHash::from_bytes(
             &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224").unwrap(),
@@ -778,6 +781,7 @@ fn test_burn_snapshot_sequence() {
         if i > 0 {
             let next_block_commit = LeaderBlockCommitOp {
                 sunset_burn: 0,
+                punished: vec![],
                 commit_outs: vec![],
                 block_header_hash: BlockHeaderHash::from_bytes(&vec![
                     i, i, i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/stackslib/src/burnchains/tests/db.rs
+++ b/stackslib/src/burnchains/tests/db.rs
@@ -515,6 +515,7 @@ pub fn make_simple_block_commit(
     let block_height = burn_header.block_height;
     let mut new_op = LeaderBlockCommitOp {
         sunset_burn: 0,
+        punished: vec![],
         block_header_hash: block_hash,
         new_seed: VRFSeed([1u8; 32]),
         parent_block_ptr: 0,

--- a/stackslib/src/burnchains/tests/db.rs
+++ b/stackslib/src/burnchains/tests/db.rs
@@ -515,7 +515,7 @@ pub fn make_simple_block_commit(
     let block_height = burn_header.block_height;
     let mut new_op = LeaderBlockCommitOp {
         sunset_burn: 0,
-        punished: vec![],
+        treatment: vec![],
         block_header_hash: block_hash,
         new_seed: VRFSeed([1u8; 32]),
         parent_block_ptr: 0,

--- a/stackslib/src/chainstate/burn/db/processing.rs
+++ b/stackslib/src/chainstate/burn/db/processing.rs
@@ -40,7 +40,7 @@ impl<'a> SortitionHandleTx<'a> {
     fn check_transaction(
         &mut self,
         burnchain: &Burnchain,
-        blockstack_op: &BlockstackOperationType,
+        blockstack_op: &mut BlockstackOperationType,
         reward_info: Option<&RewardSetInfo>,
     ) -> Result<(), BurnchainError> {
         match blockstack_op {
@@ -53,7 +53,7 @@ impl<'a> SortitionHandleTx<'a> {
                     BurnchainError::OpError(e)
                 })
             }
-            BlockstackOperationType::LeaderBlockCommit(ref op) => {
+            BlockstackOperationType::LeaderBlockCommit(ref mut op) => {
                 op.check(burnchain, self, reward_info).map_err(|e| {
                     warn!(
                         "REJECTED({}) leader block commit {} at {},{} (parent {},{}): {:?}",
@@ -259,7 +259,7 @@ impl<'a> SortitionHandleTx<'a> {
         let mut missed_block_commits = vec![];
 
         // classify and check each transaction
-        blockstack_txs.retain(|blockstack_op| {
+        blockstack_txs.retain_mut(|blockstack_op| {
             match self.check_transaction(burnchain, blockstack_op, reward_set_info) {
                 Ok(_) => true,
                 Err(BurnchainError::OpError(OpError::MissedBlockCommit(missed_op))) => {
@@ -404,6 +404,7 @@ mod tests {
             block_height: 102,
             burn_parent_modulus: (101 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x03; 32]),
+            punished: vec![],
         };
 
         let mut burnchain = Burnchain::default_unittest(100, &first_burn_hash);

--- a/stackslib/src/chainstate/burn/db/processing.rs
+++ b/stackslib/src/chainstate/burn/db/processing.rs
@@ -404,7 +404,7 @@ mod tests {
             block_height: 102,
             burn_parent_modulus: (101 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x03; 32]),
-            punished: vec![],
+            treatment: vec![],
         };
 
         let mut burnchain = Burnchain::default_unittest(100, &first_burn_hash);

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -306,7 +306,7 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
             vtxindex,
             block_height,
             burn_header_hash,
-            punished,
+            treatment: punished,
         };
         Ok(block_commit)
     }
@@ -5741,7 +5741,7 @@ impl<'a> SortitionHandleTx<'a> {
             &block_commit.sunset_burn.to_string(),
             &apparent_sender_str,
             &block_commit.burn_parent_modulus,
-            &serde_json::to_string(&block_commit.punished).unwrap(),
+            &serde_json::to_string(&block_commit.treatment).unwrap(),
         ];
 
         self.execute("INSERT INTO block_commits (txid, vtxindex, block_height, burn_header_hash, block_header_hash, new_seed, parent_block_ptr, parent_vtxindex, key_block_ptr, key_vtxindex, memo, burn_fee, input, sortition_id, commit_outs, sunset_burn, apparent_sender, burn_parent_modulus, punished) \
@@ -7137,7 +7137,7 @@ pub mod tests {
             block_height: block_height + 2,
             burn_parent_modulus: ((block_height + 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x03; 32]),
-            punished: vec![],
+            treatment: vec![],
         };
 
         let mut db = SortitionDB::connect_test(block_height, &first_burn_hash).unwrap();
@@ -7856,7 +7856,7 @@ pub mod tests {
             block_height: block_height + 2,
             burn_parent_modulus: ((block_height + 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x03; 32]),
-            punished: vec![],
+            treatment: vec![],
         };
 
         let mut db = SortitionDB::connect_test(block_height, &first_burn_hash).unwrap();
@@ -10073,7 +10073,7 @@ pub mod tests {
             block_height: block_height + 2,
             burn_parent_modulus: ((block_height + 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x03; 32]),
-            punished: vec![],
+            treatment: vec![],
         };
 
         // descends from genesis
@@ -10116,7 +10116,7 @@ pub mod tests {
             block_height: block_height + 3,
             burn_parent_modulus: ((block_height + 2) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x04; 32]),
-            punished: vec![],
+            treatment: vec![],
         };
 
         // descends from block_commit_1
@@ -10159,7 +10159,7 @@ pub mod tests {
             block_height: block_height + 4,
             burn_parent_modulus: ((block_height + 3) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x05; 32]),
-            punished: vec![],
+            treatment: vec![],
         };
 
         // descends from genesis_block_commit
@@ -10202,7 +10202,7 @@ pub mod tests {
             block_height: block_height + 5,
             burn_parent_modulus: ((block_height + 4) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: BurnchainHeaderHash([0x06; 32]),
-            punished: vec![],
+            treatment: vec![],
         };
 
         let mut db = SortitionDB::connect_test(block_height, &first_burn_hash).unwrap();

--- a/stackslib/src/chainstate/burn/distribution.rs
+++ b/stackslib/src/chainstate/burn/distribution.rs
@@ -512,6 +512,7 @@ mod tests {
         let input_txid = Txid(input_txid);
 
         LeaderBlockCommitOp {
+            punished: vec![],
             block_header_hash: BlockHeaderHash(block_header_hash),
             new_seed: VRFSeed([0; 32]),
             parent_block_ptr: (block_id - 1) as u32,
@@ -884,6 +885,7 @@ mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
@@ -929,6 +931,7 @@ mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
@@ -974,6 +977,7 @@ mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")

--- a/stackslib/src/chainstate/burn/distribution.rs
+++ b/stackslib/src/chainstate/burn/distribution.rs
@@ -512,7 +512,7 @@ mod tests {
         let input_txid = Txid(input_txid);
 
         LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             block_header_hash: BlockHeaderHash(block_header_hash),
             new_seed: VRFSeed([0; 32]),
             parent_block_ptr: (block_id - 1) as u32,
@@ -885,7 +885,7 @@ mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
@@ -931,7 +931,7 @@ mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
@@ -977,7 +977,7 @@ mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -127,7 +127,7 @@ impl LeaderBlockCommitOp {
             txid: Txid([0u8; 32]),
             vtxindex: 0,
             burn_header_hash: BurnchainHeaderHash::zero(),
-            punished: vec![],
+            treatment: vec![],
         }
     }
 
@@ -166,7 +166,7 @@ impl LeaderBlockCommitOp {
                 - 1,
 
             burn_header_hash: BurnchainHeaderHash::zero(),
-            punished: vec![],
+            treatment: vec![],
         }
     }
 
@@ -454,7 +454,7 @@ impl LeaderBlockCommitOp {
             input,
             apparent_sender,
 
-            punished: Vec::new(),
+            treatment: Vec::new(),
             txid: tx.txid(),
             vtxindex: tx.vtxindex(),
             block_height: block_height,
@@ -1128,7 +1128,7 @@ impl LeaderBlockCommitOp {
         self.check_common(epoch.epoch_id, tx)?;
 
         if reward_set_info.is_some_and(|r| r.allow_nakamoto_punishment) {
-            self.punished = punished;
+            self.treatment = punished;
         }
 
         // good to go!
@@ -1756,7 +1756,7 @@ mod tests {
                     block_height: block_height,
                     burn_parent_modulus: ((block_height - 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
                     burn_header_hash: burn_header_hash,
-                    punished: vec![],                })
+                    treatment: vec![],                })
             },
             OpFixture {
                 // invalid -- wrong opcode
@@ -1990,7 +1990,7 @@ mod tests {
             commit_outs: vec![],
 
             burn_fee: 12345,
-            punished: vec![],
+            treatment: vec![],
             input: (Txid([0; 32]), 0),
             apparent_sender: BurnchainSigner::mock_parts(
                 AddressHashMode::SerializeP2PKH,
@@ -2125,7 +2125,7 @@ mod tests {
                 // accept -- consumes leader_key_2
                 op: LeaderBlockCommitOp {
                     sunset_burn: 0,
-                    punished: vec![],
+                    treatment: vec![],
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2175,7 +2175,7 @@ mod tests {
             CheckFixture {
                 // accept -- builds directly off of genesis block and consumes leader_key_2
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2226,7 +2226,7 @@ mod tests {
             CheckFixture {
                 // accept -- also consumes leader_key_1
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2277,7 +2277,7 @@ mod tests {
             CheckFixture {
                 // reject -- bad burn parent modulus
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2340,7 +2340,7 @@ mod tests {
             CheckFixture {
                 // reject -- bad burn parent modulus
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2512,7 +2512,7 @@ mod tests {
         // consumes leader_key_1
         let block_commit_1 = LeaderBlockCommitOp {
             sunset_burn: 0,
-            punished: vec![],
+            treatment: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -2661,7 +2661,7 @@ mod tests {
             CheckFixture {
                 // reject -- predates start block
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2713,7 +2713,7 @@ mod tests {
                 // reject -- no such leader key
                 op: LeaderBlockCommitOp {
                     sunset_burn: 0,
-                    punished: vec![],
+                    treatment: vec![],
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2763,7 +2763,7 @@ mod tests {
             CheckFixture {
                 // reject -- previous block must exist
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2814,7 +2814,7 @@ mod tests {
             CheckFixture {
                 // reject -- previous block must exist in a different block
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2868,7 +2868,7 @@ mod tests {
                 // here)
                 op: LeaderBlockCommitOp {
                     sunset_burn: 0,
-                    punished: vec![],
+                    treatment: vec![],
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2918,7 +2918,7 @@ mod tests {
             CheckFixture {
                 // reject -- fee is 0
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -2969,7 +2969,7 @@ mod tests {
             CheckFixture {
                 // accept -- consumes leader_key_2
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -3020,7 +3020,7 @@ mod tests {
             CheckFixture {
                 // accept -- builds directly off of genesis block and consumes leader_key_2
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -3071,7 +3071,7 @@ mod tests {
             CheckFixture {
                 // accept -- also consumes leader_key_1
                 op: LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
@@ -3207,7 +3207,7 @@ mod tests {
         };
 
         let default_block_commit = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed([0x33; 32]),
@@ -3519,7 +3519,7 @@ mod tests {
         };
 
         let block_commit_pre_2_05 = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x02; 32]),
             new_seed: VRFSeed([0x03; 32]),
@@ -3549,7 +3549,7 @@ mod tests {
         };
 
         let block_commit_post_2_05_valid = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x03; 32]),
             new_seed: VRFSeed([0x04; 32]),
@@ -3579,7 +3579,7 @@ mod tests {
         };
 
         let block_commit_post_2_05_valid_bigger_epoch = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x03; 32]),
             new_seed: VRFSeed([0x04; 32]),
@@ -3609,7 +3609,7 @@ mod tests {
         };
 
         let block_commit_post_2_05_invalid_bad_memo = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x04; 32]),
             new_seed: VRFSeed([0x05; 32]),
@@ -3639,7 +3639,7 @@ mod tests {
         };
 
         let block_commit_post_2_05_invalid_no_memo = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x05; 32]),
             new_seed: VRFSeed([0x06; 32]),
@@ -3669,7 +3669,7 @@ mod tests {
         };
 
         let block_commit_post_2_1_valid = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x03; 32]),
             new_seed: VRFSeed([0x04; 32]),
@@ -3699,7 +3699,7 @@ mod tests {
         };
 
         let block_commit_post_2_1_valid_bigger_epoch = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x03; 32]),
             new_seed: VRFSeed([0x04; 32]),
@@ -3729,7 +3729,7 @@ mod tests {
         };
 
         let block_commit_post_2_1_invalid_bad_memo = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x04; 32]),
             new_seed: VRFSeed([0x05; 32]),
@@ -3759,7 +3759,7 @@ mod tests {
         };
 
         let block_commit_post_2_1_invalid_no_memo = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x05; 32]),
             new_seed: VRFSeed([0x06; 32]),

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -3299,6 +3299,28 @@ mod tests {
             ),
             (
                 LeaderBlockCommitOp {
+                    commit_outs: vec![reward_addrs(0), burn_addr_1.clone()],
+                    ..default_block_commit.clone()
+                },
+                Some(rs_pox_addrs.clone()),
+                Ok(vec![
+                    Treatment::Punish(reward_addrs(1)),
+                    Treatment::Reward(reward_addrs(0)),
+                ]),
+            ),
+            (
+                LeaderBlockCommitOp {
+                    commit_outs: vec![reward_addrs(1), burn_addr_1.clone()],
+                    ..default_block_commit.clone()
+                },
+                Some(rs_pox_addrs.clone()),
+                Ok(vec![
+                    Treatment::Punish(reward_addrs(0)),
+                    Treatment::Reward(reward_addrs(1)),
+                ]),
+            ),
+            (
+                LeaderBlockCommitOp {
                     commit_outs: vec![reward_addrs(0), reward_addrs(1)],
                     ..default_block_commit.clone()
                 },

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -595,6 +595,11 @@ impl RewardSetInfo {
 impl LeaderBlockCommitOp {
     /// Perform PoX checks on this block-commit, given the reward set info (which may be None if
     /// PoX is not active).
+    ///
+    /// If PoX was active (i.e., `reward_set_info` is `Some`), this method will return how the
+    ///  PoX addresses were treated by the block commit. Prior to Epoch 3.0, these will be all
+    ///  treated with rewards (attempting to punish pre-nakamoto will result in a op_error).
+    ///
     /// If `reward_set_info` is not None, then *only* the addresses in .recipients are used.  The u16
     /// indexes are *ignored* (and *must be* ignored, since this method gets called by
     /// `check_intneded_sortition()`, which does not have this information).
@@ -778,12 +783,12 @@ impl LeaderBlockCommitOp {
                 return Err(op_error::BlockCommitBadOutputs);
             }
 
-            let mut punished_outputs: Vec<_> = check_recipients
+            let mut treated_outputs: Vec<_> = check_recipients
                 .into_iter()
                 .map(|x| Treatment::Punish(x.0))
                 .collect();
-            punished_outputs.extend(rewarded);
-            return Ok(punished_outputs);
+            treated_outputs.extend(rewarded);
+            return Ok(treated_outputs);
         }
     }
 

--- a/stackslib/src/chainstate/burn/operations/mod.rs
+++ b/stackslib/src/chainstate/burn/operations/mod.rs
@@ -27,6 +27,7 @@ use stacks_common::util::hash::{hex_bytes, to_hex, Hash160, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::MessageSignature;
 use stacks_common::util::vrf::VRFPublicKey;
 
+use self::leader_block_commit::Treatment;
 use crate::burnchains::{
     Address, Burnchain, BurnchainBlockHeader, BurnchainRecipient, BurnchainSigner,
     BurnchainTransaction, Error as BurnchainError, PublicKey, Txid,
@@ -242,6 +243,13 @@ pub struct LeaderBlockCommitOp {
 
     /// PoX/Burn outputs
     pub commit_outs: Vec<PoxAddress>,
+
+    /// If this block commit punished one or both of its PoX recipients,
+    /// they will be in this vector.
+    ///
+    /// This value is set by the check() call.
+    pub punished: Vec<Treatment>,
+
     // PoX sunset burn
     pub sunset_burn: u64,
 

--- a/stackslib/src/chainstate/burn/operations/mod.rs
+++ b/stackslib/src/chainstate/burn/operations/mod.rs
@@ -244,11 +244,12 @@ pub struct LeaderBlockCommitOp {
     /// PoX/Burn outputs
     pub commit_outs: Vec<PoxAddress>,
 
-    /// If this block commit punished one or both of its PoX recipients,
-    /// they will be in this vector.
+    /// If the active epoch supports PoX reward/punishment
+    /// via burns, this vector will contain the treatment (rewarded or punished)
+    /// of the PoX addresses active during the block commit.
     ///
-    /// This value is set by the check() call.
-    pub punished: Vec<Treatment>,
+    /// This value is set by the check() call, not during parsing.
+    pub treatment: Vec<Treatment>,
 
     // PoX sunset burn
     pub sunset_burn: u64,

--- a/stackslib/src/chainstate/burn/sortition.rs
+++ b/stackslib/src/chainstate/burn/sortition.rs
@@ -1119,7 +1119,7 @@ mod test {
                 block_height: header.block_height,
                 burn_parent_modulus: (i % BURN_BLOCK_MINED_AT_MODULUS) as u8,
                 burn_header_hash: header.block_hash.clone(),
-                punished: vec![],
+                treatment: vec![],
             };
 
             let tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();

--- a/stackslib/src/chainstate/burn/sortition.rs
+++ b/stackslib/src/chainstate/burn/sortition.rs
@@ -1119,6 +1119,7 @@ mod test {
                 block_height: header.block_height,
                 burn_parent_modulus: (i % BURN_BLOCK_MINED_AT_MODULUS) as u8,
                 burn_header_hash: header.block_hash.clone(),
+                punished: vec![],
             };
 
             let tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -698,7 +698,7 @@ fn make_genesis_block_with_recipients(
 
     let commit_op = LeaderBlockCommitOp {
         sunset_burn: 0,
-        punished: vec![],
+        treatment: vec![],
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input: (Txid([0; 32]), 0),
@@ -971,7 +971,7 @@ fn make_stacks_block_with_input(
 
     let commit_op = LeaderBlockCommitOp {
         sunset_burn,
-        punished: vec![],
+        treatment: vec![],
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input,

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -698,6 +698,7 @@ fn make_genesis_block_with_recipients(
 
     let commit_op = LeaderBlockCommitOp {
         sunset_burn: 0,
+        punished: vec![],
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input: (Txid([0; 32]), 0),
@@ -970,6 +971,7 @@ fn make_stacks_block_with_input(
 
     let commit_op = LeaderBlockCommitOp {
         sunset_burn,
+        punished: vec![],
         block_header_hash: block.block_hash(),
         burn_fee: my_burn,
         input,
@@ -2408,6 +2410,7 @@ fn test_sortition_with_reward_set() {
             let bad_block_recipients = Some(RewardSetInfo {
                 anchor_block: BlockHeaderHash([0; 32]),
                 recipients,
+                allow_nakamoto_punishment: false,
             });
             let (bad_outs_op, _) = make_stacks_block_with_recipients(
                 &sort_db,
@@ -2653,6 +2656,7 @@ fn test_sortition_with_burner_reward_set() {
             let bad_block_recipients = Some(RewardSetInfo {
                 anchor_block: BlockHeaderHash([0; 32]),
                 recipients,
+                allow_nakamoto_punishment: false,
             });
             let (bad_outs_op, _) = make_stacks_block_with_recipients(
                 &sort_db,

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -90,6 +90,20 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
         let cycle = burnchain
             .block_height_to_reward_cycle(cycle_start_burn_height)
             .expect("FATAL: no reward cycle for burn height");
+        self.read_reward_set_nakamoto_of_cycle(cycle, chainstate, sortdb, block_id, debug_log)
+    }
+    /// Read a reward_set written while updating .signers at a given cycle_id
+    /// `debug_log` should be set to true if the reward set loading should
+    ///  log messages as `debug!` instead of `error!` or `info!`. This allows
+    ///  RPC endpoints to expose this without flooding loggers.
+    pub fn read_reward_set_nakamoto_of_cycle(
+        &self,
+        cycle: u64,
+        chainstate: &mut StacksChainState,
+        sortdb: &SortitionDB,
+        block_id: &StacksBlockId,
+        debug_log: bool,
+    ) -> Result<RewardSet, Error> {
         // figure out the block ID
         let Some(coinbase_height_of_calculation) = chainstate
             .eval_boot_code_read_only(

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -17,8 +17,10 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
+use clarity::boot_util::boot_code_id;
+use clarity::vm::ast::ASTRules;
 use clarity::vm::clarity::ClarityConnection;
-use clarity::vm::database::BurnStateDB;
+use clarity::vm::database::{BurnStateDB, HeadersDB};
 use clarity::vm::types::PrincipalData;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, SortitionId, StacksAddress, StacksBlockId,
@@ -28,7 +30,7 @@ use stacks_common::types::{StacksEpoch, StacksEpochId};
 
 use crate::burnchains::db::{BurnchainBlockData, BurnchainDB, BurnchainHeaderReader};
 use crate::burnchains::{Burnchain, BurnchainBlockHeader};
-use crate::chainstate::burn::db::sortdb::{get_ancestor_sort_id, SortitionDB};
+use crate::chainstate::burn::db::sortdb::{get_ancestor_sort_id, SortitionDB, SortitionHandleConn};
 use crate::chainstate::burn::operations::leader_block_commit::RewardSetInfo;
 use crate::chainstate::burn::BlockSnapshot;
 use crate::chainstate::coordinator::comm::{
@@ -43,8 +45,10 @@ use crate::chainstate::coordinator::{
 use crate::chainstate::nakamoto::NakamotoChainState;
 use crate::chainstate::stacks::boot::{RewardSet, SIGNERS_NAME};
 use crate::chainstate::stacks::db::{StacksBlockHeaderTypes, StacksChainState, StacksHeaderInfo};
+use crate::chainstate::stacks::index::marf::MarfConnection;
 use crate::chainstate::stacks::miner::{signal_mining_blocked, signal_mining_ready, MinerStatus};
 use crate::chainstate::stacks::Error as ChainstateError;
+use crate::clarity_vm::database::HeadersDBConn;
 use crate::cost_estimates::{CostEstimator, FeeEstimator};
 use crate::monitoring::increment_stx_blocks_processed_counter;
 use crate::net::Error as NetError;
@@ -92,6 +96,7 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
             .expect("FATAL: no reward cycle for burn height");
         self.read_reward_set_nakamoto_of_cycle(cycle, chainstate, sortdb, block_id, debug_log)
     }
+
     /// Read a reward_set written while updating .signers at a given cycle_id
     /// `debug_log` should be set to true if the reward set loading should
     ///  log messages as `debug!` instead of `error!` or `info!`. This allows
@@ -129,6 +134,57 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
             return Err(Error::PoXAnchorBlockRequired);
         };
 
+        self.reward_reward_set_at_calculated_block(
+            coinbase_height_of_calculation,
+            chainstate,
+            block_id,
+            debug_log,
+        )
+    }
+
+    pub fn get_height_of_pox_calculation(
+        &self,
+        cycle: u64,
+        chainstate: &mut StacksChainState,
+        sort_handle: &SortitionHandleConn,
+        block_id: &StacksBlockId,
+    ) -> Result<u64, Error> {
+        let Some(coinbase_height_of_calculation) = chainstate
+            .clarity_state
+            .eval_read_only(
+                block_id,
+                &HeadersDBConn(chainstate.state_index.sqlite_conn()),
+                sort_handle,
+                &boot_code_id(SIGNERS_NAME, chainstate.mainnet),
+                &format!("(map-get? cycle-set-height u{})", cycle),
+                ASTRules::PrecheckSize,
+            )
+            .map_err(ChainstateError::ClarityError)?
+            .expect_optional()
+            .map_err(|e| Error::ChainstateError(e.into()))?
+            .map(|x| {
+                let as_u128 = x.expect_u128()?;
+                Ok(u64::try_from(as_u128).expect("FATAL: block height exceeded u64"))
+            })
+            .transpose()
+            .map_err(|e| Error::ChainstateError(ChainstateError::ClarityError(e)))?
+        else {
+            error!(
+                "The reward set was not written to .signers before it was needed by Nakamoto";
+                "cycle_number" => cycle,
+            );
+            return Err(Error::PoXAnchorBlockRequired);
+        };
+        Ok(coinbase_height_of_calculation)
+    }
+
+    pub fn reward_reward_set_at_calculated_block(
+        &self,
+        coinbase_height_of_calculation: u64,
+        chainstate: &mut StacksChainState,
+        block_id: &StacksBlockId,
+        debug_log: bool,
+    ) -> Result<RewardSet, Error> {
         let Some(reward_set_block) = NakamotoChainState::get_header_by_coinbase_height(
             &mut chainstate.index_tx_begin()?,
             block_id,

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -134,7 +134,7 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
             return Err(Error::PoXAnchorBlockRequired);
         };
 
-        self.reward_reward_set_at_calculated_block(
+        self.read_reward_set_at_calculated_block(
             coinbase_height_of_calculation,
             chainstate,
             block_id,
@@ -178,7 +178,7 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
         Ok(coinbase_height_of_calculation)
     }
 
-    pub fn reward_reward_set_at_calculated_block(
+    pub fn read_reward_set_at_calculated_block(
         &self,
         coinbase_height_of_calculation: u64,
         chainstate: &mut StacksChainState,

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -961,7 +961,7 @@ fn pox_treatment() {
                 bitvec.set(1 + ix, false).unwrap();
                 bitvec.set(2 + ix, false).unwrap();
             });
-            block.header.signer_bitvec = bitvec;
+            block.header.pox_treatment = bitvec;
             // don't try to process this block yet, just return it so that
             //  we can assert the block error.
             false
@@ -987,7 +987,7 @@ fn pox_treatment() {
         |block| {
             // each stacker has 3 entries in the bitvec.
             // entries are ordered by PoxAddr, so this makes every entry a 1-of-3
-            block.header.signer_bitvec = BitVec::try_from(
+            block.header.pox_treatment = BitVec::try_from(
                 [
                     false, false, true, false, false, true, false, false, true, false, false, true,
                 ]
@@ -1008,7 +1008,7 @@ fn pox_treatment() {
             // we want the miner to finish assembling the block, and then we'll
             //  alter the bitvec before it signs the block (in a subsequent closure).
             // this way, we can test the block processing behavior.
-            miner.header.signer_bitvec = BitVec::try_from(
+            miner.header.pox_treatment = BitVec::try_from(
                 [
                     false, false, true, false, false, true, false, false, true, false, false, true,
                 ]
@@ -1049,7 +1049,7 @@ fn pox_treatment() {
                 bitvec.set(2 + ix, true).unwrap();
             });
 
-            block.header.signer_bitvec = bitvec;
+            block.header.pox_treatment = bitvec;
             // don't try to process this block yet, just return it so that
             //  we can assert the block error.
             false
@@ -1074,7 +1074,7 @@ fn pox_treatment() {
         |miner| {
             // each stacker has 3 entries in the bitvec.
             // entries are ordered by PoxAddr, so this makes every entry a 1-of-3
-            miner.header.signer_bitvec = BitVec::try_from(
+            miner.header.pox_treatment = BitVec::try_from(
                 [
                     false, false, true, false, false, true, false, false, true, false, false, true,
                 ]

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -36,6 +36,7 @@ use stacks_common::util::secp256k1::Secp256k1PrivateKey;
 use stacks_common::util::vrf::VRFProof;
 use wsts::curve::point::Point;
 
+use crate::burnchains::PoxConstants;
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
 use crate::chainstate::burn::operations::{BlockstackOperationType, LeaderBlockCommitOp};
 use crate::chainstate::coordinator::tests::{p2pkh_from, pox_addr_from};
@@ -65,6 +66,7 @@ use crate::core::StacksEpochExtension;
 use crate::net::relay::Relayer;
 use crate::net::stackerdb::StackerDBConfig;
 use crate::net::test::{TestEventObserver, TestPeer, TestPeerConfig};
+use crate::net::tests::NakamotoBootPlan;
 use crate::util_lib::boot::boot_code_id;
 use crate::util_lib::signed_structured_data::pox4::Pox4SignatureTopic;
 
@@ -138,102 +140,6 @@ fn advance_to_nakamoto(
         tip = Some(peer.tenure_with_txs(&txs, &mut peer_nonce));
     }
     // peer is at the start of cycle 8
-}
-
-/// Bring a TestPeer into the Nakamoto Epoch
-fn advance_to_nakamoto_long(
-    peer: &mut TestPeer,
-    test_signers: &mut TestSigners,
-    test_stackers: &[TestStacker],
-) {
-    let mut peer_nonce = 0;
-    let private_key = peer.config.private_key.clone();
-    let addr = StacksAddress::from_public_keys(
-        C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        &AddressHashMode::SerializeP2PKH,
-        1,
-        &vec![StacksPublicKey::from_private(&private_key)],
-    )
-    .unwrap();
-
-    let mut stacked_pox_4 = false;
-    let mut signer_voted = false;
-    let nakamoto_height = peer
-        .config
-        .epochs
-        .as_ref()
-        .unwrap()
-        .iter()
-        .find(|e| e.epoch_id == StacksEpochId::Epoch30)
-        .unwrap()
-        .start_height;
-    let mut tip = None;
-    loop {
-        let current_burn_height = peer.get_burn_block_height();
-        if current_burn_height >= nakamoto_height - 1 {
-            info!("Booted to nakamoto");
-            break;
-        }
-        let txs = if tip.is_none() {
-            // don't mine stack-stx txs in first block, because they cannot pass the burn block height
-            //  validation
-            vec![]
-        } else if !stacked_pox_4 {
-            // Make all the test Stackers stack
-            stacked_pox_4 = true;
-            test_stackers
-                .iter()
-                .map(|test_stacker| {
-                    let pox_addr = test_stacker.pox_address.clone().unwrap_or_else(|| {
-                        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone())
-                    });
-                    let reward_cycle = peer
-                        .config
-                        .burnchain
-                        .block_height_to_reward_cycle(current_burn_height)
-                        .unwrap();
-                    let signature = make_signer_key_signature(
-                        &pox_addr,
-                        &test_stacker.signer_private_key,
-                        reward_cycle.into(),
-                        &Pox4SignatureTopic::StackStx,
-                        12_u128,
-                        u128::MAX,
-                        1,
-                    );
-                    let signing_key =
-                        StacksPublicKey::from_private(&test_stacker.signer_private_key);
-                    make_pox_4_lockup(
-                        &test_stacker.stacker_private_key,
-                        0,
-                        test_stacker.amount,
-                        &pox_addr,
-                        12,
-                        &signing_key,
-                        current_burn_height + 2,
-                        Some(signature),
-                        u128::MAX,
-                        1,
-                    )
-                })
-                .collect()
-        } else if !signer_voted {
-            signer_voted = true;
-            with_sortdb(peer, |chainstate, sortdb| {
-                make_all_signers_vote_for_aggregate_key(
-                    chainstate,
-                    sortdb,
-                    &tip.unwrap(),
-                    test_signers,
-                    test_stackers,
-                    7,
-                )
-            })
-        } else {
-            vec![]
-        };
-        tip = Some(peer.tenure_with_txs(&txs, &mut peer_nonce));
-    }
 }
 
 pub fn make_all_signers_vote_for_aggregate_key(
@@ -388,76 +294,6 @@ pub fn boot_nakamoto<'a>(
     let mut peer = TestPeer::new_with_observer(peer_config, observer);
 
     advance_to_nakamoto(&mut peer, test_signers, test_stackers);
-
-    peer
-}
-
-/// Make a peer and transition it into the Nakamoto epoch.
-/// The node needs to be stacking otherwise, Nakamoto can't activate.
-pub fn boot_nakamoto_long_reward_sets<'a>(
-    test_name: &str,
-    mut initial_balances: Vec<(PrincipalData, u64)>,
-    test_signers: &mut TestSigners,
-    test_stackers: &[TestStacker],
-    observer: Option<&'a TestEventObserver>,
-) -> TestPeer<'a> {
-    let aggregate_public_key = test_signers.aggregate_public_key.clone();
-    let mut peer_config = TestPeerConfig::new(test_name, 0, 0);
-    let private_key = peer_config.private_key.clone();
-    let addr = StacksAddress::from_public_keys(
-        C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        &AddressHashMode::SerializeP2PKH,
-        1,
-        &vec![StacksPublicKey::from_private(&private_key)],
-    )
-    .unwrap();
-
-    // reward cycles are 5 blocks long
-    // first 25 blocks are boot-up
-    // reward cycle 6 instantiates pox-3
-    // we stack in reward cycle 7 so pox-3 is evaluated to find reward set participation
-    peer_config.aggregate_public_key = Some(aggregate_public_key.clone());
-    peer_config
-        .stacker_dbs
-        .push(boot_code_id(MINERS_NAME, false));
-    peer_config.epochs = Some(StacksEpoch::unit_test_3_0_only(37));
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
-
-    // Create some balances for test Stackers
-    let mut stacker_balances = test_stackers
-        .iter()
-        .map(|test_stacker| {
-            (
-                PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key)),
-                u64::try_from(test_stacker.amount + 10000).expect("Stacking amount too large"),
-            )
-        })
-        .collect();
-
-    // Create some balances for test Signers
-    let mut signer_balances = test_stackers
-        .iter()
-        .map(|stacker| {
-            (
-                PrincipalData::from(p2pkh_from(&stacker.signer_private_key)),
-                1000,
-            )
-        })
-        .collect();
-
-    peer_config.initial_balances.append(&mut stacker_balances);
-    peer_config.initial_balances.append(&mut signer_balances);
-    peer_config.initial_balances.append(&mut initial_balances);
-    peer_config.burnchain.pox_constants.reward_cycle_length = 10;
-    peer_config.burnchain.pox_constants.v2_unlock_height = 21;
-    peer_config.burnchain.pox_constants.pox_3_activation_height = 26;
-    peer_config.burnchain.pox_constants.v3_unlock_height = 27;
-    peer_config.burnchain.pox_constants.pox_4_activation_height = 28;
-    peer_config.test_stackers = Some(test_stackers.to_vec());
-    peer_config.test_signers = Some(test_signers.clone());
-    let mut peer = TestPeer::new_with_observer(peer_config, observer);
-
-    advance_to_nakamoto_long(&mut peer, test_signers, test_stackers);
 
     peer
 }
@@ -887,14 +723,21 @@ fn pox_treatment() {
             )),
         })
         .collect::<Vec<_>>();
-    let mut test_signers = TestSigners::new(vec![signing_key]);
-    let mut peer = boot_nakamoto_long_reward_sets(
-        function_name!(),
-        vec![(addr.into(), 100_000_000)],
-        &mut test_signers,
-        &test_stackers,
-        None,
-    );
+    let test_signers = TestSigners::new(vec![signing_key]);
+    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    pox_constants.reward_cycle_length = 10;
+    pox_constants.v2_unlock_height = 21;
+    pox_constants.pox_3_activation_height = 26;
+    pox_constants.v3_unlock_height = 27;
+    pox_constants.pox_4_activation_height = 28;
+
+    let mut boot_plan = NakamotoBootPlan::new(function_name!())
+        .with_test_stackers(test_stackers.clone())
+        .with_test_signers(test_signers.clone())
+        .with_private_key(private_key);
+    boot_plan.pox_constants = pox_constants;
+
+    let mut peer = boot_plan.boot_into_nakamoto_peer(vec![], None);
     let mut blocks = vec![];
     let pox_constants = peer.sortdb().pox_constants.clone();
     let first_burn_height = peer.sortdb().first_block_height;

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -156,7 +156,6 @@ fn advance_to_nakamoto_long(
     )
     .unwrap();
 
-    //let pox_4_stacking_height = peer.config.epochs.as_ref().unwrap().iter().find(|e| e.epoch_id == StacksEpochId::Epoch25).unwrap().start_height;
     let mut stacked_pox_4 = false;
     let mut signer_voted = false;
     let nakamoto_height = peer
@@ -394,8 +393,7 @@ pub fn boot_nakamoto<'a>(
 }
 
 /// Make a peer and transition it into the Nakamoto epoch.
-/// The node needs to be stacking and it needs to vote for an aggregate key;
-/// otherwise, Nakamoto can't activate.
+/// The node needs to be stacking otherwise, Nakamoto can't activate.
 pub fn boot_nakamoto_long_reward_sets<'a>(
     test_name: &str,
     mut initial_balances: Vec<(PrincipalData, u64)>,

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -381,7 +381,7 @@ impl NakamotoBlockBuilder {
             info.cause == Some(TenureChangeCause::BlockFound),
             info.coinbase_height,
             info.cause == Some(TenureChangeCause::Extended),
-            &self.header.signer_bitvec,
+            &self.header.pox_treatment,
             &info.tenure_block_commit,
             &info.active_reward_set,
         )?;

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -273,7 +273,7 @@ impl NakamotoBlockBuilder {
             );
             Error::NoSuchBlockError
         })?;
-        let active_reward_set = rs_provider.reward_reward_set_at_calculated_block(
+        let active_reward_set = rs_provider.read_reward_set_at_calculated_block(
             coinbase_height_of_calc,
             chainstate,
             &self.header.parent_block_id,

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -46,13 +46,14 @@ use crate::chainstate::burn::db::sortdb::{
 };
 use crate::chainstate::burn::operations::*;
 use crate::chainstate::burn::*;
+use crate::chainstate::coordinator::OnChainRewardSetProvider;
 use crate::chainstate::nakamoto::{
     MaturedMinerRewards, NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, SetupBlockResult,
 };
 use crate::chainstate::stacks::address::StacksAddressExtensions;
 use crate::chainstate::stacks::boot::MINERS_NAME;
 use crate::chainstate::stacks::db::accounts::MinerReward;
-use crate::chainstate::stacks::db::blocks::MemPoolRejection;
+use crate::chainstate::stacks::db::blocks::{DummyEventDispatcher, MemPoolRejection};
 use crate::chainstate::stacks::db::transactions::{
     handle_clarity_runtime_error, ClarityRuntimeTxError,
 };
@@ -121,7 +122,7 @@ pub struct NakamotoBlockBuilder {
     /// transactions selected
     txs: Vec<StacksTransaction>,
     /// header we're filling in
-    header: NakamotoBlockHeader,
+    pub header: NakamotoBlockHeader,
 }
 
 pub struct MinerTenureInfo<'a> {
@@ -138,6 +139,8 @@ pub struct MinerTenureInfo<'a> {
     pub parent_burn_block_height: u32,
     pub coinbase_height: u64,
     pub cause: Option<TenureChangeCause>,
+    pub active_reward_set: boot::RewardSet,
+    pub tenure_block_commit: LeaderBlockCommitOp,
 }
 
 impl NakamotoBlockBuilder {
@@ -228,6 +231,61 @@ impl NakamotoBlockBuilder {
     ) -> Result<MinerTenureInfo<'a>, Error> {
         debug!("Nakamoto miner tenure begin");
 
+        let Some(tenure_election_sn) =
+            SortitionDB::get_block_snapshot_consensus(&burn_dbconn, &self.header.consensus_hash)?
+        else {
+            warn!("Could not find sortition snapshot for burn block that elected the miner";
+                  "consensus_hash" => %self.header.consensus_hash);
+            return Err(Error::NoSuchBlockError);
+        };
+        let Some(tenure_block_commit) = SortitionDB::get_block_commit(
+            &burn_dbconn,
+            &tenure_election_sn.winning_block_txid,
+            &tenure_election_sn.sortition_id,
+        )?
+        else {
+            warn!("Could not find winning block commit for burn block that elected the miner";
+                  "consensus_hash" => %self.header.consensus_hash,
+                  "winning_txid" => %tenure_election_sn.winning_block_txid);
+            return Err(Error::NoSuchBlockError);
+        };
+
+        let elected_height = tenure_election_sn.block_height;
+        let elected_in_cycle = burn_dbconn
+            .context
+            .pox_constants
+            .block_height_to_reward_cycle(burn_dbconn.context.first_block_height, elected_height)
+            .ok_or_else(|| {
+                Error::InvalidStacksBlock(
+                    "Elected in block height before first_block_height".into(),
+                )
+            })?;
+        let rs_provider = OnChainRewardSetProvider::<DummyEventDispatcher>(None);
+        let coinbase_height_of_calc = rs_provider.get_height_of_pox_calculation(
+            elected_in_cycle,
+            chainstate,
+            burn_dbconn,
+            &self.header.parent_block_id,
+        ).map_err(|e| {
+            warn!(
+                "Cannot process Nakamoto block: could not load reward set that elected the block";
+                "err" => ?e,
+            );
+            Error::NoSuchBlockError
+        })?;
+        let active_reward_set = rs_provider.reward_reward_set_at_calculated_block(
+            coinbase_height_of_calc,
+            chainstate,
+            &self.header.parent_block_id,
+            true,
+        ).map_err(|e| {
+            warn!(
+                "Cannot process Nakamoto block: could not load reward set that elected the block";
+                "err" => ?e,
+            );
+            Error::NoSuchBlockError
+        })?;
+
         // must build off of the header's consensus hash as the burnchain view, not the canonical_tip_bhh:
         let burn_sn = SortitionDB::get_block_snapshot_consensus(burn_dbconn.conn(), &self.header.consensus_hash)?
             .ok_or_else(|| {
@@ -289,6 +347,8 @@ impl NakamotoBlockBuilder {
             parent_burn_block_height: chain_tip.burn_header_height,
             cause,
             coinbase_height,
+            active_reward_set,
+            tenure_block_commit,
         })
     }
 
@@ -321,6 +381,9 @@ impl NakamotoBlockBuilder {
             info.cause == Some(TenureChangeCause::BlockFound),
             info.coinbase_height,
             info.cause == Some(TenureChangeCause::Extended),
+            &self.header.signer_bitvec,
+            &info.tenure_block_commit,
+            &info.active_reward_set,
         )?;
         self.matured_miner_rewards_opt = matured_miner_rewards_opt;
         Ok(clarity_tx)

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -240,7 +240,7 @@ fn codec_nakamoto_header() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![MessageSignature::from_bytes(&[0x01; 65]).unwrap()],
-        signer_bitvec: BitVec::zeros(8).unwrap(),
+        pox_treatment: BitVec::zeros(8).unwrap(),
     };
 
     let mut bytes = vec![
@@ -291,7 +291,7 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
 
     // sortition-inducing tenure change
@@ -854,7 +854,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: header_signatures.clone(),
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
 
     let nakamoto_header_info = StacksHeaderInfo {
@@ -899,7 +899,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
 
     let nakamoto_header_info_2 = StacksHeaderInfo {
@@ -939,7 +939,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
 
     let nakamoto_header_info_3 = StacksHeaderInfo {
@@ -1618,7 +1618,7 @@ fn test_nakamoto_block_static_verification() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
     nakamoto_header.sign_miner(&private_key).unwrap();
 
@@ -1637,7 +1637,7 @@ fn test_nakamoto_block_static_verification() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
     nakamoto_header_bad_ch.sign_miner(&private_key).unwrap();
 
@@ -1656,7 +1656,7 @@ fn test_nakamoto_block_static_verification() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
     nakamoto_header_bad_miner_sig
         .sign_miner(&private_key)
@@ -1809,7 +1809,7 @@ pub fn test_get_highest_nakamoto_tenure() {
             state_index_root: TrieHash([0x00; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: vec![],
-            signer_bitvec: BitVec::zeros(1).unwrap(),
+            pox_treatment: BitVec::zeros(1).unwrap(),
         };
         let tenure_change = TenureChangePayload {
             tenure_consensus_hash: sn.consensus_hash.clone(),
@@ -2046,7 +2046,7 @@ fn test_make_miners_stackerdb_config() {
             block_height: snapshot.block_height,
             burn_parent_modulus: ((snapshot.block_height - 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: snapshot.burn_header_hash.clone(),
-            punished: vec![],
+            treatment: vec![],
         };
 
         let winning_ops = if i == 0 {
@@ -2114,7 +2114,7 @@ fn test_make_miners_stackerdb_config() {
             state_index_root: TrieHash([0x07; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: vec![],
-            signer_bitvec: BitVec::zeros(1).unwrap(),
+            pox_treatment: BitVec::zeros(1).unwrap(),
         };
         let block = NakamotoBlock {
             header,

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -2046,6 +2046,7 @@ fn test_make_miners_stackerdb_config() {
             block_height: snapshot.block_height,
             burn_parent_modulus: ((snapshot.block_height - 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
             burn_header_hash: snapshot.burn_header_hash.clone(),
+            punished: vec![],
         };
 
         let winning_ops = if i == 0 {

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -1051,7 +1051,7 @@ impl<'a> TestPeer<'a> {
             self.sortdb.as_ref().unwrap(),
             &mut sort_handle,
             &mut self.stacks_node.as_mut().unwrap().chainstate,
-            block.clone(),
+            block,
             None,
         )?;
         if !accepted {

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -1311,6 +1311,7 @@ mod test {
 
         let mut block_commit = LeaderBlockCommitOp {
             sunset_burn: 0,
+            punished: vec![],
             block_header_hash: header.block_hash(),
             new_seed: VRFSeed::from_proof(&header.proof),
             parent_block_ptr: 0,

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -1311,7 +1311,7 @@ mod test {
 
         let mut block_commit = LeaderBlockCommitOp {
             sunset_burn: 0,
-            punished: vec![],
+            treatment: vec![],
             block_header_hash: header.block_hash(),
             new_seed: VRFSeed::from_proof(&header.proof),
             parent_block_ptr: 0,

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -257,7 +257,7 @@ impl NakamotoBlockProposal {
             self.block.header.burn_spent,
             tenure_change,
             coinbase,
-            self.block.header.signer_bitvec.len(),
+            self.block.header.pox_treatment.len(),
         )?;
 
         let mut miner_tenure_info =

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -104,7 +104,7 @@ fn test_nakamoto_tenure_downloader() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
 
     let tenure_change_payload = TenureChangePayload {
@@ -171,7 +171,7 @@ fn test_nakamoto_tenure_downloader() {
             state_index_root: TrieHash([0x07; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: vec![],
-            signer_bitvec: BitVec::zeros(1).unwrap(),
+            pox_treatment: BitVec::zeros(1).unwrap(),
         };
 
         let mut block = NakamotoBlock {
@@ -192,7 +192,7 @@ fn test_nakamoto_tenure_downloader() {
         state_index_root: TrieHash([0x08; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
 
     let next_tenure_change_payload = TenureChangePayload {

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -28,7 +28,7 @@ use stacks_common::consts::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_H
 use stacks_common::types::chainstate::{
     StacksAddress, StacksBlockId, StacksPrivateKey, StacksPublicKey,
 };
-use stacks_common::types::Address;
+use stacks_common::types::{Address, StacksEpochId};
 use stacks_common::util::vrf::VRFProof;
 use wsts::curve::point::Point;
 
@@ -338,27 +338,35 @@ impl NakamotoBootPlan {
         let mut other_peer_nonces = vec![0; other_peers.len()];
         let addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&self.private_key));
 
-        let tip = {
-            let sort_db = peer.sortdb.as_mut().unwrap();
-            let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-            tip
-        };
-
+        let mut sortition_height = peer.get_burn_block_height();
         debug!("\n\n======================");
         debug!("PoxConstants = {:#?}", &peer.config.burnchain.pox_constants);
-        debug!("tip = {}", tip.block_height);
+        debug!("tip = {}", sortition_height);
         debug!("========================\n\n");
 
-        // advance to just past pox-3 unlock
-        let mut sortition_height = tip.block_height;
-        while sortition_height
-            <= peer
-                .config
-                .burnchain
-                .pox_constants
-                .pox_4_activation_height
-                .into()
-        {
+        let epoch_25_height = peer
+            .config
+            .epochs
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|e| e.epoch_id == StacksEpochId::Epoch25)
+            .unwrap()
+            .start_height;
+
+        let epoch_30_height = peer
+            .config
+            .epochs
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|e| e.epoch_id == StacksEpochId::Epoch30)
+            .unwrap()
+            .start_height;
+
+        // advance to just past pox-4 instantiation
+        let mut blocks_produced = false;
+        while sortition_height <= epoch_25_height {
             peer.tenure_with_txs(&vec![], &mut peer_nonce);
             for (other_peer, other_peer_nonce) in
                 other_peers.iter_mut().zip(other_peer_nonces.iter_mut())
@@ -366,12 +374,23 @@ impl NakamotoBootPlan {
                 other_peer.tenure_with_txs(&vec![], other_peer_nonce);
             }
 
-            let tip = {
-                let sort_db = peer.sortdb.as_mut().unwrap();
-                let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-                tip
-            };
-            sortition_height = tip.block_height;
+            sortition_height = peer.get_burn_block_height();
+            blocks_produced = true;
+        }
+
+        // need to produce at least 1 block before making pox-4 lockups:
+        //  the way `burn-block-height` constant works in Epoch 2.5 is such
+        //  that if its the first block produced, this will be 0 which will
+        //  prevent the lockups from being valid.
+        if !blocks_produced {
+            peer.tenure_with_txs(&vec![], &mut peer_nonce);
+            for (other_peer, other_peer_nonce) in
+                other_peers.iter_mut().zip(other_peer_nonces.iter_mut())
+            {
+                other_peer.tenure_with_txs(&vec![], other_peer_nonce);
+            }
+
+            sortition_height = peer.get_burn_block_height();
         }
 
         debug!("\n\n======================");
@@ -392,8 +411,9 @@ impl NakamotoBootPlan {
             .unwrap_or(vec![])
             .iter()
             .map(|test_stacker| {
-                let pox_addr =
-                    PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone());
+                let pox_addr = test_stacker.pox_address.clone().unwrap_or_else(|| {
+                    PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone())
+                });
                 let signature = make_signer_key_signature(
                     &pox_addr,
                     &test_stacker.signer_private_key,
@@ -410,7 +430,7 @@ impl NakamotoBootPlan {
                     &pox_addr,
                     12,
                     &StacksPublicKey::from_private(&test_stacker.signer_private_key),
-                    34,
+                    sortition_height + 1,
                     Some(signature),
                     u128::MAX,
                     1,
@@ -440,12 +460,7 @@ impl NakamotoBootPlan {
                 .for_each(|(peer, nonce)| {
                     peer.tenure_with_txs(&[], nonce);
                 });
-            let tip = {
-                let sort_db = peer.sortdb.as_mut().unwrap();
-                let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-                tip
-            };
-            sortition_height = tip.block_height;
+            sortition_height = peer.get_burn_block_height();
         }
 
         debug!("\n\n======================");
@@ -481,21 +496,14 @@ impl NakamotoBootPlan {
         debug!("========================\n\n");
 
         // advance to the start of epoch 3.0
-        while sortition_height
-            < Self::nakamoto_start_burn_height(&peer.config.burnchain.pox_constants)
-        {
+        while sortition_height < epoch_30_height - 1 {
             peer.tenure_with_txs(&vec![], &mut peer_nonce);
             for (other_peer, other_peer_nonce) in
                 other_peers.iter_mut().zip(other_peer_nonces.iter_mut())
             {
                 other_peer.tenure_with_txs(&vec![], other_peer_nonce);
             }
-            let tip = {
-                let sort_db = peer.sortdb.as_mut().unwrap();
-                let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
-                tip
-            };
-            sortition_height = tip.block_height;
+            sortition_height = peer.get_burn_block_height();
         }
 
         debug!("\n\n======================");
@@ -514,12 +522,15 @@ impl NakamotoBootPlan {
 
         let (mut peer, mut other_peers) =
             self.boot_nakamoto(test_signers.aggregate_public_key.clone(), observer);
+        if boot_plan.is_empty() {
+            debug!("No boot plan steps supplied -- returning once nakamoto epoch has been reached");
+            return (peer, other_peers);
+        }
 
         let mut all_blocks = vec![];
         let mut consensus_hashes = vec![];
         let mut last_tenure_change: Option<TenureChangePayload> = None;
         let mut blocks_since_last_tenure = 0;
-        let stx_miner_key = peer.miner.nakamoto_miner_key();
 
         debug!("\n\nProcess plan with {} steps", boot_plan.len());
 

--- a/stackslib/src/net/tests/relay/nakamoto.rs
+++ b/stackslib/src/net/tests/relay/nakamoto.rs
@@ -401,7 +401,7 @@ fn test_buffer_data_message() {
             state_index_root: TrieHash([0x07; 32]),
             miner_signature: MessageSignature::empty(),
             signer_signature: vec![],
-            signer_bitvec: BitVec::zeros(1).unwrap(),
+            pox_treatment: BitVec::zeros(1).unwrap(),
         },
         txs: vec![],
     };

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -199,6 +199,7 @@ impl BurnchainController for MocknetController {
                 }
                 BlockstackOperationType::LeaderBlockCommit(payload) => {
                     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                        punished: vec![],
                         sunset_burn: 0,
                         block_header_hash: payload.block_header_hash,
                         new_seed: payload.new_seed,

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -199,7 +199,7 @@ impl BurnchainController for MocknetController {
                 }
                 BlockstackOperationType::LeaderBlockCommit(payload) => {
                     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-                        punished: vec![],
+                        treatment: vec![],
                         sunset_burn: 0,
                         block_header_hash: payload.block_header_hash,
                         new_seed: payload.new_seed,

--- a/testnet/stacks-node/src/chain_data.rs
+++ b/testnet/stacks-node/src/chain_data.rs
@@ -277,7 +277,7 @@ impl MinerStats {
 
             // mocked commit
             let mocked_commit = LeaderBlockCommitOp {
-                punished: vec![],
+                treatment: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash(DEADBEEF.clone()),
                 new_seed: VRFSeed(DEADBEEF.clone()),
@@ -442,7 +442,7 @@ impl MinerStats {
         for (miner, last_commit) in active_miners_and_commits.iter() {
             if !commit_table.contains_key(miner) {
                 let mocked_commit = LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash(DEADBEEF.clone()),
                     new_seed: VRFSeed(DEADBEEF.clone()),
@@ -552,7 +552,7 @@ pub mod tests {
     #[test]
     fn test_burn_dist_to_prob_dist() {
         let block_commit_1 = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed([0x33; 32]),
@@ -585,7 +585,7 @@ pub mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed([0x33; 32]),
@@ -621,7 +621,7 @@ pub mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed([0x33; 32]),
@@ -822,7 +822,7 @@ EOF
             (
                 "miner-1".to_string(),
                 LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash([0x22; 32]),
                     new_seed: VRFSeed([0x33; 32]),
@@ -854,7 +854,7 @@ EOF
             (
                 "miner-2".to_string(),
                 LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash([0x22; 32]),
                     new_seed: VRFSeed([0x33; 32]),
@@ -889,7 +889,7 @@ EOF
             (
                 "miner-3".to_string(),
                 LeaderBlockCommitOp {
-                    punished: vec![],
+                    treatment: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash([0x22; 32]),
                     new_seed: VRFSeed([0x33; 32]),
@@ -924,7 +924,7 @@ EOF
 
         let unconfirmed_block_commits = vec![
             LeaderBlockCommitOp {
-                punished: vec![],
+                treatment: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),
@@ -951,7 +951,7 @@ EOF
                 burn_header_hash: BurnchainHeaderHash([0x01; 32]),
             },
             LeaderBlockCommitOp {
-                punished: vec![],
+                treatment: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),
@@ -978,7 +978,7 @@ EOF
                 burn_header_hash: BurnchainHeaderHash([0x01; 32]),
             },
             LeaderBlockCommitOp {
-                punished: vec![],
+                treatment: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),
@@ -1005,7 +1005,7 @@ EOF
                 burn_header_hash: BurnchainHeaderHash([0x01; 32]),
             },
             LeaderBlockCommitOp {
-                punished: vec![],
+                treatment: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),

--- a/testnet/stacks-node/src/chain_data.rs
+++ b/testnet/stacks-node/src/chain_data.rs
@@ -277,6 +277,7 @@ impl MinerStats {
 
             // mocked commit
             let mocked_commit = LeaderBlockCommitOp {
+                punished: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash(DEADBEEF.clone()),
                 new_seed: VRFSeed(DEADBEEF.clone()),
@@ -441,6 +442,7 @@ impl MinerStats {
         for (miner, last_commit) in active_miners_and_commits.iter() {
             if !commit_table.contains_key(miner) {
                 let mocked_commit = LeaderBlockCommitOp {
+                    punished: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash(DEADBEEF.clone()),
                     new_seed: VRFSeed(DEADBEEF.clone()),
@@ -550,6 +552,7 @@ pub mod tests {
     #[test]
     fn test_burn_dist_to_prob_dist() {
         let block_commit_1 = LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed([0x33; 32]),
@@ -582,6 +585,7 @@ pub mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed([0x33; 32]),
@@ -617,6 +621,7 @@ pub mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed([0x33; 32]),
@@ -817,6 +822,7 @@ EOF
             (
                 "miner-1".to_string(),
                 LeaderBlockCommitOp {
+                    punished: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash([0x22; 32]),
                     new_seed: VRFSeed([0x33; 32]),
@@ -848,6 +854,7 @@ EOF
             (
                 "miner-2".to_string(),
                 LeaderBlockCommitOp {
+                    punished: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash([0x22; 32]),
                     new_seed: VRFSeed([0x33; 32]),
@@ -882,6 +889,7 @@ EOF
             (
                 "miner-3".to_string(),
                 LeaderBlockCommitOp {
+                    punished: vec![],
                     sunset_burn: 0,
                     block_header_hash: BlockHeaderHash([0x22; 32]),
                     new_seed: VRFSeed([0x33; 32]),
@@ -916,6 +924,7 @@ EOF
 
         let unconfirmed_block_commits = vec![
             LeaderBlockCommitOp {
+                punished: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),
@@ -942,6 +951,7 @@ EOF
                 burn_header_hash: BurnchainHeaderHash([0x01; 32]),
             },
             LeaderBlockCommitOp {
+                punished: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),
@@ -968,6 +978,7 @@ EOF
                 burn_header_hash: BurnchainHeaderHash([0x01; 32]),
             },
             LeaderBlockCommitOp {
+                punished: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),
@@ -994,6 +1005,7 @@ EOF
                 burn_header_hash: BurnchainHeaderHash([0x01; 32]),
             },
             LeaderBlockCommitOp {
+                punished: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0x22; 32]),
                 new_seed: VRFSeed([0x33; 32]),

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -1241,7 +1241,7 @@ impl EventDispatcher {
             return;
         }
 
-        let signer_bitvec = serde_json::to_value(block.header.signer_bitvec.clone())
+        let signer_bitvec = serde_json::to_value(block.header.pox_treatment.clone())
             .unwrap_or_default()
             .as_str()
             .unwrap_or_default()

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -937,13 +937,7 @@ impl BlockMinerThread {
                 "Current reward cycle did not select a reward set. Cannot mine!".into(),
             ));
         };
-        let signer_bitvec_len = reward_set
-            .signers
-            .as_ref()
-            .map(|x| x.len())
-            .unwrap_or(0)
-            .try_into()
-            .ok();
+        let signer_bitvec_len = reward_set.rewarded_addresses.len().try_into().ok();
 
         // build the block itself
         let (mut block, consumed, size, tx_events) = NakamotoBlockBuilder::build_nakamoto_block(

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -44,7 +44,7 @@ use stacks::net::db::LocalPeer;
 use stacks::net::relay::Relayer;
 use stacks::net::NetworkResult;
 use stacks_common::types::chainstate::{
-    BlockHeaderHash, BurnchainHeaderHash, StacksBlockId, VRFSeed,
+    BlockHeaderHash, BurnchainHeaderHash, StacksBlockId, StacksPublicKey, VRFSeed,
 };
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::get_epoch_time_ms;
@@ -507,6 +507,7 @@ impl RelayerThread {
             .get_active()
             .ok_or_else(|| NakamotoNodeError::NoVRFKeyActive)?;
         let op = LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn,
             block_header_hash: BlockHeaderHash(parent_block_id.0),
             burn_fee: rest_commit,

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -507,7 +507,7 @@ impl RelayerThread {
             .get_active()
             .ok_or_else(|| NakamotoNodeError::NoVRFKeyActive)?;
         let op = LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn,
             block_header_hash: BlockHeaderHash(parent_block_id.0),
             burn_fee: rest_commit,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1113,6 +1113,7 @@ impl BlockMinerThread {
         let burn_parent_modulus = (current_burn_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
         let sender = self.keychain.get_burnchain_signer();
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn,
             block_header_hash,
             burn_fee,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1113,7 +1113,7 @@ impl BlockMinerThread {
         let burn_parent_modulus = (current_burn_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
         let sender = self.keychain.get_burnchain_signer();
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn,
             block_header_hash,
             burn_fee,

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -1035,7 +1035,7 @@ impl Node {
         let txid = Txid(txid_bytes);
 
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-            punished: vec![],
+            treatment: vec![],
             sunset_burn: 0,
             block_header_hash,
             burn_fee,

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -1035,6 +1035,7 @@ impl Node {
         let txid = Txid(txid_bytes);
 
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+            punished: vec![],
             sunset_burn: 0,
             block_header_hash,
             burn_fee,

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -602,7 +602,7 @@ fn transition_empty_blocks() {
             let burn_parent_modulus =
                 (tip_info.burn_block_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-                punished: vec![],
+                treatment: vec![],
                 sunset_burn,
                 block_header_hash: BlockHeaderHash([0xff; 32]),
                 burn_fee: rest_commit,

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -602,6 +602,7 @@ fn transition_empty_blocks() {
             let burn_parent_modulus =
                 (tip_info.burn_block_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                punished: vec![],
                 sunset_burn,
                 block_header_hash: BlockHeaderHash([0xff; 32]),
                 burn_fee: rest_commit,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -1928,6 +1928,7 @@ fn transition_empty_blocks() {
             let burn_parent_modulus =
                 ((tip_info.burn_block_height + 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8;
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                punished: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0xff; 32]),
                 burn_fee: burn_fee_cap,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -1928,7 +1928,7 @@ fn transition_empty_blocks() {
             let burn_parent_modulus =
                 ((tip_info.burn_block_height + 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8;
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-                punished: vec![],
+                treatment: vec![],
                 sunset_burn: 0,
                 block_header_hash: BlockHeaderHash([0xff; 32]),
                 burn_fee: burn_fee_cap,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -4789,7 +4789,7 @@ fn signer_chainstate() {
         state_index_root: TrieHash([0; 32]),
         miner_signature: MessageSignature([0; 65]),
         signer_signature: Vec::new(),
-        signer_bitvec: BitVec::ones(1).unwrap(),
+        pox_treatment: BitVec::ones(1).unwrap(),
     };
     sibling_block_header.sign_miner(&miner_sk).unwrap();
 
@@ -4819,7 +4819,7 @@ fn signer_chainstate() {
         state_index_root: TrieHash([0; 32]),
         miner_signature: MessageSignature([0; 65]),
         signer_signature: Vec::new(),
-        signer_bitvec: BitVec::ones(1).unwrap(),
+        pox_treatment: BitVec::ones(1).unwrap(),
     };
     sibling_block_header.sign_miner(&miner_sk).unwrap();
 
@@ -4869,7 +4869,7 @@ fn signer_chainstate() {
         state_index_root: TrieHash([0; 32]),
         miner_signature: MessageSignature([0; 65]),
         signer_signature: Vec::new(),
-        signer_bitvec: BitVec::ones(1).unwrap(),
+        pox_treatment: BitVec::ones(1).unwrap(),
     };
     sibling_block_header.sign_miner(&miner_sk).unwrap();
 
@@ -4927,7 +4927,7 @@ fn signer_chainstate() {
         state_index_root: TrieHash([0; 32]),
         miner_signature: MessageSignature([0; 65]),
         signer_signature: Vec::new(),
-        signer_bitvec: BitVec::ones(1).unwrap(),
+        pox_treatment: BitVec::ones(1).unwrap(),
     };
     sibling_block_header.sign_miner(&miner_sk).unwrap();
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -4717,7 +4717,7 @@ fn signer_chainstate() {
         let timer = Instant::now();
         while proposals_submitted.load(Ordering::SeqCst) <= before {
             thread::sleep(Duration::from_millis(5));
-            if timer.elapsed() > Duration::from_secs(20) {
+            if timer.elapsed() > Duration::from_secs(30) {
                 panic!("Timed out waiting for nakamoto miner to produce intermediate block");
             }
         }

--- a/testnet/stacks-node/src/tests/signer/v1.rs
+++ b/testnet/stacks-node/src/tests/signer/v1.rs
@@ -534,7 +534,7 @@ fn sign_request_rejected() {
         state_index_root: TrieHash([0x07; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
     let mut block1 = NakamotoBlock {
         header: header1,
@@ -561,7 +561,7 @@ fn sign_request_rejected() {
         state_index_root: TrieHash([0x08; 32]),
         miner_signature: MessageSignature::empty(),
         signer_signature: vec![],
-        signer_bitvec: BitVec::zeros(1).unwrap(),
+        pox_treatment: BitVec::zeros(1).unwrap(),
     };
     let mut block2 = NakamotoBlock {
         header: header2,


### PR DESCRIPTION
This PR implements the punish/reward scheme for PoX block commits in Nakamoto by checking the produced block's bitvectors for compliance.

This works by allowing PoX reward addresses to be replaced with burn outputs in all cases. Any elected miner's block _must_ contain a bitvector which conforms with the PoX address treatment in their winning block commit. This is enforced at the protocol's consensus level.

The bitvector itself is interpreted as a reward slot bitvec -- each slot is ordered as it is ordered by the reward set calculation (this is alphanumerically by burnchain_repr(), _descending_).

The checks are tested through a combination of unit and integration tests.

I think this PR could use a couple simple refactors (renaming `block_commit.punish` field to `pox_treatment`, renaming `signer_bitvec` to `rewards_bitvec`) and perhaps an additional assertion in the signer binary that asserts the bitvec is all 1s (for now: signers will eventually be responsible for choosing their own punishment scheme).

