### PR TITLE
Reuse BlockResponse slot for MockSignature message type

### DIFF
--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -185,8 +185,7 @@ impl SignerMessage {
     pub fn msg_id(&self) -> Option<MessageSlotID> {
         match self {
             Self::BlockProposal(_) | Self::BlockPushed(_) => None,
-            Self::BlockResponse(_) => Some(MessageSlotID::BlockResponse),
-            Self::MockSignature(_) => Some(MessageSlotID::MockSignature),
+            Self::BlockResponse(_) | Self::MockSignature(_) => Some(MessageSlotID::BlockResponse), // Mock signature reuses the same slot as block response since its exclusively used in Epoch 2.5
         }
     }
 }

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -2212,8 +2212,8 @@ fn mock_sign_epoch_25() {
             std::thread::sleep(Duration::from_millis(100));
             let messages: Vec<SignerMessage> = StackerDB::get_messages(
                 stackerdb
-                    .get_session_mut(&MessageSlotID::MockSignature)
-                    .expect("Failed to get BlockResponse stackerdb session"),
+                    .get_session_mut(&MessageSlotID::BlockResponse)
+                    .expect("Failed to get BlockResponse stackerdb session"), // Epoch 2.5 MockSignatures use the BlockResponse slot
                 &signer_slot_ids,
             )
             .expect("Failed to get message from stackerdb");


### PR DESCRIPTION
Primary Testnet is failing mock signing because I added a new message slot id and this stackerdb contract was never initialized so now this just reuses the BlockResponse slot as the contract already exists for it. (This is how it is done in the improved Mock Signing that will be released later)