### PR TITLE
bug: feature gate canonical macros

### DIFF
--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -77,7 +77,7 @@ slog_json = ["slog-json"]
 testing = ["canonical"]
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64"), not(any(target_os="windows"))))'.dependencies]
-sha2 = { version = "0.10", features = ["asm"] }
+sha2 = { version = "0.10", default-features = false }
 
 [target.'cfg(any(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")), any(target_os="windows")))'.dependencies]
-sha2 = { version = "0.10" }
+sha2 = { version = "0.10", default-features = false }

--- a/stacks-common/src/deps_common/bitcoin/util/hash.rs
+++ b/stacks-common/src/deps_common/bitcoin/util/hash.rs
@@ -50,6 +50,7 @@ impl_array_newtype!(Ripemd160Hash, u8, 20);
 /// A Bitcoin hash160, 20-bytes, computed from x as RIPEMD160(SHA256(x))
 pub struct Hash160([u8; 20]);
 impl_array_newtype!(Hash160, u8, 20);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(Hash160);
 
 impl Hash160 {

--- a/stacks-common/src/types/sqlite.rs
+++ b/stacks-common/src/types/sqlite.rs
@@ -44,14 +44,25 @@ impl ToSql for Sha256dHash {
 
 // Implement rusqlite traits for a bunch of structs that used to be defined
 //  in the chainstate code
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(ConsensusHash);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(Hash160);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(BlockHeaderHash);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(VRFSeed);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(BurnchainHeaderHash);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(VRFProof);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(TrieHash);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(Sha512Trunc256Sum);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(MessageSignature);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(SortitionId);
+#[cfg(feature = "canonical")]
 impl_byte_array_rusqlite_only!(StacksBlockId);

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -110,6 +110,7 @@ pub struct LastCommit {
     /// the tenure consensus hash for the tip's tenure
     tenure_consensus_hash: ConsensusHash,
     /// the start-block hash of the tip's tenure
+    #[allow(dead_code)] // This is used when feature = "canonical" is set.
     start_block_hash: BlockHeaderHash,
     /// What is the epoch in which this was sent?
     epoch_id: StacksEpochId,


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

We use several crates in this repository in the https://github.com/stacks-network/sbtc/ repo, and would like to forgo pulling in as many unnecessary dependencies as possible. Fortunately, things here are setup already to accommodate this by allowing users to specify the `developer-mode` feature (setting `default-features = false` doesn't quite work).

This PR makes two changes:
1. Make sure that the `impl_byte_array_rusqlite_only!` macro isn't used whenever the `canonical` feature that defines is set.
2. Remove the `asm` feature from the sha2 crate. It didn't appear to be used anywhere.



Change (2) was made because it was causing us issues. This issue would only happen during `arm64` builds (and only with `cargo-lambda` extension) so is unlikely be an "actual" issue with in this repo. But I figure we should remove an unused dependency if possible. It's not clear to me whether it's actually unused or is sneakily used somewhere.


### Applicable issues


I haven't opened them yet, (1) seems like the only "bug". You can reproduce by pulling down the `clean-up-stacks-core-dependencies` branch in https://github.com/stacks-network/sbtc and running `cargo build`. I'll open an issue here sometime later.


### Additional info (benefits, drawbacks, caveats)

Found https://github.com/stacks-network/stacks-core/pull/4435, but didn't add much color as to why `sha2-asm` needs to be here.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
