### PR TITLE
Test chore: v0 signature assert fixes

### DIFF
--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -128,9 +128,11 @@ impl SignerTest<SpawnedSigner> {
         // Verify that the signers signed the proposed block
         let signature = self.wait_for_confirmed_block_v0(&proposed_signer_signature_hash, timeout);
 
+        info!("Got {} signatures", signature.len());
+
         // NOTE: signature.len() does not need to equal signers.len(); the stacks miner can finish the block
         //  whenever it has crossed the threshold.
-        info!("Got {} signatures", signature.len());
+        assert!(signature.len() >= num_signers / 7 * 10);
 
         let reward_cycle = self.get_current_reward_cycle();
         let signers = self.get_reward_set_signers(reward_cycle);

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -132,7 +132,7 @@ impl SignerTest<SpawnedSigner> {
 
         // NOTE: signature.len() does not need to equal signers.len(); the stacks miner can finish the block
         //  whenever it has crossed the threshold.
-        assert!(signature.len() >= num_signers / 7 * 10);
+        assert!(signature.len() >= num_signers * 7 / 10);
 
         let reward_cycle = self.get_current_reward_cycle();
         let signers = self.get_reward_set_signers(reward_cycle);

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -141,6 +141,8 @@ impl SignerTest<SpawnedSigner> {
         let mut signer_index = 0;
         let mut signature_index = 0;
         let validated = loop {
+            // Since we've already checked `signature.len()`, this means we've
+            //  validated all the signatures in this loop
             let Some(signature) = signature.get(signature_index) else {
                 break true;
             };


### PR DESCRIPTION
In V0, the miner can assemble a block once it crosses the threshold, without all signers. The existing assertion causes CI to flap (because sometimes the miner is faster than the signers).
