### PR TITLE
Clarity-wasm: Linked function for skipping a serialized list

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -2023,6 +2023,7 @@ fn link_host_functions(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Er
     link_principal_of_fn(linker)?;
     link_save_constant_fn(linker)?;
     link_load_constant_fn(linker)?;
+    link_skip_list(linker)?;
 
     link_log(linker)
 }
@@ -6063,6 +6064,44 @@ fn link_load_constant_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
         .map_err(|e| {
             Error::Wasm(WasmError::UnableToLinkHostFunction(
                 "load_constant".to_string(),
+                e,
+            ))
+        })
+}
+
+fn link_skip_list<T>(linker: &mut Linker<T>) -> Result<(), Error> {
+    linker
+        .func_wrap(
+            "clarity",
+            "skip_list",
+            |mut caller: Caller<'_, T>, offset_beg: i32, offset_end: i32| {
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(Error::Wasm(WasmError::MemoryNotFound))?;
+
+                // we will read the remaining serialized buffer here, and start it with the list type prefix
+                let mut serialized_buffer = vec![0u8; (offset_end - offset_beg) as usize + 1];
+                serialized_buffer[0] = super::types::serialization::TypePrefix::List as u8;
+                memory
+                    .read(
+                        &mut caller,
+                        offset_beg as usize,
+                        &mut serialized_buffer[1..],
+                    )
+                    .map_err(|e| Error::Wasm(WasmError::Runtime(e.into())))?;
+
+                match Value::deserialize_read_count(&mut serialized_buffer.as_slice(), None, false)
+                {
+                    Ok((_, bytes_read)) => Ok(offset_beg + bytes_read as i32 - 1),
+                    Err(_) => Ok(0),
+                }
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            Error::Wasm(WasmError::UnableToLinkHostFunction(
+                "skip_list".to_string(),
                 e,
             ))
         })


### PR DESCRIPTION
This is a linked function for skipping an extra serialized list in a tuple.

This is needed to the "duplication of code issue" for `contract-call?`.
