### PR TITLE
feat: Neon mock miner replay

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -72,6 +72,7 @@ jobs:
           - tests::neon_integrations::confirm_unparsed_ongoing_ops
           - tests::neon_integrations::min_txs
           - tests::neon_integrations::vote_for_aggregate_key_burn_op_test
+          - tests::neon_integrations::mock_miner_replay
           - tests::epoch_25::microblocks_disabled
           - tests::should_succeed_handling_malformed_and_valid_txs
           - tests::nakamoto_integrations::simple_neon_integration

--- a/stacks-common/src/types/chainstate.rs
+++ b/stacks-common/src/types/chainstate.rs
@@ -30,11 +30,11 @@ impl_byte_array_serde!(TrieHash);
 
 pub const TRIEHASH_ENCODED_SIZE: usize = 32;
 
-#[derive(Serialize, Deserialize)]
 pub struct BurnchainHeaderHash(pub [u8; 32]);
 impl_array_newtype!(BurnchainHeaderHash, u8, 32);
 impl_array_hexstring_fmt!(BurnchainHeaderHash);
 impl_byte_array_newtype!(BurnchainHeaderHash, u8, 32);
+impl_byte_array_serde!(BurnchainHeaderHash);
 
 pub struct BlockHeaderHash(pub [u8; 32]);
 impl_array_newtype!(BlockHeaderHash, u8, 32);

--- a/stacks-common/src/util/macros.rs
+++ b/stacks-common/src/util/macros.rs
@@ -617,6 +617,28 @@ macro_rules! impl_byte_array_serde {
     };
 }
 
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! impl_file_io_serde_json {
+    ($thing:ident) => {
+        impl $thing {
+            pub fn serialize_to_file<P>(&self, path: P) -> Result<(), std::io::Error>
+            where
+                P: AsRef<std::path::Path>,
+            {
+                $crate::util::serialize_json_to_file(self, path)
+            }
+
+            pub fn deserialize_from_file<P>(path: P) -> Result<Self, std::io::Error>
+            where
+                P: AsRef<std::path::Path>,
+            {
+                $crate::util::deserialize_json_from_file(path)
+            }
+        }
+    };
+}
+
 // print debug statements while testing
 #[allow(unused_macros)]
 #[macro_export]

--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -28,6 +28,9 @@ pub mod uint;
 pub mod vrf;
 
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{error, fmt, thread, time};
 
@@ -119,4 +122,27 @@ pub mod db_common {
         thread::sleep(time::Duration::from_millis(sleep_count));
         true
     }
