### PR TITLE
Fix: never consider Stacks chain tips that are not on the canonical burn chain

### DIFF
--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -153,7 +153,7 @@ use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, LegacyBitcoinAddressType};
 use stacks::burnchains::db::BurnchainHeaderReader;
 use stacks::burnchains::{Burnchain, BurnchainSigner, PoxConstants, Txid};
-use stacks::chainstate::burn::db::sortdb::SortitionDB;
+use stacks::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandleConn};
 use stacks::chainstate::burn::operations::leader_block_commit::{
     RewardSetInfo, BURN_BLOCK_MINED_AT_MODULUS,
 };
@@ -1148,6 +1148,50 @@ impl BlockMinerThread {
         ret
     }
 
+    /// Is a given Stacks staging block on the canonical burnchain fork?
+    pub(crate) fn is_on_canonical_burnchain_fork(
+        candidate: &StagingBlock,
+        sortdb_tip_handle: &SortitionHandleConn,
+    ) -> bool {
+        let candidate_ch = &candidate.consensus_hash;
+        let candidate_burn_ht = match SortitionDB::get_block_snapshot_consensus(
+            sortdb_tip_handle.conn(),
+            candidate_ch,
+        ) {
+            Ok(Some(x)) => x.block_height,
+            Ok(None) => {
+                warn!("Tried to evaluate potential chain tip with an unknown consensus hash";
+                      "consensus_hash" => %candidate_ch,
+                      "stacks_block_hash" => %candidate.anchored_block_hash);
+                return false;
+            }
+            Err(e) => {
+                warn!("Error while trying to evaluate potential chain tip with an unknown consensus hash";
+                      "consensus_hash" => %candidate_ch,
+                      "stacks_block_hash" => %candidate.anchored_block_hash,
+                      "err" => ?e);
+                return false;
+            }
+        };
+        let tip_ch = match sortdb_tip_handle.get_consensus_at(candidate_burn_ht) {
+            Ok(Some(x)) => x,
+            Ok(None) => {
+                warn!("Tried to evaluate potential chain tip with a consensus hash ahead of canonical tip";
+                      "consensus_hash" => %candidate_ch,
+                      "stacks_block_hash" => %candidate.anchored_block_hash);
+                return false;
+            }
+            Err(e) => {
+                warn!("Error while trying to evaluate potential chain tip with an unknown consensus hash";
+                      "consensus_hash" => %candidate_ch,
+                      "stacks_block_hash" => %candidate.anchored_block_hash,
+                      "err" => ?e);
+                return false;
+            }
+        };
+        &tip_ch == candidate_ch
+    }
+
     /// Load all candidate tips upon which to build.  This is all Stacks blocks whose heights are
     /// less than or equal to at `at_stacks_height` (or the canonical chain tip height, if not given),
     /// but greater than or equal to this end height minus `max_depth`.
