### PR TITLE
Fix deadlock

### DIFF
--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -47,7 +47,8 @@ use crate::chainstate::nakamoto::test_signers::TestSigners;
 use crate::chainstate::nakamoto::tests::get_account;
 use crate::chainstate::nakamoto::tests::node::TestStacker;
 use crate::chainstate::nakamoto::{
-    NakamotoBlock, NakamotoBlockObtainMethod, NakamotoChainState, NakamotoStagingBlocksConnRef,
+    disable_process_block_stall, enable_process_block_stall, NakamotoBlock,
+    NakamotoBlockObtainMethod, NakamotoChainState, NakamotoStagingBlocksConnRef,
     TEST_PROCESS_BLOCK_STALL,
 };
 use crate::chainstate::stacks::address::PoxAddress;
@@ -2505,7 +2506,7 @@ fn process_next_nakamoto_block_deadlock() {
         .reopen()
         .unwrap();
 
-    TEST_PROCESS_BLOCK_STALL.lock().unwrap().replace(true);
+    enable_process_block_stall();
 
     let miner_thread = std::thread::spawn(move || {
         info!("  -------------------------------   MINING TENURE");
@@ -2523,7 +2524,7 @@ fn process_next_nakamoto_block_deadlock() {
     info!("  -------------------------------   SORTDB LOCKED");
 
     // Un-stall the block processing
-    TEST_PROCESS_BLOCK_STALL.lock().unwrap().replace(false);
+    disable_process_block_stall();
 
     // Wait a bit, to ensure the tenure will have grabbed any locks it needs
     std::thread::sleep(std::time::Duration::from_secs(10));

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -44,12 +44,11 @@ use crate::chainstate::nakamoto::coordinator::load_nakamoto_reward_set;
 use crate::chainstate::nakamoto::miner::NakamotoBlockBuilder;
 use crate::chainstate::nakamoto::signer_set::NakamotoSigners;
 use crate::chainstate::nakamoto::test_signers::TestSigners;
+use crate::chainstate::nakamoto::test_stall::*;
 use crate::chainstate::nakamoto::tests::get_account;
 use crate::chainstate::nakamoto::tests::node::TestStacker;
 use crate::chainstate::nakamoto::{
-    disable_process_block_stall, enable_process_block_stall, NakamotoBlock,
-    NakamotoBlockObtainMethod, NakamotoChainState, NakamotoStagingBlocksConnRef,
-    TEST_PROCESS_BLOCK_STALL,
+    NakamotoBlock, NakamotoBlockObtainMethod, NakamotoChainState, NakamotoStagingBlocksConnRef,
 };
 use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::boot::pox_4_tests::{get_stacking_minimum, get_tip};

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -274,6 +274,25 @@ lazy_static! {
 #[cfg(any(test, feature = "testing"))]
 pub static TEST_PROCESS_BLOCK_STALL: std::sync::Mutex<Option<bool>> = std::sync::Mutex::new(None);
 
+fn stall_block_processing() {
+    if *TEST_PROCESS_BLOCK_STALL.lock().unwrap() == Some(true) {
+        // Do an extra check just so we don't log EVERY time.
+        warn!("Block processing is stalled due to testing directive.");
+        while *TEST_PROCESS_BLOCK_STALL.lock().unwrap() == Some(true) {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        info!("Block processing is no longer stalled due to testing directive.");
+    }
+}
+
+pub fn enable_process_block_stall() {
+    TEST_PROCESS_BLOCK_STALL.lock().unwrap().replace(true);
+}
+
+pub fn disable_process_block_stall() {
+    TEST_PROCESS_BLOCK_STALL.lock().unwrap().replace(false);
+}
+
 /// Trait for common MARF getters between StacksDBConn and StacksDBTx
 pub trait StacksDBIndexed {
     fn get(&mut self, tip: &StacksBlockId, key: &str) -> Result<Option<String>, DBError>;
@@ -1727,16 +1746,8 @@ impl NakamotoChainState {
         dispatcher_opt: Option<&'a T>,
     ) -> Result<Option<StacksEpochReceipt>, ChainstateError> {
         #[cfg(any(test, feature = "testing"))]
-        {
-            if *TEST_PROCESS_BLOCK_STALL.lock().unwrap() == Some(true) {
-                // Do an extra check just so we don't log EVERY time.
-                warn!("Block processing is stalled due to testing directive.");
-                while *TEST_PROCESS_BLOCK_STALL.lock().unwrap() == Some(true) {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                }
-                info!("Block processing is no longer stalled due to testing directive.");
-            }
-        }
+        stall_block_processing();
+
         let nakamoto_blocks_db = stacks_chain_state.nakamoto_blocks_db();
         let Some((next_ready_block, block_size)) =
             nakamoto_blocks_db.next_ready_nakamoto_block(stacks_chain_state.db())?

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -270,6 +270,10 @@ lazy_static! {
     ];
 }
 
+// Cause an artifical stall in block-processing, for testing.
+#[cfg(any(test, feature = "testing"))]
+pub static TEST_PROCESS_BLOCK_STALL: std::sync::Mutex<Option<bool>> = std::sync::Mutex::new(None);
+
 /// Trait for common MARF getters between StacksDBConn and StacksDBTx
 pub trait StacksDBIndexed {
     fn get(&mut self, tip: &StacksBlockId, key: &str) -> Result<Option<String>, DBError>;
@@ -1722,6 +1726,17 @@ impl NakamotoChainState {
         canonical_sortition_tip: &SortitionId,
         dispatcher_opt: Option<&'a T>,
     ) -> Result<Option<StacksEpochReceipt>, ChainstateError> {
+        #[cfg(any(test, feature = "testing"))]
+        {
+            if *TEST_PROCESS_BLOCK_STALL.lock().unwrap() == Some(true) {
+                // Do an extra check just so we don't log EVERY time.
+                warn!("Block processing is stalled due to testing directive.");
+                while *TEST_PROCESS_BLOCK_STALL.lock().unwrap() == Some(true) {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                info!("Block processing is no longer stalled due to testing directive.");
+            }
+        }
         let nakamoto_blocks_db = stacks_chain_state.nakamoto_blocks_db();
         let Some((next_ready_block, block_size)) =
             nakamoto_blocks_db.next_ready_nakamoto_block(stacks_chain_state.db())?


### PR DESCRIPTION
Ensure that the chainstate db lock is not held when attempting to lock the sortition db to avoid deadlock.