### PR TITLE
[fix]replacement the abs() with unsigned_abs()

### DIFF
--- a/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
@@ -201,7 +201,7 @@ fn build_scriptint(n: i64) -> Vec<u8> {
 
     let neg = n < 0;
 
-    let mut abs = n.abs() as usize;
+    let mut abs = n.unsigned_abs() as usize;
     let mut v = Vec::with_capacity(size_of::<usize>() + 1);
     while abs > 0xFF {
         v.push((abs & 0xFF) as u8);


### PR DESCRIPTION
abs() may be lead to panic in the debug mode and optimized code will return i64::MIN without a panic. so need use unsigned_abs() in here

<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
The absolute value of i64::MIN cannot be represented as an i64, and attempting to calculate it will cause an overflow. This means that code in debug mode will trigger a panic on this case and optimized code will return i64::MIN without a panic. so
in here  need replace abs() with unsigned_abs()

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
