### PR TITLE
Print a warning if failed to parse the stackers response

### DIFF
--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -590,9 +590,10 @@ impl StacksClient {
                 .map_err(|e| backoff::Error::transient(e.into()))?;
             let status = response.status();
             if status.is_success() {
-                return response
-                    .json()
-                    .map_err(|e| backoff::Error::permanent(e.into()));
+                return response.json().map_err(|e| {
+                    warn!("Failed to parse the GetStackers response: {e}");
+                    backoff::Error::permanent(e.into())
+                });
             }
             let error_data = response.json::<GetStackersErrorResp>().map_err(|e| {
                 warn!("Failed to parse the GetStackers error response: {e}");


### PR DESCRIPTION
Brice and I had some trouble debugging a version mismatch between the node and the signer due to a silent failure to parse the result of a v2/stacker_set call that should have been made to v3/stacker_set. technically trying to access this endppint does not return a 404, rather it returns a text "No such file or directory" which fails at the deserialization step silently. Do not let it silently fail by logging in this case.