### PR TITLE
Fix: Signers CI tests and refresh signer config behaviors

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -95,6 +95,7 @@ jobs:
           - tests::signer::v0::mock_sign_epoch_25
           - tests::signer::v0::signer_set_rollover
           - tests::signer::v0::miner_forking
+          - tests::signer::v0::reloads_signer_set_in
           - tests::nakamoto_integrations::stack_stx_burn_op_integration_test
           - tests::nakamoto_integrations::check_block_heights
           - tests::nakamoto_integrations::clarity_burn_state

--- a/libsigner/src/runloop.rs
+++ b/libsigner/src/runloop.rs
@@ -246,13 +246,14 @@ impl<
         let (event_send, event_recv) = channel();
         event_receiver.add_consumer(event_send);
 
+        let bind_port = bind_addr.port();
         event_receiver.bind(bind_addr)?;
         let stop_signaler = event_receiver.get_stop_signaler()?;
         let mut ret_stop_signaler = event_receiver.get_stop_signaler()?;
 
         // start a thread for the event receiver
         let event_thread = thread::Builder::new()
-            .name("event_receiver".to_string())
+            .name(format!("event_receiver:{bind_port}"))
             .stack_size(THREAD_STACK_SIZE)
             .spawn(move || event_receiver.main_loop())
             .map_err(|e| {
@@ -262,7 +263,7 @@ impl<
 
         // start receiving events and doing stuff with them
         let runloop_thread = thread::Builder::new()
-            .name(format!("signer_runloop:{}", bind_addr.port()))
+            .name(format!("signer_runloop:{bind_port}"))
             .stack_size(THREAD_STACK_SIZE)
             .spawn(move || {
                 signer_loop.main_loop(event_recv, command_receiver, result_sender, stop_signaler)

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -34,6 +34,8 @@ use stacks_common::debug;
 const BACKOFF_INITIAL_INTERVAL: u64 = 128;
 /// Backoff timer max interval in milliseconds
 const BACKOFF_MAX_INTERVAL: u64 = 16384;
+/// Backoff timer max elapsed seconds
+const BACKOFF_MAX_ELAPSED: u64 = 5;
 
 #[derive(thiserror::Error, Debug)]
 /// Client error type
@@ -109,6 +111,7 @@ where
     let backoff_timer = backoff::ExponentialBackoffBuilder::new()
         .with_initial_interval(Duration::from_millis(BACKOFF_INITIAL_INTERVAL))
         .with_max_interval(Duration::from_millis(BACKOFF_MAX_INTERVAL))
+        .with_max_elapsed_time(Some(Duration::from_secs(BACKOFF_MAX_ELAPSED)))
         .build();
 
     backoff::retry_notify(backoff_timer, request_fn, notify).map_err(|_| ClientError::RetryTimeout)

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -33,7 +33,7 @@ use blockstack_lib::net::api::get_tenures_fork_info::{
 use blockstack_lib::net::api::getaccount::AccountEntryResponse;
 use blockstack_lib::net::api::getpoxinfo::RPCPoxInfoData;
 use blockstack_lib::net::api::getsortition::{SortitionInfo, RPC_SORTITION_INFO_PATH};
-use blockstack_lib::net::api::getstackers::GetStackersResponse;
+use blockstack_lib::net::api::getstackers::{GetStackersErrors, GetStackersResponse};
 use blockstack_lib::net::api::postblock::StacksBlockAcceptedData;
 use blockstack_lib::net::api::postblock_proposal::NakamotoBlockProposal;
 use blockstack_lib::net::api::postblock_v3;
@@ -541,7 +541,7 @@ impl StacksClient {
                 warn!("Failed to parse the GetStackers error response: {e}");
                 backoff::Error::permanent(e.into())
             })?;
-            if error_data.err_type == "not_available_try_again" {
+            if &error_data.err_type == GetStackersErrors::NOT_AVAILABLE_ERR_TYPE {
                 return Err(backoff::Error::transient(ClientError::NoSortitionOnChain));
             } else {
                 warn!("Got error response ({status}): {}", error_data.err_msg);

--- a/stacks-signer/src/lib.rs
+++ b/stacks-signer/src/lib.rs
@@ -61,8 +61,6 @@ use crate::runloop::{RunLoop, RunLoopCommand};
 pub trait Signer<T: SignerEventTrait>: Debug + Display {
     /// Create a new `Signer` instance
     fn new(config: SignerConfig) -> Self;
-    /// Update the `Signer` instance's with the next reward cycle data `SignerConfig`
-    fn update_signer(&mut self, next_signer_config: &SignerConfig);
     /// Get the reward cycle of the signer
     fn reward_cycle(&self) -> u64;
     /// Process an event

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -138,6 +138,58 @@ impl RewardCycleInfo {
     }
 }
 
+/// The configuration state for a reward cycle.
+/// Allows us to track if we've registered a signer for a cycle or not
+///  and to differentiate between being unregistered and simply not configured
+pub enum ConfiguredSigner<Signer, T>
+where
+    Signer: SignerTrait<T>,
+    T: StacksMessageCodec + Clone + Send + Debug,
+{
+    /// Signer is registered for the cycle and ready to process messages
+    RegisteredSigner(Signer),
+    /// The signer runloop isn't registered for this cycle (i.e., we've checked the
+    ///   the signer set and we're not in it)
+    NotRegistered {
+        /// the cycle number we're not registered for
+        cycle: u64,
+        /// Phantom data for the message codec
+        _phantom_state: std::marker::PhantomData<T>,
+    },
+}
+
+impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> std::fmt::Display
+    for ConfiguredSigner<Signer, T>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RegisteredSigner(s) => write!(f, "{s}"),
+            Self::NotRegistered { cycle, .. } => write!(f, "NotRegistered in Cycle #{cycle}"),
+        }
+    }
+}
+
+impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug>
+    ConfiguredSigner<Signer, T>
+{
+    /// Create a `NotRegistered` instance of the enum (so that callers do not need
+    ///  to supply phantom_state data).
+    pub fn not_registered(cycle: u64) -> Self {
+        Self::NotRegistered {
+            cycle,
+            _phantom_state: std::marker::PhantomData,
+        }
+    }
+
+    /// The reward cycle this signer is configured for
+    pub fn reward_cycle(&self) -> u64 {
+        match self {
+            ConfiguredSigner::RegisteredSigner(s) => s.reward_cycle(),
+            ConfiguredSigner::NotRegistered { cycle, .. } => *cycle,
+        }
+    }
+}
+
 /// The runloop for the stacks signer
 pub struct RunLoop<Signer, T>
 where
@@ -150,7 +202,7 @@ where
     pub stacks_client: StacksClient,
     /// The internal signer for an odd or even reward cycle
     /// Keyed by reward cycle % 2
-    pub stacks_signers: HashMap<u64, Signer>,
+    pub stacks_signers: HashMap<u64, ConfiguredSigner<Signer, T>>,
     /// The state of the runloop
     pub state: State,
     /// The commands received thus far
@@ -159,8 +211,6 @@ where
     pub current_reward_cycle_info: Option<RewardCycleInfo>,
     /// Cache sortitin data from `stacks-node`
     pub sortition_state: Option<SortitionsView>,
-    /// Phantom data for the message codec
-    _phantom_data: std::marker::PhantomData<T>,
 }
 
 impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLoop<Signer, T> {
@@ -175,7 +225,6 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
             commands: VecDeque::new(),
             current_reward_cycle_info: None,
             sortition_state: None,
-            _phantom_data: std::marker::PhantomData,
         }
     }
     /// Get the registered signers for a specific reward cycle
@@ -222,25 +271,40 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
         Ok(signer_slot_ids)
     }
     /// Get a signer configuration for a specific reward cycle from the stacks node
