### PR TITLE
Fix: signer slots count in develop

### DIFF
--- a/libsigner/src/v1/messages.rs
+++ b/libsigner/src/v1/messages.rs
@@ -1464,6 +1464,8 @@ mod test {
     use super::{StacksMessageCodecExtensions, *};
 
     #[test]
+    #[should_panic]
+    // V1 signer slots do not have enough slots in Epoch 2.5. Something will need to be updated!
     fn signer_slots_count_is_sane() {
         let slot_identifiers_len = MessageSlotID::ALL.len();
         assert!(

--- a/stacks-common/src/libcommon.rs
+++ b/stacks-common/src/libcommon.rs
@@ -63,5 +63,20 @@ pub mod consts {
 
     /// The number of StackerDB slots each signing key needs
     ///  to use to participate in DKG and block validation signing.
-    pub const SIGNER_SLOTS_PER_USER: u32 = 14;
+    pub const SIGNER_SLOTS_PER_USER: u32 = 13;
+}
+
+/// This test asserts that the constant above doesn't change.
+/// This exists because the constant above is used by Epoch 2.5 instantiation code.
+///
+/// Adding more slots will require instantiating more .signers contracts through either
+///  consensus changes (i.e., a new epoch) or through non-consensus-critical contract
+///  deployments.
+#[test]
+fn signer_slots_count_2_5() {
+    assert_eq!(
+        consts::SIGNER_SLOTS_PER_USER,
+        13,
+        "The .signers-x-y contracts in Epoch 2.5 were instantiated with 13 slots"
+    );
 }

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -1205,7 +1205,7 @@ mod tests {
                 let principal_data = StacksAddress::from_string(signer).unwrap().into();
 
                 let data_map = [
-                    ("num-slots".into(), ClarityValue::UInt(14)),
+                    ("num-slots".into(), ClarityValue::UInt(13)),
                     (
                         "signer".into(),
                         ClarityValue::Principal(PrincipalData::Standard(principal_data)),


### PR DESCRIPTION
This is the same PR as #4891, just targeted at `develop`.