+}
+
+/// Write any `serde_json` object directly to a file
+pub fn serialize_json_to_file<J, P>(json: &J, path: P) -> Result<(), std::io::Error>
+where
+    J: ?Sized + serde::Serialize,
+    P: AsRef<Path>,
+{
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer(&mut writer, json)?;
+    writer.flush()
+}
+
+/// Read any `serde_json` object directly from a file
+pub fn deserialize_json_from_file<J, P>(path: P) -> Result<J, std::io::Error>
+where
+    J: serde::de::DeserializeOwned,
+    P: AsRef<Path>,
+{
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    serde_json::from_reader::<_, J>(reader).map_err(std::io::Error::from)
 }

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -651,6 +651,14 @@ impl StacksBlock {
     pub fn has_microblock_parent(&self) -> bool {
         self.header.has_microblock_parent()
     }
+
+    /// Returns size in bytes of `StacksMessageCodec` representation
+    /// Note that this will serialize the block, so don't call if there is a better way to get block size
+    pub fn block_size(&self) -> Result<usize, codec_error> {
+        let mut buf = vec![];
+        self.consensus_serialize(&mut buf)?;
+        Ok(buf.len())
+    }
 }
 
 impl StacksMessageCodec for StacksMicroblockHeader {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -76,9 +76,9 @@ pub struct AssembledAnchorBlock {
     /// Consensus hash this Stacks block
     pub consensus_hash: ConsensusHash,
     /// Burnchain tip's block hash when we finished mining
-    pub my_burn_hash: BurnchainHeaderHash,
+    pub burn_hash: BurnchainHeaderHash,
     /// Burnchain tip's block height when we finished mining
-    pub my_block_height: u64,
+    pub burn_block_height: u64,
     /// Burnchain tip's block hash when we started mining (could be different)
     pub orig_burn_hash: BurnchainHeaderHash,
     /// The block we produced

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -73,6 +73,8 @@ use crate::net::Error as net_error;
 pub struct AssembledAnchorBlock {
     /// Consensus hash of the parent Stacks block
     pub parent_consensus_hash: ConsensusHash,
+    /// Consensus hash this Stacks block
+    pub consensus_hash: ConsensusHash,
     /// Burnchain tip's block hash when we finished mining
     pub my_burn_hash: BurnchainHeaderHash,
     /// Burnchain tip's block height when we finished mining

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -66,6 +66,28 @@ use crate::monitoring::{
 use crate::net::relay::Relayer;
 use crate::net::Error as net_error;
 
+/// Fully-assembled Stacks anchored, block as well as some extra metadata pertaining to how it was
+/// linked to the burnchain and what view(s) the miner had of the burnchain before and after
+/// completing the block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssembledAnchorBlock {
+    /// Consensus hash of the parent Stacks block
+    pub parent_consensus_hash: ConsensusHash,
+    /// Burnchain tip's block hash when we finished mining
+    pub my_burn_hash: BurnchainHeaderHash,
+    /// Burnchain tip's block height when we finished mining
+    pub my_block_height: u64,
+    /// Burnchain tip's block hash when we started mining (could be different)
+    pub orig_burn_hash: BurnchainHeaderHash,
+    /// The block we produced
+    pub anchored_block: StacksBlock,
+    /// The attempt count of this block (multiple blocks will be attempted per burnchain block)
+    pub attempt: u64,
+    /// Epoch timestamp in milliseconds when we started producing the block.
+    pub tenure_begin: u128,
+}
+impl_file_io_serde_json!(AssembledAnchorBlock);
+
 /// System status for mining.
 /// The miner can be Ready, in which case a miner is allowed to run
 /// The miner can be Blocked, in which case the miner *should not start* and/or *should terminate*

--- a/stackslib/src/cli.rs
+++ b/stackslib/src/cli.rs
@@ -1,0 +1,471 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Subcommands used by `stacks-inspect` binary
+
+use std::path::PathBuf;
+use std::time::Instant;
+use std::{env, fs, io, process, thread};
+
+use clarity::types::chainstate::SortitionId;
+use db::ChainstateTx;
+use regex::Regex;
+use rusqlite::{Connection, OpenFlags};
+use stacks_common::types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockId};
+use stacks_common::types::sqlite::NO_PARAMS;
+
+use crate::burnchains::db::BurnchainDB;
+use crate::burnchains::PoxConstants;
+use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle, SortitionHandleContext};
+use crate::chainstate::burn::{BlockSnapshot, ConsensusHash};
+use crate::chainstate::stacks::db::blocks::StagingBlock;
+use crate::chainstate::stacks::db::{StacksBlockHeaderTypes, StacksChainState, StacksHeaderInfo};
+use crate::chainstate::stacks::miner::*;
+use crate::chainstate::stacks::*;
+use crate::clarity_vm::clarity::ClarityInstance;
+use crate::core::*;
+use crate::util_lib::db::IndexDBTx;
+
+/// Replay blocks from chainstate database
+/// Takes args in CLI format: `<command-name> [args...]`
+/// Terminates on error using `process::exit()`
+pub fn command_replay_block(argv: &[String]) {
+    let print_help_and_exit = || -> ! {
+        let n = &argv[0];
+        eprintln!("Usage:");
+        eprintln!("  {n} <database-path>");
+        eprintln!("  {n} <database-path> prefix <index-block-hash-prefix>");
+        eprintln!("  {n} <database-path> index-range <start-block> <end-block>");
+        eprintln!("  {n} <database-path> range <start-block> <end-block>");
+        eprintln!("  {n} <database-path> <first|last> <block-count>");
+        process::exit(1);
+    };
+    let start = Instant::now();
+    let db_path = argv.get(1).unwrap_or_else(|| print_help_and_exit());
+    let mode = argv.get(2).map(String::as_str);
+    let staging_blocks_db_path = format!("{db_path}/chainstate/vm/index.sqlite");
+    let conn =
+        Connection::open_with_flags(&staging_blocks_db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .unwrap();
+
+    let query = match mode {
+        Some("prefix") => format!(
+			"SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0 AND index_block_hash LIKE \"{}%\"",
+			argv[3]
+		),
+        Some("first") => format!(
+			"SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0 ORDER BY height ASC LIMIT {}",
+			argv[3]
+		),
+        Some("range") => {
+            let arg4 = argv[3]
+                .parse::<u64>()
+                .expect("<start_block> not a valid u64");
+            let arg5 = argv[4].parse::<u64>().expect("<end-block> not a valid u64");
+            let start = arg4.saturating_sub(1);
+            let blocks = arg5.saturating_sub(arg4);
+            format!("SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0 ORDER BY height ASC LIMIT {start}, {blocks}")
+        }
+        Some("index-range") => {
+            let start = argv[3]
+                .parse::<u64>()
+                .expect("<start_block> not a valid u64");
+            let end = argv[4].parse::<u64>().expect("<end-block> not a valid u64");
+            let blocks = end.saturating_sub(start);
+            format!("SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0 ORDER BY index_block_hash ASC LIMIT {start}, {blocks}")
+        }
+        Some("last") => format!(
+			"SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0 ORDER BY height DESC LIMIT {}",
+			argv[3]
+		),
+        Some(_) => print_help_and_exit(),
+        // Default to ALL blocks
+        None => "SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0".into(),
+    };
+
+    let mut stmt = conn.prepare(&query).unwrap();
+    let mut hashes_set = stmt.query(NO_PARAMS).unwrap();
+
+    let mut index_block_hashes: Vec<String> = vec![];
+    while let Ok(Some(row)) = hashes_set.next() {
+        index_block_hashes.push(row.get(0).unwrap());
+    }
+
+    let total = index_block_hashes.len();
+    println!("Will check {total} blocks");
+    for (i, index_block_hash) in index_block_hashes.iter().enumerate() {
+        if i % 100 == 0 {
+            println!("Checked {i}...");
+        }
+        replay_staging_block(db_path, index_block_hash);
+    }
+    println!("Finished. run_time_seconds = {}", start.elapsed().as_secs());
+}
+
+/// Replay mock mined blocks from JSON files
+/// Takes args in CLI format: `<command-name> [args...]`
+/// Terminates on error using `process::exit()`
+pub fn command_replay_mock_mining(argv: &[String]) {
+    let print_help_and_exit = || -> ! {
+        let n = &argv[0];
+        eprintln!("Usage:");
+        eprintln!("  {n} <database-path> <mock-mined-blocks-path>");
+        process::exit(1);
+    };
+
+    // Process CLI args
+    let db_path = argv.get(1).unwrap_or_else(|| print_help_and_exit());
+
+    let blocks_path = argv
+        .get(2)
+        .map(PathBuf::from)
+        .map(fs::canonicalize)
+        .transpose()
+        .unwrap_or_else(|e| panic!("Not a valid path: {e}"))
+        .unwrap_or_else(|| print_help_and_exit());
+
+    // Validate directory path
+    if !blocks_path.is_dir() {
+        panic!("{blocks_path:?} is not a valid directory");
+    }
+
+    // Read entries in directory
+    let dir_entries = blocks_path
+        .read_dir()
+        .unwrap_or_else(|e| panic!("Failed to read {blocks_path:?}: {e}"))
+        .filter_map(|e| e.ok());
+
+    // Get filenames, filtering out anything that isn't a regular file
+    let filenames = dir_entries.filter_map(|e| match e.file_type() {
+        Ok(t) if t.is_file() => e.file_name().into_string().ok(),
+        _ => None,
+    });
+
+    // Get vec of (block_height, filename), to prepare for sorting
+    //
+    // NOTE: Trusting the filename is not ideal. We could sort on data read from the file,
+    // but that requires reading all files
+    let re = Regex::new(r"^([0-9]+)\.json$").unwrap();
+    let mut indexed_files = filenames
+        .filter_map(|filename| {
+            // Use regex to extract block number from filename
+            let Some(cap) = re.captures(&filename) else {
+                debug!("Regex capture failed on {filename}");
+                return None;
+            };
+            // cap.get(0) return entire filename
+            // cap.get(1) return block number
+            let i = 1;
+            let Some(m) = cap.get(i) else {
+                debug!("cap.get({i}) failed on {filename} match");
+                return None;
+            };
+            let Ok(bh) = m.as_str().parse::<u64>() else {
+                debug!("parse::<u64>() failed on '{}'", m.as_str());
+                return None;
+            };
+            Some((bh, filename))
+        })
+        .collect::<Vec<_>>();
+
+    // Sort by block height
+    indexed_files.sort_by_key(|(bh, _)| *bh);
+
+    if indexed_files.is_empty() {
+        panic!("No block files found in {blocks_path:?}");
+    }
+
+    info!(
+        "Replaying {} blocks starting at {}",
+        indexed_files.len(),
+        indexed_files[0].0
+    );
+
+    for (bh, filename) in indexed_files {
+        let filepath = blocks_path.join(filename);
+        let block = AssembledAnchorBlock::deserialize_from_file(&filepath)
+            .unwrap_or_else(|e| panic!("Error reading block {bh} from file: {e}"));
+        info!("Replaying block from {filepath:?}";
+            "block_height" => bh,
+            "block" => ?block
+        );
+        replay_mock_mined_block(&db_path, block);
+    }
+}
+
+/// Fetch and process a `StagingBlock` from database and call `replay_block()` to validate
+fn replay_staging_block(db_path: &str, index_block_hash_hex: &str) {
+    let block_id = StacksBlockId::from_hex(index_block_hash_hex).unwrap();
+    let chain_state_path = format!("{db_path}/chainstate/");
+    let sort_db_path = format!("{db_path}/burnchain/sortition");
+    let burn_db_path = format!("{db_path}/burnchain/burnchain.sqlite");
+    let burnchain_blocks_db = BurnchainDB::open(&burn_db_path, false).unwrap();
+
+    let (mut chainstate, _) =
+        StacksChainState::open(true, CHAIN_ID_MAINNET, &chain_state_path, None).unwrap();
+
+    let mut sortdb = SortitionDB::connect(
+        &sort_db_path,
+        BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT,
+        &BurnchainHeaderHash::from_hex(BITCOIN_MAINNET_FIRST_BLOCK_HASH).unwrap(),
+        BITCOIN_MAINNET_FIRST_BLOCK_TIMESTAMP.into(),
+        STACKS_EPOCHS_MAINNET.as_ref(),
+        PoxConstants::mainnet_default(),
+        None,
+        true,
+    )
+    .unwrap();
+    let sort_tx = sortdb.tx_begin_at_tip();
+
+    let blocks_path = chainstate.blocks_path.clone();
+    let (mut chainstate_tx, clarity_instance) = chainstate
+        .chainstate_tx_begin()
+        .expect("Failed to start chainstate tx");
+    let mut next_staging_block =
+        StacksChainState::load_staging_block_info(&chainstate_tx.tx, &block_id)
+            .expect("Failed to load staging block data")
+            .expect("No such index block hash in block database");
+
+    next_staging_block.block_data = StacksChainState::load_block_bytes(
+        &blocks_path,
+        &next_staging_block.consensus_hash,
+        &next_staging_block.anchored_block_hash,
+    )
+    .unwrap()
+    .unwrap_or_default();
+
+    let Some(parent_header_info) =
+        StacksChainState::get_parent_header_info(&mut chainstate_tx, &next_staging_block).unwrap()
+    else {
+        println!("Failed to load parent head info for block: {index_block_hash_hex}");
+        return;
+    };
+
+    let block =
+        StacksChainState::extract_stacks_block(&next_staging_block).expect("Failed to get block");
+    let block_size = next_staging_block.block_data.len() as u64;
+
+    replay_block(
+        sort_tx,
+        chainstate_tx,
+        clarity_instance,
+        &burnchain_blocks_db,
+        &parent_header_info,
+        &next_staging_block.parent_microblock_hash,
+        next_staging_block.parent_microblock_seq,
+        &block_id,
+        &block,
+        block_size,
+        &next_staging_block.consensus_hash,
+        &next_staging_block.anchored_block_hash,
+        next_staging_block.commit_burn,
+        next_staging_block.sortition_burn,
+    );
+}
+
+/// Process a mock mined block and call `replay_block()` to validate
+fn replay_mock_mined_block(db_path: &str, block: AssembledAnchorBlock) {
+    let chain_state_path = format!("{db_path}/chainstate/");
+    let sort_db_path = format!("{db_path}/burnchain/sortition");
+    let burn_db_path = format!("{db_path}/burnchain/burnchain.sqlite");
+    let burnchain_blocks_db = BurnchainDB::open(&burn_db_path, false).unwrap();
+
+    let (mut chainstate, _) =
+        StacksChainState::open(true, CHAIN_ID_MAINNET, &chain_state_path, None).unwrap();
+
+    let mut sortdb = SortitionDB::connect(
+        &sort_db_path,
+        BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT,
+        &BurnchainHeaderHash::from_hex(BITCOIN_MAINNET_FIRST_BLOCK_HASH).unwrap(),
+        BITCOIN_MAINNET_FIRST_BLOCK_TIMESTAMP.into(),
+        STACKS_EPOCHS_MAINNET.as_ref(),
+        PoxConstants::mainnet_default(),
+        None,
+        true,
+    )
+    .unwrap();
+    let sort_tx = sortdb.tx_begin_at_tip();
+
+    let (mut chainstate_tx, clarity_instance) = chainstate
+        .chainstate_tx_begin()
+        .expect("Failed to start chainstate tx");
+
+    let block_consensus_hash = &block.consensus_hash;
+    let block_hash = block.anchored_block.block_hash();
+    let block_id = StacksBlockId::new(block_consensus_hash, &block_hash);
+    let block_size = block
+        .anchored_block
+        .block_size()
+        .map(u64::try_from)
+        .unwrap_or_else(|e| panic!("Error serializing block {block_hash}: {e}"))
+        .expect("u64 overflow");
+
+    let Some(parent_header_info) = StacksChainState::get_anchored_block_header_info(
+        &mut chainstate_tx,
+        &block.parent_consensus_hash,
+        &block.anchored_block.header.parent_block,
+    )
+    .unwrap() else {
+        println!("Failed to load parent head info for block: {block_hash}");
+        return;
+    };
+
+    replay_block(
+        sort_tx,
+        chainstate_tx,
+        clarity_instance,
+        &burnchain_blocks_db,
+        &parent_header_info,
+        &block.anchored_block.header.parent_microblock,
+        block.anchored_block.header.parent_microblock_sequence,
+        &block_id,
+        &block.anchored_block,
+        block_size,
+        block_consensus_hash,
+        &block_hash,
+        // I think the burn is used for miner rewards but not necessary for validation
+        0,
+        0,
+    );
+}
+
+/// Validate a block against chainstate
+fn replay_block(
+    mut sort_tx: IndexDBTx<SortitionHandleContext, SortitionId>,
+    mut chainstate_tx: ChainstateTx,
+    clarity_instance: &mut ClarityInstance,
+    burnchain_blocks_db: &BurnchainDB,
+    parent_header_info: &StacksHeaderInfo,
+    parent_microblock_hash: &BlockHeaderHash,
+    parent_microblock_seq: u16,
+    block_id: &StacksBlockId,
+    block: &StacksBlock,
+    block_size: u64,
+    block_consensus_hash: &ConsensusHash,
+    block_hash: &BlockHeaderHash,
+    block_commit_burn: u64,
+    block_sortition_burn: u64,
+) {
+    let parent_block_header = match &parent_header_info.anchored_header {
+        StacksBlockHeaderTypes::Epoch2(bh) => bh,
+        StacksBlockHeaderTypes::Nakamoto(_) => panic!("Nakamoto blocks not supported yet"),
+    };
+    let parent_block_hash = parent_block_header.block_hash();
+
+    let Some(next_microblocks) = StacksChainState::inner_find_parent_microblock_stream(
+        &chainstate_tx.tx,
+        &block_hash,
+        &parent_block_hash,
+        &parent_header_info.consensus_hash,
+        parent_microblock_hash,
+        parent_microblock_seq,
+    )
+    .unwrap() else {
+        println!("No microblock stream found for {block_id}");
+        return;
+    };
+
+    let (burn_header_hash, burn_header_height, burn_header_timestamp, _winning_block_txid) =
+        match SortitionDB::get_block_snapshot_consensus(&sort_tx, &block_consensus_hash).unwrap() {
+            Some(sn) => (
+                sn.burn_header_hash,
+                sn.block_height as u32,
+                sn.burn_header_timestamp,
+                sn.winning_block_txid,
+            ),
+            None => {
+                // shouldn't happen
+                panic!("CORRUPTION: staging block {block_consensus_hash}/{block_hash} does not correspond to a burn block");
+            }
+        };
+
+    info!(
+        "Process block {}/{} = {} in burn block {}, parent microblock {}",
+        block_consensus_hash, block_hash, &block_id, &burn_header_hash, parent_microblock_hash,
+    );
+
+    if !StacksChainState::check_block_attachment(&parent_block_header, &block.header) {
+        let msg = format!(
+            "Invalid stacks block {}/{} -- does not attach to parent {}/{}",
+            &block_consensus_hash,
+            block.block_hash(),
+            parent_block_header.block_hash(),
+            &parent_header_info.consensus_hash
+        );
+        println!("{msg}");
+        return;
+    }
+
+    // validation check -- validate parent microblocks and find the ones that connect the
+    // block's parent to this block.
+    let next_microblocks = StacksChainState::extract_connecting_microblocks(
+        &parent_header_info,
+        &block_consensus_hash,
+        &block_hash,
+        block,
+        next_microblocks,
+    )
+    .unwrap();
+    let (last_microblock_hash, last_microblock_seq) = match next_microblocks.len() {
+        0 => (EMPTY_MICROBLOCK_PARENT_HASH.clone(), 0),
+        _ => {
+            let l = next_microblocks.len();
+            (
+                next_microblocks[l - 1].block_hash(),
+                next_microblocks[l - 1].header.sequence,
+            )
+        }
+    };
+    assert_eq!(*parent_microblock_hash, last_microblock_hash);
+    assert_eq!(parent_microblock_seq, last_microblock_seq);
+
+    let block_am = StacksChainState::find_stacks_tip_affirmation_map(
+        burnchain_blocks_db,
+        sort_tx.tx(),
+        block_consensus_hash,
+        block_hash,
+    )
+    .unwrap();
+
+    let pox_constants = sort_tx.context.pox_constants.clone();
+
+    match StacksChainState::append_block(
+        &mut chainstate_tx,
+        clarity_instance,
+        &mut sort_tx,
+        &pox_constants,
+        &parent_header_info,
+        block_consensus_hash,
+        &burn_header_hash,
+        burn_header_height,
+        burn_header_timestamp,
+        &block,
+        block_size,
+        &next_microblocks,
+        block_commit_burn,
+        block_sortition_burn,
+        block_am.weight(),
+        true,
+    ) {
+        Ok((_receipt, _, _)) => {
+            info!("Block processed successfully! block = {block_id}");
+        }
+        Err(e) => {
+            println!("Failed processing block! block = {block_id}, error = {e:?}");
+            process::exit(1);
+        }
+    };
+}

--- a/stackslib/src/lib.rs
+++ b/stackslib/src/lib.rs
@@ -59,17 +59,14 @@ pub extern crate libstackerdb;
 pub mod chainstate;
 
 pub mod burnchains;
-
+pub mod clarity_cli;
 /// A high level library for interacting with the Clarity vm
 pub mod clarity_vm;
+pub mod cli;
 pub mod core;
-pub mod deps;
-
-pub mod monitoring;
-
 pub mod cost_estimates;
-
-pub mod clarity_cli;
+pub mod deps;
+pub mod monitoring;
 
 // set via _compile-time_ envars
 const GIT_BRANCH: Option<&'static str> = option_env!("GIT_BRANCH");

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -26,6 +26,9 @@ extern crate stacks_common;
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
 
+use blockstack_lib::clarity_vm::clarity::ClarityInstance;
+use clarity::types::chainstate::SortitionId;
+use db::ChainstateTx;
 use regex::Regex;
 use stacks_common::types::MempoolCollectionBehavior;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_arch = "arm")))]
