### PR TITLE
fix: handle empty type_args in define-trait definition

### DIFF
--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -1657,8 +1657,8 @@ impl TypeSignature {
     ) -> Result<BTreeMap<ClarityName, FunctionSignature>> {
         let mut trait_signature: BTreeMap<ClarityName, FunctionSignature> = BTreeMap::new();
         let functions_types = type_args
-               .get(0)
-               .ok_or_else(|| CheckErrors::InvalidTypeDescription)?       
+            .get(0)
+            .ok_or_else(|| CheckErrors::InvalidTypeDescription)?
             .match_list()
             .ok_or(CheckErrors::DefineTraitBadSignature)?;
 

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -1655,11 +1655,10 @@ impl TypeSignature {
         epoch: StacksEpochId,
         clarity_version: ClarityVersion,
     ) -> Result<BTreeMap<ClarityName, FunctionSignature>> {
-        if type_args.is_empty() {
-            return Err(CheckErrors::InvalidTypeDescription);
-        }
         let mut trait_signature: BTreeMap<ClarityName, FunctionSignature> = BTreeMap::new();
-        let functions_types = type_args[0]
+        let functions_types = type_args
+               .get(0)
+               .ok_or_else(|| CheckErrors::InvalidTypeDescription)?       
             .match_list()
             .ok_or(CheckErrors::DefineTraitBadSignature)?;
 

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -1655,6 +1655,9 @@ impl TypeSignature {
         epoch: StacksEpochId,
         clarity_version: ClarityVersion,
     ) -> Result<BTreeMap<ClarityName, FunctionSignature>> {
+        if type_args.is_empty() {
+            return Err(CheckErrors::InvalidTypeDescription);
+        }
         let mut trait_signature: BTreeMap<ClarityName, FunctionSignature> = BTreeMap::new();
         let functions_types = type_args[0]
             .match_list()


### PR DESCRIPTION
Safety check in parse_trait_type_repr