### PR TITLE
fix: use lower-cardinality prometheus metrics in signer

### DIFF
--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -648,7 +648,7 @@ impl StacksClient {
         address: &StacksAddress,
     ) -> Result<AccountEntryResponse, ClientError> {
         debug!("stacks_node_client: Getting account info...");
-        let timer_label = format!("{}/v2/accounts/:stacks_address", self.http_origin);
+        let timer_label = format!("{}/v2/accounts/:principal", self.http_origin);
         let timer = crate::monitoring::new_rpc_call_timer(&timer_label, &self.http_origin);
         let send_request = || {
             self.stacks_node_client


### PR DESCRIPTION
The signer exposes prometheus metrics, but because many of the RPC timers use the "raw" RPC path, it exposes a risk of high cardinality (ie many unique labels), especially when many signers are used across many networks.

To reduce that cardinality, the PR updates some of the RPC call timers to use a more "generic" path. For example, instead of `/v2/accounts/SP123`, it uses `/v2/accounts/:stacks_address`. Similarly, for read-only functions, the contract address is replaced with `:principal`, which will make the label the same across mainnet and testnet.

Reviewers: please double check the RPC timer labels in `stacks_client.rs` to ensure there aren't other timers that have dynamic values in them. Additionally, please double check that the labels are still descriptive enough.