### PR TITLE
Add unblock log

### DIFF
--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -758,7 +758,7 @@ impl<
             match self.handle_new_nakamoto_burnchain_block() {
                 Ok(can_proceed) => {
                     if !can_proceed {
-                        error!("Missing canonical anchor block",);
+                        error!("Missing canonical anchor block");
                     }
                 }
                 Err(e) => {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -133,6 +133,7 @@ pub fn signal_mining_blocked(miner_status: Arc<Mutex<MinerStatus>>) {
 
 /// resume mining if we blocked it earlier
 pub fn signal_mining_ready(miner_status: Arc<Mutex<MinerStatus>>) {
+    debug!("Signaling miner to resume"; "thread_id" => ?std::thread::current().id());
     match miner_status.lock() {
         Ok(mut status) => {
             status.remove_blocked();


### PR DESCRIPTION
Add a debug log when unblocking the miner to match the log when blocking it. This is helpful when debugging.