### PR TITLE
Feat/buffer stackerdb messages

### DIFF
--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -1917,11 +1917,11 @@ impl ConversationP2P {
     /// Generates a Nack if we don't have this DB, or if the request's consensus hash is invalid.
     fn make_stacker_db_getchunkinv_response(
         network: &PeerNetwork,
-        sortdb: &SortitionDB,
+        chainstate: &mut StacksChainState,
         getchunkinv: &StackerDBGetChunkInvData,
     ) -> Result<StacksMessageType, net_error> {
         Ok(network.make_StackerDBChunksInv_or_Nack(
-            sortdb,
+            chainstate,
             &getchunkinv.contract_id,
             &getchunkinv.rc_consensus_hash,
         ))
@@ -1932,12 +1932,15 @@ impl ConversationP2P {
     fn handle_stacker_db_getchunkinv(
         &mut self,
         network: &PeerNetwork,
-        sortdb: &SortitionDB,
+        chainstate: &mut StacksChainState,
         preamble: &Preamble,
         getchunkinv: &StackerDBGetChunkInvData,
     ) -> Result<ReplyHandleP2P, net_error> {
-        let response =
-            ConversationP2P::make_stacker_db_getchunkinv_response(network, sortdb, getchunkinv)?;
+        let response = ConversationP2P::make_stacker_db_getchunkinv_response(
+            network,
+            chainstate,
+            getchunkinv,
+        )?;
         self.sign_and_reply(
             network.get_local_peer(),
             network.get_chain_view(),
@@ -2354,7 +2357,7 @@ impl ConversationP2P {
                 }
             }
             StacksMessageType::StackerDBGetChunkInv(ref getchunkinv) => {
-                self.handle_stacker_db_getchunkinv(network, sortdb, &msg.preamble, getchunkinv)
+                self.handle_stacker_db_getchunkinv(network, chainstate, &msg.preamble, getchunkinv)
             }
             StacksMessageType::StackerDBGetChunk(ref getchunk) => {
                 self.handle_stacker_db_getchunk(network, &msg.preamble, getchunk)

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -378,11 +378,18 @@ pub struct ConnectionOptions {
     pub max_microblock_push: u64,
     pub antientropy_retry: u64,
     pub antientropy_public: bool,
+    /// maximum number of Stacks 2.x BlocksAvailable messages that can be buffered before processing
     pub max_buffered_blocks_available: u64,
+    /// maximum number of Stacks 2.x MicroblocksAvailable that can be buffered before processing
     pub max_buffered_microblocks_available: u64,
+    /// maximum number of Stacks 2.x pushed Block messages we can buffer before processing
     pub max_buffered_blocks: u64,
+    /// maximum number of Stacks 2.x pushed Microblock messages we can buffer before processing
     pub max_buffered_microblocks: u64,
+    /// maximum number of pushed Nakamoto Block messages we can buffer before processing
     pub max_buffered_nakamoto_blocks: u64,
+    /// maximum number of pushed StackerDB chunk messages we can buffer before processing
+    pub max_buffered_stackerdb_chunks: u64,
     /// how often to query a remote peer for its mempool, in seconds
     pub mempool_sync_interval: u64,
     /// how many transactions to ask for in a mempool query
@@ -522,6 +529,7 @@ impl std::default::Default for ConnectionOptions {
             max_buffered_blocks: 5,
             max_buffered_microblocks: 1024,
             max_buffered_nakamoto_blocks: 1024,
+            max_buffered_stackerdb_chunks: 4096,
             mempool_sync_interval: 30, // number of seconds in-between mempool sync
             mempool_max_tx_query: 128, // maximum number of transactions to visit per mempool query
             mempool_sync_timeout: 180, // how long a mempool sync can go for (3 minutes)

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -4616,8 +4616,11 @@ impl PeerNetwork {
             );
             let buffered_stacks_messages =
                 mem::replace(&mut self.pending_stacks_messages, HashMap::new());
-            let unhandled =
-                self.handle_unsolicited_stacks_messages(sortdb, buffered_stacks_messages, false);
+            let unhandled = self.handle_unsolicited_stacks_messages(
+                chainstate,
+                buffered_stacks_messages,
+                false,
+            );
             ret.extend(unhandled);
         }
 
@@ -4706,7 +4709,7 @@ impl PeerNetwork {
         );
 
         let unhandled_messages =
-            self.handle_unsolicited_stacks_messages(sortdb, unhandled_messages, true);
+            self.handle_unsolicited_stacks_messages(chainstate, unhandled_messages, true);
 
         network_result.consume_unsolicited(unhandled_messages);
 

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -497,11 +497,16 @@ impl PeerNetwork {
         Ok(results)
     }
 
-    /// Create a StackerDBChunksInv, or a Nack if the requested DB isn't replicated here
+    /// Create a StackerDBChunksInv, or a Nack if the requested DB isn't replicated here.
+    /// Runs in response to a received StackerDBGetChunksInv or a StackerDBPushChunk
     pub fn make_StackerDBChunksInv_or_Nack(
         &self,
+        sortdb: &SortitionDB,
         contract_id: &QualifiedContractIdentifier,
+        rc_consensus_hash: &ConsensusHash,
     ) -> StacksMessageType {
+        // N.B. check that the DB exists first, since we want to report StaleView only if the DB
+        // exists
         let slot_versions = match self.stackerdbs.get_slot_versions(contract_id) {
             Ok(versions) => versions,
             Err(e) => {
@@ -516,6 +521,20 @@ impl PeerNetwork {
                 return StacksMessageType::Nack(NackData::new(NackErrorCodes::NoSuchDB));
             }
         };
+
+        // this DB exists, but is the view of this message recent?
+        if &self.get_chain_view().rc_consensus_hash != rc_consensus_hash {
+            // do we know about this consensus hash?
+            if let Ok(true) =
+                SortitionDB::has_block_snapshot_consensus(sortdb.conn(), rc_consensus_hash)
+            {
+                debug!("{:?}: NACK StackerDBGetChunksInv / StackerDBPushChunk since {} != {} (remote is stale)", self.get_local_peer(), &self.get_chain_view().rc_consensus_hash, rc_consensus_hash);
+                return StacksMessageType::Nack(NackData::new(NackErrorCodes::StaleView));
+            } else {
+                debug!("{:?}: NACK StackerDBGetChunksInv / StackerDBPushChunk since {} != {} (local is potentially stale)", self.get_local_peer(), &self.get_chain_view().rc_consensus_hash, rc_consensus_hash);
+                return StacksMessageType::Nack(NackData::new(NackErrorCodes::FutureView));
+            }
+        }
 
         let num_outbound_replicas = self.count_outbound_stackerdb_replicas(contract_id) as u32;
 
@@ -598,8 +617,11 @@ impl PeerNetwork {
     }
 
     /// Handle unsolicited StackerDBPushChunk messages.
-    /// Generate a reply handle for a StackerDBChunksInv to be sent to the remote peer, in which
-    /// the inventory vector is updated with this chunk's data.
+    /// Check to see that the message can be stored or buffered.
+    ///
+    /// Optionally, make a reply handle for a StackerDBChunksInv to be sent to the remote peer, in which
+    /// the inventory vector is updated with this chunk's data.  Or, send a NACK if the chunk
+    /// cannot be buffered or stored.
     ///
     /// Note that this can happen *during* a StackerDB sync's execution, so be very careful about
     /// modifying a state machine's contents!  The only modification possible here is to wakeup
@@ -609,17 +631,30 @@ impl PeerNetwork {
     /// which this chunk arrived will have already bandwidth-throttled the remote peer, and because
     /// messages can be arbitrarily delayed (and bunched up) by the network anyway.
     ///
-    /// Return Ok(true) if we should store the chunk
-    /// Return Ok(false) if we should drop it.
+    /// Returns (true, x) if we should buffer the message and try processing it again later.
+    /// Returns (false, x) if we should *not* buffer this message, because it either *won't* be valid
+    /// later, or if it can be stored right now.
+    ///
+    /// Returns (x, true) if we should forward the message to the relayer, so it can be processed.
+    /// Returns (x, false) if we should *not* forward the message to the relayer, because it will
+    /// *not* be processed.
     pub fn handle_unsolicited_StackerDBPushChunk(
         &mut self,
+        sortdb: &SortitionDB,
         event_id: usize,
         preamble: &Preamble,
         chunk_data: &StackerDBPushChunkData,
-    ) -> Result<bool, net_error> {
-        let mut payload = self.make_StackerDBChunksInv_or_Nack(&chunk_data.contract_id);
+        send_reply: bool,
+    ) -> Result<(bool, bool), net_error> {
+        let mut payload = self.make_StackerDBChunksInv_or_Nack(
+            sortdb,
+            &chunk_data.contract_id,
+            &chunk_data.rc_consensus_hash,
+        );
         match payload {
             StacksMessageType::StackerDBChunkInv(ref mut data) => {
+                // this message corresponds to an existing DB, and comes from the same view of the
+                // stacks chain tip
                 let stackerdb_config = if let Some(config) =
                     self.get_stacker_db_configs().get(&chunk_data.contract_id)
                 {
@@ -630,7 +665,7 @@ impl PeerNetwork {
                         "StackerDBChunk for {} ID {} is not available locally",
                         &chunk_data.contract_id, chunk_data.chunk_data.slot_id
                     );
-                    return Ok(false);
+                    return Ok((false, false));
                 };
 
                 // sanity check
@@ -640,7 +675,7 @@ impl PeerNetwork {
                     &chunk_data.chunk_data,
                     &data.slot_versions,
                 )? {
-                    return Ok(false);
+                    return Ok((false, false));
                 }
 
                 // patch inventory -- we'll accept this chunk
@@ -654,10 +689,28 @@ impl PeerNetwork {
                     }
                 }
             }
-            _ => {}
+            StacksMessageType::Nack(ref nack_data) => {
+                if nack_data.error_code == NackErrorCodes::FutureView {
+                    // chunk corresponds to a known DB but the view of the sender is potentially in
+                    // the future.
+                    // We should buffer this in case it becomes storable, but don't
+                    // store it yet.
+                    return Ok((true, false));
+                } else {
+                    return Ok((false, false));
+                }
+            }
+            _ => {
+                // don't recognize the message, so don't buffer
+                return Ok((false, false));
+            }
         }
 
-        // this is a reply to the pushed chunk
+        if !send_reply {
+            return Ok((false, true));
+        }
+
+        // this is a reply to the pushed chunk, and we can store it right now (so don't buffer it)
         let resp = self.sign_for_p2p_reply(event_id, preamble.seq, payload)?;
         let handle = self.send_p2p_message(
             event_id,
@@ -665,6 +718,6 @@ impl PeerNetwork {
             self.connection_opts.neighbor_request_timeout,
         )?;
         self.add_relay_handle(event_id, handle);
-        Ok(true)
+        Ok((false, true))
     }
 }

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -729,7 +729,9 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                         data.error_code
                     );
                     self.connected_replicas.remove(&naddr);
-                    if data.error_code == NackErrorCodes::StaleView {
+                    if data.error_code == NackErrorCodes::StaleView
+                        || data.error_code == NackErrorCodes::FutureView
+                    {
                         self.stale_neighbors.insert(naddr);
                     }
                     continue;
@@ -846,7 +848,9 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                         data.error_code
                     );
                     self.connected_replicas.remove(&naddr);
-                    if data.error_code == NackErrorCodes::StaleView {
+                    if data.error_code == NackErrorCodes::StaleView
+                        || data.error_code == NackErrorCodes::FutureView
+                    {
                         self.stale_neighbors.insert(naddr);
                     }
                     continue;
@@ -983,7 +987,9 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                         &self.smart_contract_id,
                         data.error_code
                     );
-                    if data.error_code == NackErrorCodes::StaleView {
+                    if data.error_code == NackErrorCodes::StaleView
+                        || data.error_code == NackErrorCodes::FutureView
+                    {
                         self.stale_neighbors.insert(naddr);
                     } else if data.error_code == NackErrorCodes::StaleVersion {
                         // try again immediately, without throttling
@@ -1129,7 +1135,9 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                         &naddr,
                         data.error_code
                     );
-                    if data.error_code == NackErrorCodes::StaleView {
+                    if data.error_code == NackErrorCodes::StaleView
+                        || data.error_code == NackErrorCodes::FutureView
+                    {
                         self.stale_neighbors.insert(naddr);
                     }
                     continue;

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -862,7 +862,7 @@ fn test_stackerdb_push_relayer_late_chunks() {
         peer_2_config.add_neighbor(&peer_3_config.to_neighbor());
         peer_3_config.add_neighbor(&peer_2_config.to_neighbor());
 
-        // set up stacker DBs for both peers
+        // set up stacker DBs for all peers
         let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::template()));
         let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::template()));
         let idx_3 = add_stackerdb(&mut peer_3_config, Some(StackerDBConfig::template()));

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -32,6 +32,7 @@ use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PrivateKey};
 
 use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::stacks::db::StacksChainState;
 use crate::net::p2p::PeerNetwork;
 use crate::net::relay::Relayer;
 use crate::net::stackerdb::db::SlotValidation;
@@ -823,6 +824,216 @@ fn test_stackerdb_push_relayer() {
             i += 1;
 
             debug!("StackerDB sync step {}", i);
+        }
+
+        debug!("Completed stacker DB sync in {} step(s)", i);
+    })
+}
+
+/// Verify that the relayer will push stackerdb chunks, AND, those chunks will get buffered if the
+/// recipient has not yet processed the sortition.
+/// Replica A has the data.
+/// Replica B receives the data via StackerDB sync
+/// Replica C receives the data from B's relayer pushes, but is not yet at the Stacks tip that A
+/// and B are on.
+/// Replica C processes them all when the Stacks tip advances
+#[test]
+fn test_stackerdb_push_relayer_late_chunks() {
+    with_timeout(600, move || {
+        std::env::set_var("STACKS_TEST_DISABLE_EDGE_TRIGGER_TEST", "1");
+        let mut peer_1_config = TestPeerConfig::from_port(BASE_PORT + 106);
+        let mut peer_2_config = TestPeerConfig::from_port(BASE_PORT + 108);
+        let mut peer_3_config = TestPeerConfig::from_port(BASE_PORT + 110);
+
+        peer_1_config.allowed = -1;
+        peer_2_config.allowed = -1;
+        peer_3_config.allowed = -1;
+
+        // short-lived walks...
+        peer_1_config.connection_opts.walk_max_duration = 10;
+        peer_2_config.connection_opts.walk_max_duration = 10;
+        peer_3_config.connection_opts.walk_max_duration = 10;
+
+        peer_3_config.connection_opts.disable_stackerdb_sync = true;
+
+        // peer 1 crawls peer 2, and peer 2 crawls peer 1 and peer 3, and peer 3 crawls peer 2
+        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_3_config.to_neighbor());
+        peer_3_config.add_neighbor(&peer_2_config.to_neighbor());
+
+        // set up stacker DBs for both peers
+        let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::template()));
+        let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::template()));
+        let idx_3 = add_stackerdb(&mut peer_3_config, Some(StackerDBConfig::template()));
+
+        let mut peer_1 = TestPeer::new(peer_1_config);
+        let mut peer_2 = TestPeer::new(peer_2_config);
+        let mut peer_3 = TestPeer::new(peer_3_config);
+
+        // advance peers 1 and 2, but not 3
+        let mut peer_1_nonce = 0;
+        let mut peer_2_nonce = 0;
+        let mut peer_3_nonce = 0;
+        peer_1.tenure_with_txs(&vec![], &mut peer_1_nonce);
+        peer_2.tenure_with_txs(&vec![], &mut peer_2_nonce);
+
+        // sanity check -- peer 1 and 2 are at the same tip, but not 3
+        let sn1 = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb().conn()).unwrap();
+        let sn2 = SortitionDB::get_canonical_burn_chain_tip(peer_2.sortdb().conn()).unwrap();
+        let sn3 = SortitionDB::get_canonical_burn_chain_tip(peer_3.sortdb().conn()).unwrap();
+        assert_eq!(sn1.consensus_hash, sn2.consensus_hash);
+        assert_eq!(sn1.block_height, sn2.block_height);
+
+        assert_ne!(sn1.consensus_hash, sn3.consensus_hash);
+        assert_ne!(sn2.consensus_hash, sn3.consensus_hash);
+        assert!(sn3.block_height < sn1.block_height);
+        assert!(sn3.block_height < sn2.block_height);
+
+        let st1 = SortitionDB::get_canonical_stacks_chain_tip_hash(peer_1.sortdb().conn()).unwrap();
+        let st2 = SortitionDB::get_canonical_stacks_chain_tip_hash(peer_2.sortdb().conn()).unwrap();
+        let st3 = SortitionDB::get_canonical_stacks_chain_tip_hash(peer_3.sortdb().conn()).unwrap();
+
+        assert_eq!(st1, st2);
+        assert_ne!(st1, st3);
+        assert_ne!(st2, st3);
+
+        // peer 1 gets the DB
+        setup_stackerdb(&mut peer_1, idx_1, true, 10);
+        setup_stackerdb(&mut peer_2, idx_2, false, 10);
+        setup_stackerdb(&mut peer_3, idx_2, false, 10);
+
+        // verify that peer 1 got the data
+        let peer_1_db_chunks = load_stackerdb(&peer_1, idx_1);
+        assert_eq!(peer_1_db_chunks.len(), 10);
+        for i in 0..10 {
+            assert_eq!(peer_1_db_chunks[i].0.slot_id, i as u32);
+            assert_eq!(peer_1_db_chunks[i].0.slot_version, 1);
+            assert!(peer_1_db_chunks[i].1.len() > 0);
+        }
+
+        // verify that peer 2 and 3 did NOT get the data
+        let peer_2_db_chunks = load_stackerdb(&peer_2, idx_2);
+        assert_eq!(peer_2_db_chunks.len(), 10);
+        for i in 0..10 {
+            assert_eq!(peer_2_db_chunks[i].0.slot_id, i as u32);
+            assert_eq!(peer_2_db_chunks[i].0.slot_version, 0);
+            assert!(peer_2_db_chunks[i].1.len() == 0);
+        }
+
+        let peer_3_db_chunks = load_stackerdb(&peer_3, idx_2);
+        assert_eq!(peer_3_db_chunks.len(), 10);
+        for i in 0..10 {
+            assert_eq!(peer_3_db_chunks[i].0.slot_id, i as u32);
+            assert_eq!(peer_3_db_chunks[i].0.slot_version, 0);
+            assert!(peer_3_db_chunks[i].1.len() == 0);
+        }
+
+        let peer_1_db_configs = peer_1.config.get_stacker_db_configs();
+        let peer_2_db_configs = peer_2.config.get_stacker_db_configs();
+        let peer_3_db_configs = peer_3.config.get_stacker_db_configs();
+
+        let mut i = 0;
+        let mut advanced_tenure = false;
+        loop {
+            // run peer network state-machines
+            peer_1.network.stacker_db_configs = peer_1_db_configs.clone();
+            peer_2.network.stacker_db_configs = peer_2_db_configs.clone();
+            peer_3.network.stacker_db_configs = peer_3_db_configs.clone();
+
+            let res_1 = peer_1.step_with_ibd(false);
+            let res_2 = peer_2.step_with_ibd(false);
+            let res_3 = peer_3.step_with_ibd(false);
+
+            if let Ok(res) = res_1 {
+                check_sync_results(&res);
+                peer_1
+                    .relayer
+                    .process_stacker_db_chunks(
+                        &peer_1.network.get_chain_view().rc_consensus_hash,
+                        &peer_1_db_configs,
+                        res.stacker_db_sync_results,
+                        None,
+                    )
+                    .unwrap();
+                peer_1
+                    .relayer
+                    .process_pushed_stacker_db_chunks(
+                        &peer_1.network.get_chain_view().rc_consensus_hash,
+                        &peer_1_db_configs,
+                        res.pushed_stackerdb_chunks,
+                        None,
+                    )
+                    .unwrap();
+            }
+
+            if let Ok(res) = res_2 {
+                check_sync_results(&res);
+                peer_2
+                    .relayer
+                    .process_stacker_db_chunks(
+                        &peer_2.network.get_chain_view().rc_consensus_hash,
+                        &peer_2_db_configs,
+                        res.stacker_db_sync_results,
+                        None,
+                    )
+                    .unwrap();
+                peer_2
+                    .relayer
+                    .process_pushed_stacker_db_chunks(
+                        &peer_2.network.get_chain_view().rc_consensus_hash,
+                        &peer_2_db_configs,
+                        res.pushed_stackerdb_chunks,
+                        None,
+                    )
+                    .unwrap();
+            }
+
+            if let Ok(res) = res_3 {
+                check_sync_results(&res);
+                peer_3
+                    .relayer
+                    .process_stacker_db_chunks(
+                        &peer_3.network.get_chain_view().rc_consensus_hash,
+                        &peer_3_db_configs,
+                        res.stacker_db_sync_results,
+                        None,
+                    )
+                    .unwrap();
+                peer_3
+                    .relayer
+                    .process_pushed_stacker_db_chunks(
+                        &peer_3.network.get_chain_view().rc_consensus_hash,
+                        &peer_3_db_configs,
+                        res.pushed_stackerdb_chunks,
+                        None,
+                    )
+                    .unwrap();
+            }
+
+            let db1 = load_stackerdb(&peer_1, idx_1);
+            let db2 = load_stackerdb(&peer_2, idx_2);
+            let db3 = load_stackerdb(&peer_3, idx_3);
+
+            if db1 == db2 && db2 == db3 {
+                break;
+            }
+            i += 1;
+
+            debug!("StackerDB sync step {}", i);
+
+            let num_pending = peer_3
+                .network
+                .pending_stacks_messages
+                .iter()
+                .fold(0, |acc, (_, msgs)| acc + msgs.len());
+            debug!("peer_3.network.pending_stacks_messages: {}", num_pending);
+
+            if num_pending >= 10 && !advanced_tenure {
+                debug!("======= Advancing peer 3 tenure ========");
+                peer_3.tenure_with_txs(&vec![], &mut peer_3_nonce);
+                advanced_tenure = true;
+            }
         }
 
         debug!("Completed stacker DB sync in {} step(s)", i);

