### PR TITLE
Test out `nakamoto_attempt_time_ms` at 60s

### DIFF
--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -193,10 +193,18 @@ impl SortitionsView {
             .cur_sortition
             .is_timed_out(self.config.block_proposal_timeout, signer_db)?
         {
+            info!(
+                "Current miner timed out, marking as invalid.";
+                "current_sortition_consensus_hash" => ?self.cur_sortition.consensus_hash,
+            );
             self.cur_sortition.miner_status = SortitionMinerStatus::InvalidatedBeforeFirstBlock;
         }
         if let Some(last_sortition) = self.last_sortition.as_mut() {
             if last_sortition.is_timed_out(self.config.block_proposal_timeout, signer_db)? {
+                info!(
+                    "Last miner timed out, marking as invalid.";
+                    "last_sortition_consensus_hash" => ?last_sortition.consensus_hash,
+                );
                 last_sortition.miner_status = SortitionMinerStatus::InvalidatedBeforeFirstBlock;
             }
         }

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -353,6 +353,7 @@ impl Signer {
             "{self}: received a block proposal for a new block. Submit block for validation. ";
             "signer_sighash" => %signer_signature_hash,
             "block_id" => %block_proposal.block.block_id(),
+            "burn_height" => block_proposal.burn_height,
         );
         crate::monitoring::increment_block_proposals_received();
         let mut block_info = BlockInfo::from(block_proposal.clone());

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1457,7 +1457,7 @@ impl BurnchainConfig {
             rpc_ssl: false,
             username: None,
             password: None,
-            timeout: 300,
+            timeout: 60,
             magic_bytes: BLOCKSTACK_MAGIC_MAINNET.clone(),
             local_mining_public_key: None,
             process_exit_at_block_height: None,

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -2370,7 +2370,7 @@ impl Default for MinerConfig {
             first_attempt_time_ms: 10,
             subsequent_attempt_time_ms: 120_000,
             microblock_attempt_time_ms: 30_000,
-            nakamoto_attempt_time_ms: 20_000,
+            nakamoto_attempt_time_ms: 5_000,
             probability_pick_no_estimate_tx: 25,
             block_reward_recipient: None,
             segwit: false,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -592,7 +592,7 @@ pub fn naka_neon_integration_conf(seed: Option<&[u8]>) -> (Config, StacksAddress
 
     conf.node.mine_microblocks = false;
     conf.miner.microblock_attempt_time_ms = 10;
-    conf.miner.nakamoto_attempt_time_ms = 20_000;
+    conf.miner.nakamoto_attempt_time_ms = 60_000;
     conf.node.microblock_frequency = 0;
     conf.node.wait_time_for_blocks = 200;
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -592,6 +592,7 @@ pub fn naka_neon_integration_conf(seed: Option<&[u8]>) -> (Config, StacksAddress
 
     conf.node.mine_microblocks = false;
     conf.miner.microblock_attempt_time_ms = 10;
+    conf.miner.nakamoto_attempt_time_ms = 20_000;
     conf.node.microblock_frequency = 0;
     conf.node.wait_time_for_blocks = 200;
 


### PR DESCRIPTION
This is a test to see if `tests::signer::v0::partial_tenure_fork` and `tests::signer::v0::bitcoind_forking_test` pass in CI when this config value is reverted to ~~20s~~ 60s.