### PR TITLE
chore: Remove unnecessary function `slice_partialeq()`

### DIFF
--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -85,19 +85,6 @@ impl error::Error for HexError {
     }
 }
 
-/// PartialEq helper method for slices of arbitrary length.
-pub fn slice_partialeq<T: PartialEq>(s1: &[T], s2: &[T]) -> bool {
-    if s1.len() != s2.len() {
-        return false;
-    }
-    for i in 0..s1.len() {
-        if s1[i] != s2[i] {
-            return false;
-        }
-    }
-    true
-}
-
 pub mod db_common {
     use std::{thread, time};
 

--- a/stackslib/src/chainstate/stacks/index/node.rs
+++ b/stackslib/src/chainstate/stacks/index/node.rs
@@ -27,7 +27,6 @@ use stacks_common::types::chainstate::{
     BlockHeaderHash, TrieHash, BLOCK_HEADER_HASH_ENCODED_SIZE, TRIEHASH_ENCODED_SIZE,
 };
 use stacks_common::util::hash::to_hex;
-use stacks_common::util::slice_partialeq;
 
 use crate::chainstate::stacks::index::bits::{
     get_path_byte_len, get_ptrs_byte_len, path_from_bytes, ptrs_from_bytes, write_path_to_bytes,
@@ -597,7 +596,7 @@ impl<T: MarfTrieId> TrieCursor<T> {
 
 impl PartialEq for TrieLeaf {
     fn eq(&self, other: &TrieLeaf) -> bool {
-        self.path == other.path && slice_partialeq(self.data.as_bytes(), other.data.as_bytes())
+        self.path == other.path && self.data.as_bytes() == other.data.as_bytes()
     }
 }
 
@@ -730,9 +729,7 @@ impl fmt::Debug for TrieNode48 {
 
 impl PartialEq for TrieNode48 {
     fn eq(&self, other: &TrieNode48) -> bool {
-        self.path == other.path
-            && slice_partialeq(&self.ptrs, &other.ptrs)
-            && slice_partialeq(&self.indexes, &other.indexes)
+        self.path == other.path && self.ptrs == other.ptrs && self.indexes == other.indexes
     }
 }
 
@@ -755,8 +752,8 @@ impl TrieNode48 {
         }
         TrieNode48 {
             path: node16.path.clone(),
-            indexes: indexes,
-            ptrs: ptrs,
+            indexes,
+            ptrs,
         }
     }
 }
@@ -781,7 +778,7 @@ impl fmt::Debug for TrieNode256 {
 
 impl PartialEq for TrieNode256 {
     fn eq(&self, other: &TrieNode256) -> bool {
-        self.path == other.path && slice_partialeq(&self.ptrs, &other.ptrs)
+        self.path == other.path && self.ptrs == other.ptrs
     }
 }
 

--- a/stackslib/src/chainstate/stacks/index/proofs.rs
+++ b/stackslib/src/chainstate/stacks/index/proofs.rs
@@ -28,7 +28,6 @@ use stacks_common::types::chainstate::{
     BlockHeaderHash, TrieHash, BLOCK_HEADER_HASH_ENCODED_SIZE, TRIEHASH_ENCODED_SIZE,
 };
 use stacks_common::util::hash::to_hex;
-use stacks_common::util::slice_partialeq;
 
 use crate::chainstate::stacks::index::bits::{
     get_leaf_hash, get_node_hash, read_root_hash, write_path_to_bytes,
@@ -118,19 +117,19 @@ impl<T: ClarityMarfTrieId> PartialEq for TrieMerkleProofType<T> {
             (
                 TrieMerkleProofType::Node4((ref chr, ref node, ref hashes)),
                 TrieMerkleProofType::Node4((ref other_chr, ref other_node, ref other_hashes)),
-            ) => chr == other_chr && node == other_node && slice_partialeq(hashes, other_hashes),
+            ) => chr == other_chr && node == other_node && hashes == other_hashes,
             (
                 TrieMerkleProofType::Node16((ref chr, ref node, ref hashes)),
                 TrieMerkleProofType::Node16((ref other_chr, ref other_node, ref other_hashes)),
-            ) => chr == other_chr && node == other_node && slice_partialeq(hashes, other_hashes),
+            ) => chr == other_chr && node == other_node && hashes == other_hashes,
             (
                 TrieMerkleProofType::Node48((ref chr, ref node, ref hashes)),
                 TrieMerkleProofType::Node48((ref other_chr, ref other_node, ref other_hashes)),
-            ) => chr == other_chr && node == other_node && slice_partialeq(hashes, other_hashes),
+            ) => chr == other_chr && node == other_node && hashes == other_hashes,
             (
                 TrieMerkleProofType::Node256((ref chr, ref node, ref hashes)),
                 TrieMerkleProofType::Node256((ref other_chr, ref other_node, ref other_hashes)),
-            ) => chr == other_chr && node == other_node && slice_partialeq(hashes, other_hashes),
+            ) => chr == other_chr && node == other_node && hashes == other_hashes,
             (
                 TrieMerkleProofType::Leaf((ref chr, ref node)),
                 TrieMerkleProofType::Leaf((ref other_chr, ref other_node)),


### PR DESCRIPTION
### Description

I noticed this function while working on #5137. It's unnecessary, as `==` works fine with slices, and I'm sure Rust's `PartialEq` implementation uses something like `memcmp()` instead of a loop, so should improve performance. Using my standard benchmark, I see a small improvement in block processing times:

```console
❯ hyperfine -w 3 -r 20 "target/release/stacks-inspect.develop replay-block /home/jbencin/data/next/mainnet range 99990 100000" "target/release/stacks-inspect.remove-slice_partialeq replay-block /home/jbencin/data/next/mainnet range 99990 100000"
Benchmark 1: target/release/stacks-inspect.develop replay-block /home/jbencin/data/next/mainnet range 99990 100000
  Time (mean ± σ):      9.753 s ±  0.044 s    [User: 9.042 s, System: 0.674 s]
  Range (min … max):    9.698 s …  9.886 s    20 runs
 
Benchmark 2: target/release/stacks-inspect.remove-slice_partialeq replay-block /home/jbencin/data/next/mainnet range 99990 100000
  Time (mean ± σ):      9.627 s ±  0.074 s    [User: 8.927 s, System: 0.661 s]
  Range (min … max):    9.540 s …  9.780 s    20 runs
 
Summary
  target/release/stacks-inspect.remove-slice_partialeq replay-block /home/jbencin/data/next/mainnet range 99990 100000 ran
    1.01 ± 0.01 times faster than target/release/stacks-inspect.develop replay-block /home/jbencin/data/next/mainnet range 99990 100000
```
