### PR TITLE
remove spurious deadlock condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - Fix block proposal rejection test (#5084)
 - Mock signing revamp (#5070)
 - Multi miner fixes jude (#5040)
+- Remove spurious deadlock condition whenever the sortition DB is opened
 
 ## [2.5.0.0.6]
 

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3456,6 +3456,14 @@ impl SortitionDB {
                         SortitionDB::apply_schema_9(&tx.deref(), epochs)?;
                         tx.commit()?;
                     } else if version == expected_version {
+                        // this transaction is almost never needed
+                        let validated_epochs = StacksEpoch::validate_epochs(epochs);
+                        let existing_epochs = Self::get_stacks_epochs(self.conn())?;
+                        if existing_epochs == validated_epochs {
+                            return Ok(());
+                        }
+
+                        // epochs are out of date
                         let tx = self.tx_begin()?;
                         SortitionDB::validate_and_replace_epochs(&tx, epochs)?;
                         tx.commit()?;


### PR DESCRIPTION
Adds commit 03b373d to the release branch

changelog updated to add this commit to release notes. 