-    fn get_signer_config(&mut self, reward_cycle: u64) -> Option<SignerConfig> {
+    fn get_signer_config(
+        &mut self,
+        reward_cycle: u64,
+    ) -> Result<Option<SignerConfig>, ClientError> {
         // We can only register for a reward cycle if a reward set exists.
-        let signer_entries = self.get_parsed_reward_set(reward_cycle).ok()??;
-        let signer_slot_ids = self
-            .get_parsed_signer_slots(&self.stacks_client, reward_cycle)
-            .ok()?;
+        let signer_entries = match self.get_parsed_reward_set(reward_cycle) {
+            Ok(Some(x)) => x,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                warn!("Error while fetching reward set {reward_cycle}: {e:?}");
+                return Err(e);
+            }
+        };
+        let signer_slot_ids = match self.get_parsed_signer_slots(&self.stacks_client, reward_cycle)
+        {
+            Ok(x) => x,
+            Err(e) => {
+                warn!("Error while fetching stackerdb slots {reward_cycle}: {e:?}");
+                return Err(e);
+            }
+        };
         let current_addr = self.stacks_client.get_signer_address();
 
         let Some(signer_slot_id) = signer_slot_ids.get(current_addr) else {
             warn!(
                     "Signer {current_addr} was not found in stacker db. Must not be registered for this reward cycle {reward_cycle}."
                 );
-            return None;
+            return Ok(None);
         };
         let Some(signer_id) = signer_entries.signer_ids.get(current_addr) else {
             warn!(
                 "Signer {current_addr} was found in stacker db but not the reward set for reward cycle {reward_cycle}."
             );
-            return None;
+            return Ok(None);
         };
         info!(
             "Signer #{signer_id} ({current_addr}) is registered for reward cycle {reward_cycle}."
@@ -250,7 +314,7 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
             .get(signer_id)
             .cloned()
             .unwrap_or_default();
-        Some(SignerConfig {
+        Ok(Some(SignerConfig {
             reward_cycle,
             signer_id: *signer_id,
             signer_slot_id: *signer_slot_id,
@@ -271,32 +335,30 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
             max_tx_fee_ustx: self.config.max_tx_fee_ustx,
             db_path: self.config.db_path.clone(),
             block_proposal_timeout: self.config.block_proposal_timeout,
-        })
+        }))
     }
 
     /// Refresh signer configuration for a specific reward cycle
     fn refresh_signer_config(&mut self, reward_cycle: u64) {
         let reward_index = reward_cycle % 2;
-        if let Some(new_signer_config) = self.get_signer_config(reward_cycle) {
-            let signer_id = new_signer_config.signer_id;
-            debug!("Signer is registered for reward cycle {reward_cycle} as signer #{signer_id}. Initializing signer state.");
-            if reward_cycle != 0 {
-                let prior_reward_cycle = reward_cycle.saturating_sub(1);
-                let prior_reward_set = prior_reward_cycle % 2;
-                if let Some(signer) = self.stacks_signers.get_mut(&prior_reward_set) {
-                    if signer.reward_cycle() == prior_reward_cycle {
-                        // The signers have been calculated for the next reward cycle. Update the current one
-                        debug!("{signer}: Next reward cycle ({reward_cycle}) signer set calculated. Reconfiguring current reward cycle signer.");
-                        signer.update_signer(&new_signer_config);
-                    }
-                }
+        let new_signer_config = match self.get_signer_config(reward_cycle) {
+            Ok(Some(new_signer_config)) => {
+                let signer_id = new_signer_config.signer_id;
+                let new_signer = Signer::new(new_signer_config);
+                info!("{new_signer} Signer is registered for reward cycle {reward_cycle} as signer #{signer_id}. Initialized signer state.");
+                ConfiguredSigner::RegisteredSigner(new_signer)
             }
-            let new_signer = Signer::new(new_signer_config);
-            info!("{new_signer} initialized.");
-            self.stacks_signers.insert(reward_index, new_signer);
-        } else {
-            warn!("Signer is not registered for reward cycle {reward_cycle}. Waiting for confirmed registration...");
-        }
+            Ok(None) => {
+                warn!("Signer is not registered for reward cycle {reward_cycle}");
+                ConfiguredSigner::not_registered(reward_cycle)
+            }
+            Err(e) => {
+                warn!("Failed to get the reward set info: {e}. Will try again later.");
+                return;
+            }
+        };
+
+        self.stacks_signers.insert(reward_index, new_signer_config);
     }
 
     fn initialize_runloop(&mut self) -> Result<(), ClientError> {
@@ -322,7 +384,11 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
         Ok(())
     }
 
-    fn refresh_runloop(&mut self, current_burn_block_height: u64) -> Result<(), ClientError> {
+    fn refresh_runloop(&mut self, ev_burn_block_height: u64) -> Result<(), ClientError> {
+        let current_burn_block_height = std::cmp::max(
+            self.stacks_client.get_peer_info()?.burn_block_height,
+            ev_burn_block_height,
+        );
         let reward_cycle_info = self
             .current_reward_cycle_info
             .as_mut()
@@ -332,48 +398,44 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
 
         // First ensure we refresh our view of the current reward cycle information
         if block_reward_cycle != current_reward_cycle {
-            let new_reward_cycle_info = retry_with_exponential_backoff(|| {
-                let info = self
-                    .stacks_client
-                    .get_current_reward_cycle_info()
-                    .map_err(backoff::Error::transient)?;
-                if info.reward_cycle < block_reward_cycle {
-                    // If the stacks-node is still processing the burn block, the /v2/pox endpoint
-                    // may return the previous reward cycle. In this case, we should retry.
-                    return Err(backoff::Error::transient(ClientError::InvalidResponse(
-                        format!("Received reward cycle ({}) does not match the expected reward cycle ({}) for block {}.",
-                            info.reward_cycle,
-                            block_reward_cycle,
-                            current_burn_block_height
-                        ),
-                    )));
-                }
-                Ok(info)
-            })?;
+            let new_reward_cycle_info = RewardCycleInfo {
+                reward_cycle: block_reward_cycle,
+                reward_cycle_length: reward_cycle_info.reward_cycle_length,
+                prepare_phase_block_length: reward_cycle_info.prepare_phase_block_length,
+                first_burnchain_block_height: reward_cycle_info.first_burnchain_block_height,
+                last_burnchain_block_height: current_burn_block_height,
+            };
             *reward_cycle_info = new_reward_cycle_info;
         }
+        let reward_cycle_before_refresh = current_reward_cycle;
         let current_reward_cycle = reward_cycle_info.reward_cycle;
-        // We should only attempt to refresh the signer if we are not configured for the next reward cycle yet and we received a new burn block for its prepare phase
-        if reward_cycle_info.is_in_next_prepare_phase(current_burn_block_height) {
-            let next_reward_cycle = current_reward_cycle.saturating_add(1);
-            if self
-                .stacks_signers
-                .get(&(next_reward_cycle % 2))
-                .map(|signer| signer.reward_cycle() != next_reward_cycle)
-                .unwrap_or(true)
-            {
-                info!("Received a new burnchain block height ({current_burn_block_height}) in the prepare phase of the next reward cycle ({next_reward_cycle}). Checking for signer registration...");
+        let is_in_next_prepare_phase =
+            reward_cycle_info.is_in_next_prepare_phase(current_burn_block_height);
+        let next_reward_cycle = current_reward_cycle.saturating_add(1);
+
+        info!(
+            "Refreshing runloop with new burn block event";
+            "latest_node_burn_ht" => current_burn_block_height,
+            "event_ht" =>  ev_burn_block_height,
+            "reward_cycle_before_refresh" => reward_cycle_before_refresh,
+            "current_reward_cycle" => current_reward_cycle,
+            "configured_for_current" => Self::is_configured_for_cycle(&self.stacks_signers, current_reward_cycle),
+            "configured_for_next" => Self::is_configured_for_cycle(&self.stacks_signers, next_reward_cycle),
+            "is_in_next_prepare_phase" => is_in_next_prepare_phase,
+        );
+
+        // Check if we need to refresh the signers:
+        //   need to refresh the current signer if we are not configured for the current reward cycle
+        //   need to refresh the next signer if we're not configured for the next reward cycle, and we're in the prepare phase
+        if !Self::is_configured_for_cycle(&self.stacks_signers, current_reward_cycle) {
+            self.refresh_signer_config(current_reward_cycle);
+        }
+        if is_in_next_prepare_phase {
+            if !Self::is_configured_for_cycle(&self.stacks_signers, next_reward_cycle) {
                 self.refresh_signer_config(next_reward_cycle);
             }
-        } else {
-            info!("Received a new burnchain block height ({current_burn_block_height}) but not in prepare phase.";
-                "reward_cycle" => reward_cycle_info.reward_cycle,
-                "reward_cycle_length" => reward_cycle_info.reward_cycle_length,
-                "prepare_phase_block_length" => reward_cycle_info.prepare_phase_block_length,
-                "first_burnchain_block_height" => reward_cycle_info.first_burnchain_block_height,
-                "last_burnchain_block_height" => reward_cycle_info.last_burnchain_block_height,
-            );
         }
+
         self.cleanup_stale_signers(current_reward_cycle);
         if self.stacks_signers.is_empty() {
             self.state = State::NoRegisteredSigners;
@@ -383,6 +445,16 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
         Ok(())
     }
 
+    fn is_configured_for_cycle(
+        stacks_signers: &HashMap<u64, ConfiguredSigner<Signer, T>>,
+        reward_cycle: u64,
+    ) -> bool {
+        let Some(signer) = stacks_signers.get(&(reward_cycle % 2)) else {
+            return false;
+        };
+        signer.reward_cycle() == reward_cycle
+    }
+
     fn cleanup_stale_signers(&mut self, current_reward_cycle: u64) {
         let mut to_delete = Vec::new();
         for (idx, signer) in &mut self.stacks_signers {
@@ -390,7 +462,13 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
             let next_reward_cycle = reward_cycle.wrapping_add(1);
             let stale = match next_reward_cycle.cmp(&current_reward_cycle) {
                 std::cmp::Ordering::Less => true, // We are more than one reward cycle behind, so we are stale
-                std::cmp::Ordering::Equal => !signer.has_pending_blocks(), // We are the next reward cycle, so check if we have any pending blocks to process
+                std::cmp::Ordering::Equal => {
+                    // We are the next reward cycle, so check if we were registered and have any pending blocks to process
+                    match signer {
+                        ConfiguredSigner::RegisteredSigner(signer) => !signer.has_pending_blocks(),
+                        _ => true,
+                    }
+                }
                 std::cmp::Ordering::Greater => false, // We are the current reward cycle, so we are not stale
             };
             if stale {
@@ -425,6 +503,19 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug>
             "Running one pass for the signer. state={:?}, cmd={cmd:?}, event={event:?}",
             self.state
         );
+        // This is the only event that we respond to from the outer signer runloop
+        if let Some(SignerEvent::StatusCheck) = event {
+            info!("Signer status check requested: {:?}.", self.state);
+            if let Err(e) = res.send(vec![StateInfo {
+                runloop_state: self.state,
+                reward_cycle_info: self.current_reward_cycle_info,
+            }
+            .into()])
+            {
+                error!("Failed to send status check result: {e}.");
+            }
+        }
+
         if let Some(cmd) = cmd {
             self.commands.push_back(cmd);
         }
@@ -447,7 +538,12 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug>
             .as_ref()
             .expect("FATAL: cannot be an initialized signer with no reward cycle info.")
             .reward_cycle;
-        for signer in self.stacks_signers.values_mut() {
+        for configured_signer in self.stacks_signers.values_mut() {
+            let ConfiguredSigner::RegisteredSigner(ref mut signer) = configured_signer else {
+                debug!("{configured_signer}: Not configured for cycle, ignoring events for cycle");
+                continue;
+            };
+
             signer.process_event(
                 &self.stacks_client,
                 &mut self.sortition_state,
@@ -465,18 +561,6 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug>
         if self.state == State::NoRegisteredSigners && event.is_some() {
             let next_reward_cycle = current_reward_cycle.saturating_add(1);
             info!("Signer is not registered for the current reward cycle ({current_reward_cycle}). Reward set is not yet determined or signer is not registered for the upcoming reward cycle ({next_reward_cycle}).");
-        }
-        // This is the only event that we respond to from the outer signer runloop
-        if let Some(SignerEvent::StatusCheck) = event {
-            info!("Signer status check requested: {:?}.", self.state);
-            if let Err(e) = res.send(vec![StateInfo {
-                runloop_state: self.state,
-                reward_cycle_info: self.current_reward_cycle_info,
-            }
-            .into()])
-            {
-                error!("Failed to send status check result: {e}.");
-            }
         }
         None
     }

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -71,10 +71,6 @@ impl SignerTrait<SignerMessage> for Signer {
         Self::from(config)
     }
 
-    /// Refresh the next signer data from the given configuration data
-    fn update_signer(&mut self, _new_signer_config: &SignerConfig) {
-        // do nothing
-    }
     /// Return the reward cycle of the signer
     fn reward_cycle(&self) -> u64 {
         self.reward_cycle

--- a/stacks-signer/src/v1/signer.rs
+++ b/stacks-signer/src/v1/signer.rs
@@ -143,16 +143,6 @@ impl SignerTrait<SignerMessage> for Signer {
         Self::from(config)
     }
 
-    /// Refresh the next signer data from the given configuration data
-    fn update_signer(&mut self, new_signer_config: &SignerConfig) {
-        self.next_signer_addresses = new_signer_config
-            .signer_entries
-            .signer_ids
-            .keys()
-            .copied()
-            .collect();
-        self.next_signer_slot_ids = new_signer_config.signer_slot_ids.clone();
-    }
     /// Return the reward cycle of the signer
     fn reward_cycle(&self) -> u64 {
         self.reward_cycle
@@ -354,6 +344,18 @@ impl Signer {
             let selected = self.coordinator_selector.get_coordinator();
             (Some(selected.0), selected.1)
         }
+    }
+
+    /// Refresh the next signer data from the given configuration data
+    #[allow(dead_code)]
+    fn update_signer(&mut self, new_signer_config: &SignerConfig) {
+        self.next_signer_addresses = new_signer_config
+            .signer_entries
+            .signer_ids
+            .keys()
+            .copied()
+            .collect();
+        self.next_signer_slot_ids = new_signer_config.signer_slot_ids.clone();
     }
 
     /// Get the current coordinator for executing DKG

--- a/stackslib/src/net/api/getstackers.rs
+++ b/stackslib/src/net/api/getstackers.rs
@@ -57,10 +57,13 @@ pub enum GetStackersErrors {
 }
 
 impl GetStackersErrors {
+    pub const NOT_AVAILABLE_ERR_TYPE: &'static str = "not_available_try_again";
+    pub const OTHER_ERR_TYPE: &'static str = "other";
+
     pub fn error_type_string(&self) -> &'static str {
         match self {
-            GetStackersErrors::NotAvailableYet(_) => "not_available_try_again",
-            GetStackersErrors::Other(_) => "other",
+            Self::NotAvailableYet(_) => Self::NOT_AVAILABLE_ERR_TYPE,
+            Self::Other(_) => Self::OTHER_ERR_TYPE,
         }
     }
 }
@@ -250,5 +253,33 @@ impl StacksHttpResponse {
         let response: GetStackersResponse = serde_json::from_value(response_json)
             .map_err(|_e| Error::DecodeError("Failed to decode JSON".to_string()))?;
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::GetStackersErrors;
+
+    #[test]
+    // Test the formatting and error type strings of GetStackersErrors
+    fn get_stackers_errors() {
+        let not_available_err = GetStackersErrors::NotAvailableYet(
+            crate::chainstate::coordinator::Error::PoXNotProcessedYet,
+        );
+        let other_err = GetStackersErrors::Other("foo".into());
+
+        assert_eq!(
+            not_available_err.error_type_string(),
+            GetStackersErrors::NOT_AVAILABLE_ERR_TYPE
+        );
+        assert_eq!(
+            other_err.error_type_string(),
+            GetStackersErrors::OTHER_ERR_TYPE
+        );
+
+        assert!(not_available_err
+            .to_string()
+            .starts_with("Could not read reward set"));
+        assert_eq!(other_err.to_string(), "foo".to_string());
     }
 }

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -631,6 +631,9 @@ impl SignCoordinator {
     /// This function begins by sending a `BlockProposal` message
     /// to the signers, and then waits for the signers to respond
     /// with their signatures.
+    // Mutants skip here: this function is covered via integration tests,
+    //  which the mutation testing does not see.
+    #[cfg_attr(test, mutants::skip)]
     pub fn begin_sign_v0(
         &mut self,
         block: &NakamotoBlock,

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -775,9 +775,10 @@ impl SignCoordinator {
                 let block_sighash = block.header.signer_signature_hash();
                 if block_sighash != response_hash {
                     warn!(
-                        "Processed signature but didn't validate over the expected block. Returning error.";
+                        "Processed signature for a different block. Will try to continue.";
                         "signature" => %signature,
                         "block_signer_signature_hash" => %block_sighash,
+                        "response_hash" => %response_hash,
                         "slot_id" => slot_id,
                         "reward_cycle_id" => reward_cycle_id,
                         "response_hash" => %response_hash

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -15,6 +15,7 @@
 mod v0;
 mod v1;
 
+use std::collections::HashSet;
 // Copyright (C) 2020-2024 Stacks Open Internet Foundation
 //
 // This program is free software: you can redistribute it and/or modify
@@ -51,17 +52,19 @@ use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::{hex_bytes, Sha512Trunc256Sum};
 use stacks_signer::client::{ClientError, SignerSlotID, StacksClient};
 use stacks_signer::config::{build_signer_config_tomls, GlobalConfig as SignerConfig, Network};
-use stacks_signer::runloop::{SignerResult, StateInfo};
+use stacks_signer::runloop::{SignerResult, State, StateInfo};
 use stacks_signer::{Signer, SpawnedSigner};
 use wsts::state_machine::PublicKeys;
 
+use super::nakamoto_integrations::wait_for;
 use crate::config::{Config as NeonConfig, EventKeyType, EventObserverConfig, InitialBalance};
 use crate::event_dispatcher::MinedNakamotoBlockEvent;
 use crate::neon::{Counters, TestFlag};
 use crate::run_loop::boot_nakamoto;
 use crate::tests::bitcoin_regtest::BitcoinCoreController;
 use crate::tests::nakamoto_integrations::{
-    naka_neon_integration_conf, next_block_and_mine_commit, POX_4_DEFAULT_STACKER_BALANCE,
+    naka_neon_integration_conf, next_block_and_mine_commit, next_block_and_wait_for_commits,
+    POX_4_DEFAULT_STACKER_BALANCE,
 };
 use crate::tests::neon_integrations::{
     get_chain_info, next_block_and_wait, run_until_burnchain_height, test_observer,
@@ -222,8 +225,12 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     }
 
     /// Send a status request to each spawned signer
-    pub fn send_status_request(&self) {
-        for port in 3000..3000 + self.spawned_signers.len() {
+    pub fn send_status_request(&self, exclude: &HashSet<usize>) {
+        for signer_ix in 0..self.spawned_signers.len() {
+            if exclude.contains(&signer_ix) {
+                continue;
+            }
+            let port = 3000 + signer_ix;
             let endpoint = format!("http://localhost:{}", port);
             let path = format!("{endpoint}/status");
             let client = reqwest::blocking::Client::new();
@@ -235,39 +242,78 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         }
     }
 
-    /// Wait for the signers to respond to a status check
-    pub fn wait_for_states(&mut self, timeout: Duration) -> Vec<StateInfo> {
-        debug!("Waiting for Status...");
-        let now = std::time::Instant::now();
-        let mut states = Vec::with_capacity(self.spawned_signers.len());
-        for signer in self.spawned_signers.iter() {
-            let old_len = states.len();
-            loop {
-                assert!(
-                    now.elapsed() < timeout,
-                    "Timed out waiting for state checks"
-                );
-                let results = signer
-                    .res_recv
-                    .recv_timeout(timeout)
-                    .expect("failed to recv state results");
-                for result in results {
-                    match result {
-                        SignerResult::OperationResult(_operation) => {
-                            panic!("Recieved an operation result.");
-                        }
-                        SignerResult::StatusCheck(state_info) => {
-                            states.push(state_info);
-                        }
-                    }
+    pub fn wait_for_registered(&mut self, timeout_secs: u64) {
+        let mut finished_signers = HashSet::new();
+        wait_for(timeout_secs, || {
+            self.send_status_request(&finished_signers);
+            thread::sleep(Duration::from_secs(1));
+            let latest_states = self.get_states(&finished_signers);
+            for (ix, state) in latest_states.iter().enumerate() {
+                let Some(state) = state else { continue; };
+                if state.runloop_state == State::RegisteredSigners {
+                    finished_signers.insert(ix);
+                } else {
+                    warn!("Signer #{ix} returned state = {:?}, will try to wait for a registered signers state from them.", state.runloop_state);
                 }
-                if states.len() > old_len {
-                    break;
+            }
+            info!("Finished signers: {:?}", finished_signers.iter().collect::<Vec<_>>());
+            Ok(finished_signers.len() == self.spawned_signers.len())
+        }).unwrap();
+    }
+
+    pub fn wait_for_cycle(&mut self, timeout_secs: u64, reward_cycle: u64) {
+        let mut finished_signers = HashSet::new();
+        wait_for(timeout_secs, || {
+            self.send_status_request(&finished_signers);
+            thread::sleep(Duration::from_secs(1));
+            let latest_states = self.get_states(&finished_signers);
+            for (ix, state) in latest_states.iter().enumerate() {
+                let Some(state) = state else { continue; };
+                let Some(reward_cycle_info) = state.reward_cycle_info else { continue; };
+                if reward_cycle_info.reward_cycle == reward_cycle {
+                    finished_signers.insert(ix);
+                } else {
+                    warn!("Signer #{ix} returned state = {:?}, will try to wait for a cycle = {} state from them.", state, reward_cycle);
+                }
+            }
+            info!("Finished signers: {:?}", finished_signers.iter().collect::<Vec<_>>());
+            Ok(finished_signers.len() == self.spawned_signers.len())
+        }).unwrap();
+    }
+
+    /// Get status check results (if returned) from each signer without blocking
+    /// Returns Some() or None() for each signer, in order of `self.spawned_signers`
+    pub fn get_states(&mut self, exclude: &HashSet<usize>) -> Vec<Option<StateInfo>> {
+        let mut output = Vec::new();
+        for (ix, signer) in self.spawned_signers.iter().enumerate() {
+            if exclude.contains(&ix) {
+                output.push(None);
+                continue;
+            }
+            let Ok(mut results) = signer.res_recv.try_recv() else {
+                debug!("Could not receive latest state from signer #{ix}");
+                output.push(None);
+                continue;
+            };
+            if results.len() > 1 {
+                warn!("Received multiple states from the signer receiver: this test function assumes it should only ever receive 1");
+                panic!();
+            }
+            let Some(result) = results.pop() else {
+                debug!("Could not receive latest state from signer #{ix}");
+                output.push(None);
+                continue;
+            };
+            match result {
+                SignerResult::OperationResult(_operation) => {
+                    panic!("Recieved an operation result.");
+                }
+                SignerResult::StatusCheck(state_info) => {
+                    output.push(Some(state_info));
                 }
             }
         }
-        debug!("Finished waiting for state checks!");
-        states
+        output
     }
 
     fn nmb_blocks_to_reward_set_calculation(&mut self) -> u64 {
@@ -337,18 +383,21 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         test_observer::get_mined_nakamoto_blocks().pop().unwrap()
     }
 
-    fn mine_block_wait_on_processing(&mut self, timeout: Duration) {
-        let commits_submitted = self.running_nodes.commits_submitted.clone();
+    fn mine_block_wait_on_processing(
+        &mut self,
+        coord_channels: &[&Arc<Mutex<CoordinatorChannels>>],
+        commits_submitted: &[&Arc<AtomicU64>],
+        timeout: Duration,
+    ) {
         let blocks_len = test_observer::get_blocks().len();
         let mined_block_time = Instant::now();
-        next_block_and_mine_commit(
+        next_block_and_wait_for_commits(
             &mut self.running_nodes.btc_regtest_controller,
             timeout.as_secs(),
-            &self.running_nodes.coord_channel,
-            &commits_submitted,
+            coord_channels,
+            commits_submitted,
         )
         .unwrap();
-
         let t_start = Instant::now();
         while test_observer::get_blocks().len() <= blocks_len {
             assert!(

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -61,8 +61,9 @@ use crate::nakamoto_node::miner::TEST_BROADCAST_STALL;
 use crate::neon::Counters;
 use crate::run_loop::boot_nakamoto;
 use crate::tests::nakamoto_integrations::{
-    boot_to_epoch_25, boot_to_epoch_3_reward_set, next_block_and, wait_for,
-    POX_4_DEFAULT_STACKER_BALANCE, POX_4_DEFAULT_STACKER_STX_AMT,
+    boot_to_epoch_25, boot_to_epoch_3_reward_set, boot_to_epoch_3_reward_set_calculation_boundary,
+    next_block_and, setup_epoch_3_reward_set, wait_for, POX_4_DEFAULT_STACKER_BALANCE,
+    POX_4_DEFAULT_STACKER_STX_AMT,
 };
 use crate::tests::neon_integrations::{
     get_account, get_chain_info, next_block_and_wait, run_until_burnchain_height, submit_tx,
@@ -742,6 +743,119 @@ struct TenureForkingResult {
     mined_c: MinedNakamotoBlockEvent,
     mined_c_2: Option<MinedNakamotoBlockEvent>,
     mined_d: MinedNakamotoBlockEvent,
+}
+
+#[test]
+#[ignore]
+/// Test to make sure that the signers are capable of reloading their reward set
+///  if the stacks-node doesn't have it available at the first block of a prepare phase (e.g., if there was no block)
+fn reloads_signer_set_in() {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let num_signers = 5;
+    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_addr = tests::to_addr(&sender_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender_addr.clone(), send_amt + send_fee)],
+        Some(Duration::from_secs(15)),
+        |_config| {},
+        |_| {},
+        &[],
+    );
+
+    setup_epoch_3_reward_set(
+        &signer_test.running_nodes.conf,
+        &signer_test.running_nodes.blocks_processed,
+        &signer_test.signer_stacks_private_keys,
+        &signer_test.signer_stacks_private_keys,
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        Some(signer_test.num_stacking_cycles),
+    );
+
+    let naka_conf = &signer_test.running_nodes.conf;
+    let epochs = naka_conf.burnchain.epochs.clone().unwrap();
+    let epoch_3 = &epochs[StacksEpoch::find_epoch_by_id(&epochs, StacksEpochId::Epoch30).unwrap()];
+    let reward_cycle_len = naka_conf.get_burnchain().pox_constants.reward_cycle_length as u64;
+    let prepare_phase_len = naka_conf.get_burnchain().pox_constants.prepare_length as u64;
+
+    let epoch_3_start_height = epoch_3.start_height;
+    assert!(
+        epoch_3_start_height > 0,
+        "Epoch 3.0 start height must be greater than 0"
+    );
+    let epoch_3_reward_cycle_boundary =
+        epoch_3_start_height.saturating_sub(epoch_3_start_height % reward_cycle_len);
+    let before_epoch_3_reward_set_calculation =
+        epoch_3_reward_cycle_boundary.saturating_sub(prepare_phase_len);
+    run_until_burnchain_height(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.blocks_processed,
+        before_epoch_3_reward_set_calculation,
+        naka_conf,
+    );
+
+    info!("Waiting for signer set calculation.");
+    let mut reward_set_calculated = false;
+    let short_timeout = Duration::from_secs(30);
+    let now = std::time::Instant::now();
+    // Make sure the signer set is calculated before continuing or signers may not
+    // recognize that they are registered signers in the subsequent burn block event
+    let reward_cycle = signer_test.get_current_reward_cycle() + 1;
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .build_next_block(1);
+    while !reward_set_calculated {
+        let reward_set = signer_test
+            .stacks_client
+            .get_reward_set_signers(reward_cycle)
+            .expect("Failed to check if reward set is calculated");
+        reward_set_calculated = reward_set.is_some();
+        if reward_set_calculated {
+            info!("Signer set: {:?}", reward_set.unwrap());
+        }
+        std::thread::sleep(Duration::from_secs(1));
+        assert!(
+            now.elapsed() < short_timeout,
+            "Timed out waiting for reward set calculation"
+        );
+    }
+    info!("Signer set calculated");
+
+    // Manually consume one more block to ensure signers refresh their state
+    info!("Waiting for signers to initialize.");
+    next_block_and_wait(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.blocks_processed,
+    );
+    signer_test.wait_for_registered(30);
+    info!("Signers initialized");
+
+    signer_test.run_until_epoch_3_boundary();
+
+    let commits_submitted = signer_test.running_nodes.commits_submitted.clone();
+
+    info!("Waiting 1 burnchain block for miner VRF key confirmation");
+    // Wait one block to confirm the VRF register, wait until a block commit is submitted
+    next_block_and(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        60,
+        || {
+            let commits_count = commits_submitted.load(Ordering::SeqCst);
+            Ok(commits_count >= 1)
+        },
+    )
+    .unwrap();
+    info!("Ready to mine Nakamoto blocks!");
+
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+    signer_test.shutdown();
 }
 
 /// This test spins up a nakamoto-neon node.

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -212,22 +212,7 @@ impl SignerTest<SpawnedSigner> {
             &mut self.running_nodes.btc_regtest_controller,
             &self.running_nodes.blocks_processed,
         );
-        let now = std::time::Instant::now();
-        loop {
-            self.send_status_request();
-            let states = self.wait_for_states(short_timeout);
-            if states
-                .iter()
-                .all(|state_info| state_info.runloop_state == State::RegisteredSigners)
-            {
-                break;
-            }
-            assert!(
-                now.elapsed() < short_timeout,
-                "Timed out waiting for signers to be registered"
-            );
-            std::thread::sleep(Duration::from_secs(1));
-        }
+        self.wait_for_registered(30);
         debug!("Signers initialized");
 
         info!("Advancing to the first full Epoch 2.5 reward cycle boundary...");
@@ -255,7 +240,7 @@ impl SignerTest<SpawnedSigner> {
             &mut self.running_nodes.btc_regtest_controller,
             Some(self.num_stacking_cycles),
         );
-        debug!("Waiting for signer set calculation.");
+        info!("Waiting for signer set calculation.");
         let mut reward_set_calculated = false;
         let short_timeout = Duration::from_secs(30);
         let now = std::time::Instant::now();
@@ -277,31 +262,16 @@ impl SignerTest<SpawnedSigner> {
                 "Timed out waiting for reward set calculation"
             );
         }
-        debug!("Signer set calculated");
+        info!("Signer set calculated");
 
         // Manually consume one more block to ensure signers refresh their state
-        debug!("Waiting for signers to initialize.");
+        info!("Waiting for signers to initialize.");
         next_block_and_wait(
             &mut self.running_nodes.btc_regtest_controller,
             &self.running_nodes.blocks_processed,
         );
-        let now = std::time::Instant::now();
-        loop {
-            self.send_status_request();
-            let states = self.wait_for_states(short_timeout);
-            if states
-                .iter()
-                .all(|state_info| state_info.runloop_state == State::RegisteredSigners)
-            {
-                break;
-            }
-            assert!(
-                now.elapsed() < short_timeout,
-                "Timed out waiting for signers to be registered"
-            );
-            std::thread::sleep(Duration::from_secs(1));
-        }
-        debug!("Singers initialized");
+        self.wait_for_registered(30);
+        info!("Signers initialized");
 
         self.run_until_epoch_3_boundary();
 
@@ -1244,6 +1214,11 @@ fn multiple_miners() {
     );
 
     let mut run_loop_2 = boot_nakamoto::BootRunLoop::new(conf_node_2.clone()).unwrap();
+    let rl2_coord_channels = run_loop_2.coordinator_channels();
+    let Counters {
+        naka_submitted_commits: rl2_commits,
+        ..
+    } = run_loop_2.counters();
     let _run_loop_2_thread = thread::Builder::new()
         .name("run_loop_2".into())
         .spawn(move || run_loop_2.start(None, 0))
@@ -1260,6 +1235,8 @@ fn multiple_miners() {
     //  is that we keep track of how many tenures each miner produced, and once enough sortitions
     //  have been produced such that each miner has produced 3 tenures, we stop and check the
     //  results at the end
+    let rl1_coord_channels = signer_test.running_nodes.coord_channel.clone();
+    let rl1_commits = signer_test.running_nodes.commits_submitted.clone();
 
     let miner_1_pk = StacksPublicKey::from_private(conf.miner.mining_key.as_ref().unwrap());
     let miner_2_pk = StacksPublicKey::from_private(conf_node_2.miner.mining_key.as_ref().unwrap());
@@ -1270,7 +1247,11 @@ fn multiple_miners() {
         if btc_blocks_mined > max_nakamoto_tenures {
             panic!("Produced {btc_blocks_mined} sortitions, but didn't cover the test scenarios, aborting");
         }
-        signer_test.mine_block_wait_on_processing(Duration::from_secs(30));
+        signer_test.mine_block_wait_on_processing(
+            &[&rl1_coord_channels, &rl2_coord_channels],
+            &[&rl1_commits, &rl2_commits],
+            Duration::from_secs(30),
+        );
         btc_blocks_mined += 1;
         let blocks = get_nakamoto_headers(&conf);
         // for this test, there should be one block per tenure
@@ -1785,25 +1766,7 @@ fn end_of_tenure() {
         std::thread::sleep(Duration::from_millis(100));
     }
 
-    let now = std::time::Instant::now();
-    // Wait for the signer to process the burn blocks and fully enter the next reward cycle
-    loop {
-        signer_test.send_status_request();
-        let states = signer_test.wait_for_states(short_timeout);
-        if states.iter().all(|state_info| {
-            state_info
-                .reward_cycle_info
-                .map(|info| info.reward_cycle == final_reward_cycle)
-                .unwrap_or(false)
-        }) {
-            break;
-        }
-        assert!(
-            now.elapsed() < short_timeout,
-            "Timed out waiting for signers to be in the next reward cycle"
-        );
-        std::thread::sleep(Duration::from_millis(100));
-    }
+    signer_test.wait_for_cycle(30, final_reward_cycle);
 
     info!("Block proposed and burn blocks consumed. Verifying that stacks block is still not processed");
 


### PR DESCRIPTION
Fix: a handful of issues causing timing-related test failures in CI
* make `not_available_try_again` error in `GetStackers`, and make it transient in the signer binary
* make signer binary timeout on retries in client
* update signer outer runloop to differentiate between 'not in signer set' and 'have not loaded info yet'
* update signer outer runloop to handle errors and non-presence differently in the signer config refresh
* update signer outer runloop to perform signer config refresh on the current cycle (if not loaded yet) and on the next cycle (if in prepare phase for the next cycle). This was causing an issue on exactly the first cycle of Nakamoto, because the signer set cannot be loaded for the first cycle until after the prepare phase
* update the signer outer runloop to check the node’s block height on event receipt as well
* update the testing harnesses to wait and check more appropriately for status checks from signers, etc.