### PR TITLE
Chore: add backtrace to db busy handler

### DIFF
--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::backtrace::Backtrace;
 use std::io::Error as IOError;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
@@ -684,7 +685,14 @@ pub fn tx_busy_handler(run_count: i32) -> bool {
 
     debug!(
         "Database is locked; sleeping {}ms and trying again",
-        &sleep_count
+        &sleep_count;
+        "backtrace" => ?{
+            if run_count > 10 && run_count % 10 == 0 {
+                Some(Backtrace::capture())
+            } else {
+                None
+            }
+        },
     );
 
     sleep_ms(sleep_count);


### PR DESCRIPTION
### Description

This adds a backtrace key to the `debug!` logs produced during sqlite tx busy handling. It will be invoked on every 10th such log for the same wait (so it will primarily be useful for debugging deadlocking situations).

