### PR TITLE
test: fix `signer_set_rollover` test

### DIFF
--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -2790,7 +2790,7 @@ fn signer_set_rollover() {
         .running_nodes
         .btc_regtest_controller
         .get_burnchain()
-        .reward_cycle_to_block_height(next_reward_cycle)
+        .nakamoto_first_block_of_cycle(next_reward_cycle)
         .saturating_add(1);
 
     info!("---- Mining to next reward set calculation -----");


### PR DESCRIPTION
Adjust the block height that it mines to to reach the next cycle in accordance with recent changes.