### PR TITLE
fix: off by one pox set offset

### DIFF
--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -117,9 +117,10 @@ fn create_event_info_data_code(
     // `prepare_offset` is 1 or 0, depending on whether current execution is in a prepare phase or not
     //
     // "is-in-next-pox-set" == effective-height <= (reward-length - prepare-length)
-    // "<=" since the txs of the first block of the prepare phase are considered in the pox-set
+    // "<" since the txs of the first block of the prepare phase are NOT considered in the pox-set,
+    // the pox-set is locked in the first block of the prepare phase, before the transactions of that block are run.
     let pox_set_offset = r#"
-        (pox-set-offset (if (<=
+        (pox-set-offset (if (<
             (mod (- %height% (var-get first-burnchain-block-height)) (var-get pox-reward-cycle-length))
             (- (var-get pox-reward-cycle-length) (var-get pox-prepare-cycle-length))
         ) u0 u1))

--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -116,7 +116,7 @@ fn create_event_info_data_code(
     // If a given burn block height is in a prepare phase, then the stacker will be in the _next_ reward cycle, so bump the cycle by 1
     // `prepare_offset` is 1 or 0, depending on whether current execution is in a prepare phase or not
     //
-    // "is-in-next-pox-set" == effective-height < (reward-length - prepare-length)
+    // "is-in-next-pox-set" == effective-height < (cycle-length - prepare-length)
     // "<" since the txs of the first block of the prepare phase are NOT considered in the pox-set,
     // the pox-set is locked in the first block of the prepare phase, before the transactions of that block are run.
     let pox_set_offset = r#"

--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -116,7 +116,7 @@ fn create_event_info_data_code(
     // If a given burn block height is in a prepare phase, then the stacker will be in the _next_ reward cycle, so bump the cycle by 1
     // `prepare_offset` is 1 or 0, depending on whether current execution is in a prepare phase or not
     //
-    // "is-in-next-pox-set" == effective-height <= (reward-length - prepare-length)
+    // "is-in-next-pox-set" == effective-height < (reward-length - prepare-length)
     // "<" since the txs of the first block of the prepare phase are NOT considered in the pox-set,
     // the pox-set is locked in the first block of the prepare phase, before the transactions of that block are run.
     let pox_set_offset = r#"

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -2462,7 +2462,7 @@ fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
     while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
-    // produce blocks until the we're 1 before the prepare phase (first block of prepare-phase not yet mined)
+    // produce blocks until the we're 1 before the prepare phase (first block of prepare-phase not yet mined, whatever txs we create now won't be included in the reward set)
     while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height + 1) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
@@ -2519,7 +2519,7 @@ fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
     let steph_stacking_receipt = txs.get(&steph_stacking.txid()).unwrap().clone();
     assert_eq!(steph_stacking_receipt.events.len(), 2);
     let steph_stacking_op_data = HashMap::from([
-        ("start-cycle-id", Value::UInt(next_cycle)),
+        ("start-cycle-id", Value::UInt(next_cycle + 1)), // +1 because steph stacked in the block before the prepare phase (too late)
         (
             "end-cycle-id",
             Value::some(Value::UInt(next_cycle + steph_lock_period)).unwrap(),


### PR DESCRIPTION
- fixes important off-by-one error in event emitting of pox-events. not consensus critical, but should be released with next release for accurate downstream reporting (e.g. by the API)

---

I'm not familiar with the test setup, but I'd like to have the tests also do the "actual" check of the reward set being locked/set. Can someone help with that?