### PR TITLE
fix: allow to get tenure-info for the latest block

### DIFF
--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -1069,7 +1069,7 @@ pub fn special_get_tenure_info(
     };
 
     let current_height = env.global_context.database.get_current_block_height();
-    if height_value >= current_height {
+    if height_value > current_height {
         return Ok(Value::none());
     }
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -6857,7 +6857,6 @@ fn check_block_times() {
     let info = get_chain_info_result(&naka_conf).unwrap();
     info!("Chain info: {:?}", info);
     let last_stacks_block_height = info.stacks_tip_height as u128;
-    let last_tenure_height = last_stacks_block_height as u128;
 
     let time0_value = call_read_only(
         &naka_conf,
@@ -6891,22 +6890,40 @@ fn check_block_times() {
         "Time from pre- and post-epoch 3.0 contracts should match"
     );
 
-    let time3_tenure_value = call_read_only(
+    let time3a_tenure_value = call_read_only(
         &naka_conf,
         &sender_addr,
         contract3_name,
         "get-tenure-time",
-        vec![&clarity::vm::Value::UInt(last_tenure_height - 1)],
+        vec![&clarity::vm::Value::UInt(last_stacks_block_height - 1)],
     );
-    let time3_tenure = time3_tenure_value
+    let time3a_tenure = time3a_tenure_value
         .expect_optional()
         .unwrap()
         .unwrap()
         .expect_u128()
         .unwrap();
     assert_eq!(
-        time0, time3_tenure,
+        time0, time3a_tenure,
         "Tenure time should match Clarity 2 block time"
+    );
+
+    let time3b_tenure_value = call_read_only(
+        &naka_conf,
+        &sender_addr,
+        contract3_name,
+        "get-tenure-time",
+        vec![&clarity::vm::Value::UInt(last_stacks_block_height)],
+    );
+    let time3b_tenure = time3b_tenure_value
+        .expect_optional()
+        .unwrap()
+        .unwrap()
+        .expect_u128()
+        .unwrap();
+    assert!(
+        time3a_tenure < time3b_tenure,
+        "Latest tenure height should have a later time"
     );
 
     let time3_block_value = call_read_only(

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -6843,7 +6843,8 @@ fn check_block_times() {
     let contract_clarity3 =
         "(define-read-only (get-block-time (height uint)) (get-stacks-block-info? time height))
          (define-read-only (get-tenure-time (height uint)) (get-tenure-info? time height))
-         (define-public (get-tenure-time-public (height uint)) (ok (get-tenure-info? time height)))";
+         (define-read-only (get-current-tenure-time) (get-tenure-info? time stacks-block-height))
+         (define-public (get-tenure-time-public) (ok (get-tenure-info? time stacks-block-height)))";
 
     let contract_tx3 = make_contract_publish(
         &sender_sk,
@@ -6916,8 +6917,8 @@ fn check_block_times() {
         &naka_conf,
         &sender_addr,
         contract3_name,
-        "get-tenure-time",
-        vec![&clarity::vm::Value::UInt(last_stacks_block_height)],
+        "get-current-tenure-time",
+        vec![],
     );
     let time3b_tenure = time3b_tenure_value
         .expect_optional()
@@ -7125,7 +7126,7 @@ fn check_block_times() {
         &sender_addr,
         contract3_name,
         "get-tenure-time-public",
-        &[clarity::vm::Value::UInt(last_stacks_block_height - 1)],
+        &[],
     );
 
     let txid_string = submit_tx(&http_origin, &call_tx);
@@ -7140,7 +7141,7 @@ fn check_block_times() {
                 .tx_events
                 .iter()
                 .find_map(|event| match event {
-                    TransactionEvent::Success(TransactionSuccessEvent { txid, .. })
+                    TransactionEvent::Success(TransactionSuccessEvent { txid, result, .. })
                         if txid == &submitted_txid =>
                     {
                         info!("Transaction was successful");


### PR DESCRIPTION
### Description

- `get-tenure-info?` should be callable on the latest stacks-block

### Applicable issues

- fixes: #5228

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
