### PR TITLE
Update vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
     "recommendations": [
         "rust-lang.rust-analyzer",
         "vadimcn.vscode-lldb",
-        "serayuzgur.crates",
+        "fill-labs.dependi",
         "editorconfig.editorconfig",
     ]
 }


### PR DESCRIPTION
The `crates` extension is deprecated and replaced with `Dependi`, so this fixes some annoyances for VSCode developers.