### PR TITLE
2.5.0.0.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Added
 - Added configuration option `connections.antientropy_retry` (#4932)
 ### Changed
-- Set default antientropy_rety to run once per hour (#4935)
+- Set default antientropy_retry to run once per hour (#4935)
 
 
 ## [2.5.0.0.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [2.5.0.0.4]
+## [2.5.0.0.5]
 ### Added
 - Added configuration option `connections.antientropy_retry` (#4932)
 ### Changed
-- Set default antientropy_rety to run once per hour
+- Set default antientropy_rety to run once per hour (#4935)
 
 
 ## [2.5.0.0.4]


### PR DESCRIPTION
fixes a typo in #4935 - the version number in the changelog was incorrect. 