### PR TITLE
Test: multiple miner nakamoto_integration test

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -97,6 +97,7 @@ jobs:
           - tests::nakamoto_integrations::check_block_info
           - tests::nakamoto_integrations::check_block_info_rewards
           - tests::nakamoto_integrations::continue_tenure_extend
+          - tests::nakamoto_integrations::multiple_miners
           # Do not run this one until we figure out why it fails in CI
           # - tests::neon_integrations::bitcoin_reorg_flap
           # - tests::neon_integrations::bitcoin_reorg_flap_with_follower

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -4104,7 +4104,7 @@ impl NakamotoChainState {
         Ok(StackerDBConfig {
             chunk_size: MAX_PAYLOAD_LEN.into(),
             signers,
-            write_freq: 5,
+            write_freq: 0,
             max_writes: u32::MAX,  // no limit on number of writes
             max_neighbors: 200, // TODO: const -- just has to be equal to or greater than the number of signers
             hint_replicas: vec![], // TODO: is there a way to get the IP addresses of stackers' preferred nodes?

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -455,6 +455,8 @@ impl MaturedMinerPaymentSchedules {
     }
 }
 
+/// Struct containing information about the miners assigned in the
+/// .miners stackerdb config
 pub struct MinersDBInformation {
     signer_0_sortition: ConsensusHash,
     signer_1_sortition: ConsensusHash,
@@ -462,6 +464,8 @@ pub struct MinersDBInformation {
 }
 
 impl MinersDBInformation {
+    /// What index in the `.miners` stackerdb is the miner who won
+    /// `sortition`?
     pub fn get_signer_index(&self, sortition: &ConsensusHash) -> Option<u16> {
         if sortition == &self.signer_0_sortition {
             Some(0)
@@ -472,6 +476,12 @@ impl MinersDBInformation {
         }
     }
 
+    /// Get all of the sortitions whose winners are included in .miners
+    pub fn get_sortitions(&self) -> [&ConsensusHash; 2] {
+        [&self.signer_0_sortition, &self.signer_1_sortition]
+    }
+
+    /// Get the index of the latest sortition winner in .miners
     pub fn get_latest_winner_index(&self) -> u16 {
         self.latest_winner
     }
@@ -4160,14 +4170,18 @@ impl NakamotoChainState {
             .map(usize::from)
         else {
             warn!("Miner is not in the miners StackerDB config";
-                  "stackerdb_slots" => format!("{:?}", &stackerdb_config.signers));
+                  "stackerdb_slots" => ?stackerdb_config.signers,
+                  "queried_sortition" => %election_sortition,
+                  "sortition_hashes" => ?miners_info.get_sortitions());
             return Ok(None);
         };
         let mut signer_ranges = stackerdb_config.signer_ranges();
         if signer_ix >= signer_ranges.len() {
             // should be unreachable, but always good to be careful
             warn!("Miner is not in the miners StackerDB config";
-                  "stackerdb_slots" => format!("{:?}", &stackerdb_config.signers));
+                  "stackerdb_slots" => ?stackerdb_config.signers,
+                  "queried_sortition" => %election_sortition,
+                  "sortition_hashes" => ?miners_info.get_sortitions());
 
             return Ok(None);
         }

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -455,6 +455,28 @@ impl MaturedMinerPaymentSchedules {
     }
 }
 
+pub struct MinersDBInformation {
+    signer_0_sortition: ConsensusHash,
+    signer_1_sortition: ConsensusHash,
+    latest_winner: u16,
+}
+
+impl MinersDBInformation {
+    pub fn get_signer_index(&self, sortition: &ConsensusHash) -> Option<u16> {
+        if sortition == &self.signer_0_sortition {
+            Some(0)
+        } else if sortition == &self.signer_1_sortition {
+            Some(1)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_latest_winner_index(&self) -> u16 {
+        self.latest_winner
+    }
+}
+
 /// Calculated matured miner rewards, from scheduled rewards
 #[derive(Debug, Clone)]
 pub struct MaturedMinerRewards {
@@ -4039,7 +4061,7 @@ impl NakamotoChainState {
     pub fn make_miners_stackerdb_config(
         sortdb: &SortitionDB,
         tip: &BlockSnapshot,
-    ) -> Result<StackerDBConfig, ChainstateError> {
+    ) -> Result<(StackerDBConfig, MinersDBInformation), ChainstateError> {
         let ih = sortdb.index_handle(&tip.sortition_id);
         let last_winner_snapshot = ih.get_last_snapshot_with_sortition(tip.block_height)?;
         let parent_winner_snapshot = ih.get_last_snapshot_with_sortition(
@@ -4051,13 +4073,13 @@ impl NakamotoChainState {
         // go get their corresponding leader keys, but preserve the miner's relative position in
         // the stackerdb signer list -- if a miner was in slot 0, then it should stay in slot 0
         // after a sortition (and vice versa for 1)
-        let sns = if last_winner_snapshot.num_sortitions % 2 == 0 {
-            [last_winner_snapshot, parent_winner_snapshot]
+        let (latest_winner_idx, sns) = if last_winner_snapshot.num_sortitions % 2 == 0 {
+            (0, [last_winner_snapshot, parent_winner_snapshot])
         } else {
-            [parent_winner_snapshot, last_winner_snapshot]
+            (1, [parent_winner_snapshot, last_winner_snapshot])
         };
 
-        for sn in sns {
+        for sn in sns.iter() {
             // find the commit
             let Some(block_commit) =
                 ih.get_block_commit_by_txid(&sn.sortition_id, &sn.winning_block_txid)?
@@ -4088,6 +4110,12 @@ impl NakamotoChainState {
             );
         }
 
+        let miners_db_info = MinersDBInformation {
+            signer_0_sortition: sns[0].consensus_hash,
+            signer_1_sortition: sns[1].consensus_hash,
+            latest_winner: latest_winner_idx,
+        };
+
         let signers = miner_key_hash160s
             .into_iter()
             .map(|hash160|
@@ -4101,14 +4129,17 @@ impl NakamotoChainState {
                 ))
             .collect();
 
-        Ok(StackerDBConfig {
-            chunk_size: MAX_PAYLOAD_LEN.into(),
-            signers,
-            write_freq: 0,
-            max_writes: u32::MAX,  // no limit on number of writes
-            max_neighbors: 200, // TODO: const -- just has to be equal to or greater than the number of signers
-            hint_replicas: vec![], // TODO: is there a way to get the IP addresses of stackers' preferred nodes?
-        })
+        Ok((
+            StackerDBConfig {
+                chunk_size: MAX_PAYLOAD_LEN.into(),
+                signers,
+                write_freq: 0,
+                max_writes: u32::MAX,  // no limit on number of writes
+                max_neighbors: 200, // TODO: const -- just has to be equal to or greater than the number of signers
+                hint_replicas: vec![], // TODO: is there a way to get the IP addresses of stackers' preferred nodes?
+            },
+            miners_db_info,
+        ))
     }
 
     /// Get the slot range for the given miner's public key.
@@ -4119,33 +4150,29 @@ impl NakamotoChainState {
     pub fn get_miner_slot(
         sortdb: &SortitionDB,
         tip: &BlockSnapshot,
-        miner_pubkey: &StacksPublicKey,
+        election_sortition: &ConsensusHash,
     ) -> Result<Option<Range<u32>>, ChainstateError> {
-        let miner_hash160 = Hash160::from_node_public_key(&miner_pubkey);
-        let stackerdb_config = Self::make_miners_stackerdb_config(sortdb, &tip)?;
+        let (stackerdb_config, miners_info) = Self::make_miners_stackerdb_config(sortdb, &tip)?;
 
         // find out which slot we're in
-        let mut slot_index = 0;
-        let mut slot_id_result = None;
-        for (addr, slot_count) in stackerdb_config.signers.iter() {
-            if addr.bytes == miner_hash160 {
-                slot_id_result = Some(Range {
-                    start: slot_index,
-                    end: slot_index + slot_count,
-                });
-                break;
-            }
-            slot_index += slot_count;
-        }
-
-        let Some(slot_id_range) = slot_id_result else {
-            // miner key does not match any slot
+        let Some(signer_ix) = miners_info
+            .get_signer_index(election_sortition)
+            .map(usize::from)
+        else {
             warn!("Miner is not in the miners StackerDB config";
-                  "miner" => %miner_hash160,
+                  "stackerdb_slots" => format!("{:?}", &stackerdb_config.signers));
+            return Ok(None);
+        };
+        let mut signer_ranges = stackerdb_config.signer_ranges();
+        if signer_ix >= signer_ranges.len() {
+            // should be unreachable, but always good to be careful
+            warn!("Miner is not in the miners StackerDB config";
                   "stackerdb_slots" => format!("{:?}", &stackerdb_config.signers));
 
             return Ok(None);
-        };
+        }
+        let slot_id_range = signer_ranges.swap_remove(signer_ix);
+
         Ok(Some(slot_id_range))
     }
 

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -2080,9 +2080,8 @@ fn test_make_miners_stackerdb_config() {
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let miner_privkey = &miner_keys[i];
         let miner_pubkey = StacksPublicKey::from_private(miner_privkey);
-        let slot_id =
-            NakamotoChainState::get_miner_slot(&sort_db, &tip, &block.header.consensus_hash)
-                .expect("Failed to get miner slot");
+        let slot_id = NakamotoChainState::get_miner_slot(&sort_db, &tip, &tip.consensus_hash)
+            .expect("Failed to get miner slot");
         if sortition {
             let slot_id = slot_id.expect("No miner slot exists for this miner").start;
             let slot_version = stackerdbs

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -2049,8 +2049,9 @@ fn test_make_miners_stackerdb_config() {
 
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         // check the stackerdb config as of this chain tip
-        let stackerdb_config =
-            NakamotoChainState::make_miners_stackerdb_config(sort_db, &tip).unwrap();
+        let stackerdb_config = NakamotoChainState::make_miners_stackerdb_config(sort_db, &tip)
+            .unwrap()
+            .0;
         eprintln!(
             "stackerdb_config at i = {} (sorition? {}): {:?}",
             &i, sortition, &stackerdb_config
@@ -2079,8 +2080,9 @@ fn test_make_miners_stackerdb_config() {
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let miner_privkey = &miner_keys[i];
         let miner_pubkey = StacksPublicKey::from_private(miner_privkey);
-        let slot_id = NakamotoChainState::get_miner_slot(&sort_db, &tip, &miner_pubkey)
-            .expect("Failed to get miner slot");
+        let slot_id =
+            NakamotoChainState::get_miner_slot(&sort_db, &tip, &block.header.consensus_hash)
+                .expect("Failed to get miner slot");
         if sortition {
             let slot_id = slot_id.expect("No miner slot exists for this miner").start;
             let slot_version = stackerdbs

--- a/stackslib/src/net/api/getneighbors.rs
+++ b/stackslib/src/net/api/getneighbors.rs
@@ -51,7 +51,41 @@ pub struct RPCNeighbor {
     pub public_key_hash: Hash160,
     pub authenticated: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "serde_opt_vec_qci")]
     pub stackerdbs: Option<Vec<QualifiedContractIdentifier>>,
+}
+
+/// Serialize and deserialize `Option<Vec<QualifiedContractIdentifier>>`
+///  using the `to_string()` and `parse()` implementations of `QualifiedContractIdentifier`.
+mod serde_opt_vec_qci {
+    use clarity::vm::types::QualifiedContractIdentifier;
+    use serde::{Deserialize, Serialize};
+
+    pub fn serialize<S: serde::Serializer>(
+        opt: &Option<Vec<QualifiedContractIdentifier>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let serialize_as: Option<Vec<_>> = opt
+            .as_ref()
+            .map(|vec_qci| vec_qci.iter().map(ToString::to_string).collect());
+        serialize_as.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<Option<Vec<QualifiedContractIdentifier>>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let from_str: Option<Vec<String>> = Deserialize::deserialize(de)?;
+        let Some(vec_str) = from_str else {
+            return Ok(None);
+        };
+        let parse_opt: Result<Vec<QualifiedContractIdentifier>, _> = vec_str
+            .into_iter()
+            .map(|x| QualifiedContractIdentifier::parse(&x).map_err(serde::de::Error::custom))
+            .collect();
+        let out_vec = parse_opt?;
+        Ok(Some(out_vec))
+    }
 }
 
 impl RPCNeighbor {

--- a/stackslib/src/net/rpc.rs
+++ b/stackslib/src/net/rpc.rs
@@ -554,12 +554,12 @@ impl ConversationHttp {
                     )?;
 
                     info!("Handled StacksHTTPRequest";
-                           "verb" => %verb,
-                           "path" => %request_path,
-                           "processing_time_ms" => start_time.elapsed().as_millis(),
-                           "latency_ms" => latency,
-                           "conn_id" => self.conn_id,
-                           "peer_addr" => &self.peer_addr);
+                          "verb" => %verb,
+                          "path" => %request_path,
+                          "processing_time_ms" => start_time.elapsed().as_millis(),
+                          "latency_ms" => latency,
+                          "conn_id" => self.conn_id,
+                          "peer_addr" => &self.peer_addr);
 
                     if let Some(msg) = msg_opt {
                         ret.push(msg);

--- a/stackslib/src/net/stackerdb/config.rs
+++ b/stackslib/src/net/stackerdb/config.rs
@@ -555,10 +555,17 @@ impl StackerDBConfig {
                 reason,
             ));
         } else if let Some(Err(e)) = res {
-            warn!(
-                "Could not use contract {} for StackerDB: {:?}",
-                contract_id, &e
-            );
+            if contract_id.is_boot() {
+                debug!(
+                    "Could not use contract {} for StackerDB: {:?}",
+                    contract_id, &e
+                );
+            } else {
+                warn!(
+                    "Could not use contract {} for StackerDB: {:?}",
+                    contract_id, &e
+                );
+            }
             return Err(e);
         }
 

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -119,6 +119,7 @@ pub mod db;
 pub mod sync;
 
 use std::collections::{HashMap, HashSet};
+use std::ops::Range;
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use libstackerdb::{SlotMetadata, STACKERDB_MAX_CHUNK_SIZE};
@@ -205,6 +206,22 @@ impl StackerDBConfig {
     pub fn num_slots(&self) -> u32 {
         self.signers.iter().fold(0, |acc, s| acc + s.1)
     }
+
+    /// What are the slot index ranges for each signer?
+    /// Returns the ranges in the same ordering as `self.signers`
+    pub fn signer_ranges(&self) -> Vec<Range<u32>> {
+        let mut slot_index = 0;
+        let mut result = Vec::with_capacity(self.signers.len());
+        for (_, slot_count) in self.signers.iter() {
+            let end = slot_index + *slot_count;
+            result.push(Range {
+                start: slot_index,
+                end,
+            });
+            slot_index = end;
+        }
+        result
+    }
 }
 
 /// This is the set of replicated chunks in all stacker DBs that this node subscribes to.
@@ -280,14 +297,16 @@ impl StackerDBs {
                 == boot_code_id(MINERS_NAME, chainstate.mainnet)
             {
                 // .miners contract -- directly generate the config
-                NakamotoChainState::make_miners_stackerdb_config(sortdb, &tip).unwrap_or_else(|e| {
-                    warn!(
-                        "Failed to generate .miners StackerDB config";
-                        "contract" => %stackerdb_contract_id,
-                        "err" => ?e,
-                    );
-                    StackerDBConfig::noop()
-                })
+                NakamotoChainState::make_miners_stackerdb_config(sortdb, &tip)
+                    .map(|(config, _)| config)
+                    .unwrap_or_else(|e| {
+                        warn!(
+                            "Failed to generate .miners StackerDB config";
+                            "contract" => %stackerdb_contract_id,
+                            "err" => ?e,
+                        );
+                        StackerDBConfig::noop()
+                    })
             } else {
                 // attempt to load the config from the contract itself
                 StackerDBConfig::from_smart_contract(
@@ -297,11 +316,20 @@ impl StackerDBs {
                     num_neighbors,
                 )
                 .unwrap_or_else(|e| {
-                    warn!(
-                        "Failed to load StackerDB config";
-                        "contract" => %stackerdb_contract_id,
-                        "err" => ?e,
-                    );
+                    if matches!(e, net_error::NoSuchStackerDB(_)) && stackerdb_contract_id.is_boot()
+                    {
+                        debug!(
+                            "Failed to load StackerDB config";
+                            "contract" => %stackerdb_contract_id,
+                            "err" => ?e,
+                        );
+                    } else {
+                        warn!(
+                            "Failed to load StackerDB config";
+                            "contract" => %stackerdb_contract_id,
+                            "err" => ?e,
+                        );
+                    }
                     StackerDBConfig::noop()
                 })
             };

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -401,6 +401,10 @@ pub struct StackerDBSync<NC: NeighborComms> {
     num_attempted_connections: u64,
     /// How many connections have been made in the last pass (gets reset)
     num_connections: u64,
+    /// Number of state machine passes
+    rounds: u128,
+    /// Round when we last pushed
+    push_round: u128,
 }
 
 impl StackerDBSyncResult {

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -1096,9 +1096,6 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             // next-prioritized chunk
             cur_priority = (cur_priority + 1) % self.chunk_push_priorities.len();
         }
-        if pushed == 0 {
-            return Err(net_error::PeerNotConnected);
-        }
         self.next_chunk_push_priority = cur_priority;
         Ok(self
             .chunk_push_priorities

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -1039,16 +1039,13 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             }
 
             let chunk_push = self.chunk_push_priorities[cur_priority].0.clone();
+            // try the first neighbor in the chunk_push_priorities list
             let selected_neighbor_opt = self.chunk_push_priorities[cur_priority]
                 .1
-                .iter()
-                .enumerate()
-                // .find(|(_i, naddr)| !self.comms.has_inflight(naddr));
-                .find(|(_i, _naddr)| true);
+                .first()
+                .map(|neighbor| (0, neighbor));
 
-            let (idx, selected_neighbor) = if let Some(x) = selected_neighbor_opt {
-                x
-            } else {
+            let Some((idx, selected_neighbor)) = selected_neighbor_opt else {
                 debug!("{:?}: pushchunks_begin: no available neighbor to send StackerDBChunk(db={},id={},ver={}) to",
                     &network.get_local_peer(),
                     &self.smart_contract_id,

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -150,6 +150,7 @@ pub struct BlockMinerThread {
     reason: MinerReason,
     /// Handle to the p2p thread for block broadcast
     p2p_handle: NetworkHandle,
+    signer_set_cache: Option<RewardSet>,
 }
 
 impl BlockMinerThread {
@@ -175,6 +176,7 @@ impl BlockMinerThread {
             parent_tenure_id,
             reason,
             p2p_handle: rt.get_p2p_handle(),
+            signer_set_cache: None,
         }
     }
 
@@ -324,6 +326,68 @@ impl BlockMinerThread {
         }
     }
 
+    /// Load the signer set active for this miner's blocks. This is the
+    ///  active reward set during `self.burn_election_block`. The miner
+    ///  thread caches this information, and this method will consult
+    ///  that cache (or populate it if necessary).
+    fn load_signer_set(&mut self) -> Result<RewardSet, NakamotoNodeError> {
+        if let Some(set) = self.signer_set_cache.as_ref() {
+            return Ok(set.clone());
+        }
+        let sort_db = SortitionDB::open(
+            &self.config.get_burn_db_file_path(),
+            true,
+            self.burnchain.pox_constants.clone(),
+        )
+        .map_err(|e| {
+            NakamotoNodeError::SigningCoordinatorFailure(format!(
+                "Failed to open sortition DB. Cannot mine! {e:?}"
+            ))
+        })?;
+
+        let mut chain_state =
+            neon_node::open_chainstate_with_faults(&self.config).map_err(|e| {
+                NakamotoNodeError::SigningCoordinatorFailure(format!(
+                    "Failed to open chainstate DB. Cannot mine! {e:?}"
+                ))
+            })?;
+
+        let burn_election_height = self.burn_election_block.block_height;
+
+        let reward_info = match load_nakamoto_reward_set(
+            self.burnchain
+                .pox_reward_cycle(burn_election_height)
+                .expect("FATAL: no reward cycle for sortition"),
+            &self.burn_election_block.sortition_id,
+            &self.burnchain,
+            &mut chain_state,
+            &self.parent_tenure_id,
+            &sort_db,
+            &OnChainRewardSetProvider::new(),
+        ) {
+            Ok(Some((reward_info, _))) => reward_info,
+            Ok(None) => {
+                return Err(NakamotoNodeError::SigningCoordinatorFailure(
+                    "No reward set stored yet. Cannot mine!".into(),
+                ));
+            }
+            Err(e) => {
+                return Err(NakamotoNodeError::SigningCoordinatorFailure(format!(
+                    "Failure while fetching reward set. Cannot initialize miner coordinator. {e:?}"
+                )));
+            }
+        };
+
+        let Some(reward_set) = reward_info.known_selected_anchor_block_owned() else {
+            return Err(NakamotoNodeError::SigningCoordinatorFailure(
+                "Current reward cycle did not select a reward set. Cannot mine!".into(),
+            ));
+        };
+
+        self.signer_set_cache = Some(reward_set.clone());
+        Ok(reward_set)
+    }
+
     /// Gather a list of signatures from the signers for the block
     fn gather_signatures(
         &mut self,
@@ -364,44 +428,8 @@ impl BlockMinerThread {
             })
         })?;
 
-        let mut chain_state =
-            neon_node::open_chainstate_with_faults(&self.config).map_err(|e| {
-                NakamotoNodeError::SigningCoordinatorFailure(format!(
-                    "Failed to open chainstate DB. Cannot mine! {e:?}"
-                ))
-            })?;
-
-        let reward_info = match load_nakamoto_reward_set(
-            self.burnchain
-                .pox_reward_cycle(tip.block_height.saturating_add(1))
-                .expect("FATAL: no reward cycle for sortition"),
-            &tip.sortition_id,
-            &self.burnchain,
-            &mut chain_state,
-            &new_block.header.parent_block_id,
-            &sort_db,
-            &OnChainRewardSetProvider::new(),
-        ) {
-            Ok(Some((reward_info, _))) => reward_info,
-            Ok(None) => {
-                return Err(NakamotoNodeError::SigningCoordinatorFailure(
-                    "No reward set stored yet. Cannot mine!".into(),
-                ));
-            }
-            Err(e) => {
-                return Err(NakamotoNodeError::SigningCoordinatorFailure(format!(
-                    "Failure while fetching reward set. Cannot initialize miner coordinator. {e:?}"
-                )));
-            }
-        };
-
-        let Some(reward_set) = reward_info.known_selected_anchor_block_owned() else {
-            return Err(NakamotoNodeError::SigningCoordinatorFailure(
-                "Current reward cycle did not select a reward set. Cannot mine!".into(),
-            ));
-        };
-
         let miner_privkey_as_scalar = Scalar::from(miner_privkey.as_slice().clone());
+        let reward_set = self.load_signer_set()?;
         let mut coordinator =
             SignCoordinator::new(&reward_set, miner_privkey_as_scalar, &self.config).map_err(
                 |e| {
@@ -421,6 +449,7 @@ impl BlockMinerThread {
             &sort_db,
             &stackerdbs,
             &self.globals.counters,
+            &self.burn_election_block.consensus_hash,
         )?;
 
         return Ok((reward_set, signature));
@@ -644,6 +673,7 @@ impl BlockMinerThread {
             MinerSlotID::BlockPushed,
             chain_state.mainnet,
             &mut miners_session,
+            &self.burn_election_block.consensus_hash,
         )
         .map_err(NakamotoNodeError::SigningCoordinatorFailure)
     }
@@ -886,6 +916,7 @@ impl BlockMinerThread {
         debug!("block miner thread ID is {:?}", thread::current().id());
 
         let burn_db_path = self.config.get_burn_db_file_path();
+        let reward_set = self.load_signer_set()?;
 
         // NOTE: read-write access is needed in order to be able to query the recipient set.
         // This is an artifact of the way the MARF is built (see #1449)
@@ -932,38 +963,6 @@ impl BlockMinerThread {
         let signer_transactions =
             self.get_signer_transactions(&mut chain_state, &burn_db, &stackerdbs)?;
 
-        let tip = SortitionDB::get_canonical_burn_chain_tip(burn_db.conn())
-            .map_err(|e| NakamotoNodeError::MiningFailure(ChainstateError::DBError(e)))?;
-
-        let reward_info = match load_nakamoto_reward_set(
-            self.burnchain
-                .pox_reward_cycle(tip.block_height.saturating_add(1))
-                .expect("FATAL: no reward cycle defined for sortition tip"),
-            &tip.sortition_id,
-            &self.burnchain,
-            &mut chain_state,
-            &parent_block_info.stacks_parent_header.index_block_hash(),
-            &burn_db,
-            &OnChainRewardSetProvider::new(),
-        ) {
-            Ok(Some((reward_info, _))) => reward_info,
-            Ok(None) => {
-                return Err(NakamotoNodeError::SigningCoordinatorFailure(
-                    "No reward set stored yet. Cannot mine!".into(),
-                ));
-            }
-            Err(e) => {
-                return Err(NakamotoNodeError::SigningCoordinatorFailure(format!(
-                    "Failure while fetching reward set. Cannot initialize miner coordinator. {e:?}"
-                )));
-            }
-        };
-
-        let Some(reward_set) = reward_info.known_selected_anchor_block_owned() else {
-            return Err(NakamotoNodeError::SigningCoordinatorFailure(
-                "Current reward cycle did not select a reward set. Cannot mine!".into(),
-            ));
-        };
         let signer_bitvec_len = reward_set.rewarded_addresses.len().try_into().ok();
 
         // build the block itself

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -23,7 +23,7 @@ use libsigner::v1::messages::{MessageSlotID, SignerMessage as SignerMessageV1};
 use libsigner::{BlockProposal, SignerEntries, SignerEvent, SignerSession, StackerDBSession};
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
-use stacks::chainstate::burn::BlockSnapshot;
+use stacks::chainstate::burn::{BlockSnapshot, ConsensusHash};
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader, NakamotoChainState};
 use stacks::chainstate::stacks::boot::{NakamotoSignerEntry, RewardSet, MINERS_NAME, SIGNERS_NAME};
 use stacks::chainstate::stacks::events::StackerDBChunksEvent;
@@ -341,6 +341,7 @@ impl SignCoordinator {
         miner_slot_id: MinerSlotID,
         is_mainnet: bool,
         miners_session: &mut StackerDBSession,
+        election_sortition: &ConsensusHash,
     ) -> Result<(), String> {
         let mut miner_sk = StacksPrivateKey::from_slice(&message_key.to_bytes()).unwrap();
         miner_sk.set_compress_public(true);
@@ -353,6 +354,7 @@ impl SignCoordinator {
             miner_slot_id,
             is_mainnet,
             miners_session,
+            election_sortition,
         )
     }
 
@@ -366,9 +368,9 @@ impl SignCoordinator {
         miner_slot_id: MinerSlotID,
         is_mainnet: bool,
         miners_session: &mut StackerDBSession,
+        election_sortition: &ConsensusHash,
     ) -> Result<(), String> {
-        let miner_pubkey = StacksPublicKey::from_private(&miner_sk);
-        let Some(slot_range) = NakamotoChainState::get_miner_slot(sortdb, tip, &miner_pubkey)
+        let Some(slot_range) = NakamotoChainState::get_miner_slot(sortdb, tip, &election_sortition)
             .map_err(|e| format!("Failed to read miner slot information: {e:?}"))?
         else {
             return Err("No slot for miner".into());
@@ -417,6 +419,7 @@ impl SignCoordinator {
         sortdb: &SortitionDB,
         stackerdbs: &StackerDBs,
         counters: &Counters,
+        election_sortiton: &ConsensusHash,
     ) -> Result<ThresholdSignature, NakamotoNodeError> {
         let sign_id = Self::get_sign_id(burn_tip.block_height, burnchain);
         let sign_iter_id = block_attempt;
@@ -450,6 +453,7 @@ impl SignCoordinator {
             MinerSlotID::BlockProposal,
             self.is_mainnet,
             &mut self.miners_session,
+            election_sortiton,
         )
         .map_err(NakamotoNodeError::SigningCoordinatorFailure)?;
         counters.bump_naka_proposed_blocks();
@@ -604,6 +608,7 @@ impl SignCoordinator {
                     MinerSlotID::BlockProposal,
                     self.is_mainnet,
                     &mut self.miners_session,
+                    election_sortiton,
                 ) {
                     Ok(()) => {
                         debug!("Miner/Coordinator: sent outbound message.");
@@ -636,6 +641,7 @@ impl SignCoordinator {
         sortdb: &SortitionDB,
         stackerdbs: &StackerDBs,
         counters: &Counters,
+        election_sortition: &ConsensusHash,
     ) -> Result<Vec<MessageSignature>, NakamotoNodeError> {
         let sign_id = Self::get_sign_id(burn_tip.block_height, burnchain);
         let sign_iter_id = block_attempt;
@@ -664,11 +670,15 @@ impl SignCoordinator {
             MinerSlotID::BlockProposal,
             self.is_mainnet,
             &mut self.miners_session,
+            election_sortition,
         )
         .map_err(NakamotoNodeError::SigningCoordinatorFailure)?;
         counters.bump_naka_proposed_blocks();
         #[cfg(test)]
         {
+            info!(
+                "SignCoordinator: sent block proposal to .miners, waiting for test signing channel"
+            );
             // In test mode, short-circuit waiting for the signers if the TEST_SIGNING
             //  channel has been created. This allows integration tests for the stacks-node
             //  independent of the stacks-signer.

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -3985,6 +3985,17 @@ impl RelayerThread {
             }
             RelayerDirective::RunTenure(registered_key, last_burn_block, issue_timestamp_ms) => {
                 debug!("Relayer: directive Run tenure");
+                let Ok(Some(next_block_epoch)) = SortitionDB::get_stacks_epoch(
+                    self.sortdb_ref().conn(),
+                    last_burn_block.block_height.saturating_add(1),
+                ) else {
+                    warn!("Failed to load Stacks Epoch for next burn block, skipping RunTenure directive");
+                    return true;
+                };
+                if next_block_epoch.epoch_id.uses_nakamoto_blocks() {
+                    info!("Next burn block is in Nakamoto epoch, skipping RunTenure directive for 2.x node");
+                    return true;
+                }
                 self.block_miner_thread_try_start(
                     registered_key,
                     last_burn_block,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -100,12 +100,13 @@ use crate::neon::{Counters, RunLoopCounter};
 use crate::operations::BurnchainOpSigner;
 use crate::run_loop::boot_nakamoto;
 use crate::tests::neon_integrations::{
-    call_read_only, get_account, get_account_result, get_chain_info_result, get_pox_info,
-    next_block_and_wait, run_until_burnchain_height, submit_tx, test_observer, wait_for_runloop,
+    call_read_only, get_account, get_account_result, get_chain_info_result, get_neighbors,
+    get_pox_info, next_block_and_wait, run_until_burnchain_height, submit_tx, test_observer,
+    wait_for_runloop,
 };
 use crate::tests::{
     get_chain_info, make_contract_publish, make_contract_publish_versioned, make_stacks_transfer,
-    to_addr,
+    set_random_binds, to_addr,
 };
 use crate::{tests, BitcoinRegtestController, BurnchainController, Config, ConfigFile, Keychain};
 
@@ -293,31 +294,79 @@ pub fn blind_signer(
     signers: &TestSigners,
     proposals_count: RunLoopCounter,
 ) -> JoinHandle<()> {
+    blind_signer_multinode(signers, &[conf], vec![proposals_count])
+}
+
+/// Spawn a blind signing thread listening to potentially multiple stacks nodes.
+/// `signer` is the private key  of the individual signer who broadcasts the response to the StackerDB.
+/// The thread will check each node's proposal counter in order to wake up, but will only read from the first
+///  node's StackerDB (it will read all of the StackerDBs to provide logging information, though).
+pub fn blind_signer_multinode(
+    signers: &TestSigners,
+    configs: &[&Config],
+    proposals_count: Vec<RunLoopCounter>,
+) -> JoinHandle<()> {
+    assert_eq!(
+        configs.len(),
+        proposals_count.len(),
+        "Expect the same number of node configs as proposals counters"
+    );
     let sender = TestSigningChannel::instantiate();
     let mut signed_blocks = HashSet::new();
-    let conf = conf.clone();
+    let configs: Vec<_> = configs.iter().map(|x| Clone::clone(*x)).collect();
     let signers = signers.clone();
-    let mut last_count = proposals_count.load(Ordering::SeqCst);
-    thread::spawn(move || loop {
-        thread::sleep(Duration::from_millis(100));
-        let cur_count = proposals_count.load(Ordering::SeqCst);
-        if cur_count <= last_count {
-            continue;
-        }
-        last_count = cur_count;
-        match read_and_sign_block_proposal(&conf, &signers, &signed_blocks, &sender) {
-            Ok(signed_block) => {
-                if signed_blocks.contains(&signed_block) {
-                    continue;
+    let mut last_count: Vec<_> = proposals_count
+        .iter()
+        .map(|x| x.load(Ordering::SeqCst))
+        .collect();
+    thread::Builder::new()
+        .name("blind-signer".into())
+        .spawn(move || loop {
+            thread::sleep(Duration::from_millis(100));
+            let cur_count: Vec<_> = proposals_count
+                .iter()
+                .map(|x| x.load(Ordering::SeqCst))
+                .collect();
+            if cur_count
+                .iter()
+                .zip(last_count.iter())
+                .all(|(cur_count, last_count)| cur_count <= last_count)
+            {
+                continue;
+            }
+            thread::sleep(Duration::from_secs(2));
+            info!("Checking for a block proposal to sign...");
+            last_count = cur_count;
+            let configs: Vec<&Config> = configs.iter().map(|x| x).collect();
+            match read_and_sign_block_proposal(configs.as_slice(), &signers, &signed_blocks, &sender) {
+                Ok(signed_block) => {
+                    if signed_blocks.contains(&signed_block) {
+                        info!("Already signed block, will sleep and try again"; "signer_sig_hash" => signed_block.to_hex());
+                        thread::sleep(Duration::from_secs(5));
+                        match read_and_sign_block_proposal(configs.as_slice(), &signers, &signed_blocks, &sender) {
+                            Ok(signed_block) => {
+                                if signed_blocks.contains(&signed_block) {
+                                    info!("Already signed block, ignoring"; "signer_sig_hash" => signed_block.to_hex());
+                                    continue;
+                                }
+                                info!("Signed block"; "signer_sig_hash" => signed_block.to_hex());
+                                signed_blocks.insert(signed_block);
+                            }
+                            Err(e) => {
+                                warn!("Error reading and signing block proposal: {e}");
+                            }
+                        };
+                        continue;
+                    }
+                    info!("Signed block"; "signer_sig_hash" => signed_block.to_hex());
+                    signed_blocks.insert(signed_block);
                 }
-                info!("Signed block"; "signer_sig_hash" => signed_block.to_hex());
-                signed_blocks.insert(signed_block);
+                Err(e) => {
+                    warn!("Error reading and signing block proposal: {e}");
+                }
             }
-            Err(e) => {
-                warn!("Error reading and signing block proposal: {e}");
-            }
-        }
-    })
+        })
+        .unwrap()
 }
 
 pub fn get_latest_block_proposal(
@@ -325,26 +374,68 @@ pub fn get_latest_block_proposal(
     sortdb: &SortitionDB,
 ) -> Result<(NakamotoBlock, StacksPublicKey), String> {
     let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
-    let miner_pubkey = StacksPublicKey::from_private(&conf.get_miner_config().mining_key.unwrap());
-    let miner_slot_id = NakamotoChainState::get_miner_slot(&sortdb, &tip, &miner_pubkey)
-        .map_err(|_| "Unable to get miner slot")?
-        .ok_or("No miner slot exists")?;
+    let (stackerdb_conf, miner_info) =
+        NakamotoChainState::make_miners_stackerdb_config(sortdb, &tip)
+            .map_err(|e| e.to_string())?;
+    let miner_ranges = stackerdb_conf.signer_ranges();
+    let latest_miner = usize::from(miner_info.get_latest_winner_index());
+    let miner_contract_id = boot_code_id(MINERS_NAME, false);
+    let mut miners_stackerdb = StackerDBSession::new(&conf.node.rpc_bind, miner_contract_id);
 
-    let proposed_block = {
-        let miner_contract_id = boot_code_id(MINERS_NAME, false);
-        let mut miners_stackerdb = StackerDBSession::new(&conf.node.rpc_bind, miner_contract_id);
-        let message: SignerMessageV0 = miners_stackerdb
-            .get_latest(miner_slot_id.start)
-            .expect("Failed to get latest chunk from the miner slot ID")
-            .expect("No chunk found");
-        let SignerMessageV0::BlockProposal(block_proposal) = message else {
-            panic!("Expected a signer message block proposal. Got {message:?}");
-        };
-        // TODO: use v1 message types behind epoch gate
-        // get_block_proposal_msg_v1(&mut miners_stackerdb, miner_slot_id.start);
-        block_proposal.block
-    };
-    Ok((proposed_block, miner_pubkey))
+    let mut proposed_blocks: Vec<_> = stackerdb_conf
+        .signers
+        .iter()
+        .enumerate()
+        .zip(miner_ranges)
+        .filter_map(|((miner_ix, (miner_addr, _)), miner_slot_id)| {
+            let proposed_block = {
+                let message: SignerMessageV0 =
+                    miners_stackerdb.get_latest(miner_slot_id.start).ok()??;
+                let SignerMessageV0::BlockProposal(block_proposal) = message else {
+                    panic!("Expected a signer message block proposal. Got {message:?}");
+                };
+                block_proposal.block
+            };
+            Some((proposed_block, miner_addr, miner_ix == latest_miner))
+        })
+        .collect();
+
+    proposed_blocks.sort_by(|(block_a, _, is_latest_a), (block_b, _, is_latest_b)| {
+        if block_a.header.chain_length > block_b.header.chain_length {
+            return std::cmp::Ordering::Greater;
+        } else if block_a.header.chain_length < block_b.header.chain_length {
+            return std::cmp::Ordering::Less;
+        }
+        // the heights are tied, tie break with the latest miner
+        if *is_latest_a {
+            return std::cmp::Ordering::Greater;
+        }
+        if *is_latest_b {
+            return std::cmp::Ordering::Less;
+        }
+        return std::cmp::Ordering::Equal;
+    });
+
+    for (b, _, is_latest) in proposed_blocks.iter() {
+        info!("Consider block"; "signer_sighash" => %b.header.signer_signature_hash(), "is_latest_sortition" => is_latest, "chain_height" => b.header.chain_length);
+    }
+
+    let (proposed_block, miner_addr, _) = proposed_blocks.pop().unwrap();
+
+    let pubkey = StacksPublicKey::recover_to_pubkey(
+        proposed_block.header.miner_signature_hash().as_bytes(),
+        &proposed_block.header.miner_signature,
+    )
+    .map_err(|e| e.to_string())?;
+    let miner_signed_addr = StacksAddress::p2pkh(false, &pubkey);
+    if miner_signed_addr.bytes != miner_addr.bytes {
+        return Err(format!(
+            "Invalid miner signature on proposal. Found {}, expected {}",
+            miner_signed_addr.bytes, miner_addr.bytes
+        ));
+    }
+
+    Ok((proposed_block, pubkey))
 }
 
 #[allow(dead_code)]
@@ -369,11 +460,12 @@ fn get_block_proposal_msg_v1(
 }
 
 pub fn read_and_sign_block_proposal(
-    conf: &Config,
+    configs: &[&Config],
     signers: &TestSigners,
     signed_blocks: &HashSet<Sha512Trunc256Sum>,
     channel: &Sender<Vec<MessageSignature>>,
 ) -> Result<Sha512Trunc256Sum, String> {
+    let conf = configs.first().unwrap();
     let burnchain = conf.get_burnchain();
     let sortdb = burnchain.open_sortition_db(true).unwrap();
     let (mut chainstate, _) = StacksChainState::open(
@@ -387,8 +479,30 @@ pub fn read_and_sign_block_proposal(
     let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
 
     let mut proposed_block = get_latest_block_proposal(conf, &sortdb)?.0;
+    let other_views_result: Result<Vec<_>, _> = configs
+        .get(1..)
+        .unwrap()
+        .iter()
+        .map(|other_conf| {
+            get_latest_block_proposal(other_conf, &sortdb).map(|proposal| {
+                (
+                    proposal.0.header.signer_signature_hash(),
+                    proposal.0.header.chain_length,
+                )
+            })
+        })
+        .collect();
     let proposed_block_hash = format!("0x{}", proposed_block.header.block_hash());
     let signer_sig_hash = proposed_block.header.signer_signature_hash();
+    let other_views = other_views_result?;
+    if !other_views.is_empty() {
+        info!(
+            "Fetched block proposals";
+            "primary_latest_signer_sighash" => %signer_sig_hash,
+            "primary_latest_block_height" => proposed_block.header.chain_length,
+            "other_views" => ?other_views,
+        );
+    }
 
     if signed_blocks.contains(&signer_sig_hash) {
         // already signed off on this block, don't sign again.
@@ -632,6 +746,17 @@ pub fn boot_to_epoch_3(
     // first mined stacks block
     next_block_and_wait(btc_regtest_controller, &blocks_processed);
 
+    let start_time = Instant::now();
+    loop {
+        if start_time.elapsed() > Duration::from_secs(20) {
+            panic!("Timed out waiting for the stacks height to increment")
+        }
+        let stacks_height = get_chain_info(&naka_conf).stacks_tip_height;
+        if stacks_height >= 1 {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
     // stack enough to activate pox-4
 
     let block_height = btc_regtest_controller.get_headers_height();
@@ -1442,6 +1567,261 @@ fn mine_multiple_per_tenure_integration() {
     run_loop_stopper.store(false, Ordering::SeqCst);
 
     run_loop_thread.join().unwrap();
+}
+
+#[test]
+#[ignore]
+/// This test spins up a nakamoto-neon node.
+/// It starts in Epoch 2.0, mines with `neon_node` to Epoch 3.0, and then switches
+///  to Nakamoto operation (activating pox-4 by submitting a stack-stx tx). The BootLoop
+///  struct handles the epoch-2/3 tear-down and spin-up.
+/// This test makes three assertions:
+///  * 5 tenures are mined after 3.0 starts
+///  * Each tenure has 10 blocks (the coinbase block and 9 interim blocks)
+fn multiple_nodes() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
+    naka_conf.node.local_peer_seed = vec![1, 1, 1, 1];
+    let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
+    naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
+    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_addr = tests::to_addr(&sender_signer_sk);
+    let tenure_count = 15;
+    let inter_blocks_per_tenure = 6;
+    // setup sender + recipient for some test stx transfers
+    // these are necessary for the interim blocks to get mined at all
+    let sender_addr = tests::to_addr(&sender_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
+    );
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
+    let recipient = PrincipalData::from(StacksAddress::burn_address(false));
+    let stacker_sk = setup_stacker(&mut naka_conf);
+
+    let mut conf_node_2 = naka_conf.clone();
+    set_random_binds(&mut conf_node_2);
+    conf_node_2.node.seed = vec![2, 2, 2, 2];
+    conf_node_2.burnchain.local_mining_public_key = Some(
+        Keychain::default(conf_node_2.node.seed.clone())
+            .get_pub_key()
+            .to_hex(),
+    );
+    conf_node_2.node.local_peer_seed = vec![2, 2, 2, 2];
+    conf_node_2.node.miner = true;
+
+    let node_1_sk = Secp256k1PrivateKey::from_seed(&naka_conf.node.local_peer_seed);
+    let node_1_pk = StacksPublicKey::from_private(&node_1_sk);
+
+    conf_node_2.node.working_dir = format!("{}-{}", conf_node_2.node.working_dir, "1");
+
+    conf_node_2.node.set_bootstrap_nodes(
+        format!("{}@{}", &node_1_pk.to_hex(), naka_conf.node.p2p_bind),
+        naka_conf.burnchain.chain_id,
+        naka_conf.burnchain.peer_version,
+    );
+
+    test_observer::spawn();
+    let observer_port = test_observer::EVENT_OBSERVER_PORT;
+    naka_conf.events_observers.insert(EventObserverConfig {
+        endpoint: format!("localhost:{observer_port}"),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(naka_conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .expect("Failed starting bitcoind");
+    let mut btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
+    btc_regtest_controller.bootstrap_chain_to_pks(
+        201,
+        &[
+            Secp256k1PublicKey::from_hex(
+                naka_conf
+                    .burnchain
+                    .local_mining_public_key
+                    .as_ref()
+                    .unwrap(),
+            )
+            .unwrap(),
+            Secp256k1PublicKey::from_hex(
+                conf_node_2
+                    .burnchain
+                    .local_mining_public_key
+                    .as_ref()
+                    .unwrap(),
+            )
+            .unwrap(),
+        ],
+    );
+
+    let mut run_loop = boot_nakamoto::BootRunLoop::new(naka_conf.clone()).unwrap();
+    let mut run_loop_2 = boot_nakamoto::BootRunLoop::new(conf_node_2.clone()).unwrap();
+    let run_loop_stopper = run_loop.get_termination_switch();
+    let Counters {
+        blocks_processed,
+        naka_submitted_commits: commits_submitted,
+        naka_proposed_blocks: proposals_submitted,
+        ..
+    } = run_loop.counters();
+
+    let run_loop_2_stopper = run_loop.get_termination_switch();
+    let Counters {
+        naka_proposed_blocks: proposals_submitted_2,
+        ..
+    } = run_loop_2.counters();
+
+    let coord_channel = run_loop.coordinator_channels();
+    let coord_channel_2 = run_loop_2.coordinator_channels();
+
+    let run_loop_2_thread = thread::Builder::new()
+        .name("run_loop_2".into())
+        .spawn(move || run_loop_2.start(None, 0))
+        .unwrap();
+
+    let run_loop_thread = thread::Builder::new()
+        .name("run_loop".into())
+        .spawn(move || run_loop.start(None, 0))
+        .unwrap();
+    wait_for_runloop(&blocks_processed);
+
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    boot_to_epoch_3(
+        &naka_conf,
+        &blocks_processed,
+        &[stacker_sk],
+        &[sender_signer_sk],
+        &mut Some(&mut signers),
+        &mut btc_regtest_controller,
+    );
+
+    info!("Bootstrapped to Epoch-3.0 boundary, starting nakamoto miner");
+
+    let burnchain = naka_conf.get_burnchain();
+    let sortdb = burnchain.open_sortition_db(true).unwrap();
+    let (chainstate, _) = StacksChainState::open(
+        naka_conf.is_mainnet(),
+        naka_conf.burnchain.chain_id,
+        &naka_conf.get_chainstate_path_str(),
+        None,
+    )
+    .unwrap();
+
+    let block_height_pre_3_0 =
+        NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+            .unwrap()
+            .unwrap()
+            .stacks_block_height;
+
+    info!("Nakamoto miner started...");
+    blind_signer_multinode(
+        &signers,
+        &[&naka_conf, &conf_node_2],
+        vec![proposals_submitted, proposals_submitted_2],
+    );
+
+    info!("Neighbors 1"; "neighbors" => ?get_neighbors(&naka_conf));
+    info!("Neighbors 2"; "neighbors" => ?get_neighbors(&conf_node_2));
+
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
+    next_block_and(&mut btc_regtest_controller, 60, || {
+        let commits_count = commits_submitted.load(Ordering::SeqCst);
+        Ok(commits_count >= 1)
+    })
+    .unwrap();
+
+    // Mine `tenure_count` nakamoto tenures
+    for tenure_ix in 0..tenure_count {
+        info!("Mining tenure {}", tenure_ix);
+        let commits_before = commits_submitted.load(Ordering::SeqCst);
+        next_block_and_process_new_stacks_block(&mut btc_regtest_controller, 60, &coord_channel)
+            .unwrap();
+
+        let mut last_tip = BlockHeaderHash([0x00; 32]);
+        let mut last_tip_height = 0;
+
+        // mine the interim blocks
+        for interim_block_ix in 0..inter_blocks_per_tenure {
+            let blocks_processed_before = coord_channel
+                .lock()
+                .expect("Mutex poisoned")
+                .get_stacks_blocks_processed();
+            // submit a tx so that the miner will mine an extra block
+            let sender_nonce = tenure_ix * inter_blocks_per_tenure + interim_block_ix;
+            let transfer_tx =
+                make_stacks_transfer(&sender_sk, sender_nonce, send_fee, &recipient, send_amt);
+            submit_tx(&http_origin, &transfer_tx);
+
+            loop {
+                let blocks_processed = coord_channel
+                    .lock()
+                    .expect("Mutex poisoned")
+                    .get_stacks_blocks_processed();
+                if blocks_processed > blocks_processed_before {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+
+            let info = get_chain_info_result(&naka_conf).unwrap();
+            assert_ne!(info.stacks_tip, last_tip);
+            assert_ne!(info.stacks_tip_height, last_tip_height);
+
+            last_tip = info.stacks_tip;
+            last_tip_height = info.stacks_tip_height;
+        }
+
+        let start_time = Instant::now();
+        while commits_submitted.load(Ordering::SeqCst) <= commits_before {
+            if start_time.elapsed() >= Duration::from_secs(20) {
+                panic!("Timed out waiting for block-commit");
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    // load the chain tip, and assert that it is a nakamoto block and at least 30 blocks have advanced in epoch 3
+    let tip = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+        .unwrap()
+        .unwrap();
+    info!(
+        "Latest tip";
+        "height" => tip.stacks_block_height,
+        "is_nakamoto" => tip.anchored_header.as_stacks_nakamoto().is_some(),
+    );
+
+    info!("Peer 1 information"; "chain_info" => ?get_chain_info(&naka_conf).stacks_tip_height);
+    info!("Peer 2 information"; "chain_info" => ?get_chain_info(&conf_node_2).stacks_tip_height);
+
+    assert!(tip.anchored_header.as_stacks_nakamoto().is_some());
+    assert_eq!(
+        tip.stacks_block_height,
+        block_height_pre_3_0 + ((inter_blocks_per_tenure + 1) * tenure_count),
+        "Should have mined (1 + interim_blocks_per_tenure) * tenure_count nakamoto blocks"
+    );
+
+    coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    coord_channel_2
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    run_loop_stopper.store(false, Ordering::SeqCst);
+    run_loop_2_stopper.store(false, Ordering::SeqCst);
+
+    run_loop_thread.join().unwrap();
+    //    run_loop_2_thread.join().unwrap();
 }
 
 #[test]

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1318,6 +1318,13 @@ pub fn get_account<F: std::fmt::Display>(http_origin: &str, account: &F) -> Acco
     get_account_result(http_origin, account).unwrap()
 }
 
+pub fn get_neighbors(conf: &Config) -> Option<serde_json::Value> {
+    let client = reqwest::blocking::Client::new();
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let path = format!("{}/v2/neighbors", http_origin);
+    client.get(&path).send().ok()?.json().ok()
+}
+
 pub fn get_pox_info(http_origin: &str) -> Option<RPCPoxInfoData> {
     let client = reqwest::blocking::Client::new();
     let path = format!("{}/v2/pox", http_origin);


### PR DESCRIPTION
This PR adds a multiple miner integration test to the `nakamoto_integrations` suite. This test _doesn't_ use the signer set (it uses the test signing channel). I'm planning on working on adding that to the signer integration test suite in a separate PR (this PR already includes a number of fixes).

As part of getting this integration test suite to work, this PR does the following:

* test: add nakamoto_integration test with multiple miners (this test uses the blind signer test signing channel)
* fix: increase the frequency of stackerdb sync, set a retry limit on stackerdb::sync pushchunks, and check for the presence of neighbors.
* fix: nakamoto miner communicates over the correct miner slot for their block election (rather than searching by pubkey)
* fix: neon miner does not submit block commits if the next burn block is in nakamoto
* perf: nakamoto miner caches the reward set for their tenure

There's also a change to the output of `v2/neighbors`:

* feat: update `/v2/neighbors` to use qualified contract identifier's ToString and parse() for JSON serialization

This makes that JSON output _much_ more readable.