### PR TITLE
test: add `BITCOIND_TEST=1` for running tests in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "lldb.adapterType": "native",
-    "lldb.launch.sourceLanguages": ["rust"]
+    "lldb.launch.sourceLanguages": ["rust"],
+    "rust-analyzer.runnables.extraEnv": {
+        "BITCOIND_TEST": "1"
+    }
 }


### PR DESCRIPTION
This makes it easier to run and debug integration tests inside of VSCode.