### PR TITLE
fix: Improve DB deadlock detection/logging

### DIFF
--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -21,7 +21,7 @@ use rusqlite::{
 };
 use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
 use stacks_common::types::sqlite::NO_PARAMS;
-use stacks_common::util::db_common::tx_busy_handler;
+use stacks_common::util::db::tx_busy_handler;
 use stacks_common::util::hash::Sha512Trunc256Sum;
 
 use super::clarity_store::{make_contract_hash_key, ContractCommitment};

--- a/stacks-common/src/util/db.rs
+++ b/stacks-common/src/util/db.rs
@@ -42,8 +42,9 @@ static LOCK_TABLE_TIMER: LazyLock<Instant> = LazyLock::new(Instant::now);
 /// Updates `LOCK_TABLE`
 pub fn update_lock_table(conn: &Connection) {
     let timestamp = LOCK_TABLE_TIMER.elapsed().as_millis();
+    // The debug format for `Connection` includes the path
     let k = format!("{conn:?}");
-    let v = format!("{:?}@{timestamp}", std::thread::current().name());
+    let v = format!("{:?}@{timestamp}", thread::current().name());
     LOCK_TABLE.lock().unwrap().insert(k, v);
 }
 

--- a/stacks-common/src/util/db.rs
+++ b/stacks-common/src/util/db.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::backtrace::Backtrace;
+use std::time::Duration;
+
+use rand::{thread_rng, Rng};
+
+use crate::util::sleep_ms;
+
+/// Called by `rusqlite` if we are waiting too long on a database lock
+/// If called too many times, will fail to avoid deadlocks
+pub fn tx_busy_handler(run_count: i32) -> bool {
+    const TIMEOUT: Duration = Duration::from_secs(60);
+    const AVG_SLEEP_TIME_MS: u64 = 100;
+
+    // First, check if this is taking unreasonably long. If so, it's probably a deadlock
+    let run_count = run_count.unsigned_abs();
+    let approx_time_elapsed =
+        Duration::from_millis(AVG_SLEEP_TIME_MS.saturating_mul(u64::from(run_count)));
+    if approx_time_elapsed > TIMEOUT {
+        error!("Probable deadlock detected. Waited {} seconds (estimated) for database lock. Giving up", approx_time_elapsed.as_secs();
+            "run_count" => run_count,
+            "backtrace" => ?Backtrace::capture()
+        );
+        return false;
+    }
+
+    let mut sleep_time_ms = 2u64.saturating_pow(run_count);
+
+    sleep_time_ms = sleep_time_ms.saturating_add(thread_rng().gen_range(0..sleep_time_ms));
+
+    if sleep_time_ms > AVG_SLEEP_TIME_MS {
+        let jitter = 10;
+        sleep_time_ms =
+            thread_rng().gen_range((AVG_SLEEP_TIME_MS - jitter)..(AVG_SLEEP_TIME_MS + jitter));
+    }
+
+    let msg = format!("Database is locked; sleeping {sleep_time_ms}ms and trying again");
+    if run_count > 10 && run_count % 10 == 0 {
+        warn!("{msg}";
+            "run_count" => run_count,
+            "backtrace" => ?Backtrace::capture()
+        );
+    } else {
+        debug!("{msg}");
+    }
+
+    sleep_ms(sleep_time_ms);
+    true
+}

--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -19,6 +19,7 @@ pub mod log;
 #[macro_use]
 pub mod macros;
 pub mod chunked_encoding;
+pub mod db;
 pub mod hash;
 pub mod pair;
 pub mod pipe;
@@ -82,32 +83,6 @@ impl error::Error for HexError {
             HexError::BadLength(_) => "hex string non-64 length",
             HexError::BadCharacter(_) => "bad hex character",
         }
