### PR TITLE
Oneliner to set signer version at compile time with STACKS_NODE_VERSION

### DIFF
--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -25,7 +25,6 @@ clarity = { path = "../clarity" }
 clap = { version = "4.1.1", features = ["derive", "env"] }
 hashbrown = { workspace = true }
 lazy_static = "1.4.0"
-once_cell = "1.8.0"
 libsigner = { path = "../libsigner" }
 libstackerdb = { path = "../libstackerdb" }
 prometheus = { version = "0.9", optional = true }

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -25,6 +25,7 @@ clarity = { path = "../clarity" }
 clap = { version = "4.1.1", features = ["derive", "env"] }
 hashbrown = { workspace = true }
 lazy_static = "1.4.0"
+once_cell = "1.8.0"
 libsigner = { path = "../libsigner" }
 libstackerdb = { path = "../libstackerdb" }
 prometheus = { version = "0.9", optional = true }

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -42,6 +42,8 @@ extern crate alloc;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
+#[command(long_version = option_env!("SIGNER_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
+
 /// The CLI arguments for the stacks signer
 pub struct Cli {
     /// Subcommand action to take

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -29,7 +29,7 @@ use clarity::util::hash::Sha256Sum;
 use clarity::util::secp256k1::MessageSignature;
 use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
 use clarity::vm::Value;
-use once_cell::sync::Lazy;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use stacks_common::address::{
     b58, AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG,
@@ -48,20 +48,22 @@ const BUILD_TYPE: &'static str = "debug";
 #[cfg(not(debug_assertions))]
 const BUILD_TYPE: &'static str = "release";
 
-static VERSION_STRING: Lazy<String> = Lazy::new(|| {
-    let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-    let git_branch = GIT_BRANCH.unwrap_or("");
-    let git_commit = GIT_COMMIT.unwrap_or("");
-    format!(
-        "{} ({}:{}, {} build, {} [{}])",
-        pkg_version,
-        git_branch,
-        git_commit,
-        BUILD_TYPE,
-        std::env::consts::OS,
-        std::env::consts::ARCH
-    )
-});
+lazy_static! {
+    static ref VERSION_STRING: String = {
+        let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        let git_branch = GIT_BRANCH.unwrap_or("");
+        let git_commit = GIT_COMMIT.unwrap_or("");
+        format!(
+            "{} ({}:{}, {} build, {} [{}])",
+            pkg_version,
+            git_branch,
+            git_commit,
+            BUILD_TYPE,
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    };
+}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -29,6 +29,7 @@ use clarity::util::hash::Sha256Sum;
 use clarity::util::secp256k1::MessageSignature;
 use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
 use clarity::vm::Value;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use stacks_common::address::{
     b58, AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG,
@@ -37,7 +38,6 @@ use stacks_common::address::{
 };
 use stacks_common::define_u8_enum;
 use stacks_common::types::chainstate::StacksPrivateKey;
-use once_cell::sync::Lazy;
 
 extern crate alloc;
 
@@ -48,11 +48,10 @@ const BUILD_TYPE: &'static str = "debug";
 #[cfg(not(debug_assertions))]
 const BUILD_TYPE: &'static str = "release";
 
-
 static VERSION_STRING: Lazy<String> = Lazy::new(|| {
     let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
     let git_branch = GIT_BRANCH.unwrap_or("");
-    let git_commit = GIT_COMMIT.unwrap_or(""); 
+    let git_commit = GIT_COMMIT.unwrap_or("");
     format!(
         "{} ({}:{}, {} build, {} [{}])",
         pkg_version,

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -37,12 +37,36 @@ use stacks_common::address::{
 };
 use stacks_common::define_u8_enum;
 use stacks_common::types::chainstate::StacksPrivateKey;
+use once_cell::sync::Lazy;
 
 extern crate alloc;
 
+const GIT_BRANCH: Option<&'static str> = option_env!("GIT_BRANCH");
+const GIT_COMMIT: Option<&'static str> = option_env!("GIT_COMMIT");
+#[cfg(debug_assertions)]
+const BUILD_TYPE: &'static str = "debug";
+#[cfg(not(debug_assertions))]
+const BUILD_TYPE: &'static str = "release";
+
+
+static VERSION_STRING: Lazy<String> = Lazy::new(|| {
+    let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    let git_branch = GIT_BRANCH.unwrap_or("");
+    let git_commit = GIT_COMMIT.unwrap_or(""); 
+    format!(
+        "{} ({}:{}, {} build, {} [{}])",
+        pkg_version,
+        git_branch,
+        git_commit,
+        BUILD_TYPE,
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    )
+});
+
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
-#[command(long_version = option_env!("SIGNER_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
+#[command(long_version = VERSION_STRING.as_str())]
 
 /// The CLI arguments for the stacks signer
 pub struct Cli {


### PR DESCRIPTION
ref #5002 

This is the minimally viable change to allow setting the signer version at build time, defaulting to `CARGO_PKG_VERSION`. 
Since the signer already uses the same build process as stacks-core, the correct version will already be set as `STACKS_NODE_VERSION`, so that is why that env var is used here vs something more suited like `SIGNER_VERSION`. 
using `SIGNER_VERSION` would simply require some downstream changes (mainly to CI workflows), but is trivial if that env var is desired. 

I did set out to try and expose a version string like `/v2/info`, but due to how Clap was expecting a str, i wasn't able to get all the desired values returned correctly. 

```bash
~/stacks-core$ cargo run --bin stacks-signer -- --version
warning: /home/wileyj/stacks-core/testnet/stacks-node/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `reqwest` dependency)
   Compiling stacks-signer v0.0.1 (/home/wileyj/stacks-core/stacks-signer)
    Finished `dev` profile [optimized + debuginfo] target(s) in 5.22s
     Running `target/debug/stacks-signer --version`
stacks-signer 0.0.1

~/stacks-core$ STACKS_NODE_VERSION=2.5.0.0.5.1 cargo run --bin stacks-signer -- --version
warning: /home/wileyj/stacks-core/testnet/stacks-node/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `reqwest` dependency)
   Compiling stackslib v0.0.1 (/home/wileyj/stacks-core/stackslib)
   Compiling libsigner v0.0.1 (/home/wileyj/stacks-core/libsigner)
   Compiling stacks-signer v0.0.1 (/home/wileyj/stacks-core/stacks-signer)
    Finished `dev` profile [optimized + debuginfo] target(s) in 11.66s
     Running `target/debug/stacks-signer --version`
stacks-signer 2.5.0.0.5.1
```


this is what i tried to emulate `/v2/info` with, but wasn't able to figure out how to return the full output as a str:
```
const GIT_BRANCH: Option<&'static str> = option_env!("GIT_BRANCH");
const GIT_COMMIT: Option<&'static str> = option_env!("GIT_COMMIT");
#[cfg(debug_assertions)]
const BUILD_TYPE: &'static str = "debug";
#[cfg(not(debug_assertions))]
const BUILD_TYPE: &'static str = "release";
fn version_string<'life>() -> &'life str {
    let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
    let git_branch = GIT_BRANCH.unwrap_or("");
    let git_commit = GIT_COMMIT.unwrap_or("");
    let formatted = format!(
        "{} ({}:{}, {} build, {} [{}])",
        pkg_version,
        git_branch,
        git_commit,
        BUILD_TYPE,
        std::env::consts::OS,
        std::env::consts::ARCH
    );
    println!("formatted= {}", formatted);
    return formatted;
}
```
`formatted` prints the expected output: 
```
formatted= 2.5.0.0.5.1 (release/signer-2.5.0.0.1:56eec5912, debug build, linux [x86_64])
```
but [Clap](https://docs.rs/clap/latest/clap/struct.Command.html#method.long_version) is expecting it to be a str. 