### PR TITLE
Fix event dispatcher stall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
+ "url",
  "warp",
  "wsts",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,6 +3421,7 @@ dependencies = [
  "stackslib",
  "stx-genesis",
  "tikv-jemallocator",
+ "tiny_http",
  "tokio",
  "toml 0.5.11",
  "tracing",

--- a/stackslib/src/net/api/getstackers.rs
+++ b/stackslib/src/net/api/getstackers.rs
@@ -121,7 +121,7 @@ impl HttpRequest for GetStackersRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(r#"^/v3/stacker_set/(?P<cycle_num>[0-9]{1,20})$"#).unwrap()
+        Regex::new(r#"^/v3/stacker_set/(?P<cycle_num>[0-9]{1,10})$"#).unwrap()
     }
 
     fn metrics_identifier(&self) -> &str {

--- a/stackslib/src/net/atlas/db.rs
+++ b/stackslib/src/net/atlas/db.rs
@@ -494,8 +494,12 @@ impl AtlasDB {
         page_index: u32,
         block_id: &StacksBlockId,
     ) -> Result<Vec<bool>, db_error> {
-        let min = page_index * AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
-        let max = min + AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE;
+        let min = page_index
+            .checked_mul(AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE)
+            .ok_or(db_error::Overflow)?;
+        let max = min
+            .checked_add(AttachmentInstance::ATTACHMENTS_INV_PAGE_SIZE)
+            .ok_or(db_error::Overflow)?;
         let qry = "SELECT attachment_index, is_available FROM attachment_instances WHERE attachment_index >= ?1 AND attachment_index < ?2 AND index_block_hash = ?3 ORDER BY attachment_index ASC";
         let args = params![min, max, block_id,];
         let rows = query_rows::<(u32, u32), _>(&self.conn, &qry, args)?;

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -971,7 +971,7 @@ impl<P: ProtocolFamily> ConnectionInbox<P> {
             // NOTE: it's important that buf not be too big, since up to buf.len()-1 bytes may need
             // to be copied if a message boundary isn't aligned with buf (which is usually the
             // case).
-            let mut buf = [0u8; 4096];
+            let mut buf = [0u8; 65536];
             let num_read = match fd.read(&mut buf) {
                 Ok(0) => {
                     // remote fd is closed, but do try to consume all remaining bytes in the buffer

--- a/stackslib/src/net/http/mod.rs
+++ b/stackslib/src/net/http/mod.rs
@@ -178,7 +178,7 @@ impl FromStr for HttpContentType {
         let s = header.to_string().to_lowercase();
         if s == "application/octet-stream" {
             Ok(HttpContentType::Bytes)
-        } else if s == "text/plain" {
+        } else if s == "text/plain" || s.starts_with("text/plain;") {
             Ok(HttpContentType::Text)
         } else if s == "application/json" {
             Ok(HttpContentType::JSON)

--- a/stackslib/src/net/http/mod.rs
+++ b/stackslib/src/net/http/mod.rs
@@ -180,7 +180,7 @@ impl FromStr for HttpContentType {
             Ok(HttpContentType::Bytes)
         } else if s == "text/plain" || s.starts_with("text/plain;") {
             Ok(HttpContentType::Text)
-        } else if s == "application/json" {
+        } else if s == "application/json" || s.starts_with("application/json;") {
             Ok(HttpContentType::JSON)
         } else {
             Err(CodecError::DeserializeError(format!(

--- a/stackslib/src/net/http/mod.rs
+++ b/stackslib/src/net/http/mod.rs
@@ -183,9 +183,9 @@ impl FromStr for HttpContentType {
         } else if s == "application/json" {
             Ok(HttpContentType::JSON)
         } else {
-            Err(CodecError::DeserializeError(
-                "Unsupported HTTP content type".to_string(),
-            ))
+            Err(CodecError::DeserializeError(format!(
+                "Unsupported HTTP content type: {header}"
+            )))
         }
     }
 }

--- a/stackslib/src/net/http/response.rs
+++ b/stackslib/src/net/http/response.rs
@@ -582,7 +582,7 @@ impl StacksMessageCodec for HttpResponsePreamble {
                     ));
                 }
 
-                if content_type.is_none() || (content_length.is_none() && !chunked_encoding) {
+                if content_length.is_none() && !chunked_encoding {
                     return Err(CodecError::DeserializeError(
                         "Invalid HTTP response: missing Content-Type, Content-Length".to_string(),
                     ));
@@ -593,7 +593,7 @@ impl StacksMessageCodec for HttpResponsePreamble {
                     status_code: status_code,
                     reason: reason,
                     keep_alive: keep_alive,
-                    content_type: content_type.unwrap(),
+                    content_type: content_type.unwrap_or(HttpContentType::Bytes), // per the RFC
                     content_length: content_length,
                     headers: headers,
                 })

--- a/stackslib/src/net/http/tests.rs
+++ b/stackslib/src/net/http/tests.rs
@@ -368,8 +368,6 @@ fn test_parse_http_response_preamble_err() {
          "Unsupported HTTP content type"),
         ("HTTP/1.1 200 OK\r\nContent-Length: foo\r\n\r\n",
          "Invalid Content-Length"),
-        ("HTTP/1.1 200 OK\r\nContent-Length: 123\r\n\r\n",
-         "missing Content-Type, Content-Length"),
         ("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n",
          "missing Content-Type, Content-Length"),
         ("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 123\r\nTransfer-Encoding: chunked\r\n\r\n",

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -1686,17 +1686,17 @@ impl ProtocolFamily for StacksHttp {
                             &req.preamble().verb,
                             &decoded_path
                         )))?;
-                    handler_index
+                    Some(handler_index)
                 } else {
-                    0
+                    None
                 };
 
                 req.send(fd)?;
 
                 // remember this so we'll know how to decode the response.
                 // The next preamble and message we'll read _must be_ a response!
-                if !self.allow_arbitrary_response {
-                    self.request_handler_index = Some(handler_index);
+                if handler_index.is_some() {
+                    self.request_handler_index = handler_index;
                 }
                 Ok(())
             }
@@ -1768,14 +1768,10 @@ pub fn decode_request_path(path: &str) -> Result<(String, String), NetError> {
 
 /// Convert a NetError into an io::Error if appropriate.
 fn handle_net_error(e: NetError, msg: &str) -> io::Error {
-    if let NetError::ReadError(ioe) = e {
-        ioe
-    } else if let NetError::WriteError(ioe) = e {
-        ioe
-    } else if let NetError::RecvTimeout = e {
-        io::Error::new(io::ErrorKind::WouldBlock, "recv timeout")
-    } else {
-        io::Error::new(io::ErrorKind::Other, format!("{}: {:?}", &e, msg).as_str())
+    match e {
+        NetError::ReadError(ioe) | NetError::WriteError(ioe) => ioe,
+        NetError::RecvTimeout => io::Error::new(io::ErrorKind::WouldBlock, "recv timeout"),
+        _ => io::Error::new(io::ErrorKind::Other, format!("{}: {:?}", &e, msg).as_str()),
     }
 }
 
@@ -1911,8 +1907,7 @@ pub fn send_http_request(
     // and dispatched any new messages to the request handle.  If so, then extract the message and
     // check that it's a well-formed HTTP response.
     debug!("send_request(receiving data)");
-    let response;
-    loop {
+    let response = loop {
         // get back the reply
         debug!("send_request(receiving data): try to receive data");
         match connection.recv_data(&mut stream) {
@@ -1932,18 +1927,15 @@ pub fn send_http_request(
         debug!("send_request(receiving data): try receive response");
         let rh = match request_handle.try_recv() {
             Ok(resp) => {
-                response = resp;
-                break;
+                break resp;
             }
-            Err(e) => match e {
-                Ok(handle) => handle,
-                Err(e) => {
-                    return Err(handle_net_error(
-                        e,
-                        "Failed to receive message after socket has been drained",
-                    ));
-                }
-            },
+            Err(Ok(handle)) => handle,
+            Err(Err(e)) => {
+                return Err(handle_net_error(
+                    e,
+                    "Failed to receive message after socket has been drained",
+                ));
+            }
         };
         request_handle = rh;
 
@@ -1953,7 +1945,7 @@ pub fn send_http_request(
                 "Timed out while receiving request",
             ));
         }
-    }
+    };
 
     // Step 5: decode the HTTP message and return it if it's not an error.
     let response_data = match response {

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -1356,16 +1356,6 @@ impl StacksHttp {
             &ConnectionOptions::default(),
         );
 
-        if !self.allow_arbitrary_response {
-            let response_handler_index =
-                http.find_response_handler(verb, request_path)
-                    .ok_or(NetError::SendError(format!(
-                        "No such handler for '{} {}'",
-                        verb, request_path
-                    )))?;
-            http.request_handler_index = Some(response_handler_index);
-        }
-
         let (preamble, message_offset) = http.read_preamble(response_buf)?;
         let is_chunked = match preamble {
             StacksHttpPreamble::Response(ref resp) => resp.is_chunked(),

--- a/stackslib/src/net/tests/httpcore.rs
+++ b/stackslib/src/net/tests/httpcore.rs
@@ -120,8 +120,6 @@ fn test_parse_stacks_http_preamble_response_err() {
          "Failed to decode HTTP request or HTTP response"),
         ("HTTP/1.1 200 OK\r\nContent-Length: foo\r\n\r\n",
          "Failed to decode HTTP request or HTTP response"),
-        ("HTTP/1.1 200 OK\r\nContent-Length: 123\r\n\r\n",
-         "Failed to decode HTTP request or HTTP response"),
         ("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n",
          "Failed to decode HTTP request or HTTP response"),
         ("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 123\r\nTransfer-Encoding: chunked\r\n\r\n",

--- a/stackslib/src/net/tests/httpcore.rs
+++ b/stackslib/src/net/tests/httpcore.rs
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::io::Write;
-use std::net::{SocketAddr, ToSocketAddrs};
-use std::str;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::sync::mpsc::{channel, Receiver};
+use std::time::{Duration, Instant};
+use std::{str, thread};
 
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId, StacksPrivateKey};
@@ -38,12 +40,12 @@ use crate::net::api::getneighbors::{RPCNeighbor, RPCNeighborsInfo};
 use crate::net::connection::ConnectionOptions;
 use crate::net::http::{
     http_error_from_code_and_text, http_reason, HttpContentType, HttpErrorResponse,
-    HttpRequestContents, HttpRequestPreamble, HttpReservedHeader, HttpResponsePreamble,
-    HttpVersion, HTTP_PREAMBLE_MAX_NUM_HEADERS,
+    HttpRequestContents, HttpRequestPreamble, HttpReservedHeader, HttpResponsePayload,
+    HttpResponsePreamble, HttpVersion, HTTP_PREAMBLE_MAX_NUM_HEADERS,
 };
 use crate::net::httpcore::{
-    HttpPreambleExtensions, HttpRequestContentsExtensions, StacksHttp, StacksHttpMessage,
-    StacksHttpPreamble, StacksHttpRequest, StacksHttpResponse,
+    send_http_request, HttpPreambleExtensions, HttpRequestContentsExtensions, StacksHttp,
+    StacksHttpMessage, StacksHttpPreamble, StacksHttpRequest, StacksHttpResponse,
 };
 use crate::net::rpc::ConversationHttp;
 use crate::net::{ProtocolFamily, TipRequest};
@@ -1117,4 +1119,158 @@ fn test_metrics_identifiers() {
         assert_eq!(metrics_identifier, metrics_identifier_expected);
         assert_eq!(response_handler_index.is_some(), should_have_handler);
     }
+}
+
+fn json_body(host: &str, port: u16, path: &str, json_bytes: &[u8]) -> StacksHttpRequest {
+    let peerhost: PeerHost = format!("{host}:{port}")
+        .parse()
+        .unwrap_or(PeerHost::DNS(host.to_string(), port));
+    let mut request = StacksHttpRequest::new_for_peer(
+        peerhost,
+        "POST".into(),
+        path.into(),
+        HttpRequestContents::new().payload_json(serde_json::from_slice(json_bytes).unwrap()),
+    )
+    .unwrap_or_else(|_| panic!("FATAL: failed to encode infallible data as HTTP request"));
+    request.add_header("Connection".into(), "close".into());
+
+    request
+}
+
+#[test]
+fn test_send_request_timeout() {
+    // Set up a TcpListener that accepts a connection but delays response
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind test listener");
+    let addr = listener.local_addr().unwrap();
+
+    // Spawn a thread that will accept the connection and do nothing, simulating a long delay
+    thread::spawn(move || {
+        let (stream, _addr) = listener.accept().unwrap();
+        // Hold the connection open to simulate a delay
+        thread::sleep(Duration::from_secs(10));
+        drop(stream); // Close the stream
+    });
+
+    // Set a timeout shorter than the sleep duration to force a timeout
+    let connection_timeout = Duration::from_secs(2);
+
+    // Attempt to connect, expecting a timeout error
+    let result = send_http_request(
+        "127.0.0.1",
+        addr.port(),
+        json_body("127.0.0.1", 80, "/", b"{}"),
+        connection_timeout,
+    );
+
+    // Assert that the result is an error, specifically a timeout
+    assert!(
+        result.is_err(),
+        "Expected a timeout error, got: {:?}",
+        result
+    );
+
+    if let Err(err) = result {
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::WouldBlock,
+            "Expected TimedOut error, got: {:?}",
+            err
+        );
+    }
+}
+
+fn start_mock_server(response: String, client_done_signal: Receiver<()>) -> String {
+    // Bind to an available port on localhost
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind server");
+    let addr = listener.local_addr().unwrap();
+
+    debug!("Mock server listening on {}", addr);
+
+    // Start the server in a new thread
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            debug!("Mock server accepted connection");
+            let mut stream = stream.expect("Failed to accept connection");
+
+            // Read the client's request (even if we don't do anything with it)
+            let mut buffer = [0; 512];
+            let _ = stream.read(&mut buffer);
+            debug!("Mock server received request");
+
+            // Simulate a basic HTTP response
+            stream
+                .write_all(response.as_bytes())
+                .expect("Failed to write response");
+            stream.flush().expect("Failed to flush stream");
+            debug!("Mock server sent response");
+
+            // Wait for the client to signal that it's done reading
+            client_done_signal
+                .recv()
+                .expect("Failed to receive client done signal");
+
+            // Explicitly drop the stream after signaling to ensure the client finishes
+            // NOTE: this will cause the test to slow down, since `send_http_request` expects
+            // `Connection: close`
+            drop(stream);
+
+            debug!("Mock server closing connection");
+
+            break; // Close after the first request
+        }
+    });
+
+    // Return the address of the mock server
+    format!("{}:{}", addr.ip(), addr.port())
+}
+
+fn parse_http_response(response: StacksHttpResponse) -> String {
+    let response_txt = match response.destruct().1 {
+        HttpResponsePayload::Text(s) => s,
+        HttpResponsePayload::Empty => "".to_string(),
+        HttpResponsePayload::JSON(js) => serde_json::to_string(&js).unwrap(),
+        HttpResponsePayload::Bytes(bytes) => String::from_utf8_lossy(bytes.as_slice()).to_string(),
+    };
+    response_txt
+}
+
+#[test]
+fn test_send_request_success() {
+    // Prepare the mock server to return a successful HTTP response
+    let mock_response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, world!";
+
+    // Create a channel to signal when the client is done reading
+    let (tx_client_done, rx_client_done) = channel();
+    let server_addr = start_mock_server(mock_response.to_string(), rx_client_done);
+    let timeout_duration = Duration::from_secs(5);
+
+    let parts = server_addr.split(':').collect::<Vec<&str>>();
+    let host = parts[0];
+    let port = parts[1].parse().unwrap();
+
+    // Attempt to send a request to the mock server
+    let result = send_http_request(
+        host,
+        port,
+        json_body(host, port, "/", b"{}"),
+        timeout_duration,
+    );
+    debug!("Got result: {:?}", result);
+
+    // Ensure the server only closes after the client has finished processing
+    if let Ok(response) = &result {
+        let body = parse_http_response(response.clone());
+        assert_eq!(body, "Hello, world!", "Unexpected response body: {}", body);
+    }
+
+    tx_client_done
+        .send(())
+        .expect("Failed to send close signal");
+
+    // Assert that the connection was successful
+    assert!(
+        result.is_ok(),
+        "Expected a successful request, but got {:?}",
+        result
+    );
 }

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -49,6 +49,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = {workspace = true}
 mutants = "0.0.3"
+tiny_http = "0.12.0"
 
 [[bin]]
 name = "stacks-node"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -15,9 +15,6 @@ serde_json = { version = "1.0", features = ["arbitrary_precision", "raw_value"] 
 stacks = { package = "stackslib", path = "../../stackslib" }
 stx-genesis = { path = "../../stx-genesis"}
 toml = "0.5.6"
-async-h1 = "2.3.2"
-async-std = { version = "1.6", features = ["attributes"] }
-http-types = "2.12"
 base64 = "0.12.0"
 backtrace = "0.3.50"
 libc = "0.2.151"
@@ -28,10 +25,13 @@ chrono = "0.4.19"
 regex = "1"
 libsigner = { path = "../../libsigner" }
 wsts = { workspace = true }
+url = "2.1.0"
 rand = { workspace = true }
 rand_core = { workspace = true }
 hashbrown = { workspace = true }
 rusqlite = { workspace = true }
+async-h1 = { version = "2.3.2", optional = true }
+async-std = { version = "1.6", optional = true, features = ["attributes"] }
 
 [target.'cfg(not(any(target_os = "macos", target_os="windows", target_arch = "arm")))'.dependencies]
 tikv-jemallocator = {workspace = true}
@@ -40,7 +40,7 @@ tikv-jemallocator = {workspace = true}
 ring = "0.16.19"
 warp = "0.3.5"
 tokio = "1.15"
-reqwest = { version = "0.11", default_features = false, features = ["blocking", "json", "rustls", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls", "rustls-tls"] }
 clarity = { path = "../../clarity", features = ["default", "testing"]}
 stacks-common = { path = "../../stacks-common", features = ["default", "testing"] }
 stacks = { package = "stackslib", path = "../../stackslib", features = ["default", "testing"] }
@@ -50,6 +50,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wsts = {workspace = true}
 mutants = "0.0.3"
 tiny_http = "0.12.0"
+http-types = "2.12"
 
 [[bin]]
 name = "stacks-node"
@@ -60,7 +61,7 @@ name = "stacks-events"
 path = "src/stacks_events.rs"
 
 [features]
-monitoring_prom = ["stacks/monitoring_prom", "libsigner/monitoring_prom", "stacks-signer/monitoring_prom"]
+monitoring_prom = ["stacks/monitoring_prom", "libsigner/monitoring_prom", "stacks-signer/monitoring_prom", "dep:async-h1", "dep:async-std"]
 slog_json = ["stacks/slog_json", "stacks-common/slog_json", "clarity/slog_json"]
 prod-genesis-chainstate = []
 default = []

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -32,6 +32,7 @@ hashbrown = { workspace = true }
 rusqlite = { workspace = true }
 async-h1 = { version = "2.3.2", optional = true }
 async-std = { version = "1.6", optional = true, features = ["attributes"] }
+http-types = { version = "2.12", optional = true }
 
 [target.'cfg(not(any(target_os = "macos", target_os="windows", target_arch = "arm")))'.dependencies]
 tikv-jemallocator = {workspace = true}
@@ -61,7 +62,7 @@ name = "stacks-events"
 path = "src/stacks_events.rs"
 
 [features]
-monitoring_prom = ["stacks/monitoring_prom", "libsigner/monitoring_prom", "stacks-signer/monitoring_prom", "dep:async-h1", "dep:async-std"]
+monitoring_prom = ["stacks/monitoring_prom", "libsigner/monitoring_prom", "stacks-signer/monitoring_prom", "async-h1", "async-std", "http-types"]
 slog_json = ["stacks/slog_json", "stacks-common/slog_json", "clarity/slog_json"]
 prod-genesis-chainstate = []
 default = []

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1,14 +1,11 @@
-use std::cmp;
+use std::convert::From;
 use std::io::Cursor;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use std::{cmp, io};
 
-use async_h1::client;
-use async_std::io::ReadExt;
-use async_std::net::TcpStream;
 use base64::encode;
-use http_types::{Method, Request, Url};
 use serde::Serialize;
 use serde_json::json;
 use serde_json::value::RawValue;
@@ -38,6 +35,9 @@ use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::stacks::address::PoxAddress;
 use stacks::core::{StacksEpoch, StacksEpochId};
 use stacks::monitoring::{increment_btc_blocks_received_counter, increment_btc_ops_sent_counter};
+use stacks::net::http::{HttpRequestContents, HttpResponsePayload};
+use stacks::net::httpcore::StacksHttpRequest;
+use stacks::net::Error as NetError;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::deps_common::bitcoin::blockdata::opcodes;
 use stacks_common::deps_common::bitcoin::blockdata::script::{Builder, Script};
@@ -50,9 +50,11 @@ use stacks_common::deps_common::bitcoin::network::serialize::deserialize as btc_
 use stacks_common::deps_common::bitcoin::network::serialize::RawEncoder;
 use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::net::PeerHost;
 use stacks_common::util::hash::{hex_bytes, Hash160};
 use stacks_common::util::secp256k1::Secp256k1PublicKey;
 use stacks_common::util::sleep_ms;
+use url::Url;
 
 use super::super::operations::BurnchainOpSigner;
 use super::super::Config;
@@ -62,6 +64,7 @@ use crate::config::{
     OP_TX_PRE_STACKS_ESTIM_SIZE, OP_TX_STACK_STX_ESTIM_SIZE, OP_TX_TRANSFER_STACKS_ESTIM_SIZE,
     OP_TX_VOTE_AGG_ESTIM_SIZE,
 };
+use crate::event_dispatcher::send_request;
 
 /// The number of bitcoin blocks that can have
 ///  passed since the UTXO cache was last refreshed before
@@ -2396,8 +2399,20 @@ pub enum RPCError {
 
 type RPCResult<T> = Result<T, RPCError>;
 
+impl From<io::Error> for RPCError {
+    fn from(ioe: io::Error) -> Self {
+        Self::Network(format!("IO Error: {:?}", &ioe))
+    }
+}
+
+impl From<NetError> for RPCError {
+    fn from(ne: NetError) -> Self {
+        Self::Network(format!("Net Error: {:?}", &ne))
+    }
+}
+
 impl BitcoinRPCRequest {
-    fn build_rpc_request(config: &Config, payload: &BitcoinRPCRequest) -> Request {
+    fn build_rpc_request(config: &Config, payload: &BitcoinRPCRequest) -> StacksHttpRequest {
         let url = {
             // some methods require a wallet ID
             let wallet_id = match payload.method.as_str() {
@@ -2412,16 +2427,35 @@ impl BitcoinRPCRequest {
             &payload.method, &config.burnchain.username, &config.burnchain.password, &url
         );
 
-        let mut req = Request::new(Method::Post, url);
+        let host = url
+            .host_str()
+            .expect("Invalid bitcoin RPC URL: missing host");
+        let port = url.port_or_known_default().unwrap_or(8333);
+        let peerhost: PeerHost = format!("{host}:{port}")
+            .parse()
+            .unwrap_or_else(|_| panic!("FATAL: could not parse URL into PeerHost"));
+
+        let mut request = StacksHttpRequest::new_for_peer(
+            peerhost,
+            "POST".into(),
+            url.path().into(),
+            HttpRequestContents::new().payload_json(
+                serde_json::to_value(payload).unwrap_or_else(|_| {
+                    panic!("FATAL: failed to encode Bitcoin RPC request as JSON")
+                }),
+            ),
+        )
+        .unwrap_or_else(|_| panic!("FATAL: failed to encode infallible data as HTTP request"));
+        request.add_header("Connection".into(), "close".into());
 
         match (&config.burnchain.username, &config.burnchain.password) {
             (Some(username), Some(password)) => {
                 let auth_token = format!("Basic {}", encode(format!("{}:{}", username, password)));
-                req.append_header("Authorization", auth_token);
+                request.add_header("Authorization".into(), auth_token);
             }
             (_, _) => {}
         };
-        req
+        request
     }
 
     #[cfg(test)]
@@ -2506,10 +2540,10 @@ impl BitcoinRPCRequest {
                     .map_err(|_| RPCError::Parsing("Failed to get bestblockhash".to_string()))?;
                 let bhh = BurnchainHeaderHash::from_hex(&bhh)
                     .map_err(|_| RPCError::Parsing("Failed to get bestblockhash".to_string()))?;
-                Ok(bhh)
+                bhh
             }
             _ => return Err(RPCError::Parsing("Failed to get UTXOs".to_string())),
-        }?;
+        };
 
         let min_conf = 0i64;
         let max_conf = 9999999i64;
@@ -2731,71 +2765,18 @@ impl BitcoinRPCRequest {
     }
 
     fn send(config: &Config, payload: BitcoinRPCRequest) -> RPCResult<serde_json::Value> {
-        let mut request = BitcoinRPCRequest::build_rpc_request(&config, &payload);
+        let request = BitcoinRPCRequest::build_rpc_request(&config, &payload);
+        let timeout = Duration::from_secs(60);
 
-        let body = match serde_json::to_vec(&json!(payload)) {
-            Ok(body) => body,
-            Err(err) => {
-                return Err(RPCError::Network(format!("RPC Error: {}", err)));
-            }
-        };
+        let host = request.preamble().host.hostname();
+        let port = request.preamble().host.port();
 
-        request.append_header("Content-Type", "application/json");
-        request.set_body(body);
-
-        let mut response = async_std::task::block_on(async move {
-            let stream = match TcpStream::connect(config.burnchain.get_rpc_socket_addr()).await {
-                Ok(stream) => stream,
-                Err(err) => {
-                    return Err(RPCError::Network(format!(
-                        "Bitcoin RPC: connection failed - {:?}",
-                        err
-                    )))
-                }
-            };
-
-            match client::connect(stream, request).await {
-                Ok(response) => Ok(response),
-                Err(err) => {
-                    return Err(RPCError::Network(format!(
-                        "Bitcoin RPC: invoking procedure failed - {:?}",
-                        err
-                    )))
-                }
-            }
-        })?;
-
-        let status = response.status();
-
-        let (res, buffer) = async_std::task::block_on(async move {
-            let mut buffer = Vec::new();
-            let mut body = response.take_body();
-            let res = body.read_to_end(&mut buffer).await;
-            (res, buffer)
-        });
-
-        if !status.is_success() {
-            return Err(RPCError::Network(format!(
-                "Bitcoin RPC: status({}) != success, body is '{:?}'",
-                status,
-                match serde_json::from_slice::<serde_json::Value>(&buffer[..]) {
-                    Ok(v) => v,
-                    Err(_e) => serde_json::from_str("\"(unparseable)\"")
-                        .expect("Failed to parse JSON literal"),
-                }
-            )));
+        let response = send_request(&host, port, request, timeout)?;
+        if let HttpResponsePayload::JSON(js) = response.destruct().1 {
+            return Ok(js);
+        } else {
+            return Err(RPCError::Parsing("Did not get a JSON response".into()));
         }
-
-        if res.is_err() {
-            return Err(RPCError::Network(format!(
-                "Bitcoin RPC: unable to read body - {:?}",
-                res
-            )));
-        }
-
-        let payload = serde_json::from_slice::<serde_json::Value>(&buffer[..])
-            .map_err(|e| RPCError::Parsing(format!("Bitcoin RPC: {}", e)))?;
-        Ok(payload)
     }
 }
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1,4 +1,19 @@
-use std::convert::From;
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::io::Cursor;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -36,7 +36,7 @@ use stacks::chainstate::stacks::address::PoxAddress;
 use stacks::core::{StacksEpoch, StacksEpochId};
 use stacks::monitoring::{increment_btc_blocks_received_counter, increment_btc_ops_sent_counter};
 use stacks::net::http::{HttpRequestContents, HttpResponsePayload};
-use stacks::net::httpcore::StacksHttpRequest;
+use stacks::net::httpcore::{send_http_request, StacksHttpRequest};
 use stacks::net::Error as NetError;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::deps_common::bitcoin::blockdata::opcodes;
@@ -64,7 +64,6 @@ use crate::config::{
     OP_TX_PRE_STACKS_ESTIM_SIZE, OP_TX_STACK_STX_ESTIM_SIZE, OP_TX_TRANSFER_STACKS_ESTIM_SIZE,
     OP_TX_VOTE_AGG_ESTIM_SIZE,
 };
-use crate::event_dispatcher::send_request;
 
 /// The number of bitcoin blocks that can have
 ///  passed since the UTXO cache was last refreshed before
@@ -2794,7 +2793,7 @@ impl BitcoinRPCRequest {
         let host = request.preamble().host.hostname();
         let port = request.preamble().host.port();
 
-        let response = send_request(&host, port, request, timeout)?;
+        let response = send_http_request(&host, port, request, timeout)?;
         if let HttpResponsePayload::JSON(js) = response.destruct().1 {
             return Ok(js);
         } else {

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -394,7 +394,7 @@ pub fn send_request(
     // ProtocolFamily messages from a Read, and write them to a Write.  The Read + Write is
     // (usually) a non-blocking socket; the network connection deals with EWOULDBLOCK internally,
     // as well as underfull socket buffers.
-    // 
+    //
     // Third, we need to _drive_ data to the socket.  We have to repeatedly (1) flush the network
     // handle (which contains the buffered bytes from the message to be fed into the socket), and
     // (2) drive bytes from the handle into the socket iself via the network connection.  This is a
@@ -450,9 +450,12 @@ pub fn send_request(
         if flushed && num_sent == 0 {
             break;
         }
-        
+
         if Instant::now().saturating_duration_since(start) > timeout {
-            return Err(io::Error::new(io::ErrorKind::WouldBlock, "Timed out while receiving request"));
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Timed out while receiving request",
+            ));
         }
     }
 
@@ -497,7 +500,10 @@ pub fn send_request(
         request_handle = rh;
 
         if Instant::now().saturating_duration_since(start) > timeout {
-            return Err(io::Error::new(io::ErrorKind::WouldBlock, "Timed out while receiving request"));
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Timed out while receiving request",
+            ));
         }
     }
 
@@ -1952,7 +1958,7 @@ mod test {
                 client_done_signal
                     .recv()
                     .expect("Failed to receive client done signal");
-                
+
                 // Explicitly drop the stream after signaling to ensure the client finishes
                 // NOTE: this will cause the test to slow down, since `send_request` expects
                 // `Connection: close`

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -318,7 +318,7 @@ fn send_request(
     url: &Url,
     timeout: Duration,
 ) -> Result<String, std::io::Error> {
-    let addr = format!("{}:{}", host, port)
+    let addr = format!("{host}:{port}")
         .to_socket_addrs()?
         .next()
         .ok_or_else(|| {

--- a/testnet/stacks-node/src/nakamoto_node/peer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/peer.rs
@@ -16,8 +16,8 @@
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::sync::mpsc::TrySendError;
+use std::thread;
 use std::time::Duration;
-use std::{cmp, thread};
 
 use stacks::burnchains::db::BurnchainHeaderReader;
 use stacks::burnchains::PoxConstants;


### PR DESCRIPTION
### Description

Update event dispatcher to use standard Rust to send payloads, replacing the use of async-h1 which was causing problems because `connect` cannot timeout.

### Applicable issues

- fixes #5097

### Additional info (benefits, drawbacks, caveats)

This did require manually implementing the HTTP protocol, so does open the possibility for some new errors there. I added integration tests using a tiny-http server to help verify. I've also run a local network complete with signers and API as event observers and everything works as expected.