### PR TITLE
Fix/5044

### DIFF
--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -542,10 +542,42 @@ impl<'a> TestPeer<'a> {
         F: FnMut(&mut NakamotoBlockBuilder),
         G: FnMut(&mut NakamotoBlock) -> bool,
     {
+        let nakamoto_tip = {
+            let chainstate = &mut self.stacks_node.as_mut().unwrap().chainstate;
+            let sort_db = self.sortdb.as_mut().unwrap();
+            NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
+                .unwrap()
+                .unwrap()
+        };
+        self.mine_single_block_tenure_at_tip(
+            &nakamoto_tip.index_block_hash(),
+            sender_key,
+            tenure_change_tx,
+            coinbase_tx,
+            miner_setup,
+            after_block,
+        )
+    }
+
+    pub fn mine_single_block_tenure_at_tip<F, G>(
+        &mut self,
+        nakamoto_tip: &StacksBlockId,
+        sender_key: &StacksPrivateKey,
+        tenure_change_tx: &StacksTransaction,
+        coinbase_tx: &StacksTransaction,
+        miner_setup: F,
+        after_block: G,
+    ) -> NakamotoBlock
+    where
+        F: FnMut(&mut NakamotoBlockBuilder),
+        G: FnMut(&mut NakamotoBlock) -> bool,
+    {
         let sender_addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&sender_key));
         let mut test_signers = self.config.test_signers.clone().unwrap();
         let recipient_addr =
             StacksAddress::from_string("ST2YM3J4KQK09V670TD6ZZ1XYNYCNGCWCVTASN5VM").unwrap();
