### PR TITLE
Test/4976 signer set handoff

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -93,6 +93,7 @@ jobs:
           - tests::signer::v0::bitcoind_forking_test
           - tests::signer::v0::multiple_miners
           - tests::signer::v0::mock_sign_epoch_25
+          - tests::signer::v0::signer_set_rollover
           - tests::nakamoto_integrations::stack_stx_burn_op_integration_test
           - tests::nakamoto_integrations::check_block_heights
           - tests::nakamoto_integrations::clarity_burn_state

--- a/libsigner/src/runloop.rs
+++ b/libsigner/src/runloop.rs
@@ -262,7 +262,7 @@ impl<
 
         // start receiving events and doing stuff with them
         let runloop_thread = thread::Builder::new()
-            .name("signer_runloop".to_string())
+            .name(format!("signer_runloop:{}", bind_addr.port()))
             .stack_size(THREAD_STACK_SIZE)
             .spawn(move || {
                 signer_loop.main_loop(event_recv, command_receiver, result_sender, stop_signaler)

--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -303,11 +303,12 @@ impl SortitionsView {
             let last_in_tenure = signer_db
                 .get_last_signed_block_in_tenure(&block.header.consensus_hash)
                 .map_err(|e| ClientError::InvalidResponse(e.to_string()))?;
-            if last_in_tenure.is_some() {
+            if let Some(last_in_tenure) = last_in_tenure {
                 warn!(
                     "Miner block proposal contains a tenure change, but we've already signed a block in this tenure. Considering proposal invalid.";
                     "proposed_block_consensus_hash" => %block.header.consensus_hash,
                     "proposed_block_signer_sighash" => %block.header.signer_signature_hash(),
+                    "last_in_tenure_signer_sighash" => %last_in_tenure.block.header.signer_signature_hash(),
                 );
                 return Ok(false);
             }

--- a/stacks-signer/src/lib.rs
+++ b/stacks-signer/src/lib.rs
@@ -147,7 +147,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SpawnedSigner
             cmd_send,
             res_recv,
             _phantom: std::marker::PhantomData,
-            config: config.clone(),
+            config,
         }
     }
 }

--- a/stacks-signer/src/lib.rs
+++ b/stacks-signer/src/lib.rs
@@ -100,6 +100,8 @@ pub struct SpawnedSigner<S: Signer<T> + Send, T: SignerEventTrait> {
     pub cmd_send: Sender<RunLoopCommand>,
     /// The result receiver for interacting with the running signer
     pub res_recv: Receiver<Vec<SignerResult>>,
+    /// The spawned signer's config
+    pub config: GlobalConfig,
     /// Phantom data for the signer type
     _phantom: std::marker::PhantomData<S>,
 }
@@ -136,7 +138,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SpawnedSigner
         {
             crate::monitoring::start_serving_monitoring_metrics(config.clone()).ok();
         }
-        let runloop = RunLoop::new(config);
+        let runloop = RunLoop::new(config.clone());
         let mut signer: RunLoopSigner<S, T> =
             libsigner::Signer::new(runloop, ev, cmd_recv, res_send);
         let running_signer = signer.spawn(endpoint).expect("Failed to spawn signer");
@@ -145,6 +147,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SpawnedSigner
             cmd_send,
             res_recv,
             _phantom: std::marker::PhantomData,
+            config: config.clone(),
         }
     }
 }

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -546,7 +546,7 @@ pub fn load_nakamoto_reward_set<U: RewardSetProvider>(
            "burnchain_height" => %anchor_block_sn.block_height);
 
     let reward_set = provider.get_reward_set_nakamoto(
-        prepare_end_height.saturating_sub(1),
+        prepare_end_height,
         chain_state,
         burnchain,
         sort_db,

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -138,6 +138,7 @@ pub struct MinedNakamotoBlockEvent {
     pub signer_signature_hash: Sha512Trunc256Sum,
     pub tx_events: Vec<TransactionEvent>,
     pub signer_bitvec: String,
+    pub signer_signature: Vec<MessageSignature>,
 }
 
 impl InnerStackerDBChannel {
@@ -1261,6 +1262,7 @@ impl EventDispatcher {
             tx_events,
             miner_signature: block.header.miner_signature.clone(),
             signer_signature_hash: block.header.signer_signature_hash(),
+            signer_signature: block.header.signer_signature.clone(),
             signer_bitvec,
         })
         .unwrap();

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -357,14 +357,6 @@ impl BlockMinerThread {
             .block_height_to_reward_cycle(burn_election_height)
             .expect("FATAL: no reward cycle for sortition");
 
-        #[cfg(test)]
-        {
-            info!(
-                "---- Fetching reward info at height {} for cycle {} ----",
-                burn_election_height, reward_cycle
-            );
-        }
-
         let reward_info = match load_nakamoto_reward_set(
             reward_cycle,
             &self.burn_election_block.sortition_id,
@@ -392,14 +384,6 @@ impl BlockMinerThread {
                 "Current reward cycle did not select a reward set. Cannot mine!".into(),
             ));
         };
-
-        #[cfg(test)]
-        {
-            info!(
-                "---- New reward set has {} signers ----",
-                reward_set.clone().signers.unwrap_or(vec![]).len(),
-            );
-        }
 
         self.signer_set_cache = Some(reward_set.clone());
         Ok(reward_set)

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -270,18 +270,16 @@ impl BlockMinerThread {
                     }
                 }
 
