### PR TITLE
CI - Remove Unit Tests From Check

### DIFF
--- a/.github/workflows/stacks-core-tests.yml
+++ b/.github/workflows/stacks-core-tests.yml
@@ -187,7 +187,6 @@ jobs:
     if: always()
     needs:
       - full-genesis
-      - unit-tests
       - open-api-validation
       - core-contracts-clarinet-test
     steps:


### PR DESCRIPTION
When `Unit Tests` CI Job has a failure, it isn't picked up by the `check-tests` job ([example](https://github.com/stacks-network/stacks-core/actions/runs/10206028421/job/28239633529)) due to the `continue-on-error: true` line in the matrix ([here](https://github.com/stacks-network/stacks-core/blob/05280cd30f7da4f56e6bfe1c404768c9d0b24b80/.github/workflows/stacks-core-tests.yml#L75)), which causes the job status of the unit tests to show up as `success`.

This PR removes the checking of the `unit-tests` job inside `check-tests`, so this 'failed but showing up as successful' scenario is not happening anymore.