### PR TITLE
Fix/5115

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -108,6 +108,7 @@ jobs:
           - tests::nakamoto_integrations::continue_tenure_extend
           - tests::nakamoto_integrations::mock_mining
           - tests::nakamoto_integrations::multiple_miners
+          - tests::nakamoto_integrations::follower_bootup_across_multiple_cycles
           # Do not run this one until we figure out why it fails in CI
           # - tests::neon_integrations::bitcoin_reorg_flap
           # - tests::neon_integrations::bitcoin_reorg_flap_with_follower

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3456,6 +3456,14 @@ impl SortitionDB {
                         SortitionDB::apply_schema_9(&tx.deref(), epochs)?;
                         tx.commit()?;
                     } else if version == expected_version {
+                        // this transaction is almost never needed
+                        let validated_epochs = StacksEpoch::validate_epochs(epochs);
+                        let existing_epochs = Self::get_stacks_epochs(self.conn())?;
+                        if existing_epochs == validated_epochs {
+                            return Ok(());
+                        }
+
+                        // epochs are out of date
                         let tx = self.tx_begin()?;
                         SortitionDB::validate_and_replace_epochs(&tx, epochs)?;
                         tx.commit()?;

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -543,20 +543,24 @@ impl<
             in_nakamoto_epoch: false,
         };
 
