### PR TITLE
fix: 2 blocks dead time between 2.5 -> 3.0 transition

### DIFF
--- a/stackslib/src/chainstate/coordinator/comm.rs
+++ b/stackslib/src/chainstate/coordinator/comm.rs
@@ -247,8 +247,8 @@ impl CoordinatorCommunication {
         };
 
         let rcvrs = CoordinatorReceivers {
-            signal_bools: signal_bools,
-            signal_wakeup: signal_wakeup,
+            signal_bools,
+            signal_wakeup,
             stacks_blocks_processed,
             sortitions_processed,
             refresh_stacker_db,

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -731,11 +731,11 @@ impl<'a> StacksMicroblockBuilder<'a> {
             anchor_block,
             anchor_block_consensus_hash,
             anchor_block_height,
-            runtime: runtime,
+            runtime,
             clarity_tx: Some(clarity_tx),
             header_reader,
             unconfirmed: false,
-            settings: settings,
+            settings,
             ast_rules,
         })
     }
@@ -809,11 +809,11 @@ impl<'a> StacksMicroblockBuilder<'a> {
             anchor_block: anchored_block_hash,
             anchor_block_consensus_hash: anchored_consensus_hash,
             anchor_block_height: anchored_block_height,
-            runtime: runtime,
+            runtime,
             clarity_tx: Some(clarity_tx),
             header_reader,
             unconfirmed: true,
-            settings: settings,
+            settings,
             ast_rules,
         })
     }

--- a/testnet/stacks-node/src/globals.rs
+++ b/testnet/stacks-node/src/globals.rs
@@ -286,6 +286,7 @@ impl<T> Globals<T> {
                                 vrf_public_key: op.public_key,
                                 block_height: op.block_height as u64,
                                 op_vtxindex: op.vtxindex as u32,
+                                memo: op.memo,
                             };
 
                             **leader_key_registration_state =

