### PR TITLE
test: add bitcoin reorg test to bitcoind/stacks-node/signers integrations

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -89,6 +89,7 @@ jobs:
           - tests::signer::v0::end_of_tenure
           - tests::signer::v0::forked_tenure_okay
           - tests::signer::v0::forked_tenure_invalid
+          - tests::signer::v0::bitcoind_forking_test
           - tests::nakamoto_integrations::stack_stx_burn_op_integration_test
           - tests::nakamoto_integrations::check_block_heights
           - tests::nakamoto_integrations::clarity_burn_state

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -46,10 +46,10 @@ use crate::nakamoto_node::miner::TEST_BROADCAST_STALL;
 use crate::nakamoto_node::relayer::TEST_SKIP_COMMIT_OP;
 use crate::tests::nakamoto_integrations::{boot_to_epoch_3_reward_set, next_block_and};
 use crate::tests::neon_integrations::{
-    get_chain_info, next_block_and_wait, submit_tx, test_observer,
+    get_account, get_chain_info, next_block_and_wait, submit_tx, test_observer,
 };
 use crate::tests::{self, make_stacks_transfer};
-use crate::{nakamoto_node, BurnchainController};
+use crate::{nakamoto_node, BurnchainController, Keychain};
 
 impl SignerTest<SpawnedSigner> {
     /// Run the test until the epoch 3 boundary
@@ -785,6 +785,155 @@ fn forked_tenure_testing(
         mined_c_2,
         mined_d,
     }
+}
+
+#[test]
+#[ignore]
+fn bitcoind_forking_test() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_addr = tests::to_addr(&sender_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender_addr.clone(), send_amt + send_fee)],
+        Some(Duration::from_secs(15)),
+        |_config| {},
+    );
+    let conf = signer_test.running_nodes.conf.clone();
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let miner_address = Keychain::default(conf.node.seed.clone())
+        .origin_address(conf.is_mainnet())
+        .unwrap();
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+    let pre_epoch_3_nonce = get_account(&http_origin, &miner_address).nonce;
+    let pre_fork_tenures = 10;
+
+    for _i in 0..pre_fork_tenures {
+        let _mined_block = signer_test.mine_nakamoto_block(Duration::from_secs(30));
+    }
+
+    let pre_fork_1_nonce = get_account(&http_origin, &miner_address).nonce;
+
+    assert_eq!(pre_fork_1_nonce, pre_epoch_3_nonce + 2 * pre_fork_tenures);
+
+    info!("------------------------- Triggering Bitcoin Fork -------------------------");
+
+    let burn_block_height = get_chain_info(&signer_test.running_nodes.conf).burn_block_height;
+    let burn_header_hash_to_fork = signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .get_block_hash(burn_block_height);
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .invalidate_block(&burn_header_hash_to_fork);
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .build_next_block(1);
+
+    info!("Wait for block off of shallow fork");
+    thread::sleep(Duration::from_secs(15));
+
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for _i in 0..3 {
+        let commits_count = signer_test
+            .running_nodes
+            .commits_submitted
+            .load(Ordering::SeqCst);
+        next_block_and(
+            &mut signer_test.running_nodes.btc_regtest_controller,
+            60,
+            || {
+                Ok(signer_test
+                    .running_nodes
+                    .commits_submitted
+                    .load(Ordering::SeqCst)
+                    > commits_count)
+            },
+        )
+        .unwrap();
+    }
+
+    let post_fork_1_nonce = get_account(&http_origin, &miner_address).nonce;
+
+    assert_eq!(post_fork_1_nonce, pre_fork_1_nonce - 1 * 2);
+
+    for _i in 0..5 {
+        signer_test.mine_nakamoto_block(Duration::from_secs(30));
+    }
+
+    let pre_fork_2_nonce = get_account(&http_origin, &miner_address).nonce;
+    assert_eq!(pre_fork_2_nonce, post_fork_1_nonce + 2 * 5);
+
+    info!(
+        "New chain info: {:?}",
+        get_chain_info(&signer_test.running_nodes.conf)
+    );
+
+    info!("------------------------- Triggering Deeper Bitcoin Fork -------------------------");
+
+    let burn_block_height = get_chain_info(&signer_test.running_nodes.conf).burn_block_height;
+    let burn_header_hash_to_fork = signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .get_block_hash(burn_block_height - 3);
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .invalidate_block(&burn_header_hash_to_fork);
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .build_next_block(4);
+
+    info!("Wait for block off of shallow fork");
+    thread::sleep(Duration::from_secs(15));
+
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for _i in 0..3 {
+        let commits_count = signer_test
+            .running_nodes
+            .commits_submitted
+            .load(Ordering::SeqCst);
+        next_block_and(
+            &mut signer_test.running_nodes.btc_regtest_controller,
+            60,
+            || {
+                Ok(signer_test
+                    .running_nodes
+                    .commits_submitted
+                    .load(Ordering::SeqCst)
+                    > commits_count)
+            },
+        )
+        .unwrap();
+    }
+
+    let post_fork_2_nonce = get_account(&http_origin, &miner_address).nonce;
+
+    assert_eq!(post_fork_2_nonce, pre_fork_2_nonce - 4 * 2);
+
+    for _i in 0..5 {
+        signer_test.mine_nakamoto_block(Duration::from_secs(30));
+    }
+
+    let test_end_nonce = get_account(&http_origin, &miner_address).nonce;
+    assert_eq!(test_end_nonce, post_fork_2_nonce + 2 * 5);
+
+    info!(
+        "New chain info: {:?}",
+        get_chain_info(&signer_test.running_nodes.conf)
+    );
+    signer_test.shutdown();
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a bitcoin reorg integration test to the nakamoto/signers integration test suite.

