### PR TITLE
feat: Signer signature count endpoint

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -113,6 +113,7 @@ jobs:
           - tests::nakamoto_integrations::follower_bootup_across_multiple_cycles
           - tests::nakamoto_integrations::utxo_check_on_startup_panic
           - tests::nakamoto_integrations::utxo_check_on_startup_recover
+          - tests::nakamoto_integrations::v3_signer_api_endpoint
           - tests::signer::v0::multiple_miners_with_nakamoto_blocks
           - tests::signer::v0::partial_tenure_fork
           # Do not run this one until we figure out why it fails in CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
     - `get-stacks-block-info?` added
     - `get-tenure-info?` added
     - `get-block-info?` removed
+- Added `/v3/signer/` endpoint
 
 ## [2.5.0.0.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
     - `get-stacks-block-info?` added
     - `get-tenure-info?` added
     - `get-block-info?` removed
-- Added `/v3/signer/` endpoint
+- Added `/v3/signer/{signer_pubkey}/{reward_cycle}` endpoint
 
 ## [2.5.0.0.7]
 

--- a/docs/rpc-endpoints.md
+++ b/docs/rpc-endpoints.md
@@ -533,3 +533,8 @@ highest sortition), `reward_cycle` identifies the reward cycle number of this
 tenure, `tip_block_id` identifies the highest-known block in this tenure, and
 `tip_height` identifies that block's height.
 
+### GET /v3/signer/[Signer Pubkey]/[Reward Cycle]
+
+Get number of blocks signed by signer during a given reward cycle
+
+Returns a non-negative integer

--- a/docs/rpc/openapi.yaml
+++ b/docs/rpc/openapi.yaml
@@ -675,3 +675,33 @@ paths:
         schema:
           type: string
 
+  /v3/signer/{signer}/{cycle_number}:
+    get:
+      summary: Get number of blocks signed by signer during a given reward cycle
+      tags:
+        - Blocks
+        - Signers
+      operationId: get_signer
+      description: Get number of blocks signed by signer during a given reward cycle
+      parameters:
+        - name: signer
+          in: path
+          required: true
+          description: Hex-encoded compressed Secp256k1 public key of signer
+          schema:
+            type: string
+      parameters:
+        - name: cycle_number
+          in: path
+          required: true
+          description: Reward cycle number
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Number of blocks signed
+          content:
+            text/plain:
+              schema:
+                type: integer
+                example: 7

--- a/docs/rpc/openapi.yaml
+++ b/docs/rpc/openapi.yaml
@@ -731,7 +731,6 @@ paths:
           description: Hex-encoded compressed Secp256k1 public key of signer
           schema:
             type: string
-      parameters:
         - name: cycle_number
           in: path
           required: true

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -268,6 +268,26 @@ lazy_static! {
     ADD COLUMN height_in_tenure;
     "#.into(),
     ];
+
+    pub static ref NAKAMOTO_CHAINSTATE_SCHEMA_4: [&'static str; 2] = [
+    r#"
+        UPDATE db_config SET version = "7";
+    "#,
+    // Add a `signer_stats` table to keep track of how many blocks have been signed by each signer
+    r#"
+        -- Table for signer stats
+        CREATE TABLE signer_stats (
+            -- Signers public key
+            public_key TEXT NOT NULL,
+            -- Stacking rewards cycle ID
+            reward_cycle INTEGER NOT NULL,
+            -- Number of blocks signed during reward cycle
+            blocks_signed INTEGER DEFAULT 0 NOT NULL,
+
+            PRIMARY KEY(public_key,reward_cycle)
+        );
+    "#,
+    ];
 }
 
 #[cfg(test)]

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -3300,7 +3300,7 @@ impl NakamotoChainState {
         chainstate_db: &Connection,
         signer_pubkey: &Secp256k1PublicKey,
         reward_cycle: u64,
-    ) -> Result<Option<u64>, ChainstateError> {
+    ) -> Result<u64, ChainstateError> {
         let sql =
             "SELECT blocks_signed FROM signer_stats WHERE public_key = ?1 AND reward_cycle = ?2";
         let params = params![serde_json::to_string(&signer_pubkey).unwrap(), reward_cycle];
@@ -3316,6 +3316,7 @@ impl NakamotoChainState {
                 })
             })
             .optional()
