### PR TITLE
`stacks-inspect`: add `index-range` option to `replay-blocks`

### DIFF
--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -37,6 +37,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
 use std::io::BufReader;
+use std::time::Instant;
 use std::{env, fs, io, process, thread};
 
 use blockstack_lib::burnchains::bitcoin::indexer::{
@@ -65,7 +66,6 @@ use blockstack_lib::chainstate::stacks::{StacksBlockHeader, *};
 use blockstack_lib::clarity::vm::costs::ExecutionCost;
 use blockstack_lib::clarity::vm::types::StacksAddressExtensions;
 use blockstack_lib::clarity::vm::ClarityVersion;
-use blockstack_lib::clarity_cli;
 use blockstack_lib::clarity_cli::vm_execute;
 use blockstack_lib::core::{MemPoolDB, *};
 use blockstack_lib::cost_estimates::metrics::UnitMetric;
@@ -76,6 +76,7 @@ use blockstack_lib::net::relay::Relayer;
 use blockstack_lib::net::StacksMessage;
 use blockstack_lib::util_lib::db::sqlite_open;
 use blockstack_lib::util_lib::strings::UrlString;
+use blockstack_lib::{clarity_cli, util_lib};
 use libstackerdb::StackerDBChunkData;
 use rusqlite::types::ToSql;
 use rusqlite::{Connection, OpenFlags};
@@ -879,6 +880,7 @@ simulating a miner.
             eprintln!("Usage:");
             eprintln!("  {n} <chainstate_path>");
             eprintln!("  {n} <chainstate_path> prefix <index-block-hash-prefix>");
+            eprintln!("  {n} <chainstate_path> index-range <start_block> <end_block>");
             eprintln!("  {n} <chainstate_path> range <start_block> <end_block>");
             eprintln!("  {n} <chainstate_path> <first|last> <block_count>");
             process::exit(1);
@@ -886,6 +888,7 @@ simulating a miner.
         if argv.len() < 2 {
             print_help_and_exit();
         }
+        let start = Instant::now();
         let stacks_path = &argv[2];
         let mode = argv.get(3).map(String::as_str);
         let staging_blocks_db_path = format!("{stacks_path}/mainnet/chainstate/vm/index.sqlite");
@@ -910,6 +913,14 @@ simulating a miner.
                 let start = arg4.saturating_sub(1);
                 let blocks = arg5.saturating_sub(arg4);
                 format!("SELECT index_block_hash FROM staging_blocks ORDER BY height ASC LIMIT {start}, {blocks}")
+            }
+            Some("index-range") => {
+                let start = argv[4]
+                    .parse::<u64>()
+                    .expect("<start_block> not a valid u64");
+                let end = argv[5].parse::<u64>().expect("<end_block> not a valid u64");
+                let blocks = end.saturating_sub(start);
+                format!("SELECT index_block_hash FROM staging_blocks ORDER BY index_block_hash ASC LIMIT {start}, {blocks}")
             }
             Some("last") => format!(
                 "SELECT index_block_hash FROM staging_blocks ORDER BY height DESC LIMIT {}",
@@ -936,7 +947,7 @@ simulating a miner.
             }
             replay_block(stacks_path, index_block_hash);
         }
-        println!("Finished!");
+        println!("Finished. run_time_seconds = {}", start.elapsed().as_secs());
         process::exit(0);
     }
 


### PR DESCRIPTION
### Description

This adds the `index-range` option to `replay-blocks`. This is useful for selecting a uniformly random slice of blocks for replay (because ordering by index block hash is indistinguishable from a pseudorandom function).


Note: As part of this PR, I also considered making the `replay-blocks` command alter the SQLite transaction behavior from IMMEDIATE to DEFERRED. The goal was to allow multiple processes to share a chainstate directory during replay-blocks. Unfortunately, this didn't really help, because `replay-blocks` does perform writes in its transactions: it just rolls back those transactions. This means that SQLite will try to obtain a write lock even in DEFERRED operation. 

However, one workable strategy for avoiding storage overhead when trying to run multiple process with `replay-blocks` is to copy the whole chainstate directory _except_ for `chainstate/vm/clarity/marf.sqlite.blobs`, and then simply symlink that file for each instance of the replay-blocks processes. That file isn't a database, so it doesn't lock on transactions (and this is safe because none of the replay-blocks processes actually write to that file). This file is also ~75% of the chainstate's disk size.