### PR TITLE
add methods to TypeMap

### DIFF
--- a/clarity/src/vm/analysis/type_checker/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/contexts.rs
@@ -87,14 +87,9 @@ impl TypeMap {
     }
 
     /// Like set_type but forcing a change if already set
-    pub fn override_type(&mut self, expr: &SymbolicExpression, type_sig: TypeSignature) {
-        match self.map {
-            TypeMapDataType::Map(ref mut map) => {
-                map.insert(expr.id, type_sig);
-            }
-            TypeMapDataType::Set(ref mut map) => {
-                map.insert(expr.id);
-            }
+    pub fn overwrite_type(&mut self, expr: &SymbolicExpression, type_sig: TypeSignature) {
+        if let TypeMapDataType::Map(ref mut map) = self.map {
+            map.insert(expr.id, type_sig);
         }
     }
 

--- a/clarity/src/vm/analysis/type_checker/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/contexts.rs
@@ -86,6 +86,25 @@ impl TypeMap {
         }
     }
 
+    /// Like set_type but forcing a change if already set
+    pub fn override_type(&mut self, expr: &SymbolicExpression, type_sig: TypeSignature) {
+        match self.map {
+            TypeMapDataType::Map(ref mut map) => {
+                map.insert(expr.id, type_sig);
+            }
+            TypeMapDataType::Set(ref mut map) => {
+                map.insert(expr.id);
+            }
+        }
+    }
+
+    pub fn get_type(&self, expr: &SymbolicExpression) -> Option<&TypeSignature> {
+        match self.map {
+            TypeMapDataType::Map(ref map) => map.get(&expr.id),
+            _ => None,
+        }
+    }
+
     pub fn get_type_expected(&self, expr: &SymbolicExpression) -> Option<&TypeSignature> {
         match self.map {
             TypeMapDataType::Map(ref map) => map.get(&expr.id),


### PR DESCRIPTION
Methods needed to implement typechecker workarounds in clarity-wasm