-                let (reward_set, signer_signature) = match self.gather_signatures(
-                    &mut new_block,
-                    self.burn_block.block_height,
-                    &mut stackerdbs,
-                    &mut attempts,
-                ) {
-                    Ok(x) => x,
-                    Err(e) => {
-                        error!("Error while gathering signatures: {e:?}. Will try mining again.");
-                        continue;
-                    }
-                };
+                let (reward_set, signer_signature) =
+                    match self.gather_signatures(&mut new_block, &mut stackerdbs, &mut attempts) {
+                        Ok(x) => x,
+                        Err(e) => {
+                            error!(
+                                "Error while gathering signatures: {e:?}. Will try mining again."
+                            );
+                            continue;
+                        }
+                    };
 
                 new_block.header.signer_signature = signer_signature;
                 if let Err(e) = self.broadcast(new_block.clone(), reward_set, &stackerdbs) {
@@ -354,10 +352,21 @@ impl BlockMinerThread {
 
         let burn_election_height = self.burn_election_block.block_height;
 
+        let reward_cycle = self
+            .burnchain
+            .block_height_to_reward_cycle(burn_election_height)
+            .expect("FATAL: no reward cycle for sortition");
+
+        #[cfg(test)]
+        {
+            info!(
+                "---- Fetching reward info at height {} for cycle {} ----",
+                burn_election_height, reward_cycle
+            );
+        }
+
         let reward_info = match load_nakamoto_reward_set(
-            self.burnchain
-                .pox_reward_cycle(burn_election_height)
-                .expect("FATAL: no reward cycle for sortition"),
+            reward_cycle,
             &self.burn_election_block.sortition_id,
             &self.burnchain,
             &mut chain_state,
@@ -384,6 +393,14 @@ impl BlockMinerThread {
             ));
         };
 
+        #[cfg(test)]
+        {
+            info!(
+                "---- New reward set has {} signers ----",
+                reward_set.clone().signers.unwrap_or(vec![]).len(),
+            );
+        }
+
         self.signer_set_cache = Some(reward_set.clone());
         Ok(reward_set)
     }
