### PR TITLE
Chore/move signer logs to info

### DIFF
--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -365,7 +365,7 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
                 self.refresh_signer_config(next_reward_cycle);
             }
         } else {
-            debug!("Received a new burnchain block height ({current_burn_block_height}) but not in prepare phase.";
+            info!("Received a new burnchain block height ({current_burn_block_height}) but not in prepare phase.";
                 "reward_cycle" => reward_cycle_info.reward_cycle,
                 "reward_cycle_length" => reward_cycle_info.reward_cycle_length,
                 "prepare_phase_block_length" => reward_cycle_info.prepare_phase_block_length,

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -153,7 +153,7 @@ impl SignerTrait<SignerMessage> for Signer {
                 burn_header_hash,
                 received_time,
             } => {
-                debug!("{self}: Receved a new burn block event for block height {burn_height}");
+                info!("{self}: Receved a new burn block event for block height {burn_height}");
                 if let Err(e) =
                     self.signer_db
                         .insert_burn_block(burn_header_hash, *burn_height, received_time)
@@ -251,7 +251,7 @@ impl Signer {
         block_proposal: &BlockProposal,
         miner_pubkey: &Secp256k1PublicKey,
     ) {
-        debug!("{self}: Received a block proposal: {block_proposal:?}");
+        info!("{self}: Received a block proposal: {block_proposal:?}");
         if block_proposal.reward_cycle != self.reward_cycle {
             // We are not signing for this reward cycle. Ignore the block.
             debug!(
@@ -388,7 +388,7 @@ impl Signer {
 
     /// Handle the block validate response returned from our prior calls to submit a block for validation
     fn handle_block_validate_response(&mut self, block_validate_response: &BlockValidateResponse) {
-        debug!("{self}: Received a block validate response: {block_validate_response:?}");
+        info!("{self}: Received a block validate response: {block_validate_response:?}");
         let (response, block_info) = match block_validate_response {
             BlockValidateResponse::Ok(block_validate_ok) => {
                 crate::monitoring::increment_block_validation_responses(true);

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -251,7 +251,7 @@ impl Signer {
         block_proposal: &BlockProposal,
         miner_pubkey: &Secp256k1PublicKey,
     ) {
-        debug!("{self}: Received a block proposal: {block_proposal:?}");
+        info!("{self}: Received a block proposal: {block_proposal:?}");
         if block_proposal.reward_cycle != self.reward_cycle {
             // We are not signing for this reward cycle. Ignore the block.
             debug!(
@@ -287,7 +287,7 @@ impl Signer {
             return;
         }
 
-        debug!(
+        info!(
             "{self}: received a block proposal for a new block. Submit block for validation. ";
             "signer_sighash" => %signer_signature_hash,
             "block_id" => %block_proposal.block.block_id(),
@@ -388,7 +388,7 @@ impl Signer {
 
     /// Handle the block validate response returned from our prior calls to submit a block for validation
     fn handle_block_validate_response(&mut self, block_validate_response: &BlockValidateResponse) {
-        debug!("{self}: Received a block validate response: {block_validate_response:?}");
+        info!("{self}: Received a block validate response: {block_validate_response:?}");
         let (response, block_info) = match block_validate_response {
             BlockValidateResponse::Ok(block_validate_ok) => {
                 crate::monitoring::increment_block_validation_responses(true);

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -251,7 +251,7 @@ impl Signer {
         block_proposal: &BlockProposal,
         miner_pubkey: &Secp256k1PublicKey,
     ) {
-        info!("{self}: Received a block proposal: {block_proposal:?}");
+        debug!("{self}: Received a block proposal: {block_proposal:?}");
         if block_proposal.reward_cycle != self.reward_cycle {
             // We are not signing for this reward cycle. Ignore the block.
             debug!(

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -153,7 +153,7 @@ impl SignerTrait<SignerMessage> for Signer {
                 burn_header_hash,
                 received_time,
             } => {
-                info!("{self}: Receved a new burn block event for block height {burn_height}");
+                info!("{self}: Received a new burn block event for block height {burn_height}");
                 if let Err(e) =
                     self.signer_db
                         .insert_burn_block(burn_header_hash, *burn_height, received_time)
@@ -251,7 +251,7 @@ impl Signer {
         block_proposal: &BlockProposal,
         miner_pubkey: &Secp256k1PublicKey,
     ) {
-        info!("{self}: Received a block proposal: {block_proposal:?}");
+        debug!("{self}: Received a block proposal: {block_proposal:?}");
         if block_proposal.reward_cycle != self.reward_cycle {
             // We are not signing for this reward cycle. Ignore the block.
             debug!(
@@ -388,7 +388,7 @@ impl Signer {
 
     /// Handle the block validate response returned from our prior calls to submit a block for validation
     fn handle_block_validate_response(&mut self, block_validate_response: &BlockValidateResponse) {
-        info!("{self}: Received a block validate response: {block_validate_response:?}");
+        debug!("{self}: Received a block validate response: {block_validate_response:?}");
         let (response, block_info) = match block_validate_response {
             BlockValidateResponse::Ok(block_validate_ok) => {
                 crate::monitoring::increment_block_validation_responses(true);

--- a/stacks-signer/src/v1/signer.rs
+++ b/stacks-signer/src/v1/signer.rs
@@ -201,7 +201,7 @@ impl SignerTrait<SignerMessage> for Signer {
         };
         match event {
             SignerEvent::BlockValidationResponse(block_validate_response) => {
-                debug!("{self}: Received a block proposal result from the stacks node...");
+                info!("{self}: Received a block proposal result from the stacks node...");
                 self.handle_block_validate_response(
                     stacks_client,
                     block_validate_response,
@@ -244,7 +244,7 @@ impl SignerTrait<SignerMessage> for Signer {
                 burn_header_hash,
                 received_time,
             } => {
-                debug!("{self}: Receved a new burn block event for block height {burn_height}");
+                info!("{self}: Received a new burn block event for block height {burn_height}");
                 if let Err(e) =
                     self.signer_db
                         .insert_burn_block(burn_header_hash, *burn_height, received_time)
@@ -703,7 +703,7 @@ impl Signer {
             };
             self.handle_packets(stacks_client, res, &[packet], current_reward_cycle);
         }
-        debug!(
+        info!(
             "{self}: Received a block validate response";
             "block_hash" => block_info.block.header.block_hash(),
             "valid" => block_info.valid,

--- a/stacks-signer/src/v1/signer.rs
+++ b/stacks-signer/src/v1/signer.rs
@@ -201,7 +201,7 @@ impl SignerTrait<SignerMessage> for Signer {
         };
         match event {
             SignerEvent::BlockValidationResponse(block_validate_response) => {
-                debug!("{self}: Received a block proposal result from the stacks node...");
+                info!("{self}: Received a block proposal result from the stacks node...");
                 self.handle_block_validate_response(
                     stacks_client,
                     block_validate_response,
@@ -703,7 +703,7 @@ impl Signer {
             };
             self.handle_packets(stacks_client, res, &[packet], current_reward_cycle);
         }
-        debug!(
+        info!(
             "{self}: Received a block validate response";
             "block_hash" => block_info.block.header.block_hash(),
             "valid" => block_info.valid,
@@ -1130,7 +1130,7 @@ impl Signer {
             match operation_result {
                 OperationResult::Sign(signature) => {
                     crate::monitoring::increment_operation_results("sign");
-                    debug!("{self}: Received signature result");
+                    info!("{self}: Received signature result");
                     self.process_signature(signature);
                 }
                 OperationResult::SignTaproot(_) => {

--- a/stacks-signer/src/v1/signer.rs
+++ b/stacks-signer/src/v1/signer.rs
@@ -201,7 +201,7 @@ impl SignerTrait<SignerMessage> for Signer {
         };
         match event {
             SignerEvent::BlockValidationResponse(block_validate_response) => {
-                info!("{self}: Received a block proposal result from the stacks node...");
+                debug!("{self}: Received a block proposal result from the stacks node...");
                 self.handle_block_validate_response(
                     stacks_client,
                     block_validate_response,
@@ -703,7 +703,7 @@ impl Signer {
             };
             self.handle_packets(stacks_client, res, &[packet], current_reward_cycle);
         }
-        info!(
+        debug!(
             "{self}: Received a block validate response";
             "block_hash" => block_info.block.header.block_hash(),
             "valid" => block_info.valid,


### PR DESCRIPTION
### Description
Moves from `debug` to `info` some of the most relevant logs in order to be displayed on signers with the default logs level. If switched to `debug` they would have to many logs and have to know how to read through them. 

### Applicable issues

- fixes #5001 

### Checklist

- [x] receive block proposal - is for stacks blocks
- [x] <strike>validate block proposal - is for stacks blocks </strike> 
 [already implemented](https://github.com/stacks-network/stacks-core/blob/861bff076b051e0338b37dacbe0a17cd1b90b3b3/stacks-signer/src/v1/signer.rs#L657)
- [x] <strike>send signature </strike> - [already implemented](https://github.com/stacks-network/stacks-core/blob/861bff076b051e0338b37dacbe0a17cd1b90b3b3/stacks-signer/src/v1/signer.rs#L1331)
- [x] receive burn block