--- a/stackslib/src/net/tests/relay/epoch2x.rs
+++ b/stackslib/src/net/tests/relay/epoch2x.rs
@@ -2592,7 +2592,9 @@ fn test_get_blocks_and_microblocks_2_peers_buffered_messages() {
                             ret
                         };
                         let mut update_sortition = false;
-                        for (event_id, pending) in peers[1].network.pending_messages.iter() {
+                        for ((event_id, _neighbor_key), pending) in
+                            peers[1].network.pending_messages.iter()
+                        {
                             debug!("Pending at {} is ({}, {})", *i, event_id, pending.len());
                             if pending.len() >= 1 {
                                 update_sortition = true;
@@ -3086,7 +3088,7 @@ fn process_new_blocks_rejects_problematic_asts() {
         },
     ];
     let mut unsolicited = HashMap::new();
-    unsolicited.insert(nk.clone(), bad_msgs.clone());
+    unsolicited.insert((1, nk.clone()), bad_msgs.clone());
 
     let mut network_result = NetworkResult::new(
         peer.network.stacks_tip.block_id(),

--- a/stackslib/src/net/tests/relay/nakamoto.rs
+++ b/stackslib/src/net/tests/relay/nakamoto.rs
@@ -388,6 +388,7 @@ fn test_buffer_data_message() {
     let (mut peer, _followers) =
         make_nakamoto_peers_from_invs(function_name!(), &observer, 10, 5, bitvecs.clone(), 1);
 
+    let peer_nk = peer.to_neighbor().addr;
     let nakamoto_block = NakamotoBlock {
         header: NakamotoBlockHeader {
             version: 1,
@@ -472,43 +473,89 @@ fn test_buffer_data_message() {
             blocks: vec![nakamoto_block],
         }),
     );
+    let stackerdb_chunk = StacksMessage::new(
+        1,
+        1,
+        1,
+        &BurnchainHeaderHash([0x01; 32]),
+        7,
+        &BurnchainHeaderHash([0x07; 32]),
+        StacksMessageType::StackerDBPushChunk(StackerDBPushChunkData {
+            contract_id: QualifiedContractIdentifier::parse(
+                "ST000000000000000000002AMW42H.signers-1-4",
+            )
+            .unwrap(),
+            rc_consensus_hash: ConsensusHash([0x01; 20]),
+            chunk_data: StackerDBChunkData {
+                slot_id: 0,
+                slot_version: 1,
+                sig: MessageSignature::empty(),
+                data: vec![1, 2, 3, 4, 5],
+            },
+        }),
+    );
 
     for _ in 0..peer.network.connection_opts.max_buffered_blocks_available {
         assert!(peer
             .network
-            .buffer_data_message(0, blocks_available.clone()));
+            .buffer_sortition_data_message(0, &peer_nk, blocks_available.clone()));
     }
     assert!(!peer
         .network
-        .buffer_data_message(0, blocks_available.clone()));
+        .buffer_sortition_data_message(0, &peer_nk, blocks_available.clone()));
 
     for _ in 0..peer
         .network
         .connection_opts
         .max_buffered_microblocks_available
     {
+        assert!(peer.network.buffer_sortition_data_message(
+            0,
+            &peer_nk,
+            microblocks_available.clone()
+        ));
+    }
+    assert!(!peer.network.buffer_sortition_data_message(
+        0,
+        &peer_nk,
+        microblocks_available.clone()
+    ));
+
+    for _ in 0..peer.network.connection_opts.max_buffered_blocks {
         assert!(peer
             .network
-            .buffer_data_message(0, microblocks_available.clone()));
+            .buffer_sortition_data_message(0, &peer_nk, block.clone()));
     }
     assert!(!peer
         .network
-        .buffer_data_message(0, microblocks_available.clone()));
-
-    for _ in 0..peer.network.connection_opts.max_buffered_blocks {
-        assert!(peer.network.buffer_data_message(0, block.clone()));
-    }
-    assert!(!peer.network.buffer_data_message(0, block.clone()));
+        .buffer_sortition_data_message(0, &peer_nk, block.clone()));
 
     for _ in 0..peer.network.connection_opts.max_buffered_microblocks {
-        assert!(peer.network.buffer_data_message(0, microblocks.clone()));
+        assert!(peer
+            .network
+            .buffer_sortition_data_message(0, &peer_nk, microblocks.clone()));
     }
