### PR TITLE
remove 2 binaries from release image: relay-server/stacks-events

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.alpine-binary
+++ b/.github/actions/dockerfiles/Dockerfile.alpine-binary
@@ -32,7 +32,7 @@ RUN case "${TAG}" in \
             ;; \
         *) \
             echo "/bin/stacks-node mainnet" > /tmp/command.sh && \
-            rm /bin/blockstack-cli /bin/clarity-cli /bin/relay-server /bin/stacks-events /bin/stacks-inspect \
+            rm /bin/blockstack-cli /bin/clarity-cli /bin/stacks-inspect \
             ;; \
     esac && \
     chmod +x /tmp/command.sh

--- a/.github/actions/dockerfiles/Dockerfile.debian-binary
+++ b/.github/actions/dockerfiles/Dockerfile.debian-binary
@@ -32,7 +32,7 @@ RUN case "${TAG}" in \
             ;; \
         *) \
             echo "/bin/stacks-node mainnet" > /tmp/command.sh && \
-            rm /bin/blockstack-cli /bin/clarity-cli /bin/relay-server /bin/stacks-events /bin/stacks-inspect \
+            rm /bin/blockstack-cli /bin/clarity-cli /bin/stacks-inspect \
             ;; \
     esac && \
     chmod +x /tmp/command.sh


### PR DESCRIPTION
fixes https://github.com/stacks-network/stacks-core/actions/runs/10390337193/job/28771769326#step:6:1832

by removing relay-server and stacks-events binaries from final image