### PR TITLE
Bug/signer node out of sync peer info

### DIFF
--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -44,9 +44,9 @@ extern crate alloc;
 const GIT_BRANCH: Option<&'static str> = option_env!("GIT_BRANCH");
 const GIT_COMMIT: Option<&'static str> = option_env!("GIT_COMMIT");
 #[cfg(debug_assertions)]
-const BUILD_TYPE: &'static str = "debug";
+const BUILD_TYPE: &str = "debug";
 #[cfg(not(debug_assertions))]
-const BUILD_TYPE: &'static str = "release";
+const BUILD_TYPE: &str = "release";
 
 lazy_static! {
     static ref VERSION_STRING: String = {

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -484,7 +484,7 @@ impl Signer {
 
     /// Send a mock signature to stackerdb to prove we are still alive
     fn mock_sign(&mut self, burn_block_height: u64, stacks_client: &StacksClient) {
-        let Ok(peer_view) = stacks_client.get_peer_info() else {
+        let Ok(peer_info) = stacks_client.get_peer_info() else {
             warn!("{self}: Failed to get peer info. Cannot mock sign.");
             return;
         };
@@ -494,15 +494,15 @@ impl Signer {
             CHAIN_ID_TESTNET
         };
         info!("Mock signing for burn block {burn_block_height:?}";
-            "stacks_tip_consensus_hash" => ?peer_view.stacks_tip_consensus_hash.clone(),
-            "stacks_tip" => ?peer_view.stacks_tip.clone(),
-            "peer_burn_block_height" => peer_view.burn_block_height,
-            "pox_consensus" => ?peer_view.pox_consensus.clone(),
-            "server_version" => peer_view.server_version.clone(),
+            "stacks_tip_consensus_hash" => ?peer_info.stacks_tip_consensus_hash.clone(),
+            "stacks_tip" => ?peer_info.stacks_tip.clone(),
+            "peer_burn_block_height" => peer_info.burn_block_height,
+            "pox_consensus" => ?peer_info.pox_consensus.clone(),
+            "server_version" => peer_info.server_version.clone(),
             "chain_id" => chain_id
         );
         let mock_signature =
-            MockSignature::new(peer_view, burn_block_height, chain_id, &self.private_key);
+            MockSignature::new(burn_block_height, peer_info, chain_id, &self.private_key);
         let message = SignerMessage::MockSignature(mock_signature);
         if let Err(e) = self
             .stackerdb

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -169,12 +169,19 @@ impl SignerTrait<SignerMessage> for Signer {
                     );
                 }
                 *sortition_state = None;
-                if let Ok(StacksEpochId::Epoch25) = stacks_client.get_node_epoch() {
-                    if self.reward_cycle == current_reward_cycle {
-                        // We are in epoch 2.5, so we should mock mine to prove we are still alive.
-                        self.mock_sign(*burn_height, stacks_client);
-                    }
+                let Ok(epoch) = stacks_client.get_node_epoch() else {
+                    warn!("{self}: Failed to determine node epoch. Cannot mock sign.");
+                    return;
                 };
+                debug!("{self}: Epoch 2.5 signer received a new burn block event.";
+                    "burn_height" => burn_height,
+                    "current_reward_cycle" => current_reward_cycle,
+                    "epoch" => ?epoch
+                );
+                if epoch == StacksEpochId::Epoch25 && self.reward_cycle == current_reward_cycle {
+                    // We are in epoch 2.5, so we should mock mine to prove we are still alive.
+                    self.mock_sign(*burn_height, stacks_client);
+                }
             }
         }
     }

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -169,9 +169,12 @@ impl SignerTrait<SignerMessage> for Signer {
                     );
                 }
                 *sortition_state = None;
-                let Ok(epoch) = stacks_client.get_node_epoch() else {
-                    warn!("{self}: Failed to determine node epoch. Cannot mock sign.");
-                    return;
+                let epoch = match stacks_client.get_node_epoch() {
+                    Ok(epoch) => epoch,
+                    Err(e) => {
+                        warn!("{self}: Failed to determine node epoch. Cannot mock sign: {e}");
+                        return;
+                    }
                 };
                 debug!("{self}: Epoch 2.5 signer received a new burn block event.";
                     "burn_height" => burn_height,

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -1663,7 +1663,8 @@ fn mock_sign_epoch_25() {
             .expect("Failed to get message from stackerdb");
             for message in messages {
                 if let SignerMessage::MockSignature(mock_signature) = message {
-                    if mock_signature.sign_data.burn_block_height == current_burn_block_height {
+                    if mock_signature.sign_data.event_burn_block_height == current_burn_block_height
+                    {
                         if !mock_signatures.contains(&mock_signature) {
                             mock_signatures.push(mock_signature);
                         }


### PR DESCRIPTION
There was an update to the RPCPeerInfo. However since we release the signer binary indepenently of the stacks node, this was causing problems in testnet. I have removed the deserialization of the entire RPCPeerInfo struct and now only deserialize the relevant fields. So long as these fields are not removed, updates to RPCPeerInfo will not affect the signer. We will have to coordinate releases that do cause breaking changes to the signer.

Charlie deployed my testing branch test/logging (which contains the exact same commits) to testnet and you can see mock signing happening as it should https://grafana.hiro.tools/explore?schemaVersion=1&panes=%7B%22e9q%22%3A%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bnamespace%3D%5C%22testnet-api%5C%22%2C+pod_name%3D%5C%22testnet-stacks-blockchain-nakamoto-3-0%5C%22%2C+container_name%3D%7E%5C%22signer-.*%5C%22%7D+%7C%3D+%60%60+%7C+json+%7C+line_format+%60%7B%7B.message%7D%7D%60%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22loki%22%7D%2C%22editorMode%22%3A%22builder%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D%7D&orgId=1 