### PR TITLE
Fix/4938

### DIFF
--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -224,7 +224,9 @@ RejectCodeTypePrefix {
     /// The block was rejected in a prior round
     RejectedInPriorRound = 2,
     /// The block was rejected due to no sortition view
-    NoSortitionView = 3
+    NoSortitionView = 3,
+    /// The block was rejected due to a mismatch with expected sortition view
+    SortitionViewMismatch = 4
 });
 
 impl TryFrom<u8> for RejectCodeTypePrefix {
@@ -243,6 +245,7 @@ impl From<&RejectCode> for RejectCodeTypePrefix {
             RejectCode::ConnectivityIssues => RejectCodeTypePrefix::ConnectivityIssues,
             RejectCode::RejectedInPriorRound => RejectCodeTypePrefix::RejectedInPriorRound,
             RejectCode::NoSortitionView => RejectCodeTypePrefix::NoSortitionView,
+            RejectCode::SortitionViewMismatch => RejectCodeTypePrefix::SortitionViewMismatch,
         }
     }
 }
@@ -258,6 +261,8 @@ pub enum RejectCode {
     ConnectivityIssues,
     /// The block was rejected in a prior round
     RejectedInPriorRound,
+    /// The block was rejected due to a mismatch with expected sortition view
+    SortitionViewMismatch,
 }
 
 define_u8_enum!(
@@ -427,7 +432,8 @@ impl StacksMessageCodec for RejectCode {
             RejectCode::ValidationFailed(code) => write_next(fd, &(*code as u8))?,
             RejectCode::ConnectivityIssues
             | RejectCode::RejectedInPriorRound
-            | RejectCode::NoSortitionView => {
+            | RejectCode::NoSortitionView
+            | RejectCode::SortitionViewMismatch => {
                 // No additional data to serialize / deserialize
             }
         };
@@ -449,6 +455,7 @@ impl StacksMessageCodec for RejectCode {
             RejectCodeTypePrefix::ConnectivityIssues => RejectCode::ConnectivityIssues,
             RejectCodeTypePrefix::RejectedInPriorRound => RejectCode::RejectedInPriorRound,
             RejectCodeTypePrefix::NoSortitionView => RejectCode::NoSortitionView,
+            RejectCodeTypePrefix::SortitionViewMismatch => RejectCode::SortitionViewMismatch,
         };
         Ok(code)
     }
@@ -469,6 +476,12 @@ impl std::fmt::Display for RejectCode {
             ),
             RejectCode::NoSortitionView => {
                 write!(f, "The block was rejected due to no sortition view.")
+            }
+            RejectCode::SortitionViewMismatch => {
+                write!(
+                    f,
+                    "The block was rejected due to a mismatch with expected sortition view."
+                )
             }
         }
     }

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -235,8 +235,6 @@ mod tests {
     use blockstack_lib::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader};
     use clarity::util::hash::{MerkleTree, Sha512Trunc256Sum};
     use libsigner::v0::messages::{BlockRejection, BlockResponse, RejectCode, SignerMessage};
-    use libsigner::BlockProposal;
-    use rand::{thread_rng, RngCore};
 
     use super::*;
     use crate::client::tests::{generate_signer_config, mock_server_from_config, write_response};

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -280,7 +280,7 @@ impl Signer {
                 .ok();
         }
 
-        // Check if proposal can be rejected now if not valid agains sortition view
+        // Check if proposal can be rejected now if not valid against sortition view
         let block_response = if let Some(sortition_state) = sortition_state {
             match sortition_state.check_proposal(
                 stacks_client,
@@ -323,7 +323,7 @@ impl Signer {
             );
             Some(BlockResponse::rejected(
                 block_proposal.block.header.signer_signature_hash(),
-                RejectCode::ValidationFailed(ValidateRejectCode::InvalidBlock),
+                RejectCode::NoSortitionView,
             ))
         };
 

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -15,7 +15,7 @@
 use std::fmt::Debug;
 use std::sync::mpsc::Sender;
 
-use blockstack_lib::net::api::postblock_proposal::{BlockValidateResponse, ValidateRejectCode};
+use blockstack_lib::net::api::postblock_proposal::BlockValidateResponse;
 use clarity::types::chainstate::StacksPrivateKey;
 use clarity::types::PrivateKey;
 use clarity::util::hash::MerkleHashFunc;
@@ -309,7 +309,7 @@ impl Signer {
                     );
                     Some(BlockResponse::rejected(
                         block_proposal.block.header.signer_signature_hash(),
-                        RejectCode::ValidationFailed(ValidateRejectCode::InvalidBlock),
+                        RejectCode::SortitionViewMismatch,
                     ))
                 }
                 // Block proposal passed check, still don't know if valid

--- a/stackslib/src/net/api/getsortition.rs
+++ b/stackslib/src/net/api/getsortition.rs
@@ -214,7 +214,9 @@ impl RPCRequestHandler for GetSortitionHandler {
                     .ok_or_else(|| ChainError::NoSuchBlockError)?;
 
                 let (miner_pk_hash160, stacks_parent_ch, committed_block_hash, last_sortition_ch) = if !sortition_sn.sortition {
-                    (None, None, None, None)
+                    let handle = sortdb.index_handle(&sortition_sn.sortition_id);
+                    let last_sortition = handle.get_last_snapshot_with_sortition(sortition_sn.block_height)?;
+                    (None, None, None, Some(last_sortition.consensus_hash))
                 } else {
                     let block_commit = SortitionDB::get_block_commit(sortdb.conn(), &sortition_sn.winning_block_txid, &sortition_sn.sortition_id)?
                         .ok_or_else(|| {


### PR DESCRIPTION
Fixes #4938 by requiring that the last block snapshot with a sortiiton be returned from /v3/sortitions.