### PR TITLE
Fix/signer block state machine

### DIFF
--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -564,13 +564,13 @@ impl StacksClient {
                 warn!("Failed to parse the GetStackers error response: {e}");
                 backoff::Error::permanent(e.into())
             })?;
-            if &error_data.err_type == GetStackersErrors::NOT_AVAILABLE_ERR_TYPE {
-                return Err(backoff::Error::transient(ClientError::NoSortitionOnChain));
+            if error_data.err_type == GetStackersErrors::NOT_AVAILABLE_ERR_TYPE {
+                Err(backoff::Error::transient(ClientError::NoSortitionOnChain))
             } else {
                 warn!("Got error response ({status}): {}", error_data.err_msg);
-                return Err(backoff::Error::permanent(ClientError::RequestFailure(
+                Err(backoff::Error::permanent(ClientError::RequestFailure(
                     status,
-                )));
+                )))
             }
         };
         let stackers_response =

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -430,10 +430,10 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
         if !Self::is_configured_for_cycle(&self.stacks_signers, current_reward_cycle) {
             self.refresh_signer_config(current_reward_cycle);
         }
-        if is_in_next_prepare_phase {
-            if !Self::is_configured_for_cycle(&self.stacks_signers, next_reward_cycle) {
-                self.refresh_signer_config(next_reward_cycle);
-            }
+        if is_in_next_prepare_phase
+            && !Self::is_configured_for_cycle(&self.stacks_signers, next_reward_cycle)
+        {
+            self.refresh_signer_config(next_reward_cycle);
         }
 
         self.cleanup_stale_signers(current_reward_cycle);

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -228,6 +228,7 @@ impl BlockInfo {
     /// Mark this block as locally accepted, valid, signed over, and records either the self or group signed timestamp in the block info if it wasn't
     ///  already set.
     pub fn mark_locally_accepted(&mut self, group_signed: bool) -> Result<(), String> {
+        self.move_to(BlockState::LocallyAccepted)?;
         self.valid = Some(true);
         self.signed_over = true;
         if group_signed {
@@ -235,28 +236,31 @@ impl BlockInfo {
         } else {
             self.signed_self.get_or_insert(get_epoch_time_secs());
         }
-        self.move_to(BlockState::LocallyAccepted)
+        Ok(())
     }
 
     /// Mark this block as valid, signed over, and records a group timestamp in the block info if it wasn't
     ///  already set.
     pub fn mark_globally_accepted(&mut self) -> Result<(), String> {
+        self.move_to(BlockState::GloballyAccepted)?;
         self.valid = Some(true);
         self.signed_over = true;
         self.signed_group.get_or_insert(get_epoch_time_secs());
-        self.move_to(BlockState::GloballyAccepted)
+        Ok(())
     }
 
     /// Mark the block as locally rejected and invalid
     pub fn mark_locally_rejected(&mut self) -> Result<(), String> {
+        self.move_to(BlockState::LocallyRejected);
         self.valid = Some(false);
-        self.move_to(BlockState::LocallyRejected)
+        Ok(())
     }
 
     /// Mark the block as globally rejected and invalid
     pub fn mark_globally_rejected(&mut self) -> Result<(), String> {
+        self.move_to(BlockState::GloballyRejected);
         self.valid = Some(false);
-        self.move_to(BlockState::GloballyRejected)
+        Ok(())
     }
 
     /// Return the block's signer signature hash

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -267,10 +267,11 @@ impl BlockInfo {
     /// Check if the block state transition is valid
     fn check_state(&self, state: BlockState) -> bool {
         let prev_state = &self.state;
+        if *prev_state == state {
+            return true;
+        }
         match state {
-            BlockState::Unprocessed => {
-                matches!(prev_state, BlockState::Unprocessed)
-            }
+            BlockState::Unprocessed => false,
             BlockState::LocallyAccepted => {
                 matches!(prev_state, BlockState::Unprocessed)
             }
@@ -687,7 +688,7 @@ impl SignerDb {
             .vote
             .as_ref()
             .map(|v| if v.rejected { "REJECT" } else { "ACCEPT" });
-        let broadcasted = self.get_block_broadcasted(block_info.reward_cycle, &hash)?;
+        let broadcasted = self.get_block_broadcasted(block_info.reward_cycle, hash)?;
         debug!("Inserting block_info.";
             "reward_cycle" => %block_info.reward_cycle,
             "burn_block_height" => %block_info.burn_block_height,
@@ -736,7 +737,7 @@ impl SignerDb {
         let qry = "INSERT OR REPLACE INTO block_signatures (signer_signature_hash, signature) VALUES (?1, ?2);";
         let args = params![
             block_sighash,
-            serde_json::to_string(signature).map_err(|e| DBError::SerializationError(e))?
+            serde_json::to_string(signature).map_err(DBError::SerializationError)?
         ];
 
         debug!("Inserting block signature.";
@@ -825,7 +826,7 @@ impl SignerDb {
         if broadcasted == 0 {
             return Ok(None);
         }
-        Ok(u64::try_from(broadcasted).ok())
+        Ok(Some(broadcasted))
     }
 
     /// Get the current state of a given block in the database
@@ -1152,15 +1153,12 @@ mod tests {
         assert_eq!(db.get_block_signatures(&block_id).unwrap(), vec![]);
 
         db.add_block_signature(&block_id, &sig1).unwrap();
-        assert_eq!(
-            db.get_block_signatures(&block_id).unwrap(),
-            vec![sig1.clone()]
-        );
+        assert_eq!(db.get_block_signatures(&block_id).unwrap(), vec![sig1]);
 
         db.add_block_signature(&block_id, &sig2).unwrap();
         assert_eq!(
             db.get_block_signatures(&block_id).unwrap(),
-            vec![sig1.clone(), sig2.clone()]
+            vec![sig1, sig2]
         );
     }
 
@@ -1222,5 +1220,46 @@ mod tests {
             .unwrap(),
             12345
         );
+    }
+    #[test]
+    fn state_machine() {
+        let (mut block, _) = create_block();
+        assert_eq!(block.state, BlockState::Unprocessed);
+        assert!(block.check_state(BlockState::Unprocessed));
+        assert!(block.check_state(BlockState::LocallyAccepted));
+        assert!(block.check_state(BlockState::LocallyRejected));
+        assert!(block.check_state(BlockState::GloballyAccepted));
+        assert!(block.check_state(BlockState::GloballyRejected));
+
+        block.move_to(BlockState::LocallyAccepted).unwrap();
+        assert_eq!(block.state, BlockState::LocallyAccepted);
+        assert!(!block.check_state(BlockState::Unprocessed));
+        assert!(block.check_state(BlockState::LocallyAccepted));
+        assert!(!block.check_state(BlockState::LocallyRejected));
+        assert!(block.check_state(BlockState::GloballyAccepted));
+        assert!(block.check_state(BlockState::GloballyRejected));
+
+        block.move_to(BlockState::GloballyAccepted).unwrap();
+        assert_eq!(block.state, BlockState::GloballyAccepted);
+        assert!(!block.check_state(BlockState::Unprocessed));
+        assert!(!block.check_state(BlockState::LocallyAccepted));
+        assert!(!block.check_state(BlockState::LocallyRejected));
+        assert!(block.check_state(BlockState::GloballyAccepted));
+        assert!(!block.check_state(BlockState::GloballyRejected));
+
+        // Must manually override as will not be able to move from GloballyAccepted to LocallyAccepted
+        block.state = BlockState::LocallyRejected;
+        assert!(!block.check_state(BlockState::Unprocessed));
+        assert!(!block.check_state(BlockState::LocallyAccepted));
+        assert!(block.check_state(BlockState::LocallyRejected));
+        assert!(block.check_state(BlockState::GloballyAccepted));
+        assert!(block.check_state(BlockState::GloballyRejected));
+
+        block.move_to(BlockState::GloballyRejected).unwrap();
+        assert!(!block.check_state(BlockState::Unprocessed));
+        assert!(!block.check_state(BlockState::LocallyAccepted));
+        assert!(!block.check_state(BlockState::LocallyRejected));
+        assert!(!block.check_state(BlockState::GloballyAccepted));
+        assert!(block.check_state(BlockState::GloballyRejected));
     }
 }


### PR DESCRIPTION
Cleaning up some spammy logs due to moving from existing state to an existing state. This is legal and happens frequently enough. This allows this conversion and also makes sure that internal state does not change if the block state fails to update.