+            .map(Option::unwrap_or_default) // It's fine to map `NONE` to `0`, because it's impossible to have `Some(0)`
             .map_err(ChainstateError::from)
     }
 

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -3305,16 +3305,7 @@ impl NakamotoChainState {
             "SELECT blocks_signed FROM signer_stats WHERE public_key = ?1 AND reward_cycle = ?2";
         let params = params![serde_json::to_string(&signer_pubkey).unwrap(), reward_cycle];
         chainstate_db
-            .query_row(sql, params, |row| {
-                let value: String = row.get(2)?;
-                value.parse::<u64>().map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        size_of::<u64>(),
-                        rusqlite::types::Type::Integer,
-                        e.into(),
-                    )
-                })
-            })
+            .query_row(sql, params, |row| row.get("blocks_signed"))
             .optional()
             .map(Option::unwrap_or_default) // It's fine to map `NONE` to `0`, because it's impossible to have `Some(0)`
             .map_err(ChainstateError::from)

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -298,14 +298,14 @@ impl DBConfig {
         });
         match epoch_id {
             StacksEpochId::Epoch10 => true,
-            StacksEpochId::Epoch20 => version_u32 >= 1 && version_u32 <= 6,
-            StacksEpochId::Epoch2_05 => version_u32 >= 2 && version_u32 <= 6,
-            StacksEpochId::Epoch21 => version_u32 >= 3 && version_u32 <= 6,
-            StacksEpochId::Epoch22 => version_u32 >= 3 && version_u32 <= 6,
-            StacksEpochId::Epoch23 => version_u32 >= 3 && version_u32 <= 6,
-            StacksEpochId::Epoch24 => version_u32 >= 3 && version_u32 <= 6,
-            StacksEpochId::Epoch25 => version_u32 >= 3 && version_u32 <= 6,
-            StacksEpochId::Epoch30 => version_u32 >= 3 && version_u32 <= 6,
+            StacksEpochId::Epoch20 => version_u32 >= 1 && version_u32 <= 7,
+            StacksEpochId::Epoch2_05 => version_u32 >= 2 && version_u32 <= 7,
+            StacksEpochId::Epoch21 => version_u32 >= 3 && version_u32 <= 7,
+            StacksEpochId::Epoch22 => version_u32 >= 3 && version_u32 <= 7,
+            StacksEpochId::Epoch23 => version_u32 >= 3 && version_u32 <= 7,
+            StacksEpochId::Epoch24 => version_u32 >= 3 && version_u32 <= 7,
+            StacksEpochId::Epoch25 => version_u32 >= 3 && version_u32 <= 7,
+            StacksEpochId::Epoch30 => version_u32 >= 3 && version_u32 <= 7,
         }
     }
 }

--- a/stackslib/src/net/api/getsigner.rs
+++ b/stackslib/src/net/api/getsigner.rs
@@ -151,7 +151,7 @@ impl RPCRequestHandler for GetSignerRequestHandler {
             )
         });
 