There's a couple of behaviors to note here:

1. During the reorg, the miner can't win a sortition, because of the Bitcoin MEV logic: after the reorg, the miner is marked as "not mining often enough", so has to issue some losing commits before they can win a commit.
2. During this time, the miner tries to submit a `TenureExtend`, but this is rejected by the signer set. The reason this happens is that (1) the bitcoin reorg creates a child of the common fork ancestor which has a successful sortition in it, (2) this new sortition is the "latest sortition" that the signer set sees, (3) the signer set doesn't allow the previous sortition (i.e., the parent of the latest sortition) to submit a `TenureExtend` because the latest sortition is valid and didn't do anything "wrong" yet, and (4), the miner doesn't submit a `BlockFound` tenure at this "latest sortition", because the nakamoto runloop (which behaves basically like the neon runloop) doesn't notify the relayer thread of sortitions until they've overtaken the old block height. This means that during the reorg, until a new sortition "wins", no nakamoto blocks are being mined.

Otherwise, the test asserts that the miner and signers recover from the reorg: blocks are mined after the reorg once the sortitions overcome behavior (1).

I think there's a valid question about whether or not something should be done to address (2). There's a couple options for how to address it. One is to update the runloop so that the relayer thread is notified of the reorging sortitions (or otherwise refactor the relayer thread to not depend on those notifications?), this would mean that the relayer thread should produce a new tenure at the new winning sortition, and then issue a tenure extend (to the latest block or to each block in the reorg?). I think this would require updating the miner thread's logic as well, because it would need to produce a block even though the bitcoin view has "changed". The second would be to update the signer set logic to mark the latest miner as "invalid" for some reason. The options for that heuristic I think are either (1) some amount of time passes before they receive a block proposal or (2) a subsequent bitcoin block has been mined before they produced a block. Of these heuristics, my initial suspicion is that (1) is easier and also perhaps better, because it also encourages miners to produce their first block proposal quickly, and that solving it from the signer set behavior is going to be simpler than updating the miner logic. At a higher level, though, its worth considering whether or not adding more logic to the signer/miner right now is worth it for this case. None of these changes would require consensus changes, so it may makes sense to try to opt for a simpler implementation for the first version of the nakamoto miner and signer binaries.