### PR TITLE
Clarity-Wasm: add error mapping for already used arg error

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -7647,11 +7647,10 @@ mod tests {
 mod error_mapping {
     use wasmtime::{AsContextMut, Instance, Trap};
 
+    use super::read_identifier_from_wasm;
     use crate::vm::errors::{CheckErrors, Error, RuntimeErrorType, ShortReturnType, WasmError};
     use crate::vm::types::ResponseData;
     use crate::vm::Value;
-
-    use super::read_identifier_from_wasm;
 
     const LOG2_ERROR_MESSAGE: &str = "log2 must be passed a positive integer";
     const SQRTI_ERROR_MESSAGE: &str = "sqrti must be passed a positive integer";


### PR DESCRIPTION
Stacks-core counterpart of https://github.com/stacks-network/clarity-wasm/pull/510.

Tested with https://github.com/stacks-network/clarity-wasm/pull/510/commits/8c902d5508d381b402786e8f88401f037dc2fdea.