### PR TITLE
Clarity-Wasm: fix for the `contract-call?` host function

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -5288,6 +5288,8 @@ fn link_contract_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
             "clarity",
             "contract_call",
             |mut caller: Caller<'_, ClarityWasmContext>,
+             trait_name_offset: i32,
+             trait_name_length: i32,
              contract_offset: i32,
              contract_length: i32,
              function_offset: i32,
@@ -5403,10 +5405,26 @@ fn link_contract_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
                 }?;
 
                 // Write the result to the return buffer
-                let return_ty = function
-                    .get_return_type()
-                    .as_ref()
-                    .ok_or(CheckErrors::DefineFunctionBadSignature)?;
+                let return_ty = if trait_name_length == 0 {
+                    // This is a direct call
+                    function.get_return_type().as_ref()
+                } else {
+                    // This is a dynamic call
+                    let trait_name = read_identifier_from_wasm(
+                        memory,
+                        &mut caller,
+                        trait_name_offset,
+                        trait_name_length,
+                    )?;
+                    contract
+                        .contract_context
+                        .defined_traits
+                        .get(trait_name.as_str())
+                        .and_then(|trait_functions| trait_functions.get(function_name.as_str()))
+                        .map(|f_ty| &f_ty.returns)
+                }
+                .ok_or(CheckErrors::DefineFunctionBadSignature)?;
+
                 let memory = caller
                     .get_export("memory")
                     .and_then(|export| export.into_memory())
@@ -5419,7 +5437,7 @@ fn link_contract_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
                     return_offset,
                     return_offset + get_type_size(return_ty),
                     &result,
-                    true,
+                    false,
                 )?;
 
                 Ok(())


### PR DESCRIPTION
This is the stacks-core part of https://github.com/stacks-network/clarity-wasm/pull/479

This is due to an issue where we have to duplicate some parts of the code.
