### PR TITLE
Clarity-Wasm: fixes for `contract-call?`

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1613,7 +1613,10 @@ fn pass_argument_to_wasm(
             Ok((buffer, offset + written, in_mem_offset + in_mem_written))
         }
         Value::Principal(PrincipalData::Standard(StandardPrincipalData(v, h))) => {
-            let bytes: Vec<u8> = std::iter::once(v).chain(h.iter()).copied().collect();
+            let mut bytes: Vec<u8> = Vec::with_capacity(22);
+            bytes.push(*v);
+            bytes.extend(h);
+            bytes.push(0);
             let buffer = vec![Val::I32(in_mem_offset), Val::I32(bytes.len() as i32)];
             memory
                 .write(&mut store, in_mem_offset as usize, &bytes)

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -533,7 +533,7 @@ pub fn call_function<'a, 'b, 'c>(
     // Determine how much space is needed for arguments
     let mut arg_size = 0;
     for arg in func_types.get_arg_types() {
-        arg_size += get_type_size(arg);
+        arg_size += get_type_in_memory_size(arg, false);
     }
     let mut in_mem_offset = offset + arg_size;
 


### PR DESCRIPTION
Those are fixes for the `contract-call?` function.

They come from the new property tests for this function that will be in the clarity-wasm repo soon.