### PR TITLE
fix: make signer's warning log more accurate

### DIFF
--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -438,7 +438,7 @@ impl SortitionsView {
             Ok(true)
         } else {
             warn!(
-                "Miner block proposal's tenure change transaction does not confirm as many blocks as we expect in the parent tenure";
+                "Miner's block proposal does not confirm as many blocks as we expect";
                 "proposed_block_consensus_hash" => %block.header.consensus_hash,
                 "proposed_block_signer_sighash" => %block.header.signer_signature_hash(),
                 "proposed_chain_length" => block.header.chain_length,


### PR DESCRIPTION
This log can be hit in the case where a nakamoto block does not build off of the most recently signed nakamoto block, so the warning message should be less specific about the other case.