### PR TITLE
Add signing_in_0th_tenure_of_reward_cycle test

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -114,6 +114,7 @@ jobs:
           - tests::signer::v0::partial_tenure_fork
           - tests::signer::v0::mine_2_nakamoto_reward_cycles
           - tests::signer::v0::signer_set_rollover
+          - tests::signer::v0::signing_in_0th_tenure_of_reward_cycle
           - tests::nakamoto_integrations::stack_stx_burn_op_integration_test
           - tests::nakamoto_integrations::check_block_heights
           - tests::nakamoto_integrations::clarity_burn_state


### PR DESCRIPTION
Closes https://github.com/stacks-network/stacks-core/issues/4747

Not sure this is exactly what was wanted. I interpreted "0th tenure of a reward cycle", being make sure that blocks can be signed in the very first burn block of a reward cycle.