### PR TITLE
fix: key register op must have a change output

### DIFF
--- a/stackslib/src/chainstate/burn/operations/leader_key_register.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_key_register.rs
@@ -135,18 +135,10 @@ impl LeaderKeyRegisterOp {
         let num_inputs = tx.num_signers();
         let num_outputs = tx.num_recipients();
 
-        if num_inputs == 0 {
+        if num_inputs == 0 || num_outputs < 1 {
             debug!(
                 "Invalid tx: inputs: {}, outputs: {}",
                 num_inputs, num_outputs,
-            );
-            return Err(op_error::InvalidInput);
-        }
-
-        if num_outputs < 1 {
-            debug!(
-                "Invalid tx: inputs: {}, outputs: {}",
-                num_inputs, num_outputs
             );
             return Err(op_error::InvalidInput);
         }

--- a/stackslib/src/chainstate/burn/operations/leader_key_register.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_key_register.rs
@@ -136,32 +136,30 @@ impl LeaderKeyRegisterOp {
         let num_outputs = tx.num_recipients();
 
         if num_inputs == 0 {
-            test_debug!(
+            debug!(
                 "Invalid tx: inputs: {}, outputs: {}",
-                num_inputs,
-                num_outputs,
+                num_inputs, num_outputs,
             );
             return Err(op_error::InvalidInput);
         }
 
         if num_outputs < 1 {
-            test_debug!(
+            debug!(
                 "Invalid tx: inputs: {}, outputs: {}",
-                num_inputs,
-                num_outputs
+                num_inputs, num_outputs
             );
             return Err(op_error::InvalidInput);
         }
 
         if tx.opcode() != Opcodes::LeaderKeyRegister as u8 {
-            test_debug!("Invalid tx: invalid opcode {}", tx.opcode());
+            debug!("Invalid tx: invalid opcode {}", tx.opcode());
             return Err(op_error::InvalidInput);
         }
 
         let data = match LeaderKeyRegisterOp::parse_data(&tx.data()) {
             Some(data) => data,
             None => {
-                test_debug!("Invalid tx data");
+                debug!("Invalid tx data");
                 return Err(op_error::ParseError);
             }
         };

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -889,7 +889,7 @@ impl BitcoinRegtestController {
             fee_rate,
             &mut utxos,
             signer,
-            false,
+            true, // key register op requires change output to exist
         )?;
 
         increment_btc_ops_sent_counter();
@@ -1466,7 +1466,7 @@ impl BitcoinRegtestController {
             fee_rate,
             &mut utxos,
             signer,
-            true, // only block commit op requires change output to exist
+            true, // block commit op requires change output to exist
         )?;
 
         let serialized_tx = SerializedTx::new(tx.clone());


### PR DESCRIPTION
Changed some `test_debug!` logs `debug!`. These would have helped to debug a VRF key registration error.