### PR TITLE
fix: don't ban peers for sending us nakamoto blocks we can't yet handle

### DIFF
--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -1725,9 +1725,6 @@ impl Relayer {
                         "Failed to validate Nakamoto blocks pushed from {:?}: {:?}",
                         neighbor_key, &e
                     );
-
-                    // punish this peer
-                    bad_neighbors.push((*neighbor_key).clone());
                     break;
                 }
 


### PR DESCRIPTION
This fixes a probable cause of the seed node in naka-3 freezing up.