@@ -52,7 +55,7 @@ use blockstack_lib::burnchains::{
     Address, Burnchain, PoxConstants, Txid, BLOCKSTACK_MAGIC_MAINNET,
 };
 use blockstack_lib::chainstate::burn::db::sortdb::{
-    get_block_commit_by_txid, SortitionDB, SortitionHandle,
+    get_block_commit_by_txid, SortitionDB, SortitionHandle, SortitionHandleContext,
 };
 use blockstack_lib::chainstate::burn::operations::BlockstackOperationType;
 use blockstack_lib::chainstate::burn::{BlockSnapshot, ConsensusHash};
@@ -77,7 +80,7 @@ use blockstack_lib::net::db::LocalPeer;
 use blockstack_lib::net::p2p::PeerNetwork;
 use blockstack_lib::net::relay::Relayer;
 use blockstack_lib::net::StacksMessage;
-use blockstack_lib::util_lib::db::sqlite_open;
+use blockstack_lib::util_lib::db::{sqlite_open, IndexDBTx};
 use blockstack_lib::util_lib::strings::UrlString;
 use blockstack_lib::{clarity_cli, util_lib};
 use libstackerdb::StackerDBChunkData;
@@ -882,20 +885,20 @@ simulating a miner.
         let print_help_and_exit = || -> ! {
             let n = &argv[0];
             eprintln!("Usage:");
-            eprintln!("  {n} <chainstate_path>");
-            eprintln!("  {n} <chainstate_path> prefix <index-block-hash-prefix>");
-            eprintln!("  {n} <chainstate_path> index-range <start_block> <end_block>");
-            eprintln!("  {n} <chainstate_path> range <start_block> <end_block>");
-            eprintln!("  {n} <chainstate_path> <first|last> <block_count>");
+            eprintln!("  {n} <database-path>");
+            eprintln!("  {n} <database-path> prefix <index-block-hash-prefix>");
+            eprintln!("  {n} <database-path> index-range <start-block> <end-block>");
+            eprintln!("  {n} <database-path> range <start-block> <end-block>");
+            eprintln!("  {n} <database-path> <first|last> <block-count>");
             process::exit(1);
         };
         if argv.len() < 2 {
             print_help_and_exit();
         }
         let start = Instant::now();
-        let stacks_path = &argv[2];
+        let db_path = &argv[2];
         let mode = argv.get(3).map(String::as_str);
-        let staging_blocks_db_path = format!("{stacks_path}/mainnet/chainstate/vm/index.sqlite");
+        let staging_blocks_db_path = format!("{db_path}/mainnet/chainstate/vm/index.sqlite");
         let conn =
             Connection::open_with_flags(&staging_blocks_db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
                 .unwrap();
@@ -913,7 +916,7 @@ simulating a miner.
                 let arg4 = argv[4]
                     .parse::<u64>()
                     .expect("<start_block> not a valid u64");
-                let arg5 = argv[5].parse::<u64>().expect("<end_block> not a valid u64");
+                let arg5 = argv[5].parse::<u64>().expect("<end-block> not a valid u64");
                 let start = arg4.saturating_sub(1);
                 let blocks = arg5.saturating_sub(arg4);
                 format!("SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0 ORDER BY height ASC LIMIT {start}, {blocks}")
@@ -922,7 +925,7 @@ simulating a miner.
                 let start = argv[4]
                     .parse::<u64>()
                     .expect("<start_block> not a valid u64");
-                let end = argv[5].parse::<u64>().expect("<end_block> not a valid u64");
+                let end = argv[5].parse::<u64>().expect("<end-block> not a valid u64");
                 let blocks = end.saturating_sub(start);
                 format!("SELECT index_block_hash FROM staging_blocks WHERE orphaned = 0 ORDER BY index_block_hash ASC LIMIT {start}, {blocks}")
             }
@@ -949,7 +952,7 @@ simulating a miner.
             if i % 100 == 0 {
                 println!("Checked {i}...");
             }
-            replay_block(stacks_path, index_block_hash);
+            replay_staging_block(db_path, index_block_hash);
         }
         println!("Finished. run_time_seconds = {}", start.elapsed().as_secs());
         process::exit(0);
@@ -1590,11 +1593,94 @@ simulating a miner.
     process::exit(0);
 }
 
-fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
-    let index_block_hash = StacksBlockId::from_hex(index_block_hash_hex).unwrap();
-    let chain_state_path = format!("{stacks_path}/mainnet/chainstate/");
-    let sort_db_path = format!("{stacks_path}/mainnet/burnchain/sortition");
-    let burn_db_path = format!("{stacks_path}/mainnet/burnchain/burnchain.sqlite");
+fn replay_mock_mining(argv: Vec<String>) {
+    let print_help_and_exit = || -> ! {
+        let n = &argv[0];
+        eprintln!("Usage:");
+        eprintln!("  {n} <database-path> <mock-mined-blocks-path>");
+        process::exit(1);
+    };
+
+    // Process CLI args
+    let db_path = argv.get(2).unwrap_or_else(|| print_help_and_exit());
+
+    let blocks_path = argv
+        .get(3)
+        .map(PathBuf::from)
+        .map(fs::canonicalize)
+        .transpose()
+        .unwrap_or_else(|e| panic!("Not a valid path: {e}"))
+        .unwrap_or_else(|| print_help_and_exit());
+
+    // Validate directory path
+    if !blocks_path.is_dir() {
+        panic!("{blocks_path:?} is not a valid directory");
+    }
+
+    // Read entries in directory
+    let dir_entries = blocks_path
+        .read_dir()
+        .unwrap_or_else(|e| panic!("Failed to read {blocks_path:?}: {e}"))
+        .filter_map(|e| e.ok());
+
+    // Get filenames, filtering out anything that isn't a regular file
+    let filenames = dir_entries.filter_map(|e| match e.file_type() {
+        Ok(t) if t.is_file() => e.file_name().into_string().ok(),
+        _ => None,
+    });
+
+    // Get vec of (block_height, filename), to prepare for sorting
+    //
+    // NOTE: Trusting the filename is not ideal. We could sort on data read from the file,
+    // but that requires reading all files
+    let re = Regex::new(r"^([0-9]+\.json)$").unwrap();
+    let mut indexed_files = filenames
+        .filter_map(|filename| {
+            // Use regex to extract block number from filename
+            let Some(cap) = re.captures(&filename) else {
+                return None;
+            };
+            let Some(m) = cap.get(0) else {
+                return None;
+            };
+            let Ok(bh) = m.as_str().parse::<u64>() else {
+                return None;
+            };
+            Some((bh, filename))
+        })
+        .collect::<Vec<_>>();
+
+    // Sort by block height
+    indexed_files.sort_by_key(|(bh, _)| *bh);
+
+    if indexed_files.is_empty() {
+        panic!("No block files found");
+    }
+
+    info!(
+        "Replaying {} blocks starting at {}",
+        indexed_files.len(),
+        indexed_files[0].0
+    );
+
+    for (bh, filename) in indexed_files {
+        let filepath = blocks_path.join(filename);
+        let block = AssembledAnchorBlock::deserialize_from_file(&filepath)
+            .unwrap_or_else(|e| panic!("Error reading block {bh} from file: {e}"));
+        debug!("Replaying block from {filepath:?}";
+            "block_height" => bh,
+            "block" => ?block
+        );
+        replay_mock_mined_block(&db_path, block);
+    }
+}
+
+/// Fetch and process a `StagingBlock` from database and call `replay_block()` to validate
+fn replay_staging_block(db_path: &str, index_block_hash_hex: &str) {
+    let block_id = StacksBlockId::from_hex(index_block_hash_hex).unwrap();
+    let chain_state_path = format!("{db_path}/mainnet/chainstate/");
+    let sort_db_path = format!("{db_path}/mainnet/burnchain/sortition");
+    let burn_db_path = format!("{db_path}/mainnet/burnchain/burnchain.sqlite");
     let burnchain_blocks_db = BurnchainDB::open(&burn_db_path, false).unwrap();
 
     let (mut chainstate, _) =
@@ -1611,14 +1697,14 @@ fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
         true,
     )
     .unwrap();
