### PR TITLE
docs: specify allowed character set for branch names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,11 @@ Branch names should use a prefix that conveys the overall goal of the branch:
 - `test/more-coverage` for branches that only add more tests
 - `refactor/formatting-fix` for refactors
 
+The branch suffix must only include ASCII lowercase and uppercase letters,
+digits, underscores, periods and dashes.
+
+The full branch name must be max 128 characters long.
+
 ### Merging PRs from Forks
 
 PRs from forks or opened by contributors without commit access require


### PR DESCRIPTION
### Description

As specified by docker tags requirements [1] and `docker-metadata` [2]. 

[1]: https://docs.docker.com/reference/cli/docker/image/tag/#description
[2]: https://github.com/docker/metadata-action?tab=readme-ov-file#image-name-and-tag-sanitization

### Applicable issues

Prevents issues like [3] on parenthesis (not actually related to tag name, but to Docker failing CI configuration).

[3]: https://github.com/stacks-network/stacks-core/actions/runs/9766520161/job/27087431713?pr=4921

### Additional info (benefits, drawbacks, caveats)

Heard this on WG call, thought it would be a nice first contribution :)