--- a/testnet/stacks-node/src/globals.rs
+++ b/testnet/stacks-node/src/globals.rs
@@ -59,7 +59,7 @@ pub struct Globals<T> {
     /// Global flag to see if we should keep running
     pub should_keep_running: Arc<AtomicBool>,
     /// Status of our VRF key registration state (shared between the main thread and the relayer)
-    leader_key_registration_state: Arc<Mutex<LeaderKeyRegistrationState>>,
+    pub leader_key_registration_state: Arc<Mutex<LeaderKeyRegistrationState>>,
     /// Last miner config loaded
     last_miner_config: Arc<Mutex<Option<MinerConfig>>>,
     /// burnchain height at which we start mining
@@ -103,6 +103,7 @@ impl<T> Globals<T> {
         sync_comms: PoxSyncWatchdogComms,
         should_keep_running: Arc<AtomicBool>,
         start_mining_height: u64,
+        leader_key_registration_state: LeaderKeyRegistrationState,
     ) -> Globals<T> {
         Globals {
             last_sortition: Arc::new(Mutex::new(None)),
@@ -113,9 +114,7 @@ impl<T> Globals<T> {
             counters,
             sync_comms,
             should_keep_running,
-            leader_key_registration_state: Arc::new(Mutex::new(
-                LeaderKeyRegistrationState::Inactive,
-            )),
+            leader_key_registration_state: Arc::new(Mutex::new(leader_key_registration_state)),
             last_miner_config: Arc::new(Mutex::new(None)),
             start_mining_height: Arc::new(Mutex::new(start_mining_height)),
             estimated_winning_probs: Arc::new(Mutex::new(HashMap::new())),

--- a/testnet/stacks-node/src/nakamoto_node.rs
+++ b/testnet/stacks-node/src/nakamoto_node.rs
@@ -28,6 +28,7 @@ use stacks::net::atlas::AtlasConfig;
 use stacks::net::p2p::PeerNetwork;
 use stacks::net::relay::Relayer;
 use stacks::net::stackerdb::StackerDBs;
+use stacks::util::hash::Hash160;
 use stacks_common::types::chainstate::SortitionId;
 use stacks_common::types::StacksEpochId;
 
@@ -178,6 +179,7 @@ impl StacksNode {
                 block_height: 1,
                 op_vtxindex: 1,
                 vrf_public_key,
+                memo: keychain.get_nakamoto_pkh().as_bytes().to_vec(),
             })
         } else {
             LeaderKeyRegistrationState::Inactive

--- a/testnet/stacks-node/src/nakamoto_node.rs
+++ b/testnet/stacks-node/src/nakamoto_node.rs
@@ -25,16 +25,15 @@ use stacks::chainstate::stacks::Error as ChainstateError;
 use stacks::monitoring;
 use stacks::monitoring::update_active_miners_count_gauge;
 use stacks::net::atlas::AtlasConfig;
-use stacks::net::p2p::PeerNetwork;
 use stacks::net::relay::Relayer;
 use stacks::net::stackerdb::StackerDBs;
-use stacks::util::hash::Hash160;
 use stacks_common::types::chainstate::SortitionId;
 use stacks_common::types::StacksEpochId;
 
 use super::{Config, EventDispatcher, Keychain};
 use crate::burnchains::bitcoin_regtest_controller::addr2str;
 use crate::neon_node::{LeaderKeyRegistrationState, StacksNode as NeonNode};
+use crate::run_loop::boot_nakamoto::Neon2NakaData;
 use crate::run_loop::nakamoto::{Globals, RunLoop};
 use crate::run_loop::RegisteredKey;
 
@@ -134,7 +133,7 @@ impl StacksNode {
         globals: Globals,
         // relay receiver endpoint for the p2p thread, so the relayer can feed it data to push
         relay_recv: Receiver<RelayerDirective>,
-        peer_network: Option<PeerNetwork>,
+        data_from_neon: Option<Neon2NakaData>,
     ) -> StacksNode {
         let config = runloop.config().clone();
         let is_miner = runloop.is_miner();
@@ -160,7 +159,10 @@ impl StacksNode {
             .connect_mempool_db()
             .expect("FATAL: database failure opening mempool");
 
-        let mut p2p_net = peer_network
+        let data_from_neon = data_from_neon.unwrap_or_default();
+
+        let mut p2p_net = data_from_neon
+            .peer_network
             .unwrap_or_else(|| NeonNode::setup_peer_network(&config, &atlas_config, burnchain));
 
         let stackerdbs = StackerDBs::connect(&config.get_stacker_db_file_path(), true)
@@ -182,8 +184,19 @@ impl StacksNode {
                 memo: keychain.get_nakamoto_pkh().as_bytes().to_vec(),
             })
         } else {
-            LeaderKeyRegistrationState::Inactive
+            match &data_from_neon.leader_key_registration_state {
+                LeaderKeyRegistrationState::Active(registered_key) => {
+                    let pubkey_hash = keychain.get_nakamoto_pkh();
+                    if pubkey_hash.as_ref() == &registered_key.memo {
+                        data_from_neon.leader_key_registration_state
+                    } else {
+                        LeaderKeyRegistrationState::Inactive
+                    }
+                }
+                _ => LeaderKeyRegistrationState::Inactive,
+            }
         };
+
         globals.set_initial_leader_key_registration_state(leader_key_registration_state);
 
         let relayer_thread =

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -44,7 +44,7 @@ use stacks::net::db::LocalPeer;
 use stacks::net::relay::Relayer;
 use stacks::net::NetworkResult;
 use stacks_common::types::chainstate::{
-    BlockHeaderHash, BurnchainHeaderHash, StacksBlockId, VRFSeed,
+    BlockHeaderHash, BurnchainHeaderHash, StacksBlockId, StacksPublicKey, VRFSeed,
 };
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::get_epoch_time_ms;

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -44,7 +44,7 @@ use stacks::net::db::LocalPeer;
 use stacks::net::relay::Relayer;
 use stacks::net::NetworkResult;
 use stacks_common::types::chainstate::{
-    BlockHeaderHash, BurnchainHeaderHash, StacksBlockId, StacksPublicKey, VRFSeed,
+    BlockHeaderHash, BurnchainHeaderHash, StacksBlockId, VRFSeed,
 };
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::get_epoch_time_ms;

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -4835,14 +4835,13 @@ impl StacksNode {
                 memo: vec![],
             })
         } else {
+            // Warn the user that they need to set up a miner key
+            if miner && config.miner.mining_key.is_none() {
+                warn!("`[miner.mining_key]` not set in config file. This will be required to mine in Epoch 3.0!")
+            }
             LeaderKeyRegistrationState::Inactive
         };
         globals.set_initial_leader_key_registration_state(leader_key_registration_state);
-
-        // Warn the user that they need to set up a miner key
-        if miner && !mock_mining && config.miner.mining_key.is_none() {
-            warn!("`[miner.mining_key]` not set in config file. This will be required to mine in Epoch 3.0!")
-        }
 
         let relayer_thread = RelayerThread::new(runloop, local_peer.clone(), relayer);
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -401,9 +401,10 @@ struct ParentStacksBlockInfo {
     coinbase_nonce: u64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum LeaderKeyRegistrationState {
     /// Not started yet
+    #[default]
     Inactive,
     /// Waiting for burnchain confirmation
     /// `u64` is the target block height in which we intend this key to land

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -4827,6 +4827,7 @@ impl StacksNode {
                 block_height: 1,
                 op_vtxindex: 1,
                 vrf_public_key,
+                memo: vec![],
             })
         } else {
             LeaderKeyRegistrationState::Inactive

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -580,6 +580,7 @@ impl Node {
                             block_height: op.block_height as u64,
                             op_vtxindex: op.vtxindex as u32,
                             target_block_height: (op.block_height as u64) - 1,
+                            memo: op.memo.clone(),
                         });
                     }
                 }

