### PR TITLE
fix: use `max_unspent_utxos` in `get_all_utxos`

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -668,7 +668,7 @@ impl BitcoinRegtestController {
                 max_conf.into(),
                 filter_addresses.clone().into(),
                 true.into(),
-                json!({ "minimumAmount": minimum_amount }),
+                json!({ "minimumAmount": minimum_amount, "maximumCount": self.config.burnchain.max_unspent_utxos }),
             ],
             id: "stacks".to_string(),
             jsonrpc: "2.0".to_string(),


### PR DESCRIPTION
I missed this other call to `listunspent` in the previous related PR.