### PR TITLE
bugfix/boot_to_epoch_3 in SignerTest should wait for a new commit

### DIFF
--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -293,7 +293,7 @@ impl SignerTest<SpawnedSigner> {
     fn mine_and_verify_confirmed_naka_block(&mut self, timeout: Duration, num_signers: usize) {
         info!("------------------------- Try mining one block -------------------------");
 
-        let old_reward_cycle = self.get_current_reward_cycle();
+        let reward_cycle = self.get_current_reward_cycle();
 
         self.mine_nakamoto_block(timeout);
 
@@ -312,13 +312,6 @@ impl SignerTest<SpawnedSigner> {
         // NOTE: signature.len() does not need to equal signers.len(); the stacks miner can finish the block
         //  whenever it has crossed the threshold.
         assert!(signature.len() >= num_signers * 7 / 10);
-
-        let new_reward_cycle = self.get_current_reward_cycle();
-        let reward_cycle = if new_reward_cycle != old_reward_cycle {
-            old_reward_cycle
-        } else {
-            new_reward_cycle
-        };
         info!(
             "Verifying signatures against signers for reward cycle {:?}",
             reward_cycle

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -63,9 +63,8 @@ use crate::nakamoto_node::sign_coordinator::TEST_IGNORE_SIGNERS;
 use crate::neon::Counters;
 use crate::run_loop::boot_nakamoto;
 use crate::tests::nakamoto_integrations::{
-    boot_to_epoch_25, boot_to_epoch_3_reward_set, next_block_and, next_block_and_mine_commit,
-    setup_epoch_3_reward_set, wait_for, POX_4_DEFAULT_STACKER_BALANCE,
-    POX_4_DEFAULT_STACKER_STX_AMT,
+    boot_to_epoch_25, boot_to_epoch_3_reward_set, next_block_and, setup_epoch_3_reward_set,
+    wait_for, POX_4_DEFAULT_STACKER_BALANCE, POX_4_DEFAULT_STACKER_STX_AMT,
 };
 use crate::tests::neon_integrations::{
     get_account, get_chain_info, next_block_and_wait, run_until_burnchain_height, submit_tx,
@@ -278,15 +277,14 @@ impl SignerTest<SpawnedSigner> {
 
         self.run_until_epoch_3_boundary();
 
+        let commits_submitted = self.running_nodes.commits_submitted.clone();
+        let commits_before = commits_submitted.load(Ordering::SeqCst);
         info!("Waiting 1 burnchain block for miner VRF key confirmation");
         // Wait one block to confirm the VRF register, wait until a block commit is submitted
-        let commits_submitted = self.running_nodes.commits_submitted.clone();
-        next_block_and_mine_commit(
-            &mut self.running_nodes.btc_regtest_controller,
-            30,
-            &self.running_nodes.coord_channel,
-            &commits_submitted,
-        )
+        next_block_and(&mut self.running_nodes.btc_regtest_controller, 60, || {
+            let commits_count = commits_submitted.load(Ordering::SeqCst);
+            Ok(commits_count > commits_before)
+        })
         .unwrap();
         info!("Ready to mine Nakamoto blocks!");
     }


### PR DESCRIPTION
This was causing stalls in mine_2_nakamoto_reward_cycles which would ue the block commit to trigger a stacks block and would therefore hang if no commit was submitted prior to mining the next burn block.
