### PR TITLE
fix: set the flag to make the type-checker store a map of types

### DIFF
--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -213,7 +213,7 @@ pub trait TransactionConnection: ClarityConnection {
                 cost_track,
                 epoch_id,
                 clarity_version,
-                false,
+                true,
             );
 
             match result {


### PR DESCRIPTION
Without this change, the types we need are not saved by the type-checker, which instead just uses a set to perform the checks it needs.