### PR TITLE
Feat: Garbage collect mempool in nakamoto using accept time

### DIFF
--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -87,9 +87,29 @@ pub enum StacksEpochId {
     Epoch30 = 0x03000,
 }
 
+pub enum MempoolCollectionBehavior {
+    ByStacksHeight,
+    ByReceiveTime,
+}
+
 impl StacksEpochId {
     pub fn latest() -> StacksEpochId {
         StacksEpochId::Epoch30
+    }
+
+    /// In this epoch, how should the mempool perform garbage collection?
+    pub fn mempool_garbage_behavior(&self) -> MempoolCollectionBehavior {
+        match self {
+            StacksEpochId::Epoch10
+            | StacksEpochId::Epoch20
+            | StacksEpochId::Epoch2_05
+            | StacksEpochId::Epoch21
+            | StacksEpochId::Epoch22
+            | StacksEpochId::Epoch23
+            | StacksEpochId::Epoch24
+            | StacksEpochId::Epoch25 => MempoolCollectionBehavior::ByStacksHeight,
+            StacksEpochId::Epoch30 => MempoolCollectionBehavior::ByReceiveTime,
+        }
     }
 
     /// Returns whether or not this Epoch should perform


### PR DESCRIPTION
This addresses #4346 by changing the mempool GC behavior in nakamoto from using the block height to using the age of the transaction (measured in time since `accept_time`).

The sets the age limit to be the same as prior limit when translated with 10 minute block times (as was expected prior to 3.0).