-    let mut sort_tx = sortdb.tx_begin_at_tip();
+    let sort_tx = sortdb.tx_begin_at_tip();
 
     let blocks_path = chainstate.blocks_path.clone();
     let (mut chainstate_tx, clarity_instance) = chainstate
         .chainstate_tx_begin()
         .expect("Failed to start chainstate tx");
     let mut next_staging_block =
-        StacksChainState::load_staging_block_info(&chainstate_tx.tx, &index_block_hash)
+        StacksChainState::load_staging_block_info(&chainstate_tx.tx, &block_id)
             .expect("Failed to load staging block data")
             .expect("No such index block hash in block database");
 
@@ -1629,45 +1715,6 @@ fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
     )
     .unwrap()
     .unwrap_or_default();
-
-    let Some(next_microblocks) =
-        StacksChainState::find_parent_microblock_stream(&chainstate_tx.tx, &next_staging_block)
-            .unwrap()
-    else {
-        println!("No microblock stream found for {index_block_hash_hex}");
-        return;
-    };
-
-    let (burn_header_hash, burn_header_height, burn_header_timestamp, _winning_block_txid) =
-        match SortitionDB::get_block_snapshot_consensus(
-            &sort_tx,
-            &next_staging_block.consensus_hash,
-        )
-        .unwrap()
-        {
-            Some(sn) => (
-                sn.burn_header_hash,
-                sn.block_height as u32,
-                sn.burn_header_timestamp,
-                sn.winning_block_txid,
-            ),
-            None => {
-                // shouldn't happen
-                panic!(
-                    "CORRUPTION: staging block {}/{} does not correspond to a burn block",
-                    &next_staging_block.consensus_hash, &next_staging_block.anchored_block_hash
-                );
-            }
-        };
-
-    info!(
-        "Process block {}/{} = {} in burn block {}, parent microblock {}",
-        next_staging_block.consensus_hash,
-        next_staging_block.anchored_block_hash,
-        &index_block_hash,
-        &burn_header_hash,
-        &next_staging_block.parent_microblock_hash,
-    );
 
     let Some(parent_header_info) =
         StacksChainState::get_parent_header_info(&mut chainstate_tx, &next_staging_block).unwrap()
@@ -1680,15 +1727,149 @@ fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
         StacksChainState::extract_stacks_block(&next_staging_block).expect("Failed to get block");
     let block_size = next_staging_block.block_data.len() as u64;
 
+    replay_block(
+        sort_tx,
+        chainstate_tx,
+        clarity_instance,
+        &burnchain_blocks_db,
+        &parent_header_info,
+        &next_staging_block.parent_microblock_hash,
+        next_staging_block.parent_microblock_seq,
+        &block_id,
+        &block,
+        block_size,
+        &next_staging_block.consensus_hash,
+        &next_staging_block.anchored_block_hash,
+        next_staging_block.commit_burn,
+        next_staging_block.sortition_burn,
+    );
+}
+
+/// Process a mock mined block and call `replay_block()` to validate
+fn replay_mock_mined_block(db_path: &str, block: AssembledAnchorBlock) {
+    let chain_state_path = format!("{db_path}/mainnet/chainstate/");
+    let sort_db_path = format!("{db_path}/mainnet/burnchain/sortition");
+    let burn_db_path = format!("{db_path}/mainnet/burnchain/burnchain.sqlite");
+    let burnchain_blocks_db = BurnchainDB::open(&burn_db_path, false).unwrap();
+
+    let (mut chainstate, _) =
+        StacksChainState::open(true, CHAIN_ID_MAINNET, &chain_state_path, None).unwrap();
+
+    let mut sortdb = SortitionDB::connect(
+        &sort_db_path,
+        BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT,
+        &BurnchainHeaderHash::from_hex(BITCOIN_MAINNET_FIRST_BLOCK_HASH).unwrap(),
+        BITCOIN_MAINNET_FIRST_BLOCK_TIMESTAMP.into(),
+        STACKS_EPOCHS_MAINNET.as_ref(),
+        PoxConstants::mainnet_default(),
+        None,
+        true,
+    )
+    .unwrap();
+    let sort_tx = sortdb.tx_begin_at_tip();
+
+    let (mut chainstate_tx, clarity_instance) = chainstate
+        .chainstate_tx_begin()
+        .expect("Failed to start chainstate tx");
+
+    let block_consensus_hash = &block.consensus_hash;
+    let block_hash = block.anchored_block.block_hash();
+    let block_id = StacksBlockId::new(block_consensus_hash, &block_hash);
+    let block_size = block
+        .anchored_block
+        .block_size()
+        .map(u64::try_from)
+        .unwrap_or_else(|e| panic!("Error serializing block {block_hash}: {e}"))
+        .expect("u64 overflow");
+
+    let Some(parent_header_info) = StacksChainState::get_anchored_block_header_info(
+        &mut chainstate_tx,
+        &block.parent_consensus_hash,
+        &block.anchored_block.header.parent_block,
+    )
+    .unwrap() else {
+        println!("Failed to load parent head info for block: {block_hash}");
+        return;
+    };
+
+    replay_block(
+        sort_tx,
+        chainstate_tx,
+        clarity_instance,
+        &burnchain_blocks_db,
+        &parent_header_info,
+        &block.anchored_block.header.parent_microblock,
+        block.anchored_block.header.parent_microblock_sequence,
+        &block_id,
+        &block.anchored_block,
+        block_size,
+        block_consensus_hash,
+        &block_hash,
+        // I think the burn is used for miner rewards but not necessary for validation
+        0,
+        0,
+    );
+}
+
+/// Validate a block against chainstate
+fn replay_block(
+    mut sort_tx: IndexDBTx<SortitionHandleContext, SortitionId>,
+    mut chainstate_tx: ChainstateTx,
+    clarity_instance: &mut ClarityInstance,
+    burnchain_blocks_db: &BurnchainDB,
+    parent_header_info: &StacksHeaderInfo,
+    parent_microblock_hash: &BlockHeaderHash,
+    parent_microblock_seq: u16,
+    block_id: &StacksBlockId,
+    block: &StacksBlock,
+    block_size: u64,
+    block_consensus_hash: &ConsensusHash,
+    block_hash: &BlockHeaderHash,
+    block_commit_burn: u64,
+    block_sortition_burn: u64,
+) {
     let parent_block_header = match &parent_header_info.anchored_header {
         StacksBlockHeaderTypes::Epoch2(bh) => bh,
         StacksBlockHeaderTypes::Nakamoto(_) => panic!("Nakamoto blocks not supported yet"),
     };
+    let parent_block_hash = parent_block_header.block_hash();
+
+    let Some(next_microblocks) = StacksChainState::inner_find_parent_microblock_stream(
+        &chainstate_tx.tx,
+        &block_hash,
+        &parent_block_hash,
+        &parent_header_info.consensus_hash,
+        parent_microblock_hash,
+        parent_microblock_seq,
+    )
+    .unwrap() else {
+        println!("No microblock stream found for {block_id}");
+        return;
+    };
+
+    let (burn_header_hash, burn_header_height, burn_header_timestamp, _winning_block_txid) =
+        match SortitionDB::get_block_snapshot_consensus(&sort_tx, &block_consensus_hash).unwrap() {
+            Some(sn) => (
+                sn.burn_header_hash,
+                sn.block_height as u32,
+                sn.burn_header_timestamp,
+                sn.winning_block_txid,
+            ),
+            None => {
+                // shouldn't happen
+                panic!("CORRUPTION: staging block {block_consensus_hash}/{block_hash} does not correspond to a burn block");
+            }
+        };
+
+    info!(
+        "Process block {}/{} = {} in burn block {}, parent microblock {}",
+        block_consensus_hash, block_hash, &block_id, &burn_header_hash, parent_microblock_hash,
+    );
 
     if !StacksChainState::check_block_attachment(&parent_block_header, &block.header) {
         let msg = format!(
             "Invalid stacks block {}/{} -- does not attach to parent {}/{}",
-            &next_staging_block.consensus_hash,
+            &block_consensus_hash,
             block.block_hash(),
             parent_block_header.block_hash(),
             &parent_header_info.consensus_hash
@@ -1701,9 +1882,9 @@ fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
     // block's parent to this block.
     let next_microblocks = StacksChainState::extract_connecting_microblocks(
         &parent_header_info,
-        &next_staging_block.consensus_hash,
-        &next_staging_block.anchored_block_hash,
-        &block,
+        &block_consensus_hash,
+        &block_hash,
+        block,
         next_microblocks,
     )
     .unwrap();
@@ -1717,20 +1898,14 @@ fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
             )
         }
     };
-    assert_eq!(
-        next_staging_block.parent_microblock_hash,
-        last_microblock_hash
-    );
-    assert_eq!(
-        next_staging_block.parent_microblock_seq,
-        last_microblock_seq
-    );
+    assert_eq!(*parent_microblock_hash, last_microblock_hash);
+    assert_eq!(parent_microblock_seq, last_microblock_seq);
 
     let block_am = StacksChainState::find_stacks_tip_affirmation_map(
-        &burnchain_blocks_db,
+        burnchain_blocks_db,
         sort_tx.tx(),
-        &next_staging_block.consensus_hash,
-        &next_staging_block.anchored_block_hash,
+        block_consensus_hash,
+        block_hash,
     )
     .unwrap();
 
