### PR TITLE
Fix: generate a well-formed Bitcoin transaction when spending multiple UTXOs

### DIFF
--- a/testnet/stacks-node/src/keychain.rs
+++ b/testnet/stacks-node/src/keychain.rs
@@ -206,7 +206,6 @@ impl Keychain {
     }
 
     /// Create a BurnchainOpSigner representation of this keychain
-    /// (this is going to be removed in 2.1)
     pub fn generate_op_signer(&self) -> BurnchainOpSigner {
         BurnchainOpSigner::new(self.get_secret_key(), false)
     }


### PR DESCRIPTION
See title.  The partially-signed bitcoin transaction wasn't properly structured, which caused block-commits which consume multiple UTXOs to fail due to invalid signatures.  This fixes this problem and adds test coverage.