### PR TITLE
Fix/net fixes stackerdb

### DIFF
--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -167,8 +167,9 @@ impl<P: ProtocolFamily> NetworkReplyHandle<P> {
     /// is destroyed in the process).
     pub fn try_recv(mut self) -> Result<P::Message, Result<NetworkReplyHandle<P>, net_error>> {
         if self.deadline > 0 && self.deadline < get_epoch_time_secs() {
-            test_debug!(
-                "Reply deadline {} exceeded (now = {})",
+            debug!(
+                "Reply deadline for event {} at {} exceeded (now = {})",
+                self.socket_event_id,
                 self.deadline,
                 get_epoch_time_secs()
             );
@@ -234,10 +235,9 @@ impl<P: ProtocolFamily> NetworkReplyHandle<P> {
                     None
                 } else {
                     // still have data to send, or we will send more.
-                    test_debug!(
+                    debug!(
                         "Still have data to send, drop_on_success = {}, ret = {}",
-                        drop_on_success,
-                        ret
+                        drop_on_success, ret
                     );
                     Some(fd)
                 }
@@ -957,7 +957,7 @@ impl<P: ProtocolFamily> ConnectionInbox<P> {
                         || e.kind() == io::ErrorKind::ConnectionReset
                     {
                         // write endpoint is dead
-                        test_debug!("reader was reset: {:?}", &e);
+                        debug!("reader was reset: {:?}", &e);
                         socket_closed = true;
                         blocked = true;
                         Ok(0)
@@ -971,7 +971,7 @@ impl<P: ProtocolFamily> ConnectionInbox<P> {
             total_read += num_read;
 
             if num_read > 0 || total_read > 0 {
-                trace!("read {} bytes; {} total", num_read, total_read);
+                debug!("read {} bytes; {} total", num_read, total_read);
             }
 
             if num_read > 0 {

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -65,6 +65,7 @@ use crate::burnchains::affirmation::AffirmationMap;
 use crate::burnchains::{Error as burnchain_error, Txid};
 use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::burn::{ConsensusHash, Opcodes};
+use crate::chainstate::coordinator::comm::CoordinatorChannels;
 use crate::chainstate::coordinator::Error as coordinator_error;
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use crate::chainstate::stacks::boot::{
@@ -626,6 +627,8 @@ pub struct RPCHandlerArgs<'a> {
     pub fee_estimator: Option<&'a dyn FeeEstimator>,
     /// tx runtime cost metric
     pub cost_metric: Option<&'a dyn CostMetric>,
+    /// coordinator channels
+    pub coord_comms: Option<&'a CoordinatorChannels>,
 }
 
 impl<'a> RPCHandlerArgs<'a> {
@@ -1026,6 +1029,7 @@ pub mod NackErrorCodes {
     pub const NoSuchDB: u32 = 6;
     pub const StaleVersion: u32 = 7;
     pub const StaleView: u32 = 8;
+    pub const FutureVersion: u32 = 9;
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/stackslib/src/net/neighbors/comms.rs
+++ b/stackslib/src/net/neighbors/comms.rs
@@ -466,12 +466,19 @@ impl PeerNetworkComms {
                 Ok(None) => {
                     if let Some(rh) = req_opt {
                         // keep trying
+                        debug!("{:?}: keep polling {}", network.get_local_peer(), naddr);
                         inflight.insert(naddr, rh);
                     }
                     continue;
                 }
                 Err(_e) => {
                     // peer was already marked as dead in the given network set
+                    debug!(
+                        "{:?}: peer {} is dead: {:?}",
+                        network.get_local_peer(),
+                        naddr,
+                        &_e
+                    );
                     continue;
                 }
             };

--- a/stackslib/src/net/neighbors/rpc.rs
+++ b/stackslib/src/net/neighbors/rpc.rs
@@ -109,16 +109,22 @@ impl NeighborRPC {
                 Ok(Some(response)) => response,
                 Ok(None) => {
                     // keep trying
+                    debug!("Still waiting for next reply from {}", &naddr);
                     inflight.insert(naddr, (event_id, request_opt));
                     continue;
                 }
                 Err(NetError::WaitingForDNS) => {
                     // keep trying
+                    debug!(
+                        "Could not yet poll next reply from {}: waiting for DNS",
+                        &naddr
+                    );
                     inflight.insert(naddr, (event_id, request_opt));
                     continue;
                 }
                 Err(_e) => {
                     // declare this neighbor as dead by default
+                    debug!("Failed to poll next reply from {}: {:?}", &naddr, &_e);
                     dead.push(naddr);
                     continue;
                 }
@@ -201,6 +207,10 @@ impl NeighborRPC {
                 })
             })?;
 
+        debug!(
+            "Send request to {} on event {}: {:?}",
+            &naddr, event_id, &request
+        );
         self.state.insert(naddr, (event_id, Some(request)));
         Ok(())
     }

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -663,7 +663,7 @@ impl Relayer {
         debug!(
             "Handle incoming Nakamoto block {}/{}",
             &block.header.consensus_hash,
-            &block.header.block_hash()
+            &block.header.block_hash(),
         );
 
         // do we have this block?  don't lock the DB needlessly if so.
@@ -745,14 +745,14 @@ impl Relayer {
         staging_db_tx.commit()?;
 
         if accepted {
-            debug!("{}", &accept_msg);
+            info!("{}", &accept_msg);
             if let Some(coord_comms) = coord_comms {
                 if !coord_comms.announce_new_stacks_block() {
                     return Err(chainstate_error::NetError(net_error::CoordinatorClosed));
                 }
             }
         } else {
-            debug!("{}", &reject_msg);
+            info!("{}", &reject_msg);
         }
 
         Ok(accepted)

--- a/stackslib/src/net/stackerdb/db.rs
+++ b/stackslib/src/net/stackerdb/db.rs
@@ -323,6 +323,8 @@ impl<'a> StackerDBTx<'a> {
                     }
                 }
 
+                debug!("Reset slot {} of {}", slot_id, smart_contract);
+
                 // new slot, or existing slot with a different signer
                 let qry = "INSERT OR REPLACE INTO chunks (stackerdb_id,signer,slot_id,version,write_time,data,data_hash,signature) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)";
                 let mut stmt = self.sql_tx.prepare(&qry)?;

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -388,6 +388,8 @@ pub struct StackerDBSync<NC: NeighborComms> {
     /// whether or not we should immediately re-fetch chunks because we learned about new chunks
     /// from our peers when they replied to our chunk-pushes with new inventory state
     need_resync: bool,
+    /// whether or not the fetched inventory was determined to be stale
+    stale_inv: bool,
     /// Track stale neighbors
     pub(crate) stale_neighbors: HashSet<NeighborAddress>,
     /// How many attempted connections have been made in the last pass (gets reset)
@@ -466,7 +468,9 @@ impl PeerNetwork {
             Err(e) => {
                 debug!(
                     "{:?}: failed to get chunk versions for {}: {:?}",
-                    self.local_peer, contract_id, &e
+                    self.get_local_peer(),
+                    contract_id,
+                    &e
                 );
 
                 // most likely indicates that this DB doesn't exist
@@ -475,6 +479,14 @@ impl PeerNetwork {
         };
 
         let num_outbound_replicas = self.count_outbound_stackerdb_replicas(contract_id) as u32;
+
+        debug!(
+            "{:?}: inventory for {} has {} outbound replicas; versions are {:?}",
+            self.get_local_peer(),
+            contract_id,
+            num_outbound_replicas,
+            &slot_versions
+        );
         StacksMessageType::StackerDBChunkInv(StackerDBChunkInvData {
             slot_versions,
             num_outbound_replicas,


### PR DESCRIPTION
Fixes StackerDB sync in `master`.  Namely, if there's a getchunk/putchunk that fails due to a stale (or future) version NACK, the StackerDB sync state machine should immediately retry sync.  Failure to do this can lead to signers and miners getting permanently out-of-sync, since if the StackerDB sync state machine runs at a slower rate than writes to these StackerDBs, then there will inevitably be failures in getchunk/putchunk that will never be resolved.