@@ -392,7 +409,6 @@ impl BlockMinerThread {
     fn gather_signatures(
         &mut self,
         new_block: &mut NakamotoBlock,
-        burn_block_height: u64,
         stackerdbs: &mut StackerDBs,
         attempts: &mut u64,
     ) -> Result<(RewardSet, Vec<MessageSignature>), NakamotoNodeError> {
@@ -442,7 +458,6 @@ impl BlockMinerThread {
         *attempts += 1;
         let signature = coordinator.begin_sign_v0(
             new_block,
-            burn_block_height,
             *attempts,
             &tip,
             &self.burnchain,

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -642,13 +642,6 @@ impl SignCoordinator {
         counters: &Counters,
         election_sortition: &ConsensusHash,
     ) -> Result<Vec<MessageSignature>, NakamotoNodeError> {
-        #[cfg(test)]
-        {
-            info!(
-                "---- Sign coordinator starting. Burn tip height: {} ----",
-                burn_tip.block_height
-            );
-        }
         let sign_id = Self::get_sign_id(burn_tip.block_height, burnchain);
         let sign_iter_id = block_attempt;
         let reward_cycle_id = burnchain
@@ -742,7 +735,7 @@ impl SignCoordinator {
                 continue;
             };
             if signer_set != u32::try_from(reward_cycle_id % 2).unwrap() {
-                info!("Received signer event for other reward cycle. Ignoring.");
+                debug!("Received signer event for other reward cycle. Ignoring.");
                 continue;
             };
             let slot_ids = modified_slots

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -7254,7 +7254,7 @@ fn mock_mining() {
         let mock_miner_timeout = Instant::now();
         while follower_naka_mined_blocks.load(Ordering::SeqCst) <= follower_naka_mined_blocks_before
         {
-            if mock_miner_timeout.elapsed() >= Duration::from_secs(30) {
+            if mock_miner_timeout.elapsed() >= Duration::from_secs(60) {
                 panic!(
                     "Timed out waiting for mock miner block {}",
                     follower_naka_mined_blocks_before + 1

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -105,7 +105,7 @@ use crate::tests::neon_integrations::{
 };
 use crate::tests::{
     get_chain_info, make_contract_publish, make_contract_publish_versioned, make_stacks_transfer,
-    set_random_binds, to_addr,
+    to_addr,
 };
 use crate::{tests, BitcoinRegtestController, BurnchainController, Config, ConfigFile, Keychain};
 

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -64,7 +64,8 @@ use crate::tests::nakamoto_integrations::{
     naka_neon_integration_conf, next_block_and_mine_commit, POX_4_DEFAULT_STACKER_BALANCE,
 };
 use crate::tests::neon_integrations::{
-    next_block_and_wait, run_until_burnchain_height, test_observer, wait_for_runloop,
+    get_chain_info, next_block_and_wait, run_until_burnchain_height, test_observer,
+    wait_for_runloop,
 };
 use crate::tests::to_addr;
 use crate::{BitcoinRegtestController, BurnchainController};
@@ -473,15 +474,15 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     }
 
     fn get_current_reward_cycle(&self) -> u64 {
-        let block_height = self
+        let block_height = get_chain_info(&self.running_nodes.conf).burn_block_height;
+        let rc = self
             .running_nodes
-            .btc_regtest_controller
-            .get_headers_height();
-        self.running_nodes
             .btc_regtest_controller
             .get_burnchain()
             .block_height_to_reward_cycle(block_height)
-            .unwrap()
+            .unwrap();
+        info!("Get current reward cycle: block_height = {block_height}, rc = {rc}");
+        rc
     }
 
     fn get_signer_index(&self, reward_cycle: u64) -> SignerSlotID {

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -125,7 +125,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         initial_balances: Vec<(StacksAddress, u64)>,
         wait_on_signers: Option<Duration>,
         mut signer_config_modifier: F,
-        node_config_modifier: G,
+        mut node_config_modifier: G,
         btc_miner_pubkeys: &[Secp256k1PublicKey],
     ) -> Self {
         // Generate Signer Data
@@ -135,7 +135,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
 
         let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
 
-        naka_modifier(&mut naka_conf);
+        node_config_modifier(&mut naka_conf);
 
         // Add initial balances to the config
         for (address, amount) in initial_balances.iter() {
@@ -192,15 +192,15 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
                     .unwrap(),
             )
             .unwrap();
-            &[pk]
+            vec![pk]
         } else {
-            btc_miner_pubkeys
+            btc_miner_pubkeys.to_vec()
         };
         let node = setup_stx_btc_node(
             naka_conf,
             &signer_stacks_private_keys,
             &signer_configs,
-            btc_miner_pubkeys,
+            btc_miner_pubkeys.as_slice(),
             node_config_modifier,
         );
         let config = signer_configs.first().unwrap();

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -2393,7 +2393,7 @@ fn signer_set_rollover() {
     let short_timeout = Duration::from_secs(20);
 
     // Verify that naka_conf has our new signer's event observers
-    for toml in new_signer_configs.clone() {
+    for toml in &new_signer_configs {
         let signer_config = SignerConfig::load_from_str(&toml).unwrap();
         let endpoint = format!("{}", signer_config.endpoint);
         assert!(signer_test

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -27,13 +27,11 @@ use libsigner::v0::messages::{
 use libsigner::{BlockProposal, SignerSession, StackerDBSession};
 use rand::RngCore;
 use stacks::address::AddressHashMode;
-use stacks::address::AddressHashMode;
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader, NakamotoChainState};
 use stacks::chainstate::stacks::address::PoxAddress;
 use stacks::chainstate::stacks::boot::MINERS_NAME;
 use stacks::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
 use stacks::codec::StacksMessageCodec;
-use stacks::core::CHAIN_ID_TESTNET;
 use stacks::core::{StacksEpochId, CHAIN_ID_TESTNET};
 use stacks::libstackerdb::StackerDBChunkData;
 use stacks::net::api::postblock_proposal::TEST_VALIDATE_STALL;
@@ -42,9 +40,6 @@ use stacks::types::PublicKey;
 use stacks::util::hash::MerkleHashFunc;
 use stacks::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use stacks::util_lib::boot::boot_code_id;
-use stacks::util_lib::signed_structured_data::pox4::{
-    make_pox_4_signer_key_signature, Pox4SignatureTopic,
-};
 use stacks::util_lib::signed_structured_data::pox4::{
     make_pox_4_signer_key_signature, Pox4SignatureTopic,
 };
@@ -64,10 +59,8 @@ use crate::nakamoto_node::miner::TEST_BROADCAST_STALL;
 use crate::nakamoto_node::relayer::TEST_SKIP_COMMIT_OP;
 use crate::run_loop::boot_nakamoto;
 use crate::tests::nakamoto_integrations::{
-    
     boot_to_epoch_25, boot_to_epoch_3_reward_set, next_block_and, POX_4_DEFAULT_STACKER_BALANCE,
     POX_4_DEFAULT_STACKER_STX_AMT,
-, POX_4_DEFAULT_STACKER_STX_AMT,
 };
 use crate::tests::neon_integrations::{
     get_account, get_chain_info, next_block_and_wait, run_until_burnchain_height, submit_tx,
@@ -1986,6 +1979,7 @@ fn signer_set_rollover() {
             }
             naka_conf.node.rpc_bind = rpc_bind.clone();
         },
+        &[],
     );
     assert_eq!(
         new_spawned_signers[0].config.node_host,

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -2080,6 +2080,7 @@ fn empty_sortition() {
                 assert!(matches!(reason_code, RejectCode::SortitionViewMismatch));
                 found_rejection = true;
             } else {
+                error!("Unexpected message type: {:?}", message);
                 panic!("Unexpected message type");
             }
         }

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -141,9 +141,6 @@ impl SignerTest<SpawnedSigner> {
     // Only call after already past the epoch 3.0 boundary
     fn mine_and_verify_confirmed_naka_block(&mut self, timeout: Duration, num_signers: usize) {
         info!("------------------------- Try mining one block -------------------------");
-        // Get the current signers _before_ the new block
-        let reward_cycle = self.get_current_reward_cycle();
-        let signers = self.get_reward_set_signers(reward_cycle);
 
         self.mine_nakamoto_block(timeout);
 
@@ -160,6 +157,9 @@ impl SignerTest<SpawnedSigner> {
         // NOTE: signature.len() does not need to equal signers.len(); the stacks miner can finish the block
         //  whenever it has crossed the threshold.
         assert!(signature.len() >= num_signers * 7 / 10);
+
+        let reward_cycle = self.get_current_reward_cycle();
+        let signers = self.get_reward_set_signers(reward_cycle);
 
         // Verify that the signers signed the proposed block
         let mut signer_index = 0;

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -2136,8 +2136,8 @@ fn signer_set_rollover() {
     let current_signers = signer_test.get_reward_set_signers(new_reward_cycle);
     assert_eq!(current_signers.len(), new_num_signers as usize);
     for signer in current_signers.iter() {
-        assert!(signer_test_public_keys.contains(&signer.signing_key.to_vec()));
-        assert!(!new_signer_public_keys.contains(&signer.signing_key.to_vec()));
+        assert!(!signer_test_public_keys.contains(&signer.signing_key.to_vec()));
+        assert!(new_signer_public_keys.contains(&signer.signing_key.to_vec()));
     }
 
     info!("---- Mining a block to verify new signer set -----");

--- a/testnet/stacks-node/src/tests/signer/v1.rs
+++ b/testnet/stacks-node/src/tests/signer/v1.rs
@@ -71,6 +71,7 @@ impl SignerTest<SpawnedSigner> {
             &self.signer_stacks_private_keys,
             &self.signer_stacks_private_keys,
             &mut self.running_nodes.btc_regtest_controller,
+            Some(self.num_stacking_cycles),
         );
         let dkg_vote = self.wait_for_dkg(timeout);
 
@@ -493,6 +494,7 @@ fn dkg() {
         &signer_test.signer_stacks_private_keys,
         &signer_test.signer_stacks_private_keys,
         &mut signer_test.running_nodes.btc_regtest_controller,
+        Some(signer_test.num_stacking_cycles),
     );
 
     info!("Pox 4 activated and at epoch 3.0 reward set calculation (2nd block of its prepare phase)! Ready for signers to perform DKG and Sign!");
@@ -696,6 +698,7 @@ fn delayed_dkg() {
         &signer_test.signer_stacks_private_keys,
         &signer_test.signer_stacks_private_keys,
         &mut signer_test.running_nodes.btc_regtest_controller,
+        Some(signer_test.num_stacking_cycles),
     );
     let reward_cycle = signer_test.get_current_reward_cycle().saturating_add(1);
     let public_keys = signer_test.get_signer_public_keys(reward_cycle);


### PR DESCRIPTION
This PR implements an integration test for handling signer set handoffs.

In this test, we boot up a signer test as usual with 5 signers. I've made modifications to only stack for one cycle in this test. 4 other signers are also spun up, but they aren't stacked yet. During the first Nakamoto cycle, the new signers are stacked. This integration test ensures that everything behaves smoothly when the new signer set is completely different than a previous one.

NB: I'm opening this in draft state, because I'm hitting some issues that I believe are bugs in the miner's reward set loading behavior. I'll leave comments on the relevant code.