@@ -1742,23 +1917,23 @@ fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
         &mut sort_tx,
         &pox_constants,
         &parent_header_info,
-        &next_staging_block.consensus_hash,
+        block_consensus_hash,
         &burn_header_hash,
         burn_header_height,
         burn_header_timestamp,
         &block,
         block_size,
         &next_microblocks,
-        next_staging_block.commit_burn,
-        next_staging_block.sortition_burn,
+        block_commit_burn,
+        block_sortition_burn,
         block_am.weight(),
         true,
     ) {
         Ok((_receipt, _, _)) => {
-            info!("Block processed successfully! block = {index_block_hash}");
+            info!("Block processed successfully! block = {block_id}");
         }
         Err(e) => {
-            println!("Failed processing block! block = {index_block_hash}, error = {e:?}");
+            println!("Failed processing block! block = {block_id}, error = {e:?}");
             process::exit(1);
         }
     };
@@ -1983,86 +2158,4 @@ fn analyze_sortition_mev(argv: Vec<String>) {
     }
 
     process::exit(0);
-}
-
-fn replay_mock_mining(argv: Vec<String>) {
-    let print_help_and_exit = || -> ! {
-        let n = &argv[0];
-        eprintln!("Usage:");
-        eprintln!("  {n} <chainstate-path> <mock-miner-output-path>");
-        process::exit(1);
-    };
-
-    // Process CLI args
-    let chainstate_path = argv.get(2).unwrap_or_else(|| print_help_and_exit());
-
-    let blocks_path = argv
-        .get(3)
-        .map(PathBuf::from)
-        .map(fs::canonicalize)
-        .transpose()
-        .unwrap_or_else(|e| panic!("Not a valid path: {e}"))
-        .unwrap_or_else(|| print_help_and_exit());
-
-    // Validate directory path
-    if !blocks_path.is_dir() {
-        panic!("{blocks_path:?} is not a valid directory");
-    }
-
-    // Read entries in directory
-    let dir_entries = blocks_path
-        .read_dir()
-        .unwrap_or_else(|e| panic!("Failed to read {blocks_path:?}: {e}"))
-        .filter_map(|e| e.ok());
-
-    // Get filenames, filtering out anything that isn't a regular file
-    let filenames = dir_entries.filter_map(|e| match e.file_type() {
-        Ok(t) if t.is_file() => e.file_name().into_string().ok(),
-        _ => None,
-    });
-
-    // Get vec of (block_height, filename), to prepare for sorting
-    //
-    // NOTE: Trusting the filename is not ideal. We could sort on data read from the file,
-    // but that requires reading all files
-    let re = Regex::new(r"^([0-9]+\.json)$").unwrap();
-    let mut indexed_files = filenames
-        .filter_map(|filename| {
-            // Use regex to extract block number from filename
-            let Some(cap) = re.captures(&filename) else {
-                return None;
-            };
-            let Some(m) = cap.get(0) else {
-                return None;
-            };
-            let Ok(bh) = m.as_str().parse::<u64>() else {
-                return None;
-            };
-            Some((bh, filename))
-        })
-        .collect::<Vec<_>>();
-
-    // Sort by block height
-    indexed_files.sort_by_key(|(bh, _)| *bh);
-
-    if indexed_files.is_empty() {
-        panic!("No block files found");
-    }
-
-    info!(
-        "Replaying {} blocks starting at {}",
-        indexed_files.len(),
-        indexed_files[0].0
-    );
-
-    for (bh, filename) in indexed_files {
-        let filepath = blocks_path.join(filename);
-        let block = AssembledAnchorBlock::deserialize_from_file(&filepath)
-            .unwrap_or_else(|e| panic!("Error reading block {bh} from file: {e}"));
-        debug!("Replaying block from {filepath:?}";
-            "block_height" => bh,
-            "block" => ?block
-        );
-        // TODO: Actually replay block
-    }
 }

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -1988,14 +1988,12 @@ fn replay_mock_mining(argv: Vec<String>) {
     let print_help_and_exit = || -> ! {
         let n = &argv[0];
         eprintln!("Usage:");
-        eprintln!("  {n} <mock-miner-output-dir>");
+        eprintln!("  {n} <chainstate-path> <mock-miner-output-path>");
         process::exit(1);
     };
 
     // Process CLI args
-    let chainstate_path = argv
-        .get(2)
-        .unwrap_or_else(|| print_help_and_exit());
+    let chainstate_path = argv.get(2).unwrap_or_else(|| print_help_and_exit());
 
     let blocks_path = argv
         .get(3)
@@ -2058,8 +2056,8 @@ fn replay_mock_mining(argv: Vec<String>) {
 
     for (bh, filename) in indexed_files {
         let filepath = blocks_path.join(filename);
-        // let block = AssembledAnchorBlock::deserialize_from_file(&filepath)
-        //     .unwrap_or_else(|e| panic!("Error reading block {bh} from file: {e}"));
+        let block = AssembledAnchorBlock::deserialize_from_file(&filepath)
+            .unwrap_or_else(|e| panic!("Error reading block {bh} from file: {e}"));
         debug!("Replaying block from {filepath:?}";
             "block_height" => bh,
             "block" => ?block

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -39,7 +39,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
 use std::io::BufReader;
-use std::path::PathBuf;
 use std::time::Instant;
 use std::{env, fs, io, process, thread};
 
@@ -94,7 +93,7 @@ use stacks_common::util::hash::{hex_bytes, to_hex, Hash160};
 use stacks_common::util::retry::LogReader;
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use stacks_common::util::vrf::VRFProof;
-use stacks_common::util::{deserialize_json_from_file, get_epoch_time_ms, log, sleep_ms};
+use stacks_common::util::{get_epoch_time_ms, log, sleep_ms};
 
 #[cfg_attr(test, mutants::skip)]
 fn main() {
@@ -1340,88 +1339,6 @@ simulating a miner.
             stacks_blocks_arrival_order.len()
         );
         return;
-    }
-    if argv[1] == "replay-mock-mining" {
-        let print_help_and_exit = || {
-            let n = &argv[0];
-            eprintln!("Usage:");
-            eprintln!("  {n} <mock-miner-output-dir>");
-            process::exit(1);
-        };
-
-        // Process CLI args
-        let dir = argv
-            .get(2)
-            .map(PathBuf::from)
-            .map(fs::canonicalize)
-            .transpose()
-            .unwrap_or_else(|e| panic!("Not a valid path: {e}"))
-            .unwrap_or_else(print_help_and_exit);
-
-        if !dir.is_dir() {
-            panic!("Not a valid directory: {dir:?}");
-        }
-
-        // Read entries in directory
-        let dir_entries = dir
-            .read_dir()
-            .unwrap_or_else(|e| panic!("Failed to read directory: {e}"))
-            .filter_map(|e| e.ok());
-
-        // Get filenames, filtering out anything that isn't a regular file
-        let filenames = dir_entries.filter_map(|e| match e.file_type() {
-            Ok(t) if t.is_file() => e.file_name().into_string().ok(),
-            _ => None,
-        });
-
-        // Get vec of (block_height, filename), to prepare for sorting
-        //
-        // NOTE: Trusting the filename is not ideal. We could sort on data read from the file,
-        // but that requires reading all files
-        let re = Regex::new(r"^([0-9]+\.json)$").unwrap();
-        let mut indexed_files = filenames
-            .filter_map(|filename| {
-                // Use regex to extract block number from filename
-                let Some(cap) = re.captures(&filename) else {
-                    return None;
-                };
-                let Some(m) = cap.get(0) else {
-                    return None;
-                };
-                let Ok(bh) = m.as_str().parse::<u64>() else {
-                    return None;
-                };
-                Some((bh, filename))
-            })
-            .collect::<Vec<_>>();
-
-        // Sort by block height
-        indexed_files.sort_by_key(|(bh, _)| *bh);
-
-        if indexed_files.is_empty() {
-            panic!("No block files found");
-        }
-
-        info!(
-            "Replaying {} blocks starting at {}",
-            indexed_files.len(),
-            indexed_files[0].0
-        );
-
-        for (bh, filename) in indexed_files {
-            let filepath = dir.join(filename);
-            info!("Replaying block from file";
-                "block_height" => bh,
-                "filepath" => ?filepath
-            );
-            // let block = AssembledAnchorBlock::deserialize_json_from_file(filepath)
-            //     .unwrap_or_else(|e| panic!("Error reading block {block} from file: {e}"));
-            // debug!("Replaying block from {filepath:?}";
-            //     "block_height" => bh,
-            //     "block" => %block
-            // );
-            // TODO: Actually replay block
-        }
     }
 
     if argv.len() < 4 {

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -1255,12 +1255,12 @@ simulating a miner.
     }
 
     if argv[1] == "replay-block" {
-        cli::command_replay_block(&argv[1..]);
+        cli::command_replay_block(&argv[1..], None);
         process::exit(0);
     }
 
     if argv[1] == "replay-mock-mining" {
-        cli::command_replay_mock_mining(&argv[1..]);
+        cli::command_replay_mock_mining(&argv[1..], None);
         process::exit(0);
     }
 

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -1701,7 +1701,8 @@ fn replay_block(stacks_path: &str, index_block_hash_hex: &str) {
     // block's parent to this block.
     let next_microblocks = StacksChainState::extract_connecting_microblocks(
         &parent_header_info,
-        &next_staging_block,
+        &next_staging_block.consensus_hash,
+        &next_staging_block.anchored_block_hash,
         &block,
         next_microblocks,
     )

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1810,6 +1810,8 @@ pub struct NodeConfig {
     pub miner: bool,
     pub stacker: bool,
     pub mock_mining: bool,
+    /// Where to output blocks from mock mining
+    pub mock_mining_output_dir: Option<PathBuf>,
     pub mine_microblocks: bool,
     pub microblock_frequency: u64,
     pub max_microblocks: u64,
@@ -2102,6 +2104,7 @@ impl Default for NodeConfig {
             miner: false,
             stacker: false,
             mock_mining: false,
+            mock_mining_output_dir: None,
             mine_microblocks: true,
             microblock_frequency: 30_000,
             max_microblocks: u16::MAX as u64,
@@ -2164,7 +2167,7 @@ impl NodeConfig {
     ) -> Neighbor {
         Neighbor {
             addr: NeighborKey {
-                peer_version: peer_version,
+                peer_version,
                 network_id: chain_id,
                 addrbytes: PeerAddress::from_socketaddr(&addr),
                 port: addr.port(),
@@ -2556,6 +2559,7 @@ pub struct NodeConfigFile {
     pub miner: Option<bool>,
     pub stacker: Option<bool>,
     pub mock_mining: Option<bool>,
+    pub mock_mining_output_dir: Option<String>,
     pub mine_microblocks: Option<bool>,
     pub microblock_frequency: Option<u64>,
     pub max_microblocks: Option<u64>,
@@ -2595,10 +2599,9 @@ impl NodeConfigFile {
             p2p_address: self.p2p_address.unwrap_or(rpc_bind.clone()),
             bootstrap_node: vec![],
             deny_nodes: vec![],
-            data_url: match self.data_url {
-                Some(data_url) => data_url,
-                None => format!("http://{}", rpc_bind),
-            },
+            data_url: self
+                .data_url
+                .unwrap_or_else(|| format!("http://{rpc_bind}")),
             local_peer_seed: match self.local_peer_seed {
                 Some(seed) => hex_bytes(&seed)
                     .map_err(|_e| format!("node.local_peer_seed should be a hex encoded string"))?,
@@ -2607,6 +2610,14 @@ impl NodeConfigFile {
             miner,
             stacker,
             mock_mining: self.mock_mining.unwrap_or(default_node_config.mock_mining),
+            mock_mining_output_dir: self
+                .mock_mining_output_dir
+                .map(PathBuf::from)
+                .map(fs::canonicalize)
+                .transpose()
+                .unwrap_or_else(|e| {
+                    panic!("Failed to construct PathBuf from node.mock_mining_output_dir: {e}")
+                }),
             mine_microblocks: self
                 .mine_microblocks
                 .unwrap_or(default_node_config.mine_microblocks),

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -10,11 +10,8 @@ extern crate stacks;
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
 
-use regex::Regex;
 pub use stacks_common::util;
 use stacks_common::util::hash::hex_bytes;
-
-use crate::neon_node::AssembledAnchorBlock;
 
 pub mod monitoring;
 
@@ -34,8 +31,7 @@ pub mod syncctl;
 pub mod tenure;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::{env, fs, panic, process};
+use std::{env, panic, process};
 
 use backtrace::Backtrace;
 use pico_args::Arguments;
@@ -261,82 +257,6 @@ fn cli_get_miner_spend(
     spend_amount
 }
 
-fn cli_replay_mock_mining(config_path: &str, path: &str) {
-    info!("Loading config at path {config_path}");
-    let config = match ConfigFile::from_path(&config_path) {
-        Ok(config_file) => Config::from_config_file(config_file, true).unwrap(),
-        Err(e) => {
-            warn!("Invalid config file: {e}");
-            process::exit(1);
-        }
-    };
-
-    // Validate directory path
-    let dir = PathBuf::from(path);
-    let dir = fs::canonicalize(dir).unwrap_or_else(|e| panic!("{path} is not a valid path: {e}"));
-
-    if !dir.is_dir() {
-        panic!("{path} is not a valid directory");
-    }
-
-    // Read entries in directory
-    let dir_entries = dir
-        .read_dir()
-        .unwrap_or_else(|e| panic!("Failed to read {path}: {e}"))
-        .filter_map(|e| e.ok());
-
-    // Get filenames, filtering out anything that isn't a regular file
-    let filenames = dir_entries.filter_map(|e| match e.file_type() {
-        Ok(t) if t.is_file() => e.file_name().into_string().ok(),
-        _ => None,
-    });
-
-    // Get vec of (block_height, filename), to prepare for sorting
-    //
-    // NOTE: Trusting the filename is not ideal. We could sort on data read from the file,
-    // but that requires reading all files
-    let re = Regex::new(r"^([0-9]+\.json)$").unwrap();
-    let mut indexed_files = filenames
-        .filter_map(|filename| {
-            // Use regex to extract block number from filename
-            let Some(cap) = re.captures(&filename) else {
-                return None;
-            };
-            let Some(m) = cap.get(0) else {
-                return None;
-            };
-            let Ok(bh) = m.as_str().parse::<u64>() else {
-                return None;
-            };
-            Some((bh, filename))
-        })
-        .collect::<Vec<_>>();
-
-    // Sort by block height
-    indexed_files.sort_by_key(|(bh, _)| *bh);
-
-    if indexed_files.is_empty() {
-        panic!("No block files found");
-    }
-
-    info!(
-        "Replaying {} blocks starting at {}",
-        indexed_files.len(),
-        indexed_files[0].0
-    );
-
-    for (bh, filename) in indexed_files {
-        let filepath = dir.join(filename);
-        let block = AssembledAnchorBlock::deserialize_from_file(&filepath)
-            .unwrap_or_else(|e| panic!("Error reading block {bh} from file: {e}"));
-        debug!("Replaying block from {filepath:?}";
-            "block_height" => bh,
-            "block" => ?block
-        );
-        // TODO: Actually replay block
-    }
-}
-
 fn main() {
     panic::set_hook(Box::new(|panic_info| {
         error!("Process abort due to thread panic: {}", panic_info);
@@ -482,13 +402,6 @@ fn main() {
 
             let spend_amount = cli_get_miner_spend(&config_path, mine_start, at_burnchain_height);
             println!("Will spend {}", spend_amount);
-            process::exit(0);
-        }
-        "replay-mock-mining" => {
-            let path: String = args.value_from_str("--path").unwrap();
-            let config_path: String = args.value_from_str("--config").unwrap();
-            args.finish();
-            cli_replay_mock_mining(&config_path, &path);
             process::exit(0);
         }
         _ => {

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -2556,6 +2556,7 @@ impl BlockMinerThread {
         let res = bitcoin_controller.submit_operation(target_epoch_id, op, &mut op_signer, attempt);
         let assembled_block = AssembledAnchorBlock {
             parent_consensus_hash: parent_block_info.parent_consensus_hash,
+            consensus_hash: cur_burn_chain_tip.consensus_hash,
             my_burn_hash: cur_burn_chain_tip.burn_header_hash,
             my_block_height: cur_burn_chain_tip.block_height,
             orig_burn_hash: self.burn_block.burn_header_hash,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -142,7 +142,6 @@ use std::cmp::Ordering as CmpOrdering;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
-use std::path::Path;
 use std::sync::mpsc::{Receiver, TrySendError};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -190,7 +189,6 @@ use stacks::net::stackerdb::{StackerDBConfig, StackerDBSync, StackerDBs};
 use stacks::net::{
     Error as NetError, NetworkResult, PeerNetworkComms, RPCHandlerArgs, ServiceFlags,
 };
-use stacks::util::{deserialize_json_from_file, serialize_json_to_file};
 use stacks::util_lib::strings::{UrlString, VecDisplay};
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -140,7 +140,7 @@
 use std::cmp;
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::net::SocketAddr;
 use std::sync::mpsc::{Receiver, TrySendError};
 use std::thread::JoinHandle;
@@ -1123,7 +1123,7 @@ impl BlockMinerThread {
     ) -> Vec<&AssembledAnchorBlock> {
         let mut ret = vec![];
         for (_, (assembled_block, _)) in last_mined_blocks.iter() {
-            if assembled_block.my_block_height >= burn_height {
+            if assembled_block.burn_block_height >= burn_height {
                 ret.push(assembled_block);
             }
         }
@@ -1633,7 +1633,7 @@ impl BlockMinerThread {
                     &prev_block.anchored_block.block_hash(),
                     &prev_block.parent_consensus_hash,
                     &prev_block.anchored_block.header.parent_block,
-                    &prev_block.my_burn_hash,
+                    &prev_block.burn_hash,
                     &prev_block.anchored_block.txs.len()
                 );
                 max_txs = cmp::max(max_txs, prev_block.anchored_block.txs.len());
@@ -1645,7 +1645,7 @@ impl BlockMinerThread {
                     continue;
                 }
                 if prev_block.parent_consensus_hash == *parent_consensus_hash
-                    && prev_block.my_burn_hash == self.burn_block.burn_header_hash
+                    && prev_block.burn_hash == self.burn_block.burn_header_hash
                     && prev_block.anchored_block.header.parent_block
                         == stacks_parent_header.anchored_header.block_hash()
                 {
@@ -1677,7 +1677,7 @@ impl BlockMinerThread {
                                 // already have.
                                 info!("Relayer: Stacks tip is unchanged since we last tried to mine a block off of {}/{} at height {} with {} txs, in {} at burn height {}, and no new microblocks ({} <= {} + 1)",
                                        &prev_block.parent_consensus_hash, &prev_block.anchored_block.header.parent_block, prev_block.anchored_block.header.total_work.work,
-                                       prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
+                                       prev_block.anchored_block.txs.len(), prev_block.burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
 
                                 return None;
                             }
@@ -1688,7 +1688,7 @@ impl BlockMinerThread {
                             // fee minus the old BTC fee
                             info!("Relayer: Stacks tip is unchanged since we last tried to mine a block off of {}/{} at height {} with {} txs, in {} at burn height {}, but there are new microblocks ({} > {} + 1)",
                                    &prev_block.parent_consensus_hash, &prev_block.anchored_block.header.parent_block, prev_block.anchored_block.header.total_work.work,
-                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
+                                   prev_block.anchored_block.txs.len(), prev_block.burn_hash, parent_block_burn_height, stream.len(), prev_block.anchored_block.header.parent_microblock_sequence);
 
                             best_attempt = cmp::max(best_attempt, prev_block.attempt);
                         }
@@ -1697,20 +1697,20 @@ impl BlockMinerThread {
                             // no microblock stream to confirm, and the stacks tip hasn't changed
                             info!("Relayer: Stacks tip is unchanged since we last tried to mine a block off of {}/{} at height {} with {} txs, in {} at burn height {}, and no microblocks present",
                                    &prev_block.parent_consensus_hash, &prev_block.anchored_block.header.parent_block, prev_block.anchored_block.header.total_work.work,
-                                   prev_block.anchored_block.txs.len(), prev_block.my_burn_hash, parent_block_burn_height);
+                                   prev_block.anchored_block.txs.len(), prev_block.burn_hash, parent_block_burn_height);
 
                             return None;
                         }
                     }
                 } else {
-                    if self.burn_block.burn_header_hash == prev_block.my_burn_hash {
+                    if self.burn_block.burn_header_hash == prev_block.burn_hash {
                         // only try and re-mine if there was no sortition since the last chain tip
                         info!("Relayer: Stacks tip has changed to {}/{} since we last tried to mine a block in {} at burn height {}; attempt was {} (for Stacks tip {}/{})",
-                               parent_consensus_hash, stacks_parent_header.anchored_header.block_hash(), prev_block.my_burn_hash, parent_block_burn_height, prev_block.attempt, &prev_block.parent_consensus_hash, &prev_block.anchored_block.header.parent_block);
+                               parent_consensus_hash, stacks_parent_header.anchored_header.block_hash(), prev_block.burn_hash, parent_block_burn_height, prev_block.attempt, &prev_block.parent_consensus_hash, &prev_block.anchored_block.header.parent_block);
                         best_attempt = cmp::max(best_attempt, prev_block.attempt);
                     } else {
                         info!("Relayer: Burn tip has changed to {} ({}) since we last tried to mine a block in {}",
-                               &self.burn_block.burn_header_hash, self.burn_block.block_height, &prev_block.my_burn_hash);
+                               &self.burn_block.burn_header_hash, self.burn_block.block_height, &prev_block.burn_hash);
                     }
                 }
             }
@@ -2554,34 +2554,48 @@ impl BlockMinerThread {
         } = self.config.get_node_config(false);
 
         let res = bitcoin_controller.submit_operation(target_epoch_id, op, &mut op_signer, attempt);
+        if res.is_none() {
+            self.failed_to_submit_last_attempt = true;
+            if !mock_mining {
+                warn!("Relayer: Failed to submit Bitcoin transaction");
+                return None;
+            }
+            debug!("Relayer: Mock-mining enabled; not sending Bitcoin transaction");
+        } else {
+            self.failed_to_submit_last_attempt = false;
+        }
+
         let assembled_block = AssembledAnchorBlock {
             parent_consensus_hash: parent_block_info.parent_consensus_hash,
             consensus_hash: cur_burn_chain_tip.consensus_hash,
-            my_burn_hash: cur_burn_chain_tip.burn_header_hash,
-            my_block_height: cur_burn_chain_tip.block_height,
+            burn_hash: cur_burn_chain_tip.burn_header_hash,
+            burn_block_height: cur_burn_chain_tip.block_height,
             orig_burn_hash: self.burn_block.burn_header_hash,
             anchored_block,
             attempt,
             tenure_begin,
         };
-        if res.is_none() {
-            self.failed_to_submit_last_attempt = true;
-            if mock_mining {
-                debug!("Relayer: Mock-mining enabled; not sending Bitcoin transaction");
-                if let Some(dir) = mock_mining_output_dir {
-                    let stacks_block_height = assembled_block.anchored_block.header.total_work.work;
-                    let filename = format!("{stacks_block_height}.json");
-                    let filepath = dir.join(filename);
-                    assembled_block
-                        .serialize_to_file(&filepath)
-                        .unwrap_or_else(|e| panic!("Failed to write to file '{filepath:?}': {e}"));
-                }
-            } else {
-                warn!("Relayer: Failed to submit Bitcoin transaction");
-                return None;
+
+        if mock_mining {
+            let stacks_block_height = assembled_block.anchored_block.header.total_work.work;
+            info!("Mock mined Stacks block {stacks_block_height}");
+            if let Some(dir) = mock_mining_output_dir {
+                info!("Writing mock mined Stacks block {stacks_block_height} to file");
+                fs::create_dir_all(&dir).unwrap_or_else(|e| match e.kind() {
+                    ErrorKind::AlreadyExists => { /* This is fine */ }
+                    _ => error!("Failed to create directory '{dir:?}': {e}"),
+                });
+                let filename = format!("{stacks_block_height}.json");
+                let filepath = dir.join(filename);
+                assembled_block
+                    .serialize_to_file(&filepath)
+                    .unwrap_or_else(|e| match e.kind() {
+                        ErrorKind::AlreadyExists => {
+                            error!("Failed to overwrite file '{filepath:?}'")
+                        }
+                        _ => error!("Failed to write to file '{filepath:?}': {e}"),
+                    });
             }
-        } else {
-            self.failed_to_submit_last_attempt = false;
         }
 
         Some(MinerThreadResult::Block(
@@ -3010,7 +3024,7 @@ impl RelayerThread {
             let AssembledAnchorBlock {
                 parent_consensus_hash,
                 anchored_block: mined_block,
-                my_burn_hash: mined_burn_hash,
+                burn_hash: mined_burn_hash,
                 attempt: _,
                 ..
             } = last_mined_block_data;
@@ -3423,16 +3437,16 @@ impl RelayerThread {
     fn clear_stale_mined_blocks(burn_height: u64, last_mined_blocks: MinedBlocks) -> MinedBlocks {
         let mut ret = HashMap::new();
         for (stacks_bhh, (assembled_block, microblock_privkey)) in last_mined_blocks.into_iter() {
-            if assembled_block.my_block_height < burn_height {
+            if assembled_block.burn_block_height < burn_height {
                 debug!(
                     "Stale mined block: {} (as of {},{})",
-                    &stacks_bhh, &assembled_block.my_burn_hash, assembled_block.my_block_height
+                    &stacks_bhh, &assembled_block.burn_hash, assembled_block.burn_block_height
                 );
                 continue;
             }
             debug!(
                 "Mined block in-flight: {} (as of {},{})",
-                &stacks_bhh, &assembled_block.my_burn_hash, assembled_block.my_block_height
+                &stacks_bhh, &assembled_block.burn_hash, assembled_block.burn_block_height
             );
             ret.insert(stacks_bhh, (assembled_block, microblock_privkey));
         }
@@ -3760,7 +3774,7 @@ impl RelayerThread {
                 ) => {
                     // finished mining a block
                     if BlockMinerThread::find_inflight_mined_blocks(
-                        last_mined_block.my_block_height,
+                        last_mined_block.burn_block_height,
                         &self.last_mined_blocks,
                     )
                     .len()
@@ -3769,7 +3783,7 @@ impl RelayerThread {
                         // first time we've mined a block in this burnchain block
                         debug!(
                             "Bump block processed for burnchain block {}",
-                            &last_mined_block.my_block_height
+                            &last_mined_block.burn_block_height
                         );
                         self.globals.counters.bump_blocks_processed();
                     }
@@ -3779,7 +3793,7 @@ impl RelayerThread {
                         &last_mined_block.anchored_block.block_hash()
                     );
 
-                    let bhh = last_mined_block.my_burn_hash.clone();
+                    let bhh = last_mined_block.burn_hash.clone();
                     let orig_bhh = last_mined_block.orig_burn_hash.clone();
                     let tenure_begin = last_mined_block.tenure_begin;
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -167,7 +167,8 @@ use stacks::chainstate::stacks::address::PoxAddress;
 use stacks::chainstate::stacks::db::blocks::StagingBlock;
 use stacks::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo, MINER_REWARD_MATURITY};
 use stacks::chainstate::stacks::miner::{
-    signal_mining_blocked, signal_mining_ready, BlockBuilderSettings, StacksMicroblockBuilder,
+    signal_mining_blocked, signal_mining_ready, AssembledAnchorBlock, BlockBuilderSettings,
+    StacksMicroblockBuilder,
 };
 use stacks::chainstate::stacks::{
     CoinbasePayload, Error as ChainstateError, StacksBlock, StacksBlockBuilder, StacksBlockHeader,
@@ -233,28 +234,6 @@ pub(crate) enum MinerThreadResult {
         MinerTip,
     ),
 }
-
-/// Fully-assembled Stacks anchored, block as well as some extra metadata pertaining to how it was
-/// linked to the burnchain and what view(s) the miner had of the burnchain before and after
-/// completing the block.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssembledAnchorBlock {
-    /// Consensus hash of the parent Stacks block
-    parent_consensus_hash: ConsensusHash,
-    /// Burnchain tip's block hash when we finished mining
-    my_burn_hash: BurnchainHeaderHash,
-    /// Burnchain tip's block height when we finished mining
-    my_block_height: u64,
-    /// Burnchain tip's block hash when we started mining (could be different)
-    orig_burn_hash: BurnchainHeaderHash,
-    /// The block we produced
-    anchored_block: StacksBlock,
-    /// The attempt count of this block (multiple blocks will be attempted per burnchain block)
-    attempt: u64,
-    /// Epoch timestamp in milliseconds when we started producing the block.
-    tenure_begin: u128,
-}
-impl_file_io_serde_json!(AssembledAnchorBlock);
 
 /// Miner chain tip, on top of which to build microblocks
 #[derive(Debug, Clone, PartialEq)]

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -12408,10 +12408,9 @@ fn next_block_and_wait_all(
         let finished = follower_blocks_processed
             .iter()
             .zip(followers_current.iter())
-            .map(|(blocks_processed, start_count)| {
+            .all(|(blocks_processed, start_count)| {
                 blocks_processed.load(Ordering::SeqCst) > *start_count
-            })
-            .all(|b| b);
+            });
 
         if finished {
             break;
@@ -12702,7 +12701,7 @@ fn mock_miner_replay() {
 
     thread::sleep(block_gap);
 
-    // first block will hold our VRF registration
+    // second block will hold our VRF registration
     next_block_and_wait_all(
         &mut btc_regtest_controller,
         &miner_blocks_processed,

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
@@ -12389,6 +12389,7 @@ fn next_block_and_wait_all(
     btc_controller: &mut BitcoinRegtestController,
     miner_blocks_processed: &Arc<AtomicU64>,
     follower_blocks_processed: &[&Arc<AtomicU64>],
+    timeout: Option<Duration>,
 ) -> bool {
     let followers_current: Vec<_> = follower_blocks_processed
         .iter()
@@ -12400,15 +12401,24 @@ fn next_block_and_wait_all(
     }
 
     // wait for followers to catch up
+    let timer = Instant::now();
     loop {
         let finished = follower_blocks_processed
             .iter()
             .zip(followers_current.iter())
-            .map(|(blocks_processed, current)| blocks_processed.load(Ordering::SeqCst) <= *current)
-            .fold(true, |acc, loaded| acc && loaded);
+            .map(|(blocks_processed, start_count)| {
+                blocks_processed.load(Ordering::SeqCst) > *start_count
+            })
+            .all(|b| b);
 
         if finished {
             break;
+        }
+
+        if let Some(t) = timeout {
+            if timer.elapsed() > t {
+                panic!("next_block_and_wait_all() timed out after {t:?}")
+            }
         }
 
         thread::sleep(Duration::from_millis(100));
@@ -12425,6 +12435,7 @@ fn bitcoin_reorg_flap_with_follower() {
     }
 
     let (conf, _miner_account) = neon_integration_test_conf();
+    let timeout = None;
 
     let mut btcd_controller = BitcoinCoreController::new(conf.clone());
     btcd_controller
@@ -12485,13 +12496,19 @@ fn bitcoin_reorg_flap_with_follower() {
     eprintln!("Follower bootup complete!");
 
     // first block wakes up the run loop
-    next_block_and_wait_all(&mut btc_regtest_controller, &miner_blocks_processed, &[]);
+    next_block_and_wait_all(
+        &mut btc_regtest_controller,
+        &miner_blocks_processed,
+        &[],
+        timeout,
+    );
 
     // first block will hold our VRF registration
     next_block_and_wait_all(
         &mut btc_regtest_controller,
         &miner_blocks_processed,
         &[&follower_blocks_processed],
+        timeout,
     );
 
     let mut miner_sort_height = miner_channel.get_sortitions_processed();
@@ -12506,6 +12523,7 @@ fn bitcoin_reorg_flap_with_follower() {
             &mut btc_regtest_controller,
             &miner_blocks_processed,
             &[&follower_blocks_processed],
+            timeout,
         );
         miner_sort_height = miner_channel.get_sortitions_processed();
         follower_sort_height = miner_channel.get_sortitions_processed();
@@ -12578,6 +12596,159 @@ fn bitcoin_reorg_flap_with_follower() {
 
     assert_eq!(miner_channel.get_sortitions_processed(), 225);
     assert_eq!(follower_channel.get_sortitions_processed(), 225);
+
+    btcd_controller.stop_bitcoind().unwrap();
+    miner_channel.stop_chains_coordinator();
+    follower_channel.stop_chains_coordinator();
+}
+
+/// Tests the following:
+///  - Mock miner output to file
+///  - Test replay of mock mined blocks using `stacks-inspect  replay-mock-mining``
+#[test]
+#[ignore]
+fn mock_miner_replay() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let timeout = Some(Duration::from_secs(30));
+    // Had to add this so that mock miner makes an attempt on EVERY block
+    let block_gap = Duration::from_secs(1);
+
+    let test_dir = PathBuf::from("/tmp/stacks-integration-test-mock_miner_replay");
+    _ = fs::remove_dir_all(&test_dir);
+
+    let (conf, _miner_account) = neon_integration_test_conf();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut miner_run_loop = neon::RunLoop::new(conf.clone());
+    let miner_blocks_processed = miner_run_loop.get_blocks_processed_arc();
+    let miner_channel = miner_run_loop.get_coordinator_channel().unwrap();
+
+    let mut follower_conf = conf.clone();
+    follower_conf.events_observers.clear();
+    follower_conf.node.mock_mining = true;
+    follower_conf.node.mock_mining_output_dir = Some(test_dir.join("mock-miner-output"));
+    follower_conf.node.working_dir = format!("{}-follower", &conf.node.working_dir);
+    follower_conf.node.seed = vec![0x01; 32];
+    follower_conf.node.local_peer_seed = vec![0x02; 32];
+
+    let mut rng = rand::thread_rng();
+
+    let (rpc_port, p2p_port) = loop {
+        let a = rng.gen_range(1024..u16::MAX); // use a non-privileged port between 1024 and 65534
+        let b = rng.gen_range(1024..u16::MAX); // use a non-privileged port between 1024 and 65534
+        if a != b {
+            break (a, b);
+        }
+    };
+
+    let localhost = "127.0.0.1";
+    follower_conf.node.rpc_bind = format!("{localhost}:{rpc_port}");
+    follower_conf.node.p2p_bind = format!("{localhost}:{p2p_port}");
+    follower_conf.node.data_url = format!("http://{localhost}:{rpc_port}");
+    follower_conf.node.p2p_address = format!("{localhost}:{p2p_port}");
+
+    thread::spawn(move || miner_run_loop.start(None, 0));
+    wait_for_runloop(&miner_blocks_processed);
+
+    // figure out the started node's port
+    let node_info = get_chain_info(&conf);
+    follower_conf.node.add_bootstrap_node(
+        &format!(
+            "{}@{}",
+            &node_info.node_public_key.unwrap(),
+            conf.node.p2p_bind
+        ),
+        CHAIN_ID_TESTNET,
+        PEER_VERSION_TESTNET,
+    );
+
+    let mut follower_run_loop = neon::RunLoop::new(follower_conf.clone());
+    let follower_blocks_processed = follower_run_loop.get_blocks_processed_arc();
+    let follower_channel = follower_run_loop.get_coordinator_channel().unwrap();
+
+    let miner_blocks_processed_start = miner_channel.get_stacks_blocks_processed();
+    let follower_blocks_processed_start = follower_channel.get_stacks_blocks_processed();
+
+    thread::spawn(move || follower_run_loop.start(None, 0));
+    wait_for_runloop(&follower_blocks_processed);
+
+    eprintln!("Follower bootup complete!");
+
+    // first block wakes up the run loop
+    next_block_and_wait_all(
+        &mut btc_regtest_controller,
+        &miner_blocks_processed,
+        &[],
+        timeout,
+    );
+
+    thread::sleep(block_gap);
+
+    // first block will hold our VRF registration
+    next_block_and_wait_all(
+        &mut btc_regtest_controller,
+        &miner_blocks_processed,
+        &[&follower_blocks_processed],
+        timeout,
+    );
+
+    thread::sleep(block_gap);
+
+    // Third block will be the first mined Stacks block.
+    next_block_and_wait_all(
+        &mut btc_regtest_controller,
+        &miner_blocks_processed,
+        &[&follower_blocks_processed],
+        timeout,
+    );
+
+    thread::sleep(block_gap);
+
+    // ---------- Setup finished, start test ----------
+
+    // Mine some blocks for mock miner output
+    for _ in 0..10 {
+        next_block_and_wait_all(
+            &mut btc_regtest_controller,
+            &miner_blocks_processed,
+            &[&follower_blocks_processed],
+            timeout,
+        );
+        thread::sleep(block_gap);
+    }
+
+    let miner_blocks_processed_end = miner_channel.get_stacks_blocks_processed();
+    let follower_blocks_processed_end = follower_channel.get_stacks_blocks_processed();
+
+    let blocks_dir = follower_conf.node.mock_mining_output_dir.clone().unwrap();
+    let file_count = follower_conf
+        .node
+        .mock_mining_output_dir
+        .unwrap()
+        .read_dir()
+        .unwrap_or_else(|e| panic!("Failed to read directory: {e}"))
+        .count();
+
+    // Check that expected output files exist
+    assert!(test_dir.is_dir());
+    assert!(blocks_dir.is_dir());
+    assert_eq!(file_count, 12);
+    assert_eq!(miner_blocks_processed_end, follower_blocks_processed_end);
+
+    // ---------- Test finished, clean up ----------
 
     btcd_controller.stop_bitcoind().unwrap();
     miner_channel.stop_chains_coordinator();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -5,6 +5,7 @@ use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
 use std::{cmp, env, fs, io, thread};
 
+use clarity::consts::BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP;
 use clarity::vm::ast::stack_depth_checker::AST_CALL_STACK_DEPTH_BUFFER;
 use clarity::vm::ast::ASTRules;
 use clarity::vm::costs::ExecutionCost;
@@ -38,7 +39,7 @@ use stacks::chainstate::stacks::{
     StacksPublicKey, StacksTransaction, TransactionContractCall, TransactionPayload,
 };
 use stacks::clarity_cli::vm_execute as execute;
-use stacks::cli;
+use stacks::cli::{self, StacksChainConfig};
 use stacks::codec::StacksMessageCodec;
 use stacks::core::mempool::MemPoolWalkTxTypes;
 use stacks::core::{
@@ -12627,7 +12628,13 @@ fn mock_miner_replay() {
         .start_bitcoind()
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
+    );
 
     btc_regtest_controller.bootstrap_chain(201);
 
@@ -12756,9 +12763,22 @@ fn mock_miner_replay() {
     let blocks_dir = blocks_dir.into_os_string().into_string().unwrap();
     let db_path = format!("{}/neon", conf.node.working_dir);
     let args: Vec<String> = vec!["replay-mock-mining".into(), db_path, blocks_dir];
+    let SortitionDB {
+        first_block_height,
+        first_burn_header_hash,
+        ..
+    } = *btc_regtest_controller.sortdb_mut();
+    let replay_config = StacksChainConfig {
+        chain_id: conf.burnchain.chain_id,
+        first_block_height,
+        first_burn_header_hash,
+        first_burn_header_timestamp: BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP.into(),
+        pox_constants: burnchain_config.pox_constants,
+        epochs: conf.burnchain.epochs.expect("Missing `epochs` in config"),
+    };
 
     info!("Replaying mock mined blocks...");
-    cli::command_replay_mock_mining(&args);
+    cli::command_replay_mock_mining(&args, Some(&replay_config));
 
     // ---------- Test finished, clean up ----------
 


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

There are two parts to this PR:
- Add new config option, `node.mock_mining_output_dir`, which causes mock miner to write mock mined blocks to files
- Add subcommand to stacks-inspect, `stacks-inspect replay-mock-mining`, which will read mock mined blocks and validate them against chainstate

### PR Status

Added integration test `neon_integrations::replay_mock_miner()` and it passes. Have not tested against mainnet yet

Should probably add some real transactions to integration test, right now it's only coinbases

Due to refactoring `replay_block()` for use in mock mining replay, I've re-tested `stacks-inspect replay-block` and confirmed it still works

### Applicable issues

- fixes #4986

### Additional info (benefits, drawbacks, caveats)

- I refactored code used by `stacks-inspect replay-block` so that could re-use it here
- I also refactored and pulled some functions out of `stackslib/src/main.rs` and into `stackslib/src/cli.rs` so that they could be called from integration tests
- The way `stacks-inspect replay-block` processes it's arguments has changed slightly, and it no longer automatically adds "mainnet/" (because it now supports testnet/devnet/etc.) into the chainstate path

### Checklist

- [x] Integration test for `stacks-inspect replay-mock-mining`
- [x] Test `stacks-inspect replay-block`
- [ ] Test `stacks-inspect replay-mock-mining` with mainnet mock miner and chainstate
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [x] New integration test(s) added to `bitcoin-tests.yml`