--- a/testnet/stacks-node/src/run_loop/mod.rs
+++ b/testnet/stacks-node/src/run_loop/mod.rs
@@ -158,6 +158,9 @@ pub struct RegisteredKey {
     pub op_vtxindex: u32,
     /// the public key itself
     pub vrf_public_key: VRFPublicKey,
+    /// `memo` field that was used to register key
+    /// Could be `Hash160(miner_pubkey)`, or empty
+    pub memo: Vec<u8>,
 }
 
 pub fn announce_boot_receipts(

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -1133,14 +1133,7 @@ fn simple_neon_integration() {
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -1362,14 +1355,7 @@ fn mine_multiple_per_tenure_integration() {
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -1687,14 +1673,7 @@ fn correct_burn_outs() {
     );
     assert_eq!(stacker_response.stacker_set.rewarded_addresses.len(), 1);
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -1897,14 +1876,7 @@ fn block_proposal_api_endpoint() {
 
     info!("Nakamoto miner started...");
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -2248,14 +2220,8 @@ fn miner_writes_proposed_block_to_stackerdb() {
 
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
 
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -2390,14 +2356,8 @@ fn vote_for_aggregate_key_burn_op() {
 
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
 
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -2657,14 +2617,7 @@ fn follower_bootup() {
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -2887,14 +2840,8 @@ fn stack_stx_burn_op_integration_test() {
 
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
 
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -3339,18 +3286,10 @@ fn forked_tenure_is_ignored() {
     blind_signer(&naka_conf, &signers, proposals_submitted);
 
     info!("Starting tenure A.");
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
-    let commits_before = commits_submitted.load(Ordering::SeqCst);
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
-        Ok(commits_count > commits_before)
+        Ok(commits_count >= 1)
     })
     .unwrap();
 
@@ -3648,14 +3587,7 @@ fn check_block_heights() {
     let preheights = heights0_value.expect_tuple().unwrap();
     info!("Heights from pre-epoch 3.0: {}", preheights);
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -4045,14 +3977,7 @@ fn nakamoto_attempt_time() {
 
     info!("Nakamoto miner started...");
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -4318,14 +4243,7 @@ fn clarity_burn_state() {
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)
@@ -4601,14 +4519,7 @@ fn signer_chainstate() {
         false,
     );
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -1079,7 +1079,6 @@ fn simple_neon_integration() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -1312,7 +1311,6 @@ fn mine_multiple_per_tenure_integration() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -1502,7 +1500,6 @@ fn correct_burn_outs() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -1836,7 +1833,6 @@ fn block_proposal_api_endpoint() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -2200,7 +2196,6 @@ fn miner_writes_proposed_block_to_stackerdb() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -2321,7 +2316,6 @@ fn vote_for_aggregate_key_burn_op() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -2575,7 +2569,6 @@ fn follower_bootup() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -2815,7 +2808,6 @@ fn stack_stx_burn_op_integration_test() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -3251,7 +3243,6 @@ fn forked_tenure_is_ignored() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         naka_mined_blocks: mined_blocks,
@@ -3517,7 +3508,6 @@ fn check_block_heights() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -3938,7 +3928,6 @@ fn nakamoto_attempt_time() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -4217,7 +4206,6 @@ fn clarity_burn_state() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -4460,7 +4448,6 @@ fn signer_chainstate() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -4975,7 +4962,6 @@ fn continue_tenure_extend() {
     let run_loop_stopper = run_loop.get_termination_switch();
     let Counters {
         blocks_processed,
-        naka_submitted_vrfs: vrfs_submitted,
         naka_submitted_commits: commits_submitted,
         naka_proposed_blocks: proposals_submitted,
         ..
@@ -5030,14 +5016,7 @@ fn continue_tenure_extend() {
     info!("Nakamoto miner started...");
     blind_signer(&naka_conf, &signers, proposals_submitted);
 
-    // first block wakes up the run loop, wait until a key registration has been submitted.
-    next_block_and(&mut btc_regtest_controller, 60, || {
-        let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-        Ok(vrf_count >= 1)
-    })
-    .unwrap();
-
-    // second block should confirm the VRF register, wait until a block commit is submitted
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(&mut btc_regtest_controller, 60, || {
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         Ok(commits_count >= 1)

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -100,20 +100,10 @@ impl SignerTest<SpawnedSigner> {
 
         self.run_until_epoch_3_boundary();
 
-        let (vrfs_submitted, commits_submitted) = (
-            self.running_nodes.vrfs_submitted.clone(),
-            self.running_nodes.commits_submitted.clone(),
-        );
-        info!("Submitting 1 BTC block for miner VRF key registration");
-        // first block wakes up the run loop, wait until a key registration has been submitted.
-        next_block_and(&mut self.running_nodes.btc_regtest_controller, 60, || {
-            let vrf_count = vrfs_submitted.load(Ordering::SeqCst);
-            Ok(vrf_count >= 1)
-        })
-        .unwrap();
+        let commits_submitted = self.running_nodes.commits_submitted.clone();
 
-        info!("Successfully triggered first block to wake up the miner runloop.");
-        // second block should confirm the VRF register, wait until a block commit is submitted
+        info!("Waiting 1 burnchain block for miner VRF key confirmation");
+        // Wait one block to confirm the VRF register, wait until a block commit is submitted
         next_block_and(&mut self.running_nodes.btc_regtest_controller, 60, || {
             let commits_count = commits_submitted.load(Ordering::SeqCst);
             Ok(commits_count >= 1)


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Fix 2 block downtime by passing `LeaderKeyRegistrationState` from Neon runloop to Nakamoto runloop

### Applicable issues

- fixes #4710

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