-    assert!(!peer.network.buffer_data_message(0, microblocks.clone()));
+    assert!(!peer
+        .network
+        .buffer_sortition_data_message(0, &peer_nk, microblocks.clone()));
 
     for _ in 0..peer.network.connection_opts.max_buffered_nakamoto_blocks {
-        assert!(peer.network.buffer_data_message(0, nakamoto_block.clone()));
+        assert!(peer
+            .network
+            .buffer_sortition_data_message(0, &peer_nk, nakamoto_block.clone()));
     }
-    assert!(!peer.network.buffer_data_message(0, nakamoto_block.clone()));
+    assert!(!peer
+        .network
+        .buffer_sortition_data_message(0, &peer_nk, nakamoto_block.clone()));
+
+    for _ in 0..peer.network.connection_opts.max_buffered_stackerdb_chunks {
+        assert!(peer
+            .network
+            .buffer_stacks_data_message(0, &peer_nk, stackerdb_chunk.clone()));
+    }
+    assert!(!peer
+        .network
+        .buffer_stacks_data_message(0, &peer_nk, stackerdb_chunk.clone()));
 }
 
 /// Verify that Nakmaoto blocks whose sortitions are known will *not* be buffered, but instead
@@ -686,7 +733,7 @@ fn test_no_buffer_ready_nakamoto_blocks() {
                             blocks: blocks.clone(),
                         }),
                     );
