### PR TITLE
First pass focusing on warn and info level logging. Couple debugs

### DIFF
--- a/stackslib/src/burnchains/affirmation.rs
+++ b/stackslib/src/burnchains/affirmation.rs
@@ -974,7 +974,8 @@ pub fn find_heaviest_block_commit<B: BurnchainHeaderReader>(
                 // found
                 debug!(
                     "PoX anchor block-commit {},{},{} has {} burnt, {} confs",
-                    &opdata.txid, opdata.block_height, opdata.vtxindex, most_burnt, most_confs
+                    &opdata.txid, opdata.block_height, opdata.vtxindex, most_burnt, most_confs;
+                    "stacks_block_hash" => opdata.block_header_hash
                 );
 
                 // sanity check -- there should be exactly as many confirmations on the suspected
@@ -996,7 +997,9 @@ pub fn find_heaviest_block_commit<B: BurnchainHeaderReader>(
                             if *op_ancestor_height == ancestor_block
                                 && *op_ancestor_vtxindex == ancestor_vtxindex
                             {
-                                debug!("Block-commit {},{} descends from likely PoX anchor block {},{}", opdata.block_height, opdata.vtxindex, op_ancestor_height, op_ancestor_vtxindex);
+                                debug!("Block-commit {},{} descends from likely PoX anchor block {},{}", opdata.block_height, opdata.vtxindex, op_ancestor_height, op_ancestor_vtxindex;
+                                    "stacks_block_hash" => opdata.block_header_hash
+                                );
                                 block_descendancy.push(true);
                                 if !found_conf {
                                     conf_count += 1;
@@ -1004,11 +1007,15 @@ pub fn find_heaviest_block_commit<B: BurnchainHeaderReader>(
                                 }
                                 burn_count += opdata.burn_fee;
                             } else {
-                                debug!("Block-commit {},{} does NOT descend from likely PoX anchor block {},{}", opdata.block_height, opdata.vtxindex, ancestor_block, ancestor_vtxindex);
+                                debug!("Block-commit {},{} does NOT descend from likely PoX anchor block {},{}", opdata.block_height, opdata.vtxindex, ancestor_block, ancestor_vtxindex;
+                                    "stacks_block_hash" => opdata.block_header_hash
+                                );
                                 block_descendancy.push(false);
                             }
                         } else {
-                            debug!("Block-commit {},{} does NOT descend from likely PoX anchor block {},{}", opdata.block_height, opdata.vtxindex, ancestor_block, ancestor_vtxindex);
+                            debug!("Block-commit {},{} does NOT descend from likely PoX anchor block {},{}", opdata.block_height, opdata.vtxindex, ancestor_block, ancestor_vtxindex;
+                                "stacks_block_hash" => opdata.block_header_hash
+                            );
                             block_descendancy.push(false);
                         }
                     }

--- a/stackslib/src/burnchains/burnchain.rs
+++ b/stackslib/src/burnchains/burnchain.rs
@@ -249,8 +249,11 @@ impl BurnchainStateTransition {
             for blocks_back in 0..(epoch_id.mining_commitment_window() - 1) {
                 if parent_snapshot.block_height < (blocks_back as u64) {
                     debug!("Mining commitment window shortened because block height is less than window size";
-                           "block_height" => %parent_snapshot.block_height,
-                           "window_size" => %epoch_id.mining_commitment_window());
+                        "block_height" => %parent_snapshot.block_height,
+                        "window_size" => %epoch_id.mining_commitment_window(),
+                        "burn_block_hash" => %parent_snapshot.burn_header_hash,
+                        "consensus_hash" => %parent_snapshot.consensus_hash
+                    );
                     break;
                 }
                 let block_height = parent_snapshot.block_height - (blocks_back as u64);
@@ -275,13 +278,17 @@ impl BurnchainStateTransition {
                 "Block {} is in a reward phase with PoX. Miner commit window is {}: {:?}",
                 parent_snapshot.block_height + 1,
                 windowed_block_commits.len(),
-                &windowed_block_commits
+                &windowed_block_commits;
+                "burn_block_hash" => %parent_snapshot.burn_header_hash,
+                "consensus_hash" => %parent_snapshot.consensus_hash
             );
         } else {
             // PoX reward-phase is not active, or we're starting a new epoch
             debug!(
                 "Block {} is in a prepare phase, in the post-PoX sunset, or in an epoch transition, so no windowing will take place",
-                parent_snapshot.block_height + 1
+                parent_snapshot.block_height + 1;
+                "burn_block_hash" => %parent_snapshot.burn_header_hash,
+                "consensus_hash" => %parent_snapshot.consensus_hash
             );
 
             assert_eq!(windowed_block_commits.len(), 1);
@@ -342,7 +349,8 @@ impl BurnchainStateTransition {
         for op in all_block_commits.values() {
             warn!(
                 "REJECTED({}) block commit {} at {},{}: Committed to an already-consumed VRF key",
-                op.block_height, &op.txid, op.block_height, op.vtxindex
+                op.block_height, &op.txid, op.block_height, op.vtxindex;
+                "stacks_block_hash" => %op.block_header_hash
             );
         }
 
@@ -1001,7 +1009,8 @@ impl Burnchain {
                     // duplicate
                     warn!(
                         "REJECTED({}) leader key register {} at {},{}: Duplicate VRF key",
-                        data.block_height, &data.txid, data.block_height, data.vtxindex
+                        data.block_height, &data.txid, data.block_height, data.vtxindex;
+                        "consensus_hash" => %data.consensus_hash
                     );
                     false
                 } else {
@@ -1071,7 +1080,7 @@ impl Burnchain {
                 "prev_reward_cycle" => %prev_reward_cycle,
                 "this_reward_cycle" => %this_reward_cycle,
                 "block_height" => %block_height,
-                "cycle-length" => %burnchain.pox_constants.reward_cycle_length
+                "cycle_length" => %burnchain.pox_constants.reward_cycle_length,
             );
             update_pox_affirmation_maps(burnchain_db, indexer, prev_reward_cycle, burnchain)?;
         }
@@ -1312,7 +1321,8 @@ impl Burnchain {
                         "Parsed block {} (epoch {}) in {}ms",
                         burnchain_block.block_height(),
                         cur_epoch.epoch_id,
-                        parse_end.saturating_sub(parse_start)
+                        parse_end.saturating_sub(parse_start);
+                        "burn_block_hash" => %burnchain_block.block_hash()
                     );
 
                     db_send
@@ -1350,7 +1360,8 @@ impl Burnchain {
                 debug!(
                     "Inserted block {} in {}ms",
                     burnchain_block.block_height(),
-                    insert_end.saturating_sub(insert_start)
+                    insert_end.saturating_sub(insert_start);
+                    "burn_block_hash" => %burnchain_block.block_hash()
                 );
             }
             Ok(last_processed)
@@ -1647,7 +1658,8 @@ impl Burnchain {
                         "Parsed block {} (in epoch {}) in {}ms",
                         burnchain_block.block_height(),
                         cur_epoch.epoch_id,
-                        parse_end.saturating_sub(parse_start)
+                        parse_end.saturating_sub(parse_start);
+                        "burn_block_hash" => %burnchain_block.block_hash()
                     );
 
                     db_send
@@ -1699,7 +1711,8 @@ impl Burnchain {
                         debug!(
                             "Inserted block {} in {}ms",
                             burnchain_block.block_height(),
-                            insert_end.saturating_sub(insert_start)
+                            insert_end.saturating_sub(insert_start);
+                            "burn_block_hash" => %burnchain_block.block_hash()
                         );
                     }
                     Ok(last_processed)

--- a/stackslib/src/burnchains/db.rs
+++ b/stackslib/src/burnchains/db.rs
@@ -404,12 +404,12 @@ impl<'a> BurnchainDBTransaction<'a> {
         match self.sql_tx.execute(sql, args) {
             Ok(_) => {
                 info!(
-                    "Set anchor block for reward cycle {} to {},{},{},{}",
-                    target_reward_cycle,
-                    &block_commit.burn_header_hash,
-                    &block_commit.txid,
-                    &block_commit.block_height,
-                    &block_commit.vtxindex
+                    "Setting anchor block for reward cycle {target_reward_cycle}.";
+                    "burn_block_hash" => %block_commit.burn_header_hash,
+                    "stacks_block_hash" => %block_commit.block_header_hash,
+                    "block_commit_txid" => %block_commit.txid,
+                    "block_commit_height" => block_commit.block_height,
+                    "block_commit_vtxindex" => block_commit.vtxindex,
                 );
                 Ok(())
             }
@@ -1419,7 +1419,9 @@ impl BurnchainDB {
     ) -> Result<Vec<BlockstackOperationType>, BurnchainError> {
         let header = block.header();
         debug!("Storing new burnchain block";
-              "burn_header_hash" => %header.block_hash.to_string());
+              "burn_block_hash" => %header.block_hash,
+              "block_height" => header.block_height
+        );
         let mut blockstack_ops =
             self.get_blockstack_transactions(burnchain, indexer, block, &header, epoch_id);
         apply_blockstack_txs_safety_checks(header.block_height, &mut blockstack_ops);

--- a/stackslib/src/chainstate/burn/db/processing.rs
+++ b/stackslib/src/chainstate/burn/db/processing.rs
@@ -48,7 +48,8 @@ impl<'a> SortitionHandleTx<'a> {
                 op.check(burnchain, self).map_err(|e| {
                     warn!(
                         "REJECTED({}) leader key register {} at {},{}: {:?}",
-                        op.block_height, &op.txid, op.block_height, op.vtxindex, &e
+                        op.block_height, &op.txid, op.block_height, op.vtxindex, &e;
+                        "consensus_hash" => %op.consensus_hash
                     );
                     BurnchainError::OpError(e)
                 })
@@ -63,7 +64,8 @@ impl<'a> SortitionHandleTx<'a> {
                         op.vtxindex,
                         op.parent_block_ptr,
                         op.parent_vtxindex,
-                        &e
+                        &e;
+                        "stacks_block_hash" => %op.block_header_hash
                     );
                     BurnchainError::OpError(e)
                 })

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -1618,8 +1618,10 @@ impl<'a> SortitionHandleTx<'a> {
                         .map(|ix| {
                             let recipient = reward_set.rewarded_addresses[ix as usize].clone();
                             info!("PoX recipient chosen";
-                                   "recipient" => recipient.to_burnchain_repr(),
-                                   "block_height" => block_height);
+                               "recipient" => recipient.to_burnchain_repr(),
+                               "block_height" => block_height,
+                               "anchor_stacks_block_hash" => &anchor_block,
+                            );
                             (recipient, u16::try_from(ix).unwrap())
                         })
                         .collect(),
@@ -1651,8 +1653,10 @@ impl<'a> SortitionHandleTx<'a> {
                         let ix = u16::try_from(ix).unwrap();
                         let recipient = self.get_reward_set_entry(ix)?;
                         info!("PoX recipient chosen";
-                               "recipient" => recipient.to_burnchain_repr(),
-                               "block_height" => block_height);
+                           "recipient" => recipient.to_burnchain_repr(),
+                           "block_height" => block_height,
+                           "stacks_block_hash" => %anchor_block
+                        );
                         recipients.push((recipient, ix));
                     }
                     Ok(Some(RewardSetInfo {
@@ -5532,7 +5536,9 @@ impl<'a> SortitionHandleTx<'a> {
             BlockstackOperationType::LeaderKeyRegister(ref op) => {
                 info!(
                     "ACCEPTED({}) leader key register {} at {},{}",
-                    op.block_height, &op.txid, op.block_height, op.vtxindex
+                    op.block_height, &op.txid, op.block_height, op.vtxindex;
+                    "consensus_hash" => %op.consensus_hash,
+                    "burn_header_hash" => %op.burn_header_hash
                 );
                 self.insert_leader_key(op, sort_id)
             }
@@ -5540,7 +5546,8 @@ impl<'a> SortitionHandleTx<'a> {
                 info!(
                     "ACCEPTED({}) leader block commit {} at {},{}",
                     op.block_height, &op.txid, op.block_height, op.vtxindex;
-                    "apparent_sender" => %op.apparent_sender
+                    "apparent_sender" => %op.apparent_sender,
+                    "stacks_block_hash" => %op.block_header_hash
                 );
                 self.insert_block_commit(op, sort_id)
             }
@@ -5561,7 +5568,8 @@ impl<'a> SortitionHandleTx<'a> {
             BlockstackOperationType::PreStx(ref op) => {
                 info!(
                     "ACCEPTED({}) pre stack stx op {} at {},{}",
-                    op.block_height, &op.txid, op.block_height, op.vtxindex
+                    op.block_height, &op.txid, op.block_height, op.vtxindex;
+                    "burn_header_hash" => %op.burn_header_hash
                 );
                 // no need to store this op in the sortition db.
                 Ok(())

--- a/stackslib/src/chainstate/burn/sortition.rs
+++ b/stackslib/src/chainstate/burn/sortition.rs
@@ -680,9 +680,10 @@ impl BlockSnapshot {
         }
 
         if let Some(reject_winner_reason) = reject_winner_reason {
-            info!("SORTITION({}): WINNER REJECTED: {}", block_height, &reject_winner_reason;
+            info!("SORTITION({block_height}): WINNER REJECTED: {reject_winner_reason:?}";
                   "txid" => %winning_block.txid,
-                  "block_hash" => %winning_block.block_header_hash);
+                  "stacks_block_hash" => %winning_block.block_header_hash,
+                  "burn_block_hash" => %winning_block.burn_header_hash);
 
             // N.B. can't use `make_snapshot_no_sortition()` helper here because then `sort_tx`
             // would be mutably borrowed twice.
@@ -714,10 +715,10 @@ impl BlockSnapshot {
             my_pox_id,
         )?;
 
-        info!(
-            "SORTITION({}): WINNER IS {:?} (from {:?})",
-            block_height, &winning_block.block_header_hash, &winning_block.txid
-        );
+        info!("SORTITION({block_height}): WINNER SELECTED";
+            "txid" => %winning_block.txid,
+            "stacks_block_hash" => %winning_block.block_header_hash,
+            "burn_block_hash" => %winning_block.burn_header_hash);
 
         let miner_pk_hash = sort_tx
             .get_leader_key_at(

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -236,7 +236,10 @@ impl NakamotoBlockBuilder {
             SortitionDB::get_block_snapshot_consensus(&burn_dbconn, &self.header.consensus_hash)?
         else {
             warn!("Could not find sortition snapshot for burn block that elected the miner";
-                  "consensus_hash" => %self.header.consensus_hash);
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(Error::NoSuchBlockError);
         };
         let Some(tenure_block_commit) = SortitionDB::get_block_commit(
@@ -246,8 +249,11 @@ impl NakamotoBlockBuilder {
         )?
         else {
             warn!("Could not find winning block commit for burn block that elected the miner";
-                  "consensus_hash" => %self.header.consensus_hash,
-                  "winning_txid" => %tenure_election_sn.winning_block_txid);
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id(),
+                "winning_txid" => %tenure_election_sn.winning_block_txid
+            );
             return Err(Error::NoSuchBlockError);
         };
 
@@ -560,8 +566,8 @@ impl NakamotoBlockBuilder {
 
         info!(
             "Miner: mined Nakamoto block";
-            "block_hash" => %block.header.block_hash(),
-            "block_id" => %block.header.block_id(),
+            "stacks_block_hash" => %block.header.block_hash(),
+            "stacks_block_id" => %block.header.block_id(),
             "height" => block.header.chain_length,
             "tx_count" => block.txs.len(),
             "parent_block_id" => %block.header.parent_block_id,

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -851,13 +851,21 @@ impl NakamotoBlock {
         }
 
         let Some(tc_payload) = self.try_get_tenure_change_payload() else {
-            warn!("Invalid block -- tx at index 0 is not a tenure tx",);
+            warn!("Invalid block -- tx at index 0 is not a tenure tx";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(());
         };
         if tc_payload.cause != TenureChangeCause::Extended {
             // not a tenure-extend, and can't be valid since all other tenure-change types require
             // a coinbase (which is not present)
-            warn!("Invalid block -- tenure tx cause is not an extension");
+            warn!("Invalid block -- tenure tx cause is not an extension";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(());
         }
 
@@ -866,7 +874,10 @@ impl NakamotoBlock {
             warn!(
                 "Invalid block -- discontiguous";
                 "previous_tenure_end" => %tc_payload.previous_tenure_end,
-                "parent_block_id" => %self.header.parent_block_id
+                "parent_block_id" => %self.header.parent_block_id,
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
             );
             return Err(());
         }
@@ -880,6 +891,8 @@ impl NakamotoBlock {
                 "tenure_consensus_hash" => %tc_payload.tenure_consensus_hash,
                 "prev_tenure_consensus_hash" => %tc_payload.prev_tenure_consensus_hash,
                 "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
             );
             return Err(());
         }
@@ -935,14 +948,21 @@ impl NakamotoBlock {
             warn!(
                 "Invalid block -- have {} coinbases and {} tenure txs",
                 coinbase_positions.len(),
-                tenure_change_positions.len()
+                tenure_change_positions.len();
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
             );
             return Err(());
         }
 
         if coinbase_positions.len() == 1 && tenure_change_positions.len() == 0 {
             // coinbase unaccompanied by a tenure change
-            warn!("Invalid block -- have coinbase without tenure change");
+            warn!("Invalid block -- have coinbase without tenure change";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(());
         }
 
@@ -953,7 +973,10 @@ impl NakamotoBlock {
                 // wrong position
                 warn!(
                     "Invalid block -- tenure change positions = {:?}, expected [0]",
-                    &tenure_change_positions,
+                    &tenure_change_positions;
+                    "consensus_hash" => %self.header.consensus_hash,
+                    "stacks_block_hash" => %self.header.block_hash(),
+                    "stacks_block_id" => %self.header.block_id()
                 );
                 return Err(());
             }
@@ -962,13 +985,21 @@ impl NakamotoBlock {
             let TransactionPayload::TenureChange(tc_payload) = &self.txs[0].payload else {
                 // this transaction is not a tenure change
                 // (should be unreachable)
-                warn!("Invalid block -- first transaction is not a tenure change");
+                warn!("Invalid block -- first transaction is not a tenure change";
+                    "consensus_hash" => %self.header.consensus_hash,
+                    "stacks_block_hash" => %self.header.block_hash(),
+                    "stacks_block_id" => %self.header.block_id()
+                );
                 return Err(());
             };
 
             if tc_payload.cause.expects_sortition() {
                 // not valid
-                warn!("Invalid block -- no coinbase, but tenure change expects sortition");
+                warn!("Invalid block -- no coinbase, but tenure change expects sortition";
+                    "consensus_hash" => %self.header.consensus_hash,
+                    "stacks_block_hash" => %self.header.block_hash(),
+                    "stacks_block_id" => %self.header.block_id()
+                );
                 return Err(());
             }
 
@@ -982,24 +1013,39 @@ impl NakamotoBlock {
         if coinbase_positions[0] != coinbase_idx && tenure_change_positions[0] != tc_idx {
             // invalid -- expect exactly one sortition-induced tenure change and exactly one coinbase expected,
             // and the tenure change must be the first transaction and the coinbase must be the second transaction
-            warn!("Invalid block -- coinbase and/or tenure change txs are in the wrong position -- ({:?}, {:?}) != [{}], [{}]", &coinbase_positions, &tenure_change_positions, coinbase_idx, tc_idx);
+            warn!("Invalid block -- coinbase and/or tenure change txs are in the wrong position -- ({:?}, {:?}) != [{}], [{}]", &coinbase_positions, &tenure_change_positions, coinbase_idx, tc_idx;
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(());
         }
         let Some(tc_payload) = self.try_get_tenure_change_payload() else {
-            warn!("Invalid block -- tx at index 0 is not a tenure tx",);
+            warn!("Invalid block -- tx at index 0 is not a tenure tx";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(());
         };
         if !tc_payload.cause.expects_sortition() {
             // the only tenure change allowed in a block with a coinbase is a sortition-triggered
             // tenure change
-            warn!("Invalid block -- tenure change does not expect a sortition");
+            warn!("Invalid block -- tenure change does not expect a sortition";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(());
         }
         if tc_payload.previous_tenure_end != self.header.parent_block_id {
             // discontinuous
             warn!(
                 "Invalid block -- discontiguous -- {} != {}",
-                &tc_payload.previous_tenure_end, &self.header.parent_block_id
+                &tc_payload.previous_tenure_end, &self.header.parent_block_id;
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
             );
             return Err(());
         }
@@ -1010,13 +1056,20 @@ impl NakamotoBlock {
             // this transaction is not a coinbase (but this should be unreachable)
             warn!(
                 "Invalid block -- tx index {} is not a coinbase",
-                coinbase_idx
+                coinbase_idx;
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
             );
             return Err(());
         };
         if vrf_proof_opt.is_none() {
             // not a Nakamoto coinbase
-            warn!("Invalid block -- no VRF proof in coinbase");
+            warn!("Invalid block -- no VRF proof in coinbase";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return Err(());
         }
 
@@ -1041,7 +1094,9 @@ impl NakamotoBlock {
         )?;
         if !block_commit.new_seed.is_from_proof(&parent_vrf_proof) {
             warn!("Invalid Nakamoto block-commit: seed does not match parent VRF proof";
-                  "block_id" => %self.block_id(),
+                  "consensus_hash" => %self.header.consensus_hash,
+                  "stacks_block_hash" => %self.header.block_hash(),
+                  "stacks_block_id" => %self.block_id(),
                   "commit_seed" => %block_commit.new_seed,
                   "proof_seed" => %VRFSeed::from_proof(&parent_vrf_proof),
                   "parent_vrf_proof" => %parent_vrf_proof.to_hex(),
@@ -1063,8 +1118,9 @@ impl NakamotoBlock {
         let recovered_miner_pubk = self.header.recover_miner_pk().ok_or_else(|| {
             warn!(
                 "Nakamoto Stacks block downloaded with unrecoverable miner public key";
-                "block_hash" => %self.header.block_hash(),
-                "block_id" => %self.header.block_id(),
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
             );
             return ChainstateError::InvalidStacksBlock("Unrecoverable miner public key".into());
         })?;
@@ -1082,8 +1138,9 @@ impl NakamotoBlock {
         if &recovered_miner_hash160 != miner_pubkey_hash160 {
             warn!(
                 "Nakamoto Stacks block signature mismatch: {recovered_miner_hash160} != {miner_pubkey_hash160} from leader-key";
-                "block_hash" => %self.header.block_hash(),
-                "block_id" => %self.header.block_id(),
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
             );
             return Err(ChainstateError::InvalidStacksBlock(
                 "Invalid miner signature".into(),
@@ -1110,8 +1167,9 @@ impl NakamotoBlock {
         if tc_payload.pubkey_hash != recovered_miner_hash160 {
             warn!(
                 "Invalid tenure-change transaction -- bad miner pubkey hash160";
-                "block_hash" => %self.header.block_hash(),
-                "block_id" => %self.header.block_id(),
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id(),
                 "pubkey_hash" => %tc_payload.pubkey_hash,
                 "recovered_miner_hash160" => %recovered_miner_hash160
             );
@@ -1125,9 +1183,9 @@ impl NakamotoBlock {
         if tc_payload.tenure_consensus_hash != self.header.consensus_hash {
             warn!(
                 "Invalid tenure-change transaction -- bad consensus hash";
-                "block_hash" => %self.header.block_hash(),
-                "block_id" => %self.header.block_id(),
                 "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id(),
                 "tc_payload.tenure_consensus_hash" => %tc_payload.tenure_consensus_hash
             );
             return Err(ChainstateError::InvalidStacksBlock(
@@ -1173,9 +1231,11 @@ impl NakamotoBlock {
 
             if !valid {
                 warn!("Invalid Nakamoto block: leader VRF key did not produce a valid proof";
-                      "block_id" => %self.block_id(),
-                      "leader_public_key" => %leader_vrf_key.to_hex(),
-                      "sortition_hash" => %sortition_hash
+                    "consensus_hash" => %self.header.consensus_hash,
+                    "stacks_block_hash" => %self.header.block_hash(),
+                    "stacks_block_id" => %self.header.block_id(),
+                    "leader_public_key" => %leader_vrf_key.to_hex(),
+                    "sortition_hash" => %sortition_hash
                 );
                 return Err(ChainstateError::InvalidStacksBlock(
                     "Invalid Nakamoto block: leader VRF key did not produce a valid proof".into(),
@@ -1210,8 +1270,10 @@ impl NakamotoBlock {
         // this block's consensus hash must match the sortition that selected it
         if tenure_burn_chain_tip.consensus_hash != self.header.consensus_hash {
             warn!("Invalid Nakamoto block: consensus hash does not match sortition";
-                  "consensus_hash" => %self.header.consensus_hash,
-                  "sortition.consensus_hash" => %tenure_burn_chain_tip.consensus_hash
+                "sortition.consensus_hash" => %tenure_burn_chain_tip.consensus_hash,
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id(),
             );
             return Err(ChainstateError::InvalidStacksBlock(
                 "Invalid Nakamoto block: invalid consensus hash".into(),
@@ -1222,8 +1284,11 @@ impl NakamotoBlock {
         if let Some(expected_burn) = expected_burn {
             if self.header.burn_spent != expected_burn {
                 warn!("Invalid Nakamoto block header: invalid total burns";
-                      "header.burn_spent" => self.header.burn_spent,
-                      "expected_burn" => expected_burn,
+                    "header.burn_spent" => self.header.burn_spent,
+                    "expected_burn" => expected_burn,
+                    "consensus_hash" => %self.header.consensus_hash,
+                    "stacks_block_hash" => %self.header.block_hash(),
+                    "stacks_block_id" => %self.header.block_id()
                 );
                 return Err(ChainstateError::InvalidStacksBlock(
                     "Invalid Nakamoto block: invalid total burns".into(),
@@ -1298,7 +1363,11 @@ impl NakamotoBlock {
             }
         } else if valid_tenure_start.is_err() {
             // bad tenure change
-            warn!("Not a well-formed tenure-start block");
+            warn!("Not a well-formed tenure-start block";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return false;
         }
         let valid_tenure_extend = self.is_wellformed_tenure_extend_block();
@@ -1308,7 +1377,11 @@ impl NakamotoBlock {
             }
         } else if valid_tenure_extend.is_err() {
             // bad tenure extend
-            warn!("Not a well-formed tenure-extend block");
+            warn!("Not a well-formed tenure-extend block";
+                "consensus_hash" => %self.header.consensus_hash,
+                "stacks_block_hash" => %self.header.block_hash(),
+                "stacks_block_id" => %self.header.block_id()
+            );
             return false;
         }
         if !StacksBlock::validate_transactions_static_epoch(&self.txs, epoch_id) {
@@ -1437,7 +1510,8 @@ impl NakamotoChainState {
 
         debug!("Process staging Nakamoto block";
                "consensus_hash" => %next_ready_block.header.consensus_hash,
-               "block_hash" => %next_ready_block.header.block_hash(),
+               "stacks_block_hash" => %next_ready_block.header.block_hash(),
+               "stacks_block_id" => %next_ready_block.header.block_id(),
                "burn_block_hash" => %next_ready_block_snapshot.burn_header_hash
         );
 
@@ -1463,7 +1537,8 @@ impl NakamotoChainState {
                 "Cannot process Nakamoto block: could not load reward set that elected the block";
                 "err" => ?e,
                 "consensus_hash" => %next_ready_block.header.consensus_hash,
-                "block_hash" => %next_ready_block.header.block_hash(),
+                "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                "stacks_block_id" => %next_ready_block.header.block_id(),
                 "parent_block_id" => %next_ready_block.header.parent_block_id,
             );
             ChainstateError::NoSuchBlockError
@@ -1477,7 +1552,8 @@ impl NakamotoChainState {
             // no parent; cannot process yet
             debug!("Cannot process Nakamoto block: missing parent header";
                    "consensus_hash" => %next_ready_block.header.consensus_hash,
-                   "block_hash" => %next_ready_block.header.block_hash(),
+                   "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                   "stacks_block_id" => %next_ready_block.header.block_id(),
                    "parent_block_id" => %next_ready_block.header.parent_block_id
             );
             return Ok(None);
@@ -1494,7 +1570,10 @@ impl NakamotoChainState {
             let msg = "Discontinuous Nakamoto Stacks block";
             warn!("{}", &msg;
                   "child parent_block_id" => %next_ready_block.header.parent_block_id,
-                  "expected parent_block_id" => %parent_block_id
+                  "expected parent_block_id" => %parent_block_id,
+                  "consensus_hash" => %next_ready_block.header.consensus_hash,
+                  "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                  "stacks_block_id" => %next_ready_block.header.block_id()
             );
             let staging_block_tx = stacks_chain_state.staging_db_tx_begin()?;
             staging_block_tx.set_block_orphaned(&block_id)?;
@@ -1518,8 +1597,8 @@ impl NakamotoChainState {
                     warn!(
                         "Cannot process Nakamoto block: could not find parent block's burnchain view";
                         "consensus_hash" => %next_ready_block.header.consensus_hash,
-                        "block_hash" => %next_ready_block.header.block_hash(),
-                        "block_id" => %next_ready_block.block_id(),
+                        "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                        "stacks_block_id" => %next_ready_block.header.block_id(),
                         "parent_block_id" => %next_ready_block.header.parent_block_id
                     );
                     ChainstateError::InvalidStacksBlock("Failed to load burn view of parent block ID".into())                    
@@ -1530,19 +1609,19 @@ impl NakamotoChainState {
                         warn!(
                             "Cannot process Nakamoto block: could not find parent block's burnchain view";
                             "consensus_hash" => %next_ready_block.header.consensus_hash,
-                            "block_hash" => %next_ready_block.header.block_hash(),
-                            "block_id" => %next_ready_block.block_id(),
+                            "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                            "stacks_block_id" => %next_ready_block.header.block_id(),
                             "parent_block_id" => %next_ready_block.header.parent_block_id
                         );
                         ChainstateError::InvalidStacksBlock("Failed to load burn view of parent block ID".into())                    
                     })?;
                 if connected_sort_id != parent_burn_view_sn.sortition_id {
                     warn!(
-                            "Cannot process Nakamoto block: parent block's burnchain view does not connect to own burn view";
-                            "consensus_hash" => %next_ready_block.header.consensus_hash,
-                            "block_hash" => %next_ready_block.header.block_hash(),
-                            "block_id" => %next_ready_block.block_id(),
-                            "parent_block_id" => %next_ready_block.header.parent_block_id
+                        "Cannot process Nakamoto block: parent block's burnchain view does not connect to own burn view";
+                        "consensus_hash" => %next_ready_block.header.consensus_hash,
+                        "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                        "stacks_block_id" => %next_ready_block.header.block_id(),
+                        "parent_block_id" => %next_ready_block.header.parent_block_id
                     );
                     return Err(ChainstateError::InvalidStacksBlock(
                         "Does not connect to burn view of parent block ID".into(),
@@ -1555,8 +1634,8 @@ impl NakamotoChainState {
                 warn!(
                     "Cannot process Nakamoto block: parent block does not have a burnchain view and current block has no tenure tx";
                     "consensus_hash" => %next_ready_block.header.consensus_hash,
-                    "block_hash" => %next_ready_block.header.block_hash(),
-                    "block_id" => %next_ready_block.block_id(),
+                    "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                    "stacks_block_id" => %next_ready_block.header.block_id(),
                     "parent_block_id" => %next_ready_block.header.parent_block_id
                 );
                 ChainstateError::InvalidStacksBlock("Failed to load burn view of parent block ID".into())
@@ -1574,7 +1653,8 @@ impl NakamotoChainState {
             warn!(
                 "Cannot process Nakamoto block: failed to find Sortition ID associated with burnchain view";
                 "consensus_hash" => %next_ready_block.header.consensus_hash,
-                "block_hash" => %next_ready_block.header.block_hash(),
+                "stacks_block_hash" => %next_ready_block.header.block_hash(),
+                "stacks_block_id" => %next_ready_block.header.block_id(),
                 "burn_view_consensus_hash" => %burnchain_view,
             );
             return Ok(None);
@@ -1649,7 +1729,8 @@ impl NakamotoChainState {
                 "Failed to append {}/{}: {:?}",
                 &next_ready_block.header.consensus_hash,
                 &next_ready_block.header.block_hash(),
-                &e
+                &e;
+                "stacks_block_id" => %next_ready_block.header.block_id()
             );
 
             // as a separate transaction, mark this block as processed and orphaned.
@@ -1854,7 +1935,7 @@ impl NakamotoChainState {
             warn!(
                 "Invalid Nakamoto block, could not validate on burnchain";
                 "consensus_hash" => %consensus_hash,
-                "block_hash" => %block_hash,
+                "stacks_block_hash" => %block_hash,
                 "error" => ?e
             );
 
@@ -1991,7 +2072,7 @@ impl NakamotoChainState {
             config.chain_id,
         ) {
             warn!("Unacceptable Nakamoto block; will not store";
-                  "block_id" => %block.block_id(),
+                  "stacks_block_id" => %block.block_id(),
                   "error" => ?e
             );
             return Ok(false);
@@ -1999,7 +2080,7 @@ impl NakamotoChainState {
 
         if let Err(e) = block.header.verify_signer_signatures(&reward_set) {
             warn!("Received block, but the signer signatures are invalid";
-                  "block_id" => %block.block_id(),
+                  "stacks_block_id" => %block.block_id(),
                   "error" => ?e,
             );
             return Err(e);
@@ -2270,7 +2351,9 @@ impl NakamotoChainState {
                 .ok_or(ChainstateError::NoSuchBlockError)
                 .map_err(|e| {
                     warn!("Nakamoto block has no parent";
-                      "block consensus_hash" => %consensus_hash);
+                        "consensus_hash" => %consensus_hash,
+                        "parent_consensus_hash" => %parent_sn.consensus_hash
+                    );
                     e
                 })?;
 
@@ -2355,7 +2438,11 @@ impl NakamotoChainState {
             SortitionDB::get_block_snapshot_consensus(sortdb_conn, &block.header.consensus_hash)?
                 .ok_or(ChainstateError::NoSuchBlockError)
                 .map_err(|e| {
-                    warn!("No block-commit for block"; "block_id" => %block.block_id());
+                    warn!("No block-commit for block";
+                        "consensus_hash" => %block.header.consensus_hash,
+                        "stacks_block_hash" => %block.header.block_hash(),
+                        "stacks_block_id" => %block.header.block_id()
+                    );
                     e
                 })?;
 
@@ -2363,7 +2450,11 @@ impl NakamotoChainState {
             get_block_commit_by_txid(sortdb_conn, &sn.sortition_id, &sn.winning_block_txid)?
                 .ok_or(ChainstateError::NoSuchBlockError)
                 .map_err(|e| {
-                    warn!("No block-commit for block"; "block_id" => %block.block_id());
+                    warn!("No block-commit for block";
+                        "consensus_hash" => %block.header.consensus_hash,
+                        "stacks_block_hash" => %block.header.block_hash(),
+                        "stacks_block_id" => %block.header.block_id()
+                    );
                     e
                 })?;
 
@@ -2562,7 +2653,7 @@ impl NakamotoChainState {
                     warn!(
                         "Failed to fetch parent block's total tx fees";
                         "parent_block_id" => %parent_hash,
-                        "block_id" => %index_block_hash,
+                        "stacks_block_id" => %index_block_hash,
                     );
                     ChainstateError::NoSuchBlockError
                 })?
@@ -3118,7 +3209,9 @@ impl NakamotoChainState {
                 || {
                     warn!(
                         "Parent of Nakamoto block is not in block headers DB yet";
-                        "block_hash" => %block.header.block_hash(),
+                        "consensus_hash" => %block.header.consensus_hash,
+                        "stacks_block_hash" => %block.header.block_hash(),
+                        "stacks_block_id" => %block.header.block_id(),
                         "parent_block_hash" => %parent_block_hash,
                         "parent_block_id" => %parent_block_id
                     );
@@ -3130,17 +3223,21 @@ impl NakamotoChainState {
         let expected_burn_opt = Self::get_expected_burns(burn_dbconn, chainstate_tx, block)
             .map_err(|e| {
                 warn!("Unacceptable Nakamoto block: could not load expected burns (unable to find its paired sortition)";
-                      "block_id" => %block.block_id(),
-                      "parent_block_id" => %block.header.parent_block_id,
-                      "error" => e.to_string(),
+                    "consensus_hash" => %block.header.consensus_hash,
+                    "stacks_block_hash" => %block.header.block_hash(),
+                    "stacks_block_id" => %block.block_id(),
+                    "parent_block_id" => %block.header.parent_block_id,
+                    "error" => e.to_string(),
                 );
                 ChainstateError::InvalidStacksBlock("Invalid Nakamoto block: could not find sortition burns".into())
             })?;
 
         let Some(expected_burn) = expected_burn_opt else {
             warn!("Unacceptable Nakamoto block: unable to find parent block's burns";
-                  "block_id" => %block.block_id(),
-                  "parent_block_id" => %block.header.parent_block_id,
+                "consensus_hash" => %block.header.consensus_hash,
+                "stacks_block_hash" => %block.header.block_hash(),
+                "stacks_block_id" => %block.block_id(),
+                "parent_block_id" => %block.header.parent_block_id,
             );
             return Err(ChainstateError::InvalidStacksBlock(
                 "Invalid Nakamoto block: could not find sortition burns".into(),
@@ -3166,9 +3263,12 @@ impl NakamotoChainState {
         )?
         .ok_or_else(|| {
             warn!("Invalid Nakamoto block: has no block-commit in its sortition";
-                      "block_id" => %block.header.block_id(),
-                      "sortition_id" => %tenure_block_snapshot.sortition_id,
-                      "block_commit_txid" => %tenure_block_snapshot.winning_block_txid);
+                "consensus_hash" => %block.header.consensus_hash,
+                "stacks_block_hash" => %block.header.block_hash(),
+                "stacks_block_id" => %block.header.block_id(),
+                "sortition_id" => %tenure_block_snapshot.sortition_id,
+                "block_commit_txid" => %tenure_block_snapshot.winning_block_txid
+            );
             ChainstateError::NoSuchBlockError
         })?;
 
@@ -3181,19 +3281,21 @@ impl NakamotoChainState {
                 Self::get_nakamoto_tenure_start_block_header(chainstate_tx.tx(), &parent_ch)?
                     .ok_or_else(|| {
                         warn!("Invalid Nakamoto block: no start-tenure block for parent";
-                          "parent_consensus_hash" => %parent_ch,
-                          "block_id" => %block.header.block_id());
-
+                            "parent_consensus_hash" => %parent_ch,
+                            "consensus_hash" => %block.header.consensus_hash,
+                            "stacks_block_hash" => %block.header.block_hash(),
+                            "stacks_block_id" => %block.header.block_id()
+                        );
                         ChainstateError::NoSuchBlockError
                     })?;
 
             if parent_tenure_start_header.index_block_hash() != tenure_block_commit.last_tenure_id()
             {
                 warn!("Invalid Nakamoto block: its tenure's block-commit's block ID hash does not match its parent tenure's start block";
-                      "block_id" => %block.header.block_id(),
-                      "parent_consensus_hash" => %parent_ch,
-                      "parent_tenure_start_block_id" => %parent_tenure_start_header.index_block_hash(),
-                      "block_commit.last_tenure_id" => %tenure_block_commit.last_tenure_id());
+                    "parent_consensus_hash" => %parent_ch,
+                    "parent_tenure_start_block_id" => %parent_tenure_start_header.index_block_hash(),
+                    "block_commit.last_tenure_id" => %tenure_block_commit.last_tenure_id()
+                );
 
                 return Err(ChainstateError::NoSuchBlockError);
             }
@@ -3670,7 +3772,11 @@ impl StacksMessageCodec for NakamotoBlock {
 
         // all transactions are unique
         if !StacksBlock::validate_transactions_unique(&txs) {
-            warn!("Invalid block: Found duplicate transaction"; "block_hash" => header.block_hash());
+            warn!("Invalid block: Found duplicate transaction";
+                "consensus_hash" => %header.consensus_hash,
+                "stacks_block_hash" => %header.block_hash(),
+                "stacks_block_id" => %header.block_id()
+            );
             return Err(CodecError::DeserializeError(
                 "Invalid block: found duplicate transaction".to_string(),
             ));
@@ -3683,7 +3789,11 @@ impl StacksMessageCodec for NakamotoBlock {
         let tx_merkle_root: Sha512Trunc256Sum = merkle_tree.root();
 
         if tx_merkle_root != header.tx_merkle_root {
-            warn!("Invalid block: Tx Merkle root mismatch"; "block_hash" => header.block_hash());
+            warn!("Invalid block: Tx Merkle root mismatch";
+                "consensus_hash" => %header.consensus_hash,
+                "stacks_block_hash" => %header.block_hash(),
+                "stacks_block_id" => %header.block_id()
+            );
             return Err(CodecError::DeserializeError(
                 "Invalid block: tx Merkle root mismatch".to_string(),
             ));

--- a/stackslib/src/chainstate/nakamoto/tenure.rs
+++ b/stackslib/src/chainstate/nakamoto/tenure.rs
@@ -1031,8 +1031,10 @@ impl NakamotoChainState {
             warn!("While processing tenure change, failed to look up parent tenure";
                   "parent_coinbase_height" => parent_coinbase_height,
                   "parent_block_id" => %block.header.parent_block_id,
-                  "block_hash" => %block.header.block_hash(),
-                  "block_consensus_hash" => %block.header.consensus_hash);
+                  "consensus_hash" => %block.header.consensus_hash,
+                  "stacks_block_hash" => %block.header.block_hash(),
+                  "stacks_block_id" => %block.header.block_id()
+            );
             ChainstateError::NoSuchBlockError
         })?;
         // fetch the parent tenure fees by reading the total tx fees from this block's
@@ -1045,8 +1047,10 @@ impl NakamotoChainState {
             )?.ok_or_else(|| {
                 warn!("While processing tenure change, failed to look up parent block's total tx fees";
                       "parent_block_id" => %block.header.parent_block_id,
-                      "block_hash" => %block.header.block_hash(),
-                      "block_consensus_hash" => %block.header.consensus_hash);
+                      "consensus_hash" => %block.header.consensus_hash,
+                      "stacks_block_hash" => %block.header.block_hash(),
+                      "stacks_block_id" => %block.header.block_id()
+                    );
                 ChainstateError::NoSuchBlockError
             })?
         } else {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -2515,7 +2515,7 @@ impl StacksBlockBuilder {
 
         info!(
             "Miner: mined anchored block";
-            "block_hash" => %block.block_hash(),
+            "stacks_block_hash" => %block.block_hash(),
             "height" => block.header.total_work.work,
             "tx_count" => block.txs.len(),
             "parent_stacks_block_hash" => %block.header.parent_block,

--- a/stackslib/src/net/download/epoch2x.rs
+++ b/stackslib/src/net/download/epoch2x.rs
@@ -522,7 +522,9 @@ impl BlockDownloader {
                                         self.broken_neighbors.push(block_key.neighbor.clone());
                                     }
                                     Err(e) => {
-                                        info!("Error decoding response from remote neighbor {:?} (at {}): {:?}", &block_key.neighbor, &block_key.data_url, &e);
+                                        info!("Error decoding response from remote neighbor {:?} (at {}): {:?}", &block_key.neighbor, &block_key.data_url, &e;
+                                            "consensus_hash" => %block_key.consensus_hash
+                                        );
                                         self.broken_peers.push(event_id);
                                         self.broken_neighbors.push(block_key.neighbor.clone());
                                     }
@@ -626,7 +628,9 @@ impl BlockDownloader {
                                     Ok(microblocks) => {
                                         if microblocks.len() == 0 {
                                             // we wouldn't have asked for a 0-length stream
-                                            info!("Got unexpected zero-length microblock stream from {:?} ({:?})", &block_key.neighbor, &block_key.data_url);
+                                            info!("Got unexpected zero-length microblock stream from {:?} ({:?})", &block_key.neighbor, &block_key.data_url;
+                                                "consensus_hash" => %block_key.consensus_hash
+                                            );
                                             self.broken_peers.push(event_id);
                                             self.broken_neighbors.push(block_key.neighbor.clone());
                                         } else {
@@ -644,7 +648,9 @@ impl BlockDownloader {
                                     Err(net_error::NotFoundError) => {
                                         // remote peer didn't have the microblock, even though their blockinv said
                                         // they did.
-                                        info!("Remote neighbor {:?} ({:?}) does not have microblock stream indexed at {}", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash);
+                                        info!("Remote neighbor {:?} ({:?}) does not have microblock stream indexed at {}", &block_key.neighbor, &block_key.data_url, &block_key.index_block_hash;
+                                            "consensus_hash" => %block_key.consensus_hash
+                                        );
 
                                         // the fact that we asked this peer means that it's block inv indicated
                                         // it was present, so the absence is the mark of a broken peer.
@@ -654,7 +660,9 @@ impl BlockDownloader {
                                         // talk to them for a while.
                                     }
                                     Err(e) => {
-                                        info!("Error decoding response from remote neighbor {:?} (at {}): {:?}", &block_key.neighbor, &block_key.data_url, &e);
+                                        info!("Error decoding response from remote neighbor {:?} (at {}): {:?}", &block_key.neighbor, &block_key.data_url, &e;
+                                            "consensus_hash" => %block_key.consensus_hash
+                                        );
                                         self.broken_peers.push(event_id);
                                         self.broken_neighbors.push(block_key.neighbor.clone());
                                     }

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -265,7 +265,7 @@ impl BlockMinerThread {
                     info!(
                         "Miner: Block signed by signer set and broadcasted";
                         "signer_sighash" => %new_block.header.signer_signature_hash(),
-                        "block_hash" => %new_block.header.block_hash(),
+                        "stacks_block_hash" => %new_block.header.block_hash(),
                         "stacks_block_id" => %new_block.header.block_id(),
                         "block_height" => new_block.header.chain_length,
                         "consensus_hash" => %new_block.header.consensus_hash,
@@ -633,8 +633,10 @@ impl BlockMinerThread {
             if *TEST_BROADCAST_STALL.lock().unwrap() == Some(true) {
                 // Do an extra check just so we don't log EVERY time.
                 warn!("Broadcasting is stalled due to testing directive.";
-                    "block_id" => %block.block_id(),
+                    "stacks_block_id" => %block.block_id(),
+                    "stacks_block_hash" => %block.header.block_hash(),
                     "height" => block.header.chain_length,
+                    "consensus_hash" => %block.header.consensus_hash
                 );
                 while *TEST_BROADCAST_STALL.lock().unwrap() == Some(true) {
                     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -642,6 +644,7 @@ impl BlockMinerThread {
                 info!("Broadcasting is no longer stalled due to testing directive.";
                     "block_id" => %block.block_id(),
                     "height" => block.header.chain_length,
+                    "consensus_hash" => %block.header.consensus_hash
                 );
             }
         }

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -891,8 +891,9 @@ impl RelayerThread {
             )
         else {
             warn!("Failure getting the first block of tenure in order to assemble block commit";
-                  "tenure_consensus_hash" => %chain_tip_header.consensus_hash,
-                  "tip_block_hash" => %chain_tip_header.anchored_header.block_hash());
+              "tenure_consensus_hash" => %chain_tip_header.consensus_hash,
+              "tip_stacks_block_hash" => %chain_tip_header.anchored_header.block_hash()
+            );
             return None;
         };
 

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -763,6 +763,8 @@ impl SignCoordinator {
                             "signature" => %signature,
                             "signer_weight" => signer_entry.weight,
                             "total_weight_signed" => total_weight_signed,
+                            "stacks_block_hash" => %block.header.block_hash(),
+                            "stacks_block_id" => %block.header.block_id()
                         );
                         gathered_signatures.insert(slot_id, signature);
                     }
@@ -777,7 +779,10 @@ impl SignCoordinator {
 
             // After gathering all signatures, return them if we've hit the threshold
             if total_weight_signed >= self.weight_threshold {
-                info!("SignCoordinator: Received enough signatures. Continuing.");
+                info!("SignCoordinator: Received enough signatures. Continuing.";
+                    "stacks_block_hash" => %block.header.block_hash(),
+                    "stacks_block_id" => %block.header.block_id()
+                );
                 return Ok(gathered_signatures.values().cloned().collect());
             }
         }

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -905,7 +905,7 @@ impl Node {
         if let Some(estimator) = fee_estimator.as_mut() {
             if let Err(e) = estimator.notify_block(&processed_block, &stacks_epoch.block_limit) {
                 warn!("FeeEstimator failed to process block receipt";
-                      "stacks_block" => %processed_block.header.anchored_header.block_hash(),
+                      "stacks_block_hash" => %processed_block.header.anchored_header.block_hash(),
                       "stacks_height" => %processed_block.header.stacks_block_height,
                       "error" => %e);
             }


### PR DESCRIPTION
I have been tearing my hair out trying to compare across log lines without knowing what is a burn header hash vs stacks block hash vs consensus hash etc. This is a quick first pass to just print all the info as available in all warn and info level logs. I also did a few debug logs that were specifically standing out to me. I think we could cleanup a lot of log lines to only ever print these hashes annotated instead of inline as they are just a nebulous blob of bytes otherwise, but will leave that for a sep PR. 

I might actually implement on top of this a trait for printing internal hashes for each object that holds them, but for now this seemed the quickest way to get it done and that might be overkill especially if the object contains parent hashes.

Note I didn't bother changing really much of the pre nakamoto lines. There are a few, but I avoided touching neon_node for example.


Closes https://github.com/stacks-network/stacks-core/issues/4922