-        let mut nakamoto_available = false;
         loop {
-            if nakamoto_available
-                || inst
-                    .can_process_nakamoto()
-                    .expect("FATAL: could not determine if Nakamoto is available")
-            {
-                // short-circuit to avoid gratuitous I/O
-                nakamoto_available = true;
-                if !inst.handle_comms_nakamoto(&comms, miner_status.clone()) {
+            let bits = comms.wait_on();
+            if inst.in_subsequent_nakamoto_reward_cycle() {
+                debug!("Coordinator: in subsequent Nakamoto reward cycle");
+                if !inst.handle_comms_nakamoto(bits, miner_status.clone()) {
+                    return;
+                }
+            } else if inst.in_first_nakamoto_reward_cycle() {
+                debug!("Coordinator: in first Nakamoto reward cycle");
+                if !inst.handle_comms_nakamoto(bits, miner_status.clone()) {
+                    return;
+                }
+                if !inst.handle_comms_epoch2(bits, miner_status.clone()) {
                     return;
                 }
             } else {
-                if !inst.handle_comms_epoch2(&comms, miner_status.clone()) {
+                debug!("Coordinator: in epoch2 reward cycle");
+                if !inst.handle_comms_epoch2(bits, miner_status.clone()) {
                     return;
                 }
             }
@@ -566,13 +570,8 @@ impl<
     /// This is the Stacks 2.x coordinator loop body, which handles communications
     /// from the given `comms`.  It returns `true` if the coordinator is still running, and `false`
     /// if not.
-    pub fn handle_comms_epoch2(
-        &mut self,
-        comms: &CoordinatorReceivers,
-        miner_status: Arc<Mutex<MinerStatus>>,
-    ) -> bool {
+    pub fn handle_comms_epoch2(&mut self, bits: u8, miner_status: Arc<Mutex<MinerStatus>>) -> bool {
         // timeout so that we handle Ctrl-C a little gracefully
-        let bits = comms.wait_on();
         if (bits & (CoordinatorEvents::NEW_STACKS_BLOCK as u8)) != 0 {
             signal_mining_blocked(miner_status.clone());
             debug!("Received new stacks block notice");

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -619,12 +619,12 @@ impl<
         let all_epochs = SortitionDB::get_stacks_epochs(self.sortition_db.conn())
             .unwrap_or_else(|e| panic!("FATAL: failed to query sortition DB for epochs: {:?}", &e));
 
-        let Some(epoch_3_idx) = StacksEpoch::find_epoch_by_id(&all_epochs, StacksEpochId::Epoch30) else {
+        let Some(epoch_3_idx) = StacksEpoch::find_epoch_by_id(&all_epochs, StacksEpochId::Epoch30)
+        else {
             // this is only reachable in tests
             if cfg!(any(test, feature = "testing")) {
                 return u64::MAX;
-            }
-            else {
+            } else {
                 panic!("FATAL: epoch3 not defined");
             }
         };

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -619,8 +619,15 @@ impl<
         let all_epochs = SortitionDB::get_stacks_epochs(self.sortition_db.conn())
             .unwrap_or_else(|e| panic!("FATAL: failed to query sortition DB for epochs: {:?}", &e));
 
-        let epoch_3_idx = StacksEpoch::find_epoch_by_id(&all_epochs, StacksEpochId::Epoch30)
-            .expect("FATAL: epoch3 not defined");
+        let Some(epoch_3_idx) = StacksEpoch::find_epoch_by_id(&all_epochs, StacksEpochId::Epoch30) else {
+            // this is only reachable in tests
+            if cfg!(any(test, feature = "testing")) {
+                return u64::MAX;
+            }
+            else {
+                panic!("FATAL: epoch3 not defined");
+            }
+        };
 
         let epoch3 = &all_epochs[epoch_3_idx];
         let first_epoch3_reward_cycle = self

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -614,38 +614,11 @@ impl<
         B: BurnchainHeaderReader,
     > ChainsCoordinator<'a, T, N, U, CE, FE, B>
 {
-    /// Check to see if we're in the last of the 2.x epochs, and we have the first PoX anchor block
-    /// for epoch 3.
-    /// NOTE: the first block in epoch3 must be after the first block in the reward phase, so as
-    /// to ensure that the PoX stackers have been selected for this cycle.  This means that we
-    /// don't proceed to process Nakamoto blocks until the reward cycle has begun.  Also, the last
-    /// reward cycle of epoch2 _must_ be PoX so we have stackers who can sign.
-    pub fn can_process_nakamoto(&mut self) -> Result<bool, Error> {
-        let canonical_sortition_tip = self
-            .canonical_sortition_tip
-            .clone()
-            .expect("FAIL: checking epoch status, but we don't have a canonical sortition tip");
+    /// Get the first nakamoto reward cycle
+    fn get_first_nakamoto_reward_cycle(&self) -> u64 {
+        let all_epochs = SortitionDB::get_stacks_epochs(self.sortition_db.conn())
+            .unwrap_or_else(|e| panic!("FATAL: failed to query sortition DB for epochs: {:?}", &e));
 
-        let canonical_sn =
-            SortitionDB::get_block_snapshot(self.sortition_db.conn(), &canonical_sortition_tip)?
-                .expect("FATAL: canonical sortition tip has no sortition");
-
-        // what epoch are we in?
-        let cur_epoch =
-            SortitionDB::get_stacks_epoch(self.sortition_db.conn(), canonical_sn.block_height)?
-                .unwrap_or_else(|| {
-                    panic!(
-                        "BUG: no epoch defined at height {}",
-                        canonical_sn.block_height
-                    )
-                });
-
-        if cur_epoch.epoch_id < StacksEpochId::Epoch30 {
-            return Ok(false);
-        }
-
-        // in epoch3
-        let all_epochs = SortitionDB::get_stacks_epochs(self.sortition_db.conn())?;
         let epoch_3_idx = StacksEpoch::find_epoch_by_id(&all_epochs, StacksEpochId::Epoch30)
             .expect("FATAL: epoch3 not defined");
 
@@ -655,32 +628,36 @@ impl<
             .block_height_to_reward_cycle(epoch3.start_height)
             .expect("FATAL: epoch3 block height has no reward cycle");
 
-        // NOTE(safety): this is not guaranteed to be the canonical best Stacks tip.
-        // However, it's safe to use here because we're only interested in loading up the first
-        // Nakamoto reward set, which uses the epoch2 anchor block selection algorithm.  There will
-        // only be one such reward set in epoch2 rules, since it's tied to a specific block-commit
-        // (note that this is not true for reward sets generated in Nakamoto prepare phases).
-        let (local_best_stacks_ch, local_best_stacks_bhh) =
-            SortitionDB::get_canonical_stacks_chain_tip_hash(self.sortition_db.conn())?;
-        let local_best_stacks_tip =
-            StacksBlockId::new(&local_best_stacks_ch, &local_best_stacks_bhh);
+        first_epoch3_reward_cycle
+    }
 
-        // only proceed if we have processed the _anchor block_ for this reward cycle.
-        let Some((rc_info, _)) = load_nakamoto_reward_set(
-            self.burnchain
-                .block_height_to_reward_cycle(canonical_sn.block_height)
-                .expect("FATAL: snapshot has no reward cycle"),
-            &canonical_sn.sortition_id,
-            &self.burnchain,
-            &mut self.chain_state_db,
-            &local_best_stacks_tip,
-            &self.sortition_db,
-            &OnChainRewardSetProvider::new(),
-        )?
-        else {
-            return Ok(false);
-        };
-        Ok(rc_info.reward_cycle >= first_epoch3_reward_cycle)
+    /// Get the current reward cycle
+    fn get_current_reward_cycle(&self) -> u64 {
+        let canonical_sortition_tip = self.canonical_sortition_tip.clone().unwrap_or_else(|| {
+            panic!("FAIL: checking epoch status, but we don't have a canonical sortition tip")
+        });
+
+        let canonical_sn =
+            SortitionDB::get_block_snapshot(self.sortition_db.conn(), &canonical_sortition_tip)
+                .unwrap_or_else(|e| panic!("FATAL: failed to query sortition DB: {:?}", &e))
+                .unwrap_or_else(|| panic!("FATAL: canonical sortition tip has no sortition"));
+
+        let cur_reward_cycle = self
+            .burnchain
+            .block_height_to_reward_cycle(canonical_sn.block_height)
+            .expect("FATAL: snapshot has no reward cycle");
+
+        cur_reward_cycle
+    }
+
+    /// Are we in the first-ever Nakamoto reward cycle?
+    pub fn in_first_nakamoto_reward_cycle(&self) -> bool {
+        self.get_current_reward_cycle() == self.get_first_nakamoto_reward_cycle()
+    }
+
+    /// Are we in the second or later Nakamoto reward cycle?
+    pub fn in_subsequent_nakamoto_reward_cycle(&self) -> bool {
+        self.get_current_reward_cycle() > self.get_first_nakamoto_reward_cycle()
     }
 
     /// This is the main loop body for the coordinator in epoch 3.
@@ -688,11 +665,10 @@ impl<
     /// Returns false otherwise.
     pub fn handle_comms_nakamoto(
         &mut self,
-        comms: &CoordinatorReceivers,
+        bits: u8,
         miner_status: Arc<Mutex<MinerStatus>>,
     ) -> bool {
         // timeout so that we handle Ctrl-C a little gracefully
-        let bits = comms.wait_on();
         if (bits & (CoordinatorEvents::NEW_STACKS_BLOCK as u8)) != 0 {
             signal_mining_blocked(miner_status.clone());
             debug!("Received new Nakamoto stacks block notice");

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -1502,7 +1502,7 @@ pub struct NetworkResult {
     pub num_connected_peers: usize,
     /// The observed burnchain height
     pub burn_height: u64,
-    /// The consensus hash of the burnchain tip (prefixed `rc_` for historical reasons)
+    /// The consensus hash of the stacks tip (prefixed `rc_` for historical reasons)
     pub rc_consensus_hash: ConsensusHash,
     /// The current StackerDB configs
     pub stacker_db_configs: HashMap<QualifiedContractIdentifier, StackerDBConfig>,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -3340,6 +3340,214 @@ fn follower_bootup() {
     follower_thread.join().unwrap();
 }
 
+/// This test boots a follower node using the block downloader, but the follower will be multiple
+/// Nakamoto reward cycles behind.
+#[test]
+#[ignore]
+fn follower_bootup_across_multiple_cycles() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
+    naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
+    naka_conf.burnchain.max_rbf = 10_000_000;
+
+    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_addr = tests::to_addr(&sender_signer_sk);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    let tenure_count = 5;
+    let inter_blocks_per_tenure = 9;
+    // setup sender + recipient for some test stx transfers
+    // these are necessary for the interim blocks to get mined at all
+    let sender_addr = tests::to_addr(&sender_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
+    );
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
+    let stacker_sk = setup_stacker(&mut naka_conf);
+
+    test_observer::spawn();
+    let observer_port = test_observer::EVENT_OBSERVER_PORT;
+    naka_conf.events_observers.insert(EventObserverConfig {
+        endpoint: format!("localhost:{observer_port}"),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(naka_conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .expect("Failed starting bitcoind");
+    let mut btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
+    btc_regtest_controller.bootstrap_chain(201);
+
+    let mut run_loop = boot_nakamoto::BootRunLoop::new(naka_conf.clone()).unwrap();
+    let run_loop_stopper = run_loop.get_termination_switch();
+    let Counters {
+        blocks_processed,
+        naka_submitted_commits: commits_submitted,
+        naka_proposed_blocks: proposals_submitted,
+        ..
+    } = run_loop.counters();
+
+    let coord_channel = run_loop.coordinator_channels();
+
+    let run_loop_thread = thread::Builder::new()
+        .name("run_loop".into())
+        .spawn(move || run_loop.start(None, 0))
+        .unwrap();
+    wait_for_runloop(&blocks_processed);
+    boot_to_epoch_3(
+        &naka_conf,
+        &blocks_processed,
+        &[stacker_sk],
+        &[sender_signer_sk],
+        &mut Some(&mut signers),
+        &mut btc_regtest_controller,
+    );
+
+    info!("Bootstrapped to Epoch-3.0 boundary, starting nakamoto miner");
+
+    let burnchain = naka_conf.get_burnchain();
+    let sortdb = burnchain.open_sortition_db(true).unwrap();
+    let (chainstate, _) = StacksChainState::open(
+        naka_conf.is_mainnet(),
+        naka_conf.burnchain.chain_id,
+        &naka_conf.get_chainstate_path_str(),
+        None,
+    )
+    .unwrap();
+
+    let block_height_pre_3_0 =
+        NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+            .unwrap()
+            .unwrap()
+            .stacks_block_height;
+
+    info!("Nakamoto miner started...");
+    blind_signer(&naka_conf, &signers, proposals_submitted);
+
+    wait_for_first_naka_block_commit(60, &commits_submitted);
+
+    // mine two reward cycles
+    for _ in 0..btc_regtest_controller
+        .get_burnchain()
+        .pox_constants
+        .reward_cycle_length
+        * 2
+    {
+        next_block_and_process_new_stacks_block(&mut btc_regtest_controller, 60, &coord_channel)
+            .unwrap();
+    }
+
+    info!("Nakamoto miner has advanced two reward cycles");
+
+    // load the chain tip, and assert that it is a nakamoto block and at least 30 blocks have advanced in epoch 3
+    let tip = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+        .unwrap()
+        .unwrap();
+    info!(
+        "Latest tip";
+        "height" => tip.stacks_block_height,
+        "is_nakamoto" => tip.anchored_header.as_stacks_nakamoto().is_some(),
+        "block_height_pre_3_0" => block_height_pre_3_0
+    );
+
+    assert!(tip.anchored_header.as_stacks_nakamoto().is_some());
+
+    // spawn follower
+    let mut follower_conf = naka_conf.clone();
+    follower_conf.events_observers.clear();
+    follower_conf.node.working_dir = format!("{}-follower", &naka_conf.node.working_dir);
+    follower_conf.node.seed = vec![0x01; 32];
+    follower_conf.node.local_peer_seed = vec![0x02; 32];
+
+    let mut rng = rand::thread_rng();
+    let mut buf = [0u8; 8];
+    rng.fill_bytes(&mut buf);
+
+    let rpc_port = u16::from_be_bytes(buf[0..2].try_into().unwrap()).saturating_add(1025) - 1; // use a non-privileged port between 1024 and 65534
+    let p2p_port = u16::from_be_bytes(buf[2..4].try_into().unwrap()).saturating_add(1025) - 1; // use a non-privileged port between 1024 and 65534
+
+    let localhost = "127.0.0.1";
+    follower_conf.node.rpc_bind = format!("{}:{}", &localhost, rpc_port);
+    follower_conf.node.p2p_bind = format!("{}:{}", &localhost, p2p_port);
+    follower_conf.node.data_url = format!("http://{}:{}", &localhost, rpc_port);
+    follower_conf.node.p2p_address = format!("{}:{}", &localhost, p2p_port);
+    follower_conf.node.pox_sync_sample_secs = 30;
+
+    let node_info = get_chain_info(&naka_conf);
+    follower_conf.node.add_bootstrap_node(
+        &format!(
+            "{}@{}",
+            &node_info.node_public_key.unwrap(),
+            naka_conf.node.p2p_bind
+        ),
+        CHAIN_ID_TESTNET,
+        PEER_VERSION_TESTNET,
+    );
+
+    let mut follower_run_loop = boot_nakamoto::BootRunLoop::new(follower_conf.clone()).unwrap();
+    let follower_run_loop_stopper = follower_run_loop.get_termination_switch();
+    let follower_coord_channel = follower_run_loop.coordinator_channels();
+
+    debug!(
+        "Booting follower-thread ({},{})",
+        &follower_conf.node.p2p_bind, &follower_conf.node.rpc_bind
+    );
+    debug!(
+        "Booting follower-thread: neighbors = {:?}",
+        &follower_conf.node.bootstrap_node
+    );
+
+    // spawn a follower thread
+    let follower_thread = thread::Builder::new()
+        .name("follower-thread".into())
+        .spawn(move || follower_run_loop.start(None, 0))
+        .unwrap();
+
+    debug!("Booted follower-thread");
+
+    wait_for(300, || {
+        sleep_ms(1000);
+        let Ok(follower_node_info) = get_chain_info_result(&follower_conf) else {
+            return Ok(false);
+        };
+
+        info!(
+            "Follower tip is now {}/{}",
+            &follower_node_info.stacks_tip_consensus_hash, &follower_node_info.stacks_tip
+        );
+        Ok(
+            follower_node_info.stacks_tip_consensus_hash == tip.consensus_hash
+                && follower_node_info.stacks_tip == tip.anchored_header.block_hash(),
+        )
+    })
+    .unwrap();
+
+    coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    run_loop_stopper.store(false, Ordering::SeqCst);
+
+    follower_coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    follower_run_loop_stopper.store(false, Ordering::SeqCst);
+
+    run_loop_thread.join().unwrap();
+    follower_thread.join().unwrap();
+}
+
 #[test]
 #[ignore]
 fn stack_stx_burn_op_integration_test() {


### PR DESCRIPTION
This fixes #5115, and also removes a spurious deadlock condition whereby the relayer and burnchain downloader can fight over the sortition DB (this arises due to the fact that we open a transaction on the sortition DB every time we open it, even though we almost never need to).