### PR TITLE
Set default antientropy_retry to one hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
 ## [2.5.0.0.4]
+### Added
+- Added configuration option `connections.antientropy_retry` (#4932)
+### Changed
+- Set default antientropy_rety to run once per hour, not once per minute
+
+
+## [2.5.0.0.4]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Added
 - Added configuration option `connections.antientropy_retry` (#4932)
 ### Changed
-- Set default antientropy_rety to run once per hour, not once per minute
+- Set default antientropy_rety to run once per hour
 
 
 ## [2.5.0.0.4]

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -479,7 +479,7 @@ impl std::default::Default for ConnectionOptions {
             public_ip_max_retries: 3, // maximum number of retries before self-throttling for $public_ip_timeout
             max_block_push: 10, // maximum number of blocksData messages to push out via our anti-entropy protocol
             max_microblock_push: 10, // maximum number of microblocks messages to push out via our anti-entropy protocol
-            antientropy_retry: 60,   // retry pushing data once every minute
+            antientropy_retry: 3600,   // retry pushing data once every hour
             antientropy_public: true, // run antientropy even if we're NOT NAT'ed
             max_buffered_blocks_available: 1,
             max_buffered_microblocks_available: 1,

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -479,7 +479,7 @@ impl std::default::Default for ConnectionOptions {
             public_ip_max_retries: 3, // maximum number of retries before self-throttling for $public_ip_timeout
             max_block_push: 10, // maximum number of blocksData messages to push out via our anti-entropy protocol
             max_microblock_push: 10, // maximum number of microblocks messages to push out via our anti-entropy protocol
-            antientropy_retry: 3600,   // retry pushing data once every hour
+            antientropy_retry: 3600, // retry pushing data once every hour
             antientropy_public: true, // run antientropy even if we're NOT NAT'ed
             max_buffered_blocks_available: 1,
             max_buffered_microblocks_available: 1,


### PR DESCRIPTION
Adds a changelog for 2.5.0.0.5 and changes the default `antientropy_retry` from 1 minute to 1 hour