@@ -1177,61 +1221,42 @@ impl BlockMinerThread {
 
         let stacks_tips: Vec<_> = stacks_tips
             .into_iter()
-            .filter(|candidate| {
-                let candidate_ch = &candidate.consensus_hash;
-                let candidate_burn_ht = match SortitionDB::get_block_snapshot_consensus(
-                    sortdb_tip_handle.conn(),
-                    candidate_ch
-                ) {
-                    Ok(Some(x)) => x.block_height,
-                    Ok(None) => {
-                        warn!("Tried to evaluate potential chain tip with an unknown consensus hash";
-                              "consensus_hash" => %candidate_ch,
-                              "stacks_block_hash" => %candidate.anchored_block_hash);
-                        return false;
-                    },
-                    Err(e) => {
-                        warn!("Error while trying to evaluate potential chain tip with an unknown consensus hash";
-                              "consensus_hash" => %candidate_ch,
-                              "stacks_block_hash" => %candidate.anchored_block_hash,
-                              "err" => ?e);
-                        return false;
-                    },
-                };
-                let tip_ch = match sortdb_tip_handle.get_consensus_at(candidate_burn_ht) {
-                    Ok(Some(x)) => x,
-                    Ok(None) => {
-                        warn!("Tried to evaluate potential chain tip with a consensus hash ahead of canonical tip";
-                              "consensus_hash" => %candidate_ch,
-                              "stacks_block_hash" => %candidate.anchored_block_hash);
-                        return false;
-                    },
-                    Err(e) => {
-                        warn!("Error while trying to evaluate potential chain tip with an unknown consensus hash";
-                              "consensus_hash" => %candidate_ch,
-                              "stacks_block_hash" => %candidate.anchored_block_hash,
-                              "err" => ?e);
-                        return false;
-                    },
-                };
-                if &tip_ch != candidate_ch {
-                    false
-                } else {
-                    true
-                }
-            })
+            .filter(|candidate| Self::is_on_canonical_burnchain_fork(candidate, &sortdb_tip_handle))
             .collect();
+
+        if stacks_tips.len() == 0 {
+            return vec![];
+        }
 
         let mut considered = HashSet::new();
         let mut candidates = vec![];
         let end_height = stacks_tips[0].height;
 
-        for cur_height in end_height.saturating_sub(max_depth)..=end_height {
-            let stacks_tips = chain_state
-                .get_stacks_chain_tips_at_height(cur_height)
-                .expect("FATAL: could not query chain tips at height");
+        // process these tips
+        for tip in stacks_tips.into_iter() {
+            let index_block_hash =
+                StacksBlockId::new(&tip.consensus_hash, &tip.anchored_block_hash);
+            let burn_height = burn_db
+                .get_consensus_hash_height(&tip.consensus_hash)
+                .expect("FATAL: could not query burnchain block height")
+                .expect("FATAL: no burnchain block height for Stacks tip");
+            let candidate = TipCandidate::new(tip, burn_height);
+            candidates.push(candidate);
+            considered.insert(index_block_hash);
+        }
 
-            for tip in stacks_tips {
+        // process earlier tips, back to max_depth
+        for cur_height in end_height.saturating_sub(max_depth)..end_height {
+            let stacks_tips: Vec<_> = chain_state
+                .get_stacks_chain_tips_at_height(cur_height)
+                .expect("FATAL: could not query chain tips at height")
+                .into_iter()
+                .filter(|candidate| {
+                    Self::is_on_canonical_burnchain_fork(candidate, &sortdb_tip_handle)
+                })
+                .collect();
+
+            for tip in stacks_tips.into_iter() {
                 let index_block_hash =
                     StacksBlockId::new(&tip.consensus_hash, &tip.anchored_block_hash);
 


### PR DESCRIPTION
This PR fixes an incident from earlier this morning whereby miners consistently failed to mine blocks because their preferred chain tip was no longer on the canonical Bitcoin fork.  This was due to (1) an omitted check when searching for ancestral Stacks tips to consider, and (2) an off-by-one error which meant that the highest considered ancestor had the same height as the already-filtered Stacks tips (instead of an earlier height).

You can see the difference as follows:

With the fix:
```
$ stacks-node pick-best-tip --config ~/mainnet-2.5.toml --at-stacks-height 153917
INFO [1718387049.331670] [testnet/stacks-node/src/main.rs:293] [main] stacks-node 0.1.0 (:, debug build, linux [x86_64])
INFO [1718387049.331731] [testnet/stacks-node/src/main.rs:66] [main] Loading config at path /home/jude/mainnet-2.5.toml
INFO [1718387049.500576] [testnet/stacks-node/src/neon_node.rs:1493] [main] Tip #0 ea37553db307bca3a2dc0413dd7eb943f4fbfecc/3a852c6ea871ea45528e9cd4800349e8685a46d9470e2c53b45b30fe15c18234 at 847851:153917 has score 1 (1 (non-ancestor) + 0 (earlier sibs) + 0 (earlier sibs) + 0 (earlier sibs))
INFO [1718387049.500607] [testnet/stacks-node/src/neon_node.rs:1493] [main] Tip #1 6a7f03e8da186957d979b0d3ec7330478f8ab600/36a21c1b248d205136378fc1409aa7d7727b61571bc3bea5c63da65c97e25817 at 847852:153917 has score 2 (1 (uncles) + 1 (non-ancestor) + 0 (earlier sibs) + 0 (earlier sibs) + 0 (earlier sibs))
INFO [1718387049.500619] [testnet/stacks-node/src/neon_node.rs:1524] [main] Best tip is #0 ea37553db307bca3a2dc0413dd7eb943f4fbfecc/3a852c6ea871ea45528e9cd4800349e8685a46d9470e2c53b45b30fe15c18234
Best tip is TipCandidate { stacks_height: 153917, consensus_hash: ea37553db307bca3a2dc0413dd7eb943f4fbfecc, anchored_block_hash: 3a852c6ea871ea45528e9cd4800349e8685a46d9470e2c53b45b30fe15c18234, parent_consensus_hash: ef78a4c1acf7a004d9ef170bee78245527cb5dcb, parent_anchored_block_hash: 678d064fbb1c9abc1a69c333ce2977535ef69791d846ed88917acefcf930dde7, burn_height: 847851, num_earlier_siblings: 0 }
```

Without the fix:
```
$ stacks-node pick-best-tip --config ~/mainnet-2.5.toml --at-stacks-height 153917
INFO [1718387084.670752] [testnet/stacks-node/src/main.rs:293] [main] stacks-node 0.1.0 (:, release build, linux [x86_64])
INFO [1718387084.670805] [testnet/stacks-node/src/main.rs:66] [main] Loading config at path /home/jude/mainnet-2.5.toml
INFO [1718387084.823874] [testnet/stacks-node/src/neon_node.rs:1472] [main] Tip #0 1b2ef7d48334989af51335211c218a5164f57ba5/7a08061efeb9516be3835e8478e15872d247be9fb2c42e690ba0af43fc494073 at 847849:153917 has score 2 (1 (non-ancestor) + 1 (non-ancestor) + 0 (earlier sibs) + 0 (earlier sibs) + 0 (earlier sibs))
INFO [1718387084.823901] [testnet/stacks-node/src/neon_node.rs:1472] [main] Tip #1 ea37553db307bca3a2dc0413dd7eb943f4fbfecc/3a852c6ea871ea45528e9cd4800349e8685a46d9470e2c53b45b30fe15c18234 at 847851:153917 has score 3 (1 (non-ancestor) + 1 (uncles) + 1 (non-ancestor) + 0 (earlier sibs) + 0 (earlier sibs) + 0 (earlier sibs))
INFO [1718387084.823918] [testnet/stacks-node/src/neon_node.rs:1472] [main] Tip #2 6a7f03e8da186957d979b0d3ec7330478f8ab600/36a21c1b248d205136378fc1409aa7d7727b61571bc3bea5c63da65c97e25817 at 847852:153917 has score 5 (2 (uncles) + 1 (non-ancestor) + 1 (uncles) + 1 (non-ancestor) + 0 (earlier sibs) + 0 (earlier sibs) + 0 (earlier sibs))
INFO [1718387084.823925] [testnet/stacks-node/src/neon_node.rs:1503] [main] Best tip is #0 1b2ef7d48334989af51335211c218a5164f57ba5/7a08061efeb9516be3835e8478e15872d247be9fb2c42e690ba0af43fc494073
Best tip is TipCandidate { stacks_height: 153917, consensus_hash: 1b2ef7d48334989af51335211c218a5164f57ba5, anchored_block_hash: 7a08061efeb9516be3835e8478e15872d247be9fb2c42e690ba0af43fc494073, parent_consensus_hash: ef78a4c1acf7a004d9ef170bee78245527cb5dcb, parent_anchored_block_hash: 678d064fbb1c9abc1a69c333ce2977535ef69791d846ed88917acefcf930dde7, burn_height: 847849, num_earlier_siblings: 0 }
```