### PR TITLE
Chore: remove infinite loop in signer during tests

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Run Tests
         id: run_tests
         timeout-minutes: ${{ fromJSON(env.TEST_TIMEOUT) }}
-        uses: stacks-network/actions/stacks-core/run-tests@feat/no-capture-2
+        uses: stacks-network/actions/stacks-core/run-tests@main
         with:
           test-name: ${{ matrix.test-name }}
           threads: 1

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Run Tests
         id: run_tests
         timeout-minutes: ${{ fromJSON(env.TEST_TIMEOUT) }}
-        uses: stacks-network/actions/stacks-core/run-tests@main
+        uses: stacks-network/actions/stacks-core/run-tests@feat/no-capture-2
         with:
           test-name: ${{ matrix.test-name }}
           threads: 1

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use std::collections::{HashMap, VecDeque};
+use std::fmt::Display;
+use std::time::{Duration, Instant};
 
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::chainstate::stacks::boot::{NakamotoSignerEntry, SIGNERS_NAME};
@@ -562,6 +564,29 @@ impl StacksClient {
         }
         let account_entry = response.json::<AccountEntryResponse>()?;
         Ok(account_entry)
+    }
+
+    /// Post a block to the stacks-node, retry forever on errors.
+    ///
+    /// In tests, this panics if the retry takes longer than 30 seconds.
+    pub fn post_block_until_ok<F: Display>(&self, log_fmt: &F, block: &NakamotoBlock) -> bool {
+        let start_time = Instant::now();
+        loop {
+            match self.post_block(block) {
+                Ok(block_push_result) => {
+                    debug!("{log_fmt}: Block pushed to stacks node: {block_push_result:?}");
+                    return block_push_result;
+                }
+                Err(e) => {
+                    if cfg!(test) && start_time.elapsed() > Duration::from_secs(30) {
+                        panic!(
+                            "{log_fmt}: Timed out in test while pushing block to stacks node: {e}"
+                        );
+                    }
+                    warn!("{log_fmt}: Failed to push block to stacks node: {e}. Retrying...");
+                }
+            };
+        }
     }
 
     /// Try to post a completed nakamoto block to our connected stacks-node

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::mpsc::Sender;
-use std::time::{Duration, Instant};
 
 use blockstack_lib::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader};
 use blockstack_lib::net::api::postblock_proposal::{
@@ -192,23 +191,7 @@ impl SignerTrait<SignerMessage> for Signer {
                                 "block_id" => %b.block_id(),
                                 "signer_sighash" => %b.header.signer_signature_hash(),
                             );
-                            let start_time = Instant::now();
-                            loop {
-                                match stacks_client.post_block(b) {
-                                    Ok(block_push_result) => {
-                                        debug!("{self}: Block pushed to stacks node: {block_push_result:?}");
-                                        break;
-                                    }
-                                    Err(e) => {
-                                        if cfg!(test)
-                                            && start_time.elapsed() > Duration::from_secs(30)
-                                        {
-                                            panic!("{self}: Timed out in test while pushing block to stacks node: {e}");
-                                        }
-                                        warn!("{self}: Failed to push block to stacks node: {e}. Retrying...");
-                                    }
-                                };
-                            }
+                            stacks_client.post_block_until_ok(self, &b);
                         }
                         SignerMessage::MockProposal(mock_proposal) => {
                             let epoch = match stacks_client.get_node_epoch() {
@@ -907,15 +890,7 @@ impl Signer {
             "{self}: Broadcasting Stacks block {} to node",
             &block.block_id()
         );
-        if let Err(e) = stacks_client.post_block(&block) {
-            warn!(
-                "{self}: Failed to post block {block_hash}: {e:?}";
-                "stacks_block_id" => %block.block_id(),
-                "parent_block_id" => %block.header.parent_block_id,
-                "burnchain_consensus_hash" => %block.header.consensus_hash
-            );
-            return;
-        }
+        stacks_client.post_block_until_ok(self, &block);
 
         if let Err(e) = self.signer_db.set_block_broadcasted(
             self.reward_cycle,


### PR DESCRIPTION
### Description

This PR removes an infinite loop in the signer when `cfg!(test)` is active. The rationale for this is that signer integration tests often stop the `stacks-node` threads (via panic, asserts, etc.) on failure before they stop the signer threads. I think this leads to a situation where a test failure loops indefinitely, which in the CI prevents logs from appearing, making diagnosing CI failures and flaky tests _very_ difficult.

This PR also removes the first block push invocation -- if the first push in the loop succeeds, there's no need to repush.