### PR TITLE
feat: Sortition tracking in signer binary

### DIFF
--- a/stacks-signer/src/lib.rs
+++ b/stacks-signer/src/lib.rs
@@ -46,6 +46,7 @@ mod tests;
 use std::fmt::{Debug, Display};
 use std::sync::mpsc::{channel, Receiver, Sender};
 
+use chainstate::SortitionsView;
 use config::GlobalConfig;
 use libsigner::{SignerEvent, SignerEventReceiver, SignerEventTrait};
 use runloop::SignerResult;
@@ -68,6 +69,7 @@ pub trait Signer<T: SignerEventTrait>: Debug + Display {
     fn process_event(
         &mut self,
         stacks_client: &StacksClient,
+        sortition_state: &mut Option<SortitionsView>,
         event: Option<&SignerEvent<T>>,
         res: Sender<Vec<SignerResult>>,
         current_reward_cycle: u64,

--- a/stacks-signer/src/v1/signer.rs
+++ b/stacks-signer/src/v1/signer.rs
@@ -53,6 +53,7 @@ use wsts::traits::Signer as _;
 use wsts::v2;
 
 use super::stackerdb_manager::StackerDBManager;
+use crate::chainstate::SortitionsView;
 use crate::client::{ClientError, SignerSlotID, StacksClient};
 use crate::config::SignerConfig;
 use crate::runloop::{RunLoopCommand, SignerCommand, SignerResult};
@@ -161,6 +162,7 @@ impl SignerTrait<SignerMessage> for Signer {
     fn process_event(
         &mut self,
         stacks_client: &StacksClient,
+        _sortition_state: &mut Option<SortitionsView>,
         event: Option<&SignerEvent<SignerMessage>>,
         res: Sender<Vec<SignerResult>>,
         current_reward_cycle: u64,
@@ -238,7 +240,7 @@ impl SignerTrait<SignerMessage> for Signer {
                 debug!("{self}: Received a status check event.")
             }
             SignerEvent::NewBurnBlock(height) => {
-                debug!("{self}: Receved a new burn block event for block height {height}")
+                debug!("{self}: Receved a new burn block event for block height {height}");
             }
         }
     }

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -262,10 +262,8 @@ fn block_proposal_rejection() {
     );
 
     info!("------------------------- Test Block Proposal Rejected -------------------------");
-    // Verify that the node correctly rejected the node
-    let proposed_signer_signature_hash =
-        signer_test.wait_for_validate_reject_response(short_timeout);
-    assert_eq!(proposed_signer_signature_hash, block_signer_signature_hash);
+    // Give signer time to reject block
+    std::thread::sleep(Duration::from_secs(3));
 
     let mut stackerdb = StackerDB::new(
         &signer_test.running_nodes.conf.node.rpc_bind,

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -15,7 +15,7 @@
 
 use std::env;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use clarity::vm::types::PrincipalData;
 use libsigner::v0::messages::{
@@ -262,8 +262,6 @@ fn block_proposal_rejection() {
     );
 
     info!("------------------------- Test Block Proposal Rejected -------------------------");
-    // Give signer time to reject block
-    std::thread::sleep(Duration::from_secs(3));
 
     let mut stackerdb = StackerDB::new(
         &signer_test.running_nodes.conf.node.rpc_bind,
@@ -280,24 +278,32 @@ fn block_proposal_rejection() {
         .collect();
     assert_eq!(signer_slot_ids.len(), num_signers);
 
-    let messages: Vec<SignerMessage> = StackerDB::get_messages(
-        stackerdb
-            .get_session_mut(&MessageSlotID::BlockResponse)
-            .expect("Failed to get BlockResponse stackerdb session"),
-        &signer_slot_ids,
-    )
-    .expect("Failed to get message from stackerdb");
-    for message in messages {
-        if let SignerMessage::BlockResponse(BlockResponse::Rejected(BlockRejection {
-            reason: _reason,
-            reason_code,
-            signer_signature_hash,
-        })) = message
-        {
-            assert_eq!(signer_signature_hash, block_signer_signature_hash);
-            assert!(matches!(reason_code, RejectCode::ValidationFailed(_)));
-        } else {
-            panic!("Unexpected message type");
+    let start_polling = Instant::now();
+    'poll: loop {
+        std::thread::sleep(Duration::from_secs(1));
+        let messages: Vec<SignerMessage> = StackerDB::get_messages(
+            stackerdb
+                .get_session_mut(&MessageSlotID::BlockResponse)
+                .expect("Failed to get BlockResponse stackerdb session"),
+            &signer_slot_ids,
+        )
+        .expect("Failed to get message from stackerdb");
+        for message in messages {
+            if let SignerMessage::BlockResponse(BlockResponse::Rejected(BlockRejection {
+                reason: _reason,
+                reason_code,
+                signer_signature_hash,
+            })) = message
+            {
+                assert_eq!(signer_signature_hash, block_signer_signature_hash);
+                assert!(matches!(reason_code, RejectCode::ValidationFailed(_)));
+                break 'poll;
+            } else {
+                panic!("Unexpected message type");
+            }
+        }
+        if start_polling.elapsed() > short_timeout {
+            panic!("Timed out after waiting for response from signer");
         }
     }
     signer_test.shutdown();


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Fetch and cache sortition state as needed, and use it to validate incoming `BlockProposal`s

### Applicable issues

- fixes #4880

### Additional info (benefits, drawbacks, caveats)

Since this is my first time contributing to the signer binary, there are some things I'm unsure of that reviewers should check:
- This adds some blocking i/o in `handle_block_proposal()`
- I think it's correct to do these checks before `submit_block_for_validation()`, since that takes longer
- I only implemented this in signer `v0`. I didn't touch `v1`
- Is the public key passed to `check_proposal()` the correct one?
- I used `inspect_err()`, which was introduced a few months ago in Rust 1.76. Is this okay, and what's our MSRV policy in general?

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
