### PR TITLE
Fix/stackerdb net fixes

### DIFF
--- a/stackslib/src/net/api/postblock_v3.rs
+++ b/stackslib/src/net/api/postblock_v3.rs
@@ -121,7 +121,7 @@ impl RPCRequestHandler for RPCPostBlockRequestHandler {
             .ok_or(NetError::SendError("`block` not set".into()))?;
 
         let response = node
-            .with_node_state(|network, sortdb, chainstate, _mempool, _rpc_args| {
+            .with_node_state(|network, sortdb, chainstate, _mempool, rpc_args| {
                 let mut handle_conn = sortdb.index_handle_at_tip();
                 let stacks_tip = network.stacks_tip.block_id();
                 Relayer::process_new_nakamoto_block(
@@ -131,7 +131,7 @@ impl RPCRequestHandler for RPCPostBlockRequestHandler {
                     chainstate,
                     &stacks_tip,
                     &block,
-                    None,
+                    rpc_args.coord_comms,
                     NakamotoBlockObtainMethod::Uploaded,
                 )
             })

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -735,10 +735,9 @@ impl ConversationP2P {
             }
         };
         if bhh != their_burn_header_hash {
-            test_debug!(
+            debug!(
                 "Burn header hash mismatch in preamble: {} != {}",
-                bhh,
-                their_burn_header_hash
+                bhh, their_burn_header_hash
             );
             return true;
         }
@@ -764,18 +763,16 @@ impl ConversationP2P {
 
         if my_epoch <= remote_epoch {
             // remote node supports same epochs we do
-            test_debug!(
-                "Remote peer has epoch {}, which is newer than our epoch {}",
-                remote_epoch,
-                my_epoch
+            debug!(
+                "Remote peer has epoch {}, which is at least as new as our epoch {}",
+                remote_epoch, my_epoch
             );
             return true;
         }
 
-        test_debug!(
+        debug!(
             "Remote peer has old network version {} (epoch {})",
-            remote_peer_version,
-            remote_epoch
+            remote_peer_version, remote_epoch
         );
 
         // what epoch are we in?
@@ -786,10 +783,9 @@ impl ConversationP2P {
 
         if cur_epoch <= remote_epoch {
             // epoch shift hasn't happened yet, and this peer supports the current epoch
-            test_debug!(
+            debug!(
                 "Remote peer has epoch {} and current epoch is {}, so still valid",
-                remote_epoch,
-                cur_epoch
+                remote_epoch, cur_epoch
             );
             return true;
         }
@@ -828,11 +824,9 @@ impl ConversationP2P {
         }
         if (msg.preamble.peer_version & 0xff000000) != (self.version & 0xff000000) {
             // major version mismatch
-            test_debug!(
+            debug!(
                 "{:?}: Preamble invalid: wrong peer version: {:x} != {:x}",
-                &self,
-                msg.preamble.peer_version,
-                self.version
+                &self, msg.preamble.peer_version, self.version
             );
             return Err(net_error::InvalidMessage);
         }
@@ -1366,11 +1360,6 @@ impl ConversationP2P {
             };
 
         if let Some(stackerdb_accept) = stackerdb_accept {
-            test_debug!(
-                "{} =?= {}",
-                &stackerdb_accept.rc_consensus_hash,
-                &burnchain_view.rc_consensus_hash
-            );
             if stackerdb_accept.rc_consensus_hash == burnchain_view.rc_consensus_hash {
                 // remote peer is in the same reward cycle as us.
                 self.update_from_stacker_db_handshake_data(stackerdb_accept);
@@ -1457,7 +1446,7 @@ impl ConversationP2P {
 
         if cfg!(test) && self.connection.options.disable_chat_neighbors {
             // never report neighbors if this is disabled by a test
-            test_debug!(
+            debug!(
                 "{:?}: Neighbor crawl is disabled; reporting 0 neighbors",
                 &local_peer
             );
@@ -1694,7 +1683,7 @@ impl ConversationP2P {
 
             if self.connection.options.disable_inv_chat {
                 // never reply that we have blocks
-                test_debug!(
+                debug!(
                     "{:?}: Disable inv chat -- pretend like we have nothing",
                     network.get_local_peer()
                 );
@@ -1759,11 +1748,9 @@ impl ConversationP2P {
             e
         })?;
 
-        test_debug!(
+        debug!(
             "Reply NakamotoInv for {} (rc {}): {:?}",
-            &get_nakamoto_inv.consensus_hash,
-            reward_cycle,
-            &nakamoto_inv
+            &get_nakamoto_inv.consensus_hash, reward_cycle, &nakamoto_inv
         );
 
         Ok(StacksMessageType::NakamotoInv(nakamoto_inv))
@@ -1798,7 +1785,7 @@ impl ConversationP2P {
 
             if self.connection.options.disable_inv_chat {
                 // never reply that we have blocks
-                test_debug!(
+                debug!(
                     "{:?}: Disable inv chat -- pretend like we have nothing",
                     network.get_local_peer()
                 );
@@ -1837,10 +1824,9 @@ impl ConversationP2P {
             Ok(Some(sn)) => {
                 if !sn.pox_valid {
                     // invalid consensus hash
-                    test_debug!(
+                    debug!(
                         "{:?}: Snapshot {:?} is not on a valid PoX fork",
-                        local_peer,
-                        sn.burn_header_hash
+                        local_peer, sn.burn_header_hash
                     );
                     return Ok(StacksMessageType::Nack(NackData::new(
                         NackErrorCodes::InvalidPoxFork,
@@ -1852,7 +1838,7 @@ impl ConversationP2P {
                     % (burnchain.pox_constants.reward_cycle_length as u64)
                     != 1
                 {
-                    test_debug!(
+                    debug!(
                         "{:?}: block height ({} - {}) % {} != 1",
                         local_peer,
                         sn.block_height,
@@ -1896,10 +1882,9 @@ impl ConversationP2P {
                 }
             }
             Ok(None) | Err(db_error::NotFoundError) => {
-                test_debug!(
+                debug!(
                     "{:?}: snapshot for consensus hash {} not found",
-                    local_peer,
-                    getpoxinv.consensus_hash
+                    local_peer, getpoxinv.consensus_hash
                 );
                 Ok(StacksMessageType::Nack(NackData::new(
                     NackErrorCodes::InvalidPoxFork,
@@ -1999,9 +1984,29 @@ impl ConversationP2P {
         ) {
             Ok(Some(chunk)) => chunk,
             Ok(None) => {
-                // request for a stale chunk
+                // TODO: this is racey
+                if let Ok(Some(actual_version)) =
+                    stacker_dbs.get_slot_version(&getchunk.contract_id, getchunk.slot_id)
+                {
+                    // request for a stale chunk
+                    debug!("{:?}: NACK StackerDBGetChunk; version mismatch for requested slot {}.{} for {}. Expected {}", local_peer, getchunk.slot_id, getchunk.slot_version, &getchunk.contract_id, actual_version);
+                    if actual_version > getchunk.slot_version {
+                        return Ok(StacksMessageType::Nack(NackData::new(
+                            NackErrorCodes::StaleVersion,
+                        )));
+                    } else {
+                        return Ok(StacksMessageType::Nack(NackData::new(
+                            NackErrorCodes::FutureVersion,
+                        )));
+                    }
+                }
+                // if we hit a DB error, just treat it as if the DB doesn't exist
+                debug!(
+                    "{:?}: NACK StackerDBGetChunk; unloadable slot {}.{} for {}",
+                    local_peer, getchunk.slot_id, getchunk.slot_version, &getchunk.contract_id
+                );
                 return Ok(StacksMessageType::Nack(NackData::new(
-                    NackErrorCodes::StaleVersion,
+                    NackErrorCodes::NoSuchDB,
                 )));
             }
             Err(e) => {
@@ -2416,14 +2421,16 @@ impl ConversationP2P {
                 Ok(num_recved) => {
                     total_recved += num_recved;
                     if num_recved > 0 {
+                        debug!("{:?}: received {} bytes", self, num_recved);
                         self.stats.last_recv_time = get_epoch_time_secs();
                         self.stats.bytes_rx += num_recved as u64;
                     } else {
+                        debug!("{:?}: received {} bytes, stopping", self, num_recved);
                         break;
                     }
                 }
                 Err(net_error::PermanentlyDrained) => {
-                    trace!(
+                    debug!(
                         "{:?}: failed to recv on P2P conversation: PermanentlyDrained",
                         self
                     );
@@ -2435,7 +2442,7 @@ impl ConversationP2P {
                 }
             }
         }
-        test_debug!("{:?}: received {} bytes", self, total_recved);
+        debug!("{:?}: received {} bytes", self, total_recved);
         Ok(total_recved)
     }
 
@@ -2463,7 +2470,7 @@ impl ConversationP2P {
                 }
             }
         }
-        test_debug!("{:?}: sent {} bytes", self, total_sent);
+        debug!("{:?}: sent {} bytes", self, total_sent);
         Ok(total_sent)
     }
 
@@ -2554,12 +2561,12 @@ impl ConversationP2P {
                 Ok(handshake_opt)
             }
             StacksMessageType::HandshakeAccept(ref data) => {
-                test_debug!("{:?}: Got HandshakeAccept", &self);
+                debug!("{:?}: Got HandshakeAccept", &self);
                 self.handle_handshake_accept(network.get_chain_view(), &msg.preamble, data, None)
                     .and_then(|_| Ok(None))
             }
             StacksMessageType::StackerDBHandshakeAccept(ref data, ref db_data) => {
-                test_debug!("{:?}: Got StackerDBHandshakeAccept", &self);
+                debug!("{:?}: Got StackerDBHandshakeAccept", &self);
                 self.handle_handshake_accept(
                     network.get_chain_view(),
                     &msg.preamble,
@@ -2569,21 +2576,21 @@ impl ConversationP2P {
                 .and_then(|_| Ok(None))
             }
             StacksMessageType::Ping(_) => {
-                test_debug!("{:?}: Got Ping", &self);
+                debug!("{:?}: Got Ping", &self);
 
                 // consume here if unsolicited
                 consume = true;
                 self.handle_ping(network.get_chain_view(), msg)
             }
             StacksMessageType::Pong(_) => {
-                test_debug!("{:?}: Got Pong", &self);
+                debug!("{:?}: Got Pong", &self);
                 Ok(None)
             }
             StacksMessageType::NatPunchRequest(ref nonce) => {
                 if cfg!(test) && self.connection.options.disable_natpunch {
                     return Err(net_error::InvalidMessage);
                 }
-                test_debug!("{:?}: Got NatPunchRequest({})", &self, nonce);
+                debug!("{:?}: Got NatPunchRequest({})", &self, nonce);
 
                 consume = true;
                 let msg = self.handle_natpunch_request(network.get_chain_view(), *nonce);
@@ -2593,11 +2600,11 @@ impl ConversationP2P {
                 if cfg!(test) && self.connection.options.disable_natpunch {
                     return Err(net_error::InvalidMessage);
                 }
-                test_debug!("{:?}: Got NatPunchReply({})", &self, _m.nonce);
+                debug!("{:?}: Got NatPunchReply({})", &self, _m.nonce);
                 Ok(None)
             }
             _ => {
-                test_debug!(
+                debug!(
                     "{:?}: Got a data-plane message (type {})",
                     &self,
                     msg.payload.get_message_name()
@@ -2626,14 +2633,14 @@ impl ConversationP2P {
         let reply_opt = match msg.payload {
             StacksMessageType::Handshake(_) => {
                 monitoring::increment_msg_counter("p2p_unauthenticated_handshake".to_string());
-                test_debug!("{:?}: Got unauthenticated Handshake", &self);
+                debug!("{:?}: Got unauthenticated Handshake", &self);
                 let (reply_opt, handled) = self.handle_handshake(network, msg, false, ibd)?;
                 consume = handled;
                 Ok(reply_opt)
             }
             StacksMessageType::HandshakeAccept(ref data) => {
                 if solicited {
-                    test_debug!("{:?}: Got unauthenticated HandshakeAccept", &self);
+                    debug!("{:?}: Got unauthenticated HandshakeAccept", &self);
                     self.handle_handshake_accept(
                         network.get_chain_view(),
                         &msg.preamble,
@@ -2642,7 +2649,7 @@ impl ConversationP2P {
                     )
                     .and_then(|_| Ok(None))
                 } else {
-                    test_debug!("{:?}: Unsolicited unauthenticated HandshakeAccept", &self);
+                    debug!("{:?}: Unsolicited unauthenticated HandshakeAccept", &self);
 
                     // don't update stats or state, and don't pass back
                     consume = true;
@@ -2651,7 +2658,7 @@ impl ConversationP2P {
             }
             StacksMessageType::StackerDBHandshakeAccept(ref data, ref db_data) => {
                 if solicited {
-                    test_debug!("{:?}: Got unauthenticated StackerDBHandshakeAccept", &self);
+                    debug!("{:?}: Got unauthenticated StackerDBHandshakeAccept", &self);
                     self.handle_handshake_accept(
                         network.get_chain_view(),
                         &msg.preamble,
@@ -2660,7 +2667,7 @@ impl ConversationP2P {
                     )
                     .and_then(|_| Ok(None))
                 } else {
-                    test_debug!(
+                    debug!(
                         "{:?}: Unsolicited unauthenticated StackerDBHandshakeAccept",
                         &self
                     );
@@ -2671,14 +2678,14 @@ impl ConversationP2P {
                 }
             }
             StacksMessageType::HandshakeReject => {
-                test_debug!("{:?}: Got unauthenticated HandshakeReject", &self);
+                debug!("{:?}: Got unauthenticated HandshakeReject", &self);
 
                 // don't NACK this back just because we were rejected.
                 // But, it's okay to forward this back (i.e. don't consume).
                 Ok(None)
             }
             StacksMessageType::Nack(_) => {
-                test_debug!("{:?}: Got unauthenticated Nack", &self);
+                debug!("{:?}: Got unauthenticated Nack", &self);
 
                 // don't NACK back.
                 // But, it's okay to forward this back (i.e. don't consume).
@@ -2688,10 +2695,9 @@ impl ConversationP2P {
                 if cfg!(test) && self.connection.options.disable_natpunch {
                     return Err(net_error::InvalidMessage);
                 }
-                test_debug!(
+                debug!(
                     "{:?}: Got unauthenticated NatPunchRequest({})",
-                    &self,
-                    *nonce
+                    &self, *nonce
                 );
                 consume = true;
                 let msg = self.handle_natpunch_request(network.get_chain_view(), *nonce);
@@ -2701,10 +2707,9 @@ impl ConversationP2P {
                 if cfg!(test) && self.connection.options.disable_natpunch {
                     return Err(net_error::InvalidMessage);
                 }
-                test_debug!(
+                debug!(
                     "{:?}: Got unauthenticated NatPunchReply({})",
-                    &self,
-                    _m.nonce
+                    &self, _m.nonce
                 );
 
                 // it's okay to forward this back (i.e. don't consume)
@@ -2939,7 +2944,7 @@ impl ConversationP2P {
         ibd: bool,
     ) -> Result<Vec<StacksMessage>, net_error> {
         let num_inbound = self.connection.inbox_len();
-        test_debug!("{:?}: {} messages pending", &self, num_inbound);
+        debug!("{:?}: {} messages pending", &self, num_inbound);
 
         let mut unsolicited = vec![];
         for _ in 0..num_inbound {
@@ -2972,7 +2977,7 @@ impl ConversationP2P {
             if let Some(mut reply) = reply_opt.take() {
                 // handler generated a reply.
                 // send back this message to the remote peer.
-                test_debug!(
+                debug!(
                     "{:?}: Send control-plane reply type {}",
                     &self,
                     reply.payload.get_message_name()
@@ -2988,11 +2993,9 @@ impl ConversationP2P {
             let _relayers = format!("{:?}", &msg.relayers);
             let _seq = msg.request_id();
 
-            test_debug!(
+            debug!(
                 "{:?}: Received message {}, relayed by {}",
-                &self,
-                &_msgtype,
-                &_relayers
+                &self, &_msgtype, &_relayers
             );
 
             // Is there someone else waiting for this message?  If so, pass it along.
@@ -3004,33 +3007,27 @@ impl ConversationP2P {
                         &self, _msgtype, _seq
                     );
                 } else {
-                    test_debug!(
+                    debug!(
                         "{:?}: Try handling message (type {} seq {})",
-                        &self,
-                        _msgtype,
-                        _seq
+                        &self, _msgtype, _seq
                     );
                     if let Some(msg) = self.handle_data_message(network, sortdb, chainstate, msg)? {
                         // this message was unsolicited
-                        test_debug!(
+                        debug!(
                             "{:?}: Did not handle message (type {} seq {}); passing upstream",
-                            &self,
-                            _msgtype,
-                            _seq
+                            &self, _msgtype, _seq
                         );
                         unsolicited.push(msg);
                     } else {
                         // expected and handled the message
-                        test_debug!("{:?}: Handled message {} seq {}", &self, _msgtype, _seq);
+                        debug!("{:?}: Handled message {} seq {}", &self, _msgtype, _seq);
                     }
                 }
             } else {
-                // no one was waiting for this reply, so just drop it
-                test_debug!(
+                // message was passed to the relevant message handle
+                debug!(
                     "{:?}: Fulfilled pending message request (type {} seq {})",
-                    &self,
-                    _msgtype,
-                    _seq
+                    &self, _msgtype, _seq
                 );
             }
         }

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -167,8 +167,9 @@ impl<P: ProtocolFamily> NetworkReplyHandle<P> {
     /// is destroyed in the process).
     pub fn try_recv(mut self) -> Result<P::Message, Result<NetworkReplyHandle<P>, net_error>> {
         if self.deadline > 0 && self.deadline < get_epoch_time_secs() {
-            test_debug!(
-                "Reply deadline {} exceeded (now = {})",
+            debug!(
+                "Reply deadline for event {} at {} exceeded (now = {})",
+                self.socket_event_id,
                 self.deadline,
                 get_epoch_time_secs()
             );
@@ -234,10 +235,9 @@ impl<P: ProtocolFamily> NetworkReplyHandle<P> {
                     None
                 } else {
                     // still have data to send, or we will send more.
-                    test_debug!(
+                    debug!(
                         "Still have data to send, drop_on_success = {}, ret = {}",
-                        drop_on_success,
-                        ret
+                        drop_on_success, ret
                     );
                     Some(fd)
                 }
@@ -990,7 +990,7 @@ impl<P: ProtocolFamily> ConnectionInbox<P> {
                         || e.kind() == io::ErrorKind::ConnectionReset
                     {
                         // write endpoint is dead
-                        test_debug!("reader was reset: {:?}", &e);
+                        debug!("reader was reset: {:?}", &e);
                         socket_closed = true;
                         blocked = true;
                         Ok(0)
@@ -1004,7 +1004,7 @@ impl<P: ProtocolFamily> ConnectionInbox<P> {
             total_read += num_read;
 
             if num_read > 0 || total_read > 0 {
-                trace!("read {} bytes; {} total", num_read, total_read);
+                debug!("read {} bytes; {} total", num_read, total_read);
             }
 
             if num_read > 0 {

--- a/stackslib/src/net/inv/epoch2x.rs
+++ b/stackslib/src/net/inv/epoch2x.rs
@@ -609,7 +609,9 @@ impl NeighborBlockStats {
         let mut broken = false;
         let mut stale = false;
 
-        if nack_data.error_code == NackErrorCodes::Throttled {
+        if nack_data.error_code == NackErrorCodes::Throttled
+            || nack_data.error_code == NackErrorCodes::HandshakeRequired
+        {
             // TODO: do something smarter here, like just back off
             return NodeStatus::Dead;
         } else if nack_data.error_code == NackErrorCodes::NoSuchBurnchainBlock {
@@ -2125,6 +2127,7 @@ impl PeerNetwork {
                 break;
             }
 
+            debug!("Inv sync state is {:?}", &stats.state);
             let again = match stats.state {
                 InvWorkState::GetPoxInvBegin => self
                     .inv_getpoxinv_begin(sortdb, nk, stats, request_timeout)
@@ -2629,7 +2632,7 @@ impl PeerNetwork {
         }
 
         // synchronize peer block inventories
-        let (done, throttled, dead_neighbors, broken_neighbors) =
+        let (done, throttled, broken_neighbors, dead_neighbors) =
             self.sync_inventories_epoch2x(sortdb, ibd);
 
         // disconnect and ban broken peers

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -30,8 +30,8 @@ use crate::net::db::PeerDB;
 use crate::net::neighbors::comms::PeerNetworkComms;
 use crate::net::p2p::PeerNetwork;
 use crate::net::{
-    Error as NetError, GetNakamotoInvData, NakamotoInvData, NeighborAddress, NeighborComms,
-    NeighborKey, StacksMessage, StacksMessageType,
+    Error as NetError, GetNakamotoInvData, NackErrorCodes, NakamotoInvData, NeighborAddress,
+    NeighborComms, NeighborKey, StacksMessage, StacksMessageType,
 };
 use crate::util_lib::db::Error as DBError;
 
@@ -86,14 +86,14 @@ impl InvTenureInfo {
             tenure_id_consensus_hash,
         )?
         .map(|tenure| {
-            test_debug!("BlockFound tenure for {}", &tenure_id_consensus_hash);
+            debug!("BlockFound tenure for {}", &tenure_id_consensus_hash);
             Self {
                 tenure_id_consensus_hash: tenure.tenure_id_consensus_hash,
                 parent_tenure_id_consensus_hash: tenure.prev_tenure_id_consensus_hash,
             }
         })
         .or_else(|| {
-            test_debug!("No BlockFound tenure for {}", &tenure_id_consensus_hash);
+            debug!("No BlockFound tenure for {}", &tenure_id_consensus_hash);
             None
         }))
     }
@@ -125,9 +125,7 @@ impl InvGenerator {
         tip_block_id: &StacksBlockId,
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Option<InvTenureInfo>, NetError> {
-        if let Some(info_opt) = self.processed_tenures.get(&tenure_id_consensus_hash) {
-            return Ok((*info_opt).clone());
-        };
+        // TODO: MARF-aware cache
         // not cached so go load it
         let loaded_info_opt =
             InvTenureInfo::load(chainstate, tip_block_id, &tenure_id_consensus_hash)?;
@@ -224,12 +222,16 @@ impl InvGenerator {
             };
             let parent_sortition_consensus_hash = cur_sortition_info.parent_consensus_hash.clone();
 
-            test_debug!("Get sortition and tenure info for height {}. cur_consensus_hash = {}, cur_tenure_info = {:?}, cur_sortition_info = {:?}", cur_height, &cur_consensus_hash, &cur_tenure_opt, cur_sortition_info);
+            debug!("Get sortition and tenure info for height {}. cur_consensus_hash = {}, cur_tenure_info = {:?}, cur_sortition_info = {:?}", cur_height, &cur_consensus_hash, &cur_tenure_opt, cur_sortition_info);
 
             if let Some(cur_tenure_info) = cur_tenure_opt.as_ref() {
                 // a tenure was active when this sortition happened...
                 if cur_tenure_info.tenure_id_consensus_hash == cur_consensus_hash {
                     // ...and this tenure started in this sortition
+                    debug!(
+                        "Tenure was started for {} (height {})",
+                        cur_consensus_hash, cur_height
+                    );
                     tenure_status.push(true);
                     cur_tenure_opt = self.get_processed_tenure(
                         chainstate,
@@ -238,11 +240,19 @@ impl InvGenerator {
                     )?;
                 } else {
                     // ...but this tenure did not start in this sortition
+                    debug!(
+                        "Tenure was NOT started for {} (bit {})",
+                        cur_consensus_hash, cur_height
+                    );
                     tenure_status.push(false);
                 }
             } else {
                 // no active tenure during this sortition. Check the parent sortition to see if a
                 // tenure begain there.
+                debug!(
+                    "No winning sortition for {} (bit {})",
+                    cur_consensus_hash, cur_height
+                );
                 tenure_status.push(false);
                 cur_tenure_opt = self.get_processed_tenure(
                     chainstate,
@@ -260,6 +270,10 @@ impl InvGenerator {
         }
 
         tenure_status.reverse();
+        debug!(
+            "Tenure bits off of {} and {}: {:?}",
+            nakamoto_tip, &tip.consensus_hash, &tenure_status
+        );
         Ok(tenure_status)
     }
 }
@@ -370,7 +384,7 @@ impl NakamotoTenureInv {
     /// Adjust the next reward cycle to query.
     /// Returns the reward cycle to query.
     pub fn next_reward_cycle(&mut self) -> u64 {
-        test_debug!("Next reward cycle: {}", self.cur_reward_cycle + 1);
+        debug!("Next reward cycle: {}", self.cur_reward_cycle + 1);
         let query_rc = self.cur_reward_cycle;
         self.cur_reward_cycle = self.cur_reward_cycle.saturating_add(1);
         query_rc
@@ -383,7 +397,7 @@ impl NakamotoTenureInv {
         if self.start_sync_time + inv_sync_interval <= now
             && (self.cur_reward_cycle >= cur_rc || !self.online)
         {
-            test_debug!("Reset inv comms for {}", &self.neighbor_address);
+            debug!("Reset inv comms for {}", &self.neighbor_address);
             self.online = true;
             self.start_sync_time = now;
             self.cur_reward_cycle = start_rc;
@@ -473,7 +487,11 @@ impl NakamotoTenureInv {
             StacksMessageType::Nack(nack_data) => {
                 info!("{:?}: remote peer NACKed our GetNakamotoInv", network.get_local_peer();
                       "error_code" => nack_data.error_code);
-                self.set_online(false);
+
+                if nack_data.error_code != NackErrorCodes::NoSuchBurnchainBlock {
+                    // any other error besides this one is a problem
+                    self.set_online(false);
+                }
                 return Ok(false);
             }
             _ => {
@@ -557,7 +575,7 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
         let reorg = PeerNetwork::is_reorg(self.last_sort_tip.as_ref(), tip, sortdb);
         if reorg {
             // drop the last two reward cycles
-            test_debug!("Detected reorg! Refreshing inventory consensus hashes");
+            debug!("Detected reorg! Refreshing inventory consensus hashes");
             let highest_rc = self
                 .reward_cycle_consensus_hashes
                 .last_key_value()
@@ -585,10 +603,9 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
             )
             .expect("FATAL: snapshot occurred before system start");
 
-        test_debug!(
+        debug!(
             "Load all reward cycle consensus hashes from {} to {}",
-            highest_rc,
-            tip_rc
+            highest_rc, tip_rc
         );
         for rc in highest_rc..=tip_rc {
             if self.reward_cycle_consensus_hashes.contains_key(&rc) {
@@ -599,7 +616,7 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
                 warn!("Failed to load consensus hash for reward cycle {}", rc);
                 return Err(DBError::NotFoundError.into());
             };
-            test_debug!("Inv reward cycle consensus hash for {} is {}", rc, &ch);
+            debug!("Inv reward cycle consensus hash for {} is {}", rc, &ch);
             self.reward_cycle_consensus_hashes.insert(rc, ch);
         }
         Ok(tip_rc)
@@ -628,6 +645,7 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
         // make sure we know all consensus hashes for all reward cycles.
         let current_reward_cycle =
             self.update_reward_cycle_consensus_hashes(&network.burnchain_tip, sortdb)?;
+
         let nakamoto_start_height = network
             .get_epoch_by_epoch_id(StacksEpochId::Epoch30)
             .start_height;
@@ -639,6 +657,12 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
         // we're updating inventories, so preserve the state we have
         let mut new_inventories = HashMap::new();
         let event_ids: Vec<usize> = network.iter_peer_event_ids().map(|e_id| *e_id).collect();
+
+        debug!(
+            "Send GetNakamotoInv to up to {} peers (ibd={})",
+            event_ids.len(),
+            ibd
+        );
         for event_id in event_ids.into_iter() {
             let Some(convo) = network.get_p2p_convo(event_id) else {
                 continue;
@@ -677,12 +701,15 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
                 )
             });
 
-            let proceed = inv.getnakamotoinv_begin(network, current_reward_cycle);
+            // try to get all of the reward cycles we know about, plus the next one. We try to get
+            // the next one as well in case we're at a reward cycle boundary, but we're not at the
+            // chain tip -- the block downloader still needs that next inventory to proceed.
+            let proceed = inv.getnakamotoinv_begin(network, current_reward_cycle.saturating_add(1));
             let inv_rc = inv.reward_cycle();
             new_inventories.insert(naddr.clone(), inv);
 
             if self.comms.has_inflight(&naddr) {
-                test_debug!(
+                debug!(
                     "{:?}: still waiting for reply from {}",
                     network.get_local_peer(),
                     &naddr
@@ -732,7 +759,7 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
         let num_msgs = replies.len();
 
         for (naddr, reply) in replies.into_iter() {
-            test_debug!(
+            debug!(
                 "{:?}: got reply from {}: {:?}",
                 network.get_local_peer(),
                 &naddr,
@@ -833,7 +860,7 @@ impl PeerNetwork {
     /// Return whether or not we learned something
     pub fn do_network_inv_sync_nakamoto(&mut self, sortdb: &SortitionDB, ibd: bool) -> bool {
         if cfg!(test) && self.connection_opts.disable_inv_sync {
-            test_debug!("{:?}: inv sync is disabled", &self.local_peer);
+            debug!("{:?}: inv sync is disabled", &self.local_peer);
             return false;
         }
 

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -64,6 +64,7 @@ use crate::burnchains::affirmation::AffirmationMap;
 use crate::burnchains::{Error as burnchain_error, Txid};
 use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::burn::{ConsensusHash, Opcodes};
+use crate::chainstate::coordinator::comm::CoordinatorChannels;
 use crate::chainstate::coordinator::Error as coordinator_error;
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use crate::chainstate::stacks::boot::{
@@ -631,6 +632,8 @@ pub struct RPCHandlerArgs<'a> {
     pub fee_estimator: Option<&'a dyn FeeEstimator>,
     /// tx runtime cost metric
     pub cost_metric: Option<&'a dyn CostMetric>,
+    /// coordinator channels
+    pub coord_comms: Option<&'a CoordinatorChannels>,
 }
 
 impl<'a> RPCHandlerArgs<'a> {
@@ -1044,6 +1047,7 @@ pub mod NackErrorCodes {
     pub const NoSuchDB: u32 = 6;
     pub const StaleVersion: u32 = 7;
     pub const StaleView: u32 = 8;
+    pub const FutureVersion: u32 = 9;
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/stackslib/src/net/neighbors/comms.rs
+++ b/stackslib/src/net/neighbors/comms.rs
@@ -466,12 +466,19 @@ impl PeerNetworkComms {
                 Ok(None) => {
                     if let Some(rh) = req_opt {
                         // keep trying
+                        debug!("{:?}: keep polling {}", network.get_local_peer(), naddr);
                         inflight.insert(naddr, rh);
                     }
                     continue;
                 }
                 Err(_e) => {
                     // peer was already marked as dead in the given network set
+                    debug!(
+                        "{:?}: peer {} is dead: {:?}",
+                        network.get_local_peer(),
+                        naddr,
+                        &_e
+                    );
                     continue;
                 }
             };

--- a/stackslib/src/net/neighbors/rpc.rs
+++ b/stackslib/src/net/neighbors/rpc.rs
@@ -109,16 +109,22 @@ impl NeighborRPC {
                 Ok(Some(response)) => response,
                 Ok(None) => {
                     // keep trying
+                    debug!("Still waiting for next reply from {}", &naddr);
                     inflight.insert(naddr, (event_id, request_opt));
                     continue;
                 }
                 Err(NetError::WaitingForDNS) => {
                     // keep trying
+                    debug!(
+                        "Could not yet poll next reply from {}: waiting for DNS",
+                        &naddr
+                    );
                     inflight.insert(naddr, (event_id, request_opt));
                     continue;
                 }
                 Err(_e) => {
                     // declare this neighbor as dead by default
+                    debug!("Failed to poll next reply from {}: {:?}", &naddr, &_e);
                     dead.push(naddr);
                     continue;
                 }
@@ -201,6 +207,10 @@ impl NeighborRPC {
                 })
             })?;
 
+        debug!(
+            "Send request to {} on event {}: {:?}",
+            &naddr, event_id, &request
+        );
         self.state.insert(naddr, (event_id, Some(request)));
         Ok(())
     }

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -659,11 +659,9 @@ impl PeerNetwork {
         let (p2p_handle, bound_p2p_addr) = net.bind(my_addr)?;
         let (http_handle, bound_http_addr) = net.bind(http_addr)?;
 
-        test_debug!(
+        debug!(
             "{:?}: bound on p2p {:?}, http {:?}",
-            &self.local_peer,
-            bound_p2p_addr,
-            bound_http_addr
+            &self.local_peer, bound_p2p_addr, bound_http_addr
         );
 
         self.network = Some(net);
@@ -913,6 +911,12 @@ impl PeerNetwork {
                     return Err(e);
                 }
                 Ok(sz) => {
+                    if sz > 0 {
+                        debug!(
+                            "Sent {} bytes on p2p socket {:?} for conversation {:?}",
+                            sz, client_sock, convo
+                        );
+                    }
                     total_sent += sz;
                     if sz == 0 {
                         break;
@@ -1202,7 +1206,7 @@ impl PeerNetwork {
 
         let next_event_id = match self.network {
             None => {
-                test_debug!("{:?}: network not connected", &self.local_peer);
+                debug!("{:?}: network not connected", &self.local_peer);
                 return Err(net_error::NotConnected);
             }
             Some(ref mut network) => {
@@ -1510,7 +1514,7 @@ impl PeerNetwork {
                         (convo.to_neighbor_key(), Some(neighbor))
                     }
                     None => {
-                        test_debug!(
+                        debug!(
                             "No such neighbor in peer DB, but will ban nevertheless: {:?}",
                             convo.to_neighbor_key()
                         );
@@ -1674,11 +1678,9 @@ impl PeerNetwork {
 
         // already connected?
         if let Some(event_id) = self.get_event_id(&neighbor_key) {
-            test_debug!(
+            debug!(
                 "{:?}: already connected to {:?} on event {}",
-                &self.local_peer,
-                &neighbor_key,
-                event_id
+                &self.local_peer, &neighbor_key, event_id
             );
             return Err(net_error::AlreadyConnected(event_id, neighbor_key.clone()));
         }
@@ -1956,7 +1958,7 @@ impl PeerNetwork {
         match self.events.get(&peer_key) {
             None => {
                 // not connected
-                test_debug!("Could not sign for peer {:?}: not connected", peer_key);
+                debug!("Could not sign for peer {:?}: not connected", peer_key);
                 Err(net_error::PeerNotConnected)
             }
             Some(event_id) => self.sign_for_p2p(*event_id, message_payload),
@@ -1976,7 +1978,7 @@ impl PeerNetwork {
                 message_payload,
             );
         }
-        test_debug!("Could not sign for peer {}: not connected", event_id);
+        debug!("Could not sign for peer {}: not connected", event_id);
         Err(net_error::PeerNotConnected)
     }
 
@@ -1997,7 +1999,7 @@ impl PeerNetwork {
                 message_payload,
             );
         }
-        test_debug!("Could not sign for peer {}: not connected", event_id);
+        debug!("Could not sign for peer {}: not connected", event_id);
         Err(net_error::PeerNotConnected)
     }
 
@@ -2071,7 +2073,7 @@ impl PeerNetwork {
             match (self.peers.remove(&event_id), self.sockets.remove(&event_id)) {
                 (Some(convo), Some(sock)) => (convo, sock),
                 (Some(convo), None) => {
-                    test_debug!("{:?}: Rogue socket event {}", &self.local_peer, event_id);
+                    debug!("{:?}: Rogue socket event {}", &self.local_peer, event_id);
                     self.peers.insert(event_id, convo);
                     return Err(net_error::PeerNotConnected);
                 }
@@ -2084,7 +2086,7 @@ impl PeerNetwork {
                     return Err(net_error::PeerNotConnected);
                 }
                 (None, None) => {
-                    test_debug!("{:?}: Rogue socket event {}", &self.local_peer, event_id);
+                    debug!("{:?}: Rogue socket event {}", &self.local_peer, event_id);
                     return Err(net_error::PeerNotConnected);
                 }
             };
@@ -2213,7 +2215,7 @@ impl PeerNetwork {
             ) {
                 Ok((convo_unhandled, alive)) => (convo_unhandled, alive),
                 Err(_e) => {
-                    test_debug!(
+                    debug!(
                         "{:?}: Connection to {:?} failed: {:?}",
                         &self.local_peer,
                         self.get_p2p_convo(*event_id),
@@ -2225,7 +2227,7 @@ impl PeerNetwork {
             };
 
             if !alive {
-                test_debug!(
+                debug!(
                     "{:?}: Connection to {:?} is no longer alive",
                     &self.local_peer,
                     self.get_p2p_convo(*event_id),
@@ -2412,11 +2414,9 @@ impl PeerNetwork {
                 }
             };
             if neighbor.allowed < 0 || (neighbor.allowed as u64) > now {
-                test_debug!(
+                debug!(
                     "{:?}: event {} is allowed: {:?}",
-                    &self.local_peer,
-                    event_id,
-                    &nk
+                    &self.local_peer, event_id, &nk
                 );
                 safe.insert(*event_id);
             }
@@ -2503,17 +2503,19 @@ impl PeerNetwork {
         let mut relay_handles = std::mem::replace(&mut self.relay_handles, HashMap::new());
         for (event_id, handle_list) in relay_handles.iter_mut() {
             if handle_list.len() == 0 {
+                debug!("No handles for event {}", event_id);
                 drained.push(*event_id);
                 continue;
             }
 
-            test_debug!(
+            debug!(
                 "Flush {} relay handles to event {}",
                 handle_list.len(),
                 event_id
             );
 
             while handle_list.len() > 0 {
+                debug!("Flush {} relay handles", handle_list.len());
                 let res = self.with_p2p_convo(*event_id, |_network, convo, client_sock| {
                     if let Some(handle) = handle_list.front_mut() {
                         let (num_sent, flushed) =
@@ -2525,12 +2527,9 @@ impl PeerNetwork {
                                 }
                             };
 
-                        test_debug!(
+                        debug!(
                             "Flushed relay handle to {:?} ({:?}): sent={}, flushed={}",
-                            client_sock,
-                            convo,
-                            num_sent,
-                            flushed
+                            client_sock, convo, num_sent, flushed
                         );
                         return Ok((num_sent, flushed));
                     }
@@ -2541,6 +2540,7 @@ impl PeerNetwork {
                     Ok(Ok(x)) => x,
                     Ok(Err(_)) | Err(_) => {
                         // connection broken; next list
+                        debug!("Relay handle broken to event {}", event_id);
                         broken.push(*event_id);
                         break;
                     }
@@ -2548,7 +2548,7 @@ impl PeerNetwork {
 
                 if !flushed && num_sent == 0 {
                     // blocked on this peer's socket
-                    test_debug!("Relay handle to event {} is blocked", event_id);
+                    debug!("Relay handle to event {} is blocked", event_id);
                     break;
                 }
 
@@ -2582,7 +2582,7 @@ impl PeerNetwork {
     /// Return true if we finish, and true if we're throttled
     fn do_network_neighbor_walk(&mut self, ibd: bool) -> bool {
         if cfg!(test) && self.connection_opts.disable_neighbor_walk {
-            test_debug!("neighbor walk is disabled");
+            debug!("neighbor walk is disabled");
             return true;
         }
 
@@ -2780,7 +2780,7 @@ impl PeerNetwork {
     fn need_public_ip(&mut self) -> bool {
         if !self.public_ip_learned {
             // IP was given, not learned.  nothing to do
-            test_debug!("{:?}: IP address was given to us", &self.local_peer);
+            debug!("{:?}: IP address was given to us", &self.local_peer);
             return false;
         }
         if self.local_peer.public_ip_address.is_some()
@@ -2788,7 +2788,7 @@ impl PeerNetwork {
                 >= get_epoch_time_secs()
         {
             // still fresh
-            test_debug!("{:?}: learned IP address is still fresh", &self.local_peer);
+            debug!("{:?}: learned IP address is still fresh", &self.local_peer);
             return false;
         }
         let throttle_timeout = if self.local_peer.public_ip_address.is_none() {
@@ -2851,7 +2851,7 @@ impl PeerNetwork {
         match self.do_learn_public_ip() {
             Ok(b) => {
                 if !b {
-                    test_debug!("{:?}: try do_learn_public_ip again", &self.local_peer);
+                    debug!("{:?}: try do_learn_public_ip again", &self.local_peer);
                     return false;
                 }
             }
@@ -2938,7 +2938,7 @@ impl PeerNetwork {
 
             for (_, block, _) in network_result.blocks.iter() {
                 if block_set.contains(&block.block_hash()) {
-                    test_debug!("Duplicate block {}", block.block_hash());
+                    debug!("Duplicate block {}", block.block_hash());
                 }
                 block_set.insert(block.block_hash());
             }
@@ -2946,7 +2946,7 @@ impl PeerNetwork {
             for (_, mblocks, _) in network_result.confirmed_microblocks.iter() {
                 for mblock in mblocks.iter() {
                     if microblock_set.contains(&mblock.block_hash()) {
-                        test_debug!("Duplicate microblock {}", mblock.block_hash());
+                        debug!("Duplicate microblock {}", mblock.block_hash());
                     }
                     microblock_set.insert(mblock.block_hash());
                 }
@@ -3760,7 +3760,7 @@ impl PeerNetwork {
                         }
                         None => {
                             // skip this step -- no DNS client available
-                            test_debug!(
+                            debug!(
                                 "{:?}: no DNS client provided; skipping block download",
                                 &self.local_peer
                             );
@@ -3866,7 +3866,7 @@ impl PeerNetwork {
             }
             None => {
                 // skip this step -- no DNS client available
-                test_debug!(
+                debug!(
                     "{:?}: no DNS client provided; skipping block download",
                     &self.local_peer
                 );
@@ -3915,7 +3915,11 @@ impl PeerNetwork {
                 convo.to_neighbor_key(),
             ),
             None => {
-                test_debug!("No such neighbor event={}", event_id);
+                debug!(
+                    "{:?}: No such neighbor event={}",
+                    self.get_local_peer(),
+                    event_id
+                );
                 return None;
             }
         };
@@ -3924,10 +3928,9 @@ impl PeerNetwork {
             let reciprocal_event_id = match self.find_reciprocal_event(event_id) {
                 Some(re) => re,
                 None => {
-                    test_debug!(
+                    debug!(
                         "{:?}: no reciprocal conversation for {:?}",
-                        &self.local_peer,
-                        &neighbor_key
+                        &self.local_peer, &neighbor_key
                     );
                     return None;
                 }
@@ -3941,32 +3944,26 @@ impl PeerNetwork {
                         convo.to_neighbor_key(),
                     ),
                     None => {
-                        test_debug!(
+                        debug!(
                             "{:?}: No reciprocal conversation for {} (event={})",
-                            &self.local_peer,
-                            &neighbor_key,
-                            event_id
+                            &self.local_peer, &neighbor_key, event_id
                         );
                         return None;
                     }
                 };
 
             if !is_authenticated && !reciprocal_is_authenticated {
-                test_debug!(
+                debug!(
                     "{:?}: {:?} and {:?} are not authenticated",
-                    &self.local_peer,
-                    &neighbor_key,
-                    &reciprocal_neighbor_key
+                    &self.local_peer, &neighbor_key, &reciprocal_neighbor_key
                 );
                 return None;
             }
 
             if !is_outbound && !reciprocal_is_outbound {
-                test_debug!(
+                debug!(
                     "{:?}: {:?} and {:?} are not outbound",
-                    &self.local_peer,
-                    &neighbor_key,
-                    &reciprocal_neighbor_key
+                    &self.local_peer, &neighbor_key, &reciprocal_neighbor_key
                 );
                 return None;
             }
@@ -3994,7 +3991,7 @@ impl PeerNetwork {
     /// for.  Add them to our network pingbacks
     fn schedule_network_pingbacks(&mut self, event_ids: Vec<usize>) {
         if cfg!(test) && self.connection_opts.disable_pingbacks {
-            test_debug!("{:?}: pingbacks are disabled for testing", &self.local_peer);
+            debug!("{:?}: pingbacks are disabled for testing", &self.local_peer);
             return;
         }
 
@@ -4076,7 +4073,7 @@ impl PeerNetwork {
             }
         }
 
-        test_debug!(
+        debug!(
             "{:?}: have {} pingbacks scheduled",
             &self.local_peer,
             self.walk_pingbacks.len()
@@ -4247,7 +4244,7 @@ impl PeerNetwork {
                 .as_stacks_nakamoto()
                 .is_some(),
         };
-        test_debug!(
+        debug!(
             "{:?}: Parent Stacks tip off of {} is {:?}",
             self.get_local_peer(),
             &stacks_tip_block_id,
@@ -4261,7 +4258,7 @@ impl PeerNetwork {
         if self.current_reward_sets.len() > 3 {
             self.current_reward_sets.retain(|old_rc, _| {
                 if (*old_rc).saturating_add(2) < rc {
-                    test_debug!("Drop reward cycle info for cycle {}", old_rc);
+                    debug!("Drop reward cycle info for cycle {}", old_rc);
                     return false;
                 }
                 true
@@ -4343,10 +4340,9 @@ impl PeerNetwork {
                 anchor_block_hash: anchor_block_header.anchored_header.block_hash(),
             };
 
-            test_debug!(
+            debug!(
                 "Store cached reward set for reward cycle {} anchor block {}",
-                rc,
-                &rc_info.anchor_block_hash
+                rc, &rc_info.anchor_block_hash
             );
             self.current_reward_sets.insert(rc, rc_info);
         }
@@ -4469,6 +4465,13 @@ impl PeerNetwork {
             };
 
             // update cached burnchain view for /v2/info
+            debug!(
+                "{:?}: chain view for burn block {} has stacks tip consensus {}",
+                &self.local_peer,
+                new_chain_view.burn_block_height,
+                &new_chain_view.rc_consensus_hash
+            );
+
             self.chain_view = new_chain_view;
             self.chain_view_stable_consensus_hash = new_chain_view_stable_consensus_hash;
         }
@@ -4538,7 +4541,7 @@ impl PeerNetwork {
                 .get_last_selected_anchor_block_txid()?
                 .unwrap_or(Txid([0x00; 32]));
 
-            test_debug!(
+            debug!(
                 "{:?}: chain view is {:?}",
                 &self.get_local_peer(),
                 &self.chain_view
@@ -4588,12 +4591,12 @@ impl PeerNetwork {
             };
             self.parent_stacks_tip = parent_stacks_tip;
 
-            test_debug!(
+            debug!(
                 "{:?}: canonical Stacks tip is now {:?}",
                 self.get_local_peer(),
                 &self.stacks_tip
             );
-            test_debug!(
+            debug!(
                 "{:?}: parent canonical Stacks tip is now {:?}",
                 self.get_local_peer(),
                 &self.parent_stacks_tip

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -805,9 +805,10 @@ impl Relayer {
         obtained_method: NakamotoBlockObtainMethod,
     ) -> Result<bool, chainstate_error> {
         debug!(
-            "Handle incoming Nakamoto block {}/{}",
+            "Handle incoming Nakamoto block {}/{} obtained via {}",
             &block.header.consensus_hash,
-            &block.header.block_hash()
+            &block.header.block_hash(),
+            &obtained_method,
         );
 
         // do we have this block?  don't lock the DB needlessly if so.
@@ -935,14 +936,14 @@ impl Relayer {
         staging_db_tx.commit()?;
 
         if accepted {
-            debug!("{}", &accept_msg);
+            info!("{}", &accept_msg);
             if let Some(coord_comms) = coord_comms {
                 if !coord_comms.announce_new_stacks_block() {
                     return Err(chainstate_error::NetError(net_error::CoordinatorClosed));
                 }
             }
         } else {
-            debug!("{}", &reject_msg);
+            info!("{}", &reject_msg);
         }
 
         Ok(accepted)

--- a/stackslib/src/net/stackerdb/db.rs
+++ b/stackslib/src/net/stackerdb/db.rs
@@ -324,6 +324,8 @@ impl<'a> StackerDBTx<'a> {
                     }
                 }
 
+                debug!("Reset slot {} of {}", slot_id, smart_contract);
+
                 // new slot, or existing slot with a different signer
                 let qry = "INSERT OR REPLACE INTO chunks (stackerdb_id,signer,slot_id,version,write_time,data,data_hash,signature) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)";
                 let mut stmt = self.sql_tx.prepare(&qry)?;

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -71,6 +71,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             total_pushed: 0,
             last_run_ts: 0,
             need_resync: false,
+            stale_inv: false,
             stale_neighbors: HashSet::new(),
             num_connections: 0,
             num_attempted_connections: 0,
@@ -212,6 +213,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
         self.write_freq = config.write_freq;
 
         self.need_resync = false;
+        self.stale_inv = false;
         self.last_run_ts = get_epoch_time_secs();
 
         self.state = StackerDBSyncState::ConnectBegin;
@@ -256,7 +258,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             .get_slot_write_timestamps(&self.smart_contract_id)?;
 
         if local_slot_versions.len() != local_write_timestamps.len() {
-            let msg = format!("Local slot versions ({}) out of sync with DB slot versions ({}); abandoning sync and trying again", local_slot_versions.len(), local_write_timestamps.len());
+            let msg = format!("Local slot versions ({}) out of sync with DB slot versions ({}) for {}; abandoning sync and trying again", local_slot_versions.len(), local_write_timestamps.len(), &self.smart_contract_id);
             warn!("{}", &msg);
             return Err(net_error::Transient(msg));
         }
@@ -270,12 +272,13 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             let write_ts = local_write_timestamps[i];
             if write_ts + self.write_freq > now {
                 debug!(
-                    "{:?}: Chunk {} was written too frequently ({} + {} >= {}), so will not fetch chunk",
+                    "{:?}: Chunk {} was written too frequently ({} + {} >= {}) in {}, so will not fetch chunk",
                     network.get_local_peer(),
                     i,
                     write_ts,
                     self.write_freq,
-                    now
+                    now,
+                    &self.smart_contract_id,
                 );
                 continue;
             }
@@ -343,10 +346,11 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
         schedule.reverse();
 
         debug!(
-            "{:?}: Will request up to {} chunks for {}",
+            "{:?}: Will request up to {} chunks for {}. Schedule: {:?}",
             network.get_local_peer(),
             &schedule.len(),
             &self.smart_contract_id,
+            &schedule
         );
         Ok(schedule)
     }
@@ -520,12 +524,13 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                 if *old_version < new_inv.slot_versions[old_slot_id] {
                     // remote peer indicated that it has a newer version of this chunk.
                     debug!(
-                        "{:?}: peer {:?} has a newer version of slot {} ({} < {})",
+                        "{:?}: peer {:?} has a newer version of slot {} ({} < {}) in {}",
                         _network.get_local_peer(),
                         &naddr,
                         old_slot_id,
                         old_version,
-                        new_inv.slot_versions[old_slot_id]
+                        new_inv.slot_versions[old_slot_id],
+                        &self.smart_contract_id,
                     );
                     resync = true;
                     break;
@@ -634,9 +639,10 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             self.replicas = replicas;
         }
         debug!(
-            "{:?}: connect_begin: establish StackerDB sessions to {} neighbors",
+            "{:?}: connect_begin: establish StackerDB sessions to {} neighbors (out of {} p2p peers)",
             network.get_local_peer(),
-            self.replicas.len()
+            self.replicas.len(),
+            network.get_num_p2p_convos()
         );
         if self.replicas.len() == 0 {
             // nothing to do
@@ -833,9 +839,10 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                 }
                 StacksMessageType::Nack(data) => {
                     debug!(
-                        "{:?}: remote peer {:?} NACK'ed our StackerDBGetChunksInv us with code {}",
+                        "{:?}: remote peer {:?} NACK'ed our StackerDBGetChunksInv us (on {}) with code {}",
                         &network.get_local_peer(),
                         &naddr,
+                        &self.smart_contract_id,
                         data.error_code
                     );
                     self.connected_replicas.remove(&naddr);
@@ -851,9 +858,10 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                 }
             };
             debug!(
-                "{:?}: getchunksinv_try_finish: Received StackerDBChunkInv from {:?}",
+                "{:?}: getchunksinv_try_finish: Received StackerDBChunkInv from {:?}: {:?}",
                 network.get_local_peer(),
-                &naddr
+                &naddr,
+                &chunk_inv_opt
             );
 
             if let Some(chunk_inv) = chunk_inv_opt {
@@ -969,14 +977,17 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                 StacksMessageType::StackerDBChunk(data) => data,
                 StacksMessageType::Nack(data) => {
                     debug!(
-                        "{:?}: remote peer {:?} NACK'ed our StackerDBGetChunk with code {}",
+                        "{:?}: remote peer {:?} NACK'ed our StackerDBGetChunk (on {}) with code {}",
                         network.get_local_peer(),
                         &naddr,
+                        &self.smart_contract_id,
                         data.error_code
                     );
-                    self.connected_replicas.remove(&naddr);
                     if data.error_code == NackErrorCodes::StaleView {
                         self.stale_neighbors.insert(naddr);
+                    } else if data.error_code == NackErrorCodes::StaleVersion {
+                        // try again immediately, without throttling
+                        self.stale_inv = true;
                     }
                     continue;
                 }
@@ -1079,7 +1090,6 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                     &selected_neighbor,
                     &e
                 );
-                self.connected_replicas.remove(&selected_neighbor);
                 continue;
             }
 
@@ -1119,7 +1129,6 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                         &naddr,
                         data.error_code
                     );
-                    self.connected_replicas.remove(&naddr);
                     if data.error_code == NackErrorCodes::StaleView {
                         self.stale_neighbors.insert(naddr);
                     }
@@ -1219,8 +1228,11 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                     let done = self.connect_begin(network)?;
                     if done {
                         self.state = StackerDBSyncState::ConnectFinish;
-                        blocked = false;
+                    } else {
+                        // no replicas; try again
+                        self.state = StackerDBSyncState::Finished;
                     }
+                    blocked = false;
                 }
                 StackerDBSyncState::ConnectFinish => {
                     let done = self.connect_try_finish(network)?;
@@ -1268,6 +1280,11 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                         {
                             // someone pushed newer chunk data to us, and getting chunks is
                             // enabled, so immediately go request them
+                            debug!(
+                                "{:?}: immediately retry StackerDB GetChunks on {} due to PushChunk NACK",
+                                network.get_local_peer(),
+                                &self.smart_contract_id
+                            );
                             self.recalculate_chunk_request_schedule(network)?;
                             self.state = StackerDBSyncState::GetChunks;
                         } else {
@@ -1279,8 +1296,19 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                     }
                 }
                 StackerDBSyncState::Finished => {
+                    let stale_inv = self.stale_inv;
+
                     let result = self.reset(Some(network), config);
                     self.state = StackerDBSyncState::ConnectBegin;
+
+                    if stale_inv {
+                        debug!(
+                            "{:?}: immediately retry StackerDB sync on {} due to stale inventory",
+                            network.get_local_peer(),
+                            &self.smart_contract_id
+                        );
+                        self.wakeup();
+                    }
                     return Ok(Some(result));
                 }
             };


### PR DESCRIPTION
This pulls fixes from #5040 specific to the networking stack (and StackerDB) into `develop`, so we can put them into a release candidate without doing a genesis sync.