### PR TITLE
Update rusqlite version (and sqlite)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,12 +114,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
-
-[[package]]
-name = "ahash"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
@@ -717,7 +711,7 @@ name = "clarity"
 version = "0.0.1"
 dependencies = [
  "assert-json-diff",
- "hashbrown 0.14.3",
+ "hashbrown",
  "integer-sqrt",
  "lazy_static",
  "mutants",
@@ -1188,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -1497,31 +1491,22 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.8",
+ "ahash",
  "allocator-api2",
  "serde",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.6.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1758,7 +1743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1920,7 +1905,7 @@ name = "libsigner"
 version = "0.0.1"
 dependencies = [
  "clarity",
- "hashbrown 0.14.3",
+ "hashbrown",
  "lazy_static",
  "libc",
  "libstackerdb",
@@ -1946,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.20.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2722,7 +2707,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "relay-server"
 version = "0.0.1"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2874,17 +2859,15 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.24.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38ee71cbab2c827ec0ac24e76f82eca723cee92c509a65f67dee393c25112"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.4.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "memchr",
  "serde_json",
  "smallvec",
 ]
@@ -3380,7 +3363,7 @@ dependencies = [
  "chrono",
  "curve25519-dalek 2.0.0",
  "ed25519-dalek",
- "hashbrown 0.14.3",
+ "hashbrown",
  "lazy_static",
  "libc",
  "nix",
@@ -3416,7 +3399,7 @@ dependencies = [
  "base64 0.12.3",
  "chrono",
  "clarity",
- "hashbrown 0.14.3",
+ "hashbrown",
  "http-types",
  "lazy_static",
  "libc",
@@ -3453,7 +3436,7 @@ dependencies = [
  "backoff",
  "clap 4.5.0",
  "clarity",
- "hashbrown 0.14.3",
+ "hashbrown",
  "lazy_static",
  "libsigner",
  "libstackerdb",
@@ -3493,7 +3476,7 @@ dependencies = [
  "criterion",
  "curve25519-dalek 2.0.0",
  "ed25519-dalek",
- "hashbrown 0.14.3",
+ "hashbrown",
  "integer-sqrt",
  "lazy_static",
  "libc",
@@ -4611,7 +4594,7 @@ checksum = "9c80d57a61294350ed91e91eb20a6c34da084ec8f15d039bab79ce3efabbd1a4"
 dependencies = [
  "aes-gcm 0.10.3",
  "bs58 0.5.0",
- "hashbrown 0.14.3",
+ "hashbrown",
  "hex",
  "num-traits",
  "p256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8"
 rand_chacha = "0.3.1"
 tikv-jemallocator = "0.5.4"
 wsts = { version = "9.0.0", default-features = false }
+rusqlite = { version = "0.31.0", features = ["blob", "serde_json", "i128_blob", "bundled", "trace"] }
 
 # Use a bit more than default optimization for
 #  dev builds to speed up test execution

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -31,15 +31,11 @@ stacks_common = { package = "stacks-common", path = "../stacks-common", optional
 rstest = "0.17.0"
 rstest_reuse = "0.5.0"
 hashbrown = { workspace = true }
+rusqlite = { workspace = true, optional = true}
 
 [dependencies.serde_json]
 version = "1.0"
 features = ["arbitrary_precision", "unbounded_depth"]
-
-[dependencies.rusqlite]
-version = "0.31.0"
-optional = true
-features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [dependencies.time]
 version = "0.2.23"

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -37,7 +37,7 @@ version = "1.0"
 features = ["arbitrary_precision", "unbounded_depth"]
 
 [dependencies.rusqlite]
-version = "=0.24.2"
+version = "0.31.0"
 optional = true
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -16,7 +16,7 @@
 
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::{
-    Connection, Error as SqliteError, ErrorCode as SqliteErrorCode, OptionalExtension, Row,
+    params, Connection, Error as SqliteError, ErrorCode as SqliteErrorCode, OptionalExtension, Row,
     Savepoint,
 };
 use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
@@ -44,11 +44,8 @@ pub struct SqliteConnection {
 }
 
 fn sqlite_put(conn: &Connection, key: &str, value: &str) -> Result<()> {
-    let params: [&dyn ToSql; 2] = [&key, &value];
-    match conn.execute(
-        "REPLACE INTO data_table (key, value) VALUES (?, ?)",
-        &params,
-    ) {
+    let params: &[&dyn ToSql] = params![key, value];
+    match conn.execute("REPLACE INTO data_table (key, value) VALUES (?, ?)", params) {
         Ok(_) => Ok(()),
         Err(e) => {
             error!("Failed to insert/replace ({},{}): {:?}", key, value, &e);
@@ -59,11 +56,11 @@ fn sqlite_put(conn: &Connection, key: &str, value: &str) -> Result<()> {
 
 fn sqlite_get(conn: &Connection, key: &str) -> Result<Option<String>> {
     trace!("sqlite_get {}", key);
-    let params: [&dyn ToSql; 1] = [&key];
+    let params: &[&dyn ToSql] = params![key];
     let res = match conn
         .query_row(
             "SELECT value FROM data_table WHERE key = ?",
-            &params,
+            params,
             |row| row.get(0),
         )
         .optional()
@@ -156,11 +153,11 @@ impl SqliteConnection {
         value: &str,
     ) -> Result<()> {
         let key = format!("clr-meta::{}::{}", contract_hash, key);
-        let params: [&dyn ToSql; 3] = [&bhh, &key, &value];
+        let params: &[&dyn ToSql] = params![bhh, key, value];
 
         if let Err(e) = conn.execute(
             "INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)",
-            &params,
+            params,
         ) {
             error!(
                 "Failed to insert ({},{},{}): {:?}",
@@ -179,10 +176,10 @@ impl SqliteConnection {
         from: &StacksBlockId,
         to: &StacksBlockId,
     ) -> Result<()> {
-        let params = [to, from];
+        let params: &[&dyn ToSql] = params![to, from];
         if let Err(e) = conn.execute(
             "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
-            &params,
+            params,
         ) {
             error!("Failed to update {} to {}: {:?}", &from, &to, &e);
             return Err(InterpreterError::DBError(SQL_FAIL_MESSAGE.into()).into());
@@ -191,7 +188,10 @@ impl SqliteConnection {
     }
 
     pub fn drop_metadata(conn: &Connection, from: &StacksBlockId) -> Result<()> {
-        if let Err(e) = conn.execute("DELETE FROM metadata_table WHERE blockhash = ?", &[from]) {
+        if let Err(e) = conn.execute(
+            "DELETE FROM metadata_table WHERE blockhash = ?",
+            params![from],
+        ) {
             error!("Failed to drop metadata from {}: {:?}", &from, &e);
             return Err(InterpreterError::DBError(SQL_FAIL_MESSAGE.into()).into());
         }
@@ -205,12 +205,12 @@ impl SqliteConnection {
         key: &str,
     ) -> Result<Option<String>> {
         let key = format!("clr-meta::{}::{}", contract_hash, key);
-        let params: [&dyn ToSql; 2] = [&bhh, &key];
+        let params: &[&dyn ToSql] = params![bhh, key];
 
         match conn
             .query_row(
                 "SELECT value FROM metadata_table WHERE blockhash = ? AND key = ?",
-                &params,
+                params,
                 |row| row.get(0),
             )
             .optional()
@@ -265,10 +265,10 @@ impl SqliteConnection {
     pub fn check_schema(conn: &Connection) -> Result<()> {
         let sql = "SELECT sql FROM sqlite_master WHERE name=?";
         let _: String = conn
-            .query_row(sql, &["data_table"], |row| row.get(0))
+            .query_row(sql, params!["data_table"], |row| row.get(0))
             .map_err(|x| InterpreterError::SqliteError(IncomparableError { err: x }))?;
         let _: String = conn
-            .query_row(sql, &["metadata_table"], |row| row.get(0))
+            .query_row(sql, params!["metadata_table"], |row| row.get(0))
             .map_err(|x| InterpreterError::SqliteError(IncomparableError { err: x }))?;
         Ok(())
     }

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -44,7 +44,7 @@ pub struct SqliteConnection {
 }
 
 fn sqlite_put(conn: &Connection, key: &str, value: &str) -> Result<()> {
-    let params: &[&dyn ToSql] = params![key, value];
+    let params = params![key, value];
     match conn.execute("REPLACE INTO data_table (key, value) VALUES (?, ?)", params) {
         Ok(_) => Ok(()),
         Err(e) => {
@@ -56,7 +56,7 @@ fn sqlite_put(conn: &Connection, key: &str, value: &str) -> Result<()> {
 
 fn sqlite_get(conn: &Connection, key: &str) -> Result<Option<String>> {
     trace!("sqlite_get {}", key);
-    let params: &[&dyn ToSql] = params![key];
+    let params = params![key];
     let res = match conn
         .query_row(
             "SELECT value FROM data_table WHERE key = ?",
@@ -153,7 +153,7 @@ impl SqliteConnection {
         value: &str,
     ) -> Result<()> {
         let key = format!("clr-meta::{}::{}", contract_hash, key);
-        let params: &[&dyn ToSql] = params![bhh, key, value];
+        let params = params![bhh, key, value];
 
         if let Err(e) = conn.execute(
             "INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)",
@@ -176,7 +176,7 @@ impl SqliteConnection {
         from: &StacksBlockId,
         to: &StacksBlockId,
     ) -> Result<()> {
-        let params: &[&dyn ToSql] = params![to, from];
+        let params = params![to, from];
         if let Err(e) = conn.execute(
             "UPDATE metadata_table SET blockhash = ? WHERE blockhash = ?",
             params,
@@ -205,7 +205,7 @@ impl SqliteConnection {
         key: &str,
     ) -> Result<Option<String>> {
         let key = format!("clr-meta::{}::{}", contract_hash, key);
-        let params: &[&dyn ToSql] = params![bhh, key];
+        let params = params![bhh, key];
 
         match conn
             .query_row(

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -17,9 +17,10 @@
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::{
     Connection, Error as SqliteError, ErrorCode as SqliteErrorCode, OptionalExtension, Row,
-    Savepoint, NO_PARAMS,
+    Savepoint,
 };
 use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::db_common::tx_busy_handler;
 use stacks_common::util::hash::Sha512Trunc256Sum;
 

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -33,6 +33,7 @@ chrono = "0.4.19"
 libc = "0.2.82"
 wsts = { workspace = true }
 hashbrown = { workspace = true }
+rusqlite = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
@@ -50,11 +51,6 @@ features = ["arbitrary_precision", "unbounded_depth"]
 [dependencies.secp256k1]
 version = "0.24.3"
 features = ["serde", "recovery"]
-
-[dependencies.rusqlite]
-version = "0.31.0"
-optional = true
-features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [dependencies.ed25519-dalek]
 workspace = true

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -52,7 +52,7 @@ version = "0.24.3"
 features = ["serde", "recovery"]
 
 [dependencies.rusqlite]
-version = "=0.24.2"
+version = "0.31.0"
 optional = true
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 

--- a/stacks-common/src/bitvec.rs
+++ b/stacks-common/src/bitvec.rs
@@ -15,9 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #[cfg(feature = "canonical")]
-use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef};
-#[cfg(feature = "canonical")]
-use rusqlite::ToSql;
+use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use serde::{Deserialize, Serialize};
 
 use crate::codec::{

--- a/stacks-common/src/types/sqlite.rs
+++ b/stacks-common/src/types/sqlite.rs
@@ -25,6 +25,8 @@ use crate::util::hash::{Hash160, Sha512Trunc256Sum};
 use crate::util::secp256k1::MessageSignature;
 use crate::util::vrf::VRFProof;
 
+pub const NO_PARAMS: &[&dyn rusqlite::ToSql] = &[];
+
 impl FromSql for Sha256dHash {
     fn column_result(value: ValueRef) -> FromSqlResult<Sha256dHash> {
         let hex_str = value.as_str()?;

--- a/stacks-common/src/types/sqlite.rs
+++ b/stacks-common/src/types/sqlite.rs
@@ -25,7 +25,7 @@ use crate::util::hash::{Hash160, Sha512Trunc256Sum};
 use crate::util::secp256k1::MessageSignature;
 use crate::util::vrf::VRFProof;
 
-pub const NO_PARAMS: &[&dyn rusqlite::ToSql] = &[];
+pub const NO_PARAMS: &[&dyn ToSql] = &[];
 
 impl FromSql for Sha256dHash {
     fn column_result(value: ValueRef) -> FromSqlResult<Sha256dHash> {

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -46,15 +46,12 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = { workspace = true }
 rand = { workspace = true }
 url = "2.1.0"
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 clarity = { path = "../clarity", features = ["testing"] }
 polynomial = "0.2.6"
 num-traits = "0.2.18"
-
-[dependencies.rusqlite]
-version = "0.31.0"
-features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [dependencies.serde_json]
 version = "1.0"

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -53,7 +53,7 @@ polynomial = "0.2.6"
 num-traits = "0.2.18"
 
 [dependencies.rusqlite]
-version = "=0.24.2"
+version = "0.31.0"
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [dependencies.serde_json]

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -640,7 +640,7 @@ mod tests {
             format!(
                 r#"
 Stacks node host: 127.0.0.1:20443
-Signer endpoint: [::1]:30000
+Signer endpoint: 127.0.0.1:30000
 Stacks address: ST3FPN8KBZ3YPBP0ZJGAAHTVFMQDTJCR5QPS7VTNJ
 Public key: 03bc489f27da3701d9f9e577c88de5567cf4023111b7577042d55cde4d823a3505
 Network: testnet

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -635,10 +635,8 @@ mod tests {
     fn test_config_to_string() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
         let config_str = config.config_to_log_string();
-        assert_eq!(
-            config_str,
-            format!(
-                r#"
+
+        let expected_str_v4 = r#"
 Stacks node host: 127.0.0.1:20443
 Signer endpoint: 127.0.0.1:30000
 Stacks address: ST3FPN8KBZ3YPBP0ZJGAAHTVFMQDTJCR5QPS7VTNJ
@@ -647,8 +645,23 @@ Network: testnet
 Database path: :memory:
 DKG transaction fee: 0.01 uSTX
 Metrics endpoint: 0.0.0.0:9090
-"#
-            )
+"#;
+
+        let expected_str_v6 = r#"
+Stacks node host: 127.0.0.1:20443
+Signer endpoint: [::1]:30000
+Stacks address: ST3FPN8KBZ3YPBP0ZJGAAHTVFMQDTJCR5QPS7VTNJ
+Public key: 03bc489f27da3701d9f9e577c88de5567cf4023111b7577042d55cde4d823a3505
+Network: testnet
+Database path: :memory:
+DKG transaction fee: 0.01 uSTX
+Metrics endpoint: 0.0.0.0:9090
+"#;
+
+        assert!(
+            config_str == expected_str_v4 || config_str == expected_str_v6,
+            "Config string does not match expected output. Actual:\n{}",
+            config_str
         );
     }
 

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -230,10 +230,6 @@ impl SignerDb {
 
         Ok(())
     }
-
-    fn get_sqlite_version(&self) -> Result<Option<String>, DBError> {
-        query_row(&self.db, "SELECT sqlite_version()", NO_PARAMS)
-    }
 }
 
 fn try_deserialize<T>(s: Option<String>) -> Result<Option<T>, DBError>
@@ -428,6 +424,9 @@ mod tests {
     fn test_sqlite_version() {
         let db_path = tmp_db_path();
         let db = SignerDb::new(db_path).expect("Failed to create signer db");
-        assert_eq!(db.get_sqlite_version().unwrap(), Some("3.45.0".to_string()));
+        assert_eq!(
+            query_row(&db.db, "SELECT sqlite_version()", NO_PARAMS).unwrap(),
+            Some("3.45.0".to_string())
+        );
     }
 }

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -230,6 +230,10 @@ impl SignerDb {
 
         Ok(())
     }
+
+    fn get_sqlite_version(&self) -> Result<Option<String>, DBError> {
+        query_row(&self.db, "SELECT sqlite_version()", NO_PARAMS)
+    }
 }
 
 fn try_deserialize<T>(s: Option<String>) -> Result<Option<T>, DBError>
@@ -418,5 +422,12 @@ mod tests {
             .get_encrypted_signer_state(9)
             .expect("Failed to get signer state")
             .is_none());
+    }
+
+    #[test]
+    fn test_sqlite_version() {
+        let db_path = tmp_db_path();
+        let db = SignerDb::new(db_path).expect("Failed to create signer db");
+        assert_eq!(db.get_sqlite_version().unwrap(), Some("3.45.0".to_string()));
     }
 }

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -21,11 +21,12 @@ use blockstack_lib::util_lib::db::{
     query_row, sqlite_open, table_exists, u64_to_sql, Error as DBError,
 };
 use libsigner::BlockProposal;
-use rusqlite::{params, Connection, Error as SqliteError, OpenFlags, NO_PARAMS};
+use rusqlite::{params, Connection, Error as SqliteError, OpenFlags};
 use serde::{Deserialize, Serialize};
 use slog::slog_debug;
 use stacks_common::debug;
 use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::Sha512Trunc256Sum;
 use wsts::net::NonceRequest;
 
@@ -163,7 +164,7 @@ impl SignerDb {
     ) -> Result<(), DBError> {
         self.db.execute(
             "INSERT OR REPLACE INTO signer_states (reward_cycle, encrypted_state) VALUES (?1, ?2)",
-            params![&u64_to_sql(reward_cycle)?, &encrypted_signer_state],
+            params![u64_to_sql(reward_cycle)?, encrypted_signer_state],
         )?;
         Ok(())
     }
@@ -178,7 +179,7 @@ impl SignerDb {
         let result: Option<String> = query_row(
             &self.db,
             "SELECT block_info FROM blocks WHERE reward_cycle = ? AND signer_signature_hash = ?",
-            params![&u64_to_sql(reward_cycle)?, hash.to_string()],
+            params![u64_to_sql(reward_cycle)?, hash.to_string()],
         )?;
 
         try_deserialize(result)
@@ -220,7 +221,7 @@ impl SignerDb {
             .execute(
                 "INSERT OR REPLACE INTO blocks (reward_cycle, burn_block_height, signer_signature_hash, block_info, signed_over, stacks_height, consensus_hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 params![
-                    u64_to_sql(block_info.reward_cycle)?, u64_to_sql(block_info.burn_block_height)?, hash.to_string(), &block_json,
+                    u64_to_sql(block_info.reward_cycle)?, u64_to_sql(block_info.burn_block_height)?, hash.to_string(), block_json,
                     signed_over,
                     u64_to_sql(block_info.block.header.chain_length)?,
                     block_info.block.header.consensus_hash.to_hex(),

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -58,6 +58,7 @@ libstackerdb = { path = "../libstackerdb" }
 siphasher = "0.3.7"
 wsts = { workspace = true }
 hashbrown = { workspace = true }
+rusqlite = { workspace = true }
 
 [target.'cfg(not(any(target_os = "macos",target_os="windows", target_arch = "arm" )))'.dependencies]
 tikv-jemallocator = {workspace = true}
@@ -78,10 +79,6 @@ features = ["arbitrary_precision", "unbounded_depth"]
 [dependencies.secp256k1]
 version = "0.24.3"
 features = ["serde", "recovery"]
-
-[dependencies.rusqlite]
-version = "0.31.0"
-features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [dependencies.ed25519-dalek]
 workspace = true

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -80,7 +80,7 @@ version = "0.24.3"
 features = ["serde", "recovery"]
 
 [dependencies.rusqlite]
-version = "=0.24.2"
+version = "0.31.0"
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [dependencies.ed25519-dalek]

--- a/stackslib/src/burnchains/bitcoin/spv.rs
+++ b/stackslib/src/burnchains/bitcoin/spv.rs
@@ -424,7 +424,7 @@ impl SpvClient {
         }
 
         let tx = self.tx_begin()?;
-        let args: &[&dyn ToSql] = params![u64_to_sql(interval)?, work.to_hex_be()];
+        let args = params![u64_to_sql(interval)?, work.to_hex_be()];
         tx.execute(
             "INSERT OR REPLACE INTO chain_work (interval,work) VALUES (?1,?2)",
             args,
@@ -707,7 +707,7 @@ impl SpvClient {
         let mut headers = vec![];
 
         let sql_query = "SELECT * FROM headers WHERE height >= ?1 AND height < ?2 ORDER BY height";
-        let sql_args: &[&dyn ToSql] = params![u64_to_sql(start_block)?, u64_to_sql(end_block)?];
+        let sql_args = params![u64_to_sql(start_block)?, u64_to_sql(end_block)?];
 
         let mut stmt = self
             .headers_db
@@ -749,7 +749,7 @@ impl SpvClient {
         let sql = "INSERT OR REPLACE INTO headers 
         (version, prev_blockhash, merkle_root, time, bits, nonce, height, hash)
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             header.version,
             header.prev_blockhash,
             header.merkle_root,

--- a/stackslib/src/burnchains/bitcoin/spv.rs
+++ b/stackslib/src/burnchains/bitcoin/spv.rs
@@ -20,7 +20,7 @@ use std::ops::Deref;
 use std::{cmp, fs};
 
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction, NO_PARAMS};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction};
 use stacks_common::deps_common::bitcoin::blockdata::block::{BlockHeader, LoneBlockHeader};
 use stacks_common::deps_common::bitcoin::blockdata::constants::genesis_block;
 use stacks_common::deps_common::bitcoin::network::constants::Network;
@@ -31,6 +31,7 @@ use stacks_common::deps_common::bitcoin::network::serialize::{
 };
 use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::{hex_bytes, to_hex};
 use stacks_common::util::uint::Uint256;
 use stacks_common::util::{get_epoch_time_secs, log};

--- a/stackslib/src/burnchains/bitcoin/spv.rs
+++ b/stackslib/src/burnchains/bitcoin/spv.rs
@@ -20,7 +20,7 @@ use std::ops::Deref;
 use std::{cmp, fs};
 
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Row, Transaction};
 use stacks_common::deps_common::bitcoin::blockdata::block::{BlockHeader, LoneBlockHeader};
 use stacks_common::deps_common::bitcoin::blockdata::constants::genesis_block;
 use stacks_common::deps_common::bitcoin::network::constants::Network;
@@ -424,7 +424,7 @@ impl SpvClient {
         }
 
         let tx = self.tx_begin()?;
-        let args: &[&dyn ToSql] = &[&u64_to_sql(interval)?, &work.to_hex_be()];
+        let args: &[&dyn ToSql] = params![u64_to_sql(interval)?, work.to_hex_be()];
         tx.execute(
             "INSERT OR REPLACE INTO chain_work (interval,work) VALUES (?1,?2)",
             args,
@@ -707,7 +707,7 @@ impl SpvClient {
         let mut headers = vec![];
 
         let sql_query = "SELECT * FROM headers WHERE height >= ?1 AND height < ?2 ORDER BY height";
-        let sql_args: &[&dyn ToSql] = &[&u64_to_sql(start_block)?, &u64_to_sql(end_block)?];
+        let sql_args: &[&dyn ToSql] = params![u64_to_sql(start_block)?, u64_to_sql(end_block)?];
 
         let mut stmt = self
             .headers_db
@@ -749,15 +749,15 @@ impl SpvClient {
         let sql = "INSERT OR REPLACE INTO headers 
         (version, prev_blockhash, merkle_root, time, bits, nonce, height, hash)
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
-        let args: &[&dyn ToSql] = &[
-            &header.version,
-            &header.prev_blockhash,
-            &header.merkle_root,
-            &header.time,
-            &header.bits,
-            &header.nonce,
-            &u64_to_sql(height)?,
-            &BurnchainHeaderHash::from_bitcoin_hash(&header.bitcoin_hash()),
+        let args: &[&dyn ToSql] = params![
+            header.version,
+            header.prev_blockhash,
+            header.merkle_root,
+            header.time,
+            header.bits,
+            header.nonce,
+            u64_to_sql(height)?,
+            BurnchainHeaderHash::from_bitcoin_hash(&header.bitcoin_hash()),
         ];
 
         tx.execute(sql, args)

--- a/stackslib/src/burnchains/db.rs
+++ b/stackslib/src/burnchains/db.rs
@@ -904,8 +904,7 @@ impl<'a> BurnchainDBTransaction<'a> {
         for op in block_ops.iter() {
             let serialized_op =
                 serde_json::to_string(op).expect("Failed to serialize parsed BlockstackOp");
-            let args =
-                params![block_header.block_hash, op.txid_ref(), serialized_op];
+            let args = params![block_header.block_hash, op.txid_ref(), serialized_op];
             stmt.execute(args)?;
         }
 

--- a/stackslib/src/burnchains/db.rs
+++ b/stackslib/src/burnchains/db.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::{cmp, fmt, fs, io};
 
 use rusqlite::types::ToSql;
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Row, Transaction};
 use serde_json;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::sqlite::NO_PARAMS;
@@ -322,12 +322,12 @@ impl<'a> BurnchainDBTransaction<'a> {
         let sql = "INSERT OR IGNORE INTO burnchain_db_block_headers
                    (block_height, block_hash, parent_block_hash, num_txs, timestamp)
                    VALUES (?, ?, ?, ?, ?)";
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(header.block_height)?,
-            &header.block_hash,
-            &header.parent_block_hash,
-            &u64_to_sql(header.num_txs)?,
-            &u64_to_sql(header.timestamp)?,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(header.block_height)?,
+            header.block_hash,
+            header.parent_block_hash,
+            u64_to_sql(header.num_txs)?,
+            u64_to_sql(header.timestamp)?,
         ];
         let affected_rows = self.sql_tx.execute(sql, args)?;
         if affected_rows == 0 {
@@ -347,7 +347,7 @@ impl<'a> BurnchainDBTransaction<'a> {
     ) -> Result<u64, DBError> {
         let weight = affirmation_map.weight();
         let sql = "INSERT INTO affirmation_maps (affirmation_map,weight) VALUES (?1,?2)";
-        let args: &[&dyn ToSql] = &[&affirmation_map.encode(), &u64_to_sql(weight)?];
+        let args: &[&dyn ToSql] = params![affirmation_map.encode(), u64_to_sql(weight)?];
         match self.sql_tx.execute(sql, args) {
             Ok(_) => {
                 let am_id = BurnchainDB::get_affirmation_map_id(&self.sql_tx, &affirmation_map)?
@@ -368,11 +368,11 @@ impl<'a> BurnchainDBTransaction<'a> {
         affirmation_id: u64,
     ) -> Result<(), DBError> {
         let sql = "UPDATE block_commit_metadata SET affirmation_id = ?1, anchor_block_descendant = ?2 WHERE burn_block_hash = ?3 AND txid = ?4";
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(affirmation_id)?,
-            &opt_u64_to_sql(anchor_block_descendant)?,
-            &block_commit.burn_header_hash,
-            &block_commit.txid,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(affirmation_id)?,
+            opt_u64_to_sql(anchor_block_descendant)?,
+            block_commit.burn_header_hash,
+            block_commit.txid,
         ];
         match self.sql_tx.execute(sql, args) {
             Ok(_) => {
@@ -391,16 +391,16 @@ impl<'a> BurnchainDBTransaction<'a> {
         target_reward_cycle: u64,
     ) -> Result<(), DBError> {
         let sql = "INSERT OR REPLACE INTO anchor_blocks (reward_cycle) VALUES (?1)";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(target_reward_cycle)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(target_reward_cycle)?];
         self.sql_tx
             .execute(sql, args)
             .map_err(|e| DBError::SqliteError(e))?;
 
         let sql = "UPDATE block_commit_metadata SET anchor_block = ?1 WHERE burn_block_hash = ?2 AND txid = ?3";
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(target_reward_cycle)?,
-            &block_commit.burn_header_hash,
-            &block_commit.txid,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(target_reward_cycle)?,
+            block_commit.burn_header_hash,
+            block_commit.txid,
         ];
         match self.sql_tx.execute(sql, args) {
             Ok(_) => {
@@ -421,7 +421,7 @@ impl<'a> BurnchainDBTransaction<'a> {
     /// Unmark all block-commit(s) that were anchor block(s) for this reward cycle.
     pub fn clear_anchor_block(&self, reward_cycle: u64) -> Result<(), DBError> {
         let sql = "UPDATE block_commit_metadata SET anchor_block = NULL WHERE anchor_block = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(reward_cycle)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(reward_cycle)?];
         self.sql_tx
             .execute(sql, args)
             .map(|_| ())
@@ -878,14 +878,14 @@ impl<'a> BurnchainDBTransaction<'a> {
                                    (burn_block_hash, txid, block_height, vtxindex, anchor_block, anchor_block_descendant, affirmation_id)
                                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
         let mut stmt = self.sql_tx.prepare(commit_metadata_sql)?;
-        let args: &[&dyn ToSql] = &[
-            &bcm.burn_block_hash,
-            &bcm.txid,
-            &u64_to_sql(bcm.block_height)?,
-            &bcm.vtxindex,
-            &opt_u64_to_sql(bcm.anchor_block)?,
-            &opt_u64_to_sql(bcm.anchor_block_descendant)?,
-            &u64_to_sql(bcm.affirmation_id)?,
+        let args: &[&dyn ToSql] = params![
+            bcm.burn_block_hash,
+            bcm.txid,
+            u64_to_sql(bcm.block_height)?,
+            bcm.vtxindex,
+            opt_u64_to_sql(bcm.anchor_block)?,
+            opt_u64_to_sql(bcm.anchor_block_descendant)?,
+            u64_to_sql(bcm.affirmation_id)?,
         ];
         stmt.execute(args)?;
         Ok(())
@@ -904,7 +904,8 @@ impl<'a> BurnchainDBTransaction<'a> {
         for op in block_ops.iter() {
             let serialized_op =
                 serde_json::to_string(op).expect("Failed to serialize parsed BlockstackOp");
-            let args: &[&dyn ToSql] = &[&block_header.block_hash, op.txid_ref(), &serialized_op];
+            let args: &[&dyn ToSql] =
+                params![block_header.block_hash, op.txid_ref(), serialized_op];
             stmt.execute(args)?;
         }
 
@@ -959,7 +960,7 @@ impl<'a> BurnchainDBTransaction<'a> {
         assert_eq!((affirmation_map.len() as u64) + 1, reward_cycle);
         let qry =
             "INSERT OR REPLACE INTO overrides (reward_cycle, affirmation_map) VALUES (?1, ?2)";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(reward_cycle)?, &affirmation_map.encode()];
+        let args: &[&dyn ToSql] = params![u64_to_sql(reward_cycle)?, affirmation_map.encode()];
 
         let mut stmt = self.sql_tx.prepare(qry)?;
         stmt.execute(args)?;
@@ -968,7 +969,7 @@ impl<'a> BurnchainDBTransaction<'a> {
 
     pub fn clear_override_affirmation_map(&self, reward_cycle: u64) -> Result<(), DBError> {
         let qry = "DELETE FROM overrides WHERE reward_cycle = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(reward_cycle)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(reward_cycle)?];
 
         let mut stmt = self.sql_tx.prepare(qry)?;
         stmt.execute(args)?;
@@ -981,7 +982,7 @@ impl BurnchainDB {
         let exists: i64 = query_row(
             self.conn(),
             "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?1",
-            &[LAST_BURNCHAIN_DB_INDEX],
+            params![LAST_BURNCHAIN_DB_INDEX],
         )?
         .unwrap_or(0);
         if exists == 0 {
@@ -1039,7 +1040,7 @@ impl BurnchainDB {
             db_tx.sql_tx.execute_batch(BURNCHAIN_DB_SCHEMA)?;
             db_tx.sql_tx.execute(
                 "INSERT INTO db_config (version) VALUES (?1)",
-                &[&BURNCHAIN_DB_VERSION],
+                params![&BURNCHAIN_DB_VERSION],
             )?;
 
             let first_block_header = BurnchainBlockHeader {
@@ -1121,7 +1122,7 @@ impl BurnchainDB {
         height: u64,
     ) -> Result<bool, BurnchainError> {
         let qry = "SELECT 1 FROM burnchain_db_block_headers WHERE block_height = ?1";
-        let args = &[&u64_to_sql(height)?];
+        let args = params![u64_to_sql(height)?];
         let res: Option<i64> = query_row(conn, qry, args)?;
         Ok(res.is_some())
     }
@@ -1135,7 +1136,7 @@ impl BurnchainDB {
             return Ok(None);
         };
         let qry = "SELECT * FROM burnchain_db_block_headers WHERE block_hash = ?1";
-        let args = &[&hdr.block_hash];
+        let args = params![hdr.block_hash];
         let res: Option<BurnchainBlockHeader> = query_row(conn, qry, args)?;
         Ok(res)
     }
@@ -1148,9 +1149,9 @@ impl BurnchainDB {
             "SELECT * FROM burnchain_db_block_headers WHERE block_hash = ? LIMIT 1";
         let block_ops_qry = "SELECT DISTINCT * FROM burnchain_db_block_ops WHERE block_hash = ?";
 
-        let block_header = query_row(conn, block_header_qry, &[block])?
+        let block_header = query_row(conn, block_header_qry, params![block])?
             .ok_or_else(|| BurnchainError::UnknownBlock(block.clone()))?;
-        let block_ops = query_rows(conn, block_ops_qry, &[block])?;
+        let block_ops = query_rows(conn, block_ops_qry, params![block])?;
 
         Ok(BurnchainBlockData {
             header: block_header,
@@ -1165,7 +1166,7 @@ impl BurnchainDB {
     ) -> Option<BlockstackOperationType> {
         let qry =
             "SELECT DISTINCT op FROM burnchain_db_block_ops WHERE txid = ?1 AND block_hash = ?2";
-        let args: &[&dyn ToSql] = &[txid, burn_header_hash];
+        let args: &[&dyn ToSql] = params![txid, burn_header_hash];
 
         match query_row(conn, qry, args) {
             Ok(res) => res,
@@ -1184,7 +1185,7 @@ impl BurnchainDB {
         txid: &Txid,
     ) -> Option<BlockstackOperationType> {
         let qry = "SELECT DISTINCT op FROM burnchain_db_block_ops WHERE txid = ?1";
-        let args: &[&dyn ToSql] = &[txid];
+        let args: &[&dyn ToSql] = params![txid];
 
         let ops: Vec<BlockstackOperationType> =
             query_rows(&self.conn, qry, args).expect("FATAL: burnchain DB query error");
@@ -1255,7 +1256,7 @@ impl BurnchainDB {
         affirmation_id: u64,
     ) -> Result<Option<AffirmationMap>, DBError> {
         let sql = "SELECT affirmation_map FROM affirmation_maps WHERE affirmation_id = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(affirmation_id)?];
+        let args: &[&dyn ToSql] = params![&u64_to_sql(affirmation_id)?];
         query_row(conn, sql, args)
     }
 
@@ -1264,7 +1265,7 @@ impl BurnchainDB {
         affirmation_id: u64,
     ) -> Result<Option<u64>, DBError> {
         let sql = "SELECT weight FROM affirmation_maps WHERE affirmation_id = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(affirmation_id)?];
+        let args: &[&dyn ToSql] = params![&u64_to_sql(affirmation_id)?];
         query_row(conn, sql, args)
     }
 
@@ -1273,7 +1274,7 @@ impl BurnchainDB {
         affirmation_map: &AffirmationMap,
     ) -> Result<Option<u64>, DBError> {
         let sql = "SELECT affirmation_id FROM affirmation_maps WHERE affirmation_map = ?1";
-        let args: &[&dyn ToSql] = &[&affirmation_map.encode()];
+        let args: &[&dyn ToSql] = params![&affirmation_map.encode()];
         query_row(conn, sql, args)
     }
 
@@ -1283,7 +1284,7 @@ impl BurnchainDB {
         txid: &Txid,
     ) -> Result<Option<u64>, DBError> {
         let sql = "SELECT affirmation_id FROM block_commit_metadata WHERE burn_block_hash = ?1 AND txid = ?2";
-        let args: &[&dyn ToSql] = &[burn_header_hash, txid];
+        let args: &[&dyn ToSql] = params![burn_header_hash, txid];
         query_row(conn, sql, args)
     }
 
@@ -1304,13 +1305,13 @@ impl BurnchainDB {
         txid: &Txid,
     ) -> Result<bool, DBError> {
         let sql = "SELECT 1 FROM block_commit_metadata WHERE anchor_block IS NOT NULL AND burn_block_hash = ?1 AND txid = ?2";
-        let args: &[&dyn ToSql] = &[burn_header_hash, txid];
+        let args: &[&dyn ToSql] = params![burn_header_hash, txid];
         query_row(conn, sql, args)?.ok_or(DBError::NotFoundError)
     }
 
     pub fn has_anchor_block(conn: &DBConn, reward_cycle: u64) -> Result<bool, DBError> {
         let sql = "SELECT 1 FROM block_commit_metadata WHERE anchor_block = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(reward_cycle)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(reward_cycle)?];
         Ok(query_row::<bool, _>(conn, sql, args)?.is_some())
     }
 
@@ -1319,7 +1320,7 @@ impl BurnchainDB {
         reward_cycle: u64,
     ) -> Result<Vec<BlockCommitMetadata>, DBError> {
         let sql = "SELECT * FROM block_commit_metadata WHERE anchor_block = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(reward_cycle)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(reward_cycle)?];
 
         let metadatas: Vec<BlockCommitMetadata> = query_rows(conn, sql, args)?;
         Ok(metadatas)
@@ -1331,7 +1332,7 @@ impl BurnchainDB {
         reward_cycle: u64,
     ) -> Result<Option<BlockCommitMetadata>, DBError> {
         let sql = "SELECT * FROM block_commit_metadata WHERE anchor_block = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(reward_cycle)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(reward_cycle)?];
 
         let metadatas: Vec<BlockCommitMetadata> = query_rows(conn, sql, args)?;
         for metadata in metadatas {
@@ -1372,7 +1373,7 @@ impl BurnchainDB {
     ) -> Result<Option<(LeaderBlockCommitOp, BlockCommitMetadata)>, DBError> {
         let sql =
             "SELECT * FROM block_commit_metadata WHERE anchor_block = ?1 AND burn_block_hash = ?2";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(reward_cycle)?, anchor_block_burn_header_hash];
+        let args: &[&dyn ToSql] = params![u64_to_sql(reward_cycle)?, anchor_block_burn_header_hash];
         if let Some(commit_metadata) = query_row::<BlockCommitMetadata, _>(conn, sql, args)? {
             let commit = BurnchainDB::get_block_commit(
                 conn,
@@ -1450,7 +1451,7 @@ impl BurnchainDB {
         vtxindex: u16,
     ) -> Result<Option<LeaderBlockCommitOp>, DBError> {
         let qry = "SELECT txid FROM block_commit_metadata WHERE block_height = ?1 AND vtxindex = ?2 AND burn_block_hash = ?3";
-        let args: &[&dyn ToSql] = &[&block_ptr, &vtxindex, &header_hash];
+        let args: &[&dyn ToSql] = params![block_ptr, vtxindex, header_hash];
         let txid = match query_row(&conn, qry, args) {
             Ok(Some(txid)) => txid,
             Ok(None) => {
@@ -1496,7 +1497,7 @@ impl BurnchainDB {
         burn_block_hash: &BurnchainHeaderHash,
         txid: &Txid,
     ) -> Result<Option<BlockCommitMetadata>, DBError> {
-        let args: &[&dyn ToSql] = &[burn_block_hash, txid];
+        let args: &[&dyn ToSql] = params![burn_block_hash, txid];
         query_row_panic(
             conn,
             "SELECT * FROM block_commit_metadata WHERE burn_block_hash = ?1 AND txid = ?2",
@@ -1611,7 +1612,7 @@ impl BurnchainDB {
         let am_opt: Option<AffirmationMap> = query_row_panic(
             conn,
             "SELECT affirmation_map FROM overrides WHERE reward_cycle = ?1",
-            &[&u64_to_sql(reward_cycle)?],
+            params![u64_to_sql(reward_cycle)?],
             || format!("BUG: more than one override affirmation map for the same reward cycle"),
         )?;
         if let Some(am) = &am_opt {

--- a/stackslib/src/burnchains/db.rs
+++ b/stackslib/src/burnchains/db.rs
@@ -19,9 +19,10 @@ use std::path::Path;
 use std::{cmp, fmt, fs, io};
 
 use rusqlite::types::ToSql;
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction, NO_PARAMS};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction};
 use serde_json;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::sqlite::NO_PARAMS;
 
 use crate::burnchains::affirmation::*;
 use crate::burnchains::{

--- a/stackslib/src/burnchains/tests/db.rs
+++ b/stackslib/src/burnchains/tests/db.rs
@@ -54,8 +54,10 @@ impl BurnchainDB {
         &self,
         block_hash: &BurnchainHeaderHash,
     ) -> Result<Vec<BlockstackOperationType>, BurnchainError> {
+        use rusqlite::params;
+
         let sql = "SELECT op FROM burnchain_db_block_ops WHERE block_hash = ?1";
-        let args: &[&dyn ToSql] = &[block_hash];
+        let args: &[&dyn ToSql] = params![block_hash];
         let mut ops: Vec<BlockstackOperationType> = query_rows(&self.conn, sql, args)?;
         ops.sort_by(|a, b| a.vtxindex().cmp(&b.vtxindex()));
         Ok(ops)

--- a/stackslib/src/burnchains/tests/db.rs
+++ b/stackslib/src/burnchains/tests/db.rs
@@ -57,7 +57,7 @@ impl BurnchainDB {
         use rusqlite::params;
 
         let sql = "SELECT op FROM burnchain_db_block_ops WHERE block_hash = ?1";
-        let args: &[&dyn ToSql] = params![block_hash];
+        let args = params![block_hash];
         let mut ops: Vec<BlockstackOperationType> = query_rows(&self.conn, sql, args)?;
         ops.sort_by(|a, b| a.vtxindex().cmp(&b.vtxindex()));
         Ok(ops)

--- a/stackslib/src/burnchains/tests/db.rs
+++ b/stackslib/src/burnchains/tests/db.rs
@@ -16,11 +16,12 @@
 
 use std::cmp;
 
-use rusqlite::{ToSql, NO_PARAMS};
+use rusqlite::ToSql;
 use stacks_common::address::AddressHashMode;
 use stacks_common::deps_common::bitcoin::blockdata::transaction::Transaction as BtcTx;
 use stacks_common::deps_common::bitcoin::network::serialize::deserialize;
 use stacks_common::types::chainstate::StacksAddress;
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::*;
 
 use super::*;

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -861,7 +861,7 @@ pub fn get_block_commit_by_txid(
     txid: &Txid,
 ) -> Result<Option<LeaderBlockCommitOp>, db_error> {
     let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 AND txid = ?2 LIMIT 1";
-    let args: &[&dyn ToSql] = params![sort_id, txid];
+    let args = params![sort_id, txid];
     query_row(conn, qry, args)
 }
 
@@ -1206,7 +1206,7 @@ impl<'a> SortitionHandleTx<'a> {
             };
 
         let qry = "SELECT * FROM leader_keys WHERE sortition_id = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             ancestor_snapshot.sortition_id,
             u64_to_sql(key_block_height)?,
             key_vtxindex,
@@ -1675,7 +1675,7 @@ impl<'a> SortitionHandleTx<'a> {
         sortition_id: &SortitionId,
     ) -> Result<(Vec<PoxAddress>, u128), db_error> {
         let sql = "SELECT pox_payouts FROM snapshots WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = params![sortition_id];
+        let args = params![sortition_id];
         let pox_addrs_json: String = query_row(self, sql, args)?.ok_or(db_error::NotFoundError)?;
 
         let pox_addrs: (Vec<PoxAddress>, u128) =
@@ -1770,7 +1770,7 @@ impl<'a> SortitionHandleTx<'a> {
         stacks_block_height: u64,
     ) -> Result<(), db_error> {
         let sql = "INSERT OR REPLACE INTO stacks_chain_tips (sortition_id,consensus_hash,block_hash,block_height) VALUES (?1,?2,?3,?4)";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             sort_id,
             consensus_hash,
             stacks_block_hash,
@@ -1820,7 +1820,7 @@ impl<'a> SortitionHandleTx<'a> {
 
         // in epoch 2.x, where we track canonical stacks tip via the sortition DB
         let arrival_index = SortitionDB::get_max_arrival_index(self)?;
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             u64_to_sql(stacks_block_height)?,
             u64_to_sql(arrival_index + 1)?,
             consensus_hash,
@@ -2540,7 +2540,7 @@ impl<'a> SortitionHandleConn<'a> {
         sortition_id: &SortitionId,
     ) -> Result<(Vec<PoxAddress>, u128), db_error> {
         let sql = "SELECT pox_payouts FROM snapshots WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = params![sortition_id];
+        let args = params![sortition_id];
         let pox_addrs_json: String = query_row(self, sql, args)?.ok_or(db_error::NotFoundError)?;
 
         let pox_addrs: (Vec<PoxAddress>, u128) =
@@ -2850,7 +2850,7 @@ impl SortitionDB {
     ) -> Result<(), db_error> {
         let epochs = StacksEpoch::validate_epochs(epochs);
         for epoch in epochs.into_iter() {
-            let args: &[&dyn ToSql] = params![
+            let args = params![
                 (epoch.epoch_id as u32),
                 u64_to_sql(epoch.start_height)?,
                 u64_to_sql(epoch.end_height)?,
@@ -2924,7 +2924,7 @@ impl SortitionDB {
         info!("Replace existing epochs with new epochs");
         db_tx.execute("DELETE FROM epochs;", NO_PARAMS)?;
         for epoch in epochs.into_iter() {
-            let args: &[&dyn ToSql] = params![
+            let args = params![
                 (epoch.epoch_id as u32),
                 u64_to_sql(epoch.start_height)?,
                 u64_to_sql(epoch.end_height)?,
@@ -2946,7 +2946,7 @@ impl SortitionDB {
         sortition_id: &SortitionId,
     ) -> Result<Option<LeaderBlockCommitOp>, db_error> {
         let qry = "SELECT * FROM block_commits WHERE txid = ?1 AND sortition_id = ?2";
-        let args: &[&dyn ToSql] = params![txid, sortition_id];
+        let args = params![txid, sortition_id];
         query_row(conn, qry, args)
     }
 
@@ -2958,7 +2958,7 @@ impl SortitionDB {
         sortition_id: &SortitionId,
     ) -> Result<Option<SortitionId>, db_error> {
         let qry = "SELECT parent_sortition_id AS sortition_id FROM block_commit_parents WHERE block_commit_parents.block_commit_txid = ?1 AND block_commit_parents.block_commit_sortition_id = ?2";
-        let args: &[&dyn ToSql] = params![txid, sortition_id];
+        let args = params![txid, sortition_id];
         query_row(conn, qry, args)
     }
 
@@ -3109,9 +3109,9 @@ impl SortitionDB {
             tx.execute_batch(sql_exec)?;
         }
 
-        let typical_rules: &[&dyn ToSql] = params![(ASTRules::Typical as u8), 0i64];
+        let typical_rules = params![(ASTRules::Typical as u8), 0i64];
 
-        let precheck_size_rules: &[&dyn ToSql] = params![
+        let precheck_size_rules = params![
             (ASTRules::PrecheckSize as u8),
             u64_to_sql(AST_RULES_PRECHECK_SIZE)?,
         ];
@@ -3209,7 +3209,7 @@ impl SortitionDB {
         // skip if this step was done
         if table_exists(&tx, "stacks_chain_tips")? {
             let sql = "SELECT 1 FROM stacks_chain_tips WHERE sortition_id = ?1";
-            let args: &[&dyn ToSql] = params![canonical_tip.sortition_id];
+            let args = params![canonical_tip.sortition_id];
             if let Ok(Some(_)) = query_row::<i64, _>(&tx, sql, args) {
                 info!("`stacks_chain_tips` appears to have been populated already; skipping this step");
                 return Ok(());
@@ -3225,7 +3225,7 @@ impl SortitionDB {
             );
             for snapshot in snapshots.into_iter() {
                 let sql = "INSERT OR REPLACE INTO stacks_chain_tips (sortition_id,consensus_hash,block_hash,block_height) VALUES (?1,?2,?3,?4)";
-                let args: &[&dyn ToSql] = params![
+                let args = params![
                     snapshot.sortition_id,
                     snapshot.canonical_stacks_tip_consensus_hash,
                     snapshot.canonical_stacks_tip_hash,
@@ -3453,7 +3453,7 @@ impl SortitionDB {
         ast_rules: ASTRules,
         height: u64,
     ) -> Result<(), db_error> {
-        let rules: &[&dyn ToSql] = params![u64_to_sql(height)?, (ast_rules as u8)];
+        let rules = params![u64_to_sql(height)?, (ast_rules as u8)];
 
         tx.execute(
             "UPDATE ast_rule_heights SET block_height = ?1 WHERE ast_rule_id = ?2",
@@ -3506,7 +3506,7 @@ impl SortitionDB {
         }
         let sql = "REPLACE INTO preprocessed_reward_sets (sortition_id,reward_set) VALUES (?1,?2)";
         let rc_json = serde_json::to_string(rc_info).map_err(db_error::SerializationError)?;
-        let args: &[&dyn ToSql] = params![sortition_id, rc_json];
+        let args = params![sortition_id, rc_json];
         sort_tx.execute(sql, args)?;
         Ok(())
     }
@@ -3589,7 +3589,7 @@ impl SortitionDB {
         sortition_id: &SortitionId,
     ) -> Result<Option<RewardCycleInfo>, db_error> {
         let sql = "SELECT reward_set FROM preprocessed_reward_sets WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = params![sortition_id];
+        let args = params![sortition_id];
         let reward_set_opt: Option<String> =
             sortdb.query_row(sql, args, |row| row.get(0)).optional()?;
 
@@ -3821,7 +3821,7 @@ impl<'a> SortitionDBConn<'a> {
         sortition_id: &SortitionId,
     ) -> Result<(Vec<PoxAddress>, u128), db_error> {
         let sql = "SELECT pox_payouts FROM snapshots WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = params![sortition_id];
+        let args = params![sortition_id];
         let pox_addrs_json: String =
             query_row(self.conn(), sql, args)?.ok_or(db_error::NotFoundError)?;
 
@@ -4028,7 +4028,7 @@ impl SortitionDB {
         stacks_block_accepted: Option<bool>,
     ) -> Result<(), BurnchainError> {
         if let Some(stacks_block_accepted) = stacks_block_accepted {
-            let args: &[&dyn ToSql] = params![
+            let args = params![
                 sortition_id,
                 u64_to_sql(canonical_stacks_height)?,
                 canonical_stacks_bhh,
@@ -4040,7 +4040,7 @@ impl SortitionDB {
                 args
             )?;
         } else {
-            let args: &[&dyn ToSql] = params![
+            let args = params![
                 sortition_id,
                 u64_to_sql(canonical_stacks_height)?,
                 canonical_stacks_bhh,
@@ -4607,7 +4607,7 @@ impl SortitionDB {
         burnchain_header_hash: &BurnchainHeaderHash,
     ) -> Result<Option<BurnchainHeaderHash>, db_error> {
         let sql = "SELECT parent_burn_header_hash AS burn_header_hash FROM snapshots WHERE burn_header_hash = ?1";
-        let args: &[&dyn ToSql] = params![burnchain_header_hash];
+        let args = params![burnchain_header_hash];
         let mut rows = query_rows::<BurnchainHeaderHash, _>(conn, sql, args)?;
 
         // there can be more than one if there was a PoX reorg.  If so, make sure they're _all the
@@ -4882,7 +4882,7 @@ impl SortitionDB {
         conn: &Connection,
     ) -> Result<(u64, BurnchainHeaderHash), db_error> {
         let sql = "SELECT block_height, burn_header_hash FROM snapshots WHERE consensus_hash = ?1";
-        let args: &[&dyn ToSql] = params![ConsensusHash::empty()];
+        let args = params![ConsensusHash::empty()];
         let mut stmt = conn.prepare(sql)?;
         let mut rows = stmt.query(args)?;
         while let Some(row) = rows.next()? {
@@ -4970,7 +4970,7 @@ impl SortitionDB {
         sortition: &SortitionId,
     ) -> Result<Vec<LeaderBlockCommitOp>, db_error> {
         let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 ORDER BY vtxindex ASC";
-        let args: &[&dyn ToSql] = params![sortition];
+        let args = params![sortition];
 
         query_rows(conn, qry, args)
     }
@@ -4982,7 +4982,7 @@ impl SortitionDB {
         sortition: &SortitionId,
     ) -> Result<Vec<MissedBlockCommit>, db_error> {
         let qry = "SELECT * FROM missed_commits WHERE intended_sortition_id = ?1";
-        let args: &[&dyn ToSql] = params![sortition];
+        let args = params![sortition];
 
         query_rows(conn, qry, args)
     }
@@ -4994,7 +4994,7 @@ impl SortitionDB {
         sortition: &SortitionId,
     ) -> Result<Vec<LeaderKeyRegisterOp>, db_error> {
         let qry = "SELECT * FROM leader_keys WHERE sortition_id = ?1 ORDER BY vtxindex ASC";
-        let args: &[&dyn ToSql] = params![sortition];
+        let args = params![sortition];
 
         query_rows(conn, qry, args)
     }
@@ -5008,7 +5008,7 @@ impl SortitionDB {
         let qry = "SELECT vtxindex FROM block_commits WHERE sortition_id = ?1 
                     AND txid = (
                       SELECT winning_block_txid FROM snapshots WHERE sortition_id = ?2 LIMIT 1) LIMIT 1";
-        let args: &[&dyn ToSql] = params![sortition, sortition];
+        let args = params![sortition, sortition];
         conn.query_row(qry, args, |row| row.get(0))
             .optional()
             .map_err(db_error::from)
@@ -5090,7 +5090,7 @@ impl SortitionDB {
         assert!(block_height < BLOCK_HEIGHT_MAX);
 
         let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2";
-        let args: &[&dyn ToSql] = params![sortition, u64_to_sql(block_height)?, vtxindex];
+        let args = params![sortition, u64_to_sql(block_height)?, vtxindex];
         query_row_panic(conn, qry, args, || {
             format!(
                 "Multiple parent blocks at {},{} in {}",
@@ -5119,7 +5119,7 @@ impl SortitionDB {
         };
 
         let qry = "SELECT * FROM leader_keys WHERE sortition_id = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             ancestor_snapshot.sortition_id,
             u64_to_sql(key_block_height)?,
             key_vtxindex,
@@ -5157,7 +5157,7 @@ impl SortitionDB {
         };
 
         let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 AND block_header_hash = ?2 AND txid = ?3";
-        let args: &[&dyn ToSql] = params![sortition_id, block_hash, winning_txid];
+        let args = params![sortition_id, block_hash, winning_txid];
         query_row_panic(conn, qry, args, || {
             format!("FATAL: multiple block commits for {}", &block_hash)
         })
@@ -5213,7 +5213,7 @@ impl SortitionDB {
     ) -> Result<Option<StacksEpoch>, db_error> {
         let sql =
             "SELECT * FROM epochs WHERE start_block_height <= ?1 AND ?2 < end_block_height LIMIT 1";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             u64_to_sql(burn_block_height)?,
             u64_to_sql(burn_block_height)?,
         ];
@@ -5244,7 +5244,7 @@ impl SortitionDB {
         epoch_id: &StacksEpochId,
     ) -> Result<Option<StacksEpoch>, db_error> {
         let sql = "SELECT * FROM epochs WHERE epoch_id = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = params![*epoch_id as u32];
+        let args = params![*epoch_id as u32];
         query_row(conn, sql, args)
     }
 
@@ -5481,7 +5481,7 @@ impl<'a> SortitionHandleTx<'a> {
         let create = "CREATE TABLE IF NOT EXISTS snapshot_burn_distributions (sortition_id TEXT PRIMARY KEY, data TEXT NOT NULL);";
         self.execute(create, NO_PARAMS).unwrap();
         let sql = "INSERT INTO snapshot_burn_distributions (sortition_id, data) VALUES (?, ?)";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             new_sortition,
             serde_json::to_string(&transition.burn_dist).unwrap(),
         ];
@@ -5502,7 +5502,7 @@ impl<'a> SortitionHandleTx<'a> {
         transition: &BurnchainStateTransition,
     ) -> Result<(), db_error> {
         let sql = "INSERT INTO snapshot_transition_ops (sortition_id, accepted_ops, consumed_keys) VALUES (?, ?, ?)";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             new_sortition,
             serde_json::to_string(&transition.accepted_ops).unwrap(),
             serde_json::to_string(&transition.consumed_leader_keys).unwrap(),
@@ -5593,7 +5593,7 @@ impl<'a> SortitionHandleTx<'a> {
     ) -> Result<(), db_error> {
         assert!(leader_key.block_height < BLOCK_HEIGHT_MAX);
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             leader_key.txid,
             leader_key.vtxindex,
             u64_to_sql(leader_key.block_height)?,
@@ -5611,7 +5611,7 @@ impl<'a> SortitionHandleTx<'a> {
 
     /// Insert a stack-stx op
     fn insert_stack_stx(&mut self, op: &StackStxOp) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             op.txid,
             op.vtxindex,
             u64_to_sql(op.block_height)?,
@@ -5632,7 +5632,7 @@ impl<'a> SortitionHandleTx<'a> {
 
     /// Insert a delegate-stx op
     fn insert_delegate_stx(&mut self, op: &DelegateStxOp) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             op.txid,
             op.vtxindex,
             u64_to_sql(op.block_height)?,
@@ -5654,7 +5654,7 @@ impl<'a> SortitionHandleTx<'a> {
         &mut self,
         op: &VoteForAggregateKeyOp,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             op.txid,
             op.vtxindex,
             u64_to_sql(op.block_height)?,
@@ -5674,7 +5674,7 @@ impl<'a> SortitionHandleTx<'a> {
 
     /// Insert a transfer-stx op
     fn insert_transfer_stx(&mut self, op: &TransferStxOp) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             op.txid,
             op.vtxindex,
             u64_to_sql(op.block_height)?,
@@ -5723,7 +5723,7 @@ impl<'a> SortitionHandleTx<'a> {
             }
         }
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             block_commit.txid,
             block_commit.vtxindex,
             u64_to_sql(block_commit.block_height)?,
@@ -5748,7 +5748,7 @@ impl<'a> SortitionHandleTx<'a> {
         self.execute("INSERT INTO block_commits (txid, vtxindex, block_height, burn_header_hash, block_header_hash, new_seed, parent_block_ptr, parent_vtxindex, key_block_ptr, key_vtxindex, memo, burn_fee, input, sortition_id, commit_outs, sunset_burn, apparent_sender, burn_parent_modulus, punished) \
                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)", args)?;
 
-        let parent_args: &[&dyn ToSql] = params![sort_id, block_commit.txid, parent_sortition_id];
+        let parent_args = params![sort_id, block_commit.txid, parent_sortition_id];
 
         debug!(
             "Parent sortition of {},{},{} is {} (parent at {},{})",
@@ -5776,7 +5776,7 @@ impl<'a> SortitionHandleTx<'a> {
         let tx_input_str =
             serde_json::to_string(&op.input).map_err(|e| db_error::SerializationError(e))?;
 
-        let args: &[&dyn ToSql] = params![op.txid, op.intended_sortition, tx_input_str];
+        let args = params![op.txid, op.intended_sortition, tx_input_str];
 
         self.execute(
             "INSERT OR REPLACE INTO missed_commits (txid, intended_sortition_id, input) \
@@ -5828,7 +5828,7 @@ impl<'a> SortitionHandleTx<'a> {
             }
         }
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             u64_to_sql(snapshot.block_height)?,
             snapshot.burn_header_hash,
             u64_to_sql(snapshot.burn_header_timestamp)?,
@@ -6458,7 +6458,7 @@ impl<'a> SortitionHandleTx<'a> {
         best_bhh: BlockHeaderHash,
         best_height: u64,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             best_chh,
             best_bhh,
             u64_to_sql(best_height)?,
@@ -6730,7 +6730,7 @@ pub mod tests {
             let pox_payouts_json = serde_json::to_string(&pox_payout)
                 .expect("FATAL: could not encode `total_pox_payouts` as JSON");
 
-            let args: &[&dyn ToSql] = params![
+            let args = params![
                 u64_to_sql(first_snapshot.block_height)?,
                 first_snapshot.burn_header_hash,
                 u64_to_sql(first_snapshot.burn_header_timestamp)?,
@@ -6788,7 +6788,7 @@ pub mod tests {
             height: u64,
         ) -> Result<(), db_error> {
             let tip = SortitionDB::get_canonical_burn_chain_tip(conn)?;
-            let args: &[&dyn ToSql] = params![ch, bhh, u64_to_sql(height)?, tip.sortition_id];
+            let args = params![ch, bhh, u64_to_sql(height)?, tip.sortition_id];
             conn.execute("UPDATE snapshots SET canonical_stacks_tip_consensus_hash = ?1, canonical_stacks_tip_hash = ?2, canonical_stacks_tip_height = ?3
                         WHERE sortition_id = ?4", args)
                 .map_err(db_error::SqliteError)?;
@@ -6865,7 +6865,7 @@ pub mod tests {
             let apparent_sender_str =
                 serde_json::to_string(sender).map_err(|e| db_error::SerializationError(e))?;
             let sql = "SELECT * FROM block_commits WHERE apparent_sender = ?1 ORDER BY block_height DESC LIMIT 1";
-            let args: &[&dyn ToSql] = params![apparent_sender_str];
+            let args = params![apparent_sender_str];
             query_row(conn, sql, args)
         }
     }

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -29,7 +29,8 @@ use rand;
 use rand::RngCore;
 use rusqlite::types::ToSql;
 use rusqlite::{
-    params, Connection, Error as sqlite_error, OpenFlags, OptionalExtension, Row, Transaction, TransactionBehavior
+    params, Connection, Error as sqlite_error, OpenFlags, OptionalExtension, Row, Transaction,
+    TransactionBehavior,
 };
 use sha2::{Digest, Sha512_256};
 use stacks_common::address::AddressHashMode;
@@ -860,7 +861,7 @@ pub fn get_block_commit_by_txid(
     txid: &Txid,
 ) -> Result<Option<LeaderBlockCommitOp>, db_error> {
     let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 AND txid = ?2 LIMIT 1";
-    let args: &[&dyn ToSql] = &[sort_id, txid];
+    let args: &[&dyn ToSql] = params![sort_id, txid];
     query_row(conn, qry, args)
 }
 
@@ -1205,10 +1206,10 @@ impl<'a> SortitionHandleTx<'a> {
             };
 
         let qry = "SELECT * FROM leader_keys WHERE sortition_id = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2";
-        let args: &[&dyn ToSql] = &[
-            &ancestor_snapshot.sortition_id,
-            &u64_to_sql(key_block_height)?,
-            &key_vtxindex,
+        let args: &[&dyn ToSql] = params![
+            ancestor_snapshot.sortition_id,
+            u64_to_sql(key_block_height)?,
+            key_vtxindex,
         ];
         query_row_panic(self.tx(), qry, args, || {
             format!(
@@ -1674,7 +1675,7 @@ impl<'a> SortitionHandleTx<'a> {
         sortition_id: &SortitionId,
     ) -> Result<(Vec<PoxAddress>, u128), db_error> {
         let sql = "SELECT pox_payouts FROM snapshots WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = &[sortition_id];
+        let args: &[&dyn ToSql] = params![sortition_id];
         let pox_addrs_json: String = query_row(self, sql, args)?.ok_or(db_error::NotFoundError)?;
 
         let pox_addrs: (Vec<PoxAddress>, u128) =
@@ -1769,11 +1770,11 @@ impl<'a> SortitionHandleTx<'a> {
         stacks_block_height: u64,
     ) -> Result<(), db_error> {
         let sql = "INSERT OR REPLACE INTO stacks_chain_tips (sortition_id,consensus_hash,block_hash,block_height) VALUES (?1,?2,?3,?4)";
-        let args: &[&dyn ToSql] = &[
+        let args: &[&dyn ToSql] = params![
             sort_id,
             consensus_hash,
             stacks_block_hash,
-            &u64_to_sql(stacks_block_height)?,
+            u64_to_sql(stacks_block_height)?,
         ];
         self.execute(sql, args)?;
         Ok(())
@@ -1819,9 +1820,9 @@ impl<'a> SortitionHandleTx<'a> {
 
         // in epoch 2.x, where we track canonical stacks tip via the sortition DB
         let arrival_index = SortitionDB::get_max_arrival_index(self)?;
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(stacks_block_height)?,
-            &u64_to_sql(arrival_index + 1)?,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(stacks_block_height)?,
+            u64_to_sql(arrival_index + 1)?,
             consensus_hash,
             stacks_block_hash,
         ];
@@ -2539,7 +2540,7 @@ impl<'a> SortitionHandleConn<'a> {
         sortition_id: &SortitionId,
     ) -> Result<(Vec<PoxAddress>, u128), db_error> {
         let sql = "SELECT pox_payouts FROM snapshots WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = &[sortition_id];
+        let args: &[&dyn ToSql] = params![sortition_id];
         let pox_addrs_json: String = query_row(self, sql, args)?.ok_or(db_error::NotFoundError)?;
 
         let pox_addrs: (Vec<PoxAddress>, u128) =
@@ -2849,12 +2850,12 @@ impl SortitionDB {
     ) -> Result<(), db_error> {
         let epochs = StacksEpoch::validate_epochs(epochs);
         for epoch in epochs.into_iter() {
-            let args: &[&dyn ToSql] = &[
-                &(epoch.epoch_id as u32),
-                &u64_to_sql(epoch.start_height)?,
-                &u64_to_sql(epoch.end_height)?,
-                &epoch.block_limit,
-                &epoch.network_epoch,
+            let args: &[&dyn ToSql] = params![
+                (epoch.epoch_id as u32),
+                u64_to_sql(epoch.start_height)?,
+                u64_to_sql(epoch.end_height)?,
+                epoch.block_limit,
+                epoch.network_epoch,
             ];
             db_tx.execute(
                 "INSERT INTO epochs (epoch_id,start_block_height,end_block_height,block_limit,network_epoch) VALUES (?1,?2,?3,?4,?5)",
@@ -2923,12 +2924,12 @@ impl SortitionDB {
         info!("Replace existing epochs with new epochs");
         db_tx.execute("DELETE FROM epochs;", NO_PARAMS)?;
         for epoch in epochs.into_iter() {
-            let args: &[&dyn ToSql] = &[
-                &(epoch.epoch_id as u32),
-                &u64_to_sql(epoch.start_height)?,
-                &u64_to_sql(epoch.end_height)?,
-                &epoch.block_limit,
-                &epoch.network_epoch,
+            let args: &[&dyn ToSql] = params![
+                (epoch.epoch_id as u32),
+                u64_to_sql(epoch.start_height)?,
+                u64_to_sql(epoch.end_height)?,
+                epoch.block_limit,
+                epoch.network_epoch,
             ];
             db_tx.execute(
                 "INSERT INTO epochs (epoch_id,start_block_height,end_block_height,block_limit,network_epoch) VALUES (?1,?2,?3,?4,?5)",
@@ -2945,8 +2946,8 @@ impl SortitionDB {
         sortition_id: &SortitionId,
     ) -> Result<Option<LeaderBlockCommitOp>, db_error> {
         let qry = "SELECT * FROM block_commits WHERE txid = ?1 AND sortition_id = ?2";
-        let args: [&dyn ToSql; 2] = [&txid, &sortition_id];
-        query_row(conn, qry, &args)
+        let args: &[&dyn ToSql] = params![txid, sortition_id];
+        query_row(conn, qry, args)
     }
 
     /// Get the Sortition ID for the burnchain block containing `txid`'s parent.
@@ -2957,7 +2958,7 @@ impl SortitionDB {
         sortition_id: &SortitionId,
     ) -> Result<Option<SortitionId>, db_error> {
         let qry = "SELECT parent_sortition_id AS sortition_id FROM block_commit_parents WHERE block_commit_parents.block_commit_txid = ?1 AND block_commit_parents.block_commit_sortition_id = ?2";
-        let args: &[&dyn ToSql] = &[txid, sortition_id];
+        let args: &[&dyn ToSql] = params![txid, sortition_id];
         query_row(conn, qry, args)
     }
 
@@ -3108,11 +3109,11 @@ impl SortitionDB {
             tx.execute_batch(sql_exec)?;
         }
 
-        let typical_rules: &[&dyn ToSql] = &[&(ASTRules::Typical as u8), &0i64];
+        let typical_rules: &[&dyn ToSql] = params![(ASTRules::Typical as u8), 0i64];
 
-        let precheck_size_rules: &[&dyn ToSql] = &[
-            &(ASTRules::PrecheckSize as u8),
-            &u64_to_sql(AST_RULES_PRECHECK_SIZE)?,
+        let precheck_size_rules: &[&dyn ToSql] = params![
+            (ASTRules::PrecheckSize as u8),
+            u64_to_sql(AST_RULES_PRECHECK_SIZE)?,
         ];
 
         tx.execute(
@@ -3208,7 +3209,7 @@ impl SortitionDB {
         // skip if this step was done
         if table_exists(&tx, "stacks_chain_tips")? {
             let sql = "SELECT 1 FROM stacks_chain_tips WHERE sortition_id = ?1";
-            let args = params![canonical_tip.sortition_id];
+            let args: &[&dyn ToSql] = params![canonical_tip.sortition_id];
             if let Ok(Some(_)) = query_row::<i64, _>(&tx, sql, args) {
                 info!("`stacks_chain_tips` appears to have been populated already; skipping this step");
                 return Ok(());
@@ -3224,11 +3225,11 @@ impl SortitionDB {
             );
             for snapshot in snapshots.into_iter() {
                 let sql = "INSERT OR REPLACE INTO stacks_chain_tips (sortition_id,consensus_hash,block_hash,block_height) VALUES (?1,?2,?3,?4)";
-                let args: &[&dyn ToSql] = &[
-                    &snapshot.sortition_id,
-                    &snapshot.canonical_stacks_tip_consensus_hash,
-                    &snapshot.canonical_stacks_tip_hash,
-                    &u64_to_sql(snapshot.canonical_stacks_tip_height)?,
+                let args: &[&dyn ToSql] = params![
+                    snapshot.sortition_id,
+                    snapshot.canonical_stacks_tip_consensus_hash,
+                    snapshot.canonical_stacks_tip_hash,
+                    u64_to_sql(snapshot.canonical_stacks_tip_height)?,
                 ];
                 tx.execute(sql, args)?;
             }
@@ -3452,7 +3453,7 @@ impl SortitionDB {
         ast_rules: ASTRules,
         height: u64,
     ) -> Result<(), db_error> {
-        let rules: &[&dyn ToSql] = &[&u64_to_sql(height)?, &(ast_rules as u8)];
+        let rules: &[&dyn ToSql] = params![u64_to_sql(height)?, (ast_rules as u8)];
 
         tx.execute(
             "UPDATE ast_rule_heights SET block_height = ?1 WHERE ast_rule_id = ?2",
@@ -3505,7 +3506,7 @@ impl SortitionDB {
         }
         let sql = "REPLACE INTO preprocessed_reward_sets (sortition_id,reward_set) VALUES (?1,?2)";
         let rc_json = serde_json::to_string(rc_info).map_err(db_error::SerializationError)?;
-        let args = params![sortition_id, rc_json];
+        let args: &[&dyn ToSql] = params![sortition_id, rc_json];
         sort_tx.execute(sql, args)?;
         Ok(())
     }
@@ -3588,7 +3589,7 @@ impl SortitionDB {
         sortition_id: &SortitionId,
     ) -> Result<Option<RewardCycleInfo>, db_error> {
         let sql = "SELECT reward_set FROM preprocessed_reward_sets WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = &[sortition_id];
+        let args: &[&dyn ToSql] = params![sortition_id];
         let reward_set_opt: Option<String> =
             sortdb.query_row(sql, args, |row| row.get(0)).optional()?;
 
@@ -3820,7 +3821,7 @@ impl<'a> SortitionDBConn<'a> {
         sortition_id: &SortitionId,
     ) -> Result<(Vec<PoxAddress>, u128), db_error> {
         let sql = "SELECT pox_payouts FROM snapshots WHERE sortition_id = ?1";
-        let args: &[&dyn ToSql] = &[sortition_id];
+        let args: &[&dyn ToSql] = params![sortition_id];
         let pox_addrs_json: String =
             query_row(self.conn(), sql, args)?.ok_or(db_error::NotFoundError)?;
 
@@ -4027,21 +4028,21 @@ impl SortitionDB {
         stacks_block_accepted: Option<bool>,
     ) -> Result<(), BurnchainError> {
         if let Some(stacks_block_accepted) = stacks_block_accepted {
-            let args: &[&dyn ToSql] = &[
+            let args: &[&dyn ToSql] = params![
                 sortition_id,
-                &u64_to_sql(canonical_stacks_height)?,
+                u64_to_sql(canonical_stacks_height)?,
                 canonical_stacks_bhh,
                 canonical_stacks_ch,
-                &stacks_block_accepted,
+                stacks_block_accepted,
             ];
             tx.execute(
                 "UPDATE snapshots SET pox_valid = 1, canonical_stacks_tip_height = ?2, canonical_stacks_tip_hash = ?3, canonical_stacks_tip_consensus_hash = ?4, stacks_block_accepted = ?5 WHERE sortition_id = ?1",
                 args
             )?;
         } else {
-            let args: &[&dyn ToSql] = &[
+            let args: &[&dyn ToSql] = params![
                 sortition_id,
-                &u64_to_sql(canonical_stacks_height)?,
+                u64_to_sql(canonical_stacks_height)?,
                 canonical_stacks_bhh,
                 canonical_stacks_ch,
             ];
@@ -4606,7 +4607,7 @@ impl SortitionDB {
         burnchain_header_hash: &BurnchainHeaderHash,
     ) -> Result<Option<BurnchainHeaderHash>, db_error> {
         let sql = "SELECT parent_burn_header_hash AS burn_header_hash FROM snapshots WHERE burn_header_hash = ?1";
-        let args: &[&dyn ToSql] = &[burnchain_header_hash];
+        let args: &[&dyn ToSql] = params![burnchain_header_hash];
         let mut rows = query_rows::<BurnchainHeaderHash, _>(conn, sql, args)?;
 
         // there can be more than one if there was a PoX reorg.  If so, make sure they're _all the
@@ -4881,7 +4882,7 @@ impl SortitionDB {
         conn: &Connection,
     ) -> Result<(u64, BurnchainHeaderHash), db_error> {
         let sql = "SELECT block_height, burn_header_hash FROM snapshots WHERE consensus_hash = ?1";
-        let args = params![ConsensusHash::empty()];
+        let args: &[&dyn ToSql] = params![ConsensusHash::empty()];
         let mut stmt = conn.prepare(sql)?;
         let mut rows = stmt.query(args)?;
         while let Some(row) = rows.next()? {
@@ -4969,7 +4970,7 @@ impl SortitionDB {
         sortition: &SortitionId,
     ) -> Result<Vec<LeaderBlockCommitOp>, db_error> {
         let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 ORDER BY vtxindex ASC";
-        let args: &[&dyn ToSql] = &[sortition];
+        let args: &[&dyn ToSql] = params![sortition];
 
         query_rows(conn, qry, args)
     }
@@ -4981,7 +4982,7 @@ impl SortitionDB {
         sortition: &SortitionId,
     ) -> Result<Vec<MissedBlockCommit>, db_error> {
         let qry = "SELECT * FROM missed_commits WHERE intended_sortition_id = ?1";
-        let args: &[&dyn ToSql] = &[sortition];
+        let args: &[&dyn ToSql] = params![sortition];
 
         query_rows(conn, qry, args)
     }
@@ -4993,7 +4994,7 @@ impl SortitionDB {
         sortition: &SortitionId,
     ) -> Result<Vec<LeaderKeyRegisterOp>, db_error> {
         let qry = "SELECT * FROM leader_keys WHERE sortition_id = ?1 ORDER BY vtxindex ASC";
-        let args: &[&dyn ToSql] = &[sortition];
+        let args: &[&dyn ToSql] = params![sortition];
 
         query_rows(conn, qry, args)
     }
@@ -5007,7 +5008,7 @@ impl SortitionDB {
         let qry = "SELECT vtxindex FROM block_commits WHERE sortition_id = ?1 
                     AND txid = (
                       SELECT winning_block_txid FROM snapshots WHERE sortition_id = ?2 LIMIT 1) LIMIT 1";
-        let args: &[&dyn ToSql] = &[sortition, sortition];
+        let args: &[&dyn ToSql] = params![sortition, sortition];
         conn.query_row(qry, args, |row| row.get(0))
             .optional()
             .map_err(db_error::from)
@@ -5089,7 +5090,7 @@ impl SortitionDB {
         assert!(block_height < BLOCK_HEIGHT_MAX);
 
         let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2";
-        let args: &[&dyn ToSql] = &[sortition, &u64_to_sql(block_height)?, &vtxindex];
+        let args: &[&dyn ToSql] = params![sortition, u64_to_sql(block_height)?, vtxindex];
         query_row_panic(conn, qry, args, || {
             format!(
                 "Multiple parent blocks at {},{} in {}",
@@ -5118,10 +5119,10 @@ impl SortitionDB {
         };
 
         let qry = "SELECT * FROM leader_keys WHERE sortition_id = ?1 AND block_height = ?2 AND vtxindex = ?3 LIMIT 2";
-        let args: &[&dyn ToSql] = &[
-            &ancestor_snapshot.sortition_id,
-            &u64_to_sql(key_block_height)?,
-            &key_vtxindex,
+        let args: &[&dyn ToSql] = params![
+            ancestor_snapshot.sortition_id,
+            u64_to_sql(key_block_height)?,
+            key_vtxindex,
         ];
         query_row_panic(ic, qry, args, || {
             format!(
@@ -5156,8 +5157,8 @@ impl SortitionDB {
         };
 
         let qry = "SELECT * FROM block_commits WHERE sortition_id = ?1 AND block_header_hash = ?2 AND txid = ?3";
-        let args: [&dyn ToSql; 3] = [&sortition_id, &block_hash, &winning_txid];
-        query_row_panic(conn, qry, &args, || {
+        let args: &[&dyn ToSql] = params![sortition_id, block_hash, winning_txid];
+        query_row_panic(conn, qry, args, || {
             format!("FATAL: multiple block commits for {}", &block_hash)
         })
     }
@@ -5212,9 +5213,9 @@ impl SortitionDB {
     ) -> Result<Option<StacksEpoch>, db_error> {
         let sql =
             "SELECT * FROM epochs WHERE start_block_height <= ?1 AND ?2 < end_block_height LIMIT 1";
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(burn_block_height)?,
-            &u64_to_sql(burn_block_height)?,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(burn_block_height)?,
+            u64_to_sql(burn_block_height)?,
         ];
         query_row(conn, sql, args)
     }
@@ -5243,7 +5244,7 @@ impl SortitionDB {
         epoch_id: &StacksEpochId,
     ) -> Result<Option<StacksEpoch>, db_error> {
         let sql = "SELECT * FROM epochs WHERE epoch_id = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = &[&(*epoch_id as u32)];
+        let args: &[&dyn ToSql] = params![*epoch_id as u32];
         query_row(conn, sql, args)
     }
 
@@ -5480,9 +5481,9 @@ impl<'a> SortitionHandleTx<'a> {
         let create = "CREATE TABLE IF NOT EXISTS snapshot_burn_distributions (sortition_id TEXT PRIMARY KEY, data TEXT NOT NULL);";
         self.execute(create, NO_PARAMS).unwrap();
         let sql = "INSERT INTO snapshot_burn_distributions (sortition_id, data) VALUES (?, ?)";
-        let args: &[&dyn ToSql] = &[
+        let args: &[&dyn ToSql] = params![
             new_sortition,
-            &serde_json::to_string(&transition.burn_dist).unwrap(),
+            serde_json::to_string(&transition.burn_dist).unwrap(),
         ];
         self.execute(sql, args).unwrap();
     }
@@ -5501,10 +5502,10 @@ impl<'a> SortitionHandleTx<'a> {
         transition: &BurnchainStateTransition,
     ) -> Result<(), db_error> {
         let sql = "INSERT INTO snapshot_transition_ops (sortition_id, accepted_ops, consumed_keys) VALUES (?, ?, ?)";
-        let args: &[&dyn ToSql] = &[
+        let args: &[&dyn ToSql] = params![
             new_sortition,
-            &serde_json::to_string(&transition.accepted_ops).unwrap(),
-            &serde_json::to_string(&transition.consumed_leader_keys).unwrap(),
+            serde_json::to_string(&transition.accepted_ops).unwrap(),
+            serde_json::to_string(&transition.consumed_leader_keys).unwrap(),
         ];
         self.execute(sql, args)?;
         self.store_burn_distribution(new_sortition, transition);
@@ -5592,14 +5593,14 @@ impl<'a> SortitionHandleTx<'a> {
     ) -> Result<(), db_error> {
         assert!(leader_key.block_height < BLOCK_HEIGHT_MAX);
 
-        let args: &[&dyn ToSql] = &[
-            &leader_key.txid,
-            &leader_key.vtxindex,
-            &u64_to_sql(leader_key.block_height)?,
-            &leader_key.burn_header_hash,
-            &leader_key.consensus_hash,
-            &leader_key.public_key.to_hex(),
-            &to_hex(&leader_key.memo),
+        let args: &[&dyn ToSql] = params![
+            leader_key.txid,
+            leader_key.vtxindex,
+            u64_to_sql(leader_key.block_height)?,
+            leader_key.burn_header_hash,
+            leader_key.consensus_hash,
+            leader_key.public_key.to_hex(),
+            to_hex(&leader_key.memo),
             sort_id,
         ];
 
@@ -5610,18 +5611,18 @@ impl<'a> SortitionHandleTx<'a> {
 
     /// Insert a stack-stx op
     fn insert_stack_stx(&mut self, op: &StackStxOp) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = &[
-            &op.txid,
-            &op.vtxindex,
-            &u64_to_sql(op.block_height)?,
-            &op.burn_header_hash,
-            &op.sender.to_string(),
-            &op.reward_addr.to_db_string(),
-            &op.stacked_ustx.to_string(),
-            &op.num_cycles,
-            &serde_json::to_string(&op.signer_key).unwrap(),
-            &serde_json::to_string(&op.max_amount).unwrap(),
-            &op.auth_id,
+        let args: &[&dyn ToSql] = params![
+            op.txid,
+            op.vtxindex,
+            u64_to_sql(op.block_height)?,
+            op.burn_header_hash,
+            op.sender.to_string(),
+            op.reward_addr.to_db_string(),
+            op.stacked_ustx.to_string(),
+            op.num_cycles,
+            serde_json::to_string(&op.signer_key).unwrap(),
+            serde_json::to_string(&op.max_amount).unwrap(),
+            op.auth_id,
         ];
 
         self.execute("REPLACE INTO stack_stx (txid, vtxindex, block_height, burn_header_hash, sender_addr, reward_addr, stacked_ustx, num_cycles, signer_key, max_amount, auth_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)", args)?;
@@ -5631,16 +5632,16 @@ impl<'a> SortitionHandleTx<'a> {
 
     /// Insert a delegate-stx op
     fn insert_delegate_stx(&mut self, op: &DelegateStxOp) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = &[
-            &op.txid,
-            &op.vtxindex,
-            &u64_to_sql(op.block_height)?,
-            &op.burn_header_hash,
-            &op.sender.to_string(),
-            &op.delegate_to.to_string(),
-            &serde_json::to_string(&op.reward_addr).unwrap(),
-            &op.delegated_ustx.to_string(),
-            &opt_u64_to_sql(op.until_burn_height)?,
+        let args: &[&dyn ToSql] = params![
+            op.txid,
+            op.vtxindex,
+            u64_to_sql(op.block_height)?,
+            op.burn_header_hash,
+            op.sender.to_string(),
+            op.delegate_to.to_string(),
+            serde_json::to_string(&op.reward_addr).unwrap(),
+            op.delegated_ustx.to_string(),
+            opt_u64_to_sql(op.until_burn_height)?,
         ];
 
         self.execute("REPLACE INTO delegate_stx (txid, vtxindex, block_height, burn_header_hash, sender_addr, delegate_to, reward_addr, delegated_ustx, until_burn_height) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)", args)?;
@@ -5653,17 +5654,17 @@ impl<'a> SortitionHandleTx<'a> {
         &mut self,
         op: &VoteForAggregateKeyOp,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = &[
-            &op.txid,
-            &op.vtxindex,
-            &u64_to_sql(op.block_height)?,
-            &op.burn_header_hash,
-            &op.sender.to_string(),
-            &serde_json::to_string(&op.aggregate_key).unwrap(),
-            &op.round,
-            &u64_to_sql(op.reward_cycle)?,
-            &op.signer_index,
-            &serde_json::to_string(&op.signer_key).unwrap(),
+        let args: &[&dyn ToSql] = params![
+            op.txid,
+            op.vtxindex,
+            u64_to_sql(op.block_height)?,
+            op.burn_header_hash,
+            op.sender.to_string(),
+            serde_json::to_string(&op.aggregate_key).unwrap(),
+            op.round,
+            u64_to_sql(op.reward_cycle)?,
+            op.signer_index,
+            serde_json::to_string(&op.signer_key).unwrap(),
         ];
 
         self.execute("REPLACE INTO vote_for_aggregate_key (txid, vtxindex, block_height, burn_header_hash, sender_addr, aggregate_key, round, reward_cycle, signer_index, signer_key) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)", args)?;
@@ -5673,15 +5674,15 @@ impl<'a> SortitionHandleTx<'a> {
 
     /// Insert a transfer-stx op
     fn insert_transfer_stx(&mut self, op: &TransferStxOp) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = &[
-            &op.txid,
-            &op.vtxindex,
-            &u64_to_sql(op.block_height)?,
-            &op.burn_header_hash,
-            &op.sender.to_string(),
-            &op.recipient.to_string(),
-            &op.transfered_ustx.to_string(),
-            &to_hex(&op.memo),
+        let args: &[&dyn ToSql] = params![
+            op.txid,
+            op.vtxindex,
+            u64_to_sql(op.block_height)?,
+            op.burn_header_hash,
+            op.sender.to_string(),
+            op.recipient.to_string(),
+            op.transfered_ustx.to_string(),
+            to_hex(&op.memo),
         ];
 
         self.execute("REPLACE INTO transfer_stx (txid, vtxindex, block_height, burn_header_hash, sender_addr, recipient_addr, transfered_ustx, memo) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)", args)?;
@@ -5722,32 +5723,32 @@ impl<'a> SortitionHandleTx<'a> {
             }
         }
 
-        let args: &[&dyn ToSql] = &[
-            &block_commit.txid,
-            &block_commit.vtxindex,
-            &u64_to_sql(block_commit.block_height)?,
-            &block_commit.burn_header_hash,
-            &block_commit.block_header_hash,
-            &block_commit.new_seed,
-            &block_commit.parent_block_ptr,
-            &block_commit.parent_vtxindex,
-            &block_commit.key_block_ptr,
-            &block_commit.key_vtxindex,
-            &to_hex(&block_commit.memo[..]),
-            &block_commit.burn_fee.to_string(),
-            &tx_input_str,
+        let args: &[&dyn ToSql] = params![
+            block_commit.txid,
+            block_commit.vtxindex,
+            u64_to_sql(block_commit.block_height)?,
+            block_commit.burn_header_hash,
+            block_commit.block_header_hash,
+            block_commit.new_seed,
+            block_commit.parent_block_ptr,
+            block_commit.parent_vtxindex,
+            block_commit.key_block_ptr,
+            block_commit.key_vtxindex,
+            to_hex(&block_commit.memo[..]),
+            block_commit.burn_fee.to_string(),
+            tx_input_str,
             sort_id,
-            &serde_json::to_value(&block_commit.commit_outs).unwrap(),
-            &block_commit.sunset_burn.to_string(),
-            &apparent_sender_str,
-            &block_commit.burn_parent_modulus,
-            &serde_json::to_string(&block_commit.treatment).unwrap(),
+            serde_json::to_value(&block_commit.commit_outs).unwrap(),
+            block_commit.sunset_burn.to_string(),
+            apparent_sender_str,
+            block_commit.burn_parent_modulus,
+            serde_json::to_string(&block_commit.treatment).unwrap(),
         ];
 
         self.execute("INSERT INTO block_commits (txid, vtxindex, block_height, burn_header_hash, block_header_hash, new_seed, parent_block_ptr, parent_vtxindex, key_block_ptr, key_vtxindex, memo, burn_fee, input, sortition_id, commit_outs, sunset_burn, apparent_sender, burn_parent_modulus, punished) \
                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)", args)?;
 
-        let parent_args: &[&dyn ToSql] = &[sort_id, &block_commit.txid, &parent_sortition_id];
+        let parent_args: &[&dyn ToSql] = params![sort_id, block_commit.txid, parent_sortition_id];
 
         debug!(
             "Parent sortition of {},{},{} is {} (parent at {},{})",
@@ -5775,7 +5776,7 @@ impl<'a> SortitionHandleTx<'a> {
         let tx_input_str =
             serde_json::to_string(&op.input).map_err(|e| db_error::SerializationError(e))?;
 
-        let args: &[&dyn ToSql] = &[&op.txid, &op.intended_sortition, &tx_input_str];
+        let args: &[&dyn ToSql] = params![op.txid, op.intended_sortition, tx_input_str];
 
         self.execute(
             "INSERT OR REPLACE INTO missed_commits (txid, intended_sortition_id, input) \
@@ -5827,32 +5828,32 @@ impl<'a> SortitionHandleTx<'a> {
             }
         }
 
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(snapshot.block_height)?,
-            &snapshot.burn_header_hash,
-            &u64_to_sql(snapshot.burn_header_timestamp)?,
-            &snapshot.parent_burn_header_hash,
-            &snapshot.consensus_hash,
-            &snapshot.ops_hash,
-            &snapshot.total_burn.to_string(),
-            &snapshot.sortition,
-            &snapshot.sortition_hash,
-            &snapshot.winning_block_txid,
-            &snapshot.winning_stacks_block_hash,
-            &snapshot.index_root,
-            &u64_to_sql(snapshot.num_sortitions)?,
-            &snapshot.stacks_block_accepted,
-            &u64_to_sql(snapshot.stacks_block_height)?,
-            &u64_to_sql(snapshot.arrival_index)?,
-            &u64_to_sql(snapshot.canonical_stacks_tip_height)?,
-            &snapshot.canonical_stacks_tip_hash,
-            &snapshot.canonical_stacks_tip_consensus_hash,
-            &snapshot.sortition_id,
-            &snapshot.parent_sortition_id,
-            &snapshot.pox_valid,
-            &snapshot.accumulated_coinbase_ustx.to_string(),
-            &pox_payouts_json,
-            &snapshot.miner_pk_hash,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(snapshot.block_height)?,
+            snapshot.burn_header_hash,
+            u64_to_sql(snapshot.burn_header_timestamp)?,
+            snapshot.parent_burn_header_hash,
+            snapshot.consensus_hash,
+            snapshot.ops_hash,
+            snapshot.total_burn.to_string(),
+            snapshot.sortition,
+            snapshot.sortition_hash,
+            snapshot.winning_block_txid,
+            snapshot.winning_stacks_block_hash,
+            snapshot.index_root,
+            u64_to_sql(snapshot.num_sortitions)?,
+            snapshot.stacks_block_accepted,
+            u64_to_sql(snapshot.stacks_block_height)?,
+            u64_to_sql(snapshot.arrival_index)?,
+            u64_to_sql(snapshot.canonical_stacks_tip_height)?,
+            snapshot.canonical_stacks_tip_hash,
+            snapshot.canonical_stacks_tip_consensus_hash,
+            snapshot.sortition_id,
+            snapshot.parent_sortition_id,
+            snapshot.pox_valid,
+            snapshot.accumulated_coinbase_ustx.to_string(),
+            pox_payouts_json,
+            snapshot.miner_pk_hash,
         ];
 
         self.execute("INSERT INTO snapshots \
@@ -6457,11 +6458,11 @@ impl<'a> SortitionHandleTx<'a> {
         best_bhh: BlockHeaderHash,
         best_height: u64,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = &[
-            &best_chh,
-            &best_bhh,
-            &u64_to_sql(best_height)?,
-            &u64_to_sql(tip.block_height)?,
+        let args: &[&dyn ToSql] = params![
+            best_chh,
+            best_bhh,
+            u64_to_sql(best_height)?,
+            u64_to_sql(tip.block_height)?,
         ];
 
         debug!(
@@ -6729,7 +6730,7 @@ pub mod tests {
             let pox_payouts_json = serde_json::to_string(&pox_payout)
                 .expect("FATAL: could not encode `total_pox_payouts` as JSON");
 
-            let args = params![
+            let args: &[&dyn ToSql] = params![
                 u64_to_sql(first_snapshot.block_height)?,
                 first_snapshot.burn_header_hash,
                 u64_to_sql(first_snapshot.burn_header_timestamp)?,
@@ -6787,7 +6788,7 @@ pub mod tests {
             height: u64,
         ) -> Result<(), db_error> {
             let tip = SortitionDB::get_canonical_burn_chain_tip(conn)?;
-            let args: &[&dyn ToSql] = &[ch, bhh, &u64_to_sql(height)?, &tip.sortition_id];
+            let args: &[&dyn ToSql] = params![ch, bhh, u64_to_sql(height)?, tip.sortition_id];
             conn.execute("UPDATE snapshots SET canonical_stacks_tip_consensus_hash = ?1, canonical_stacks_tip_hash = ?2, canonical_stacks_tip_height = ?3
                         WHERE sortition_id = ?4", args)
                 .map_err(db_error::SqliteError)?;
@@ -6864,7 +6865,7 @@ pub mod tests {
             let apparent_sender_str =
                 serde_json::to_string(sender).map_err(|e| db_error::SerializationError(e))?;
             let sql = "SELECT * FROM block_commits WHERE apparent_sender = ?1 ORDER BY block_height DESC LIMIT 1";
-            let args = params![apparent_sender_str];
+            let args: &[&dyn ToSql] = params![apparent_sender_str];
             query_row(conn, sql, args)
         }
     }

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -30,7 +30,7 @@ use clarity::vm::{ClarityVersion, SymbolicExpression, Value};
 use lazy_static::{__Deref, lazy_static};
 use rusqlite::blob::Blob;
 use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql, NO_PARAMS};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql};
 use sha2::{Digest as Sha2Digest, Sha512_256};
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::{
@@ -44,6 +44,7 @@ use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, StacksAddress, StacksBlockId,
     StacksPrivateKey, StacksPublicKey, TrieHash, VRFSeed,
 };
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::hash::{to_hex, Hash160, MerkleHashFunc, MerkleTree, Sha512Trunc256Sum};
 use stacks_common::util::retry::BoundReader;
@@ -2056,7 +2057,7 @@ impl NakamotoChainState {
         let qry = "SELECT DISTINCT tenure_id_consensus_hash AS consensus_hash FROM nakamoto_tenures WHERE coinbase_height = ?1";
 
         let candidate_chs: Vec<ConsensusHash> =
-            query_rows(tx.tx(), qry, &[u64_to_sql(coinbase_height)?])?;
+            query_rows(tx.tx(), qry, params![u64_to_sql(coinbase_height)?])?;
 
         if candidate_chs.len() == 0 {
             // no nakamoto_tenures at that tenure height, check if there's a stack block header where
@@ -2638,7 +2639,7 @@ impl NakamotoChainState {
         reward_set: &RewardSet,
     ) -> Result<(), ChainstateError> {
         let sql = "INSERT INTO nakamoto_reward_sets (index_block_hash, reward_set) VALUES (?, ?)";
-        let args = rusqlite::params![block_id, &reward_set.metadata_serialize(),];
+        let args = params![block_id, reward_set.metadata_serialize(),];
         tx.execute(sql, args)?;
         Ok(())
     }

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2289,7 +2289,7 @@ impl NakamotoChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<(bool, bool)>, ChainstateError> {
         let sql = "SELECT processed, orphaned FROM nakamoto_staging_blocks WHERE consensus_hash = ?1 AND block_hash = ?2";
-        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
+        let args = params![consensus_hash, block_hash];
         let Some((processed, orphaned)) = query_row_panic(&staging_blocks_conn, sql, args, || {
             "FATAL: multiple rows for the same consensus hash and block hash".to_string()
         })
@@ -2327,7 +2327,7 @@ impl NakamotoChainState {
         consensus_hash: &ConsensusHash,
     ) -> Result<Option<VRFProof>, ChainstateError> {
         let sql = "SELECT vrf_proof FROM nakamoto_block_headers WHERE consensus_hash = ?1 AND tenure_changed = 1";
-        let args: &[&dyn ToSql] = params![consensus_hash];
+        let args = params![consensus_hash];
         let proof_bytes: Option<String> = query_row(chainstate_conn, sql, args)?;
         if let Some(bytes) = proof_bytes {
             let proof = VRFProof::from_hex(&bytes)
@@ -2415,7 +2415,7 @@ impl NakamotoChainState {
             ))
         })?;
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             u64_to_sql(*stacks_block_height)?,
             index_root,
             consensus_hash,
@@ -2622,7 +2622,7 @@ impl NakamotoChainState {
         if applied_epoch_transition {
             debug!("Block {} applied an epoch transition", &index_block_hash);
             let sql = "INSERT INTO epoch_transitions (block_id) VALUES (?)";
-            let args: &[&dyn ToSql] = params![index_block_hash];
+            let args = params![index_block_hash];
             headers_tx.deref_mut().execute(sql, args)?;
         }
 
@@ -2639,7 +2639,7 @@ impl NakamotoChainState {
         reward_set: &RewardSet,
     ) -> Result<(), ChainstateError> {
         let sql = "INSERT INTO nakamoto_reward_sets (index_block_hash, reward_set) VALUES (?, ?)";
-        let args: &[&dyn ToSql] = params![block_id, reward_set.metadata_serialize(),];
+        let args = params![block_id, reward_set.metadata_serialize(),];
         tx.execute(sql, args)?;
         Ok(())
     }

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -29,8 +29,8 @@ use clarity::vm::types::{PrincipalData, StacksAddressExtensions, TupleData};
 use clarity::vm::{ClarityVersion, SymbolicExpression, Value};
 use lazy_static::{__Deref, lazy_static};
 use rusqlite::blob::Blob;
-use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql};
+use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use sha2::{Digest as Sha2Digest, Sha512_256};
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::{
@@ -127,13 +127,13 @@ define_named_enum!(HeaderTypeNames {
 });
 
 impl ToSql for HeaderTypeNames {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         self.get_name_str().to_sql()
     }
 }
 
 impl FromSql for HeaderTypeNames {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> FromSqlResult<Self> {
         Self::lookup_by_name(value.as_str()?).ok_or_else(|| FromSqlError::InvalidType)
     }
 }
@@ -2289,7 +2289,7 @@ impl NakamotoChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<(bool, bool)>, ChainstateError> {
         let sql = "SELECT processed, orphaned FROM nakamoto_staging_blocks WHERE consensus_hash = ?1 AND block_hash = ?2";
-        let args: &[&dyn ToSql] = &[consensus_hash, block_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
         let Some((processed, orphaned)) = query_row_panic(&staging_blocks_conn, sql, args, || {
             "FATAL: multiple rows for the same consensus hash and block hash".to_string()
         })
@@ -2327,7 +2327,7 @@ impl NakamotoChainState {
         consensus_hash: &ConsensusHash,
     ) -> Result<Option<VRFProof>, ChainstateError> {
         let sql = "SELECT vrf_proof FROM nakamoto_block_headers WHERE consensus_hash = ?1 AND tenure_changed = 1";
-        let args: &[&dyn ToSql] = &[consensus_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash];
         let proof_bytes: Option<String> = query_row(chainstate_conn, sql, args)?;
         if let Some(bytes) = proof_bytes {
             let proof = VRFProof::from_hex(&bytes)
@@ -2415,32 +2415,32 @@ impl NakamotoChainState {
             ))
         })?;
 
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(*stacks_block_height)?,
-            &index_root,
-            &consensus_hash,
-            &burn_header_hash,
-            &burn_header_height,
-            &u64_to_sql(*burn_header_timestamp)?,
-            &block_size_str,
-            &HeaderTypeNames::Nakamoto,
-            &header.version,
-            &u64_to_sql(header.chain_length)?,
-            &u64_to_sql(header.burn_spent)?,
-            &header.miner_signature,
-            &signer_signature,
-            &header.tx_merkle_root,
-            &header.state_index_root,
-            &u64_to_sql(header.timestamp)?,
-            &block_hash,
-            &index_block_hash,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(*stacks_block_height)?,
+            index_root,
+            consensus_hash,
+            burn_header_hash,
+            burn_header_height,
+            u64_to_sql(*burn_header_timestamp)?,
+            block_size_str,
+            HeaderTypeNames::Nakamoto,
+            header.version,
+            u64_to_sql(header.chain_length)?,
+            u64_to_sql(header.burn_spent)?,
+            header.miner_signature,
+            signer_signature,
+            header.tx_merkle_root,
+            header.state_index_root,
+            u64_to_sql(header.timestamp)?,
+            block_hash,
+            index_block_hash,
             block_cost,
             total_tenure_cost,
-            &tenure_tx_fees.to_string(),
-            &header.parent_block_id,
-            if tenure_changed { &1i64 } else { &0i64 },
-            &vrf_proof_bytes.as_ref(),
-            &header.pox_treatment,
+            tenure_tx_fees.to_string(),
+            header.parent_block_id,
+            if tenure_changed { 1i64 } else { 0i64 },
+            vrf_proof_bytes.as_ref(),
+            header.pox_treatment,
             tip_info.burn_view.as_ref().ok_or_else(|| {
                 error!(
                     "Attempted to store nakamoto block header information without burnchain view";
@@ -2622,7 +2622,7 @@ impl NakamotoChainState {
         if applied_epoch_transition {
             debug!("Block {} applied an epoch transition", &index_block_hash);
             let sql = "INSERT INTO epoch_transitions (block_id) VALUES (?)";
-            let args: &[&dyn ToSql] = &[&index_block_hash];
+            let args: &[&dyn ToSql] = params![index_block_hash];
             headers_tx.deref_mut().execute(sql, args)?;
         }
 
@@ -2639,7 +2639,7 @@ impl NakamotoChainState {
         reward_set: &RewardSet,
     ) -> Result<(), ChainstateError> {
         let sql = "INSERT INTO nakamoto_reward_sets (index_block_hash, reward_set) VALUES (?, ?)";
-        let args = params![block_id, reward_set.metadata_serialize(),];
+        let args: &[&dyn ToSql] = params![block_id, reward_set.metadata_serialize(),];
         tx.execute(sql, args)?;
         Ok(())
     }

--- a/stackslib/src/chainstate/nakamoto/signer_set.rs
+++ b/stackslib/src/chainstate/nakamoto/signer_set.rs
@@ -26,7 +26,7 @@ use clarity::vm::types::{
 use clarity::vm::{ClarityVersion, ContractName, SymbolicExpression, Value};
 use lazy_static::{__Deref, lazy_static};
 use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OptionalExtension, ToSql, NO_PARAMS};
+use rusqlite::{params, Connection, OptionalExtension, ToSql};
 use sha2::{Digest as Sha2Digest, Sha512_256};
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::{
@@ -40,6 +40,7 @@ use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, StacksAddress, StacksBlockId,
     StacksPrivateKey, StacksPublicKey, TrieHash, VRFSeed,
 };
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::{to_hex, Hash160, MerkleHashFunc, MerkleTree, Sha512Trunc256Sum};

--- a/stackslib/src/chainstate/nakamoto/signer_set.rs
+++ b/stackslib/src/chainstate/nakamoto/signer_set.rs
@@ -25,8 +25,8 @@ use clarity::vm::types::{
 };
 use clarity::vm::{ClarityVersion, ContractName, SymbolicExpression, Value};
 use lazy_static::{__Deref, lazy_static};
-use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OptionalExtension, ToSql};
+use rusqlite::types::{FromSql, FromSqlError, ToSql};
+use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest as Sha2Digest, Sha512_256};
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::{

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -20,8 +20,8 @@ use std::path::PathBuf;
 
 use lazy_static::lazy_static;
 use rusqlite::blob::Blob;
-use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql};
+use rusqlite::types::{FromSql, FromSqlError, ToSql};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
 use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::{get_epoch_time_secs, sleep_ms};
@@ -188,7 +188,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         // this block must be a processed Nakamoto block
         let ibh = StacksBlockId::new(&ch, &bhh);
         let qry = "SELECT 1 FROM nakamoto_staging_blocks WHERE processed = 1 AND index_block_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = &[&ibh];
+        let args: &[&dyn ToSql] = params![ibh];
         let res: Option<i64> = query_row(self, qry, args)?;
         Ok(res.is_some())
     }
@@ -202,7 +202,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<bool, ChainstateError> {
         let qry = "SELECT 1 FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = &[index_block_hash];
+        let args: &[&dyn ToSql] = params![index_block_hash];
         let res: Option<i64> = query_row(self, qry, args)?;
         Ok(res.is_some())
     }
@@ -213,7 +213,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         consensus_hash: &ConsensusHash,
     ) -> Result<Option<NakamotoBlock>, ChainstateError> {
         let qry = "SELECT data FROM nakamoto_staging_blocks WHERE is_tenure_start = 1 AND consensus_hash = ?1";
-        let args: &[&dyn ToSql] = &[consensus_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash];
         let data: Option<Vec<u8>> = query_row(self, qry, args)?;
         let Some(block_bytes) = data else {
             return Ok(None);
@@ -235,7 +235,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<i64>, ChainstateError> {
         let sql = "SELECT rowid FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = &[index_block_hash];
+        let args: &[&dyn ToSql] = params![index_block_hash];
         let res: Option<i64> = query_row(self, sql, args)?;
         Ok(res)
     }
@@ -250,7 +250,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<(NakamotoBlock, u64)>, ChainstateError> {
         let qry = "SELECT data FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = &[index_block_hash];
+        let args: &[&dyn ToSql] = params![index_block_hash];
         let res: Option<Vec<u8>> = query_row(self, qry, args)?;
         let Some(block_bytes) = res else {
             return Ok(None);
@@ -279,7 +279,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<u64>, ChainstateError> {
         let qry = "SELECT length(data) FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = &[index_block_hash];
+        let args: &[&dyn ToSql] = params![index_block_hash];
         let res = query_row(self, qry, args)?
             .map(|size: i64| u64::try_from(size).expect("FATAL: block size exceeds i64::MAX"));
         Ok(res)

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -188,7 +188,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         // this block must be a processed Nakamoto block
         let ibh = StacksBlockId::new(&ch, &bhh);
         let qry = "SELECT 1 FROM nakamoto_staging_blocks WHERE processed = 1 AND index_block_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = params![ibh];
+        let args = params![ibh];
         let res: Option<i64> = query_row(self, qry, args)?;
         Ok(res.is_some())
     }
@@ -202,7 +202,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<bool, ChainstateError> {
         let qry = "SELECT 1 FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = params![index_block_hash];
+        let args = params![index_block_hash];
         let res: Option<i64> = query_row(self, qry, args)?;
         Ok(res.is_some())
     }
@@ -213,7 +213,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         consensus_hash: &ConsensusHash,
     ) -> Result<Option<NakamotoBlock>, ChainstateError> {
         let qry = "SELECT data FROM nakamoto_staging_blocks WHERE is_tenure_start = 1 AND consensus_hash = ?1";
-        let args: &[&dyn ToSql] = params![consensus_hash];
+        let args = params![consensus_hash];
         let data: Option<Vec<u8>> = query_row(self, qry, args)?;
         let Some(block_bytes) = data else {
             return Ok(None);
@@ -235,7 +235,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<i64>, ChainstateError> {
         let sql = "SELECT rowid FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = params![index_block_hash];
+        let args = params![index_block_hash];
         let res: Option<i64> = query_row(self, sql, args)?;
         Ok(res)
     }
@@ -250,7 +250,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<(NakamotoBlock, u64)>, ChainstateError> {
         let qry = "SELECT data FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = params![index_block_hash];
+        let args = params![index_block_hash];
         let res: Option<Vec<u8>> = query_row(self, qry, args)?;
         let Some(block_bytes) = res else {
             return Ok(None);
@@ -279,7 +279,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<u64>, ChainstateError> {
         let qry = "SELECT length(data) FROM nakamoto_staging_blocks WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = params![index_block_hash];
+        let args = params![index_block_hash];
         let res = query_row(self, qry, args)?
             .map(|size: i64| u64::try_from(size).expect("FATAL: block size exceeds i64::MAX"));
         Ok(res)

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -21,8 +21,9 @@ use std::path::PathBuf;
 use lazy_static::lazy_static;
 use rusqlite::blob::Blob;
 use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql, NO_PARAMS};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, ToSql};
 use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::{get_epoch_time_secs, sleep_ms};
 
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
@@ -369,7 +370,7 @@ impl<'a> NakamotoStagingBlocksTx<'a> {
                                   WHERE index_block_hash = ?1";
         self.execute(
             &clear_staged_block,
-            params![&block, &u64_to_sql(get_epoch_time_secs())?],
+            params![block, u64_to_sql(get_epoch_time_secs())?],
         )?;
 
         Ok(())
@@ -389,7 +390,7 @@ impl<'a> NakamotoStagingBlocksTx<'a> {
                                   WHERE index_block_hash = ?1";
         self.execute(
             &clear_staged_block,
-            params![&block, &u64_to_sql(get_epoch_time_secs())?],
+            params![block, u64_to_sql(get_epoch_time_secs())?],
         )?;
 
         Ok(())

--- a/stackslib/src/chainstate/nakamoto/tenure.rs
+++ b/stackslib/src/chainstate/nakamoto/tenure.rs
@@ -68,7 +68,7 @@ use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::types::StacksAddressExtensions;
 use lazy_static::{__Deref, lazy_static};
 use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OptionalExtension, ToSql, NO_PARAMS};
+use rusqlite::{params, Connection, OptionalExtension, ToSql};
 use sha2::{Digest as Sha2Digest, Sha512_256};
 use stacks_common::codec::{
     read_next, write_next, Error as CodecError, StacksMessageCodec, MAX_MESSAGE_LEN,
@@ -80,6 +80,7 @@ use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, StacksBlockId, StacksPrivateKey,
     StacksPublicKey, TrieHash, VRFSeed,
 };
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::{to_hex, Hash160, MerkleHashFunc, MerkleTree, Sha512Trunc256Sum};
@@ -587,7 +588,7 @@ impl NakamotoChainState {
         burn_view: &ConsensusHash,
     ) -> Result<Option<NakamotoTenure>, ChainstateError> {
         let sql = "SELECT * FROM nakamoto_tenures WHERE burn_view_consensus_hash = ?1 ORDER BY tenure_index DESC LIMIT 1";
-        let args = rusqlite::params![burn_view];
+        let args = params![burn_view];
         let tenure_opt: Option<NakamotoTenure> = query_row(headers_conn, sql, args)?;
         Ok(tenure_opt)
     }

--- a/stackslib/src/chainstate/nakamoto/tenure.rs
+++ b/stackslib/src/chainstate/nakamoto/tenure.rs
@@ -67,8 +67,8 @@ use clarity::vm::database::BurnStateDB;
 use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::types::StacksAddressExtensions;
 use lazy_static::{__Deref, lazy_static};
-use rusqlite::types::{FromSql, FromSqlError};
-use rusqlite::{params, Connection, OptionalExtension, ToSql};
+use rusqlite::types::{FromSql, FromSqlError, ToSql};
+use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest as Sha2Digest, Sha512_256};
 use stacks_common::codec::{
     read_next, write_next, Error as CodecError, StacksMessageCodec, MAX_MESSAGE_LEN,
@@ -438,7 +438,7 @@ impl NakamotoChainState {
     ) -> Result<bool, ChainstateError> {
         // a tenure will have been processed if any of its children have been processed
         let sql = "SELECT 1 FROM nakamoto_tenures WHERE prev_tenure_id_consensus_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = &[tenure_id_consensus_hash];
+        let args: &[&dyn ToSql] = params![tenure_id_consensus_hash];
         let found: Option<i64> = query_row(conn, sql, args)?;
         Ok(found.is_some())
     }
@@ -454,16 +454,16 @@ impl NakamotoChainState {
     ) -> Result<(), ChainstateError> {
         // NOTE: this is checked with check_nakamoto_tenure()
         assert_eq!(block_header.consensus_hash, tenure.tenure_consensus_hash);
-        let args: &[&dyn ToSql] = &[
-            &tenure.tenure_consensus_hash,
-            &tenure.prev_tenure_consensus_hash,
-            &tenure.burn_view_consensus_hash,
-            &tenure.cause.as_u8(),
-            &block_header.block_hash(),
-            &block_header.block_id(),
-            &u64_to_sql(coinbase_height)?,
-            &u64_to_sql(tenure_index)?,
-            &tenure.previous_tenure_blocks,
+        let args: &[&dyn ToSql] = params![
+            tenure.tenure_consensus_hash,
+            tenure.prev_tenure_consensus_hash,
+            tenure.burn_view_consensus_hash,
+            tenure.cause.as_u8(),
+            block_header.block_hash(),
+            block_header.block_id(),
+            u64_to_sql(coinbase_height)?,
+            u64_to_sql(tenure_index)?,
+            tenure.previous_tenure_blocks,
         ];
         tx.execute(
             "INSERT INTO nakamoto_tenures
@@ -511,7 +511,7 @@ impl NakamotoChainState {
         consensus_hash: &ConsensusHash,
     ) -> Result<Option<ConsensusHash>, ChainstateError> {
         let sql = "SELECT prev_tenure_id_consensus_hash AS consensus_hash FROM nakamoto_tenures WHERE tenure_id_consensus_hash = ?1 ORDER BY tenure_index DESC LIMIT 1";
-        let args: &[&dyn ToSql] = &[consensus_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash];
         query_row(chainstate_conn, sql, args).map_err(ChainstateError::DBError)
     }
 
@@ -577,7 +577,7 @@ impl NakamotoChainState {
         tenure_consensus_hash: &ConsensusHash,
     ) -> Result<Option<NakamotoTenure>, ChainstateError> {
         let sql = "SELECT * FROM nakamoto_tenures WHERE tenure_id_consensus_hash = ?1 ORDER BY tenure_index DESC LIMIT 1";
-        let args: &[&dyn ToSql] = &[&tenure_consensus_hash];
+        let args: &[&dyn ToSql] = params![tenure_consensus_hash];
         let tenure_opt: Option<NakamotoTenure> = query_row(headers_conn, sql, args)?;
         Ok(tenure_opt)
     }
@@ -588,7 +588,7 @@ impl NakamotoChainState {
         burn_view: &ConsensusHash,
     ) -> Result<Option<NakamotoTenure>, ChainstateError> {
         let sql = "SELECT * FROM nakamoto_tenures WHERE burn_view_consensus_hash = ?1 ORDER BY tenure_index DESC LIMIT 1";
-        let args = params![burn_view];
+        let args: &[&dyn ToSql] = params![burn_view];
         let tenure_opt: Option<NakamotoTenure> = query_row(headers_conn, sql, args)?;
         Ok(tenure_opt)
     }
@@ -601,9 +601,9 @@ impl NakamotoChainState {
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Option<NakamotoTenure>, ChainstateError> {
         let sql = "SELECT * FROM nakamoto_tenures WHERE tenure_id_consensus_hash = ?1 AND cause = ?2 ORDER BY tenure_index DESC LIMIT 1";
-        let args: &[&dyn ToSql] = &[
+        let args: &[&dyn ToSql] = params![
             tenure_id_consensus_hash,
-            &TenureChangeCause::BlockFound.as_u8(),
+            TenureChangeCause::BlockFound.as_u8(),
         ];
         let tenure_opt: Option<NakamotoTenure> = query_row(headers_conn, sql, args)?;
         Ok(tenure_opt)

--- a/stackslib/src/chainstate/nakamoto/tenure.rs
+++ b/stackslib/src/chainstate/nakamoto/tenure.rs
@@ -438,7 +438,7 @@ impl NakamotoChainState {
     ) -> Result<bool, ChainstateError> {
         // a tenure will have been processed if any of its children have been processed
         let sql = "SELECT 1 FROM nakamoto_tenures WHERE prev_tenure_id_consensus_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = params![tenure_id_consensus_hash];
+        let args = params![tenure_id_consensus_hash];
         let found: Option<i64> = query_row(conn, sql, args)?;
         Ok(found.is_some())
     }
@@ -454,7 +454,7 @@ impl NakamotoChainState {
     ) -> Result<(), ChainstateError> {
         // NOTE: this is checked with check_nakamoto_tenure()
         assert_eq!(block_header.consensus_hash, tenure.tenure_consensus_hash);
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             tenure.tenure_consensus_hash,
             tenure.prev_tenure_consensus_hash,
             tenure.burn_view_consensus_hash,
@@ -511,7 +511,7 @@ impl NakamotoChainState {
         consensus_hash: &ConsensusHash,
     ) -> Result<Option<ConsensusHash>, ChainstateError> {
         let sql = "SELECT prev_tenure_id_consensus_hash AS consensus_hash FROM nakamoto_tenures WHERE tenure_id_consensus_hash = ?1 ORDER BY tenure_index DESC LIMIT 1";
-        let args: &[&dyn ToSql] = params![consensus_hash];
+        let args = params![consensus_hash];
         query_row(chainstate_conn, sql, args).map_err(ChainstateError::DBError)
     }
 
@@ -577,7 +577,7 @@ impl NakamotoChainState {
         tenure_consensus_hash: &ConsensusHash,
     ) -> Result<Option<NakamotoTenure>, ChainstateError> {
         let sql = "SELECT * FROM nakamoto_tenures WHERE tenure_id_consensus_hash = ?1 ORDER BY tenure_index DESC LIMIT 1";
-        let args: &[&dyn ToSql] = params![tenure_consensus_hash];
+        let args = params![tenure_consensus_hash];
         let tenure_opt: Option<NakamotoTenure> = query_row(headers_conn, sql, args)?;
         Ok(tenure_opt)
     }
@@ -588,7 +588,7 @@ impl NakamotoChainState {
         burn_view: &ConsensusHash,
     ) -> Result<Option<NakamotoTenure>, ChainstateError> {
         let sql = "SELECT * FROM nakamoto_tenures WHERE burn_view_consensus_hash = ?1 ORDER BY tenure_index DESC LIMIT 1";
-        let args: &[&dyn ToSql] = params![burn_view];
+        let args = params![burn_view];
         let tenure_opt: Option<NakamotoTenure> = query_row(headers_conn, sql, args)?;
         Ok(tenure_opt)
     }
@@ -601,7 +601,7 @@ impl NakamotoChainState {
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Option<NakamotoTenure>, ChainstateError> {
         let sql = "SELECT * FROM nakamoto_tenures WHERE tenure_id_consensus_hash = ?1 AND cause = ?2 ORDER BY tenure_index DESC LIMIT 1";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             tenure_id_consensus_hash,
             TenureChangeCause::BlockFound.as_u8(),
         ];

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -181,7 +181,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Vec<NakamotoBlock>, ChainstateError> {
         let qry = "SELECT data FROM nakamoto_staging_blocks WHERE consensus_hash = ?1 ORDER BY height ASC";
-        let args: &[&dyn ToSql] = params![tenure_id_consensus_hash];
+        let args = params![tenure_id_consensus_hash];
         let block_data: Vec<Vec<u8>> = query_rows(self, qry, args)?;
         let mut blocks = Vec::with_capacity(block_data.len());
         for data in block_data.into_iter() {

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -26,7 +26,8 @@ use clarity::vm::types::StacksAddressExtensions;
 use clarity::vm::Value;
 use libstackerdb::StackerDBChunkData;
 use rand::{thread_rng, RngCore};
-use rusqlite::{Connection, ToSql};
+use rusqlite::types::ToSql;
+use rusqlite::{params, Connection};
 use stacks_common::address::AddressHashMode;
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
@@ -180,7 +181,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Vec<NakamotoBlock>, ChainstateError> {
         let qry = "SELECT data FROM nakamoto_staging_blocks WHERE consensus_hash = ?1 ORDER BY height ASC";
-        let args: &[&dyn ToSql] = &[tenure_id_consensus_hash];
+        let args: &[&dyn ToSql] = params![tenure_id_consensus_hash];
         let block_data: Vec<Vec<u8>> = query_rows(self, qry, args)?;
         let mut blocks = Vec::with_capacity(block_data.len());
         for data in block_data.into_iter() {

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -20,6 +20,7 @@ use clarity::types::chainstate::TenureBlockId;
 use clarity::vm::database::clarity_store::*;
 use clarity::vm::database::*;
 use clarity::vm::types::*;
+use rusqlite::params;
 use rusqlite::types::ToSql;
 use rusqlite::Row;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
@@ -734,12 +735,12 @@ impl StacksChainState {
         let qry =
             "SELECT * FROM payments WHERE consensus_hash = ?1 AND block_hash = ?2 AND miner = 1"
                 .to_string();
-        let args = [
-            consensus_hash as &dyn ToSql,
-            stacks_block_hash as &dyn ToSql,
+        let args = params![
+            consensus_hash,
+            stacks_block_hash,
         ];
         let mut rows =
-            query_rows::<MinerPaymentSchedule, _>(conn, &qry, &args).map_err(Error::DBError)?;
+            query_rows::<MinerPaymentSchedule, _>(conn, &qry, args).map_err(Error::DBError)?;
         let len = rows.len();
         match len {
             0 => {

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -414,7 +414,7 @@ impl StacksChainState {
             }
         };
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             block_reward.address.to_string(),
             block_reward.recipient.to_string(),
             block_reward.block_hash,
@@ -504,7 +504,7 @@ impl StacksChainState {
             child_index_block_hash
         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)";
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             reward.address.to_string(),
             reward.recipient.to_string(),
             reward.vtxindex,
@@ -613,7 +613,7 @@ impl StacksChainState {
         child_block_id: &TenureBlockId,
     ) -> Result<Vec<MinerReward>, Error> {
         let sql = "SELECT * FROM matured_rewards WHERE parent_index_block_hash = ?1 AND child_index_block_hash = ?2 AND vtxindex = 0";
-        let args: &[&dyn ToSql] = params![parent_block_id.0, child_block_id.0];
+        let args = params![parent_block_id.0, child_block_id.0];
         let ret: Vec<MinerReward> = query_rows(conn, sql, args).map_err(|e| Error::DBError(e))?;
         Ok(ret)
     }
@@ -676,7 +676,7 @@ impl StacksChainState {
     ) -> Result<Vec<MinerPaymentSchedule>, Error> {
         let qry =
             "SELECT * FROM payments WHERE index_block_hash = ?1 ORDER BY vtxindex ASC".to_string();
-        let args: &[&dyn ToSql] = params![index_block_hash];
+        let args = params![index_block_hash];
         let rows =
             query_rows::<MinerPaymentSchedule, _>(conn, &qry, args).map_err(Error::DBError)?;
         test_debug!("{} rewards in {}", rows.len(), index_block_hash);
@@ -698,7 +698,7 @@ impl StacksChainState {
         };
 
         let qry = "SELECT * FROM payments WHERE block_hash = ?1 AND consensus_hash = ?2 ORDER BY vtxindex ASC".to_string();
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             ancestor_info.anchored_header.block_hash(),
             ancestor_info.consensus_hash,
         ];
@@ -734,7 +734,7 @@ impl StacksChainState {
         let qry =
             "SELECT * FROM payments WHERE consensus_hash = ?1 AND block_hash = ?2 AND miner = 1"
                 .to_string();
-        let args: &[&dyn ToSql] = params![consensus_hash, stacks_block_hash,];
+        let args = params![consensus_hash, stacks_block_hash,];
         let mut rows =
             query_rows::<MinerPaymentSchedule, _>(conn, &qry, args).map_err(Error::DBError)?;
         let len = rows.len();

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -20,9 +20,8 @@ use clarity::types::chainstate::TenureBlockId;
 use clarity::vm::database::clarity_store::*;
 use clarity::vm::database::*;
 use clarity::vm::types::*;
-use rusqlite::params;
 use rusqlite::types::ToSql;
-use rusqlite::Row;
+use rusqlite::{params, Row};
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
 
 use crate::burnchains::Address;
@@ -415,24 +414,24 @@ impl StacksChainState {
             }
         };
 
-        let args: &[&dyn ToSql] = &[
-            &block_reward.address.to_string(),
-            &block_reward.recipient.to_string(),
-            &block_reward.block_hash,
-            &block_reward.consensus_hash,
-            &block_reward.parent_block_hash,
-            &block_reward.parent_consensus_hash,
-            &block_reward.coinbase.to_string(),
-            &db_tx_fees_anchored.to_string(),
-            &db_tx_fees_streamed.to_string(),
-            &u64_to_sql(block_reward.burnchain_commit_burn)?,
-            &u64_to_sql(block_reward.burnchain_sortition_burn)?,
-            &u64_to_sql(block_reward.stacks_block_height)?,
-            &true,
-            &0i64,
-            &index_block_hash,
-            &payment_type,
-            &"0".to_string(),
+        let args: &[&dyn ToSql] = params![
+            block_reward.address.to_string(),
+            block_reward.recipient.to_string(),
+            block_reward.block_hash,
+            block_reward.consensus_hash,
+            block_reward.parent_block_hash,
+            block_reward.parent_consensus_hash,
+            block_reward.coinbase.to_string(),
+            db_tx_fees_anchored.to_string(),
+            db_tx_fees_streamed.to_string(),
+            u64_to_sql(block_reward.burnchain_commit_burn)?,
+            u64_to_sql(block_reward.burnchain_sortition_burn)?,
+            u64_to_sql(block_reward.stacks_block_height)?,
+            true,
+            0i64,
+            index_block_hash,
+            payment_type,
+            "0".to_string(),
         ];
 
         tx.execute(
@@ -505,14 +504,14 @@ impl StacksChainState {
             child_index_block_hash
         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)";
 
-        let args: &[&dyn ToSql] = &[
-            &reward.address.to_string(),
-            &reward.recipient.to_string(),
-            &reward.vtxindex,
-            &reward.coinbase.to_string(),
-            &reward.tx_fees_anchored.to_string(),
-            &reward.tx_fees_streamed_confirmed.to_string(),
-            &reward.tx_fees_streamed_produced.to_string(),
+        let args: &[&dyn ToSql] = params![
+            reward.address.to_string(),
+            reward.recipient.to_string(),
+            reward.vtxindex,
+            reward.coinbase.to_string(),
+            reward.tx_fees_anchored.to_string(),
+            reward.tx_fees_streamed_confirmed.to_string(),
+            reward.tx_fees_streamed_produced.to_string(),
             parent_block_id,
             child_block_id,
         ];
@@ -614,7 +613,7 @@ impl StacksChainState {
         child_block_id: &TenureBlockId,
     ) -> Result<Vec<MinerReward>, Error> {
         let sql = "SELECT * FROM matured_rewards WHERE parent_index_block_hash = ?1 AND child_index_block_hash = ?2 AND vtxindex = 0";
-        let args: &[&dyn ToSql] = &[&parent_block_id.0, &child_block_id.0];
+        let args: &[&dyn ToSql] = params![parent_block_id.0, child_block_id.0];
         let ret: Vec<MinerReward> = query_rows(conn, sql, args).map_err(|e| Error::DBError(e))?;
         Ok(ret)
     }
@@ -677,7 +676,7 @@ impl StacksChainState {
     ) -> Result<Vec<MinerPaymentSchedule>, Error> {
         let qry =
             "SELECT * FROM payments WHERE index_block_hash = ?1 ORDER BY vtxindex ASC".to_string();
-        let args: &[&dyn ToSql] = &[index_block_hash];
+        let args: &[&dyn ToSql] = params![index_block_hash];
         let rows =
             query_rows::<MinerPaymentSchedule, _>(conn, &qry, args).map_err(Error::DBError)?;
         test_debug!("{} rewards in {}", rows.len(), index_block_hash);
@@ -699,9 +698,9 @@ impl StacksChainState {
         };
 
         let qry = "SELECT * FROM payments WHERE block_hash = ?1 AND consensus_hash = ?2 ORDER BY vtxindex ASC".to_string();
-        let args: &[&dyn ToSql] = &[
-            &ancestor_info.anchored_header.block_hash(),
-            &ancestor_info.consensus_hash,
+        let args: &[&dyn ToSql] = params![
+            ancestor_info.anchored_header.block_hash(),
+            ancestor_info.consensus_hash,
         ];
         let rows = query_rows::<MinerPaymentSchedule, _>(tx, &qry, args).map_err(Error::DBError)?;
         test_debug!(
@@ -735,10 +734,7 @@ impl StacksChainState {
         let qry =
             "SELECT * FROM payments WHERE consensus_hash = ?1 AND block_hash = ?2 AND miner = 1"
                 .to_string();
-        let args = params![
-            consensus_hash,
-            stacks_block_hash,
-        ];
+        let args: &[&dyn ToSql] = params![consensus_hash, stacks_block_hash,];
         let mut rows =
             query_rows::<MinerPaymentSchedule, _>(conn, &qry, args).map_err(Error::DBError)?;
         let len = rows.len();

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -770,7 +770,7 @@ impl StacksChainState {
 
         for (consensus_hash, block_hash) in blocks.drain(..) {
             let list_microblock_sql = "SELECT * FROM staging_microblocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 ORDER BY sequence".to_string();
-            let list_microblock_args: &[&dyn ToSql] = params![block_hash, consensus_hash];
+            let list_microblock_args = params![block_hash, consensus_hash];
             let mut microblocks = query_rows::<StagingMicroblock, _>(
                 blocks_conn,
                 &list_microblock_sql,
@@ -964,7 +964,7 @@ impl StacksChainState {
         minimum_block_height: i64,
     ) -> bool {
         let sql = "SELECT 1 FROM staging_blocks WHERE microblock_pubkey_hash = ?1 AND height >= ?2";
-        let args: &[&dyn ToSql] = params![pubkey_hash, minimum_block_height];
+        let args = params![pubkey_hash, minimum_block_height];
         block_conn
             .query_row(sql, args, |_r| Ok(()))
             .optional()
@@ -980,7 +980,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<StagingBlock>, Error> {
         let sql = "SELECT * FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 AND orphaned = 0 AND processed = 0".to_string();
-        let args: &[&dyn ToSql] = params![block_hash, consensus_hash];
+        let args = params![block_hash, consensus_hash];
         let mut rows =
             query_rows::<StagingBlock, _>(block_conn, &sql, args).map_err(Error::DBError)?;
         let len = rows.len();
@@ -1009,7 +1009,7 @@ impl StacksChainState {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<StagingBlock>, Error> {
         let sql = "SELECT * FROM staging_blocks WHERE index_block_hash = ?1 AND orphaned = 0";
-        let args: &[&dyn ToSql] = params![index_block_hash];
+        let args = params![index_block_hash];
         query_row::<StagingBlock, _>(block_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -1059,7 +1059,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<Hash160>, Error> {
         let sql = "SELECT microblock_pubkey_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 AND processed = 0 AND orphaned = 0";
-        let args: &[&dyn ToSql] = params![block_hash, consensus_hash];
+        let args = params![block_hash, consensus_hash];
         let rows = query_row_columns::<Hash160, _>(block_conn, sql, args, "microblock_pubkey_hash")
             .map_err(Error::DBError)?;
         match rows.len() {
@@ -1114,7 +1114,7 @@ impl StacksChainState {
         microblock_hash: &BlockHeaderHash,
     ) -> Result<Option<StagingMicroblock>, Error> {
         let sql = "SELECT * FROM staging_microblocks WHERE index_block_hash = ?1 AND microblock_hash = ?2 AND orphaned = 0 LIMIT 1";
-        let args: &[&dyn ToSql] = params![parent_index_block_hash, microblock_hash];
+        let args = params![parent_index_block_hash, microblock_hash];
         query_row::<StagingMicroblock, _>(blocks_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -1127,7 +1127,7 @@ impl StacksChainState {
         index_microblock_hash: &StacksBlockId,
     ) -> Result<Option<StagingMicroblock>, Error> {
         let sql = "SELECT * FROM staging_microblocks WHERE index_microblock_hash = ?1 AND orphaned = 0 LIMIT 1";
-        let args: &[&dyn ToSql] = params![index_microblock_hash];
+        let args = params![index_microblock_hash];
         query_row::<StagingMicroblock, _>(blocks_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -1332,7 +1332,7 @@ impl StacksChainState {
             "SELECT * FROM staging_microblocks WHERE index_block_hash = ?1 AND sequence >= ?2 AND sequence < ?3 AND orphaned = 0 ORDER BY sequence ASC".to_string()
         };
 
-        let args: &[&dyn ToSql] = params![parent_index_block_hash, start_seq, last_seq];
+        let args = params![parent_index_block_hash, start_seq, last_seq];
         let staging_microblocks =
             query_rows::<StagingMicroblock, _>(blocks_conn, &sql, args).map_err(Error::DBError)?;
 
@@ -1565,7 +1565,7 @@ impl StacksChainState {
             // if this block has an unprocessed staging parent, then it's not attachable until its parent is.
             let has_unprocessed_parent_sql = "SELECT anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 AND processed = 0 AND orphaned = 0 LIMIT 1";
             let has_parent_sql = "SELECT anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 LIMIT 1";
-            let has_parent_args: &[&dyn ToSql] =
+            let has_parent_args =
                 params![block.header.parent_block, parent_consensus_hash];
             let has_unprocessed_parent_rows = query_row_columns::<BlockHeaderHash, _>(
                 &tx,
@@ -1618,7 +1618,7 @@ impl StacksChainState {
                    download_time) \
                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)";
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             block_hash,
             block.header.parent_block,
             consensus_hash,
@@ -1691,7 +1691,7 @@ impl StacksChainState {
 
         // store microblock metadata
         let sql = "INSERT OR REPLACE INTO staging_microblocks (anchored_block_hash, consensus_hash, index_block_hash, microblock_hash, parent_hash, index_microblock_hash, sequence, processed, orphaned) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             parent_anchored_block_hash,
             parent_consensus_hash,
             index_block_hash,
@@ -1710,7 +1710,7 @@ impl StacksChainState {
         let block_sql = "INSERT OR REPLACE INTO staging_microblocks_data \
                          (block_hash, block_data)
                          VALUES (?1, ?2)";
-        let block_args: &[&dyn ToSql] = params![microblock.block_hash(), microblock_bytes];
+        let block_args = params![microblock.block_hash(), microblock_bytes];
 
         tx.execute(&block_sql, block_args)
             .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
@@ -1855,7 +1855,7 @@ impl StacksChainState {
             };
 
         let sql = "SELECT 1 FROM staging_microblocks WHERE index_block_hash = ?1 AND microblock_hash = ?2 AND processed = 1 AND orphaned = 0";
-        let args: &[&dyn ToSql] = params![parent_index_block_hash, parent_microblock_hash];
+        let args = params![parent_index_block_hash, parent_microblock_hash];
         let res = self
             .db()
             .query_row(sql, args, |_r| Ok(()))
@@ -2028,7 +2028,7 @@ impl StacksChainState {
         );
 
         let sql = "SELECT COALESCE(MIN(block_height), 0), COALESCE(MAX(block_height), 0) FROM block_headers WHERE burn_header_height >= ?1 AND burn_header_height < ?2";
-        let args: &[&dyn ToSql] =
+        let args =
             params![u64_to_sql(burn_height_start)?, u64_to_sql(burn_height_end)?,];
 
         self.db()
@@ -2077,7 +2077,7 @@ impl StacksChainState {
                    FROM staging_blocks LEFT JOIN staging_microblocks \
                    ON staging_blocks.parent_microblock_hash = staging_microblocks.microblock_hash \
                    WHERE staging_blocks.height >= ?1 AND staging_blocks.height <= ?2";
-        let args: &[&dyn ToSql] = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
+        let args = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
 
         let mut stmt = self.db().prepare(sql)?;
 
@@ -2154,7 +2154,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Vec<ConsensusHash>, Error> {
         let qry = "SELECT consensus_hash FROM staging_blocks WHERE anchored_block_hash = ?1";
-        let args: &[&dyn ToSql] = params![block_hash];
+        let args = params![block_hash];
         query_rows(conn, qry, args).map_err(|e| e.into())
     }
 
@@ -2300,16 +2300,16 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         // This block is orphaned
         let update_block_sql = "UPDATE staging_blocks SET orphaned = 1, processed = 1, attachable = 0 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let update_block_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
+        let update_block_args = params![consensus_hash, anchored_block_hash];
 
         // All descendants of this processed block are never attachable.
         // Indicate this by marking all children as orphaned (but not procesed), across all burnchain forks.
         let update_children_sql = "UPDATE staging_blocks SET orphaned = 1, processed = 0, attachable = 0 WHERE parent_consensus_hash = ?1 AND parent_anchored_block_hash = ?2";
-        let update_children_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
+        let update_children_args = params![consensus_hash, anchored_block_hash];
 
         // find all orphaned microblocks, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let find_orphaned_microblocks_args: &[&dyn ToSql] =
+        let find_orphaned_microblocks_args =
             params![consensus_hash, anchored_block_hash];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
@@ -2320,7 +2320,7 @@ impl StacksChainState {
 
         // drop microblocks (this processes them)
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let update_microblock_children_args: &[&dyn ToSql] =
+        let update_microblock_children_args =
             params![consensus_hash, anchored_block_hash];
 
         tx.execute(update_block_sql, update_block_args)?;
@@ -2368,7 +2368,7 @@ impl StacksChainState {
         );
 
         let sql = "DELETE FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND orphaned = 1 AND processed = 1";
-        let args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
+        let args = params![consensus_hash, anchored_block_hash];
 
         tx.execute(sql, args)?;
 
@@ -2392,7 +2392,7 @@ impl StacksChainState {
         accept: bool,
     ) -> Result<(), Error> {
         let sql = "SELECT * FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND orphaned = 0".to_string();
-        let args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
+        let args = params![consensus_hash, anchored_block_hash];
 
         let has_stored_block = StacksChainState::has_stored_block(
             tx,
@@ -2406,7 +2406,7 @@ impl StacksChainState {
             0 => {
                 // not an error if this block was already orphaned
                 let orphan_sql = "SELECT * FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND orphaned = 1".to_string();
-                let orphan_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
+                let orphan_args = params![consensus_hash, anchored_block_hash];
                 let orphan_rows = query_rows::<StagingBlock, _>(tx, &orphan_sql, orphan_args)
                     .map_err(Error::DBError)?;
                 if orphan_rows.len() == 1 {
@@ -2460,7 +2460,7 @@ impl StacksChainState {
         }
 
         let update_sql = "UPDATE staging_blocks SET processed = 1, processed_time = ?1 WHERE consensus_hash = ?2 AND anchored_block_hash = ?3".to_string();
-        let update_args: &[&dyn ToSql] = params![
+        let update_args = params![
             u64_to_sql(get_epoch_time_secs())?,
             consensus_hash,
             anchored_block_hash,
@@ -2528,11 +2528,11 @@ impl StacksChainState {
             &index_block_hash
         );
         let update_block_sql = "UPDATE staging_blocks SET orphaned = 1, processed = 1, attachable = 0 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2".to_string();
-        let update_block_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
+        let update_block_args = params![consensus_hash, anchored_block_hash];
 
         // find all orphaned microblocks, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let find_orphaned_microblocks_args: &[&dyn ToSql] =
+        let find_orphaned_microblocks_args =
             params![consensus_hash, anchored_block_hash];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
@@ -2550,7 +2550,7 @@ impl StacksChainState {
             &index_block_hash
         );
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2".to_string();
-        let update_microblock_children_args: &[&dyn ToSql] =
+        let update_microblock_children_args =
             params![consensus_hash, anchored_block_hash];
 
         tx.execute(&update_block_sql, update_block_args)
@@ -2587,7 +2587,7 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         // find offending sequence
         let seq_sql = "SELECT sequence FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND microblock_hash = ?3 AND processed = 0 AND orphaned = 0".to_string();
-        let seq_args: &[&dyn ToSql] =
+        let seq_args =
             params![consensus_hash, anchored_block_hash, invalid_block_hash];
         let seq = match query_int::<_>(tx, &seq_sql, seq_args) {
             Ok(seq) => seq,
@@ -2609,7 +2609,7 @@ impl StacksChainState {
 
         // drop staging children at and beyond the invalid block
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE anchored_block_hash = ?1 AND sequence >= ?2".to_string();
-        let update_microblock_children_args: &[&dyn ToSql] = params![anchored_block_hash, seq];
+        let update_microblock_children_args = params![anchored_block_hash, seq];
 
         tx.execute(
             &update_microblock_children_sql,
@@ -2619,7 +2619,7 @@ impl StacksChainState {
 
         // find all orphaned microblocks hashes, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE anchored_block_hash = ?1 AND sequence >= ?2";
-        let find_orphaned_microblocks_args: &[&dyn ToSql] = params![anchored_block_hash, seq];
+        let find_orphaned_microblocks_args = params![anchored_block_hash, seq];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
             find_orphaned_microblocks_sql,
@@ -2674,7 +2674,7 @@ impl StacksChainState {
             test_debug!("Set {}-{} processed", &parent_index_hash, &mblock_hash);
 
             // confirm this microblock
-            let args: &[&dyn ToSql] =
+            let args =
                 params![parent_consensus_hash, parent_block_hash, mblock_hash];
             tx.execute(sql, args)
                 .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
@@ -2746,7 +2746,7 @@ impl StacksChainState {
         index_microblock_hash: &StacksBlockId,
     ) -> Result<bool, Error> {
         let sql = "SELECT 1 FROM staging_microblocks WHERE index_microblock_hash = ?1 AND processed = 1 AND orphaned = 0";
-        let args: &[&dyn ToSql] = params![index_microblock_hash];
+        let args = params![index_microblock_hash];
         let res = conn
             .query_row(&sql, args, |_r| Ok(()))
             .optional()
@@ -2840,7 +2840,7 @@ impl StacksChainState {
             "SELECT {},{} FROM staging_blocks WHERE index_block_hash = ?1",
             consensus_hash_col, anchored_block_col
         );
-        let args: &[&dyn ToSql] = params![index_block_hash];
+        let args = params![index_block_hash];
 
         blocks_db
             .query_row(&sql, args, |row| {
@@ -2892,7 +2892,7 @@ impl StacksChainState {
                    staging_microblocks JOIN staging_microblocks_data \
                    ON staging_microblocks.microblock_hash = staging_microblocks_data.block_hash \
                    WHERE staging_microblocks.index_block_hash = ?1 AND staging_microblocks.microblock_hash = ?2";
-        let args: &[&dyn ToSql] = params![parent_index_block_hash, microblock_hash,];
+        let args = params![parent_index_block_hash, microblock_hash,];
         query_row(blocks_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -2905,7 +2905,7 @@ impl StacksChainState {
     ) -> Result<Vec<StagingMicroblock>, Error> {
         let sql = "SELECT * FROM staging_microblocks WHERE index_block_hash = ?1 ORDER BY sequence"
             .to_string();
-        let args: &[&dyn ToSql] = params![parent_index_block_hash];
+        let args = params![parent_index_block_hash];
         let microblock_info =
             query_rows::<StagingMicroblock, _>(blocks_conn, &sql, args).map_err(Error::DBError)?;
         Ok(microblock_info)
@@ -2947,7 +2947,7 @@ impl StacksChainState {
     ) -> Result<bool, Error> {
         let sql =
             "SELECT 1 FROM staging_blocks WHERE orphaned = 0 AND processed = 0 AND height >= ?1 AND arrival_time >= ?2";
-        let args: &[&dyn ToSql] = params![u64_to_sql(height)?, u64_to_sql(deadline)?];
+        let args = params![u64_to_sql(height)?, u64_to_sql(deadline)?];
         let res = conn
             .query_row(sql, args, |_r| Ok(()))
             .optional()
@@ -3177,7 +3177,7 @@ impl StacksChainState {
         parent_block_hash: &BlockHeaderHash,
     ) -> Result<bool, db_error> {
         let sql = "SELECT 1 FROM epoch_transitions WHERE block_id = ?1";
-        let args: &[&dyn ToSql] = params![StacksBlockHeader::make_index_block_hash(
+        let args = params![StacksBlockHeader::make_index_block_hash(
             parent_consensus_hash,
             parent_block_hash,
         )];
@@ -3841,7 +3841,7 @@ impl StacksChainState {
         end_height: u64,
     ) -> Result<Vec<i64>, Error> {
         let sql = "SELECT processed_time - arrival_time FROM staging_blocks WHERE processed = 1 AND height >= ?1 AND height < ?2";
-        let args: &[&dyn ToSql] = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
+        let args = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
         let list = query_rows::<i64, _>(blocks_conn, &sql, args)?;
         Ok(list)
     }
@@ -3854,7 +3854,7 @@ impl StacksChainState {
         end_height: u64,
     ) -> Result<Vec<i64>, Error> {
         let sql = "SELECT download_time FROM staging_blocks WHERE height >= ?1 AND height < ?2";
-        let args: &[&dyn ToSql] = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
+        let args = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
         let list = query_rows::<i64, _>(blocks_conn, &sql, args)?;
         Ok(list)
     }
@@ -3936,7 +3936,7 @@ impl StacksChainState {
                         // not the first-ever block.  Does this connect to a previously-accepted
                         // block in the headers database?
                         let hdr_sql = "SELECT * FROM block_headers WHERE block_hash = ?1 AND consensus_hash = ?2".to_string();
-                        let hdr_args: &[&dyn ToSql] = params![
+                        let hdr_args = params![
                             candidate.parent_anchored_block_hash,
                             candidate.parent_consensus_hash,
                         ];
@@ -6537,7 +6537,7 @@ impl StacksChainState {
         let (consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn())?;
         let sql = "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = params![consensus_hash, block_bhh];
+        let args = params![consensus_hash, block_bhh];
         query_row(&self.db(), sql, args).map_err(Error::DBError)
     }
 
@@ -6546,7 +6546,7 @@ impl StacksChainState {
         let (consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn())?;
         let sql = "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = params![consensus_hash, block_bhh];
+        let args = params![consensus_hash, block_bhh];
         let Some(staging_block): Option<StagingBlock> =
             query_row(&self.db(), sql, args).map_err(Error::DBError)?
         else {
@@ -6559,7 +6559,7 @@ impl StacksChainState {
     pub fn get_stacks_chain_tips_at_height(&self, height: u64) -> Result<Vec<StagingBlock>, Error> {
         let sql =
             "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND height = ?1";
-        let args: &[&dyn ToSql] = params![u64_to_sql(height)?];
+        let args = params![u64_to_sql(height)?];
         query_rows(&self.db(), sql, args).map_err(Error::DBError)
     }
 
@@ -6569,7 +6569,7 @@ impl StacksChainState {
         staging_block: &StagingBlock,
     ) -> Result<Option<StagingBlock>, Error> {
         let sql = "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             staging_block.parent_consensus_hash,
             staging_block.parent_anchored_block_hash,
         ];
@@ -6583,7 +6583,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<u64>, Error> {
         let sql = "SELECT height FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
+        let args = params![consensus_hash, block_hash];
         query_row(&self.db(), sql, args).map_err(Error::DBError)
     }
 

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -1565,8 +1565,7 @@ impl StacksChainState {
             // if this block has an unprocessed staging parent, then it's not attachable until its parent is.
             let has_unprocessed_parent_sql = "SELECT anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 AND processed = 0 AND orphaned = 0 LIMIT 1";
             let has_parent_sql = "SELECT anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 LIMIT 1";
-            let has_parent_args =
-                params![block.header.parent_block, parent_consensus_hash];
+            let has_parent_args = params![block.header.parent_block, parent_consensus_hash];
             let has_unprocessed_parent_rows = query_row_columns::<BlockHeaderHash, _>(
                 &tx,
                 has_unprocessed_parent_sql,
@@ -2028,8 +2027,7 @@ impl StacksChainState {
         );
 
         let sql = "SELECT COALESCE(MIN(block_height), 0), COALESCE(MAX(block_height), 0) FROM block_headers WHERE burn_header_height >= ?1 AND burn_header_height < ?2";
-        let args =
-            params![u64_to_sql(burn_height_start)?, u64_to_sql(burn_height_end)?,];
+        let args = params![u64_to_sql(burn_height_start)?, u64_to_sql(burn_height_end)?,];
 
         self.db()
             .query_row(sql, args, |row| {
@@ -2309,8 +2307,7 @@ impl StacksChainState {
 
         // find all orphaned microblocks, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let find_orphaned_microblocks_args =
-            params![consensus_hash, anchored_block_hash];
+        let find_orphaned_microblocks_args = params![consensus_hash, anchored_block_hash];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
             find_orphaned_microblocks_sql,
@@ -2320,8 +2317,7 @@ impl StacksChainState {
 
         // drop microblocks (this processes them)
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let update_microblock_children_args =
-            params![consensus_hash, anchored_block_hash];
+        let update_microblock_children_args = params![consensus_hash, anchored_block_hash];
 
         tx.execute(update_block_sql, update_block_args)?;
 
@@ -2532,8 +2528,7 @@ impl StacksChainState {
 
         // find all orphaned microblocks, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let find_orphaned_microblocks_args =
-            params![consensus_hash, anchored_block_hash];
+        let find_orphaned_microblocks_args = params![consensus_hash, anchored_block_hash];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
             find_orphaned_microblocks_sql,
@@ -2550,8 +2545,7 @@ impl StacksChainState {
             &index_block_hash
         );
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2".to_string();
-        let update_microblock_children_args =
-            params![consensus_hash, anchored_block_hash];
+        let update_microblock_children_args = params![consensus_hash, anchored_block_hash];
 
         tx.execute(&update_block_sql, update_block_args)
             .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
@@ -2587,8 +2581,7 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         // find offending sequence
         let seq_sql = "SELECT sequence FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND microblock_hash = ?3 AND processed = 0 AND orphaned = 0".to_string();
-        let seq_args =
-            params![consensus_hash, anchored_block_hash, invalid_block_hash];
+        let seq_args = params![consensus_hash, anchored_block_hash, invalid_block_hash];
         let seq = match query_int::<_>(tx, &seq_sql, seq_args) {
             Ok(seq) => seq,
             Err(e) => match e {
@@ -2674,8 +2667,7 @@ impl StacksChainState {
             test_debug!("Set {}-{} processed", &parent_index_hash, &mblock_hash);
 
             // confirm this microblock
-            let args =
-                params![parent_consensus_hash, parent_block_hash, mblock_hash];
+            let args = params![parent_consensus_hash, parent_block_hash, mblock_hash];
             tx.execute(sql, args)
                 .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
 

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -34,7 +34,10 @@ use clarity::vm::types::{
     TypeSignature, Value,
 };
 use rand::{thread_rng, Rng, RngCore};
-use rusqlite::{params, Connection, DatabaseName, Error as sqlite_error, OptionalExtension, Params};
+use rusqlite::types::ToSql;
+use rusqlite::{
+    params, Connection, DatabaseName, Error as sqlite_error, OptionalExtension, Params,
+};
 use serde::Serialize;
 use serde_json::json;
 use stacks_common::bitvec::BitVec;
@@ -767,11 +770,11 @@ impl StacksChainState {
 
         for (consensus_hash, block_hash) in blocks.drain(..) {
             let list_microblock_sql = "SELECT * FROM staging_microblocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 ORDER BY sequence".to_string();
-            let list_microblock_args: [&dyn ToSql; 2] = [&block_hash, &consensus_hash];
+            let list_microblock_args: &[&dyn ToSql] = params![block_hash, consensus_hash];
             let mut microblocks = query_rows::<StagingMicroblock, _>(
                 blocks_conn,
                 &list_microblock_sql,
-                &list_microblock_args,
+                list_microblock_args,
             )
             .map_err(Error::DBError)?;
 
@@ -961,7 +964,7 @@ impl StacksChainState {
         minimum_block_height: i64,
     ) -> bool {
         let sql = "SELECT 1 FROM staging_blocks WHERE microblock_pubkey_hash = ?1 AND height >= ?2";
-        let args: &[&dyn ToSql] = &[pubkey_hash, &minimum_block_height];
+        let args: &[&dyn ToSql] = params![pubkey_hash, minimum_block_height];
         block_conn
             .query_row(sql, args, |_r| Ok(()))
             .optional()
@@ -977,7 +980,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<StagingBlock>, Error> {
         let sql = "SELECT * FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 AND orphaned = 0 AND processed = 0".to_string();
-        let args: &[&dyn ToSql] = &[&block_hash, &consensus_hash];
+        let args: &[&dyn ToSql] = params![block_hash, consensus_hash];
         let mut rows =
             query_rows::<StagingBlock, _>(block_conn, &sql, args).map_err(Error::DBError)?;
         let len = rows.len();
@@ -1006,7 +1009,7 @@ impl StacksChainState {
         index_block_hash: &StacksBlockId,
     ) -> Result<Option<StagingBlock>, Error> {
         let sql = "SELECT * FROM staging_blocks WHERE index_block_hash = ?1 AND orphaned = 0";
-        let args: &[&dyn ToSql] = &[&index_block_hash];
+        let args: &[&dyn ToSql] = params![index_block_hash];
         query_row::<StagingBlock, _>(block_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -1056,7 +1059,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<Hash160>, Error> {
         let sql = "SELECT microblock_pubkey_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 AND processed = 0 AND orphaned = 0";
-        let args: &[&dyn ToSql] = &[&block_hash, &consensus_hash];
+        let args: &[&dyn ToSql] = params![block_hash, consensus_hash];
         let rows = query_row_columns::<Hash160, _>(block_conn, sql, args, "microblock_pubkey_hash")
             .map_err(Error::DBError)?;
         match rows.len() {
@@ -1111,7 +1114,7 @@ impl StacksChainState {
         microblock_hash: &BlockHeaderHash,
     ) -> Result<Option<StagingMicroblock>, Error> {
         let sql = "SELECT * FROM staging_microblocks WHERE index_block_hash = ?1 AND microblock_hash = ?2 AND orphaned = 0 LIMIT 1";
-        let args: &[&dyn ToSql] = &[&parent_index_block_hash, &microblock_hash];
+        let args: &[&dyn ToSql] = params![parent_index_block_hash, microblock_hash];
         query_row::<StagingMicroblock, _>(blocks_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -1124,7 +1127,7 @@ impl StacksChainState {
         index_microblock_hash: &StacksBlockId,
     ) -> Result<Option<StagingMicroblock>, Error> {
         let sql = "SELECT * FROM staging_microblocks WHERE index_microblock_hash = ?1 AND orphaned = 0 LIMIT 1";
-        let args: &[&dyn ToSql] = &[&index_microblock_hash];
+        let args: &[&dyn ToSql] = params![index_microblock_hash];
         query_row::<StagingMicroblock, _>(blocks_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -1329,7 +1332,7 @@ impl StacksChainState {
             "SELECT * FROM staging_microblocks WHERE index_block_hash = ?1 AND sequence >= ?2 AND sequence < ?3 AND orphaned = 0 ORDER BY sequence ASC".to_string()
         };
 
-        let args: &[&dyn ToSql] = &[parent_index_block_hash, &start_seq, &last_seq];
+        let args: &[&dyn ToSql] = params![parent_index_block_hash, start_seq, last_seq];
         let staging_microblocks =
             query_rows::<StagingMicroblock, _>(blocks_conn, &sql, args).map_err(Error::DBError)?;
 
@@ -1563,7 +1566,7 @@ impl StacksChainState {
             let has_unprocessed_parent_sql = "SELECT anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 AND processed = 0 AND orphaned = 0 LIMIT 1";
             let has_parent_sql = "SELECT anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ?1 AND consensus_hash = ?2 LIMIT 1";
             let has_parent_args: &[&dyn ToSql] =
-                &[&block.header.parent_block, &parent_consensus_hash];
+                params![block.header.parent_block, parent_consensus_hash];
             let has_unprocessed_parent_rows = query_row_columns::<BlockHeaderHash, _>(
                 &tx,
                 has_unprocessed_parent_sql,
@@ -1707,7 +1710,7 @@ impl StacksChainState {
         let block_sql = "INSERT OR REPLACE INTO staging_microblocks_data \
                          (block_hash, block_data)
                          VALUES (?1, ?2)";
-        let block_args: &[&dyn ToSql] = &[&microblock.block_hash(), &microblock_bytes];
+        let block_args: &[&dyn ToSql] = params![microblock.block_hash(), microblock_bytes];
 
         tx.execute(&block_sql, block_args)
             .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
@@ -1852,7 +1855,7 @@ impl StacksChainState {
             };
 
         let sql = "SELECT 1 FROM staging_microblocks WHERE index_block_hash = ?1 AND microblock_hash = ?2 AND processed = 1 AND orphaned = 0";
-        let args: &[&dyn ToSql] = &[&parent_index_block_hash, &parent_microblock_hash];
+        let args: &[&dyn ToSql] = params![parent_index_block_hash, parent_microblock_hash];
         let res = self
             .db()
             .query_row(sql, args, |_r| Ok(()))
@@ -2025,10 +2028,8 @@ impl StacksChainState {
         );
 
         let sql = "SELECT COALESCE(MIN(block_height), 0), COALESCE(MAX(block_height), 0) FROM block_headers WHERE burn_header_height >= ?1 AND burn_header_height < ?2";
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(burn_height_start)?,
-            &u64_to_sql(burn_height_end)?,
-        ];
+        let args: &[&dyn ToSql] =
+            params![u64_to_sql(burn_height_start)?, u64_to_sql(burn_height_end)?,];
 
         self.db()
             .query_row(sql, args, |row| {
@@ -2076,7 +2077,7 @@ impl StacksChainState {
                    FROM staging_blocks LEFT JOIN staging_microblocks \
                    ON staging_blocks.parent_microblock_hash = staging_microblocks.microblock_hash \
                    WHERE staging_blocks.height >= ?1 AND staging_blocks.height <= ?2";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(start_height)?, &u64_to_sql(end_height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
 
         let mut stmt = self.db().prepare(sql)?;
 
@@ -2153,7 +2154,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Vec<ConsensusHash>, Error> {
         let qry = "SELECT consensus_hash FROM staging_blocks WHERE anchored_block_hash = ?1";
-        let args: &[&dyn ToSql] = &[block_hash];
+        let args: &[&dyn ToSql] = params![block_hash];
         query_rows(conn, qry, args).map_err(|e| e.into())
     }
 
@@ -2299,16 +2300,17 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         // This block is orphaned
         let update_block_sql = "UPDATE staging_blocks SET orphaned = 1, processed = 1, attachable = 0 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let update_block_args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let update_block_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
 
         // All descendants of this processed block are never attachable.
         // Indicate this by marking all children as orphaned (but not procesed), across all burnchain forks.
         let update_children_sql = "UPDATE staging_blocks SET orphaned = 1, processed = 0, attachable = 0 WHERE parent_consensus_hash = ?1 AND parent_anchored_block_hash = ?2";
-        let update_children_args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let update_children_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
 
         // find all orphaned microblocks, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let find_orphaned_microblocks_args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let find_orphaned_microblocks_args: &[&dyn ToSql] =
+            params![consensus_hash, anchored_block_hash];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
             find_orphaned_microblocks_sql,
@@ -2318,7 +2320,8 @@ impl StacksChainState {
 
         // drop microblocks (this processes them)
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let update_microblock_children_args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let update_microblock_children_args: &[&dyn ToSql] =
+            params![consensus_hash, anchored_block_hash];
 
         tx.execute(update_block_sql, update_block_args)?;
 
@@ -2365,7 +2368,7 @@ impl StacksChainState {
         );
 
         let sql = "DELETE FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND orphaned = 1 AND processed = 1";
-        let args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
 
         tx.execute(sql, args)?;
 
@@ -2389,7 +2392,7 @@ impl StacksChainState {
         accept: bool,
     ) -> Result<(), Error> {
         let sql = "SELECT * FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND orphaned = 0".to_string();
-        let args: &[&dyn ToSql] = &[&consensus_hash, &anchored_block_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
 
         let has_stored_block = StacksChainState::has_stored_block(
             tx,
@@ -2403,7 +2406,7 @@ impl StacksChainState {
             0 => {
                 // not an error if this block was already orphaned
                 let orphan_sql = "SELECT * FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND orphaned = 1".to_string();
-                let orphan_args: &[&dyn ToSql] = &[&consensus_hash, &anchored_block_hash];
+                let orphan_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
                 let orphan_rows = query_rows::<StagingBlock, _>(tx, &orphan_sql, orphan_args)
                     .map_err(Error::DBError)?;
                 if orphan_rows.len() == 1 {
@@ -2457,10 +2460,10 @@ impl StacksChainState {
         }
 
         let update_sql = "UPDATE staging_blocks SET processed = 1, processed_time = ?1 WHERE consensus_hash = ?2 AND anchored_block_hash = ?3".to_string();
-        let update_args: &[&dyn ToSql] = &[
-            &u64_to_sql(get_epoch_time_secs())?,
-            &consensus_hash,
-            &anchored_block_hash,
+        let update_args: &[&dyn ToSql] = params![
+            u64_to_sql(get_epoch_time_secs())?,
+            consensus_hash,
+            anchored_block_hash,
         ];
 
         tx.execute(&update_sql, update_args)
@@ -2525,11 +2528,12 @@ impl StacksChainState {
             &index_block_hash
         );
         let update_block_sql = "UPDATE staging_blocks SET orphaned = 1, processed = 1, attachable = 0 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2".to_string();
-        let update_block_args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let update_block_args: &[&dyn ToSql] = params![consensus_hash, anchored_block_hash];
 
         // find all orphaned microblocks, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let find_orphaned_microblocks_args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let find_orphaned_microblocks_args: &[&dyn ToSql] =
+            params![consensus_hash, anchored_block_hash];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
             find_orphaned_microblocks_sql,
@@ -2546,7 +2550,8 @@ impl StacksChainState {
             &index_block_hash
         );
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE consensus_hash = ?1 AND anchored_block_hash = ?2".to_string();
-        let update_microblock_children_args: &[&dyn ToSql] = &[consensus_hash, anchored_block_hash];
+        let update_microblock_children_args: &[&dyn ToSql] =
+            params![consensus_hash, anchored_block_hash];
 
         tx.execute(&update_block_sql, update_block_args)
             .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
@@ -2582,7 +2587,8 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         // find offending sequence
         let seq_sql = "SELECT sequence FROM staging_microblocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2 AND microblock_hash = ?3 AND processed = 0 AND orphaned = 0".to_string();
-        let seq_args: &[&dyn ToSql] = &[&consensus_hash, &anchored_block_hash, &invalid_block_hash];
+        let seq_args: &[&dyn ToSql] =
+            params![consensus_hash, anchored_block_hash, invalid_block_hash];
         let seq = match query_int::<_>(tx, &seq_sql, seq_args) {
             Ok(seq) => seq,
             Err(e) => match e {
@@ -2603,7 +2609,7 @@ impl StacksChainState {
 
         // drop staging children at and beyond the invalid block
         let update_microblock_children_sql = "UPDATE staging_microblocks SET orphaned = 1, processed = 1 WHERE anchored_block_hash = ?1 AND sequence >= ?2".to_string();
-        let update_microblock_children_args: &[&dyn ToSql] = &[&anchored_block_hash, &seq];
+        let update_microblock_children_args: &[&dyn ToSql] = params![anchored_block_hash, seq];
 
         tx.execute(
             &update_microblock_children_sql,
@@ -2613,7 +2619,7 @@ impl StacksChainState {
 
         // find all orphaned microblocks hashes, and delete the block data
         let find_orphaned_microblocks_sql = "SELECT microblock_hash FROM staging_microblocks WHERE anchored_block_hash = ?1 AND sequence >= ?2";
-        let find_orphaned_microblocks_args: &[&dyn ToSql] = &[&anchored_block_hash, &seq];
+        let find_orphaned_microblocks_args: &[&dyn ToSql] = params![anchored_block_hash, seq];
         let orphaned_microblock_hashes = query_row_columns::<BlockHeaderHash, _>(
             tx,
             find_orphaned_microblocks_sql,
@@ -2668,7 +2674,8 @@ impl StacksChainState {
             test_debug!("Set {}-{} processed", &parent_index_hash, &mblock_hash);
 
             // confirm this microblock
-            let args: &[&dyn ToSql] = &[&parent_consensus_hash, &parent_block_hash, &mblock_hash];
+            let args: &[&dyn ToSql] =
+                params![parent_consensus_hash, parent_block_hash, mblock_hash];
             tx.execute(sql, args)
                 .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
 
@@ -2739,7 +2746,7 @@ impl StacksChainState {
         index_microblock_hash: &StacksBlockId,
     ) -> Result<bool, Error> {
         let sql = "SELECT 1 FROM staging_microblocks WHERE index_microblock_hash = ?1 AND processed = 1 AND orphaned = 0";
-        let args: &[&dyn ToSql] = &[index_microblock_hash];
+        let args: &[&dyn ToSql] = params![index_microblock_hash];
         let res = conn
             .query_row(&sql, args, |_r| Ok(()))
             .optional()
@@ -2833,7 +2840,7 @@ impl StacksChainState {
             "SELECT {},{} FROM staging_blocks WHERE index_block_hash = ?1",
             consensus_hash_col, anchored_block_col
         );
-        let args = params![index_block_hash];
+        let args: &[&dyn ToSql] = params![index_block_hash];
 
         blocks_db
             .query_row(&sql, args, |row| {
@@ -2885,10 +2892,7 @@ impl StacksChainState {
                    staging_microblocks JOIN staging_microblocks_data \
                    ON staging_microblocks.microblock_hash = staging_microblocks_data.block_hash \
                    WHERE staging_microblocks.index_block_hash = ?1 AND staging_microblocks.microblock_hash = ?2";
-        let args = params![
-            parent_index_block_hash,
-            microblock_hash,
-        ];
+        let args: &[&dyn ToSql] = params![parent_index_block_hash, microblock_hash,];
         query_row(blocks_conn, sql, args).map_err(Error::DBError)
     }
 
@@ -2901,7 +2905,7 @@ impl StacksChainState {
     ) -> Result<Vec<StagingMicroblock>, Error> {
         let sql = "SELECT * FROM staging_microblocks WHERE index_block_hash = ?1 ORDER BY sequence"
             .to_string();
-        let args = params![parent_index_block_hash];
+        let args: &[&dyn ToSql] = params![parent_index_block_hash];
         let microblock_info =
             query_rows::<StagingMicroblock, _>(blocks_conn, &sql, args).map_err(Error::DBError)?;
         Ok(microblock_info)
@@ -3173,7 +3177,7 @@ impl StacksChainState {
         parent_block_hash: &BlockHeaderHash,
     ) -> Result<bool, db_error> {
         let sql = "SELECT 1 FROM epoch_transitions WHERE block_id = ?1";
-        let args: &[&dyn ToSql] = &[&StacksBlockHeader::make_index_block_hash(
+        let args: &[&dyn ToSql] = params![StacksBlockHeader::make_index_block_hash(
             parent_consensus_hash,
             parent_block_hash,
         )];
@@ -3837,7 +3841,7 @@ impl StacksChainState {
         end_height: u64,
     ) -> Result<Vec<i64>, Error> {
         let sql = "SELECT processed_time - arrival_time FROM staging_blocks WHERE processed = 1 AND height >= ?1 AND height < ?2";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(start_height)?, &u64_to_sql(end_height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
         let list = query_rows::<i64, _>(blocks_conn, &sql, args)?;
         Ok(list)
     }
@@ -3850,7 +3854,7 @@ impl StacksChainState {
         end_height: u64,
     ) -> Result<Vec<i64>, Error> {
         let sql = "SELECT download_time FROM staging_blocks WHERE height >= ?1 AND height < ?2";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(start_height)?, &u64_to_sql(end_height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(start_height)?, u64_to_sql(end_height)?];
         let list = query_rows::<i64, _>(blocks_conn, &sql, args)?;
         Ok(list)
     }
@@ -3932,9 +3936,9 @@ impl StacksChainState {
                         // not the first-ever block.  Does this connect to a previously-accepted
                         // block in the headers database?
                         let hdr_sql = "SELECT * FROM block_headers WHERE block_hash = ?1 AND consensus_hash = ?2".to_string();
-                        let hdr_args: &[&dyn ToSql] = &[
-                            &candidate.parent_anchored_block_hash,
-                            &candidate.parent_consensus_hash,
+                        let hdr_args: &[&dyn ToSql] = params![
+                            candidate.parent_anchored_block_hash,
+                            candidate.parent_consensus_hash,
                         ];
                         let hdr_row = query_row_panic::<StacksHeaderInfo, _, _>(
                             blocks_tx,
@@ -6533,7 +6537,7 @@ impl StacksChainState {
         let (consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn())?;
         let sql = "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = &[&consensus_hash, &block_bhh];
+        let args: &[&dyn ToSql] = params![consensus_hash, block_bhh];
         query_row(&self.db(), sql, args).map_err(Error::DBError)
     }
 
@@ -6542,7 +6546,7 @@ impl StacksChainState {
         let (consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn())?;
         let sql = "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = &[&consensus_hash, &block_bhh];
+        let args: &[&dyn ToSql] = params![consensus_hash, block_bhh];
         let Some(staging_block): Option<StagingBlock> =
             query_row(&self.db(), sql, args).map_err(Error::DBError)?
         else {
@@ -6555,7 +6559,7 @@ impl StacksChainState {
     pub fn get_stacks_chain_tips_at_height(&self, height: u64) -> Result<Vec<StagingBlock>, Error> {
         let sql =
             "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND height = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(height)?];
         query_rows(&self.db(), sql, args).map_err(Error::DBError)
     }
 
@@ -6565,9 +6569,9 @@ impl StacksChainState {
         staging_block: &StagingBlock,
     ) -> Result<Option<StagingBlock>, Error> {
         let sql = "SELECT * FROM staging_blocks WHERE processed = 1 AND orphaned = 0 AND consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = &[
-            &staging_block.parent_consensus_hash,
-            &staging_block.parent_anchored_block_hash,
+        let args: &[&dyn ToSql] = params![
+            staging_block.parent_consensus_hash,
+            staging_block.parent_anchored_block_hash,
         ];
         query_row(&self.db(), sql, args).map_err(Error::DBError)
     }
@@ -6579,7 +6583,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<u64>, Error> {
         let sql = "SELECT height FROM staging_blocks WHERE consensus_hash = ?1 AND anchored_block_hash = ?2";
-        let args: &[&dyn ToSql] = &[consensus_hash, block_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
         query_row(&self.db(), sql, args).map_err(Error::DBError)
     }
 

--- a/stackslib/src/chainstate/stacks/db/headers.rs
+++ b/stackslib/src/chainstate/stacks/db/headers.rs
@@ -139,7 +139,7 @@ impl StacksChainState {
 
         assert!(block_height < (i64::MAX as u64));
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             header.version,
             total_burn_str,
             total_work_str,
@@ -209,7 +209,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<bool, Error> {
         let sql = "SELECT 1 FROM block_headers WHERE consensus_hash = ?1 AND block_hash = ?2";
-        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
+        let args = params![consensus_hash, block_hash];
         match conn.query_row(sql, args, |_| Ok(true)) {
             Ok(_) => Ok(true),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
@@ -225,7 +225,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<StacksHeaderInfo>, Error> {
         let sql = "SELECT * FROM block_headers WHERE consensus_hash = ?1 AND block_hash = ?2";
-        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
+        let args = params![consensus_hash, block_hash];
         query_row_panic(conn, sql, args, || {
             "FATAL: multiple rows for the same block hash".to_string()
         })
@@ -319,7 +319,7 @@ impl StacksChainState {
     pub fn get_genesis_header_info(conn: &Connection) -> Result<StacksHeaderInfo, Error> {
         // by construction, only one block can have height 0 in this DB
         let sql = "SELECT * FROM block_headers WHERE consensus_hash = ?1 AND block_height = 0";
-        let args: &[&dyn ToSql] = params![FIRST_BURNCHAIN_CONSENSUS_HASH];
+        let args = params![FIRST_BURNCHAIN_CONSENSUS_HASH];
         let row_opt = query_row(conn, sql, args)?;
         Ok(row_opt.expect("BUG: no genesis header info"))
     }
@@ -330,7 +330,7 @@ impl StacksChainState {
         block_id: &StacksBlockId,
     ) -> Result<Option<StacksBlockId>, Error> {
         let sql = "SELECT parent_block_id FROM block_headers WHERE index_block_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = params![block_id];
+        let args = params![block_id];
         let mut rows = query_row_columns::<StacksBlockId, _>(conn, sql, args, "parent_block_id")?;
         Ok(rows.pop())
     }
@@ -338,7 +338,7 @@ impl StacksChainState {
     /// Is this block present and processed?
     pub fn has_stacks_block(conn: &Connection, block_id: &StacksBlockId) -> Result<bool, Error> {
         let sql = "SELECT 1 FROM block_headers WHERE index_block_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = params![block_id];
+        let args = params![block_id];
         Ok(conn
             .query_row(sql, args, |_r| Ok(()))
             .optional()
@@ -383,7 +383,7 @@ impl StacksChainState {
     ) -> Result<Vec<StacksHeaderInfo>, Error> {
         let qry =
             "SELECT * FROM block_headers WHERE block_height = ?1 AND affirmation_weight = ?2 ORDER BY burn_header_height DESC";
-        let args: &[&dyn ToSql] = params![u64_to_sql(height)?, u64_to_sql(affirmation_weight)?];
+        let args = params![u64_to_sql(height)?, u64_to_sql(affirmation_weight)?];
         query_rows(conn, qry, args).map_err(|e| e.into())
     }
 

--- a/stackslib/src/chainstate/stacks/db/headers.rs
+++ b/stackslib/src/chainstate/stacks/db/headers.rs
@@ -139,29 +139,29 @@ impl StacksChainState {
 
         assert!(block_height < (i64::MAX as u64));
 
-        let args: &[&dyn ToSql] = &[
-            &header.version,
-            &total_burn_str,
-            &total_work_str,
-            &header.proof,
-            &header.parent_block,
-            &header.parent_microblock,
-            &header.parent_microblock_sequence,
-            &header.tx_merkle_root,
-            &header.state_index_root,
-            &header.microblock_pubkey_hash,
-            &block_hash,
-            &index_block_hash,
-            &consensus_hash,
-            &burn_header_hash,
-            &(burn_header_height as i64),
-            &(burn_header_timestamp as i64),
-            &(block_height as i64),
-            &index_root,
+        let args: &[&dyn ToSql] = params![
+            header.version,
+            total_burn_str,
+            total_work_str,
+            header.proof,
+            header.parent_block,
+            header.parent_microblock,
+            header.parent_microblock_sequence,
+            header.tx_merkle_root,
+            header.state_index_root,
+            header.microblock_pubkey_hash,
+            block_hash,
+            index_block_hash,
+            consensus_hash,
+            burn_header_hash,
+            (burn_header_height as i64),
+            (burn_header_timestamp as i64),
+            (block_height as i64),
+            index_root,
             anchored_block_cost,
-            &block_size_str,
+            block_size_str,
             parent_id,
-            &u64_to_sql(affirmation_weight)?,
+            u64_to_sql(affirmation_weight)?,
         ];
 
         tx.execute("INSERT INTO block_headers \
@@ -209,7 +209,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<bool, Error> {
         let sql = "SELECT 1 FROM block_headers WHERE consensus_hash = ?1 AND block_hash = ?2";
-        let args: &[&dyn ToSql] = &[&consensus_hash, &block_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
         match conn.query_row(sql, args, |_| Ok(true)) {
             Ok(_) => Ok(true),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
@@ -225,7 +225,7 @@ impl StacksChainState {
         block_hash: &BlockHeaderHash,
     ) -> Result<Option<StacksHeaderInfo>, Error> {
         let sql = "SELECT * FROM block_headers WHERE consensus_hash = ?1 AND block_hash = ?2";
-        let args: &[&dyn ToSql] = &[&consensus_hash, &block_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash, block_hash];
         query_row_panic(conn, sql, args, || {
             "FATAL: multiple rows for the same block hash".to_string()
         })
@@ -319,7 +319,7 @@ impl StacksChainState {
     pub fn get_genesis_header_info(conn: &Connection) -> Result<StacksHeaderInfo, Error> {
         // by construction, only one block can have height 0 in this DB
         let sql = "SELECT * FROM block_headers WHERE consensus_hash = ?1 AND block_height = 0";
-        let args: &[&dyn ToSql] = &[&FIRST_BURNCHAIN_CONSENSUS_HASH];
+        let args: &[&dyn ToSql] = params![FIRST_BURNCHAIN_CONSENSUS_HASH];
         let row_opt = query_row(conn, sql, args)?;
         Ok(row_opt.expect("BUG: no genesis header info"))
     }
@@ -330,7 +330,7 @@ impl StacksChainState {
         block_id: &StacksBlockId,
     ) -> Result<Option<StacksBlockId>, Error> {
         let sql = "SELECT parent_block_id FROM block_headers WHERE index_block_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = &[block_id];
+        let args: &[&dyn ToSql] = params![block_id];
         let mut rows = query_row_columns::<StacksBlockId, _>(conn, sql, args, "parent_block_id")?;
         Ok(rows.pop())
     }
@@ -338,7 +338,7 @@ impl StacksChainState {
     /// Is this block present and processed?
     pub fn has_stacks_block(conn: &Connection, block_id: &StacksBlockId) -> Result<bool, Error> {
         let sql = "SELECT 1 FROM block_headers WHERE index_block_hash = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = &[block_id];
+        let args: &[&dyn ToSql] = params![block_id];
         Ok(conn
             .query_row(sql, args, |_r| Ok(()))
             .optional()
@@ -383,7 +383,7 @@ impl StacksChainState {
     ) -> Result<Vec<StacksHeaderInfo>, Error> {
         let qry =
             "SELECT * FROM block_headers WHERE block_height = ?1 AND affirmation_weight = ?2 ORDER BY burn_header_height DESC";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(height)?, &u64_to_sql(affirmation_weight)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(height)?, u64_to_sql(affirmation_weight)?];
         query_rows(conn, qry, args).map_err(|e| e.into())
     }
 

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -36,11 +36,12 @@ use clarity::vm::types::TupleData;
 use clarity::vm::{SymbolicExpression, Value};
 use lazy_static::lazy_static;
 use rusqlite::types::ToSql;
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction, NO_PARAMS};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Row, Transaction};
 use serde::de::Error as de_Error;
 use serde::Deserialize;
 use stacks_common::codec::{read_next, write_next, StacksMessageCodec};
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId, TrieHash};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util;
 use stacks_common::util::hash::{hex_bytes, to_hex};
 
@@ -1022,10 +1023,10 @@ impl StacksChainState {
             }
             tx.execute(
                 "INSERT INTO db_config (version,mainnet,chain_id) VALUES (?1,?2,?3)",
-                &[
-                    &"1".to_string(),
-                    &(if mainnet { 1 } else { 0 }) as &dyn ToSql,
-                    &chain_id as &dyn ToSql,
+                params![
+                    "1".to_string(),
+                    (if mainnet { 1 } else { 0 }),
+                    chain_id,
                 ],
             )?;
 

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -2969,4 +2969,13 @@ pub mod test {
         };
         assert!(db.supports_epoch(StacksEpochId::latest()));
     }
+
+    #[test]
+    fn test_sqlite_version() {
+        let chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+        assert_eq!(
+            query_row(chainstate.db(), "SELECT sqlite_version()", NO_PARAMS).unwrap(),
+            Some("3.45.0".to_string())
+        );
+    }
 }

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -669,7 +669,7 @@ impl<'a> ChainstateTx<'a> {
                 let txid = tx_event.transaction.txid();
                 let tx_hex = tx_event.transaction.serialize_to_dbstring();
                 let result = tx_event.result.to_string();
-                let params: &[&dyn ToSql] = params![txid, block_id, tx_hex, result];
+                let params = params![txid, block_id, tx_hex, result];
                 if let Err(e) = self.tx.tx().execute(insert, params) {
                     warn!("Failed to log TX: {}", e);
                 }
@@ -2472,7 +2472,7 @@ impl StacksChainState {
         index_block_hash: &StacksBlockId,
     ) -> Result<Vec<Txid>, Error> {
         let sql = "SELECT txids FROM burnchain_txids WHERE index_block_hash = ?1";
-        let args: &[&dyn ToSql] = &[index_block_hash];
+        let args = params![index_block_hash];
 
         let txids = conn
             .query_row(sql, args, |r| {
@@ -2552,7 +2552,7 @@ impl StacksChainState {
         let txids_json =
             serde_json::to_string(&txids).expect("FATAL: could not serialize Vec<Txid>");
         let sql = "INSERT INTO burnchain_txids (index_block_hash, txids) VALUES (?1, ?2)";
-        let args: &[&dyn ToSql] = &[index_block_hash, &txids_json];
+        let args = params![index_block_hash, &txids_json];
         tx.execute(sql, args)?;
         Ok(())
     }
@@ -2682,7 +2682,7 @@ impl StacksChainState {
         if applied_epoch_transition {
             debug!("Block {} applied an epoch transition", &index_block_hash);
             let sql = "INSERT INTO epoch_transitions (block_id) VALUES (?)";
-            let args: &[&dyn ToSql] = &[&index_block_hash];
+            let args = params![&index_block_hash];
             headers_tx.deref_mut().execute(sql, args)?;
         }
 

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -669,7 +669,7 @@ impl<'a> ChainstateTx<'a> {
                 let txid = tx_event.transaction.txid();
                 let tx_hex = tx_event.transaction.serialize_to_dbstring();
                 let result = tx_event.result.to_string();
-                let params: &[&dyn ToSql] = &[&txid, block_id, &tx_hex, &result];
+                let params: &[&dyn ToSql] = params![txid, block_id, tx_hex, result];
                 if let Err(e) = self.tx.tx().execute(insert, params) {
                     warn!("Failed to log TX: {}", e);
                 }
@@ -1023,11 +1023,7 @@ impl StacksChainState {
             }
             tx.execute(
                 "INSERT INTO db_config (version,mainnet,chain_id) VALUES (?1,?2,?3)",
-                params![
-                    "1".to_string(),
-                    (if mainnet { 1 } else { 0 }),
-                    chain_id,
-                ],
+                params!["1".to_string(), (if mainnet { 1 } else { 0 }), chain_id,],
             )?;
 
             if migrate {

--- a/stackslib/src/chainstate/stacks/index/cache.rs
+++ b/stackslib/src/chainstate/stacks/index/cache.rs
@@ -27,11 +27,12 @@ use std::{cmp, env, error, fmt, fs, io, os};
 use rusqlite::types::{FromSql, ToSql};
 use rusqlite::{
     Connection, Error as SqliteError, ErrorCode as SqliteErrorCode, OpenFlags, OptionalExtension,
-    Transaction, NO_PARAMS,
+    Transaction,
 };
 use stacks_common::types::chainstate::{
     BlockHeaderHash, TrieHash, BLOCK_HEADER_HASH_ENCODED_SIZE, TRIEHASH_ENCODED_SIZE,
 };
+use stacks_common::types::sqlite::NO_PARAMS;
 
 use crate::chainstate::stacks::index::bits::{
     get_node_byte_len, get_node_hash, read_block_identifier, read_hash_bytes, read_node_hash_bytes,

--- a/stackslib/src/chainstate/stacks/index/file.rs
+++ b/stackslib/src/chainstate/stacks/index/file.rs
@@ -28,11 +28,12 @@ use std::{cmp, env, error, fmt, fs, io, os};
 use rusqlite::types::{FromSql, ToSql};
 use rusqlite::{
     Connection, Error as SqliteError, ErrorCode as SqliteErrorCode, OpenFlags, OptionalExtension,
-    Transaction, NO_PARAMS,
+    Transaction,
 };
 use stacks_common::types::chainstate::{
     BlockHeaderHash, TrieHash, BLOCK_HEADER_HASH_ENCODED_SIZE, TRIEHASH_ENCODED_SIZE,
 };
+use stacks_common::types::sqlite::NO_PARAMS;
 
 use crate::chainstate::stacks::index::bits::{
     get_node_byte_len, get_node_hash, read_block_identifier, read_hash_bytes, read_node_hash_bytes,

--- a/stackslib/src/chainstate/stacks/index/storage.rs
+++ b/stackslib/src/chainstate/stacks/index/storage.rs
@@ -27,12 +27,13 @@ use std::{cmp, env, error, fmt, fs, io, os};
 use rusqlite::types::{FromSql, ToSql};
 use rusqlite::{
     Connection, Error as SqliteError, ErrorCode as SqliteErrorCode, OpenFlags, OptionalExtension,
-    Transaction, NO_PARAMS,
+    Transaction,
 };
 use sha2::Digest;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, TrieHash, BLOCK_HEADER_HASH_ENCODED_SIZE, TRIEHASH_ENCODED_SIZE,
 };
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::log;
 

--- a/stackslib/src/chainstate/stacks/index/trie_sql.rs
+++ b/stackslib/src/chainstate/stacks/index/trie_sql.rs
@@ -239,7 +239,7 @@ pub fn write_trie_blob<T: MarfTrieId>(
     block_hash: &T,
     data: &[u8],
 ) -> Result<u32, Error> {
-    let args: &[&dyn ToSql] = params![block_hash, data, 0, 0, 0,];
+    let args = params![block_hash, data, 0, 0, 0,];
     let mut s =
         conn.prepare("INSERT INTO marf_data (block_hash, data, unconfirmed, external_offset, external_length) VALUES (?, ?, ?, ?, ?)")?;
     let block_id = s
@@ -266,7 +266,7 @@ fn inner_write_external_trie_blob<T: MarfTrieId>(
     let block_id = if let Some(block_id) = block_id {
         // existing entry (i.e. a migration)
         let empty_blob: &[u8] = &[];
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             block_hash,
             empty_blob,
             0,
@@ -286,7 +286,7 @@ fn inner_write_external_trie_blob<T: MarfTrieId>(
     } else {
         // new entry
         let empty_blob: &[u8] = &[];
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             block_hash,
             empty_blob,
             0,
@@ -342,13 +342,13 @@ pub fn write_trie_blob_to_mined<T: MarfTrieId>(
 ) -> Result<u32, Error> {
     if let Ok(block_id) = get_mined_block_identifier(conn, block_hash) {
         // already exists; update
-        let args: &[&dyn ToSql] = params![data, block_id];
+        let args = params![data, block_id];
         let mut s = conn.prepare("UPDATE mined_blocks SET data = ? WHERE block_id = ?")?;
         s.execute(args)
             .expect("EXHAUSTION: MARF cannot track more than 2**31 - 1 blocks");
     } else {
         // doesn't exist yet; insert
-        let args: &[&dyn ToSql] = params![block_hash, data];
+        let args = params![block_hash, data];
         let mut s = conn.prepare("INSERT INTO mined_blocks (block_hash, data) VALUES (?, ?)")?;
         s.execute(args)
             .expect("EXHAUSTION: MARF cannot track more than 2**31 - 1 blocks");
@@ -375,13 +375,13 @@ pub fn write_trie_blob_to_unconfirmed<T: MarfTrieId>(
 
     if let Ok(Some(block_id)) = get_unconfirmed_block_identifier(conn, block_hash) {
         // already exists; update
-        let args: &[&dyn ToSql] = params![data, block_id];
+        let args = params![data, block_id];
         let mut s = conn.prepare("UPDATE marf_data SET data = ? WHERE block_id = ?")?;
         s.execute(args)
             .expect("EXHAUSTION: MARF cannot track more than 2**31 - 1 blocks");
     } else {
         // doesn't exist yet; insert
-        let args: &[&dyn ToSql] = params![block_hash, data, 1];
+        let args = params![block_hash, data, 1];
         let mut s =
             conn.prepare("INSERT INTO marf_data (block_hash, data, unconfirmed, external_offset, external_length) VALUES (?, ?, ?, 0, 0)")?;
         s.execute(args)
@@ -515,7 +515,7 @@ pub fn get_external_trie_offset_length(
     block_id: u32,
 ) -> Result<(u64, u64), Error> {
     let qry = "SELECT external_offset, external_length FROM marf_data WHERE block_id = ?1";
-    let args: &[&dyn ToSql] = params![block_id];
+    let args = params![block_id];
     let (offset, length) = query_row(conn, qry, args)?.ok_or(Error::NotFoundError)?;
     Ok((offset, length))
 }
@@ -526,7 +526,7 @@ pub fn get_external_trie_offset_length_by_bhh<T: MarfTrieId>(
     bhh: &T,
 ) -> Result<(u64, u64), Error> {
     let qry = "SELECT external_offset, external_length FROM marf_data WHERE block_hash = ?1";
-    let args: &[&dyn ToSql] = params![bhh];
+    let args = params![bhh];
     let (offset, length) = query_row(conn, qry, args)?.ok_or(Error::NotFoundError)?;
     Ok((offset, length))
 }

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -27,8 +27,8 @@ use clarity::vm::types::{
     PrincipalData, QualifiedContractIdentifier, StandardPrincipalData, Value,
 };
 use clarity::vm::ClarityVersion;
-use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef};
-use rusqlite::{Error as RusqliteError, ToSql};
+use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
+use rusqlite::Error as RusqliteError;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha512_256};

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -32,6 +32,7 @@ use clarity::vm::test_util::TEST_BURN_STATE_DB;
 use clarity::vm::types::*;
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
+use rusqlite::params;
 use stacks_common::address::*;
 use stacks_common::types::chainstate::SortitionId;
 use stacks_common::util::hash::MerkleTree;
@@ -4799,7 +4800,7 @@ fn paramaterized_mempool_walk_test(
                 mempool_tx
                     .execute(
                         "UPDATE mempool SET fee_rate = ? WHERE txid = ?",
-                        rusqlite::params![Some(123.0), &txid],
+                        params![Some(123.0), &txid],
                     )
                     .unwrap();
             } else {
@@ -4807,7 +4808,7 @@ fn paramaterized_mempool_walk_test(
                 mempool_tx
                     .execute(
                         "UPDATE mempool SET fee_rate = ? WHERE txid = ?",
-                        rusqlite::params![none, &txid],
+                        params![none, &txid],
                     )
                     .unwrap();
             }

--- a/stackslib/src/clarity_cli.rs
+++ b/stackslib/src/clarity_cli.rs
@@ -24,7 +24,7 @@ use clarity::vm::coverage::CoverageReporter;
 use lazy_static::lazy_static;
 use rand::Rng;
 use rusqlite::types::ToSql;
-use rusqlite::{Connection, OpenFlags, Row, Transaction, NO_PARAMS};
+use rusqlite::{Connection, OpenFlags, Row, Transaction};
 use serde::Serialize;
 use serde_json::json;
 use stacks_common::address::c32::c32_address;
@@ -33,6 +33,7 @@ use stacks_common::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, StacksAddress, StacksBlockId, VRFSeed, *,
 };
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::{bytes_to_hex, Hash160, Sha512Trunc256Sum};
 use stacks_common::util::{get_epoch_time_ms, log};
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -1887,9 +1887,9 @@ mod tests {
     use clarity::vm::database::{ClarityBackingStore, STXBalance};
     use clarity::vm::test_util::{TEST_BURN_STATE_DB, TEST_HEADER_DB};
     use clarity::vm::types::{StandardPrincipalData, Value};
-    use rusqlite::NO_PARAMS;
     use stacks_common::consts::CHAIN_ID_TESTNET;
     use stacks_common::types::chainstate::ConsensusHash;
+    use stacks_common::types::sqlite::NO_PARAMS;
 
     use super::*;
     use crate::chainstate::stacks::index::ClarityMarfTrieId;

--- a/stackslib/src/clarity_vm/database/mod.rs
+++ b/stackslib/src/clarity_vm/database/mod.rs
@@ -12,7 +12,7 @@ use clarity::vm::database::{
 };
 use clarity::vm::errors::{InterpreterResult, RuntimeErrorType};
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, TupleData};
-use rusqlite::{Connection, OptionalExtension, Row, ToSql};
+use rusqlite::{params, Connection, OptionalExtension, Row, ToSql};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, StacksAddress, StacksBlockId,
     TenureBlockId, VRFSeed,
@@ -649,7 +649,7 @@ fn get_matured_reward(
     let parent_id_bhh = conn
         .query_row(
             &format!("SELECT parent_block_id FROM {table_name} WHERE index_block_hash = ?"),
-            [child_id_bhh.0].iter(),
+            params![child_id_bhh.0],
             |x| {
                 Ok(StacksBlockId::from_column(x, "parent_block_id")
                     .expect("Bad parent_block_id in database"))

--- a/stackslib/src/clarity_vm/database/mod.rs
+++ b/stackslib/src/clarity_vm/database/mod.rs
@@ -12,7 +12,8 @@ use clarity::vm::database::{
 };
 use clarity::vm::errors::{InterpreterResult, RuntimeErrorType};
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, TupleData};
-use rusqlite::{params, Connection, OptionalExtension, Row, ToSql};
+use rusqlite::types::ToSql;
+use rusqlite::{params, Connection, OptionalExtension, Row};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, StacksAddress, StacksBlockId,
     TenureBlockId, VRFSeed,
@@ -512,7 +513,7 @@ pub fn get_stacks_header_column_from_table<F, R>(
 where
     F: Fn(&Row) -> R,
 {
-    let args: &[&dyn ToSql] = &[id_bhh];
+    let args: &[&dyn ToSql] = params![id_bhh];
     let table_name = if nakamoto {
         "nakamoto_block_headers"
     } else {
@@ -589,7 +590,7 @@ fn get_first_block_in_tenure(
     };
     let ch = consensus_hash
         .expect("Unexpected SQL failure querying block header table for 'consensus_hash'");
-    let args: &[&dyn ToSql] = &[&ch];
+    let args: &[&dyn ToSql] = params![ch];
     conn.query_row(
         "
         SELECT index_block_hash
@@ -618,7 +619,7 @@ fn get_miner_column<F, R>(
 where
     F: FnOnce(&Row) -> R,
 {
-    let args: &[&dyn ToSql] = &[&id_bhh.0];
+    let args: &[&dyn ToSql] = params![id_bhh.0];
     conn.query_row(
         &format!(
             "SELECT {} FROM payments WHERE index_block_hash = ? AND miner = 1",

--- a/stackslib/src/clarity_vm/database/mod.rs
+++ b/stackslib/src/clarity_vm/database/mod.rs
@@ -513,7 +513,7 @@ pub fn get_stacks_header_column_from_table<F, R>(
 where
     F: Fn(&Row) -> R,
 {
-    let args: &[&dyn ToSql] = params![id_bhh];
+    let args = params![id_bhh];
     let table_name = if nakamoto {
         "nakamoto_block_headers"
     } else {
@@ -590,7 +590,7 @@ fn get_first_block_in_tenure(
     };
     let ch = consensus_hash
         .expect("Unexpected SQL failure querying block header table for 'consensus_hash'");
-    let args: &[&dyn ToSql] = params![ch];
+    let args = params![ch];
     conn.query_row(
         "
         SELECT index_block_hash
@@ -619,7 +619,7 @@ fn get_miner_column<F, R>(
 where
     F: FnOnce(&Row) -> R,
 {
-    let args: &[&dyn ToSql] = params![id_bhh.0];
+    let args = params![id_bhh.0];
     conn.query_row(
         &format!(
             "SELECT {} FROM payments WHERE index_block_hash = ? AND miner = 1",

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -1922,7 +1922,7 @@ impl MemPoolDB {
 
         debug!(
             "Mempool iteration finished";
-            "considered_txs" => total_considered as u128,
+            "considered_txs" => u128::from(total_considered),
             "elapsed_ms" => start_time.elapsed().as_millis()
         );
         Ok(total_considered)

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -29,7 +29,7 @@ use rand::distributions::Uniform;
 use rand::prelude::Distribution;
 use rusqlite::types::ToSql;
 use rusqlite::{
-    params, Connection, Error as SqliteError, OpenFlags, OptionalExtension, Row, Rows, Transaction
+    params, Connection, Error as SqliteError, OpenFlags, OptionalExtension, Row, Rows, Transaction,
 };
 use siphasher::sip::SipHasher; // this is SipHash-2-4
 use stacks_common::codec::{
@@ -859,7 +859,7 @@ impl<'a> MemPoolTx<'a> {
     /// Used to clear out txids that are now outside the bloom counter's depth.
     fn prune_bloom_counter(&mut self, target_height: u64) -> Result<(), MemPoolRejection> {
         let sql = "SELECT a.txid FROM mempool AS a LEFT OUTER JOIN removed_txids AS b ON a.txid = b.txid WHERE b.txid IS NULL AND a.height = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(target_height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(target_height)?];
         let txids: Vec<Txid> = query_rows(&self.tx, sql, args)?;
         let _num_txs = txids.len();
 
@@ -871,7 +871,7 @@ impl<'a> MemPoolTx<'a> {
                 bloom_counter.remove_raw(dbtx, &txid.0)?;
 
                 let sql = "INSERT OR REPLACE INTO removed_txids (txid) VALUES (?1)";
-                let args: &[&dyn ToSql] = &[&txid];
+                let args: &[&dyn ToSql] = params![txid];
                 dbtx.execute(sql, args).map_err(db_error::SqliteError)?;
             }
             // help the type inference out
@@ -902,7 +902,7 @@ impl<'a> MemPoolTx<'a> {
     ) -> Result<Option<Txid>, MemPoolRejection> {
         // is this the first-ever txid at this height?
         let sql = "SELECT 1 FROM mempool WHERE height = ?1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(height)?];
         let present: Option<i64> = query_row(&self.tx, sql, args)?;
         if present.is_none() && height > (BLOOM_COUNTER_DEPTH as u64) {
             // this is the first-ever tx at this height.
@@ -925,7 +925,7 @@ impl<'a> MemPoolTx<'a> {
                     // remove lowest-fee tx (they're paying the least, so replication is
                     // deprioritized)
                     let sql = "SELECT a.txid FROM mempool AS a LEFT OUTER JOIN removed_txids AS b ON a.txid = b.txid WHERE b.txid IS NULL AND a.height > ?1 ORDER BY a.tx_fee ASC LIMIT 1";
-                    let args: &[&dyn ToSql] = &[&u64_to_sql(
+                    let args: &[&dyn ToSql] = params![u64_to_sql(
                         height.saturating_sub(BLOOM_COUNTER_DEPTH as u64),
                     )?];
                     let evict_txid: Option<Txid> = query_row(&dbtx, sql, args)?;
@@ -933,7 +933,7 @@ impl<'a> MemPoolTx<'a> {
                         bloom_counter.remove_raw(dbtx, &evict_txid.0)?;
 
                         let sql = "INSERT OR REPLACE INTO removed_txids (txid) VALUES (?1)";
-                        let args: &[&dyn ToSql] = &[&evict_txid];
+                        let args: &[&dyn ToSql] = params![evict_txid];
                         dbtx.execute(sql, args).map_err(db_error::SqliteError)?;
 
                         Some(evict_txid)
@@ -963,7 +963,7 @@ impl<'a> MemPoolTx<'a> {
         let hashed_txid = Txid(Sha512Trunc256Sum::from_data(&randomized_buff).0);
 
         let sql = "INSERT OR REPLACE INTO randomized_txids (txid,hashed_txid) VALUES (?1,?2)";
-        let args: &[&dyn ToSql] = &[txid, &hashed_txid];
+        let args: &[&dyn ToSql] = params![txid, hashed_txid];
 
         self.execute(sql, args).map_err(db_error::SqliteError)?;
 
@@ -1504,12 +1504,12 @@ impl MemPoolDB {
     ) -> Result<Vec<StacksAddress>, db_error> {
         let sql = "SELECT DISTINCT origin_address FROM mempool WHERE height > ?1 AND height <= ?2 AND tx_fee >= ?3
                    ORDER BY tx_fee DESC LIMIT ?4 OFFSET ?5";
-        let args: &[&dyn ToSql] = &[
-            &start_height,
-            &end_height,
-            &u64_to_sql(min_fees)?,
-            &count,
-            &offset,
+        let args: &[&dyn ToSql] = params![
+            start_height,
+            end_height,
+            u64_to_sql(min_fees)?,
+            count,
+            offset,
         ];
         query_row_columns(self.conn(), sql, args, "origin_address")
     }
@@ -1942,20 +1942,12 @@ impl MemPoolDB {
     }
 
     pub fn db_has_tx(conn: &DBConn, txid: &Txid) -> Result<bool, db_error> {
-        query_row(
-            conn,
-            "SELECT 1 FROM mempool WHERE txid = ?1",
-            params![txid],
-        )
-        .and_then(|row_opt: Option<i64>| Ok(row_opt.is_some()))
+        query_row(conn, "SELECT 1 FROM mempool WHERE txid = ?1", params![txid])
+            .and_then(|row_opt: Option<i64>| Ok(row_opt.is_some()))
     }
 
     pub fn get_tx(conn: &DBConn, txid: &Txid) -> Result<Option<MemPoolTxInfo>, db_error> {
-        query_row(
-            conn,
-            "SELECT * FROM mempool WHERE txid = ?1",
-            params![txid],
-        )
+        query_row(conn, "SELECT * FROM mempool WHERE txid = ?1", params![txid])
     }
 
     /// Get all transactions across all tips
@@ -1974,7 +1966,7 @@ impl MemPoolDB {
         block_header_hash: &BlockHeaderHash,
     ) -> Result<usize, db_error> {
         let sql = "SELECT * FROM mempool WHERE consensus_hash = ?1 AND block_header_hash = ?2";
-        let args: &[&dyn ToSql] = &[consensus_hash, block_header_hash];
+        let args: &[&dyn ToSql] = params![consensus_hash, block_header_hash];
         let rows = query_rows::<MemPoolTxInfo, _>(conn, &sql, args)?;
         Ok(rows.len())
     }
@@ -1988,7 +1980,8 @@ impl MemPoolDB {
         timestamp: u64,
     ) -> Result<Vec<MemPoolTxInfo>, db_error> {
         let sql = "SELECT * FROM mempool WHERE accept_time = ?1 AND consensus_hash = ?2 AND block_header_hash = ?3 ORDER BY origin_nonce ASC";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(timestamp)?, consensus_hash, block_header_hash];
+        let args: &[&dyn ToSql] =
+            params![u64_to_sql(timestamp)?, consensus_hash, block_header_hash];
         let rows = query_rows::<MemPoolTxInfo, _>(conn, &sql, args)?;
         Ok(rows)
     }
@@ -1996,7 +1989,7 @@ impl MemPoolDB {
     /// Given a chain tip, find the highest block-height from _before_ this tip
     pub fn get_previous_block_height(conn: &DBConn, height: u64) -> Result<Option<u64>, db_error> {
         let sql = "SELECT height FROM mempool WHERE height < ?1 ORDER BY height DESC LIMIT 1";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(height)?];
         query_row(conn, sql, args)
     }
 
@@ -2009,11 +2002,11 @@ impl MemPoolDB {
         count: u64,
     ) -> Result<Vec<MemPoolTxInfo>, db_error> {
         let sql = "SELECT * FROM mempool WHERE accept_time >= ?1 AND consensus_hash = ?2 AND block_header_hash = ?3 ORDER BY tx_fee DESC LIMIT ?4";
-        let args: &[&dyn ToSql] = &[
-            &u64_to_sql(timestamp)?,
+        let args: &[&dyn ToSql] = params![
+            u64_to_sql(timestamp)?,
             consensus_hash,
             block_header_hash,
-            &u64_to_sql(count)?,
+            u64_to_sql(count)?,
         ];
         let rows = query_rows::<MemPoolTxInfo, _>(conn, &sql, args)?;
         Ok(rows)
@@ -2046,7 +2039,7 @@ impl MemPoolDB {
                           FROM mempool WHERE {0}_address = ?1 AND {0}_nonce = ?2",
             if is_origin { "origin" } else { "sponsor" }
         );
-        let args: &[&dyn ToSql] = &[&addr.to_string(), &u64_to_sql(nonce)?];
+        let args: &[&dyn ToSql] = params![addr.to_string(), u64_to_sql(nonce)?];
         query_row(conn, &sql, args)
     }
 
@@ -2181,19 +2174,19 @@ impl MemPoolDB {
             tx)
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
-        let args: &[&dyn ToSql] = &[
-            &txid,
-            &origin_address.to_string(),
-            &u64_to_sql(origin_nonce)?,
-            &sponsor_address.to_string(),
-            &u64_to_sql(sponsor_nonce)?,
-            &u64_to_sql(tx_fee)?,
-            &u64_to_sql(length)?,
+        let args: &[&dyn ToSql] = params![
+            txid,
+            origin_address.to_string(),
+            u64_to_sql(origin_nonce)?,
+            sponsor_address.to_string(),
+            u64_to_sql(sponsor_nonce)?,
+            u64_to_sql(tx_fee)?,
+            u64_to_sql(length)?,
             consensus_hash,
             block_header_hash,
-            &u64_to_sql(height)?,
-            &u64_to_sql(get_epoch_time_secs())?,
-            &tx_bytes,
+            u64_to_sql(height)?,
+            u64_to_sql(get_epoch_time_secs())?,
+            tx_bytes,
         ];
 
         tx.execute(sql, args)
@@ -2243,7 +2236,7 @@ impl MemPoolDB {
         event_observer: Option<&dyn MemPoolEventDispatcher>,
     ) -> Result<(), db_error> {
         let threshold_time = get_epoch_time_secs().saturating_sub(age.as_secs());
-        let args: &[&dyn ToSql] = &[&u64_to_sql(threshold_time)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(threshold_time)?];
         if let Some(event_observer) = event_observer {
             let sql = "SELECT txid FROM mempool WHERE accept_time < ?1";
             let txids = query_rows(tx, sql, args)?;
@@ -2264,7 +2257,7 @@ impl MemPoolDB {
         min_height: u64,
         event_observer: Option<&dyn MemPoolEventDispatcher>,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = &[&u64_to_sql(min_height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(min_height)?];
 
         if let Some(event_observer) = event_observer {
             let sql = "SELECT txid FROM mempool WHERE height < ?1";
@@ -2562,7 +2555,7 @@ impl MemPoolDB {
     ) -> Result<(), db_error> {
         for txid in txids {
             let sql = "INSERT OR REPLACE INTO tx_blacklist (txid, arrival_time) VALUES (?1, ?2)";
-            let args: &[&dyn ToSql] = &[&txid, &u64_to_sql(now)?];
+            let args: &[&dyn ToSql] = params![txid, &u64_to_sql(now)?];
             tx.execute(sql, args)?;
         }
         Ok(())
@@ -2577,7 +2570,7 @@ impl MemPoolDB {
         max_size: u64,
     ) -> Result<(), db_error> {
         let sql = "DELETE FROM tx_blacklist WHERE arrival_time + ?1 < ?2";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(timeout)?, &u64_to_sql(now)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(timeout)?, u64_to_sql(now)?];
         tx.execute(sql, args)?;
 
         // if we get too big, then drop some txs at random
@@ -2591,10 +2584,7 @@ impl MemPoolDB {
                 params![u64_to_sql(to_delete)?],
             )?;
             for txid in txids.into_iter() {
-                tx.execute(
-                    "DELETE FROM tx_blacklist WHERE txid = ?1",
-                    params![txid],
-                )?;
+                tx.execute("DELETE FROM tx_blacklist WHERE txid = ?1", params![txid])?;
             }
         }
         Ok(())
@@ -2606,7 +2596,7 @@ impl MemPoolDB {
         txid: &Txid,
     ) -> Result<Option<u64>, db_error> {
         let sql = "SELECT arrival_time FROM tx_blacklist WHERE txid = ?1";
-        let args: &[&dyn ToSql] = &[&txid];
+        let args: &[&dyn ToSql] = params![txid];
         query_row(conn, sql, args)
     }
 
@@ -2729,7 +2719,7 @@ impl MemPoolDB {
         };
         let min_height = max_height.saturating_sub(BLOOM_COUNTER_DEPTH as u64);
         let sql = "SELECT mempool.txid FROM mempool WHERE height > ?1 AND height <= ?2 AND NOT EXISTS (SELECT 1 FROM removed_txids WHERE txid = mempool.txid)";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(min_height)?, &u64_to_sql(max_height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(min_height)?, u64_to_sql(max_height)?];
         query_rows(&self.conn(), sql, args)
     }
 
@@ -2757,7 +2747,7 @@ impl MemPoolDB {
         };
         let min_height = max_height.saturating_sub(BLOOM_COUNTER_DEPTH as u64);
         let sql = "SELECT COUNT(txid) FROM mempool WHERE height > ?1 AND height <= ?2";
-        let args: &[&dyn ToSql] = &[&u64_to_sql(min_height)?, &u64_to_sql(max_height)?];
+        let args: &[&dyn ToSql] = params![u64_to_sql(min_height)?, u64_to_sql(max_height)?];
         query_int(conn, sql, args).map(|cnt| cnt as u64)
     }
 
@@ -2778,7 +2768,7 @@ impl MemPoolDB {
     /// Get the hashed txid for a txid
     pub fn get_randomized_txid(&self, txid: &Txid) -> Result<Option<Txid>, db_error> {
         let sql = "SELECT hashed_txid FROM randomized_txids WHERE txid = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = &[txid];
+        let args: &[&dyn ToSql] = params![txid];
         query_row(&self.conn(), sql, args)
     }
 
@@ -2825,10 +2815,10 @@ impl MemPoolDB {
                         (SELECT 1 FROM removed_txids WHERE txid = mempool.txid) \
                    ORDER BY randomized_txids.hashed_txid ASC LIMIT ?3";
 
-        let args: &[&dyn ToSql] = &[
-            &last_randomized_txid,
-            &u64_to_sql(height.saturating_sub(BLOOM_COUNTER_DEPTH as u64))?,
-            &u64_to_sql(max_run)?,
+        let args: &[&dyn ToSql] = params![
+            last_randomized_txid,
+            u64_to_sql(height.saturating_sub(BLOOM_COUNTER_DEPTH as u64))?,
+            u64_to_sql(max_run)?,
         ];
 
         let mut tags_table = HashSet::new();

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -1922,7 +1922,7 @@ impl MemPoolDB {
 
         debug!(
             "Mempool iteration finished";
-            "considered_txs" => total_considered,
+            "considered_txs" => total_considered as u128,
             "elapsed_ms" => start_time.elapsed().as_millis()
         );
         Ok(total_considered)

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -859,7 +859,7 @@ impl<'a> MemPoolTx<'a> {
     /// Used to clear out txids that are now outside the bloom counter's depth.
     fn prune_bloom_counter(&mut self, target_height: u64) -> Result<(), MemPoolRejection> {
         let sql = "SELECT a.txid FROM mempool AS a LEFT OUTER JOIN removed_txids AS b ON a.txid = b.txid WHERE b.txid IS NULL AND a.height = ?1";
-        let args: &[&dyn ToSql] = params![u64_to_sql(target_height)?];
+        let args = params![u64_to_sql(target_height)?];
         let txids: Vec<Txid> = query_rows(&self.tx, sql, args)?;
         let _num_txs = txids.len();
 
@@ -871,7 +871,7 @@ impl<'a> MemPoolTx<'a> {
                 bloom_counter.remove_raw(dbtx, &txid.0)?;
 
                 let sql = "INSERT OR REPLACE INTO removed_txids (txid) VALUES (?1)";
-                let args: &[&dyn ToSql] = params![txid];
+                let args = params![txid];
                 dbtx.execute(sql, args).map_err(db_error::SqliteError)?;
             }
             // help the type inference out
@@ -902,7 +902,7 @@ impl<'a> MemPoolTx<'a> {
     ) -> Result<Option<Txid>, MemPoolRejection> {
         // is this the first-ever txid at this height?
         let sql = "SELECT 1 FROM mempool WHERE height = ?1";
-        let args: &[&dyn ToSql] = params![u64_to_sql(height)?];
+        let args = params![u64_to_sql(height)?];
         let present: Option<i64> = query_row(&self.tx, sql, args)?;
         if present.is_none() && height > (BLOOM_COUNTER_DEPTH as u64) {
             // this is the first-ever tx at this height.
@@ -925,7 +925,7 @@ impl<'a> MemPoolTx<'a> {
                     // remove lowest-fee tx (they're paying the least, so replication is
                     // deprioritized)
                     let sql = "SELECT a.txid FROM mempool AS a LEFT OUTER JOIN removed_txids AS b ON a.txid = b.txid WHERE b.txid IS NULL AND a.height > ?1 ORDER BY a.tx_fee ASC LIMIT 1";
-                    let args: &[&dyn ToSql] = params![u64_to_sql(
+                    let args = params![u64_to_sql(
                         height.saturating_sub(BLOOM_COUNTER_DEPTH as u64),
                     )?];
                     let evict_txid: Option<Txid> = query_row(&dbtx, sql, args)?;
@@ -933,7 +933,7 @@ impl<'a> MemPoolTx<'a> {
                         bloom_counter.remove_raw(dbtx, &evict_txid.0)?;
 
                         let sql = "INSERT OR REPLACE INTO removed_txids (txid) VALUES (?1)";
-                        let args: &[&dyn ToSql] = params![evict_txid];
+                        let args = params![evict_txid];
                         dbtx.execute(sql, args).map_err(db_error::SqliteError)?;
 
                         Some(evict_txid)
@@ -963,7 +963,7 @@ impl<'a> MemPoolTx<'a> {
         let hashed_txid = Txid(Sha512Trunc256Sum::from_data(&randomized_buff).0);
 
         let sql = "INSERT OR REPLACE INTO randomized_txids (txid,hashed_txid) VALUES (?1,?2)";
-        let args: &[&dyn ToSql] = params![txid, hashed_txid];
+        let args = params![txid, hashed_txid];
 
         self.execute(sql, args).map_err(db_error::SqliteError)?;
 
@@ -1504,7 +1504,7 @@ impl MemPoolDB {
     ) -> Result<Vec<StacksAddress>, db_error> {
         let sql = "SELECT DISTINCT origin_address FROM mempool WHERE height > ?1 AND height <= ?2 AND tx_fee >= ?3
                    ORDER BY tx_fee DESC LIMIT ?4 OFFSET ?5";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             start_height,
             end_height,
             u64_to_sql(min_fees)?,
@@ -1966,7 +1966,7 @@ impl MemPoolDB {
         block_header_hash: &BlockHeaderHash,
     ) -> Result<usize, db_error> {
         let sql = "SELECT * FROM mempool WHERE consensus_hash = ?1 AND block_header_hash = ?2";
-        let args: &[&dyn ToSql] = params![consensus_hash, block_header_hash];
+        let args = params![consensus_hash, block_header_hash];
         let rows = query_rows::<MemPoolTxInfo, _>(conn, &sql, args)?;
         Ok(rows.len())
     }
@@ -1980,7 +1980,7 @@ impl MemPoolDB {
         timestamp: u64,
     ) -> Result<Vec<MemPoolTxInfo>, db_error> {
         let sql = "SELECT * FROM mempool WHERE accept_time = ?1 AND consensus_hash = ?2 AND block_header_hash = ?3 ORDER BY origin_nonce ASC";
-        let args: &[&dyn ToSql] =
+        let args =
             params![u64_to_sql(timestamp)?, consensus_hash, block_header_hash];
         let rows = query_rows::<MemPoolTxInfo, _>(conn, &sql, args)?;
         Ok(rows)
@@ -1989,7 +1989,7 @@ impl MemPoolDB {
     /// Given a chain tip, find the highest block-height from _before_ this tip
     pub fn get_previous_block_height(conn: &DBConn, height: u64) -> Result<Option<u64>, db_error> {
         let sql = "SELECT height FROM mempool WHERE height < ?1 ORDER BY height DESC LIMIT 1";
-        let args: &[&dyn ToSql] = params![u64_to_sql(height)?];
+        let args = params![u64_to_sql(height)?];
         query_row(conn, sql, args)
     }
 
@@ -2002,7 +2002,7 @@ impl MemPoolDB {
         count: u64,
     ) -> Result<Vec<MemPoolTxInfo>, db_error> {
         let sql = "SELECT * FROM mempool WHERE accept_time >= ?1 AND consensus_hash = ?2 AND block_header_hash = ?3 ORDER BY tx_fee DESC LIMIT ?4";
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             u64_to_sql(timestamp)?,
             consensus_hash,
             block_header_hash,
@@ -2039,7 +2039,7 @@ impl MemPoolDB {
                           FROM mempool WHERE {0}_address = ?1 AND {0}_nonce = ?2",
             if is_origin { "origin" } else { "sponsor" }
         );
-        let args: &[&dyn ToSql] = params![addr.to_string(), u64_to_sql(nonce)?];
+        let args = params![addr.to_string(), u64_to_sql(nonce)?];
         query_row(conn, &sql, args)
     }
 
@@ -2174,7 +2174,7 @@ impl MemPoolDB {
             tx)
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             txid,
             origin_address.to_string(),
             u64_to_sql(origin_nonce)?,
@@ -2236,7 +2236,7 @@ impl MemPoolDB {
         event_observer: Option<&dyn MemPoolEventDispatcher>,
     ) -> Result<(), db_error> {
         let threshold_time = get_epoch_time_secs().saturating_sub(age.as_secs());
-        let args: &[&dyn ToSql] = params![u64_to_sql(threshold_time)?];
+        let args = params![u64_to_sql(threshold_time)?];
         if let Some(event_observer) = event_observer {
             let sql = "SELECT txid FROM mempool WHERE accept_time < ?1";
             let txids = query_rows(tx, sql, args)?;
@@ -2257,7 +2257,7 @@ impl MemPoolDB {
         min_height: u64,
         event_observer: Option<&dyn MemPoolEventDispatcher>,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![u64_to_sql(min_height)?];
+        let args = params![u64_to_sql(min_height)?];
 
         if let Some(event_observer) = event_observer {
             let sql = "SELECT txid FROM mempool WHERE height < ?1";
@@ -2555,7 +2555,7 @@ impl MemPoolDB {
     ) -> Result<(), db_error> {
         for txid in txids {
             let sql = "INSERT OR REPLACE INTO tx_blacklist (txid, arrival_time) VALUES (?1, ?2)";
-            let args: &[&dyn ToSql] = params![txid, &u64_to_sql(now)?];
+            let args = params![txid, &u64_to_sql(now)?];
             tx.execute(sql, args)?;
         }
         Ok(())
@@ -2570,7 +2570,7 @@ impl MemPoolDB {
         max_size: u64,
     ) -> Result<(), db_error> {
         let sql = "DELETE FROM tx_blacklist WHERE arrival_time + ?1 < ?2";
-        let args: &[&dyn ToSql] = params![u64_to_sql(timeout)?, u64_to_sql(now)?];
+        let args = params![u64_to_sql(timeout)?, u64_to_sql(now)?];
         tx.execute(sql, args)?;
 
         // if we get too big, then drop some txs at random
@@ -2596,7 +2596,7 @@ impl MemPoolDB {
         txid: &Txid,
     ) -> Result<Option<u64>, db_error> {
         let sql = "SELECT arrival_time FROM tx_blacklist WHERE txid = ?1";
-        let args: &[&dyn ToSql] = params![txid];
+        let args = params![txid];
         query_row(conn, sql, args)
     }
 
@@ -2719,7 +2719,7 @@ impl MemPoolDB {
         };
         let min_height = max_height.saturating_sub(BLOOM_COUNTER_DEPTH as u64);
         let sql = "SELECT mempool.txid FROM mempool WHERE height > ?1 AND height <= ?2 AND NOT EXISTS (SELECT 1 FROM removed_txids WHERE txid = mempool.txid)";
-        let args: &[&dyn ToSql] = params![u64_to_sql(min_height)?, u64_to_sql(max_height)?];
+        let args = params![u64_to_sql(min_height)?, u64_to_sql(max_height)?];
         query_rows(&self.conn(), sql, args)
     }
 
@@ -2747,7 +2747,7 @@ impl MemPoolDB {
         };
         let min_height = max_height.saturating_sub(BLOOM_COUNTER_DEPTH as u64);
         let sql = "SELECT COUNT(txid) FROM mempool WHERE height > ?1 AND height <= ?2";
-        let args: &[&dyn ToSql] = params![u64_to_sql(min_height)?, u64_to_sql(max_height)?];
+        let args = params![u64_to_sql(min_height)?, u64_to_sql(max_height)?];
         query_int(conn, sql, args).map(|cnt| cnt as u64)
     }
 
@@ -2768,7 +2768,7 @@ impl MemPoolDB {
     /// Get the hashed txid for a txid
     pub fn get_randomized_txid(&self, txid: &Txid) -> Result<Option<Txid>, db_error> {
         let sql = "SELECT hashed_txid FROM randomized_txids WHERE txid = ?1 LIMIT 1";
-        let args: &[&dyn ToSql] = params![txid];
+        let args = params![txid];
         query_row(&self.conn(), sql, args)
     }
 
@@ -2815,7 +2815,7 @@ impl MemPoolDB {
                         (SELECT 1 FROM removed_txids WHERE txid = mempool.txid) \
                    ORDER BY randomized_txids.hashed_txid ASC LIMIT ?3";
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             last_randomized_txid,
             u64_to_sql(height.saturating_sub(BLOOM_COUNTER_DEPTH as u64))?,
             u64_to_sql(max_run)?,

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -1980,8 +1980,7 @@ impl MemPoolDB {
         timestamp: u64,
     ) -> Result<Vec<MemPoolTxInfo>, db_error> {
         let sql = "SELECT * FROM mempool WHERE accept_time = ?1 AND consensus_hash = ?2 AND block_header_hash = ?3 ORDER BY origin_nonce ASC";
-        let args =
-            params![u64_to_sql(timestamp)?, consensus_hash, block_header_hash];
+        let args = params![u64_to_sql(timestamp)?, consensus_hash, block_header_hash];
         let rows = query_rows::<MemPoolTxInfo, _>(conn, &sql, args)?;
         Ok(rows)
     }

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -26,6 +26,7 @@ use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StacksAddre
 use clarity::vm::{ClarityName, ContractName, Value};
 use rand::prelude::*;
 use rand::thread_rng;
+use rusqlite::params;
 use stacks_common::address::AddressHashMode;
 use stacks_common::codec::{read_next, Error as codec_error, StacksMessageCodec};
 use stacks_common::types::chainstate::{
@@ -645,7 +646,7 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
             mempool_tx
                 .execute(
                     "UPDATE mempool SET fee_rate = ? WHERE txid = ?",
-                    rusqlite::params![Some(123.0), &txid],
+                    params![Some(123.0), txid],
                 )
                 .unwrap();
         } else {
@@ -653,7 +654,7 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
             mempool_tx
                 .execute(
                     "UPDATE mempool SET fee_rate = ? WHERE txid = ?",
-                    rusqlite::params![none, &txid],
+                    params![none, txid],
                 )
                 .unwrap();
         }
@@ -1198,7 +1199,7 @@ fn test_iterate_candidates_concurrent_write_lock() {
             mempool_tx
                 .execute(
                     "UPDATE mempool SET fee_rate = ? WHERE txid = ?",
-                    rusqlite::params![Some(123.0), &txid],
+                    params![Some(123.0), txid],
                 )
                 .unwrap();
         } else {
@@ -1206,7 +1207,7 @@ fn test_iterate_candidates_concurrent_write_lock() {
             mempool_tx
                 .execute(
                     "UPDATE mempool SET fee_rate = ? WHERE txid = ?",
-                    rusqlite::params![none, &txid],
+                    params![none, txid],
                 )
                 .unwrap();
         }

--- a/stackslib/src/cost_estimates/fee_medians.rs
+++ b/stackslib/src/cost_estimates/fee_medians.rs
@@ -4,9 +4,10 @@ use std::path::Path;
 
 use clarity::types::sqlite::NO_PARAMS;
 use clarity::vm::costs::ExecutionCost;
-use rusqlite::types::{FromSql, FromSqlError};
+use rusqlite::types::{FromSql, FromSqlError, ToSql};
 use rusqlite::{
-    params, AndThenRows, Connection, Error as SqliteError, OptionalExtension, ToSql, Transaction as SqlTransaction
+    params, AndThenRows, Connection, Error as SqliteError, OpenFlags, OptionalExtension,
+    Transaction as SqlTransaction,
 };
 use serde_json::Value as JsonValue;
 
@@ -62,7 +63,7 @@ impl<M: CostMetric> WeightedMedianFeeRateEstimator<M> {
     pub fn open(p: &Path, metric: M, window_size: u32) -> Result<Self, SqliteError> {
         let mut db = sqlite_open(
             p,
-            rusqlite::OpenFlags::SQLITE_OPEN_CREATE | rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+            OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_READ_WRITE,
             false,
         )?;
 

--- a/stackslib/src/cost_estimates/fee_scalar.rs
+++ b/stackslib/src/cost_estimates/fee_scalar.rs
@@ -4,9 +4,10 @@ use std::path::Path;
 use clarity::types::sqlite::NO_PARAMS;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::database::{ClaritySerializable, STXBalance};
-use rusqlite::types::{FromSql, FromSqlError};
+use rusqlite::types::{FromSql, FromSqlError, ToSql};
 use rusqlite::{
-    params, Connection, Error as SqliteError, OptionalExtension, ToSql, Transaction as SqlTransaction
+    params, Connection, Error as SqliteError, OpenFlags, OptionalExtension,
+    Transaction as SqlTransaction,
 };
 use serde_json::Value as JsonValue;
 
@@ -47,7 +48,7 @@ impl<M: CostMetric> ScalarFeeRateEstimator<M> {
     pub fn open(p: &Path, metric: M) -> Result<Self, SqliteError> {
         let mut db = sqlite_open(
             p,
-            rusqlite::OpenFlags::SQLITE_OPEN_CREATE | rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+            OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_READ_WRITE,
             false,
         )?;
 

--- a/stackslib/src/cost_estimates/fee_scalar.rs
+++ b/stackslib/src/cost_estimates/fee_scalar.rs
@@ -1,11 +1,12 @@
 use std::cmp;
 use std::path::Path;
 
+use clarity::types::sqlite::NO_PARAMS;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::database::{ClaritySerializable, STXBalance};
 use rusqlite::types::{FromSql, FromSqlError};
 use rusqlite::{
-    Connection, Error as SqliteError, OptionalExtension, ToSql, Transaction as SqlTransaction,
+    params, Connection, Error as SqliteError, OptionalExtension, ToSql, Transaction as SqlTransaction
 };
 use serde_json::Value as JsonValue;
 
@@ -72,7 +73,7 @@ impl<M: CostMetric> ScalarFeeRateEstimator<M> {
 
     fn instantiate_db(tx: &SqlTransaction) -> Result<(), SqliteError> {
         if !Self::db_already_instantiated(tx)? {
-            tx.execute(CREATE_TABLE, rusqlite::NO_PARAMS)?;
+            tx.execute(CREATE_TABLE, NO_PARAMS)?;
         }
 
         Ok(())
@@ -130,7 +131,7 @@ impl<M: CostMetric> ScalarFeeRateEstimator<M> {
 
         tx.execute(
             sql,
-            rusqlite::params![
+            params![
                 SINGLETON_ROW_ID,
                 next_estimate.high,
                 next_estimate.middle,
@@ -238,7 +239,7 @@ impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
     fn get_rate_estimates(&self) -> Result<FeeRateEstimate, EstimatorError> {
         let sql = "SELECT high, middle, low FROM scalar_fee_estimator WHERE estimate_key = ?";
         self.db
-            .query_row(sql, &[SINGLETON_ROW_ID], |row| {
+            .query_row(sql, params![SINGLETON_ROW_ID], |row| {
                 let high: f64 = row.get(0)?;
                 let middle: f64 = row.get(1)?;
                 let low: f64 = row.get(2)?;

--- a/stackslib/src/cost_estimates/pessimistic.rs
+++ b/stackslib/src/cost_estimates/pessimistic.rs
@@ -1,10 +1,11 @@
 use std::cmp;
 use std::path::Path;
 
+use clarity::types::sqlite::NO_PARAMS;
 use clarity::vm::costs::ExecutionCost;
 use rusqlite::types::{FromSql, FromSqlError};
 use rusqlite::{
-    Connection, Error as SqliteError, OptionalExtension, ToSql, Transaction as SqliteTransaction,
+    params, Connection, Error as SqliteError, OptionalExtension, ToSql, Transaction as SqliteTransaction
 };
 use serde_json::Value as JsonValue;
 
@@ -146,7 +147,7 @@ impl Samples {
         let current_value = u64_to_sql(self.mean()).unwrap_or_else(|_| i64::MAX);
         tx.execute(
             sql,
-            rusqlite::params![identifier, current_value, self.to_json()],
+            params![identifier, current_value, self.to_json()],
         )
         .expect("SQLite failure");
     }
@@ -205,7 +206,7 @@ impl PessimisticEstimator {
 
     fn instantiate_db(tx: &SqliteTransaction) -> Result<(), SqliteError> {
         if !Self::db_already_instantiated(tx)? {
-            tx.execute(CREATE_TABLE, rusqlite::NO_PARAMS)?;
+            tx.execute(CREATE_TABLE, NO_PARAMS)?;
         }
 
         Ok(())

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -769,7 +769,7 @@ simulating a miner.
         if let Some(value) = value_opt {
             let conn = sqlite_open(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)
                 .expect("Failed to open DB");
-            let args: &[&dyn ToSql] = &[&value.to_hex()];
+            let args: &[&dyn ToSql] = params![&value.to_hex()];
             let res: Result<String, SqliteError> = conn.query_row_and_then(
                 "SELECT value FROM __fork_storage WHERE value_hash = ?1",
                 args,

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -80,13 +80,14 @@ use blockstack_lib::util_lib::strings::UrlString;
 use blockstack_lib::{clarity_cli, util_lib};
 use libstackerdb::StackerDBChunkData;
 use rusqlite::types::ToSql;
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{params, Connection, Error as SqliteError, OpenFlags};
 use serde_json::{json, Value};
 use stacks_common::codec::{read_next, StacksMessageCodec};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, PoxId, StacksAddress, StacksBlockId,
 };
 use stacks_common::types::net::PeerAddress;
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::{hex_bytes, to_hex, Hash160};
 use stacks_common::util::retry::LogReader;
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
@@ -769,7 +770,7 @@ simulating a miner.
             let conn = sqlite_open(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)
                 .expect("Failed to open DB");
             let args: &[&dyn ToSql] = &[&value.to_hex()];
-            let res: Result<String, rusqlite::Error> = conn.query_row_and_then(
+            let res: Result<String, SqliteError> = conn.query_row_and_then(
                 "SELECT value FROM __fork_storage WHERE value_hash = ?1",
                 args,
                 |row| {
@@ -829,18 +830,18 @@ simulating a miner.
         let tip = BlockHeaderHash::from_hex(&argv[3]).unwrap();
         let burntip = BurnchainHeaderHash::from_hex(&argv[4]).unwrap();
 
-        let conn = rusqlite::Connection::open(path).unwrap();
+        let conn = Connection::open(path).unwrap();
         let mut cur_burn = burntip.clone();
         let mut cur_tip = tip.clone();
         loop {
             println!("{}, {}", cur_burn, cur_tip);
             let (next_burn, next_tip) = match
                 conn.query_row("SELECT parent_burn_header_hash, parent_anchored_block_hash FROM staging_blocks WHERE anchored_block_hash = ? and burn_header_hash = ?",
-                               &[&cur_tip as &dyn rusqlite::types::ToSql, &cur_burn], |row| Ok((row.get_unwrap(0), row.get_unwrap(1)))) {
+                               params![cur_tip, cur_burn], |row| Ok((row.get_unwrap(0), row.get_unwrap(1)))) {
                     Ok(x) => x,
                     Err(e) => {
                         match e {
-                            rusqlite::Error::QueryReturnedNoRows => {},
+                            SqliteError::QueryReturnedNoRows => {},
                             e => {
                                 eprintln!("SQL Error: {}", e);
                             },
@@ -933,7 +934,7 @@ simulating a miner.
         };
 
         let mut stmt = conn.prepare(&query).unwrap();
-        let mut hashes_set = stmt.query(rusqlite::NO_PARAMS).unwrap();
+        let mut hashes_set = stmt.query(NO_PARAMS).unwrap();
 
         let mut index_block_hashes: Vec<String> = vec![];
         while let Ok(Some(row)) = hashes_set.next() {
@@ -965,7 +966,7 @@ simulating a miner.
             byte_prefix
         );
         let mut stmt = conn.prepare(&query).unwrap();
-        let mut rows = stmt.query(rusqlite::NO_PARAMS).unwrap();
+        let mut rows = stmt.query(NO_PARAMS).unwrap();
         while let Ok(Some(row)) = rows.next() {
             let val_string: String = row.get(0).unwrap();
             let clarity_value = match clarity::vm::Value::try_deserialize_hex_untyped(&val_string) {

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -769,7 +769,7 @@ simulating a miner.
         if let Some(value) = value_opt {
             let conn = sqlite_open(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)
                 .expect("Failed to open DB");
-            let args: &[&dyn ToSql] = params![&value.to_hex()];
+            let args = params![&value.to_hex()];
             let res: Result<String, SqliteError> = conn.query_row_and_then(
                 "SELECT value FROM __fork_storage WHERE value_hash = ?1",
                 args,

--- a/stackslib/src/monitoring/mod.rs
+++ b/stackslib/src/monitoring/mod.rs
@@ -23,6 +23,7 @@ use std::{fmt, fs};
 use clarity::vm::costs::ExecutionCost;
 use lazy_static::lazy_static;
 use rusqlite::{OpenFlags, OptionalExtension};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::uint::{Uint256, Uint512};
 
@@ -210,7 +211,7 @@ fn txid_tracking_db(chainstate_root_path: &str) -> Result<DBConn, DatabaseError>
     if create_flag {
         conn.execute(
             "CREATE TABLE processed_txids (txid TEXT NOT NULL PRIMARY KEY)",
-            rusqlite::NO_PARAMS,
+            NO_PARAMS,
         )?;
     }
 

--- a/stackslib/src/net/atlas/db.rs
+++ b/stackslib/src/net/atlas/db.rs
@@ -461,7 +461,7 @@ impl AtlasDB {
         let min = page_index * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let max = (page_index + 1) * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let qry = "SELECT MIN(block_height) as min, MAX(block_height) as max FROM attachment_instances WHERE attachment_index >= ?1 AND attachment_index < ?2";
-        let args: &[&dyn ToSql] = params![min, max];
+        let args = params![min, max];
         let mut stmt = self.conn.prepare(&qry)?;
         let mut rows = stmt.query(args)?;
 
@@ -497,7 +497,7 @@ impl AtlasDB {
         let min = page_index * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let max = min + AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let qry = "SELECT attachment_index, is_available FROM attachment_instances WHERE attachment_index >= ?1 AND attachment_index < ?2 AND index_block_hash = ?3 ORDER BY attachment_index ASC";
-        let args: &[&dyn ToSql] = params![min, max, block_id,];
+        let args = params![min, max, block_id,];
         let rows = query_rows::<(u32, u32), _>(&self.conn, &qry, args)?;
 
         let mut bool_vector = vec![true; AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE as usize];
@@ -598,7 +598,7 @@ impl AtlasDB {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 0"
             .to_string();
-        let args: &[&dyn ToSql] = params![hex_content_hash];
+        let args = params![hex_content_hash];
         let row = query_row::<Attachment, _>(&self.conn, &qry, args)?;
         Ok(row)
     }
@@ -633,7 +633,7 @@ impl AtlasDB {
     ) -> Result<Vec<AttachmentInstance>, db_error> {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT * FROM attachment_instances WHERE content_hash = ?1 AND status = ?2";
-        let args: &[&dyn ToSql] = params![hex_content_hash, AttachmentInstanceStatus::Checked];
+        let args = params![hex_content_hash, AttachmentInstanceStatus::Checked];
         let rows = query_rows(&self.conn, qry, args)?;
         Ok(rows)
     }
@@ -642,7 +642,7 @@ impl AtlasDB {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 1"
             .to_string();
-        let args: &[&dyn ToSql] = params![hex_content_hash];
+        let args = params![hex_content_hash];
         let row = query_row::<Attachment, _>(&self.conn, &qry, args)?;
         Ok(row)
     }

--- a/stackslib/src/net/atlas/db.rs
+++ b/stackslib/src/net/atlas/db.rs
@@ -461,7 +461,7 @@ impl AtlasDB {
         let min = page_index * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let max = (page_index + 1) * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let qry = "SELECT MIN(block_height) as min, MAX(block_height) as max FROM attachment_instances WHERE attachment_index >= ?1 AND attachment_index < ?2";
-        let args = params![min, max];
+        let args: &[&dyn ToSql] = params![min, max];
         let mut stmt = self.conn.prepare(&qry)?;
         let mut rows = stmt.query(args)?;
 
@@ -497,11 +497,7 @@ impl AtlasDB {
         let min = page_index * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let max = min + AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let qry = "SELECT attachment_index, is_available FROM attachment_instances WHERE attachment_index >= ?1 AND attachment_index < ?2 AND index_block_hash = ?3 ORDER BY attachment_index ASC";
-        let args = params![
-            min,
-            max,
-            block_id,
-        ];
+        let args: &[&dyn ToSql] = params![min, max, block_id,];
         let rows = query_rows::<(u32, u32), _>(&self.conn, &qry, args)?;
 
         let mut bool_vector = vec![true; AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE as usize];
@@ -602,8 +598,8 @@ impl AtlasDB {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 0"
             .to_string();
-        let args = params![hex_content_hash];
-        let row = query_row::<Attachment, _>(&self.conn, &qry, &args)?;
+        let args: &[&dyn ToSql] = params![hex_content_hash];
+        let row = query_row::<Attachment, _>(&self.conn, &qry, args)?;
         Ok(row)
     }
 
@@ -637,7 +633,7 @@ impl AtlasDB {
     ) -> Result<Vec<AttachmentInstance>, db_error> {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT * FROM attachment_instances WHERE content_hash = ?1 AND status = ?2";
-        let args = params![hex_content_hash, AttachmentInstanceStatus::Checked];
+        let args: &[&dyn ToSql] = params![hex_content_hash, AttachmentInstanceStatus::Checked];
         let rows = query_rows(&self.conn, qry, args)?;
         Ok(rows)
     }
@@ -646,8 +642,8 @@ impl AtlasDB {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 1"
             .to_string();
-        let args = params![hex_content_hash];
-        let row = query_row::<Attachment, _>(&self.conn, &qry, &args)?;
+        let args: &[&dyn ToSql] = params![hex_content_hash];
+        let row = query_row::<Attachment, _>(&self.conn, &qry, args)?;
         Ok(row)
     }
 

--- a/stackslib/src/net/atlas/db.rs
+++ b/stackslib/src/net/atlas/db.rs
@@ -38,9 +38,10 @@ use std::fs;
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput, ValueRef};
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction, NO_PARAMS};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Row, Transaction};
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::StacksBlockId;
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util;
 use stacks_common::util::hash::{bin_bytes, hex_bytes, to_bin, to_hex, Hash160};
 use stacks_common::util::log;
@@ -206,11 +207,9 @@ impl AtlasDB {
 
     /// Get the database schema version, given a DB connection
     fn get_schema_version(conn: &Connection) -> Result<String, db_error> {
-        let version = conn.query_row(
-            "SELECT MAX(version) from db_config",
-            rusqlite::NO_PARAMS,
-            |row| row.get(0),
-        )?;
+        let version = conn.query_row("SELECT MAX(version) from db_config", NO_PARAMS, |row| {
+            row.get(0)
+        })?;
         Ok(version)
     }
 
@@ -228,7 +227,7 @@ impl AtlasDB {
 
         tx.execute(
             "INSERT INTO db_config (version) VALUES (?1)",
-            &[&ATLASDB_VERSION],
+            params![ATLASDB_VERSION],
         )?;
 
         if let Some(attachments) = genesis_attachments {
@@ -236,10 +235,10 @@ impl AtlasDB {
             for attachment in attachments {
                 tx.execute(
                     "INSERT INTO attachments (hash, content, was_instantiated, created_at) VALUES (?, ?, 1, ?)",
-                    &[
-                        &attachment.hash() as &dyn ToSql,
-                        &attachment.content as &dyn ToSql,
-                        &now as &dyn ToSql,
+                    params![
+                        attachment.hash(),
+                        attachment.content,
+                        now,
                     ],
                 )
                 .map_err(db_error::SqliteError)?;
@@ -348,7 +347,7 @@ impl AtlasDB {
 
         db_conn.execute(
             "INSERT OR REPLACE INTO db_config (version) VALUES (?1)",
-            &["2"],
+            params!["2"],
         )?;
 
         Ok(())
@@ -406,17 +405,17 @@ impl AtlasDB {
             tx.execute_batch(row_text)?;
         }
 
-        tx.execute("INSERT INTO db_config (version) VALUES (?1)", &["1"])?;
+        tx.execute("INSERT INTO db_config (version) VALUES (?1)", params!["1"])?;
 
         if let Some(attachments) = genesis_attachments {
             let now = util::get_epoch_time_secs() as i64;
             for attachment in attachments {
                 tx.execute(
                     "INSERT INTO attachments (hash, content, was_instantiated, created_at) VALUES (?, ?, 1, ?)",
-                    rusqlite::params![
-                        &attachment.hash(),
-                        &attachment.content,
-                        &now,
+                    params![
+                        attachment.hash(),
+                        attachment.content,
+                        now,
                     ],
                 )?;
             }
@@ -462,9 +461,9 @@ impl AtlasDB {
         let min = page_index * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let max = (page_index + 1) * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let qry = "SELECT MIN(block_height) as min, MAX(block_height) as max FROM attachment_instances WHERE attachment_index >= ?1 AND attachment_index < ?2";
-        let args = [&min as &dyn ToSql, &max as &dyn ToSql];
+        let args = params![min, max];
         let mut stmt = self.conn.prepare(&qry)?;
-        let mut rows = stmt.query(&args)?;
+        let mut rows = stmt.query(args)?;
 
         match rows.next() {
             Ok(Some(row)) => {
@@ -498,12 +497,12 @@ impl AtlasDB {
         let min = page_index * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let max = min + AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
         let qry = "SELECT attachment_index, is_available FROM attachment_instances WHERE attachment_index >= ?1 AND attachment_index < ?2 AND index_block_hash = ?3 ORDER BY attachment_index ASC";
-        let args = [
-            &min as &dyn ToSql,
-            &max as &dyn ToSql,
-            block_id as &dyn ToSql,
+        let args = params![
+            min,
+            max,
+            block_id,
         ];
-        let rows = query_rows::<(u32, u32), _>(&self.conn, &qry, &args)?;
+        let rows = query_rows::<(u32, u32), _>(&self.conn, &qry, args)?;
 
         let mut bool_vector = vec![true; AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE as usize];
         for (attachment_index, is_available) in rows.into_iter() {
@@ -529,10 +528,10 @@ impl AtlasDB {
         let now = util::get_epoch_time_secs() as i64;
         let res = tx.execute(
             "INSERT OR REPLACE INTO attachments (hash, content, was_instantiated, created_at) VALUES (?, ?, 0, ?)",
-            &[
-                &attachment.hash() as &dyn ToSql,
-                &attachment.content as &dyn ToSql,
-                &now as &dyn ToSql,
+            params![
+                attachment.hash(),
+                attachment.content,
+                now,
             ],
         );
         res.map_err(db_error::SqliteError)?;
@@ -544,7 +543,7 @@ impl AtlasDB {
         let tx = self.tx_begin()?;
         let res = tx.execute(
             "DELETE FROM attachments WHERE hash IN (SELECT hash FROM attachments WHERE was_instantiated = 0 ORDER BY created_at ASC LIMIT ?)",
-            &[&k as &dyn ToSql],
+            params![k],
         );
         res.map_err(db_error::SqliteError)?;
         tx.commit().map_err(db_error::SqliteError)?;
@@ -557,7 +556,7 @@ impl AtlasDB {
         let tx = self.tx_begin()?;
         let res = tx.execute(
             "DELETE FROM attachments WHERE was_instantiated = 0 AND created_at < ?",
-            &[&cut_off as &dyn ToSql],
+            params![cut_off],
         );
         res.map_err(db_error::SqliteError)?;
         tx.commit().map_err(db_error::SqliteError)?;
@@ -586,11 +585,11 @@ impl AtlasDB {
         let tx = self.tx_begin()?;
         tx.execute(
             "INSERT OR REPLACE INTO attachments (hash, content, was_instantiated, created_at) VALUES (?, ?, 1, ?)",
-            rusqlite::params![&attachment.hash(), &attachment.content, &now],
+            params![attachment.hash(), attachment.content, now],
         )?;
         tx.execute(
             "UPDATE attachment_instances SET is_available = 1 WHERE content_hash = ?1 AND status = ?2",
-            rusqlite::params![&attachment.hash(), &AttachmentInstanceStatus::Checked],
+            params![attachment.hash(), AttachmentInstanceStatus::Checked],
         )?;
         tx.commit()?;
         Ok(())
@@ -603,7 +602,7 @@ impl AtlasDB {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 0"
             .to_string();
-        let args = [&hex_content_hash as &dyn ToSql];
+        let args = params![hex_content_hash];
         let row = query_row::<Attachment, _>(&self.conn, &qry, &args)?;
         Ok(row)
     }
@@ -617,7 +616,7 @@ impl AtlasDB {
         let tx = self.tx_begin()?;
         let res = tx.execute(
             "DELETE FROM attachment_instances WHERE is_available = 0 AND created_at < ?",
-            &[&cut_off as &dyn ToSql],
+            params![cut_off],
         );
         res.map_err(db_error::SqliteError)?;
         tx.commit().map_err(db_error::SqliteError)?;
@@ -628,7 +627,7 @@ impl AtlasDB {
         &mut self,
     ) -> Result<Vec<AttachmentInstance>, db_error> {
         let qry = "SELECT * FROM attachment_instances WHERE is_available = 0 AND status = ?";
-        let rows = query_rows(&self.conn, qry, &[&AttachmentInstanceStatus::Checked])?;
+        let rows = query_rows(&self.conn, qry, params![AttachmentInstanceStatus::Checked])?;
         Ok(rows)
     }
 
@@ -638,7 +637,7 @@ impl AtlasDB {
     ) -> Result<Vec<AttachmentInstance>, db_error> {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT * FROM attachment_instances WHERE content_hash = ?1 AND status = ?2";
-        let args = rusqlite::params![&hex_content_hash, &AttachmentInstanceStatus::Checked];
+        let args = params![hex_content_hash, AttachmentInstanceStatus::Checked];
         let rows = query_rows(&self.conn, qry, args)?;
         Ok(rows)
     }
@@ -647,7 +646,7 @@ impl AtlasDB {
         let hex_content_hash = to_hex(&content_hash.0[..]);
         let qry = "SELECT content, hash FROM attachments WHERE hash = ?1 AND was_instantiated = 1"
             .to_string();
-        let args = [&hex_content_hash as &dyn ToSql];
+        let args = params![hex_content_hash];
         let row = query_row::<Attachment, _>(&self.conn, &qry, &args)?;
         Ok(row)
     }
@@ -681,7 +680,7 @@ impl AtlasDB {
         query_rows(
             &self.conn,
             "SELECT * FROM attachment_instances WHERE status = ?1 LIMIT ?2",
-            rusqlite::params![&AttachmentInstanceStatus::Queued, MAX_PROCESS_PER_ROUND],
+            params![AttachmentInstanceStatus::Queued, MAX_PROCESS_PER_ROUND],
         )
     }
 
@@ -694,12 +693,12 @@ impl AtlasDB {
         self.conn.execute(
             "UPDATE attachment_instances SET status = ?1, is_available = ?2
               WHERE index_block_hash = ?3 AND contract_id = ?4 AND attachment_index = ?5",
-            rusqlite::params![
-                &AttachmentInstanceStatus::Checked,
-                &is_available,
-                &attachment.index_block_hash,
-                &attachment.contract_id.to_string(),
-                &attachment.attachment_index,
+            params![
+                AttachmentInstanceStatus::Checked,
+                is_available,
+                attachment.index_block_hash,
+                attachment.contract_id.to_string(),
+                attachment.attachment_index,
             ],
         )?;
         Ok(())
@@ -720,17 +719,17 @@ impl AtlasDB {
                attachment_index, block_height, is_available,
                 metadata, contract_id, tx_id, status)
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            rusqlite::params![
-                &attachment.content_hash,
-                &now,
-                &attachment.index_block_hash,
-                &attachment.attachment_index,
-                &u64_to_sql(attachment.stacks_block_height)?,
-                &is_available,
-                &attachment.metadata,
-                &attachment.contract_id.to_string(),
-                &attachment.tx_id,
-                &status
+            params![
+                attachment.content_hash,
+                now,
+                attachment.index_block_hash,
+                attachment.attachment_index,
+                u64_to_sql(attachment.stacks_block_height)?,
+                is_available,
+                attachment.metadata,
+                attachment.contract_id.to_string(),
+                attachment.tx_id,
+                status
             ],
         )?;
         sql_tx.commit()?;

--- a/stackslib/src/net/atlas/tests.rs
+++ b/stackslib/src/net/atlas/tests.rs
@@ -18,6 +18,7 @@ use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::{thread, time};
 
 use clarity::vm::types::QualifiedContractIdentifier;
+use rusqlite::params;
 use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
 use stacks_common::types::net::{PeerAddress, PeerHost};
 use stacks_common::util::hash::Hash160;
@@ -832,16 +833,16 @@ fn schema_2_migration() {
                attachment_index, block_height, is_available,
                 metadata, contract_id, tx_id)
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            rusqlite::params![
-                &attachment.content_hash,
-                &0,
-                &attachment.index_block_hash,
-                &attachment.attachment_index,
-                &u64_to_sql(attachment.stacks_block_height).unwrap(),
-                &true,
-                &attachment.metadata,
-                &attachment.contract_id.to_string(),
-                &attachment.tx_id,
+            params![
+                attachment.content_hash,
+                0,
+                attachment.index_block_hash,
+                attachment.attachment_index,
+                u64_to_sql(attachment.stacks_block_height).unwrap(),
+                true,
+                attachment.metadata,
+                attachment.contract_id.to_string(),
+                attachment.tx_id,
             ],
         )
         .unwrap();

--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -446,7 +446,7 @@ impl PeerDB {
 
         PeerDB::apply_schema_migrations(&tx)?;
 
-        let local_peer_args: &[&dyn ToSql] = params![
+        let local_peer_args = params![
             network_id,
             parent_network_id,
             to_hex(&localpeer.nonce),
@@ -556,7 +556,7 @@ impl PeerDB {
         p2p_port: u16,
         stacker_dbs: &[QualifiedContractIdentifier],
     ) -> Result<(), db_error> {
-        let local_peer_args: &[&dyn ToSql] = params![
+        let local_peer_args = params![
             p2p_port,
             data_url.as_str(),
             serde_json::to_string(stacker_dbs)
@@ -839,7 +839,7 @@ impl PeerDB {
         privkey: &Secp256k1PrivateKey,
         expire_block: u64,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![to_hex(&privkey.to_bytes()), u64_to_sql(expire_block)?];
+        let args = params![to_hex(&privkey.to_bytes()), u64_to_sql(expire_block)?];
         tx.execute(
             "UPDATE local_peer SET private_key = ?1, private_key_expire = ?2",
             args,
@@ -912,7 +912,7 @@ impl PeerDB {
         peer_port: u16,
     ) -> Result<Option<Neighbor>, db_error> {
         let qry = "SELECT * FROM frontier WHERE network_id = ?1 AND addrbytes = ?2 AND port = ?3";
-        let args: &[&dyn ToSql] = params![network_id, peer_addr.to_bin(), peer_port,];
+        let args = params![network_id, peer_addr.to_bin(), peer_port,];
         query_row::<Neighbor, _>(conn, qry, args)
     }
 
@@ -923,7 +923,7 @@ impl PeerDB {
         peer_port: u16,
     ) -> Result<bool, db_error> {
         let qry = "SELECT 1 FROM frontier WHERE network_id = ?1 AND addrbytes = ?2 AND port = ?3";
-        let args: &[&dyn ToSql] = params![network_id, peer_addr.to_bin(), peer_port];
+        let args = params![network_id, peer_addr.to_bin(), peer_port];
         Ok(query_row::<i64, _>(conn, &qry, args)?
             .map(|x| x == 1)
             .unwrap_or(false))
@@ -937,7 +937,7 @@ impl PeerDB {
         peer_port: u16,
     ) -> Result<Option<Neighbor>, db_error> {
         let qry = "SELECT * FROM frontier WHERE network_id = ?1 AND port = ?2";
-        let args: &[&dyn ToSql] = params![network_id, peer_port];
+        let args = params![network_id, peer_port];
         query_row::<Neighbor, _>(conn, &qry, args)
     }
 
@@ -948,14 +948,14 @@ impl PeerDB {
         slot: u32,
     ) -> Result<Option<Neighbor>, db_error> {
         let qry = "SELECT * FROM frontier WHERE network_id = ?1 AND slot = ?2";
-        let args: &[&dyn ToSql] = params![network_id, slot];
+        let args = params![network_id, slot];
         query_row::<Neighbor, _>(conn, &qry, args)
     }
 
     /// Is there any peer at a particular slot?
     pub fn has_peer_at(conn: &DBConn, network_id: u32, slot: u32) -> Result<bool, db_error> {
         let qry = "SELECT 1 FROM frontier WHERE network_id = ?1 AND slot = ?2";
-        let args: &[&dyn ToSql] = params![network_id, slot];
+        let args = params![network_id, slot];
         Ok(query_row::<i64, _>(conn, &qry, args)?
             .map(|x| x == 1)
             .unwrap_or(false))
@@ -1032,7 +1032,7 @@ impl PeerDB {
     ) -> Result<(), db_error> {
         for cid in smart_contracts {
             test_debug!("Add Stacker DB contract to slot {}: {}", slot, cid);
-            let args: &[&dyn ToSql] = params![cid.to_string(), slot];
+            let args = params![cid.to_string(), slot];
             tx.execute("INSERT OR REPLACE INTO stackerdb_peers (smart_contract_id,peer_slot) VALUES (?1,?2)", args)
                 .map_err(db_error::SqliteError)?;
         }
@@ -1054,7 +1054,7 @@ impl PeerDB {
     ) -> Result<(), db_error> {
         let old_peer_opt = PeerDB::get_peer_at(tx, neighbor.addr.network_id, slot)?;
 
-        let neighbor_args: &[&dyn ToSql] = params![
+        let neighbor_args = params![
             neighbor.addr.peer_version,
             neighbor.addr.network_id,
             to_bin(neighbor.addr.addrbytes.as_bytes()),
@@ -1201,7 +1201,7 @@ impl PeerDB {
         peer_port: u16,
         deny_deadline: u64,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             u64_to_sql(deny_deadline)?,
             network_id,
             peer_addr.to_bin(),
@@ -1247,7 +1247,7 @@ impl PeerDB {
             neighbor.addr.port,
         )?;
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             neighbor.addr.peer_version,
             to_hex(&neighbor.public_key.to_bytes_compressed()),
             u64_to_sql(neighbor.expire_block)?,
@@ -1299,7 +1299,7 @@ impl PeerDB {
     ) -> Result<Option<u32>, db_error> {
         let qry =
             "SELECT slot FROM frontier WHERE network_id = ?1 AND addrbytes = ?2 AND port = ?3";
-        let args: &[&dyn ToSql] = params![network_id, addrbytes.to_bin(), port];
+        let args = params![network_id, addrbytes.to_bin(), port];
         Ok(query_row::<u32, _>(conn, qry, args)?)
     }
 
@@ -1325,7 +1325,7 @@ impl PeerDB {
         smart_contract: &QualifiedContractIdentifier,
     ) -> Result<Vec<u32>, db_error> {
         let qry = "SELECT peer_slot FROM stackerdb_peers WHERE smart_contract_id = ?1";
-        let args: &[&dyn ToSql] = params![smart_contract.to_string()];
+        let args = params![smart_contract.to_string()];
         query_rows(conn, qry, args)
     }
 
@@ -1385,7 +1385,7 @@ impl PeerDB {
         let sql = "DELETE FROM stackerdb_peers WHERE smart_contract_id = ?1 AND peer_slot = ?2";
         for cid in to_delete.into_iter() {
             test_debug!("Delete Stacker DB for {:?}: {}", &neighbor.addr, &cid);
-            let args: &[&dyn ToSql] = params![cid.to_string(), slot];
+            let args = params![cid.to_string(), slot];
             tx.execute(sql, args).map_err(db_error::SqliteError)?;
         }
 
@@ -1393,7 +1393,7 @@ impl PeerDB {
             "INSERT OR REPLACE INTO stackerdb_peers (smart_contract_id,peer_slot) VALUES (?1,?2)";
         for cid in to_insert.iter() {
             test_debug!("Add Stacker DB for {:?}: {}", &neighbor.addr, &cid);
-            let args: &[&dyn ToSql] = params![cid.to_string(), slot];
+            let args = params![cid.to_string(), slot];
             tx.execute(sql, args).map_err(db_error::SqliteError)?;
         }
 
@@ -1450,7 +1450,7 @@ impl PeerDB {
         prefix: &PeerAddress,
         mask: u32,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![prefix.to_bin(), mask];
+        let args = params![prefix.to_bin(), mask];
         tx.execute(
             &format!(
                 "INSERT OR REPLACE INTO {} (prefix, mask) VALUES (?1, ?2)",
@@ -1469,7 +1469,7 @@ impl PeerDB {
         prefix: &PeerAddress,
         mask: u32,
     ) -> Result<(), db_error> {
-        let args: &[&dyn ToSql] = params![prefix.to_bin(), mask];
+        let args = params![prefix.to_bin(), mask];
         tx.execute(
             &format!("DELETE FROM {} WHERE prefix = ?1 AND mask = ?2", table),
             args,
@@ -1546,7 +1546,7 @@ impl PeerDB {
     ) -> Result<(), db_error> {
         assert!(mask > 0 && mask <= 128);
         let prefix_txt = PeerDB::cidr_prefix_to_string(prefix, mask);
-        let args: &[&dyn ToSql] = params![value, mask, prefix_txt];
+        let args = params![value, mask, prefix_txt];
         tx.execute(
             &format!(
                 "UPDATE frontier SET {} = ?1 WHERE SUBSTR(addrbytes,1,?2) = SUBSTR(?3,1,?2)",
@@ -1624,7 +1624,7 @@ impl PeerDB {
         if always_include_allowed {
             // always include allowed neighbors, freshness be damned
             let allow_qry = "SELECT * FROM frontier WHERE network_id = ?1 AND denied < ?2 AND (allowed < 0 OR ?3 < allowed) AND (peer_version & 0x000000ff) >= ?4";
-            let allow_args: &[&dyn ToSql] = params![
+            let allow_args = params![
                 network_id,
                 u64_to_sql(now_secs)?,
                 u64_to_sql(now_secs)?,
@@ -1654,7 +1654,7 @@ impl PeerDB {
                  (allowed < 0 OR (allowed >= 0 AND allowed <= ?5)) AND (peer_version & 0x000000ff) >= ?6 ORDER BY RANDOM() LIMIT ?7"
         };
 
-        let random_peers_args: &[&dyn ToSql] = params![
+        let random_peers_args = params![
             network_id,
             u64_to_sql(min_age)?,
             u64_to_sql(block_height)?,
@@ -1730,7 +1730,7 @@ impl PeerDB {
         let addr_u32 = addrbits.ipv4_bits().unwrap();
 
         let qry = "SELECT * FROM asn4 WHERE prefix = (?1 & ~((1 << (32 - mask)) - 1)) ORDER BY prefix DESC LIMIT 1";
-        let args: &[&dyn ToSql] = params![addr_u32];
+        let args = params![addr_u32];
         let rows = query_rows::<ASEntry4, _>(conn, &qry, args)?;
         match rows.len() {
             0 => Ok(None),
@@ -1753,7 +1753,7 @@ impl PeerDB {
     #[cfg_attr(test, mutants::skip)]
     pub fn asn_count(conn: &DBConn, asn: u32) -> Result<u64, db_error> {
         let qry = "SELECT COUNT(*) FROM frontier WHERE asn = ?1";
-        let args: &[&dyn ToSql] = params![asn];
+        let args = params![asn];
         let count = query_count(conn, &qry, args)?;
         Ok(count as u64)
     }
@@ -1786,7 +1786,7 @@ impl PeerDB {
         }
         let qry = "SELECT DISTINCT frontier.* FROM frontier JOIN stackerdb_peers ON stackerdb_peers.peer_slot = frontier.slot WHERE stackerdb_peers.smart_contract_id = ?1 AND frontier.network_id = ?2 AND frontier.last_contact_time >= ?3 ORDER BY RANDOM() LIMIT ?4";
         let max_count_u32 = u32::try_from(max_count).unwrap_or(u32::MAX);
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             smart_contract.to_string(),
             network_id,
             u64_to_sql(min_age)?,

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -1699,13 +1699,13 @@ pub mod test {
     use std::{fs, io, thread};
 
     use clarity::boot_util::boot_code_id;
+    use clarity::types::sqlite::NO_PARAMS;
     use clarity::vm::ast::ASTRules;
     use clarity::vm::costs::ExecutionCost;
     use clarity::vm::database::STXBalance;
     use clarity::vm::types::*;
     use clarity::vm::ClarityVersion;
     use rand::{Rng, RngCore};
-    use rusqlite::NO_PARAMS;
     use stacks_common::address::*;
     use stacks_common::codec::StacksMessageCodec;
     use stacks_common::deps_common::bitcoin::network::serialize::BitcoinHash;

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -36,8 +36,7 @@ use libstackerdb::{
 };
 use rand::{thread_rng, RngCore};
 use regex::Regex;
-use rusqlite::types::ToSqlOutput;
-use rusqlite::ToSql;
+use rusqlite::types::{ToSql, ToSqlOutput};
 use serde::de::Error as de_Error;
 use serde::ser::Error as ser_Error;
 use serde::{Deserialize, Serialize};

--- a/stackslib/src/net/rpc.rs
+++ b/stackslib/src/net/rpc.rs
@@ -37,12 +37,13 @@ use clarity::vm::{ClarityName, ClarityVersion, ContractName, SymbolicExpression,
 use libstackerdb::{StackerDBChunkAckData, StackerDBChunkData};
 use rand::prelude::*;
 use rand::thread_rng;
-use rusqlite::{DatabaseName, NO_PARAMS};
+use rusqlite::DatabaseName;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, StacksAddress, StacksBlockId,
 };
 use stacks_common::types::net::{PeerAddress, PeerHost};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::types::StacksPublicKeyBuffer;
 use stacks_common::util::chunked_encoding::*;
 use stacks_common::util::get_epoch_time_secs;

--- a/stackslib/src/net/stackerdb/db.rs
+++ b/stackslib/src/net/stackerdb/db.rs
@@ -158,7 +158,7 @@ fn inner_get_stackerdb_id(
     smart_contract: &QualifiedContractIdentifier,
 ) -> Result<i64, net_error> {
     let sql = "SELECT rowid FROM databases WHERE smart_contract_id = ?1";
-    let args: &[&dyn ToSql] = params![smart_contract.to_string()];
+    let args = params![smart_contract.to_string()];
     Ok(query_row(conn, sql, args)?.ok_or(net_error::NoSuchStackerDB(smart_contract.clone()))?)
 }
 
@@ -172,7 +172,7 @@ fn inner_get_slot_metadata(
 ) -> Result<Option<SlotMetadata>, net_error> {
     let stackerdb_id = inner_get_stackerdb_id(conn, smart_contract)?;
     let sql = "SELECT slot_id,version,data_hash,signature FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-    let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
+    let args = params![stackerdb_id, slot_id];
     query_row(conn, &sql, args).map_err(|e| e.into())
 }
 
@@ -187,7 +187,7 @@ fn inner_get_slot_validation(
     let stackerdb_id = inner_get_stackerdb_id(conn, smart_contract)?;
     let sql =
         "SELECT signer,write_time,version FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-    let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
+    let args = params![stackerdb_id, slot_id];
     query_row(conn, &sql, args).map_err(|e| e.into())
 }
 
@@ -207,7 +207,7 @@ impl<'a> StackerDBTx<'a> {
         smart_contract_id: &QualifiedContractIdentifier,
     ) -> Result<(), net_error> {
         let qry = "DELETE FROM databases WHERE smart_contract_id = ?1";
-        let args: &[&dyn ToSql] = params![smart_contract_id.to_string()];
+        let args = params![smart_contract_id.to_string()];
         let mut stmt = self.sql_tx.prepare(qry)?;
         stmt.execute(args)?;
         Ok(())
@@ -247,7 +247,7 @@ impl<'a> StackerDBTx<'a> {
 
         let qry = "INSERT OR REPLACE INTO databases (smart_contract_id) VALUES (?1)";
         let mut stmt = self.sql_tx.prepare(&qry)?;
-        let args: &[&dyn ToSql] = params![smart_contract.to_string()];
+        let args = params![smart_contract.to_string()];
         stmt.execute(args)?;
 
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
@@ -259,7 +259,7 @@ impl<'a> StackerDBTx<'a> {
         for (principal, slot_count) in slots.iter() {
             test_debug!("Create StackerDB slots: ({}, {})", &principal, slot_count);
             for _ in 0..*slot_count {
-                let args: &[&dyn ToSql] = params![
+                let args = params![
                     stackerdb_id,
                     principal.to_string(),
                     slot_id,
@@ -287,7 +287,7 @@ impl<'a> StackerDBTx<'a> {
     ) -> Result<(), net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "DELETE FROM chunks WHERE stackerdb_id = ?1";
-        let args: &[&dyn ToSql] = params![stackerdb_id];
+        let args = params![stackerdb_id];
         let mut stmt = self.sql_tx.prepare(&qry)?;
         stmt.execute(args)?;
         Ok(())
@@ -327,7 +327,7 @@ impl<'a> StackerDBTx<'a> {
                 // new slot, or existing slot with a different signer
                 let qry = "INSERT OR REPLACE INTO chunks (stackerdb_id,signer,slot_id,version,write_time,data,data_hash,signature) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)";
                 let mut stmt = self.sql_tx.prepare(&qry)?;
-                let args: &[&dyn ToSql] = params![
+                let args = params![
                     stackerdb_id,
                     principal.to_string(),
                     slot_id,
@@ -375,7 +375,7 @@ impl<'a> StackerDBTx<'a> {
         let sql = "UPDATE chunks SET version = ?1, data_hash = ?2, signature = ?3, data = ?4, write_time = ?5 WHERE stackerdb_id = ?6 AND slot_id = ?7";
         let mut stmt = self.sql_tx.prepare(&sql)?;
 
-        let args: &[&dyn ToSql] = params![
+        let args = params![
             slot_desc.slot_version,
             Sha512Trunc256Sum::from_data(chunk),
             slot_desc.signature,
@@ -549,7 +549,7 @@ impl StackerDBs {
     ) -> Result<Option<StacksAddress>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT signer FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
+        let args = params![stackerdb_id, slot_id];
         query_row(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -562,7 +562,7 @@ impl StackerDBs {
     ) -> Result<Vec<StacksAddress>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT signer FROM chunks WHERE stackerdb_id = ?1 GROUP BY signer";
-        let args: &[&dyn ToSql] = params![stackerdb_id];
+        let args = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -583,7 +583,7 @@ impl StackerDBs {
     ) -> Result<Vec<SlotMetadata>, net_error> {
         let stackerdb_id = inner_get_stackerdb_id(&self.conn, smart_contract)?;
         let sql = "SELECT slot_id,version,data_hash,signature FROM chunks WHERE stackerdb_id = ?1 ORDER BY slot_id ASC";
-        let args: &[&dyn ToSql] = params![stackerdb_id];
+        let args = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -607,7 +607,7 @@ impl StackerDBs {
     ) -> Result<Option<u32>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "SELECT version FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
+        let args = params![stackerdb_id, slot_id];
 
         self.conn
             .query_row(qry, args, |row| row.get(0))
@@ -622,7 +622,7 @@ impl StackerDBs {
     ) -> Result<Vec<u32>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT version FROM chunks WHERE stackerdb_id = ?1 ORDER BY slot_id";
-        let args: &[&dyn ToSql] = params![stackerdb_id];
+        let args = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -633,7 +633,7 @@ impl StackerDBs {
     ) -> Result<Vec<u64>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT write_time FROM chunks WHERE stackerdb_id = ?1 ORDER BY slot_id";
-        let args: &[&dyn ToSql] = params![stackerdb_id];
+        let args = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -648,7 +648,7 @@ impl StackerDBs {
     ) -> Result<Option<Vec<u8>>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "SELECT data FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
+        let args = params![stackerdb_id, slot_id];
 
         self.conn
             .query_row(qry, args, |row| row.get(0))
@@ -681,7 +681,7 @@ impl StackerDBs {
     ) -> Result<Option<StackerDBChunkData>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "SELECT slot_id,version,signature,data FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2 AND version = ?3";
-        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id, slot_version];
+        let args = params![stackerdb_id, slot_id, slot_version];
         query_row(&self.conn, &qry, args).map_err(|e| e.into())
     }
 }

--- a/stackslib/src/net/stackerdb/db.rs
+++ b/stackslib/src/net/stackerdb/db.rs
@@ -22,8 +22,9 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use clarity::vm::ContractName;
 use libstackerdb::{SlotMetadata, STACKERDB_MAX_CHUNK_SIZE};
 use rusqlite::types::ToSql;
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Transaction, NO_PARAMS};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Row, Transaction};
 use stacks_common::types::chainstate::{ConsensusHash, StacksAddress};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::Sha512Trunc256Sum;
 use stacks_common::util::secp256k1::MessageSignature;
@@ -258,15 +259,15 @@ impl<'a> StackerDBTx<'a> {
         for (principal, slot_count) in slots.iter() {
             test_debug!("Create StackerDB slots: ({}, {})", &principal, slot_count);
             for _ in 0..*slot_count {
-                let args: &[&dyn ToSql] = &[
-                    &stackerdb_id,
-                    &principal.to_string(),
-                    &slot_id,
-                    &NO_VERSION,
-                    &0,
-                    &vec![],
-                    &Sha512Trunc256Sum([0u8; 32]),
-                    &MessageSignature::empty(),
+                let args: &[&dyn ToSql] = params![
+                    stackerdb_id,
+                    principal.to_string(),
+                    slot_id,
+                    NO_VERSION,
+                    0,
+                    vec![],
+                    Sha512Trunc256Sum([0u8; 32]),
+                    MessageSignature::empty(),
                 ];
                 stmt.execute(args)?;
 
@@ -326,15 +327,15 @@ impl<'a> StackerDBTx<'a> {
                 // new slot, or existing slot with a different signer
                 let qry = "INSERT OR REPLACE INTO chunks (stackerdb_id,signer,slot_id,version,write_time,data,data_hash,signature) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)";
                 let mut stmt = self.sql_tx.prepare(&qry)?;
-                let args: &[&dyn ToSql] = &[
-                    &stackerdb_id,
-                    &principal.to_string(),
-                    &slot_id,
-                    &NO_VERSION,
-                    &0,
-                    &vec![],
-                    &Sha512Trunc256Sum([0u8; 32]),
-                    &MessageSignature::empty(),
+                let args: &[&dyn ToSql] = params![
+                    stackerdb_id,
+                    principal.to_string(),
+                    slot_id,
+                    NO_VERSION,
+                    0,
+                    vec![],
+                    Sha512Trunc256Sum([0u8; 32]),
+                    MessageSignature::empty(),
                 ];
 
                 stmt.execute(args)?;

--- a/stackslib/src/net/stackerdb/db.rs
+++ b/stackslib/src/net/stackerdb/db.rs
@@ -158,7 +158,7 @@ fn inner_get_stackerdb_id(
     smart_contract: &QualifiedContractIdentifier,
 ) -> Result<i64, net_error> {
     let sql = "SELECT rowid FROM databases WHERE smart_contract_id = ?1";
-    let args: &[&dyn ToSql] = &[&smart_contract.to_string()];
+    let args: &[&dyn ToSql] = params![smart_contract.to_string()];
     Ok(query_row(conn, sql, args)?.ok_or(net_error::NoSuchStackerDB(smart_contract.clone()))?)
 }
 
@@ -172,7 +172,7 @@ fn inner_get_slot_metadata(
 ) -> Result<Option<SlotMetadata>, net_error> {
     let stackerdb_id = inner_get_stackerdb_id(conn, smart_contract)?;
     let sql = "SELECT slot_id,version,data_hash,signature FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-    let args: &[&dyn ToSql] = &[&stackerdb_id, &slot_id];
+    let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
     query_row(conn, &sql, args).map_err(|e| e.into())
 }
 
@@ -187,7 +187,7 @@ fn inner_get_slot_validation(
     let stackerdb_id = inner_get_stackerdb_id(conn, smart_contract)?;
     let sql =
         "SELECT signer,write_time,version FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-    let args: &[&dyn ToSql] = &[&stackerdb_id, &slot_id];
+    let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
     query_row(conn, &sql, args).map_err(|e| e.into())
 }
 
@@ -207,7 +207,7 @@ impl<'a> StackerDBTx<'a> {
         smart_contract_id: &QualifiedContractIdentifier,
     ) -> Result<(), net_error> {
         let qry = "DELETE FROM databases WHERE smart_contract_id = ?1";
-        let args: &[&dyn ToSql] = &[&smart_contract_id.to_string()];
+        let args: &[&dyn ToSql] = params![smart_contract_id.to_string()];
         let mut stmt = self.sql_tx.prepare(qry)?;
         stmt.execute(args)?;
         Ok(())
@@ -247,7 +247,7 @@ impl<'a> StackerDBTx<'a> {
 
         let qry = "INSERT OR REPLACE INTO databases (smart_contract_id) VALUES (?1)";
         let mut stmt = self.sql_tx.prepare(&qry)?;
-        let args: &[&dyn ToSql] = &[&smart_contract.to_string()];
+        let args: &[&dyn ToSql] = params![smart_contract.to_string()];
         stmt.execute(args)?;
 
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
@@ -287,7 +287,7 @@ impl<'a> StackerDBTx<'a> {
     ) -> Result<(), net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "DELETE FROM chunks WHERE stackerdb_id = ?1";
-        let args: &[&dyn ToSql] = &[&stackerdb_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id];
         let mut stmt = self.sql_tx.prepare(&qry)?;
         stmt.execute(args)?;
         Ok(())
@@ -375,14 +375,14 @@ impl<'a> StackerDBTx<'a> {
         let sql = "UPDATE chunks SET version = ?1, data_hash = ?2, signature = ?3, data = ?4, write_time = ?5 WHERE stackerdb_id = ?6 AND slot_id = ?7";
         let mut stmt = self.sql_tx.prepare(&sql)?;
 
-        let args: &[&dyn ToSql] = &[
-            &slot_desc.slot_version,
-            &Sha512Trunc256Sum::from_data(chunk),
-            &slot_desc.signature,
-            &chunk,
-            &u64_to_sql(get_epoch_time_secs())?,
-            &stackerdb_id,
-            &slot_desc.slot_id,
+        let args: &[&dyn ToSql] = params![
+            slot_desc.slot_version,
+            Sha512Trunc256Sum::from_data(chunk),
+            slot_desc.signature,
+            chunk,
+            u64_to_sql(get_epoch_time_secs())?,
+            stackerdb_id,
+            slot_desc.slot_id,
         ];
 
         stmt.execute(args)?;
@@ -549,7 +549,7 @@ impl StackerDBs {
     ) -> Result<Option<StacksAddress>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT signer FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-        let args: &[&dyn ToSql] = &[&stackerdb_id, &slot_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
         query_row(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -562,7 +562,7 @@ impl StackerDBs {
     ) -> Result<Vec<StacksAddress>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT signer FROM chunks WHERE stackerdb_id = ?1 GROUP BY signer";
-        let args: &[&dyn ToSql] = &[&stackerdb_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -583,7 +583,7 @@ impl StackerDBs {
     ) -> Result<Vec<SlotMetadata>, net_error> {
         let stackerdb_id = inner_get_stackerdb_id(&self.conn, smart_contract)?;
         let sql = "SELECT slot_id,version,data_hash,signature FROM chunks WHERE stackerdb_id = ?1 ORDER BY slot_id ASC";
-        let args: &[&dyn ToSql] = &[&stackerdb_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -607,7 +607,7 @@ impl StackerDBs {
     ) -> Result<Option<u32>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "SELECT version FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-        let args: &[&dyn ToSql] = &[&stackerdb_id, &slot_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
 
         self.conn
             .query_row(qry, args, |row| row.get(0))
@@ -622,7 +622,7 @@ impl StackerDBs {
     ) -> Result<Vec<u32>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT version FROM chunks WHERE stackerdb_id = ?1 ORDER BY slot_id";
-        let args: &[&dyn ToSql] = &[&stackerdb_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -633,7 +633,7 @@ impl StackerDBs {
     ) -> Result<Vec<u64>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let sql = "SELECT write_time FROM chunks WHERE stackerdb_id = ?1 ORDER BY slot_id";
-        let args: &[&dyn ToSql] = &[&stackerdb_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id];
         query_rows(&self.conn, &sql, args).map_err(|e| e.into())
     }
 
@@ -648,7 +648,7 @@ impl StackerDBs {
     ) -> Result<Option<Vec<u8>>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "SELECT data FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2";
-        let args: &[&dyn ToSql] = &[&stackerdb_id, &slot_id];
+        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id];
 
         self.conn
             .query_row(qry, args, |row| row.get(0))
@@ -681,7 +681,7 @@ impl StackerDBs {
     ) -> Result<Option<StackerDBChunkData>, net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
         let qry = "SELECT slot_id,version,signature,data FROM chunks WHERE stackerdb_id = ?1 AND slot_id = ?2 AND version = ?3";
-        let args: &[&dyn ToSql] = &[&stackerdb_id, &slot_id, &slot_version];
+        let args: &[&dyn ToSql] = params![stackerdb_id, slot_id, slot_version];
         query_row(&self.conn, &qry, args).map_err(|e| e.into())
     }
 }

--- a/stackslib/src/util_lib/bloom.rs
+++ b/stackslib/src/util_lib/bloom.rs
@@ -362,7 +362,7 @@ impl<H: BloomHash + Clone + StacksMessageCodec> BloomCounter<H> {
             "INSERT INTO {} (counts, num_bins, num_hashes, hasher) VALUES (?1, ?2, ?3, ?4)",
             table_name
         );
-        let args: &[&dyn ToSql] = params![counts_vec, num_bins, num_hashes, hasher_vec];
+        let args = params![counts_vec, num_bins, num_hashes, hasher_vec];
 
         tx.execute(&sql, args).map_err(db_error::SqliteError)?;
 

--- a/stackslib/src/util_lib/bloom.rs
+++ b/stackslib/src/util_lib/bloom.rs
@@ -22,7 +22,8 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use rand::prelude::*;
 use rand::thread_rng;
 use rusqlite::blob::Blob;
-use rusqlite::{Error as sqlite_error, Row, ToSql};
+use rusqlite::types::ToSql;
+use rusqlite::{params, Error as sqlite_error, Row};
 use siphasher::sip::SipHasher; // this is SipHash-2-4
 use stacks_common::codec::{read_next, write_next, Error as codec_error, StacksMessageCodec};
 use stacks_common::types::sqlite::NO_PARAMS;
@@ -361,7 +362,7 @@ impl<H: BloomHash + Clone + StacksMessageCodec> BloomCounter<H> {
             "INSERT INTO {} (counts, num_bins, num_hashes, hasher) VALUES (?1, ?2, ?3, ?4)",
             table_name
         );
-        let args: &[&dyn ToSql] = &[&counts_vec, &num_bins, &num_hashes, &hasher_vec];
+        let args: &[&dyn ToSql] = params![counts_vec, num_bins, num_hashes, hasher_vec];
 
         tx.execute(&sql, args).map_err(db_error::SqliteError)?;
 

--- a/stackslib/src/util_lib/bloom.rs
+++ b/stackslib/src/util_lib/bloom.rs
@@ -22,9 +22,10 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use rand::prelude::*;
 use rand::thread_rng;
 use rusqlite::blob::Blob;
-use rusqlite::{Error as sqlite_error, Row, ToSql, NO_PARAMS};
+use rusqlite::{Error as sqlite_error, Row, ToSql};
 use siphasher::sip::SipHasher; // this is SipHash-2-4
 use stacks_common::codec::{read_next, write_next, Error as codec_error, StacksMessageCodec};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::{to_hex, Sha512Trunc256Sum};
 
 use crate::util_lib::db::{query_expect_row, DBConn, DBTx, Error as db_error};
@@ -381,7 +382,7 @@ impl<H: BloomHash + Clone + StacksMessageCodec> BloomCounter<H> {
         let sql = format!("SELECT rowid,* FROM {}", table_name);
         let result = conn.query_row_and_then(&sql, NO_PARAMS, |row| {
             let mut hasher_blob = row
-                .get_raw("hasher")
+                .get_ref("hasher")?
                 .as_blob()
                 .expect("Unable to read hasher as blob");
             let hasher =

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -25,7 +25,8 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use rand::{thread_rng, Rng, RngCore};
 use rusqlite::types::{FromSql, ToSql};
 use rusqlite::{
-    params, Connection, Error as sqlite_error, OpenFlags, OptionalExtension, Params, Row, Transaction, TransactionBehavior
+    params, Connection, Error as sqlite_error, OpenFlags, OptionalExtension, Params, Row,
+    Transaction, TransactionBehavior,
 };
 use serde_json::Error as serde_error;
 use stacks_common::types::chainstate::{SortitionId, StacksAddress, StacksBlockId, TrieHash};

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -25,11 +25,11 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use rand::{thread_rng, Rng, RngCore};
 use rusqlite::types::{FromSql, ToSql};
 use rusqlite::{
-    Connection, Error as sqlite_error, OpenFlags, OptionalExtension, Row, Transaction,
-    TransactionBehavior, NO_PARAMS,
+    params, Connection, Error as sqlite_error, OpenFlags, OptionalExtension, Params, Row, Transaction, TransactionBehavior
 };
 use serde_json::Error as serde_error;
 use stacks_common::types::chainstate::{SortitionId, StacksAddress, StacksBlockId, TrieHash};
+use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::types::Address;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
@@ -397,8 +397,7 @@ fn log_sql_eqp(_conn: &Connection, _sql_query: &str) {}
 /// boilerplate code for querying rows
 pub fn query_rows<T, P>(conn: &Connection, sql_query: &str, sql_args: P) -> Result<Vec<T>, Error>
 where
-    P: IntoIterator,
-    P::Item: ToSql,
+    P: Params,
     T: FromRow<T>,
 {
     log_sql_eqp(conn, sql_query);
@@ -412,8 +411,7 @@ where
 ///   if more than 1 row is returned, excess rows are ignored.
 pub fn query_row<T, P>(conn: &Connection, sql_query: &str, sql_args: P) -> Result<Option<T>, Error>
 where
-    P: IntoIterator,
-    P::Item: ToSql,
+    P: Params,
     T: FromRow<T>,
 {
     log_sql_eqp(conn, sql_query);
@@ -433,8 +431,7 @@ pub fn query_expect_row<T, P>(
     sql_args: P,
 ) -> Result<Option<T>, Error>
 where
-    P: IntoIterator,
-    P::Item: ToSql,
+    P: Params,
     T: FromRow<T>,
 {
     log_sql_eqp(conn, sql_query);
@@ -459,8 +456,7 @@ pub fn query_row_panic<T, P, F>(
     panic_message: F,
 ) -> Result<Option<T>, Error>
 where
-    P: IntoIterator,
-    P::Item: ToSql,
+    P: Params,
     T: FromRow<T>,
     F: FnOnce() -> String,
 {
@@ -485,8 +481,7 @@ pub fn query_row_columns<T, P>(
     column_name: &str,
 ) -> Result<Vec<T>, Error>
 where
-    P: IntoIterator,
-    P::Item: ToSql,
+    P: Params,
     T: FromColumn<T>,
 {
     log_sql_eqp(conn, sql_query);
@@ -506,8 +501,7 @@ where
 /// Boilerplate for querying a single integer (first and only item of the query must be an int)
 pub fn query_int<P>(conn: &Connection, sql_query: &str, sql_args: P) -> Result<i64, Error>
 where
-    P: IntoIterator,
-    P::Item: ToSql,
+    P: Params,
 {
     log_sql_eqp(conn, sql_query);
     let mut stmt = conn.prepare(sql_query)?;
@@ -530,8 +524,7 @@ where
 
 pub fn query_count<P>(conn: &Connection, sql_query: &str, sql_args: P) -> Result<i64, Error>
 where
-    P: IntoIterator,
-    P::Item: ToSql,
+    P: Params,
 {
     query_int(conn, sql_query, sql_args)
 }
@@ -790,7 +783,7 @@ fn load_indexed(conn: &DBConn, marf_value: &MARFValue) -> Result<Option<String>,
         .prepare("SELECT value FROM __fork_storage WHERE value_hash = ?1 LIMIT 2")
         .map_err(Error::SqliteError)?;
     let mut rows = stmt
-        .query(&[&marf_value.to_hex() as &dyn ToSql])
+        .query(params![marf_value.to_hex()])
         .map_err(Error::SqliteError)?;
     let mut value = None;
 

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -31,6 +31,7 @@ wsts = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
 hashbrown = { workspace = true }
+rusqlite = { workspace = true }
 
 [target.'cfg(not(any(target_os = "macos", target_os="windows", target_arch = "arm")))'.dependencies]
 tikv-jemallocator = {workspace = true}
@@ -48,10 +49,6 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = {workspace = true}
 mutants = "0.0.3"
-
-[dependencies.rusqlite]
-version = "0.31.0"
-features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [[bin]]
 name = "stacks-node"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -50,7 +50,7 @@ wsts = {workspace = true}
 mutants = "0.0.3"
 
 [dependencies.rusqlite]
-version = "=0.24.2"
+version = "0.31.0"
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [[bin]]

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -12,7 +12,7 @@ use clarity::vm::types::serialization::SerializationError;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::{ClarityName, ClarityVersion, ContractName, Value, MAX_CALL_STACK_DEPTH};
 use rand::{Rng, RngCore};
-use rusqlite::types::ToSql;
+use rusqlite::params;
 use serde::Deserialize;
 use serde_json::json;
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, LegacyBitcoinAddressType};

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -8765,7 +8765,7 @@ fn atlas_stress_integration_test() {
                 let mut hashes = query_row_columns::<Hash160, _>(
                     &atlasdb.conn,
                     "SELECT content_hash FROM attachment_instances WHERE index_block_hash = ?1 AND attachment_index = ?2",
-                    &[ibh as &dyn ToSql, &u64_to_sql(*index).unwrap() as &dyn ToSql],
+                    params![ibh, u64_to_sql(*index).unwrap()],
                     "content_hash")
                 .unwrap();
                 if hashes.len() > 0 {


### PR DESCRIPTION
### Description
Updates rusqlite to latest version `0.31.0`. That updates the sqlite version used by it from `3.33.0` to `3.45.0`.

### Applicable issues

- fixes #4824

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] update rusqlite version to `0.31.0`
- [x] update changed methods
  - [x] NO_PARAMS: got removed from rusqlite. create [const equivalent](https://github.com/stacks-network/stacks-core/blob/feat/sqlite-upgrade/stacks-common/src/types/sqlite.rs#L28) in `stacks_commons` where sqlite related data was defined
  - [x] [get_raw](https://docs.rs/rusqlite/0.24.2/rusqlite/struct.Statement.html#method.query) renamed to [get_ref](https://docs.rs/rusqlite/latest/rusqlite/struct.Statement.html#method.query)
  - [x] `query` and `query_rows` header updated constraints on the generic type P: [0.24.2](https://docs.rs/rusqlite/0.24.2/rusqlite/struct.Statement.html#method.query) vs [0.31.0](https://docs.rs/rusqlite/latest/rusqlite/struct.Statement.html#method.query)
- [x] use `params!` macro in all implementations the same way instead of having `&[&variable as &dyn ToSql]` / `params!` / `rusqlite::params!` across the codebase
  - [x] explicitly define the type `&[&dyn ToSql]` where `params!` is used 
- [x] update ToSql to be `use rusqlite::Types::ToSql` everywhere instead of a combination of `use rusqlite::Types::ToSql` and `use rusqlite::ToSql` 
- [x] pass tests running `RUST_BACKTRACE=1 BITCOIND_TEST=1 cargo nextest run --test-threads 1` 
  - [x] fixed [these 2 tests](https://github.com/stacks-network/stacks-core/blob/feat/sqlite-upgrade/stacks-signer/src/config.rs#L634-L693) from stacks-signer are failing   
     ```
     Summary [1733.775s] 5141 tests run: 5141 passed (2 slow), 195 skipped
     ```
- [x] run stacks-inspect with index range for blocks to check no breaking changes
  - [x] last 1k blocks - from [2.5.0.0.5-latest archive](https://archive.hiro.so/mainnet/stacks-blockchain/mainnet-stacks-blockchain-2.5.0.0.5-latest.sha256)
  - [x] first 1k blocks
  - [x] range 
    - [x] 99,990 to 100,000
    - [x] 150,000 to 150,400
    - [x] 132,000 to 132,300
    - [x] 116,200 to 116,800
