### PR TITLE
Fix/safer remove origin for prom metrics

### DIFF
--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -376,10 +376,12 @@ impl StacksClient {
             "last_sortition" => %last_sortition,
         );
         let path = self.tenure_forking_info_path(chosen_parent, last_sortition);
-        let timer = crate::monitoring::new_rpc_call_timer(
-            "/v3/tenures/fork_info/:start/:stop",
-            &self.http_origin,
+        // Use a seperate metrics path to allow the same metric for different start and stop hashes
+        let metrics_path = format!(
+            "{}{RPC_TENURE_FORKING_INFO_PATH}/:start/:stop",
+            self.http_origin
         );
+        let timer = crate::monitoring::new_rpc_call_timer(&metrics_path, &self.http_origin);
         let send_request = || {
             self.stacks_node_client
                 .get(&path)

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -376,7 +376,7 @@ impl StacksClient {
             "last_sortition" => %last_sortition,
         );
         let path = self.tenure_forking_info_path(chosen_parent, last_sortition);
-        // Use a seperate metrics path to allow the same metric for different start and stop hashes
+        // Use a separate metrics path to allow the same metric for different start and stop hashes
         let metrics_path = format!(
             "{}{RPC_TENURE_FORKING_INFO_PATH}/:start/:stop",
             self.http_origin

--- a/stacks-signer/src/monitoring/mod.rs
+++ b/stacks-signer/src/monitoring/mod.rs
@@ -92,13 +92,22 @@ pub fn update_signer_nonce(nonce: u64) {
     prometheus::SIGNER_NONCE.set(nonce as i64);
 }
 
+// Allow dead code because this is only used in the `monitoring_prom` feature
+// but we want to run it in a test
+#[allow(dead_code)]
+/// Remove the origin from the full path to avoid duplicate metrics for different origins
+fn remove_origin_from_path(full_path: &str, origin: &str) -> String {
+    let path = full_path.replace(origin, "");
+    path
+}
+
 /// Start a new RPC call timer.
 /// The `origin` parameter is the base path of the RPC call, e.g. `http://node.com`.
 /// The `origin` parameter is removed from `full_path` when storing in prometheus.
 #[cfg(feature = "monitoring_prom")]
 pub fn new_rpc_call_timer(full_path: &str, origin: &str) -> HistogramTimer {
-    let path = &full_path[origin.len()..];
-    let histogram = prometheus::SIGNER_RPC_CALL_LATENCIES_HISTOGRAM.with_label_values(&[path]);
+    let path = remove_origin_from_path(full_path, origin);
+    let histogram = prometheus::SIGNER_RPC_CALL_LATENCIES_HISTOGRAM.with_label_values(&[&path]);
     histogram.start_timer()
 }
 
@@ -139,4 +148,17 @@ pub fn start_serving_monitoring_metrics(config: GlobalConfig) -> Result<(), Stri
         }
     }
     Ok(())
+}
+
+#[test]
+fn test_remove_origin_from_path() {
+    let full_path = "http://localhost:20443/v2/info";
+    let origin = "http://localhost:20443";
+    let path = remove_origin_from_path(full_path, origin);
+    assert_eq!(path, "/v2/info");
+
+    let full_path = "/v2/info";
+    let origin = "http://localhost:20443";
+    let path = remove_origin_from_path(full_path, origin);
+    assert_eq!(path, "/v2/info");
 }


### PR DESCRIPTION
A bug came up (fixed in https://github.com/stacks-network/stacks-core/pull/5275) that was related to determining the `path` label for RPC metrics. When the provided path string _didn't_ include the HTTP origin, the function could fail due to trying to slice a string at an index larger than the string's length. This changes that implementation to do a string replacement, which is more resilient to the case of accidentally not providing a `full_path` that included the origin.