### PR TITLE
Update pox_4_tests to run in 2.5 and 3.0

### DIFF
--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -82,6 +82,7 @@ pub enum StacksEpochId {
     Epoch30 = 0x03000,
 }
 
+#[derive(Debug)]
 pub enum MempoolCollectionBehavior {
     ByStacksHeight,
     ByReceiveTime,

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -517,7 +517,7 @@ impl PoxConstants {
         }
     }
 
-    /// What's the first block in the prepare phase
+    /// The first block of the prepare phase during `reward_cycle`. This is the prepare phase _for the next cycle_. 
     pub fn prepare_phase_start(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
         let reward_cycle_start =
             self.reward_cycle_to_block_height(first_block_height, reward_cycle);
@@ -526,16 +526,35 @@ impl PoxConstants {
         prepare_phase_start
     }
 
+    /// Is this the first block to receive rewards in its cycle?
+    /// This is the mod 1 block. Note: in nakamoto, the signer set for cycle N signs
+    ///  the mod 0 block.
     pub fn is_reward_cycle_start(&self, first_block_height: u64, burn_height: u64) -> bool {
         let effective_height = burn_height - first_block_height;
         // first block of the new reward cycle
         (effective_height % u64::from(self.reward_cycle_length)) == 1
     }
 
+    /// Is this the first block to be signed by the signer set in cycle N?
+    /// This is the mod 0 block.
+    pub fn is_naka_signing_cycle_start(&self, first_block_height: u64, burn_height: u64) -> bool {
+        let effective_height = burn_height - first_block_height;
+        // first block of the new reward cycle
+        (effective_height % u64::from(self.reward_cycle_length)) == 0
+    }
+
+    /// return the first burn block which receives reward in `reward_cycle`.
+    /// this is the modulo 1 block
     pub fn reward_cycle_to_block_height(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
         // NOTE: the `+ 1` is because the height of the first block of a reward cycle is mod 1, not
         // mod 0.
         first_block_height + reward_cycle * u64::from(self.reward_cycle_length) + 1
+    }
+
+    /// the first burn block that must be *signed* by the signer set of `reward_cycle`.
+    /// this is the modulo 0 block
+    pub fn nakamoto_first_block_of_cycle(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
+        first_block_height + reward_cycle * u64::from(self.reward_cycle_length)
     }
 
     pub fn reward_cycle_index(&self, first_block_height: u64, burn_height: u64) -> Option<u64> {
@@ -606,6 +625,35 @@ impl PoxConstants {
             //  `mod 0` may not have any rewards, but it does not behave like "prepare phase" blocks:
             //  is it already a member of reward cycle "N" where N = block_height / reward_cycle_len
             reward_index == 0 || reward_index > u64::from(reward_cycle_length - prepare_length)
+        }
+    }
+
+    /// The prepare phase is the last prepare_phase_length blocks of the cycle
+    /// This cannot include the 0 block for nakamoto
+    pub fn is_in_naka_prepare_phase(&self, first_block_height: u64, block_height: u64) -> bool {
+        Self::static_is_in_naka_prepare_phase(
+            first_block_height,
+            u64::from(self.reward_cycle_length),
+            u64::from(self.prepare_length),
+            block_height,
+        )
+    }
+
+    /// The prepare phase is the last prepare_phase_length blocks of the cycle
+    /// This cannot include the 0 block for nakamoto
+    pub fn static_is_in_naka_prepare_phase(
+        first_block_height: u64,
+        reward_cycle_length: u64,
+        prepare_length: u64,
+        block_height: u64,
+    ) -> bool {
+        if block_height <= first_block_height {
+            // not a reward cycle start if we're the first block after genesis.
+            false
+        } else {
+            let effective_height = block_height - first_block_height;
+            let reward_index = effective_height % reward_cycle_length;
+            reward_index > u64::from(reward_cycle_length - prepare_length)
         }
     }
 

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -517,7 +517,7 @@ impl PoxConstants {
         }
     }
 