-                    unsolicited.insert(peer_nk.clone(), vec![msg]);
+                    unsolicited.insert((1, peer_nk.clone()), vec![msg]);
 
                     if let Some(mut network_result) = network_result.take() {
                         network_result.consume_unsolicited(unsolicited);
@@ -882,7 +929,8 @@ fn test_buffer_nonready_nakamoto_blocks() {
 
                     // pass this and other blocks to the p2p network's unsolicited message handler,
                     // so they can be buffered up and processed.
-                    let mut unsolicited_msgs: HashMap<usize, Vec<StacksMessage>> = HashMap::new();
+                    let mut unsolicited_msgs: HashMap<(usize, NeighborKey), Vec<StacksMessage>> =
+                        HashMap::new();
                     for (event_id, convo) in follower.network.peers.iter() {
                         for blks in all_blocks.iter() {
                             let msg = StacksMessage::from_chain_view(
@@ -893,16 +941,17 @@ fn test_buffer_nonready_nakamoto_blocks() {
                                     blocks: blks.clone(),
                                 }),
                             );
-
-                            if let Some(msgs) = unsolicited_msgs.get_mut(event_id) {
+                            let nk = convo.to_neighbor_key();
+                            if let Some(msgs) = unsolicited_msgs.get_mut(&(*event_id, nk)) {
                                 msgs.push(msg);
                             } else {
-                                unsolicited_msgs.insert(*event_id, vec![msg]);
+                                unsolicited_msgs
+                                    .insert((*event_id, convo.to_neighbor_key()), vec![msg]);
                             }
                         }
                     }
 
-                    follower.network.handle_unsolicited_messages(
+                    follower.network.handle_unsolicited_sortition_messages(
                         &sortdb,
                         &node.chainstate,
                         unsolicited_msgs,

--- a/stackslib/src/net/unsolicited.rs
+++ b/stackslib/src/net/unsolicited.rs
@@ -22,7 +22,7 @@ use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::nakamoto::NakamotoBlock;
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::{Error as ChainstateError, StacksBlockHeader};
-use crate::net::p2p::{PeerNetwork, PeerNetworkWorkState};
+use crate::net::p2p::{PeerNetwork, PeerNetworkWorkState, PendingMessages};
 use crate::net::{
     BlocksAvailableData, BlocksData, BlocksDatum, Error as NetError, MicroblocksData,
     NakamotoBlocksData, NeighborKey, Preamble, StacksMessage, StacksMessageType,
@@ -62,7 +62,7 @@ impl PeerNetwork {
         else {
             test_debug!(
                 "{:?}: No such neighbor event={}",
-                &self.local_peer,
+                &self.get_local_peer(),
                 event_id
             );
             return None;
@@ -72,7 +72,7 @@ impl PeerNetwork {
             // drop -- a correct peer will have authenticated before sending this message
             test_debug!(
                 "{:?}: Unauthenticated neighbor {:?}",
-                &self.local_peer,
+                &self.get_local_peer(),
                 &remote_neighbor_key
             );
             return None;
@@ -116,7 +116,9 @@ impl PeerNetwork {
             Ok(None) => {
                 debug!(
                     "{:?}: We already know the inventory state in {} for {}",
-                    &self.local_peer, outbound_neighbor_key, consensus_hash
+                    &self.get_local_peer(),
+                    outbound_neighbor_key,
+                    consensus_hash
                 );
                 return Ok(None);
             }
@@ -124,12 +126,12 @@ impl PeerNetwork {
                 // is this remote node simply ahead of us?
                 if let Some(convo) = self.peers.get(&event_id) {
                     if self.chain_view.burn_block_height < convo.burnchain_tip_height {
-                        debug!("{:?}: Unrecognized consensus hash {}; it is possible that {} is ahead of us", &self.local_peer, consensus_hash, outbound_neighbor_key);
+                        debug!("{:?}: Unrecognized consensus hash {}; it is possible that {} is ahead of us", &self.get_local_peer(), consensus_hash, outbound_neighbor_key);
                         return Err(NetError::NotFoundError);
                     }
                 }
                 // not ahead of us -- it's a bad consensus hash
-                debug!("{:?}: Unrecognized consensus hash {}; assuming that {} has a different chain view", &self.local_peer, consensus_hash, outbound_neighbor_key);
+                debug!("{:?}: Unrecognized consensus hash {}; assuming that {} has a different chain view", &self.get_local_peer(), consensus_hash, outbound_neighbor_key);
                 return Ok(None);
             }
             Err(NetError::InvalidMessage) => {
@@ -178,6 +180,7 @@ impl PeerNetwork {
         let mut blocks_data = 0;
         let mut microblocks_data = 0;
         let mut nakamoto_blocks_data = 0;
+        let mut stackerdb_chunks_data = 0;
         for stored_msg in msgs.iter() {
             match &stored_msg.payload {
                 StacksMessageType::BlocksAvailable(_) => {
@@ -187,7 +190,7 @@ impl PeerNetwork {
                     {
                         debug!(
                             "{:?}: Cannot buffer BlocksAvailable from event {} -- already have {} buffered",
-                            &self.local_peer, event_id, blocks_available
+                            &self.get_local_peer(), event_id, blocks_available
                         );
                         return false;
                     }
@@ -200,7 +203,7 @@ impl PeerNetwork {
                     {
                         debug!(
                             "{:?}: Cannot buffer MicroblocksAvailable from event {} -- already have {} buffered",
-                            &self.local_peer, event_id, microblocks_available
+                            &self.get_local_peer(), event_id, microblocks_available
                         );
                         return false;
                     }
@@ -212,7 +215,7 @@ impl PeerNetwork {
                     {
                         debug!(
                             "{:?}: Cannot buffer BlocksData from event {} -- already have {} buffered",
-                            &self.local_peer, event_id, blocks_data
+                            &self.get_local_peer(), event_id, blocks_data
                         );
                         return false;
                     }
@@ -224,7 +227,7 @@ impl PeerNetwork {
                     {
                         debug!(
                             "{:?}: Cannot buffer MicroblocksData from event {} -- already have {} buffered",
-                            &self.local_peer, event_id, microblocks_data
+                            &self.get_local_peer(), event_id, microblocks_data
                         );
                         return false;
                     }
@@ -236,7 +239,20 @@ impl PeerNetwork {
                     {
                         debug!(
                             "{:?}: Cannot buffer NakamotoBlocksData from event {} -- already have {} buffered",
-                            &self.local_peer, event_id, nakamoto_blocks_data
+                            &self.get_local_peer(), event_id, nakamoto_blocks_data
+                        );
+                        return false;
+                    }
+                }
+                StacksMessageType::StackerDBPushChunk(_) => {
+                    stackerdb_chunks_data += 1;
+                    if matches!(&msg.payload, StacksMessageType::StackerDBPushChunk(..))
+                        && stackerdb_chunks_data
+                            >= self.connection_opts.max_buffered_stackerdb_chunks
+                    {
+                        debug!(
+                            "{:?}: Cannot buffer StackerDBPushChunks from event {} -- already have {} buffered",
+                            self.get_local_peer(), event_id, stackerdb_chunks_data
                         );
                         return false;
                     }
@@ -253,12 +269,19 @@ impl PeerNetwork {
     /// If there is no space for the message, then silently drop it.
     /// Returns true if buffered.
     /// Returns false if not.
-    pub(crate) fn buffer_data_message(&mut self, event_id: usize, msg: StacksMessage) -> bool {
-        let Some(msgs) = self.pending_messages.get(&event_id) else {
-            self.pending_messages.insert(event_id, vec![msg]);
+    pub(crate) fn buffer_sortition_data_message(
+        &mut self,
+        event_id: usize,
+        neighbor_key: &NeighborKey,
+        msg: StacksMessage,
+    ) -> bool {
+        let key = (event_id, neighbor_key.clone());
+        let Some(msgs) = self.pending_messages.get(&key) else {
+            self.pending_messages.insert(key.clone(), vec![msg]);
             debug!(
                 "{:?}: Event {} has 1 messages buffered",
-                &self.local_peer, event_id
+                &self.get_local_peer(),
+                event_id
             );
             return true;
         };
@@ -269,15 +292,71 @@ impl PeerNetwork {
             return false;
         }
 
-        if let Some(msgs) = self.pending_messages.get_mut(&event_id) {
+        let debug_msg = format!(
+            "{:?}: buffer message from event {} (buffered: {}): {:?}",
+            self.get_local_peer(),
+            event_id,
+            msgs.len() + 1,
+            &msg
+        );
+        if let Some(msgs) = self.pending_messages.get_mut(&key) {
             // should always be reachable
+            debug!("{}", &debug_msg);
             msgs.push(msg);
+        }
+        true
+    }
+
+    #[cfg_attr(test, mutants::skip)]
+    /// Buffer a message for re-processing once the stacks view updates.
+    /// If there is no space for the message, then silently drop it.
+    /// Returns true if buffered.
+    /// Returns false if not.
+    pub(crate) fn buffer_stacks_data_message(
+        &mut self,
+        event_id: usize,
+        neighbor_key: &NeighborKey,
+        msg: StacksMessage,
+    ) -> bool {
+        let key = (event_id, neighbor_key.clone());
+        let Some(msgs) = self.pending_stacks_messages.get(&key) else {
+            // check limits against connection opts, and if the limit is not met, then buffer up the
+            // message.
+            if !self.can_buffer_data_message(event_id, &[], &msg) {
+                return false;
+            }
             debug!(
-                "{:?}: Event {} has {} messages buffered",
-                &self.local_peer,
+                "{:?}: buffer message from event {}: {:?}",
+                self.get_local_peer(),
                 event_id,
-                msgs.len()
+                &msg
             );
+            self.pending_stacks_messages.insert(key.clone(), vec![msg]);
+            debug!(
+                "{:?}: Event {} has 1 messages buffered",
+                &self.get_local_peer(),
+                event_id
+            );
+            return true;
+        };
+
+        // check limits against connection opts, and if the limit is not met, then buffer up the
+        // message.
+        if !self.can_buffer_data_message(event_id, msgs, &msg) {
+            return false;
+        }
+
+        let debug_msg = format!(
+            "{:?}: buffer message from event {} (buffered: {}): {:?}",
+            self.get_local_peer(),
+            event_id,
+            msgs.len() + 1,
+            &msg
+        );
+        if let Some(msgs) = self.pending_stacks_messages.get_mut(&key) {
+            // should always be reachable
+            debug!("{}", &debug_msg);
+            msgs.push(msg);
         }
         true
     }
@@ -341,7 +420,7 @@ impl PeerNetwork {
 
         debug!(
             "{:?}: Process BlocksAvailable from {:?} with {} entries",
-            &self.local_peer,
+            &self.get_local_peer(),
             &outbound_neighbor_key,
             new_blocks.available.len()
         );
@@ -361,7 +440,7 @@ impl PeerNetwork {
                 }
                 Err(NetError::NotFoundError) => {
                     if buffer {
-                        debug!("{:?}: Will buffer BlocksAvailable for {} until the next burnchain view update", &self.local_peer, &consensus_hash);
+                        debug!("{:?}: Will buffer BlocksAvailable for {} until the next burnchain view update", &self.get_local_peer(), &consensus_hash);
                         to_buffer = true;
                     }
                     continue;
@@ -369,7 +448,11 @@ impl PeerNetwork {
                 Err(e) => {
                     info!(
                         "{:?}: Failed to handle BlocksAvailable({}/{}) from {}: {:?}",
-                        &self.local_peer, &consensus_hash, &block_hash, &outbound_neighbor_key, &e
+                        &self.get_local_peer(),
+                        &consensus_hash,
+                        &block_hash,
+                        &outbound_neighbor_key,
+                        &e
                     );
                     continue;
                 }
@@ -408,7 +491,7 @@ impl PeerNetwork {
 
                         // advance straight to download state if we're in inv state
                         if self.work_state == PeerNetworkWorkState::BlockInvSync {
-                            debug!("{:?}: advance directly to block download with knowledge of block sortition {}", &self.local_peer, block_sortition_height);
+                            debug!("{:?}: advance directly to block download with knowledge of block sortition {}", &self.get_local_peer(), block_sortition_height);
                         }
                         self.have_data_to_download = true;
                     }
@@ -453,7 +536,7 @@ impl PeerNetwork {
 
         debug!(
             "{:?}: Process MicroblocksAvailable from {:?} with {} entries",
-            &self.local_peer,
+            &self.get_local_peer(),
             outbound_neighbor_key,
             new_mblocks.available.len()
         );
@@ -473,7 +556,7 @@ impl PeerNetwork {
                 }
                 Err(NetError::NotFoundError) => {
                     if buffer {
-                        debug!("{:?}: Will buffer MicroblocksAvailable for {} until the next burnchain view update", &self.local_peer, &consensus_hash);
+                        debug!("{:?}: Will buffer MicroblocksAvailable for {} until the next burnchain view update", &self.get_local_peer(), &consensus_hash);
                         to_buffer = true;
                     }
                     continue;
@@ -481,7 +564,11 @@ impl PeerNetwork {
                 Err(e) => {
                     info!(
                         "{:?}: Failed to handle MicroblocksAvailable({}/{}) from {:?}: {:?}",
-                        &self.local_peer, &consensus_hash, &block_hash, &outbound_neighbor_key, &e
+                        &self.get_local_peer(),
+                        &consensus_hash,
+                        &block_hash,
+                        &outbound_neighbor_key,
+                        &e
                     );
                     continue;
                 }
@@ -516,7 +603,7 @@ impl PeerNetwork {
 
                     // advance straight to download state if we're in inv state
                     if self.work_state == PeerNetworkWorkState::BlockInvSync {
-                        debug!("{:?}: advance directly to block download with knowledge of microblock stream {}", &self.local_peer, mblock_sortition_height);
+                        debug!("{:?}: advance directly to block download with knowledge of microblock stream {}", &self.get_local_peer(), mblock_sortition_height);
                     }
                     self.have_data_to_download = true;
                 }
@@ -551,7 +638,7 @@ impl PeerNetwork {
 
         debug!(
             "{:?}: Process BlocksData from {:?} with {} entries",
-            &self.local_peer,
+            &self.get_local_peer(),
             outbound_neighbor_key_opt
                 .clone()
                 .or_else(|| { self.check_peer_authenticated(event_id) }),
@@ -570,7 +657,7 @@ impl PeerNetwork {
                     if buffer {
                         debug!(
                             "{:?}: Will buffer unsolicited BlocksData({}/{}) ({}) -- consensus hash not (yet) recognized",
-                            &self.local_peer,
+                            &self.get_local_peer(),
                             &consensus_hash,
                             &block.block_hash(),
                             StacksBlockHeader::make_index_block_hash(
@@ -582,7 +669,7 @@ impl PeerNetwork {
                     } else {
                         debug!(
                             "{:?}: Will drop unsolicited BlocksData({}/{}) ({}) -- consensus hash not (yet) recognized",
-                            &self.local_peer,
+                            &self.get_local_peer(),
                             &consensus_hash,
                             &block.block_hash(),
                             StacksBlockHeader::make_index_block_hash(
@@ -596,7 +683,9 @@ impl PeerNetwork {
                 Err(e) => {
                     info!(
                         "{:?}: Failed to query block snapshot for {}: {:?}",
-                        &self.local_peer, consensus_hash, &e
+                        &self.get_local_peer(),
+                        consensus_hash,
+                        &e
                     );
                     continue;
                 }
@@ -605,7 +694,8 @@ impl PeerNetwork {
             if !sn.pox_valid {
                 info!(
                     "{:?}: Failed to query snapshot for {}: not on the valid PoX fork",
-                    &self.local_peer, consensus_hash
+                    &self.get_local_peer(),
+                    consensus_hash
                 );
                 continue;
             }
@@ -613,7 +703,7 @@ impl PeerNetwork {
             if sn.winning_stacks_block_hash != block.block_hash() {
                 info!(
                     "{:?}: Ignoring block {} -- winning block was {} (sortition: {})",
-                    &self.local_peer,
+                    &self.get_local_peer(),
                     block.block_hash(),
                     sn.winning_stacks_block_hash,
                     sn.sortition
@@ -667,7 +757,7 @@ impl PeerNetwork {
 
         debug!(
             "{:?}: Process MicroblocksData from {:?} for {} with {} entries",
-            &self.local_peer,
+            &self.get_local_peer(),
             outbound_neighbor_key_opt.or_else(|| { self.check_peer_authenticated(event_id) }),
             &new_microblocks.index_anchor_block,
             new_microblocks.microblocks.len()
@@ -677,20 +767,22 @@ impl PeerNetwork {
         match chainstate.get_block_header_hashes(&new_microblocks.index_anchor_block) {
             Ok(Some(_)) => {
                 // yup; can process now
-                debug!("{:?}: have microblock parent anchored block {}, so can process its microblocks", &self.local_peer, &new_microblocks.index_anchor_block);
+                debug!("{:?}: have microblock parent anchored block {}, so can process its microblocks", &self.get_local_peer(), &new_microblocks.index_anchor_block);
                 !buffer
             }
             Ok(None) => {
                 if buffer {
                     debug!(
                         "{:?}: Will buffer unsolicited MicroblocksData({})",
-                        &self.local_peer, &new_microblocks.index_anchor_block
+                        &self.get_local_peer(),
+                        &new_microblocks.index_anchor_block
                     );
                     true
                 } else {
                     debug!(
                         "{:?}: Will not buffer unsolicited MicroblocksData({})",
-                        &self.local_peer, &new_microblocks.index_anchor_block
+                        &self.get_local_peer(),
+                        &new_microblocks.index_anchor_block
                     );
                     false
                 }
@@ -698,7 +790,9 @@ impl PeerNetwork {
             Err(e) => {
                 warn!(
                     "{:?}: Failed to get header hashes for {:?}: {:?}",
-                    &self.local_peer, &new_microblocks.index_anchor_block, &e
+                    &self.get_local_peer(),
+                    &new_microblocks.index_anchor_block,
+                    &e
                 );
                 false
             }
@@ -811,7 +905,7 @@ impl PeerNetwork {
         {
             debug!(
                 "{:?}: Aleady have Nakamoto block {}",
-                &self.local_peer,
+                &self.get_local_peer(),
                 &nakamoto_block.block_id()
             );
             return false;
@@ -850,7 +944,7 @@ impl PeerNetwork {
     ) -> bool {
         debug!(
             "{:?}: Process NakamotoBlocksData from {:?} with {} entries",
-            &self.local_peer,
+            &self.get_local_peer(),
             &remote_neighbor_key_opt,
             nakamoto_blocks.blocks.len()
         );
@@ -860,7 +954,7 @@ impl PeerNetwork {
             if self.is_nakamoto_block_bufferable(sortdb, chainstate, nakamoto_block) {
                 debug!(
                     "{:?}: Will buffer unsolicited NakamotoBlocksData({}) ({})",
-                    &self.local_peer,
+                    &self.get_local_peer(),
                     &nakamoto_block.block_id(),
                     &nakamoto_block.header.consensus_hash,
                 );
@@ -905,7 +999,12 @@ impl PeerNetwork {
     /// Handle an unsolicited message, with either the intention of just processing it (in which
     /// case, `buffer` will be `false`), or with the intention of not only processing it, but also
     /// determining if it can be bufferred and retried later (in which case, `buffer` will be
-    /// `true`).
+    /// `true`).  This applies to messages that can be reprocessed after the next sortition (not
+    /// the next Stacks tenure)
+    ///
+    /// This code gets called with `buffer` set to true when the message is first received.  If
+    /// this method returns (true, x), then this code gets called with the same message a
+    /// subsequent time when the sortition changes (and in that case, `buffer` will be false).
     ///
     /// Returns (true, x) if we should buffer the message and try processing it again later.
     /// Returns (false, x) if we should *not* buffer this message, because it *won't* be valid
@@ -914,12 +1013,11 @@ impl PeerNetwork {
     /// Returns (x, true) if we should forward the message to the relayer, so it can be processed.
     /// Returns (x, false) if we should *not* forward the message to the relayer, because it will
     /// *not* be processed.
-    fn handle_unsolicited_message(
+    fn handle_unsolicited_sortition_message(
         &mut self,
         sortdb: &SortitionDB,
         chainstate: &StacksChainState,
         event_id: usize,
-        preamble: &Preamble,
         payload: &StacksMessageType,
         ibd: bool,
         buffer: bool,
@@ -984,29 +1082,115 @@ impl PeerNetwork {
 
                 (to_buffer, true)
             }
+            _ => (false, true),
+        }
+    }
+
+    #[cfg_attr(test, mutants::skip)]
+    /// Handle an unsolicited message, with either the intention of just processing it (in which
+    /// case, `buffer` will be `false`), or with the intention of not only processing it, but also
+    /// determining if it can be bufferred and retried later (in which case, `buffer` will be
+    /// `true`).  This applies to messages that can be reprocessed after the next Stacks tenure.
+    ///
+    /// This code gets called with `buffer` set to true when the message is first received.  If
+    /// this method returns (true, x), then this code gets called with the same message a
+    /// subsequent time when the sortition changes (and in that case, `buffer` will be false).
+    ///
+    /// Returns (true, x) if we should buffer the message and try processing it again later.
+    /// Returns (false, x) if we should *not* buffer this message, because it *won't* be valid
+    /// later.
+    ///
+    /// Returns (x, true) if we should forward the message to the relayer, so it can be processed.
+    /// Returns (x, false) if we should *not* forward the message to the relayer, because it will
+    /// *not* be processed.
+    fn handle_unsolicited_stacks_message(
+        &mut self,
+        chainstate: &mut StacksChainState,
+        event_id: usize,
+        preamble: &Preamble,
+        payload: &StacksMessageType,
+        buffer: bool,
+    ) -> (bool, bool) {
+        match payload {
             StacksMessageType::StackerDBPushChunk(ref data) => {
-                match self.handle_unsolicited_StackerDBPushChunk(event_id, preamble, data) {
-                    Ok(x) => {
-                        // don't buffer, but do reject if invalid
-                        (false, x)
-                    }
-                    Err(e) => {
+                // N.B. send back a reply if we're calling to buffer, since this would be the first
+                // time we're seeing this message (instead of a subsequent time on follow-up
+                // processing).
+                let (can_buffer, can_store) = self
+                    .handle_unsolicited_StackerDBPushChunk(
+                        chainstate, event_id, preamble, data, buffer,
+                    )
+                    .unwrap_or_else(|e| {
                         info!(
-                            "{:?}: failed to handle unsolicited {:?}: {:?}",
-                            &self.local_peer, payload, &e
+                            "{:?}: failed to handle unsolicited {:?} when buffer = {}: {:?}",
+                            self.get_local_peer(),
+                            payload,
+                            buffer,
+                            &e
                         );
                         (false, false)
-                    }
+                    });
+                if buffer && can_buffer && !can_store {
+                    debug!(
+                        "{:?}: Buffering {:?} to retry on next sortition",
+                        self.get_local_peer(),
+                        &payload
+                    );
                 }
+                (can_buffer, can_store)
             }
             _ => (false, true),
         }
+    }
+
+    /// Authenticate unsolicited messages -- find the address of the neighbor that sent them.
+    pub fn authenticate_unsolicited_messages(
+        &self,
+        unsolicited: HashMap<usize, Vec<StacksMessage>>,
+    ) -> PendingMessages {
+        unsolicited.into_iter().filter_map(|(event_id, messages)| {
+            if messages.len() == 0 {
+                // no messages for this event
+                return None;
+            }
+            if self.check_peer_authenticated(event_id).is_none() {
+                if cfg!(test)
+                    && self
+                        .connection_opts
+                        .test_disable_unsolicited_message_authentication
+                {
+                    test_debug!(
+                        "{:?}: skip unsolicited message authentication",
+                        &self.get_local_peer()
+                    );
+                } else {
+                    debug!("Will not handle unsolicited messages from unauthenticated or dead event {}", event_id);
+                    return None;
+                }
+            };
+            let neighbor_key = if let Some(convo) = self.peers.get(&event_id) {
+                convo.to_neighbor_key()
+            } else {
+                debug!(
+                    "{:?}: No longer such neighbor event={}, dropping {} unsolicited messages",
+                    &self.get_local_peer(),
+                    event_id,
+                    messages.len()
+                );
+                return None;
+            };
+            Some(((event_id, neighbor_key), messages))
+        })
+        .collect()
     }
 
     #[cfg_attr(test, mutants::skip)]
     /// Handle unsolicited messages propagated up to us from our ongoing ConversationP2Ps.
     /// Return messages that we couldn't handle here, but key them by neighbor, not event, so the
     /// relayer can do something useful with them.
+    ///
+    /// This applies only to messages that might be processable after the next sortition.  It does
+    /// *NOT* apply to messages that might be processable after the next tenure.
     ///
     /// Invalid messages are dropped silently, with an log message.
     ///
@@ -1016,100 +1200,126 @@ impl PeerNetwork {
     /// If `buffer` is false, then if the message handler deems the message valid, it will be
     /// forwraded to the relayer.
     ///
-    /// Returns the messages to be forward to the relayer, keyed by sender.
-    pub fn handle_unsolicited_messages(
+    /// Returns messages we could not buffer, keyed by sender and event ID.  This can be fed
+    /// directly into `handle_unsolicited_stacks_messages()`
+    pub fn handle_unsolicited_sortition_messages(
         &mut self,
         sortdb: &SortitionDB,
         chainstate: &StacksChainState,
-        unsolicited: HashMap<usize, Vec<StacksMessage>>,
+        mut unsolicited: PendingMessages,
         ibd: bool,
         buffer: bool,
-    ) -> HashMap<NeighborKey, Vec<StacksMessage>> {
-        let mut unhandled: HashMap<NeighborKey, Vec<StacksMessage>> = HashMap::new();
-        for (event_id, messages) in unsolicited.into_iter() {
-            if messages.len() == 0 {
-                // no messages for this event
-                continue;
-            }
-            if buffer && self.check_peer_authenticated(event_id).is_none() {
-                if cfg!(test)
-                    && self
-                        .connection_opts
-                        .test_disable_unsolicited_message_authentication
-                {
-                    test_debug!(
-                        "{:?}: skip unsolicited message authentication",
-                        &self.local_peer
-                    );
-                } else {
-                    // do not buffer messages from unknown peers
-                    // (but it's fine to process messages that were previosuly buffered, since the peer
-                    // may have since disconnected)
-                    debug!("Will not handle unsolicited messages from unauthenticated or dead event {}", event_id);
-                    continue;
-                }
-            };
-            let neighbor_key = if let Some(convo) = self.peers.get(&event_id) {
-                convo.to_neighbor_key()
-            } else {
-                debug!(
-                    "{:?}: No longer such neighbor event={}, dropping {} unsolicited messages",
-                    &self.local_peer,
-                    event_id,
-                    messages.len()
-                );
-                continue;
-            };
-
-            debug!("{:?}: Process {} unsolicited messages from {:?}", &self.local_peer, messages.len(), &neighbor_key; "buffer" => %buffer);
-
-            for message in messages.into_iter() {
+    ) -> HashMap<(usize, NeighborKey), Vec<StacksMessage>> {
+        unsolicited.retain(|(event_id, neighbor_key), messages| {
+            debug!("{:?}: Process {} unsolicited sortition-bound messages from {:?}", &self.get_local_peer(), messages.len(), neighbor_key; "buffer" => %buffer);
+            messages.retain(|message| {
                 if buffer
                     && !self.can_buffer_data_message(
-                        event_id,
-                        self.pending_messages.get(&event_id).unwrap_or(&vec![]),
+                        *event_id,
+                        self.pending_messages.get(&(*event_id, neighbor_key.clone())).unwrap_or(&vec![]),
                         &message,
                     )
                 {
-                    // asked to buffer, but we don't have space
-                    continue;
+                    // unable to store this due to quota being exceeded
+                    return false;
                 }
 
                 if !buffer {
                     debug!(
-                        "{:?}: Re-try handling buffered message {} from {:?}",
-                        &self.local_peer,
+                        "{:?}: Re-try handling buffered sortition-bound message {} from {:?}",
+                        &self.get_local_peer(),
                         &message.payload.get_message_description(),
                         &neighbor_key
                     );
                 }
-                let (to_buffer, relay) = self.handle_unsolicited_message(
+                let (to_buffer, relay) = self.handle_unsolicited_sortition_message(
                     sortdb,
                     chainstate,
-                    event_id,
-                    &message.preamble,
+                    *event_id,
                     &message.payload,
                     ibd,
                     buffer,
                 );
                 if buffer && to_buffer {
-                    self.buffer_data_message(event_id, message);
-                } else if relay {
+                    self.buffer_sortition_data_message(*event_id, neighbor_key, message.clone());
+                    return false;
+                }
+                if relay {
                     // forward to relayer for processing
                     debug!(
                         "{:?}: Will forward message {} from {:?} to relayer",
-                        &self.local_peer,
+                        &self.get_local_peer(),
                         &message.payload.get_message_description(),
                         &neighbor_key
                     );
-                    if let Some(msgs) = unhandled.get_mut(&neighbor_key) {
-                        msgs.push(message);
-                    } else {
-                        unhandled.insert(neighbor_key.clone(), vec![message]);
-                    }
                 }
+                true
+            });
+            messages.len() > 0
+        });
+        unsolicited
+    }
+
+    #[cfg_attr(test, mutants::skip)]
+    /// Handle unsolicited and unhandled messages returned by
+    /// `handle_unsolicited_sortition_messages()`, to see if any of them could be processed at the
+    /// start of the next Stacks tenure.  That is, the `unsolicited` map contains messages that
+    /// came from authenticated peers and do not exceed buffer quotas.
+    ///
+    /// Invalid messages are dropped silently, with a log message.
+    ///
+    /// If `buffer` is true, then this message will be buffered up and tried again in a subsequent
+    /// call if the handler for it deems the message valid.
+    ///
+    /// If `buffer` is false, then if the message handler deems the message valid, it will be
+    /// forwraded to the relayer.
+    ///
+    /// Returns messages we could not buffer, keyed by sender.
+    pub fn handle_unsolicited_stacks_messages(
+        &mut self,
+        chainstate: &mut StacksChainState,
+        mut unsolicited: PendingMessages,
+        buffer: bool,
+    ) -> HashMap<(usize, NeighborKey), Vec<StacksMessage>> {
+        unsolicited.retain(|(event_id, neighbor_key), messages| {
+            if messages.len() == 0 {
+                // no messages for this node
+                return false;
             }
-        }
-        unhandled
+            debug!("{:?}: Process {} unsolicited tenure-bound messages from {:?}", &self.get_local_peer(), messages.len(), &neighbor_key; "buffer" => %buffer);
+            messages.retain(|message| {
+                if !buffer {
+                    debug!(
+                        "{:?}: Re-try handling buffered tenure-bound message {} from {:?}",
+                        &self.get_local_peer(),
+                        &message.payload.get_message_description(),
+                        neighbor_key
+                    );
+                }
+                let (to_buffer, relay) = self.handle_unsolicited_stacks_message(
+                    chainstate,
+                    *event_id,
+                    &message.preamble,
+                    &message.payload,
+                    buffer,
+                );
+                if buffer && to_buffer {
+                    self.buffer_stacks_data_message(*event_id, neighbor_key, message.clone());
+                    return false;
+                }
+                if relay {
+                    // forward to relayer for processing
+                    debug!(
+                        "{:?}: Will forward message {} from {:?} to relayer",
+                        &self.get_local_peer(),
+                        &message.payload.get_message_description(),
+                        &neighbor_key
+                    );
+                }
+                true
+            });
+            messages.len() > 0
+        });
+        unsolicited
     }
 }

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -606,8 +606,22 @@ impl BitcoinRegtestController {
             received_at: Instant::now(),
         };
 
+        let received = self
+            .chain_tip
+            .as_ref()
+            .map(|tip| tip.block_snapshot.block_height)
+            .unwrap_or(0)
+            == burnchain_tip.block_snapshot.block_height;
         self.chain_tip = Some(burnchain_tip.clone());
         debug!("Done receiving blocks");
+
+        if self.config.burnchain.fault_injection_burnchain_block_delay > 0 && received {
+            info!(
+                "Fault injection: delaying burnchain blocks by {} milliseconds",
+                self.config.burnchain.fault_injection_burnchain_block_delay
+            );
+            sleep_ms(self.config.burnchain.fault_injection_burnchain_block_delay);
+        }
 
         Ok((burnchain_tip, burnchain_height))
     }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1440,6 +1440,9 @@ pub struct BurnchainConfig {
     pub wallet_name: String,
     pub ast_precheck_size_height: Option<u64>,
     pub affirmation_overrides: HashMap<u64, AffirmationMap>,
+    /// fault injection to simulate a slow burnchain peer.
+    /// Delay burnchain block downloads by the given number of millseconds
+    pub fault_injection_burnchain_block_delay: u64,
 }
 
 impl BurnchainConfig {
@@ -1479,6 +1482,7 @@ impl BurnchainConfig {
             wallet_name: "".to_string(),
             ast_precheck_size_height: None,
             affirmation_overrides: HashMap::new(),
+            fault_injection_burnchain_block_delay: 0,
         }
     }
     pub fn get_rpc_url(&self, wallet: Option<String>) -> String {
@@ -1573,6 +1577,7 @@ pub struct BurnchainConfigFile {
     pub wallet_name: Option<String>,
     pub ast_precheck_size_height: Option<u64>,
     pub affirmation_overrides: Option<Vec<AffirmationOverride>>,
+    pub fault_injection_burnchain_block_delay: Option<u64>,
 }
 
 impl BurnchainConfigFile {
@@ -1785,6 +1790,9 @@ impl BurnchainConfigFile {
                 .pox_prepare_length
                 .or(default_burnchain_config.pox_prepare_length),
             affirmation_overrides,
+            fault_injection_burnchain_block_delay: self
+                .fault_injection_burnchain_block_delay
+                .unwrap_or(default_burnchain_config.fault_injection_burnchain_block_delay),
         };
 
         if let BitcoinNetworkType::Mainnet = config.get_bitcoin_network().1 {

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -3942,6 +3942,9 @@ fn forked_tenure_is_ignored() {
 
     info!("Starting Tenure C.");
 
+    // force the timestamp to be different
+    sleep_ms(2000);
+
     // Submit a block commit op for tenure C.
     // It should also build on block A, since the node has paused processing of block B.
     let commits_before = commits_submitted.load(Ordering::SeqCst);
@@ -3973,6 +3976,7 @@ fn forked_tenure_is_ignored() {
     let block_c = blocks.last().unwrap();
     info!("Tenure C tip block: {}", &block_tenure_c.index_block_hash());
     info!("Tenure C last block: {}", &block_c.block_id);
+    assert_ne!(block_tenure_b.block_id(), block_tenure_c.index_block_hash());
 
     // Block C was built AFTER Block B was built, but BEFORE it was broadcasted (processed), so it should be built off of Block A
     assert_eq!(


### PR DESCRIPTION
This PR updates the unsolicited message handling logic to allow unsolicited p2p messages to be stored and retried in one of two conditions:

* When the next sortition happens
* (NEW) When the Stacks tenure changes

This new code path is required to correctly buffer and retry `StackerDBPushChunk` messages, which can arrive at a Stacks node before the message's identified tenure tip has been processed.  With this patch, the node buffers up `StackerDBPushChunk` messages and retries them when the Stacks tenure changes.  Before, they were erroneously retried when the sortition tip changed (meaning, they were likely to be dropped since the new sortition would have arrived before the corresponding tenure-change block).

This improves miner signer reliability in the face of Stacks nodes not all arriving at the same Stacks tip at the same time.

This closes #5116 