### PR TITLE
Ugly addition of a stop receiver channel to exit the signer runloop

### DIFF
--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -59,7 +59,7 @@ pub use crate::events::{
     BlockProposal, EventReceiver, EventStopSignaler, SignerEvent, SignerEventReceiver,
     SignerEventTrait, SignerStopSignaler,
 };
-pub use crate::runloop::{RunningSigner, Signer, SignerRunLoop};
+pub use crate::runloop::{set_runloop_signal_handler, RunningSigner, Signer, SignerRunLoop};
 pub use crate::session::{SignerSession, StackerDBSession};
 pub use crate::signer_set::{Error as ParseSignerEntriesError, SignerEntries};
 

--- a/libsigner/src/tests/mod.rs
+++ b/libsigner/src/tests/mod.rs
@@ -77,6 +77,7 @@ impl<T: SignerEventTrait> SignerRunLoop<Vec<SignerEvent<T>>, Command, T> for Sim
         event: Option<SignerEvent<T>>,
         _cmd: Option<Command>,
         _res: &Sender<Vec<SignerEvent<T>>>,
+        _stop: &Receiver<()>,
     ) -> Option<Vec<SignerEvent<T>>> {
         debug!("Got event: {:?}", &event);
         if let Some(event) = event {
@@ -150,8 +151,9 @@ fn test_simple_signer() {
             num_sent += 1;
         }
     });
+    let (stop_send, stop_recv) = channel();
 
-    let running_signer = signer.spawn(endpoint).unwrap();
+    let running_signer = signer.spawn(endpoint, stop_recv).unwrap();
     sleep_ms(5000);
     let accepted_events = running_signer.stop().unwrap();
 
@@ -208,7 +210,8 @@ fn test_status_endpoint() {
         sock.flush().unwrap();
     });
 
-    let running_signer = signer.spawn(endpoint).unwrap();
+    let (_stop_send, stop_recv) = channel();
+    let running_signer = signer.spawn(endpoint, stop_recv).unwrap();
     sleep_ms(3000);
     let accepted_events = running_signer.stop().unwrap();
 

--- a/stacks-signer/src/v1/signer.rs
+++ b/stacks-signer/src/v1/signer.rs
@@ -16,7 +16,7 @@
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{Receiver, Sender};
 use std::time::Instant;
 
 use blockstack_lib::chainstate::burn::ConsensusHashExtensions;
@@ -156,6 +156,7 @@ impl SignerTrait<SignerMessage> for Signer {
         event: Option<&SignerEvent<SignerMessage>>,
         res: &Sender<Vec<SignerResult>>,
         current_reward_cycle: u64,
+        _stop_recv: &Receiver<()>,
     ) {
         let event_parity = match event {
             Some(SignerEvent::BlockValidationResponse(_)) => Some(current_reward_cycle % 2),


### PR DESCRIPTION
This is so ugly but I couldn't think of a better way to do this. I could of course just exit if it fails on retry and NOT store the block if it fails, but Jude specifically requested that the signer loop infinitely until the block is acknowledged by the node.
It is probably not a bad idea to have a means to terminate the signer runloop anyway, but I can't stand how involved of a change this was XD