### PR TITLE
CI Mutants: add workfow dispatch for GUI

### DIFF
--- a/.github/workflows/pr-differences-mutants.yml
+++ b/.github/workflows/pr-differences-mutants.yml
@@ -9,6 +9,16 @@ on:
       - ready_for_review
     paths:
       - '**.rs'
+  workflow_dispatch:
+    inputs:
+      ignore_timeout:
+        description: "Ignore mutants timeout limit"
+        required: false
+        type: choice
+        options:
+          - true
+          - false
+        default: 'true'
 
 concurrency:
   group: pr-differences-${{ github.head_ref || github.ref || github.run_id }}


### PR DESCRIPTION
This is required so that the workflow dispatch button will appear on the GUI. It is the bare minimum required for that, then the dispatch is interpreted based on the branch it is called for.

After this PR is merged, the GUI will have the manual dispatch and the custom action will be tested
 https://github.com/stacks-network/actions/pull/50.
The PR for develop branch referencing is: https://github.com/stacks-network/stacks-core/pull/5083. That should be only merged after #5082 and the actions PR are merged.