-    }
-}
-
-pub mod db_common {
-    use std::{thread, time};
-
-    use rand::{thread_rng, Rng};
-
-    pub fn tx_busy_handler(run_count: i32) -> bool {
-        let mut sleep_count = 10;
-        if run_count > 0 {
-            sleep_count = 2u64.saturating_pow(run_count as u32);
-        }
-        sleep_count = sleep_count.saturating_add(thread_rng().gen::<u64>() % sleep_count);
-
-        if sleep_count > 5000 {
-            sleep_count = 5000;
-        }
-
-        debug!(
-            "Database is locked; sleeping {}ms and trying again",
-            &sleep_count
-        );
-
-        thread::sleep(time::Duration::from_millis(sleep_count));
-        true
     }
 }
 

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -657,43 +657,7 @@ impl<'a, C: Clone, T: MarfTrieId> DerefMut for IndexDBTx<'a, C, T> {
 
 /// Called by `rusqlite` if we are waiting too long on a database lock
 pub fn tx_busy_handler(run_count: i32) -> bool {
-    const TIMEOUT: Duration = Duration::from_secs(60);
-    const AVG_SLEEP_TIME_MS: u64 = 100;
-
-    // First, check if this is taking unreasonably long. If so, it's probably a deadlock
-    let run_count = run_count.unsigned_abs();
-    let approx_time_elapsed =
-        Duration::from_millis(AVG_SLEEP_TIME_MS.saturating_mul(u64::from(run_count)));
-    if approx_time_elapsed > TIMEOUT {
-        error!("Probable deadlock detected. Waited {} seconds (estimated) for database lock. Giving up", approx_time_elapsed.as_secs();
-            "run_count" => run_count,
-            "backtrace" => ?Backtrace::capture()
-        );
-        return false;
-    }
-
-    let mut sleep_time_ms = 2u64.saturating_pow(run_count);
-
-    sleep_time_ms = sleep_time_ms.saturating_add(thread_rng().gen_range(0..sleep_time_ms));
-
-    if sleep_time_ms > AVG_SLEEP_TIME_MS {
-        let jitter = 10;
-        sleep_time_ms =
-            thread_rng().gen_range((AVG_SLEEP_TIME_MS - jitter)..(AVG_SLEEP_TIME_MS + jitter));
-    }
-
-    let msg = format!("Database is locked; sleeping {sleep_time_ms}ms and trying again");
-    if run_count > 10 && run_count % 10 == 0 {
-        warn!("{msg}";
-            "run_count" => run_count,
-            "backtrace" => ?Backtrace::capture()
-        );
-    } else {
-        debug!("{msg}");
-    }
-
-    sleep_ms(sleep_time_ms);
-    true
+    stacks_common::util::db::tx_busy_handler(run_count)
 }
 
 /// Begin an immediate-mode transaction, and handle busy errors with exponential backoff.

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -677,9 +677,9 @@ pub fn tx_busy_handler(run_count: i32) -> bool {
     sleep_time_ms = sleep_time_ms.saturating_add(thread_rng().gen_range(0..sleep_time_ms));
 
     if sleep_time_ms > AVG_SLEEP_TIME_MS {
-        let bound = 10;
-        let jitter = thread_rng().gen_range(0..bound * 2);
-        sleep_time_ms = (AVG_SLEEP_TIME_MS - bound) + jitter;
+        let jitter = 10;
+        sleep_time_ms =
+            thread_rng().gen_range((AVG_SLEEP_TIME_MS - jitter)..(AVG_SLEEP_TIME_MS + jitter));
     }
 
     let msg = format!("Database is locked; sleeping {sleep_time_ms}ms and trying again");


### PR DESCRIPTION

### Description

This PR makes two changes to `tx_busy_handler()`, which is passed as a callback to rusqlite and called if waiting too long for a DB lock

- Improve logging. Previously, all logs in `tx_busy_handler()` were debug level, now we have warn/error level messages if we are waiting too long
- After a certain amount of time has passed (about a minute) we should assume we have a deadlock, stop trying to open the DB, log and return an error
 
Note that this PR doesn't make deadlocks less likely to occur, it just makes them easier to find, and generates an error when they are detected, which may be recoverable or may crash the application (depending on how the caller handles the error)

### Applicable issues

- #5112

### Additional info (benefits, drawbacks, caveats)

I could have added precise timing using `Instant::now()`, but that would require wrapping `tx_busy_handler()` in a closure, which creates lifetime issues because it's a callback. This could be addressed by adding the `Box`ed callback to the `DBTx` type, but this would require changing a lot of code, which I didn't think was worth it

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