-    /// The first block of the prepare phase during `reward_cycle`. This is the prepare phase _for the next cycle_. 
+    /// The first block of the prepare phase during `reward_cycle`. This is the prepare phase _for the next cycle_.
     pub fn prepare_phase_start(&self, first_block_height: u64, reward_cycle: u64) -> u64 {
         let reward_cycle_start =
             self.reward_cycle_to_block_height(first_block_height, reward_cycle);

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3908,11 +3908,11 @@ impl<'a> SortitionDBConn<'a> {
         tip: &SortitionId,
         reward_cycle_id: u64,
     ) -> Result<SortitionId, db_error> {
-        let reward_cycle_of_prepare_phase = reward_cycle_id.checked_sub(1).ok_or_else(|| db_error::Other("No prepare phase exists for cycle 0".into()))?;
-        let prepare_phase_start = pox_constants.prepare_phase_start(
-            first_block_height,
-            reward_cycle_of_prepare_phase,
-        );
+        let reward_cycle_of_prepare_phase = reward_cycle_id
+            .checked_sub(1)
+            .ok_or_else(|| db_error::Other("No prepare phase exists for cycle 0".into()))?;
+        let prepare_phase_start =
+            pox_constants.prepare_phase_start(first_block_height, reward_cycle_of_prepare_phase);
 
         let first_sortition =
             get_ancestor_sort_id(self, prepare_phase_start, tip)?.ok_or_else(|| {

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3584,42 +3584,6 @@ impl SortitionDB {
         Ok(())
     }
 
-    /// Get the prepare phase end sortition ID of a reward cycle.  This is the last prepare
-    /// phase sortition for the prepare phase that began this reward cycle (i.e. the returned
-    /// sortition will be in the preceding reward cycle)
-    /// Wrapper around SortitionDBConn::get_prepare_phase_end_sortition_id_for_reward_ccyle()
-    pub fn get_prepare_phase_end_sortition_id_for_reward_cycle(
-        &self,
-        tip: &SortitionId,
-        reward_cycle_id: u64,
-    ) -> Result<SortitionId, db_error> {
-        self.index_conn()
-            .get_prepare_phase_end_sortition_id_for_reward_cycle(
-                &self.pox_constants,
-                self.first_block_height,
-                tip,
-                reward_cycle_id,
-            )
-    }
-
-    /// Get the prepare phase start sortition ID of a reward cycle.  This is the first prepare
-    /// phase sortition for the prepare phase that began this reward cycle (i.e. the returned
-    /// sortition will be in the preceding reward cycle)
-    /// Wrapper around SortitionDBConn::get_prepare_phase_start_sortition_id_for_reward_cycle().
-    pub fn get_prepare_phase_start_sortition_id_for_reward_cycle(
-        &self,
-        tip: &SortitionId,
-        reward_cycle_id: u64,
-    ) -> Result<SortitionId, db_error> {
-        self.index_conn()
-            .get_prepare_phase_start_sortition_id_for_reward_cycle(
-                &self.pox_constants,
-                self.first_block_height,
-                tip,
-                reward_cycle_id,
-            )
-    }
-
     /// Figure out the reward cycle for `tip` and lookup the preprocessed
     /// reward set (if it exists) for the active reward cycle during `tip`.
     /// Returns the reward cycle info on success.
@@ -3934,33 +3898,6 @@ impl<'a> SortitionDBConn<'a> {
         .and_then(|(reward_cycle_info, _anchor_sortition_id)| Ok(reward_cycle_info))
     }
 
-    /// Get the prepare phase end sortition ID of a reward cycle.  This is the last prepare
-    /// phase sortition for the prepare phase that began this reward cycle (i.e. the returned
-    /// sortition will be in the preceding reward cycle)
-    pub fn get_prepare_phase_end_sortition_id_for_reward_cycle(
-        &self,
-        pox_constants: &PoxConstants,
-        first_block_height: u64,
-        tip: &SortitionId,
-        reward_cycle_id: u64,
-    ) -> Result<SortitionId, db_error> {
-        let prepare_phase_end = pox_constants
-            .reward_cycle_to_block_height(first_block_height, reward_cycle_id)
-            .saturating_sub(1);
-
-        let last_sortition =
-            get_ancestor_sort_id(self, prepare_phase_end, tip)?.ok_or_else(|| {
-                error!(
-                    "Could not find prepare phase end ancestor while fetching reward set";
-                    "tip_sortition_id" => %tip,
-                    "reward_cycle_id" => reward_cycle_id,
-                    "prepare_phase_end_height" => prepare_phase_end
-                );
-                db_error::NotFoundError
-            })?;
-        Ok(last_sortition)
-    }
-
     /// Get the prepare phase start sortition ID of a reward cycle.  This is the first prepare
     /// phase sortition for the prepare phase that began this reward cycle (i.e. the returned
     /// sortition will be in the preceding reward cycle)
@@ -3971,9 +3908,11 @@ impl<'a> SortitionDBConn<'a> {
         tip: &SortitionId,
         reward_cycle_id: u64,
     ) -> Result<SortitionId, db_error> {
-        let prepare_phase_start = pox_constants
-            .reward_cycle_to_block_height(first_block_height, reward_cycle_id)
-            .saturating_sub(pox_constants.prepare_length.into());
+        let reward_cycle_of_prepare_phase = reward_cycle_id.checked_sub(1).ok_or_else(|| db_error::Other("No prepare phase exists for cycle 0".into()))?;
+        let prepare_phase_start = pox_constants.prepare_phase_start(
+            first_block_height,
+            reward_cycle_of_prepare_phase,
+        );
 
         let first_sortition =
             get_ancestor_sort_id(self, prepare_phase_start, tip)?.ok_or_else(|| {
@@ -5945,10 +5884,10 @@ impl<'a> SortitionHandleTx<'a> {
 
     /// Get the expected number of PoX payouts per output
     fn get_num_pox_payouts(&self, burn_block_height: u64) -> usize {
-        let op_num_outputs = if Burnchain::static_is_in_prepare_phase(
+        let op_num_outputs = if PoxConstants::static_is_in_prepare_phase(
             self.context.first_block_height,
-            self.context.pox_constants.reward_cycle_length as u64,
-            self.context.pox_constants.prepare_length.into(),
+            u64::from(self.context.pox_constants.reward_cycle_length),
+            u64::from(self.context.pox_constants.prepare_length),
             burn_block_height,
         ) {
             1
@@ -6173,7 +6112,7 @@ impl<'a> SortitionHandleTx<'a> {
                     }
                     // if there are qualifying auto-unlocks, record them
                     if !reward_set.start_cycle_state.is_empty() {
-                        let cycle_number = Burnchain::static_block_height_to_reward_cycle(
+                        let cycle_number = PoxConstants::static_block_height_to_reward_cycle(
                             snapshot.block_height,
                             self.context.first_block_height,
                             self.context.pox_constants.reward_cycle_length.into(),

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -299,7 +299,6 @@ pub trait RewardSetProvider {
         &self,
         chainstate: &mut StacksChainState,
         cycle: u64,
-        burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
     ) -> Result<RewardSet, Error>;
@@ -374,11 +373,10 @@ impl<'a, T: BlockEventDispatcher> RewardSetProvider for OnChainRewardSetProvider
         &self,
         chainstate: &mut StacksChainState,
         reward_cycle: u64,
-        burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
     ) -> Result<RewardSet, Error> {
-        self.read_reward_set_nakamoto(chainstate, reward_cycle, burnchain, sortdb, block_id, false)
+        self.read_reward_set_nakamoto(chainstate, reward_cycle, sortdb, block_id, false)
     }
 }
 

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -297,8 +297,8 @@ pub trait RewardSetProvider {
 
     fn get_reward_set_nakamoto(
         &self,
-        cycle_start_burn_height: u64,
         chainstate: &mut StacksChainState,
+        cycle: u64,
         burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
@@ -372,20 +372,13 @@ impl<'a, T: BlockEventDispatcher> RewardSetProvider for OnChainRewardSetProvider
 
     fn get_reward_set_nakamoto(
         &self,
-        cycle_start_burn_height: u64,
         chainstate: &mut StacksChainState,
+        reward_cycle: u64,
         burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
     ) -> Result<RewardSet, Error> {
-        self.read_reward_set_nakamoto(
-            cycle_start_burn_height,
-            chainstate,
-            burnchain,
-            sortdb,
-            block_id,
-            false,
-        )
+        self.read_reward_set_nakamoto(chainstate, reward_cycle, burnchain, sortdb, block_id, false)
     }
 }
 

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -522,7 +522,6 @@ impl RewardSetProvider for StubbedRewardSetProvider {
         &self,
         chainstate: &mut StacksChainState,
         cycle: u64,
-        burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
     ) -> Result<RewardSet, CoordError> {

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -520,8 +520,8 @@ impl RewardSetProvider for StubbedRewardSetProvider {
 
     fn get_reward_set_nakamoto(
         &self,
-        cycle_start_burn_height: u64,
         chainstate: &mut StacksChainState,
+        cycle: u64,
         burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -90,7 +90,6 @@ impl<'a, T: BlockEventDispatcher> OnChainRewardSetProvider<'a, T> {
         &self,
         chainstate: &mut StacksChainState,
         cycle: u64,
-        burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
         debug_log: bool,
@@ -547,13 +546,8 @@ pub fn load_nakamoto_reward_set<U: RewardSetProvider>(
            "cycle_start_height" => %cycle_start_height,
            "burnchain_height" => %anchor_block_sn.block_height);
 
-    let reward_set = provider.get_reward_set_nakamoto(
-        chain_state,
-        reward_cycle,
-        burnchain,
-        sort_db,
-        &block_id,
-    )?;
+    let reward_set =
+        provider.get_reward_set_nakamoto(chain_state, reward_cycle, sort_db, &block_id)?;
     debug!(
         "Stacks anchor block (ch {}) {} cycle {} is processed",
         &anchor_block_header.consensus_hash, &block_id, reward_cycle;

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -598,7 +598,7 @@ impl<'a> TestPeer<'a> {
         info!(
             "Burnchain block produced: {burn_height}, in_prepare_phase?: {}, first_reward_block?: {}",
             pox_constants.is_in_prepare_phase(first_burn_height, burn_height),
-            pox_constants.is_reward_cycle_start(first_burn_height, burn_height)
+            pox_constants.is_naka_signing_cycle_start(first_burn_height, burn_height)
         );
         let vrf_proof = self.make_nakamoto_vrf_proof(miner_key);
 
@@ -761,6 +761,9 @@ fn pox_treatment() {
             peer.single_block_tenure(&private_key, |_| {}, |_| {}, |_| true);
         blocks.push(block);
 
+        // note: we use `is_reward_cycle_start` here rather than naka_reward_cycle_start
+        //  because in this test, we're interested in getting to the reward blocks,
+        //  not validating the signer set. the reward blocks only begin at modulo 1
         if pox_constants.is_reward_cycle_start(first_burn_height, burn_height + 1) {
             break;
         }
@@ -1571,7 +1574,7 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
         if peer
             .config
             .burnchain
-            .is_reward_cycle_start(tip.block_height)
+            .is_naka_signing_cycle_start(tip.block_height)
         {
             rc_blocks.push(all_blocks.clone());
             rc_burn_ops.push(all_burn_ops.clone());
@@ -2316,7 +2319,7 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
         if peer
             .config
             .burnchain
-            .is_reward_cycle_start(tip.block_height)
+            .is_naka_signing_cycle_start(tip.block_height)
         {
             rc_blocks.push(all_blocks.clone());
             rc_burn_ops.push(all_burn_ops.clone());

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -835,6 +835,12 @@ impl NakamotoBlockHeader {
             public_key_bytes.copy_from_slice(&public_key.to_bytes_compressed()[..]);
 
             let (signer, signer_index) = signers_by_pk.get(&public_key_bytes).ok_or_else(|| {
+                warn!(
+                    "Found an invalid public key. Reward set has {} signers. Chain length {}. Signatures length {}",
+                    signers.len(),
+                    self.chain_length,
+                    self.signer_signature.len(),
+                );
                 ChainstateError::InvalidStacksBlock(format!(
                     "Public key {} not found in the reward set",
                     public_key.to_hex()

--- a/stackslib/src/chainstate/nakamoto/test_signers.rs
+++ b/stackslib/src/chainstate/nakamoto/test_signers.rs
@@ -324,6 +324,12 @@ impl TestSigners {
             .map(|s| s.signing_key.to_vec())
             .collect::<Vec<_>>();
 
+        info!(
+            "TestSigners: Signing Nakamoto block. TestSigners has {} signers. Reward set has {} signers.", 
+            test_signers_by_pk.len(),
+            reward_set_keys.len(),
+        );
+
         let mut signatures = Vec::with_capacity(reward_set_keys.len());
 
         let mut missing_keys = 0;

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -737,7 +737,7 @@ impl TestStacksNode {
             let reward_set = load_nakamoto_reward_set(
                 miner
                     .burnchain
-                    .pox_reward_cycle(sort_tip_sn.block_height)
+                    .block_height_to_reward_cycle(sort_tip_sn.block_height)
                     .expect("FATAL: no reward cycle for sortition"),
                 &sort_tip_sn.sortition_id,
                 &miner.burnchain,

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -490,7 +490,7 @@ impl BurnStateDB for TestSimBurnStateDB {
             let first_block = self.get_burn_start_height();
             let prepare_len = self.get_pox_prepare_length();
             let rc_len = self.get_pox_reward_cycle_length();
-            if Burnchain::static_is_in_prepare_phase(
+            if PoxConstants::static_is_in_prepare_phase(
                 first_block.into(),
                 rc_len.into(),
                 prepare_len.into(),

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1773,6 +1773,7 @@ pub mod test {
         let data = if let Some(d) = value_opt.expect_optional().unwrap() {
             d
         } else {
+            warn!("get_stacker_info: No PoX info for {}", addr);
             return None;
         };
 

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -8435,8 +8435,6 @@ pub fn prepare_pox4_test<'a>(
             .map(|key| TestStacker {
                 signer_private_key: key.clone(),
                 stacker_private_key: key.clone(),
-                // amount: u64::MAX as u128 - 10000,
-                // amount: 2048000 * POX_THRESHOLD_STEPS_USTX * 2,
                 amount: 1024 * POX_THRESHOLD_STEPS_USTX,
                 pox_addr: Some(pox_addr_from(&key)),
                 max_amount: None,
@@ -8466,7 +8464,6 @@ pub fn prepare_pox4_test<'a>(
 
         info!("---- Booting into Nakamoto Peer ----");
         let peer = boot_plan.boot_into_nakamoto_peer(vec![], observer);
-        // let mut blocks = vec![];
         let sort_db = peer.sortdb.as_ref().unwrap();
         let latest_block = sort_db
             .index_handle_at_tip()
@@ -8489,8 +8486,6 @@ pub fn prepare_pox4_test<'a>(
             test_signers,
         )
     } else {
-        // assert_eq!(burnchain.pox_constants.reward_slots(), 6);
-
         // Advance into pox4
         let target_height = burnchain.pox_constants.pox_4_activation_height;
         let mut coinbase_nonce = 0;
@@ -8512,81 +8507,6 @@ pub fn prepare_pox4_test<'a>(
             coinbase_nonce,
             TestSigners::new(vec![]),
         )
-        // let target_epoch = if use_nakamoto {
-        //     StacksEpochId::Epoch30
-        // } else {
-        //     StacksEpochId::Epoch25
-        // };
-        // let height_25 = epochs
-        //     .iter()
-        //     .find(|e| e.epoch_id == StacksEpochId::Epoch25)
-        //     .unwrap()
-        //     .start_height;
-        // // let height_25 = epochs.iter().find(|e| e.epoch_id == StacksEpochId::Epoch25).unwrap().start_height;
-        // let target_height = epochs
-        //     .iter()
-        //     .find(|e| e.epoch_id == target_epoch)
-        //     .unwrap()
-        //     .start_height;
-        // let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
-        // if use_nakamoto {
-        //     // Go to 2.5, stack, then 3.0
-        //     while get_tip(peer.sortdb.as_ref()).block_height < height_25 {
-        //         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
-        //     }
-
-        //     let tip = get_tip(peer.sortdb.as_ref());
-        //     let reward_cycle = peer.get_reward_cycle() as u128;
-
-        //     let min_ustx = with_sortdb(&mut peer, |chainstate, sortdb| {
-        //         chainstate.get_stacking_minimum(sortdb, &latest_block)
-        //     })
-        //     .unwrap();
-        //     info!("Building stacking txs");
-        //     // Make all the test Stackers stack
-        //     let stack_txs: Vec<_> = test_stackers
-        //         .clone()
-        //         .iter()
-        //         .map(|test_stacker| {
-        //             info!(
-        //                 "Making PoX-4 lockup for {}; {}",
-        //                 test_stacker.amount,
-        //                 test_stacker.amount > min_ustx
-        //             );
-        //             let pox_addr = test_stacker.pox_addr.clone().unwrap();
-        //             let max_amount = test_stacker.max_amount.unwrap_or(u128::MAX);
-        //             let signature = make_signer_key_signature(
-        //                 &pox_addr,
-        //                 &test_stacker.signer_private_key,
-        //                 reward_cycle.into(),
-        //                 &crate::util_lib::signed_structured_data::pox4::Pox4SignatureTopic::StackStx,
-        //                 12_u128,
-        //                 max_amount,
-        //                 1,
-        //             );
-        //             make_pox_4_lockup(
-        //                 &test_stacker.stacker_private_key,
-        //                 0,
-        //                 test_stacker.amount,
-        //                 &pox_addr,
-        //                 12,
-        //                 &StacksPublicKey::from_private(&test_stacker.signer_private_key),
-        //                 tip.block_height,
-        //                 Some(signature),
-        //                 max_amount,
-        //                 1,
-        //             )
-        //         })
-        //         .collect();
-        //     latest_block = peer.tenure_with_txs(&stack_txs, &mut coinbase_nonce);
-        // }
-        // while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
-        //     latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
-        //     // if we reach epoch 2.1, perform the check
-        //     // if get_tip(peer.sortdb.as_ref()).block_height > epochs[3].start_height {
-        //     //     assert_latest_was_burn(&mut peer);
-        //     // }
-        // }
     }
 }
 

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -171,7 +171,8 @@ fn make_signer_sanity_panic_1() {
 
 #[test]
 fn signers_get_config() {
-    let (burnchain, mut peer, keys, latest_block, ..) = prepare_pox4_test(function_name!(), None);
+    let (burnchain, mut peer, keys, latest_block, ..) =
+        prepare_pox4_test(function_name!(), None, false);
 
     assert_eq!(
         readonly_call(

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -4952,7 +4952,7 @@ impl StacksChainState {
         chain_tip_burn_header_height: u32,
         parent_sortition_id: &SortitionId,
     ) -> Result<Vec<StacksTransactionEvent>, Error> {
-        let pox_reward_cycle = Burnchain::static_block_height_to_reward_cycle(
+        let pox_reward_cycle = PoxConstants::static_block_height_to_reward_cycle(
             burn_tip_height,
             burn_dbconn.get_burn_start_height().into(),
             burn_dbconn.get_pox_reward_cycle_length().into(),

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -2749,7 +2749,7 @@ pub mod test {
     }
 
     pub fn chainstate_path(test_name: &str) -> String {
-        format!("/tmp/blockstack-test-chainstate-{}", test_name)
+        format!("/tmp/stacks-node-tests/cs-{}", test_name)
     }
 
     #[test]

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -1392,8 +1392,9 @@ fn mempool_do_not_replace_tx() {
 #[case(MempoolCollectionBehavior::ByStacksHeight)]
 #[case(MempoolCollectionBehavior::ByReceiveTime)]
 fn mempool_db_load_store_replace_tx(#[case] behavior: MempoolCollectionBehavior) {
-    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
-    let chainstate_path = chainstate_path(function_name!());
+    let path_name = format!("{}::{:?}", function_name!(), behavior);
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, &path_name);
+    let chainstate_path = chainstate_path(&path_name);
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let mut txs = codec_all_transactions(

--- a/stackslib/src/net/api/getstackers.rs
+++ b/stackslib/src/net/api/getstackers.rs
@@ -92,7 +92,6 @@ impl GetStackersResponse {
         cycle_number: u64,
     ) -> Result<Self, GetStackersErrors> {
         let cycle_start_height = burnchain.reward_cycle_to_block_height(cycle_number);
-
         let pox_contract_name = burnchain
             .pox_constants
             .active_pox_contract(cycle_start_height);
@@ -107,7 +106,7 @@ impl GetStackersResponse {
 
         let provider = OnChainRewardSetProvider::new();
         let stacker_set = provider
-            .read_reward_set_nakamoto(cycle_start_height, chainstate, burnchain, sortdb, tip, true)
+            .read_reward_set_nakamoto(chainstate, cycle_number, burnchain, sortdb, tip, true)
             .map_err(GetStackersErrors::NotAvailableYet)?;
 
         Ok(Self { stacker_set })

--- a/stackslib/src/net/api/getstackers.rs
+++ b/stackslib/src/net/api/getstackers.rs
@@ -106,7 +106,7 @@ impl GetStackersResponse {
 
         let provider = OnChainRewardSetProvider::new();
         let stacker_set = provider
-            .read_reward_set_nakamoto(chainstate, cycle_number, burnchain, sortdb, tip, true)
+            .read_reward_set_nakamoto(chainstate, cycle_number, sortdb, tip, true)
             .map_err(GetStackersErrors::NotAvailableYet)?;
 
         Ok(Self { stacker_set })

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -4292,7 +4292,7 @@ impl PeerNetwork {
         let ih = sortdb.index_handle(&tip_sn.sortition_id);
 
         for rc in [cur_rc, prev_rc, prev_prev_rc] {
-            let rc_start_height = self.burnchain.reward_cycle_to_block_height(rc);
+            let rc_start_height = self.burnchain.nakamoto_first_block_of_cycle(rc);
             let Some(ancestor_sort_id) =
                 get_ancestor_sort_id(&ih, rc_start_height, &tip_sn.sortition_id)?
             else {

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -599,7 +599,7 @@ impl Relayer {
 
             // is the block signed by the active reward set?
             let sn_rc = burnchain
-                .pox_reward_cycle(sn.block_height)
+                .block_height_to_reward_cycle(sn.block_height)
                 .expect("FATAL: sortition has no reward cycle");
             let reward_cycle_info = if let Some(rc_info) = loaded_reward_sets.get(&sn_rc) {
                 rc_info
@@ -840,6 +840,7 @@ impl Relayer {
 
         // NOTE: it's `+ 1` because the first Nakamoto block is built atop the last epoch 2.x
         // tenure, right after the last 2.x sortition
+        // TODO: is this true?
         let epoch_id = SortitionDB::get_stacks_epoch(sort_handle, block_sn.block_height + 1)?
             .expect("FATAL: no epoch defined")
             .epoch_id;
@@ -885,7 +886,7 @@ impl Relayer {
 
         let reward_info = match load_nakamoto_reward_set(
             burnchain
-                .pox_reward_cycle(block_sn.block_height)
+                .block_height_to_reward_cycle(block_sn.block_height)
                 .expect("FATAL: block snapshot has no reward cycle"),
             &tip,
             burnchain,

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -2101,7 +2101,10 @@ fn test_nakamoto_download_run_2_peers() {
         .get_nakamoto_tip_block_id()
         .unwrap()
         .unwrap();
-    assert_eq!(tip.block_height, 81);
+    assert_eq!(
+        tip.block_height,
+        41 + bitvecs.iter().map(|x| x.len() as u64).sum::<u64>()
+    );
 
     // make a neighbor from this peer
     let boot_observer = TestEventObserver::new();

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -474,17 +474,6 @@ impl NakamotoBootPlan {
             .block_height_to_reward_cycle(sortition_height.into())
             .unwrap();
 
-        let sortdb = peer.sortdb();
-        let tip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn()).unwrap();
-        let tip_index_block = tip.get_canonical_stacks_block_id();
-
-        let min_ustx = with_sortdb(peer, |chainstate, sortdb| {
-            chainstate.get_stacking_minimum(sortdb, &tip_index_block)
-        })
-        .unwrap();
-
-        info!("Minimum USTX for stacking: {}", min_ustx);
-
         // Make all the test Stackers stack
         let stack_txs: Vec<_> = peer
             .config
@@ -493,11 +482,6 @@ impl NakamotoBootPlan {
             .unwrap_or(vec![])
             .iter()
             .map(|test_stacker| {
-                info!(
-                    "Making PoX-4 lockup for {}; {}",
-                    test_stacker.amount,
-                    test_stacker.amount > min_ustx
-                );
                 let pox_addr = test_stacker
                     .pox_addr
                     .clone()

--- a/stackslib/src/net/tests/relay/nakamoto.rs
+++ b/stackslib/src/net/tests/relay/nakamoto.rs
@@ -618,7 +618,7 @@ fn test_no_buffer_ready_nakamoto_blocks() {
                                     follower
                                         .network
                                         .burnchain
-                                        .pox_reward_cycle(block_sn.block_height)
+                                        .block_height_to_reward_cycle(block_sn.block_height)
                                         .unwrap()
                                 ),
                                 true
@@ -642,7 +642,7 @@ fn test_no_buffer_ready_nakamoto_blocks() {
                                     follower
                                         .network
                                         .burnchain
-                                        .pox_reward_cycle(
+                                        .block_height_to_reward_cycle(
                                             follower.network.burnchain_tip.block_height
                                         )
                                         .unwrap()
@@ -670,7 +670,7 @@ fn test_no_buffer_ready_nakamoto_blocks() {
                                     follower
                                         .network
                                         .burnchain
-                                        .pox_reward_cycle(ancestor_sn.block_height)
+                                        .block_height_to_reward_cycle(ancestor_sn.block_height)
                                         .unwrap()
                                 ),
                                 true
@@ -816,9 +816,12 @@ fn test_buffer_nonready_nakamoto_blocks() {
     let mut all_blocks = vec![];
 
     thread::scope(|s| {
-        s.spawn(|| {
-            SeedNode::main(peer, rc_len, seed_comms);
-        });
+        thread::Builder::new()
+            .name("seed".into())
+            .spawn_scoped(s, || {
+                SeedNode::main(peer, rc_len, seed_comms);
+            })
+            .unwrap();
 
         let mut seed_exited = false;
         let mut exited_peer = None;

--- a/stackslib/src/net/unsolicited.rs
+++ b/stackslib/src/net/unsolicited.rs
@@ -715,10 +715,11 @@ impl PeerNetwork {
     ) -> bool {
         let Some(rc_data) = self.current_reward_sets.get(&reward_cycle) else {
             info!(
-                "{:?}: Failed to validate Nakamoto block {}/{}: no reward set",
+                "{:?}: Failed to validate Nakamoto block {}/{}: no reward set for cycle {}",
                 self.get_local_peer(),
                 &nakamoto_block.header.consensus_hash,
-                &nakamoto_block.header.block_hash()
+                &nakamoto_block.header.block_hash(),
+                reward_cycle,
             );
             return false;
         };
@@ -733,7 +734,7 @@ impl PeerNetwork {
 
         if let Err(e) = nakamoto_block.header.verify_signer_signatures(reward_set) {
             info!(
-                "{:?}: signature verification failrue for Nakamoto block {}/{} in reward cycle {}: {:?}", self.get_local_peer(), &nakamoto_block.header.consensus_hash, &nakamoto_block.header.block_hash(), reward_cycle, &e
+                "{:?}: signature verification failure for Nakamoto block {}/{} in reward cycle {}: {:?}", self.get_local_peer(), &nakamoto_block.header.consensus_hash, &nakamoto_block.header.block_hash(), reward_cycle, &e
             );
             return false;
         }
@@ -788,7 +789,7 @@ impl PeerNetwork {
 
         let reward_set_sn_rc = self
             .burnchain
-            .pox_reward_cycle(reward_set_sn.block_height)
+            .block_height_to_reward_cycle(reward_set_sn.block_height)
             .expect("FATAL: sortition has no reward cycle");
 
         return (Some(reward_set_sn_rc), can_process);

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -818,7 +818,7 @@ impl MicroblockMinerThread {
                 &mined_microblock.block_hash()
             );
 
-            #[cfg(any(test, feature = "testing"))]
+            #[cfg(test)]
             {
                 use std::path::Path;
                 if let Ok(path) = std::env::var("STACKS_BAD_BLOCKS_DIR") {
@@ -1773,7 +1773,7 @@ impl BlockMinerThread {
     ///
     /// In testing, we ignore the parent stacks block hash because we don't have an easy way to
     /// reproduce it in integration tests.
-    #[cfg(not(any(test, feature = "testing")))]
+    #[cfg(not(test))]
     fn make_microblock_private_key(
         &mut self,
         parent_stacks_hash: &StacksBlockId,
@@ -1786,7 +1786,7 @@ impl BlockMinerThread {
 
     /// Get the microblock private key we'll be using for this tenure, should we win.
     /// Return the private key on success
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     fn make_microblock_private_key(
         &mut self,
         _parent_stacks_hash: &StacksBlockId,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -1296,12 +1296,7 @@ fn transition_adds_get_pox_addr_recipients() {
                             // NOTE: there's an even number of payouts here, so this works
                             eprintln!("payout at {} = {}", burn_block_height, &payout);
 
-                            if Burnchain::static_is_in_prepare_phase(
-                                0,
-                                pox_constants.reward_cycle_length as u64,
-                                pox_constants.prepare_length.into(),
-                                burn_block_height,
-                            ) {
+                            if pox_constants.is_in_prepare_phase(0, burn_block_height) {
                                 // in prepare phase
                                 eprintln!("{} in prepare phase", burn_block_height);
                                 assert_eq!(payout, conf.burnchain.burn_fee_cap as u128);

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -510,7 +510,7 @@ pub fn read_and_sign_block_proposal(
 
     let reward_set = load_nakamoto_reward_set(
         burnchain
-            .pox_reward_cycle(tip.block_height.saturating_add(1))
+            .block_height_to_reward_cycle(tip.block_height)
             .unwrap(),
         &tip.sortition_id,
         &burnchain,


### PR DESCRIPTION
- Closes #5049

To help catch edge cases related to Nakamoto, this PR updates the `pox_4_tests` test suite to run tests in both epoch 2.5 and 3.0. Previously, all tests only ran in 2.5.

This PR also includes the work from @kantai to add consistent behavior to mod 0 blocks in Nakamoto, which was the cause of a previous reward cycle calculation bug. That work is included in https://github.com/stacks-network/stacks-core/pull/5072/commits/1d836175730eff88eaec9440c608267eb6303494.

This PR adds a `nakamoto_cases` rstest template, so that tests will run twice, and they're provided a `use_nakamoto` parameter. Certain setup functions have been updated (such as `prepare_pox4_test`) to utilize this argument. When `use_nakamoto` is true, the setup function utilizes the `NakamotoBootPlan` struct to boot into Nakamoto. Using `NakamotoBootPlan` adds things like automatically stacking a single signer and uses the Nakamoto VRF proof when mining blocks.

For the most part, the tests themselves are not updated. There are certain instances, such as expecting a reward set with 1 signer, which are updated to expect 2 signers when in epoch 3.0.

I've also added a helper function, `tenure_with_txs`, which mimicks the `peer.tenure_with_txs` function. In 3.0, this function creates a tenure with a Nakamoto block that includes the transactions.