+
+        let sender_acct = self.get_account(nakamoto_tip, &sender_addr.to_account_principal());
 
         // do a stx transfer in each block to a given recipient
         let mut blocks_and_sizes = self.make_nakamoto_tenure_and(
@@ -555,12 +587,11 @@ impl<'a> TestPeer<'a> {
             miner_setup,
             |_miner, chainstate, sortdb, blocks_so_far| {
                 if blocks_so_far.len() < 1 {
-                    let account = get_account(chainstate, sortdb, &sender_addr);
                     let stx_transfer = make_token_transfer(
                         chainstate,
                         sortdb,
                         &sender_key,
-                        account.nonce,
+                        sender_acct.nonce,
                         100,
                         1,
                         &recipient_addr,
@@ -607,12 +638,33 @@ impl<'a> TestPeer<'a> {
         tenure_change.tenure_consensus_hash = consensus_hash.clone();
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
+        let nakamoto_tip =
+            if let Some(nakamoto_parent_tenure) = self.nakamoto_parent_tenure_opt.as_ref() {
+                nakamoto_parent_tenure.last().as_ref().unwrap().block_id()
+            } else {
+                let tip = {
+                    let chainstate = &mut self.stacks_node.as_mut().unwrap().chainstate;
+                    let sort_db = self.sortdb.as_mut().unwrap();
+                    NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
+                        .unwrap()
+                        .unwrap()
+                };
+                tip.index_block_hash()
+            };
+
+        let miner_addr = self.miner.origin_address().unwrap();
+        let miner_acct = self.get_account(&nakamoto_tip, &miner_addr.to_account_principal());
+
         let tenure_change_tx = self
             .miner
-            .make_nakamoto_tenure_change(tenure_change.clone());
-        let coinbase_tx = self.miner.make_nakamoto_coinbase(None, vrf_proof);
+            .make_nakamoto_tenure_change_with_nonce(tenure_change.clone(), miner_acct.nonce);
 
-        let block = self.mine_single_block_tenure(
+        let coinbase_tx =
+            self.miner
+                .make_nakamoto_coinbase_with_nonce(None, vrf_proof, miner_acct.nonce + 1);
+
+        let block = self.mine_single_block_tenure_at_tip(
+            &nakamoto_tip,
             sender_key,
             &tenure_change_tx,
             &coinbase_tx,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -215,6 +215,15 @@ impl TestMiner {
         recipient: Option<PrincipalData>,
         vrf_proof: VRFProof,
     ) -> StacksTransaction {
+        self.make_nakamoto_coinbase_with_nonce(recipient, vrf_proof, self.nonce)
+    }
+
+    pub fn make_nakamoto_coinbase_with_nonce(
+        &mut self,
+        recipient: Option<PrincipalData>,
+        vrf_proof: VRFProof,
+        nonce: u64,
+    ) -> StacksTransaction {
         let mut tx_coinbase = StacksTransaction::new(
             TransactionVersion::Testnet,
             self.as_transaction_auth().unwrap(),
@@ -226,7 +235,7 @@ impl TestMiner {
         );
         tx_coinbase.chain_id = 0x80000000;
         tx_coinbase.anchor_mode = TransactionAnchorMode::OnChainOnly;
-        tx_coinbase.auth.set_origin_nonce(self.nonce);
+        tx_coinbase.auth.set_origin_nonce(nonce);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_coinbase);
         self.sign_as_origin(&mut tx_signer);
@@ -238,6 +247,14 @@ impl TestMiner {
         &mut self,
         tenure_change: TenureChangePayload,
     ) -> StacksTransaction {
+        self.make_nakamoto_tenure_change_with_nonce(tenure_change, self.nonce)
+    }
+
+    pub fn make_nakamoto_tenure_change_with_nonce(
+        &mut self,
+        tenure_change: TenureChangePayload,
+        nonce: u64,
+    ) -> StacksTransaction {
         let mut tx_tenure_change = StacksTransaction::new(
             TransactionVersion::Testnet,
             self.as_transaction_auth().unwrap(),
@@ -245,7 +262,7 @@ impl TestMiner {
         );
         tx_tenure_change.chain_id = 0x80000000;
         tx_tenure_change.anchor_mode = TransactionAnchorMode::OnChainOnly;
-        tx_tenure_change.auth.set_origin_nonce(self.nonce);
+        tx_tenure_change.auth.set_origin_nonce(nonce);
 
         let mut tx_signer = StacksTransactionSigner::new(&tx_tenure_change);
         self.sign_as_origin(&mut tx_signer);
@@ -504,38 +521,50 @@ impl TestStacksNode {
             };
 
         // the tenure-change contains a pointer to the end of the last tenure, which is currently
-        // the canonical tip
-        let (previous_tenure_end, previous_tenure_consensus_hash, previous_tenure_blocks) = {
-            let hdr = NakamotoChainState::get_canonical_block_header(self.chainstate.db(), &sortdb)
-                .unwrap()
-                .unwrap();
-            if hdr.anchored_header.as_stacks_nakamoto().is_some() {
-                // building atop nakamoto
-                let tenure_len = NakamotoChainState::get_nakamoto_tenure_length(
-                    self.chainstate.db(),
-                    &hdr.index_block_hash(),
-                )
-                .unwrap();
-                debug!(
-                    "Tenure length of Nakamoto tenure {} is {}; tipped at {}",
-                    &hdr.consensus_hash,
-                    tenure_len,
-                    &hdr.index_block_hash()
-                );
-                (hdr.index_block_hash(), hdr.consensus_hash, tenure_len)
-            } else {
-                // building atop epoch2
-                debug!(
-                    "Tenure length of epoch2 tenure {} is {}; tipped at {}",
-                    &parent_block_snapshot.consensus_hash, 1, &last_tenure_id
-                );
+        // the canonical tip unless overridden
+        let (previous_tenure_end, previous_tenure_consensus_hash, previous_tenure_blocks) =
+            if let Some(nakamoto_parent_tenure) = parent_nakamoto_tenure.as_ref() {
+                let start_block = nakamoto_parent_tenure.first().clone().unwrap();
+                let end_block = nakamoto_parent_tenure.last().clone().unwrap();
+                let tenure_len =
+                    end_block.header.chain_length + 1 - start_block.header.chain_length;
                 (
-                    last_tenure_id,
-                    parent_block_snapshot.consensus_hash.clone(),
-                    1,
+                    end_block.block_id(),
+                    end_block.header.consensus_hash,
+                    tenure_len as u32,
                 )
-            }
-        };
+            } else {
+                let hdr =
+                    NakamotoChainState::get_canonical_block_header(self.chainstate.db(), &sortdb)
+                        .unwrap()
+                        .unwrap();
+                if hdr.anchored_header.as_stacks_nakamoto().is_some() {
+                    // building atop nakamoto
+                    let tenure_len = NakamotoChainState::get_nakamoto_tenure_length(
+                        self.chainstate.db(),
+                        &hdr.index_block_hash(),
+                    )
+                    .unwrap();
+                    debug!(
+                        "Tenure length of Nakamoto tenure {} is {}; tipped at {}",
+                        &hdr.consensus_hash,
+                        tenure_len,
+                        &hdr.index_block_hash()
+                    );
+                    (hdr.index_block_hash(), hdr.consensus_hash, tenure_len)
+                } else {
+                    // building atop epoch2
+                    debug!(
+                        "Tenure length of epoch2 tenure {} is {}; tipped at {}",
+                        &parent_block_snapshot.consensus_hash, 1, &last_tenure_id
+                    );
+                    (
+                        last_tenure_id,
+                        parent_block_snapshot.consensus_hash.clone(),
+                        1,
+                    )
+                }
+            };
 
         let tenure_change_payload = TenureChangePayload {
             tenure_consensus_hash: ConsensusHash([0x00; 20]), // will be overwritten
@@ -576,7 +605,7 @@ impl TestStacksNode {
     ///     * the block
     ///     * its size
     ///     * its execution cost
-    ///     * a list of malleablized blocks with the same sighash
+    ///     * a list of malleablized blocks with the same contents, if desired
     pub fn make_nakamoto_tenure_blocks<'a, S, F, G>(
         chainstate: &mut StacksChainState,
         sortdb: &mut SortitionDB,
@@ -597,6 +626,8 @@ impl TestStacksNode {
         mut miner_setup: S,
         mut block_builder: F,
         mut after_block: G,
+        malleablize: bool,
+        mined_canonical: bool,
     ) -> Vec<(NakamotoBlock, u64, ExecutionCost, Vec<NakamotoBlock>)>
     where
         S: FnMut(&mut NakamotoBlockBuilder),
@@ -829,8 +860,9 @@ impl TestStacksNode {
                     coord.handle_new_nakamoto_stacks_block().unwrap();
                     processed_blocks.push(block_to_store.clone());
 
-                    if block_to_store.block_id() == block_id {
-                        // confirm that the chain tip advanced
+                    if block_to_store.block_id() == block_id && mined_canonical {
+                        // confirm that the chain tip advanced -- we intended to mine on the
+                        // canonical tip
                         let stacks_chain_tip = NakamotoChainState::get_canonical_block_header(
                             chainstate.db(),
                             &sortdb,
@@ -856,6 +888,11 @@ impl TestStacksNode {
                             &block_to_store.block_id()
                         );
                     }
+                }
+
+                if !malleablize {
+                    debug!("Will not produce malleablized blocks");
+                    break;
                 }
 
                 let num_sigs = block_to_store.header.signer_signature.len();
@@ -977,7 +1014,6 @@ impl<'a> TestPeer<'a> {
         StacksBlockId,
         Option<StacksBlock>,
         Option<Vec<NakamotoBlock>>,
-        Option<BlockSnapshot>,
     ) {
         let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         if let Some(parent_blocks) = stacks_node.get_last_nakamoto_tenure(miner) {
@@ -987,43 +1023,22 @@ impl<'a> TestPeer<'a> {
             let first_parent = parent_blocks.first().unwrap();
             debug!("First parent is {:?}", first_parent);
 
-            let first_parent_sn = SortitionDB::get_block_snapshot_consensus(
-                sortdb.conn(),
-                &first_parent.header.consensus_hash,
-            )
-            .unwrap()
-            .unwrap();
-
-            assert!(first_parent_sn.sortition);
-
-            let parent_sortition_id = SortitionDB::get_block_commit_parent_sortition_id(
-                sortdb.conn(),
-                &first_parent_sn.winning_block_txid,
-                &first_parent_sn.sortition_id,
-            )
-            .unwrap()
-            .unwrap();
-            let parent_sortition =
-                SortitionDB::get_block_snapshot(sortdb.conn(), &parent_sortition_id)
-                    .unwrap()
-                    .unwrap();
-
-            debug!(
-                "First parent Nakamoto block sortition: {:?}",
-                &parent_sortition
+            // sanity check -- this parent must correspond to a sortition
+            assert!(
+                SortitionDB::get_block_snapshot_consensus(
+                    sortdb.conn(),
+                    &first_parent.header.consensus_hash,
+                )
+                .unwrap()
+                .unwrap()
+                .sortition
             );
-            let parent_sortition_opt = Some(parent_sortition);
 
             let last_tenure_id = StacksBlockId::new(
                 &first_parent.header.consensus_hash,
                 &first_parent.header.block_hash(),
             );
-            (
-                last_tenure_id,
-                None,
-                Some(parent_blocks),
-                parent_sortition_opt,
-            )
+            (last_tenure_id, None, Some(parent_blocks))
         } else {
             // parent may be an epoch 2.x block
             let (parent_opt, parent_sortition_opt) = if let Some(parent_block) =
@@ -1059,7 +1074,7 @@ impl<'a> TestPeer<'a> {
                 // must be a genesis block (testing only!)
                 StacksBlockId(BOOT_BLOCK_HASH.0.clone())
             };
-            (last_tenure_id, parent_opt, None, parent_sortition_opt)
+            (last_tenure_id, parent_opt, None)
         }
     }
 
@@ -1080,8 +1095,16 @@ impl<'a> TestPeer<'a> {
         let mut burn_block = TestBurnchainBlock::new(&tip, 0);
         let mut stacks_node = self.stacks_node.take().unwrap();
 
-        let (last_tenure_id, parent_block_opt, parent_tenure_opt, parent_sortition_opt) =
-            Self::get_nakamoto_parent(&self.miner, &stacks_node, &sortdb);
+        let (last_tenure_id, parent_block_opt, parent_tenure_opt) =
+            if let Some(nakamoto_parent_tenure) = self.nakamoto_parent_tenure_opt.as_ref() {
+                (
+                    nakamoto_parent_tenure.first().as_ref().unwrap().block_id(),
+                    None,
+                    Some(nakamoto_parent_tenure.clone()),
+                )
+            } else {
+                Self::get_nakamoto_parent(&self.miner, &stacks_node, &sortdb)
+            };
 
         // find the VRF leader key register tx to use.
         // it's the one pointed to by the parent tenure
@@ -1345,6 +1368,8 @@ impl<'a> TestPeer<'a> {
             miner_setup,
             block_builder,
             after_block,
+            self.mine_malleablized_blocks,
+            self.nakamoto_parent_tenure_opt.is_none(),
         );
 
         let just_blocks = blocks
@@ -1435,6 +1460,8 @@ impl<'a> TestPeer<'a> {
             |_| {},
             block_builder,
             |_| true,
+            self.mine_malleablized_blocks,
+            self.nakamoto_parent_tenure_opt.is_none(),
         );
 
         let just_blocks = blocks

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -415,9 +415,11 @@ impl StacksChainState {
     ) {
         clarity_tx
             .with_clarity_db(|ref mut db| {
-                let next_nonce = cur_nonce
-                    .checked_add(1)
-                    .unwrap_or_else(|| panic!("OUT OF NONCES"));
+                let next_nonce = cur_nonce.checked_add(1).unwrap_or_else(|| {
+                    error!("OUT OF NONCES");
+                    panic!();
+                });
+
                 db.set_account_nonce(&principal, next_nonce)?;
                 Ok(())
             })

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -267,14 +267,26 @@ impl StacksChainState {
                 })
             })
             .map_err(Error::ClarityError)
-            .unwrap()
+            .unwrap_or_else(|e| {
+                error!(
+                    "FATAL: Failed to query account for {:?}: {:?}",
+                    principal, &e
+                );
+                panic!();
+            })
     }
 
     pub fn get_nonce<T: ClarityConnection>(clarity_tx: &mut T, principal: &PrincipalData) -> u64 {
         clarity_tx
             .with_clarity_db_readonly(|ref mut db| db.get_account_nonce(principal))
             .map_err(|x| Error::ClarityError(x.into()))
-            .unwrap()
+            .unwrap_or_else(|e| {
+                error!(
+                    "FATAL: Failed to query account nonce for {:?}: {:?}",
+                    principal, &e
+                );
+                panic!();
+            })
     }
 
     pub fn get_account_ft(
@@ -337,7 +349,13 @@ impl StacksChainState {
                 snapshot.save()?;
                 Ok(())
             })
-            .expect("FATAL: failed to debit account")
+            .unwrap_or_else(|e| {
+                error!(
+                    "FATAL: failed to debit account {:?} for {} uSTX: {:?}",
+                    principal, amount, &e
+                );
+                panic!();
+            })
     }
 
     /// Called each time a transaction sends STX to this principal.
@@ -358,7 +376,13 @@ impl StacksChainState {
                 info!("{} credited: {} uSTX", principal, new_balance);
                 Ok(())
             })
-            .expect("FATAL: failed to credit account")
+            .unwrap_or_else(|e| {
+                error!(
+                    "FATAL: failed to credit account {:?} for {} uSTX: {:?}",
+                    principal, amount, &e
+                );
+                panic!();
+            })
     }
 
     /// Called during the genesis / boot sequence.
@@ -374,7 +398,13 @@ impl StacksChainState {
                 snapshot.save()?;
                 Ok(())
             })
-            .expect("FATAL: failed to credit account")
+            .unwrap_or_else(|e| {
+                error!(
+                    "FATAL: failed to credit genesis account {:?} for {} uSTX: {:?}",
+                    principal, amount, &e
+                );
+                panic!();
+            })
     }
 
     /// Increment an account's nonce
@@ -385,11 +415,19 @@ impl StacksChainState {
     ) {
         clarity_tx
             .with_clarity_db(|ref mut db| {
-                let next_nonce = cur_nonce.checked_add(1).expect("OUT OF NONCES");
+                let next_nonce = cur_nonce
+                    .checked_add(1)
+                    .unwrap_or_else(|| panic!("OUT OF NONCES"));
                 db.set_account_nonce(&principal, next_nonce)?;
                 Ok(())
             })
-            .expect("FATAL: failed to set account nonce")
+            .unwrap_or_else(|e| {
+                error!(
+                    "FATAL: failed to update account nonce for account {:?} from {}: {:?}",
+                    principal, cur_nonce, &e
+                );
+                panic!();
+            })
     }
 
     /// Schedule a miner payment in the future.

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -35,12 +35,13 @@ use crate::net::{
 };
 use crate::util_lib::db::Error as DBError;
 
+const TIP_ANCESTOR_SEARCH_DEPTH: u64 = 10;
+
 /// Cached data for a sortition in the sortition DB.
 /// Caching this allows us to avoid calls to `SortitionDB::get_block_snapshot_consensus()`.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct InvSortitionInfo {
     parent_consensus_hash: ConsensusHash,
-    block_height: u64,
 }
 
 impl InvSortitionInfo {
@@ -57,7 +58,6 @@ impl InvSortitionInfo {
 
         Ok(Self {
             parent_consensus_hash: parent_sn.consensus_hash,
-            block_height: sn.block_height,
         })
     }
 }
@@ -105,8 +105,14 @@ impl InvTenureInfo {
 /// in sync.  By caching (immutable) tenure data in this struct, we can enusre that this happens
 /// all the time except for during node bootup.
 pub struct InvGenerator {
-    processed_tenures: HashMap<ConsensusHash, Option<InvTenureInfo>>,
+    /// Map stacks tips to a table of (tenure ID, optional tenure info)
+    processed_tenures: HashMap<StacksBlockId, HashMap<ConsensusHash, Option<InvTenureInfo>>>,
+    /// Map consensus hashes to sortition data about them
     sortitions: HashMap<ConsensusHash, InvSortitionInfo>,
+    /// how far back to search for ancestor Stacks blocks when processing a new tip
+    tip_ancestor_search_depth: u64,
+    /// count cache misses for `processed_tenures`
+    cache_misses: u128,
 }
 
 impl InvGenerator {
@@ -114,24 +120,134 @@ impl InvGenerator {
         Self {
             processed_tenures: HashMap::new(),
             sortitions: HashMap::new(),
+            tip_ancestor_search_depth: TIP_ANCESTOR_SEARCH_DEPTH,
+            cache_misses: 0,
         }
     }
 
-    /// Get a processed tenure. If it's not cached, then load it.
-    /// Returns Some(..) if there existed a tenure-change tx for this given consensus hash
-    fn get_processed_tenure(
+    pub fn with_tip_ancestor_search_depth(mut self, depth: u64) -> Self {
+        self.tip_ancestor_search_depth = depth;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cache_misses(&self) -> u128 {
+        self.cache_misses
+    }
+
+    /// Find the highest ancestor of `tip_block_id` that has an entry in `processed_tenures`.
+    /// Search up to `self.tip_ancestor_search_depth` ancestors back.
+    ///
+    /// The intuition here is that `tip_block_id` is the highest block known to the node, and it
+    /// can advance when new blocks are processed.  We associate a set of cached processed tenures with
+    /// each tip, but if the tip advances, we simply move the cached processed tenures "up to" the
+    /// new tip instead of reloading them from disk each time.
+    ///
+    /// However, searching for an ancestor tip incurs a sqlite DB read, so we want to bound the
+    /// search depth.  In practice, the bound on this depth would be derived from how often the
+    /// chain tip changes relative to how often we serve up inventory data.  The depth should be
+    /// the maximum expected number of blocks to be processed in-between handling `GetNakamotoInv`
+    /// messages.
+    ///
+    /// If found, then return the ancestor block ID represented in `self.processed_tenures`.
+    /// If not, then reutrn None.
+    pub(crate) fn find_ancestor_processed_tenures(
+        &self,
+        chainstate: &StacksChainState,
+        tip_block_id: &StacksBlockId,
+    ) -> Result<Option<StacksBlockId>, NetError> {
+        let mut cursor = tip_block_id.clone();
+        for _ in 0..self.tip_ancestor_search_depth {
+            let parent_id_opt =
+                NakamotoChainState::get_nakamoto_parent_block_id(chainstate.db(), &cursor)?;
+            let Some(parent_id) = parent_id_opt else {
+                return Ok(None);
+            };
+            if self.processed_tenures.contains_key(&parent_id) {
+                return Ok(Some(parent_id));
+            }
+            cursor = parent_id;
+        }
+        Ok(None)
+    }
+
+    /// Get a processed tenure. If it's not cached, then load it from disk.
+    ///
+    /// Loading it is expensive, so once loaded, store it with the cached processed tenure map
+    /// associated with `tip_block_id`.
+    ///
+    /// If there is no such map, then see if a recent ancestor of `tip_block_id` is represented. If
+    /// so, then remove that map and associate it with `tip_block_id`.  This way, as the blockchain
+    /// advances, cached tenure information for the same Stacks fork stays associated with that
+    /// fork's chain tip (assuming this code gets run sufficiently often relative to the
+    /// advancement of the `tip_block_id` tip value).
+    ///
+    /// Returns Ok(Some(..)) if there existed a tenure-change tx for this given consensus hash
+    /// Returns Ok(None) if not
+    /// Returns Err(..) on DB error
+    pub(crate) fn get_processed_tenure(
         &mut self,
         chainstate: &StacksChainState,
         tip_block_id: &StacksBlockId,
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Option<InvTenureInfo>, NetError> {
-        // TODO: MARF-aware cache
-        // not cached so go load it
-        let loaded_info_opt =
-            InvTenureInfo::load(chainstate, tip_block_id, &tenure_id_consensus_hash)?;
-        self.processed_tenures
-            .insert(tenure_id_consensus_hash.clone(), loaded_info_opt.clone());
-        Ok(loaded_info_opt)
+        if self.processed_tenures.get(tip_block_id).is_none() {
+            // this tip has no known table.
+            // does it have an ancestor with a table? If so, then move its ancestor's table to this
+            // tip. Otherwise, make a new table.
+            if let Some(ancestor_tip_id) =
+                self.find_ancestor_processed_tenures(chainstate, tip_block_id)?
+            {
+                let ancestor_tenures = self
+                    .processed_tenures
+                    .remove(&ancestor_tip_id)
+                    .unwrap_or_else(|| {
+                        panic!("FATAL: did not have ancestor tip reported by search");
+                    });
+
+                self.processed_tenures
+                    .insert(tip_block_id.clone(), ancestor_tenures);
+            } else {
+                self.processed_tenures
+                    .insert(tip_block_id.clone(), HashMap::new());
+            }
+        }
+
+        let Some(tenure_infos) = self.processed_tenures.get_mut(tip_block_id) else {
+            unreachable!("FATAL: inserted table for chain tip, but didn't get it back");
+        };
+
+        // this tip has a known table
+        if let Some(loaded_tenure_info) = tenure_infos.get_mut(tenure_id_consensus_hash) {
+            // we've loaded this tenure info before for this tip
+            return Ok(loaded_tenure_info.clone());
+        } else {
+            // we have not loaded the tenure info for this tip, so go get it
+            let loaded_info_opt =
+                InvTenureInfo::load(chainstate, tip_block_id, &tenure_id_consensus_hash)?;
+            tenure_infos.insert(tenure_id_consensus_hash.clone(), loaded_info_opt.clone());
+
+            self.cache_misses = self.cache_misses.saturating_add(1);
+            return Ok(loaded_info_opt);
+        }
+    }
+
+    /// Get sortition info, loading it from our cache if needed
+    pub(crate) fn get_sortition_info(
+        &mut self,
+        sortdb: &SortitionDB,
+        cur_consensus_hash: &ConsensusHash,
+    ) -> Result<&InvSortitionInfo, NetError> {
+        if !self.sortitions.contains_key(cur_consensus_hash) {
+            let loaded_info = InvSortitionInfo::load(sortdb, cur_consensus_hash)?;
+            self.sortitions
+                .insert(cur_consensus_hash.clone(), loaded_info);
+        };
+
+        Ok(self
+            .sortitions
+            .get(cur_consensus_hash)
+            .expect("infallible: just inserted this data"))
     }
 
     /// Generate an block inventory bit vector for a reward cycle.
@@ -210,19 +326,10 @@ impl InvGenerator {
                 // done scanning this reward cycle
                 break;
             }
-            let cur_sortition_info = if let Some(info) = self.sortitions.get(&cur_consensus_hash) {
-                info
-            } else {
-                let loaded_info = InvSortitionInfo::load(sortdb, &cur_consensus_hash)?;
-                self.sortitions
-                    .insert(cur_consensus_hash.clone(), loaded_info);
-                self.sortitions
-                    .get(&cur_consensus_hash)
-                    .expect("infallible: just inserted this data")
-            };
-            let parent_sortition_consensus_hash = cur_sortition_info.parent_consensus_hash.clone();
+            let cur_sortition_info = self.get_sortition_info(sortdb, &cur_consensus_hash)?;
+            let parent_sortition_consensus_hash = cur_sortition_info.parent_consensus_hash;
 
-            debug!("Get sortition and tenure info for height {}. cur_consensus_hash = {}, cur_tenure_info = {:?}, cur_sortition_info = {:?}", cur_height, &cur_consensus_hash, &cur_tenure_opt, cur_sortition_info);
+            debug!("Get sortition and tenure info for height {}. cur_consensus_hash = {}, cur_tenure_info = {:?}, parent_sortition_consensus_hash = {}", cur_height, &cur_consensus_hash, &cur_tenure_opt, &parent_sortition_consensus_hash);
 
             if let Some(cur_tenure_info) = cur_tenure_opt.as_ref() {
                 // a tenure was active when this sortition happened...

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -218,7 +218,7 @@ impl InvGenerator {
         };
 
         // this tip has a known table
-        if let Some(loaded_tenure_info) = tenure_infos.get_mut(tenure_id_consensus_hash) {
+        if let Some(loaded_tenure_info) = tenure_infos.get(tenure_id_consensus_hash) {
             // we've loaded this tenure info before for this tip
             return Ok(loaded_tenure_info.clone());
         } else {

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2275,6 +2275,10 @@ pub mod test {
         >,
         /// list of malleablized blocks produced when mining.
         pub malleablized_blocks: Vec<NakamotoBlock>,
+        pub mine_malleablized_blocks: bool,
+        /// tenure-start block of tenure to mine on.
+        /// gets consumed on the call to begin_nakamoto_tenure
+        pub nakamoto_parent_tenure_opt: Option<Vec<NakamotoBlock>>,
     }
 
     impl<'a> TestPeer<'a> {
@@ -2689,6 +2693,8 @@ pub mod test {
                 coord: coord,
                 indexer: Some(indexer),
                 malleablized_blocks: vec![],
+                mine_malleablized_blocks: true,
+                nakamoto_parent_tenure_opt: None,
             }
         }
 
@@ -3509,6 +3515,10 @@ pub mod test {
             self.sortdb.as_mut().unwrap()
         }
 
+        pub fn sortdb_ref(&mut self) -> &SortitionDB {
+            self.sortdb.as_ref().unwrap()
+        }
+
         pub fn with_db_state<F, R>(&mut self, f: F) -> Result<R, net_error>
         where
             F: FnOnce(
@@ -4197,6 +4207,43 @@ pub mod test {
                     assert!(!orphaned);
                 }
             }
+        }
+
+        /// Set the nakamoto tenure to mine on
+        pub fn mine_nakamoto_on(&mut self, parent_tenure: Vec<NakamotoBlock>) {
+            self.nakamoto_parent_tenure_opt = Some(parent_tenure);
+        }
+
+        /// Clear the tenure to mine on. This causes the miner to build on the canonical tip
+        pub fn mine_nakamoto_on_canonical_tip(&mut self) {
+            self.nakamoto_parent_tenure_opt = None;
+        }
+
+        /// Get an account off of a tip
+        pub fn get_account(
+            &mut self,
+            tip: &StacksBlockId,
+            account: &PrincipalData,
+        ) -> StacksAccount {
+            let sortdb = self.sortdb.take().expect("FATAL: sortdb not restored");
+            let mut node = self
+                .stacks_node
+                .take()
+                .expect("FATAL: chainstate not restored");
+
+            let acct = node
+                .chainstate
+                .maybe_read_only_clarity_tx(
+                    &sortdb.index_handle_at_block(&node.chainstate, tip).unwrap(),
+                    tip,
+                    |clarity_tx| StacksChainState::get_account(clarity_tx, account),
+                )
+                .unwrap()
+                .unwrap();
+
+            self.sortdb = Some(sortdb);
+            self.stacks_node = Some(node);
+            acct
         }
     }
 


### PR DESCRIPTION
This fixes #5044 by making a fork-aware cache for inventory data -- namely, cached sortitions we had to load, and cached per-fork tenures.  See tests and doc strings for how it works.