### PR TITLE
Workflow to lock closed issues/pr/discussions

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,37 @@
+## Workflow to lock closed PRs/issues/discussions
+## timeframe to lock defaults to:
+##    issues: 30 days
+##    prs: 30 days
+##    discussions: 365 days
+
+name: "Lock Threads"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  ## Lock closed issues/prs/discussions
+  lock:
+    name: Lock Threads
+    runs-on: ubuntu-latest
+    steps:
+      ## Perform a lookup to check if the cache already exists
+      - name: Lock Threads
+        id: lock_threads
+        uses: stacks-network/actions/lock-threads@main
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          issue-inactive-days: 7
+          pr-inactive-days: 7
+          discussion-inactive-days: 7
+    

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -25,7 +25,6 @@ jobs:
     name: Lock Threads
     runs-on: ubuntu-latest
     steps:
-      ## Perform a lookup to check if the cache already exists
       - name: Lock Threads
         id: lock_threads
         uses: stacks-network/actions/lock-threads@main

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,5 +16,5 @@ libsigner/**/*.rs @stacks-network/blockchain-team-signer
 stacks-signer/**/*.rs @stacks-network/blockchain-team-signer
 
 # CI workflows
-./github/workflows/ @stacks-network/blockchain-team-ci
-./github/actions/ @stacks-network/blockchain-team-ci
+/.github/workflows/ @stacks-network/blockchain-team-ci
+/.github/actions/ @stacks-network/blockchain-team-ci


### PR DESCRIPTION
This is a reaction from recent events where spammers replied to closed issues and PR's (note: because of the way github works, you cannot delete PR comments after merge). 
In one case, they were able to get their userid added to the list of reviewers. 

To solve for this, an existing action https://github.com/dessant/lock-threads is used with some updated defaults and a hardcoded sha in our composite action repo: https://github.com/stacks-network/actions/tree/main/lock-threads

This PR simply adds a worflow the to stacks-core repo to lock all closed PR/issues/discussions after **7** days. 
This is adjustable however, and i think we would likely want to change so that items are locked:
prs: 1 day
issues: 1 day
discussions: 7 days

The workflow is designed to run manually and scheduled at 00:00 daily. 