### PR TITLE
Force forked_tenure_is_ignored test_observer to receive a block befor…

### DIFF
--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -4195,9 +4195,6 @@ fn forked_tenure_is_ignored() {
     .unwrap();
 
     info!("Tenure C produced a block!");
-    let block_tenure_c = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
-        .unwrap()
-        .unwrap();
     let start = Instant::now();
     while test_observer::get_mined_nakamoto_blocks().len() <= blocks_observed_before {
         thread::sleep(Duration::from_secs(1));
@@ -4206,6 +4203,9 @@ fn forked_tenure_is_ignored() {
             "FAIL: Test timed out while waiting to observe new mined nakamoto block",
         );
     }
+    let block_tenure_c = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+        .unwrap()
+        .unwrap();
     let blocks = test_observer::get_mined_nakamoto_blocks();
     let block_c = blocks.last().unwrap();
     info!("Tenure C tip block: {}", &block_tenure_c.index_block_hash());
@@ -4252,10 +4252,6 @@ fn forked_tenure_is_ignored() {
     .unwrap();
 
     info!("Tenure C produced a second block!");
-
-    let block_2_tenure_c = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
-        .unwrap()
-        .unwrap();
     let start = Instant::now();
     while test_observer::get_mined_nakamoto_blocks().len() <= blocks_observed_before {
         thread::sleep(Duration::from_secs(1));
@@ -4264,6 +4260,9 @@ fn forked_tenure_is_ignored() {
             "FAIL: Test timed out while waiting to observe new mined nakamoto block",
         );
     }
+    let block_2_tenure_c = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+        .unwrap()
+        .unwrap();
     let blocks = test_observer::get_mined_nakamoto_blocks();
     let block_2_c = blocks.last().unwrap();
 
@@ -4295,9 +4294,6 @@ fn forked_tenure_is_ignored() {
     })
     .unwrap();
 
-    let block_tenure_d = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
-        .unwrap()
-        .unwrap();
     let start = Instant::now();
     while test_observer::get_mined_nakamoto_blocks().len() <= blocks_observed_before {
         thread::sleep(Duration::from_secs(1));
@@ -4306,6 +4302,9 @@ fn forked_tenure_is_ignored() {
             "FAIL: Test timed out while waiting to observe new mined nakamoto block",
         );
     }
+    let block_tenure_d = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
+        .unwrap()
+        .unwrap();
     let blocks = test_observer::get_mined_nakamoto_blocks();
     let block_d = blocks.last().unwrap();
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -4174,6 +4174,7 @@ fn forked_tenure_is_ignored() {
     // It should also build on block A, since the node has paused processing of block B.
     let commits_before = commits_submitted.load(Ordering::SeqCst);
     let blocks_before = mined_blocks.load(Ordering::SeqCst);
+    let blocks_observed_before = test_observer::get_mined_nakamoto_blocks().len();
     let blocks_processed_before = coord_channel
         .lock()
         .expect("Mutex poisoned")
@@ -4197,6 +4198,14 @@ fn forked_tenure_is_ignored() {
     let block_tenure_c = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
         .unwrap()
         .unwrap();
+    let start = Instant::now();
+    while test_observer::get_mined_nakamoto_blocks().len() <= blocks_observed_before {
+        thread::sleep(Duration::from_secs(1));
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "FAIL: Test timed out while waiting to observe new mined nakamoto block",
+        );
+    }
     let blocks = test_observer::get_mined_nakamoto_blocks();
     let block_c = blocks.last().unwrap();
     info!("Tenure C tip block: {}", &block_tenure_c.index_block_hash());
@@ -4210,6 +4219,7 @@ fn forked_tenure_is_ignored() {
     );
 
     // Now let's produce a second block for tenure C and ensure it builds off of block C.
+    let blocks_observed_before = test_observer::get_mined_nakamoto_blocks().len();
     let blocks_before = mined_blocks.load(Ordering::SeqCst);
     let blocks_processed_before = coord_channel
         .lock()
@@ -4246,6 +4256,14 @@ fn forked_tenure_is_ignored() {
     let block_2_tenure_c = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
         .unwrap()
         .unwrap();
+    let start = Instant::now();
+    while test_observer::get_mined_nakamoto_blocks().len() <= blocks_observed_before {
+        thread::sleep(Duration::from_secs(1));
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "FAIL: Test timed out while waiting to observe new mined nakamoto block",
+        );
+    }
     let blocks = test_observer::get_mined_nakamoto_blocks();
     let block_2_c = blocks.last().unwrap();
 
@@ -4257,6 +4275,7 @@ fn forked_tenure_is_ignored() {
 
     info!("Starting tenure D.");
     // Submit a block commit op for tenure D and mine a stacks block
+    let blocks_observed_before = test_observer::get_mined_nakamoto_blocks().len();
     let commits_before = commits_submitted.load(Ordering::SeqCst);
     let blocks_before = mined_blocks.load(Ordering::SeqCst);
     let blocks_processed_before = coord_channel
@@ -4279,6 +4298,14 @@ fn forked_tenure_is_ignored() {
     let block_tenure_d = NakamotoChainState::get_canonical_block_header(chainstate.db(), &sortdb)
         .unwrap()
         .unwrap();
+    let start = Instant::now();
+    while test_observer::get_mined_nakamoto_blocks().len() <= blocks_observed_before {
+        thread::sleep(Duration::from_secs(1));
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "FAIL: Test timed out while waiting to observe new mined nakamoto block",
+        );
+    }
     let blocks = test_observer::get_mined_nakamoto_blocks();
     let block_d = blocks.last().unwrap();
 

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -4795,7 +4795,6 @@ fn miner_recovers_when_broadcast_block_delay_across_tenures_occurs() {
     // Induce block N+2 to get mined
     let transfer_tx =
         make_stacks_transfer(&sender_sk, sender_nonce, send_fee, &recipient, send_amt);
-    sender_nonce += 1;
 
     let tx = submit_tx(&http_origin, &transfer_tx);
     info!("Submitted tx {tx} in to attempt to mine block N+2");


### PR DESCRIPTION
I think CI is failing because the test_observer is slow to receive an updated block when it checks for a new nakamoto block.