### PR TITLE
refactor: use relative path for workspace dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,16 +12,10 @@ fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity
 #linker = "/usr/bin/clang"
 #rustflags = ["-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Wl,--no-rosegment"]
 
-# Uncomment the two patches below to use local versions of stacks-core and clarity-wasm
-# [patch.'https://github.com/stacks-network/stacks-core.git']
-# clarity = { path = "clarity" }
-# stacks-common = { path = "stacks-common" }
-# pox-locking = { path = "pox-locking" }
-# libstackerdb = { path = "libstackerdb" }
-# stx-genesis = { path = "stx-genesis"}
-# stacks = { package = "stackslib", path = "stackslib" }
-# libsigner = { path = "libsigner" }
-# stacks-signer = { path = "stacks-signer" }
+[patch."https://github.com/stacks-network/stacks-core.git"]
+clarity = { path = "./clarity" }
+stacks-common = { path = "./stacks-common" }
 
+# Uncomment the patch below to use the local version of clarity-wasm
 # [patch.'https://github.com/stacks-network/clarity-wasm.git']
 # clar2wasm = { path = "../clarity-wasm/clar2wasm" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,12 +751,12 @@ source = "git+https://github.com/stacks-network/clarity-wasm.git?branch=main#a25
 dependencies = [
  "chrono",
  "clap 4.5.10",
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "clarity",
  "lazy_static",
  "regex",
  "rusqlite",
  "sha2 0.10.8",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
  "walrus",
  "wasmtime",
  "wat",
@@ -784,32 +784,7 @@ dependencies = [
  "serde_stacker",
  "sha2-asm 0.5.5",
  "slog",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "wasmtime",
-]
-
-[[package]]
-name = "clarity"
-version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
-dependencies = [
- "getrandom 0.2.15",
- "hashbrown 0.14.5",
- "integer-sqrt",
- "lazy_static",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "regex",
- "rstest 0.17.0",
- "rstest_reuse 0.5.0",
- "rusqlite",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_stacker",
- "sha2-asm 0.5.5",
- "slog",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
  "wasmtime",
 ]
 
@@ -2348,11 +2323,11 @@ dependencies = [
 name = "libsigner"
 version = "0.0.1"
 dependencies = [
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "clarity",
  "hashbrown 0.14.5",
  "lazy_static",
  "libc",
- "libstackerdb 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "libstackerdb",
  "mutants",
  "prometheus",
  "rand 0.8.5",
@@ -2366,34 +2341,8 @@ dependencies = [
  "slog",
  "slog-json",
  "slog-term",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "stackslib 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "thiserror",
- "tiny_http",
- "wsts",
-]
-
-[[package]]
-name = "libsigner"
-version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
-dependencies = [
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "hashbrown 0.14.5",
- "lazy_static",
- "libc",
- "libstackerdb 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "prometheus",
- "secp256k1",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_stacker",
- "sha2 0.10.8",
- "slog",
- "slog-term",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "stackslib 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
+ "stackslib",
  "thiserror",
  "tiny_http",
  "wsts",
@@ -2414,27 +2363,13 @@ dependencies = [
 name = "libstackerdb"
 version = "0.0.1"
 dependencies = [
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "clarity",
  "secp256k1",
  "serde",
  "serde_derive",
  "serde_stacker",
  "sha2 0.10.8",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
-]
-
-[[package]]
-name = "libstackerdb"
-version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
-dependencies = [
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "secp256k1",
- "serde",
- "serde_derive",
- "serde_stacker",
- "sha2 0.10.8",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
 ]
 
 [[package]]
@@ -2972,20 +2907,10 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 name = "pox-locking"
 version = "2.4.0"
 dependencies = [
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "clarity",
  "mutants",
  "slog",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
-]
-
-[[package]]
-name = "pox-locking"
-version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
-dependencies = [
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "slog",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
 ]
 
 [[package]]
@@ -4033,38 +3958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stacks-common"
-version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
-dependencies = [
- "chrono",
- "curve25519-dalek 2.0.0",
- "ed25519-dalek",
- "getrandom 0.2.15",
- "hashbrown 0.14.5",
- "lazy_static",
- "libc",
- "libsecp256k1",
- "nix",
- "percent-encoding",
- "rand 0.8.5",
- "ripemd",
- "rusqlite",
- "secp256k1",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "sha3",
- "slog",
- "slog-json",
- "slog-term",
- "time 0.3.36",
- "winapi 0.3.9",
- "wsts",
-]
-
-[[package]]
 name = "stacks-node"
 version = "0.1.0"
 dependencies = [
@@ -4073,12 +3966,12 @@ dependencies = [
  "backtrace",
  "base64 0.12.3",
  "chrono",
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "clarity",
  "hashbrown 0.14.5",
  "http-types",
  "lazy_static",
  "libc",
- "libsigner 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "libsigner",
  "mutants",
  "pico-args",
  "rand 0.8.5",
@@ -4092,10 +3985,10 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "slog",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "stacks-signer 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "stackslib 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "stx-genesis 0.1.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
+ "stacks-signer",
+ "stackslib",
+ "stx-genesis",
  "tikv-jemallocator",
  "tokio",
  "toml 0.5.11",
@@ -4111,11 +4004,11 @@ version = "0.0.1"
 dependencies = [
  "backoff",
  "clap 4.5.10",
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "clarity",
  "hashbrown 0.14.5",
  "lazy_static",
- "libsigner 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "libstackerdb 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "libsigner",
+ "libstackerdb",
  "num-traits",
  "polynomial",
  "prometheus",
@@ -4132,43 +4025,8 @@ dependencies = [
  "slog",
  "slog-json",
  "slog-term",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "stackslib 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "thiserror",
- "tiny_http",
- "toml 0.5.11",
- "tracing",
- "tracing-subscriber",
- "url",
- "wsts",
-]
-
-[[package]]
-name = "stacks-signer"
-version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
-dependencies = [
- "backoff",
- "clap 4.5.10",
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "hashbrown 0.14.5",
- "lazy_static",
- "libsigner 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "libstackerdb 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "prometheus",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "reqwest",
- "rusqlite",
- "secp256k1",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_stacker",
- "slog",
- "slog-term",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "stackslib 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
+ "stackslib",
  "thiserror",
  "tiny_http",
  "toml 0.5.11",
@@ -4185,7 +4043,7 @@ dependencies = [
  "assert-json-diff",
  "chrono",
  "clar2wasm",
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "clarity",
  "criterion",
  "curve25519-dalek 2.0.0",
  "ed25519-dalek",
@@ -4193,12 +4051,12 @@ dependencies = [
  "integer-sqrt",
  "lazy_static",
  "libc",
- "libstackerdb 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "libstackerdb",
  "mio 0.6.23",
  "mutants",
  "nix",
  "percent-encoding",
- "pox-locking 2.4.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "pox-locking",
  "prometheus",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4218,53 +4076,9 @@ dependencies = [
  "slog",
  "slog-json",
  "slog-term",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stacks-common",
  "stdext",
- "stx-genesis 0.1.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "tikv-jemallocator",
- "time 0.3.36",
- "url",
- "winapi 0.3.9",
- "wsts",
-]
-
-[[package]]
-name = "stackslib"
-version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
-dependencies = [
- "chrono",
- "clar2wasm",
- "clarity 2.3.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "curve25519-dalek 2.0.0",
- "ed25519-dalek",
- "hashbrown 0.14.5",
- "integer-sqrt",
- "lazy_static",
- "libc",
- "libstackerdb 0.0.1 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "mio 0.6.23",
- "nix",
- "percent-encoding",
- "pox-locking 2.4.0 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
- "prometheus",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "regex",
- "ripemd",
- "rusqlite",
- "secp256k1",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "sha3",
- "siphasher",
- "slog",
- "slog-json",
- "slog-term",
- "stacks-common 0.0.2 (git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop)",
+ "stx-genesis",
  "tikv-jemallocator",
  "time 0.3.36",
  "url",
@@ -4351,15 +4165,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "stx-genesis"
 version = "0.1.0"
-dependencies = [
- "libflate",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "stx-genesis"
-version = "0.1.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-develop#630c339dce8b3bafcc555f6f63ca41f68c092d2d"
 dependencies = [
  "libflate",
  "sha2 0.10.8",

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -29,7 +29,7 @@ regex = "1.9.3"
 lazy_static = "1.4.0"
 integer-sqrt = "0.1.3"
 slog = { version = "2.5.2", features = [ "max_level_trace" ], optional = true }
-stacks_common = { package = "stacks-common", git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", optional = true, default-features = false }
+stacks-common = { path= "../stacks-common", optional = true, default-features = false }
 rstest = { version = "0.17.0", optional = true }
 rstest_reuse = { version = "0.5.0", optional = true }
 wasmtime = { version = "15.0.0", optional = true }
@@ -57,12 +57,12 @@ mutants = "0.0.3"
 
 [features]
 default = ["canonical", "log", "clarity-wasm"]
-canonical = ["rusqlite", "stacks_common/canonical", "serde_stacker"]
+canonical = ["rusqlite", "stacks-common/canonical", "serde_stacker"]
 clarity-wasm = ["wasmtime"]
-log = ["slog", "stacks_common/log"]
-wasm = ["stacks_common/wasm", "developer-mode", "log", "getrandom"]
-developer-mode = ["stacks_common/developer-mode"]
-slog_json = ["stacks_common/slog_json"]
+log = ["slog", "stacks-common/log"]
+wasm = ["stacks-common/wasm", "developer-mode", "log", "getrandom"]
+developer-mode = ["stacks-common/developer-mode"]
+slog_json = ["stacks-common/slog_json"]
 testing = ["canonical", "rstest", "rstest_reuse"]
 devtools = []
 

--- a/libsigner/Cargo.toml
+++ b/libsigner/Cargo.toml
@@ -16,11 +16,11 @@ name = "libsigner"
 path = "./src/libsigner.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+clarity = { path = "../clarity"  }
 hashbrown = { workspace = true }
 lazy_static = "1.4.0"
 libc = "0.2"
-libstackerdb = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+libstackerdb = { path = "../libstackerdb"  }
 prometheus = { version = "0.9", optional = true }
 serde = "1"
 serde_derive = "1"
@@ -28,8 +28,8 @@ serde_stacker = "0.1"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 slog-term = "2.6.0"
 slog-json = { version = "2.3.0", optional = true }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+stacks-common = { path = "../stacks-common"  }
+stackslib = { path = "../stackslib"  }
 thiserror = "1.0"
 tiny_http = "0.12"
 wsts = { workspace = true }

--- a/libstackerdb/Cargo.toml
+++ b/libstackerdb/Cargo.toml
@@ -19,8 +19,8 @@ path = "./src/libstackerdb.rs"
 serde = "1"
 serde_derive = "1"
 serde_stacker = "0.1"
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+stacks-common = { path = "../stacks-common" }
+clarity = { path = "../clarity" }
 
 [dependencies.secp256k1]
 version = "0.24.3"

--- a/pox-locking/Cargo.toml
+++ b/pox-locking/Cargo.toml
@@ -19,14 +19,14 @@ name = "pox_locking"
 path = "src/lib.rs"
 
 [dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", default-features = false, optional = true }
-stacks_common = { package = "stacks-common", git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", default-features = false, optional = true  }
+clarity = { path = "../clarity", default-features = false, optional = true }
+stacks-common = { path = "../stacks-common", default-features = false, optional = true  }
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 
 [dev-dependencies]
 mutants = "0.0.3"
 
 [features]
-default = ["stacks_common/default", "clarity/default"]
-slog_json = ["stacks_common/slog_json", "clarity/slog_json"]
-wasm = ["stacks_common/wasm", "clarity/wasm"]
+default = ["stacks-common/default", "clarity/default"]
+slog_json = ["stacks-common/slog_json", "clarity/slog_json"]
+wasm = ["stacks-common/wasm", "clarity/wasm"]

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/main.rs"
 
 [dependencies]
 backoff = "0.4"
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+clarity = { path = "../clarity" }
 clap = { version = "4.1.1", features = ["derive", "env"] }
 hashbrown = { workspace = true }
-libsigner = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-libstackerdb = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+libsigner = { path = "../libsigner" }
+libstackerdb = { path = "../libstackerdb" }
 lazy_static = "1.4.0"
 prometheus = { version = "0.9", optional = true }
 rand_core = "0.6"
@@ -36,8 +36,8 @@ serde_stacker = "0.1"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 slog-json = { version = "2.3.0", optional = true }
 slog-term = "2.6.0"
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+stacks-common = { path = "../stacks-common" }
+stackslib = { path = "../stackslib" }
 thiserror = "1.0"
 tiny_http = { version = "0.12", optional = true }
 toml = "0.5.6"
@@ -48,7 +48,7 @@ rand = { workspace = true }
 url = "2.1.0"
 
 [dev-dependencies]
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", features = ["testing"] }
+clarity = { path = "../clarity", features = ["testing"] }
 serial_test = "3.0.0"
 polynomial = "0.2.6"
 num-traits = "0.2.18"

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -50,10 +50,10 @@ slog-term = "2.6.0"
 slog-json = { version = "2.3.0", optional = true }
 chrono = "0.4.19"
 libc = "0.2.82"
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-libstackerdb = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+clarity = { path = "../clarity" }
+stacks-common = { path = "../stacks-common" }
+pox-locking = { path = "../pox-locking" }
+libstackerdb = { path = "../libstackerdb" }
 siphasher = "0.3.7"
 wsts = { workspace = true }
 hashbrown = { workspace = true }
@@ -98,9 +98,9 @@ features = ["std"]
 assert-json-diff = "1.0.0"
 criterion = "0.3.5"
 stdext = "0.3.1"
-stx-genesis = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-clarity = { features = ["default", "testing"], git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-stacks-common = { features = ["default", "testing"], git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+stx-genesis = { path = "../stx-genesis" }
+clarity = { path = "../clarity", features = ["default", "testing"] }
+stacks-common = { path = "../stacks-common", features = ["default", "testing"] }
 rstest = "0.17.0"
 rstest_reuse = "0.5.0"
 mutants = "0.0.3"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -12,8 +12,8 @@ pico-args = "0.5.0"
 serde = "1"
 serde_derive = "1"
 serde_json = { version = "1.0", features = ["arbitrary_precision", "raw_value"] }
-stacks = { package = "stackslib", git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-stx-genesis = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+stacks = { path = "../../stackslib", package = "stackslib" }
+stx-genesis = { path = "../../stx-genesis" }
 toml = "0.5.6"
 async-h1 = "2.3.2"
 async-std = { version = "1.6", features = ["attributes"] }
@@ -22,11 +22,11 @@ base64 = "0.12.0"
 backtrace = "0.3.50"
 libc = "0.2.151"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+clarity = { path = "../../clarity" }
+stacks-common = { path = "../../stacks-common" }
 chrono = "0.4.19"
 regex = "1"
-libsigner = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+libsigner = { path = "../../libsigner" }
 wsts = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
@@ -40,10 +40,10 @@ ring = "0.16.19"
 warp = "0.3.5"
 tokio = "1.15"
 reqwest = { version = "0.11", default_features = false, features = ["blocking", "json", "rustls", "rustls-tls"] }
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", features = ["default", "testing"] }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", features = ["default", "testing"] }
-stacks = { package = "stackslib", git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", features = ["default", "testing"] }
-stacks-signer = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop" }
+clarity = { path = "../../clarity", features = ["default", "testing"] }
+stacks-common = { path = "../../stacks-common", features = ["default", "testing"] }
+stacks = { path = "../../stackslib", package = "stackslib", features = ["default", "testing"] }
+stacks-signer = { path = "../../stacks-signer" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = {workspace = true}


### PR DESCRIPTION
_PR targeting `feat/clarity-wasm-develop` which is the WIP branch used in `clarity-wasm`._

Switch back the workspace internal dependencies to local path.

Since `clarity-wasm` depends on `clarity` and `stacks-common` from github.com, these dependencies are patched to always target relative versions.

Making our lives way easier