### PR TITLE
Test: miner correctly sets bitvec to reward set length in naka_node now

### DIFF
--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -2309,7 +2309,7 @@ fn miner_writes_proposed_block_to_stackerdb() {
     let signer_bitvec = BitVec::<4000>::consensus_deserialize(&mut signer_bitvec_bytes.as_slice())
         .expect("Failed to deserialize signer bitvec");
 
-    assert_eq!(signer_bitvec.len(), 1);
+    assert_eq!(signer_bitvec.len(), 30);
 
     assert_eq!(
         format!("0x{}", observed_block.block_hash),


### PR DESCRIPTION
This fixes an integration test assertion in `develop`. The naka_node miner is correctly setting the bitvec length, which altered the assertion in this test.