-        let response = match result {
+        let blocks_signed = match result {
             Ok(response) => response,
             Err(error) => {
                 return StacksHttpResponse::new_error(
@@ -162,6 +162,8 @@ impl RPCRequestHandler for GetSignerRequestHandler {
                 .map_err(NetError::from);
             }
         };
+
+        let response = GetSignerResponse { blocks_signed };
 
         let mut preamble = HttpResponsePreamble::ok_json(&preamble);
         preamble.set_canonical_stacks_tip_height(Some(node.canonical_stacks_tip_height()));

--- a/stackslib/src/net/api/getsigner.rs
+++ b/stackslib/src/net/api/getsigner.rs
@@ -45,8 +45,17 @@ use crate::util_lib::db::Error as DBError;
 
 #[derive(Clone, Default)]
 pub struct GetSignerRequestHandler {
-    signer_pubkey: Option<Secp256k1PublicKey>,
-    reward_cycle: Option<u64>,
+    pub signer_pubkey: Option<Secp256k1PublicKey>,
+    pub reward_cycle: Option<u64>,
+}
+
+impl GetSignerRequestHandler {
+    pub fn new() -> Self {
+        Self {
+            signer_pubkey: None,
+            reward_cycle: None,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -61,8 +70,10 @@ impl HttpRequest for GetSignerRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(r#"^/v3/signer/(?P<signer_pubkey>[0-9a-f]{66})/(?P<cycle_num>[0-9]{1,10})$"#)
-            .unwrap()
+        Regex::new(
+            r#"^/v3/signer/(?P<signer_pubkey>0[23][0-9a-f]{64})/(?P<cycle_num>[0-9]{1,10})$"#,
+        )
+        .unwrap()
     }
 
     fn metrics_identifier(&self) -> &str {

--- a/stackslib/src/net/api/getsigner.rs
+++ b/stackslib/src/net/api/getsigner.rs
@@ -61,10 +61,8 @@ impl HttpRequest for GetSignerRequestHandler {
     }
 
     fn path_regex(&self) -> Regex {
-        Regex::new(
-            r#"^/v3/stacker_set/(?P<signer_pubkey>[0-9a-f]{66})/(?P<cycle_num>[0-9]{1,10})$"#,
-        )
-        .unwrap()
+        Regex::new(r#"^/v3/signer/(?P<signer_pubkey>[0-9a-f]{66})/(?P<cycle_num>[0-9]{1,10})$"#)
+            .unwrap()
     }
 
     fn metrics_identifier(&self) -> &str {

--- a/stackslib/src/net/api/getsigner.rs
+++ b/stackslib/src/net/api/getsigner.rs
@@ -22,6 +22,7 @@ use stacks_common::util::hash::Sha256Sum;
 use crate::burnchains::Burnchain;
 use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::coordinator::OnChainRewardSetProvider;
+use crate::chainstate::nakamoto::NakamotoChainState;
 use crate::chainstate::stacks::boot::{
     PoxVersions, RewardSet, POX_1_NAME, POX_2_NAME, POX_3_NAME, POX_4_NAME,
 };
@@ -51,38 +52,6 @@ pub struct GetSignerRequestHandler {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSignerResponse {
     pub blocks_signed: u64,
-}
-
-pub enum GetSignerErrors {
-    NotAvailableYet(crate::chainstate::coordinator::Error),
-    Other(String),
-}
-
-impl GetSignerErrors {
-    pub const NOT_AVAILABLE_ERR_TYPE: &'static str = "not_available_try_again";
-    pub const OTHER_ERR_TYPE: &'static str = "other";
-
-    pub fn error_type_string(&self) -> &'static str {
-        match self {
-            Self::NotAvailableYet(_) => Self::NOT_AVAILABLE_ERR_TYPE,
-            Self::Other(_) => Self::OTHER_ERR_TYPE,
-        }
-    }
-}
-
-impl From<&str> for GetSignerErrors {
-    fn from(value: &str) -> Self {
-        GetSignerErrors::Other(value.into())
-    }
-}
-
-impl std::fmt::Display for GetSignerErrors {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GetSignerErrors::NotAvailableYet(e) => write!(f, "Could not read reward set. Prepare phase may not have started for this cycle yet. Err = {e:?}"),
-            GetSignerErrors::Other(msg) => write!(f, "{msg}")
-        }
-    }
 }
 
 /// Decode the HTTP request
@@ -128,11 +97,11 @@ impl HttpRequest for GetSignerRequestHandler {
             ));
         };
 
-        let cycle_num = u64::from_str_radix(cycle_num_str.into(), 10)
-            .map_err(|e| Error::DecodeError(format!("Failed to parse cycle number: {e}")))?;
-
         let signer_pubkey = Secp256k1PublicKey::from_hex(signer_pubkey_str.into())
             .map_err(|e| Error::DecodeError(format!("Failed to signer public key: {e}")))?;
+
+        let cycle_num = u64::from_str_radix(cycle_num_str.into(), 10)
+            .map_err(|e| Error::DecodeError(format!("Failed to parse cycle number: {e}")))?;
 
         self.signer_pubkey = Some(signer_pubkey);
         self.reward_cycle = Some(cycle_num);
@@ -152,16 +121,9 @@ impl RPCRequestHandler for GetSignerRequestHandler {
     fn try_handle_request(
         &mut self,
         preamble: HttpRequestPreamble,
-        contents: HttpRequestContents,
+        _contents: HttpRequestContents,
         node: &mut StacksNodeState,
     ) -> Result<(HttpResponsePreamble, HttpResponseContents), NetError> {
-        let tip = match node.load_stacks_chain_tip(&preamble, &contents) {
-            Ok(tip) => tip,
-            Err(error_resp) => {
-                return error_resp.try_into_contents().map_err(NetError::from);
-            }
-        };
-
         let signer_pubkey = self
             .signer_pubkey
             .take()
@@ -172,13 +134,12 @@ impl RPCRequestHandler for GetSignerRequestHandler {
             .take()
             .ok_or(NetError::SendError("Missing `reward_cycle`".into()))?;
 
-        let result = node.with_node_state(|_network, _sortdb, _chainstate, _mempool, _rpc_args| {
-            // TODO
-            if true {
-                Ok(0u64)
-            } else {
-                Err("Something went wrong")
-            }
+        let result = node.with_node_state(|_network, _sortdb, chainstate, _mempool, _rpc_args| {
+            NakamotoChainState::get_signer_block_count(
+                &chainstate.index_conn(),
+                &signer_pubkey,
+                reward_cycle,
+            )
         });
 
         let response = match result {
@@ -236,33 +197,5 @@ impl StacksHttpResponse {
         let response: GetSignerResponse = serde_json::from_value(response_json)
             .map_err(|_e| Error::DecodeError("Failed to decode JSON".to_string()))?;
         Ok(response)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::GetSignerErrors;
-
-    #[test]
-    // Test the formatting and error type strings of GetSignerErrors
-    fn get_signer_errors() {
-        let not_available_err = GetSignerErrors::NotAvailableYet(
-            crate::chainstate::coordinator::Error::PoXNotProcessedYet,
-        );
-        let other_err = GetSignerErrors::Other("foo".into());
-
-        assert_eq!(
-            not_available_err.error_type_string(),
-            GetSignerErrors::NOT_AVAILABLE_ERR_TYPE
-        );
-        assert_eq!(
-            other_err.error_type_string(),
-            GetSignerErrors::OTHER_ERR_TYPE
-        );
-
-        assert!(not_available_err
-            .to_string()
-            .starts_with("Could not read reward set"));
-        assert_eq!(other_err.to_string(), "foo".to_string());
     }
 }

--- a/stackslib/src/net/api/getsigner.rs
+++ b/stackslib/src/net/api/getsigner.rs
@@ -1,0 +1,268 @@
+// Copyright (C) 2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+use clarity::util::secp256k1::Secp256k1PublicKey;
+use regex::{Captures, Regex};
+use serde_json::json;
+use stacks_common::types::chainstate::StacksBlockId;
+use stacks_common::types::net::PeerHost;
+use stacks_common::util::hash::Sha256Sum;
+
+use crate::burnchains::Burnchain;
+use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::coordinator::OnChainRewardSetProvider;
+use crate::chainstate::stacks::boot::{
+    PoxVersions, RewardSet, POX_1_NAME, POX_2_NAME, POX_3_NAME, POX_4_NAME,
+};
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::Error as ChainError;
+use crate::core::mempool::MemPoolDB;
+use crate::net::http::{
+    parse_json, Error, HttpBadRequest, HttpNotFound, HttpRequest, HttpRequestContents,
+    HttpRequestPreamble, HttpResponse, HttpResponseContents, HttpResponsePayload,
+    HttpResponsePreamble, HttpServerError,
+};
+use crate::net::httpcore::{
+    HttpPreambleExtensions, HttpRequestContentsExtensions, RPCRequestHandler, StacksHttp,
+    StacksHttpRequest, StacksHttpResponse,
+};
+use crate::net::p2p::PeerNetwork;
+use crate::net::{Error as NetError, StacksNodeState, TipRequest};
+use crate::util_lib::boot::boot_code_id;
+use crate::util_lib::db::Error as DBError;
+
+#[derive(Clone, Default)]
+pub struct GetSignerRequestHandler {
+    signer_pubkey: Option<Secp256k1PublicKey>,
+    reward_cycle: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetSignerResponse {
+    pub blocks_signed: u64,
+}
+
+pub enum GetSignerErrors {
+    NotAvailableYet(crate::chainstate::coordinator::Error),
+    Other(String),
+}
+
+impl GetSignerErrors {
+    pub const NOT_AVAILABLE_ERR_TYPE: &'static str = "not_available_try_again";
+    pub const OTHER_ERR_TYPE: &'static str = "other";
+
+    pub fn error_type_string(&self) -> &'static str {
+        match self {
+            Self::NotAvailableYet(_) => Self::NOT_AVAILABLE_ERR_TYPE,
+            Self::Other(_) => Self::OTHER_ERR_TYPE,
+        }
+    }
+}
+
+impl From<&str> for GetSignerErrors {
+    fn from(value: &str) -> Self {
+        GetSignerErrors::Other(value.into())
+    }
+}
+
+impl std::fmt::Display for GetSignerErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GetSignerErrors::NotAvailableYet(e) => write!(f, "Could not read reward set. Prepare phase may not have started for this cycle yet. Err = {e:?}"),
+            GetSignerErrors::Other(msg) => write!(f, "{msg}")
+        }
+    }
+}
+
+/// Decode the HTTP request
+impl HttpRequest for GetSignerRequestHandler {
+    fn verb(&self) -> &'static str {
+        "GET"
+    }
+
+    fn path_regex(&self) -> Regex {
+        Regex::new(
+            r#"^/v3/stacker_set/(?P<signer_pubkey>[0-9a-f]{66})/(?P<cycle_num>[0-9]{1,10})$"#,
+        )
+        .unwrap()
+    }
+
+    fn metrics_identifier(&self) -> &str {
+        "/v3/signer/:signer_pubkey/:cycle_num"
+    }
+
+    /// Try to decode this request.
+    /// There's nothing to load here, so just make sure the request is well-formed.
+    fn try_parse_request(
+        &mut self,
+        preamble: &HttpRequestPreamble,
+        captures: &Captures,
+        query: Option<&str>,
+        _body: &[u8],
+    ) -> Result<HttpRequestContents, Error> {
+        if preamble.get_content_length() != 0 {
+            return Err(Error::DecodeError(
+                "Invalid Http request: expected 0-length body".into(),
+            ));
+        }
+
+        let Some(cycle_num_str) = captures.name("cycle_num") else {
+            return Err(Error::DecodeError(
+                "Missing in request path: `cycle_num`".into(),
+            ));
+        };
+        let Some(signer_pubkey_str) = captures.name("signer_pubkey") else {
+            return Err(Error::DecodeError(
+                "Missing in request path: `signer_pubkey`".into(),
+            ));
+        };
+
+        let cycle_num = u64::from_str_radix(cycle_num_str.into(), 10)
+            .map_err(|e| Error::DecodeError(format!("Failed to parse cycle number: {e}")))?;
+
+        let signer_pubkey = Secp256k1PublicKey::from_hex(signer_pubkey_str.into())
+            .map_err(|e| Error::DecodeError(format!("Failed to signer public key: {e}")))?;
+
+        self.signer_pubkey = Some(signer_pubkey);
+        self.reward_cycle = Some(cycle_num);
+
+        Ok(HttpRequestContents::new().query_string(query))
+    }
+}
+
+impl RPCRequestHandler for GetSignerRequestHandler {
+    /// Reset internal state
+    fn restart(&mut self) {
+        self.signer_pubkey = None;
+        self.reward_cycle = None;
+    }
+
+    /// Make the response
+    fn try_handle_request(
+        &mut self,
+        preamble: HttpRequestPreamble,
+        contents: HttpRequestContents,
+        node: &mut StacksNodeState,
+    ) -> Result<(HttpResponsePreamble, HttpResponseContents), NetError> {
+        let tip = match node.load_stacks_chain_tip(&preamble, &contents) {
+            Ok(tip) => tip,
+            Err(error_resp) => {
+                return error_resp.try_into_contents().map_err(NetError::from);
+            }
+        };
+
+        let signer_pubkey = self
+            .signer_pubkey
+            .take()
+            .ok_or(NetError::SendError("Missing `signer_pubkey`".into()))?;
+
+        let reward_cycle = self
+            .reward_cycle
+            .take()
+            .ok_or(NetError::SendError("Missing `reward_cycle`".into()))?;
+
+        let result = node.with_node_state(|_network, _sortdb, _chainstate, _mempool, _rpc_args| {
+            // TODO
+            if true {
+                Ok(0u64)
+            } else {
+                Err("Something went wrong")
+            }
+        });
+
+        let response = match result {
+            Ok(response) => response,
+            Err(error) => {
+                return StacksHttpResponse::new_error(
+                    &preamble,
+                    &HttpNotFound::new(error.to_string()),
+                )
+                .try_into_contents()
+                .map_err(NetError::from);
+            }
+        };
+
+        let mut preamble = HttpResponsePreamble::ok_json(&preamble);
+        preamble.set_canonical_stacks_tip_height(Some(node.canonical_stacks_tip_height()));
+        let body = HttpResponseContents::try_from_json(&response)?;
+        Ok((preamble, body))
+    }
+}
+
+impl HttpResponse for GetSignerRequestHandler {
+    fn try_parse_response(
+        &self,
+        preamble: &HttpResponsePreamble,
+        body: &[u8],
+    ) -> Result<HttpResponsePayload, Error> {
+        let response: GetSignerResponse = parse_json(preamble, body)?;
+        Ok(HttpResponsePayload::try_from_json(response)?)
+    }
+}
+
+impl StacksHttpRequest {
+    /// Make a new getinfo request to this endpoint
+    pub fn new_getsigner(
+        host: PeerHost,
+        signer_pubkey: &Secp256k1PublicKey,
+        cycle_num: u64,
+        tip_req: TipRequest,
+    ) -> StacksHttpRequest {
+        StacksHttpRequest::new_for_peer(
+            host,
+            "GET".into(),
+            format!("/v3/signer/{}/{cycle_num}", signer_pubkey.to_hex()),
+            HttpRequestContents::new().for_tip(tip_req),
+        )
+        .expect("FATAL: failed to construct request from infallible data")
+    }
+}
+
+impl StacksHttpResponse {
+    pub fn decode_signer(self) -> Result<GetSignerResponse, NetError> {
+        let contents = self.get_http_payload_ok()?;
+        let response_json: serde_json::Value = contents.try_into()?;
+        let response: GetSignerResponse = serde_json::from_value(response_json)
+            .map_err(|_e| Error::DecodeError("Failed to decode JSON".to_string()))?;
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::GetSignerErrors;
+
+    #[test]
+    // Test the formatting and error type strings of GetSignerErrors
+    fn get_signer_errors() {
+        let not_available_err = GetSignerErrors::NotAvailableYet(
+            crate::chainstate::coordinator::Error::PoXNotProcessedYet,
+        );
+        let other_err = GetSignerErrors::Other("foo".into());
+
+        assert_eq!(
+            not_available_err.error_type_string(),
+            GetSignerErrors::NOT_AVAILABLE_ERR_TYPE
+        );
+        assert_eq!(
+            other_err.error_type_string(),
+            GetSignerErrors::OTHER_ERR_TYPE
+        );
+
+        assert!(not_available_err
+            .to_string()
+            .starts_with("Could not read reward set"));
+        assert_eq!(other_err.to_string(), "foo".to_string());
+    }
+}

--- a/stackslib/src/net/api/mod.rs
+++ b/stackslib/src/net/api/mod.rs
@@ -125,6 +125,7 @@ impl StacksHttp {
         self.register_rpc_endpoint(
             gettransaction_unconfirmed::RPCGetTransactionUnconfirmedRequestHandler::new(),
         );
+        self.register_rpc_endpoint(getsigner::GetSignerRequestHandler::default());
         self.register_rpc_endpoint(
             liststackerdbreplicas::RPCListStackerDBReplicasRequestHandler::new(),
         );

--- a/stackslib/src/net/api/mod.rs
+++ b/stackslib/src/net/api/mod.rs
@@ -55,6 +55,7 @@ pub mod getmicroblocks_indexed;
 pub mod getmicroblocks_unconfirmed;
 pub mod getneighbors;
 pub mod getpoxinfo;
+pub mod getsigner;
 pub mod getsortition;
 pub mod getstackerdbchunk;
 pub mod getstackerdbmetadata;

--- a/stackslib/src/net/api/tests/getsigner.rs
+++ b/stackslib/src/net/api/tests/getsigner.rs
@@ -1,0 +1,96 @@
+// Copyright (C) 2024 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use clarity::types::chainstate::{StacksBlockId, StacksPrivateKey, StacksPublicKey};
+use rand::{thread_rng, RngCore};
+use stacks_common::types::chainstate::{BurnchainHeaderHash, ConsensusHash};
+use stacks_common::types::net::PeerHost;
+
+use crate::net::api::getsigner::{self, GetSignerRequestHandler};
+use crate::net::api::tests::{test_rpc, TestRPC};
+use crate::net::connection::ConnectionOptions;
+use crate::net::http::{Error as HttpError, HttpRequestPreamble, HttpVersion};
+use crate::net::httpcore::{
+    RPCRequestHandler, StacksHttp, StacksHttpPreamble, StacksHttpRequest, TipRequest,
+};
+use crate::net::test::TestEventObserver;
+use crate::net::{Error as NetError, ProtocolFamily};
+
+fn make_preamble(query: &str) -> HttpRequestPreamble {
+    HttpRequestPreamble {
+        version: HttpVersion::Http11,
+        verb: "GET".into(),
+        path_and_query_str: format!("/v3/signer{query}"),
+        host: PeerHost::DNS("localhost".into(), 0),
+        content_type: None,
+        content_length: Some(0),
+        keep_alive: false,
+        headers: BTreeMap::new(),
+    }
+}
+
+#[test]
+fn test_try_parse_request() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+    let http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
+    let private_key = StacksPrivateKey::new();
+    let signer_pubkey = StacksPublicKey::from_private(&private_key);
+    let signer_pubkey_hex = signer_pubkey.to_hex();
+    let cycle_num = thread_rng().next_u32() as u64;
+
+    let mut handler = getsigner::GetSignerRequestHandler::new();
+    let mut bad_content_length_preamble =
+        make_preamble(&format!("/{signer_pubkey_hex}/{cycle_num}"));
+    bad_content_length_preamble.content_length = Some(1);
+    let tests = vec![
+        (
+            make_preamble(&format!("/{signer_pubkey_hex}/{cycle_num}")),
+            Ok((Some(signer_pubkey), Some(cycle_num))),
+        ),
+        (
+            make_preamble(&format!("/foo/{cycle_num}")),
+            Err(NetError::NotFoundError),
+        ),
+        (
+            make_preamble(&format!("/{signer_pubkey_hex}/bar")),
+            Err(NetError::NotFoundError),
+        ),
+        (
+            bad_content_length_preamble,
+            Err(
+                HttpError::DecodeError("Invalid Http request: expected 0-length body".into())
+                    .into(),
+            ),
+        ),
+    ];
+
+    for (inp, expected_result) in tests.into_iter() {
+        handler.restart();
+        let parsed_request = http.handle_try_parse_request(&mut handler, &inp, &[]);
+        match expected_result {
+            Ok((key, cycle)) => {
+                assert!(parsed_request.is_ok());
+                assert_eq!(handler.signer_pubkey, key);
+                assert_eq!(handler.reward_cycle, cycle);
+            }
+            Err(e) => {
+                assert_eq!(e, parsed_request.unwrap_err());
+            }
+        }
+    }
+}

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -73,6 +73,7 @@ mod getmicroblocks_indexed;
 mod getmicroblocks_unconfirmed;
 mod getneighbors;
 mod getpoxinfo;
+mod getsigner;
 mod getsortition;
 mod getstackerdbchunk;
 mod getstackerdbmetadata;

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -67,6 +67,7 @@ use stacks::core::{
 use stacks::libstackerdb::SlotMetadata;
 use stacks::net::api::callreadonly::CallReadOnlyRequestBody;
 use stacks::net::api::get_tenures_fork_info::TenureForkingInfo;
+use stacks::net::api::getsigner::GetSignerResponse;
 use stacks::net::api::getstackers::GetStackersResponse;
 use stacks::net::api::postblock_proposal::{
     BlockValidateReject, BlockValidateResponse, NakamotoBlockProposal, ValidateRejectCode,
@@ -8555,11 +8556,9 @@ fn v3_signer_api_endpoint() {
         info!("Send request: GET {url}");
         reqwest::blocking::get(url)
             .unwrap_or_else(|e| panic!("GET request failed: {e}"))
-            .text()
-            .inspect(|response| info!("Recieved response: GET {url} -> {response}"))
-            .expect("Empty response")
-            .parse::<u64>()
-            .unwrap_or_else(|e| panic!("Failed to parse response as `u64`: {e}"))
+            .json::<GetSignerResponse>()
+            .unwrap()
+            .blocks_signed
     };
 
     // Check reward cycle 1, should be 0 (pre-nakamoto)

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -7983,14 +7983,15 @@ fn v3_signer_api_endpoint() {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let get_v3_signer = |pubkey: &Secp256k1PublicKey, reward_cycle: u64| {
-        let url = format!(
+        let url = &format!(
             "{http_origin}/v3/signer/{pk}/{reward_cycle}",
             pk = pubkey.to_hex()
         );
-        info!("Sending GET {url}");
+        info!("Send request: GET {url}");
         reqwest::blocking::get(url)
             .unwrap_or_else(|e| panic!("GET request failed: {e}"))
             .text()
+            .inspect(|response| info!("Recieved response: GET {url} -> {response}"))
             .expect("Empty response")
             .parse::<u64>()
             .unwrap_or_else(|e| panic!("Failed to parse response as `u64`: {e}"))


### PR DESCRIPTION
### Description

Add RPC endpoint `/v3/signer/{signer_pubkey}/{reward_cycle}` that returns number of blocks signed by signer during given reward cycle

### Applicable issues

- fixes #5106

### Additional info (benefits, drawbacks, caveats)

Someone with more experience with chainstate DB and SQL in general please double-check the schema migration and queries

### Progress

- [x] Add `signer_stats` table to chainstate DB
- [x] Update `signer_stats` database in `append_block()`
- [x] Add endpoint to query `signer_stats` table
- [x] Integration test

### Checklist

- [x] Test coverage for new or modified code paths
- [x] Changelog is updated
- [x] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [x] New integration test(s) added to `bitcoin-tests.yml`
