### PR TITLE
fix/5274: add test coverage for microforks

### DIFF
--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -1805,13 +1805,6 @@ impl NakamotoChainState {
             )
         });
 
-        debug!("Process staging Nakamoto block";
-               "consensus_hash" => %next_ready_block.header.consensus_hash,
-               "stacks_block_hash" => %next_ready_block.header.block_hash(),
-               "stacks_block_id" => %next_ready_block.header.block_id(),
-               "burn_block_hash" => %next_ready_block_snapshot.burn_header_hash
-        );
-
         let elected_height = sort_db
             .get_consensus_hash_height(&next_ready_block.header.consensus_hash)?
             .ok_or_else(|| ChainstateError::NoSuchBlockError)?;
@@ -1877,6 +1870,14 @@ impl NakamotoChainState {
             staging_block_tx.commit()?;
             return Err(ChainstateError::InvalidStacksBlock(msg.into()));
         }
+
+        debug!("Process staging Nakamoto block";
+               "consensus_hash" => %next_ready_block.header.consensus_hash,
+               "stacks_block_hash" => %next_ready_block.header.block_hash(),
+               "stacks_block_id" => %next_ready_block.header.block_id(),
+               "burn_block_hash" => %next_ready_block_snapshot.burn_header_hash,
+               "parent_block_id" => %next_ready_block.header.parent_block_id,
+        );
 
         // set the sortition handle's pointer to the block's burnchain view.
         //   this is either:
@@ -4061,7 +4062,8 @@ impl NakamotoChainState {
                 warn!("Invalid Nakamoto block: its tenure's block-commit's block ID hash does not match its parent tenure's start block";
                     "parent_consensus_hash" => %parent_ch,
                     "parent_tenure_start_block_id" => %parent_tenure_start_header.index_block_hash(),
-                    "block_commit.last_tenure_id" => %tenure_block_commit.last_tenure_id()
+                    "block_commit.last_tenure_id" => %tenure_block_commit.last_tenure_id(),
+                    "parent_tip" => %parent_block_id,
                 );
 
                 return Err(ChainstateError::NoSuchBlockError);

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -332,6 +332,47 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         )))
     }
 
+    /// Get a Nakamoto tenure, starting a the given index block hash.
+    /// Item 0 in the block list is the tenure-start block.
+    /// The last item is the block given by the index block hash
+    #[cfg(any(test, feature = "testing"))]
+    pub fn load_nakamoto_tenure(
+        &self,
+        tip: &StacksBlockId,
+    ) -> Result<Option<Vec<NakamotoBlock>>, ChainstateError> {
+        let Some((block, ..)) = self.get_nakamoto_block(tip)? else {
+            return Ok(None);
+        };
+        if block.is_wellformed_tenure_start_block().map_err(|_| {
+            ChainstateError::InvalidStacksBlock("Malformed tenure-start block".into())
+        })? {
+            // we're done
+            return Ok(Some(vec![block]));
+        }
+
+        // this is an intermediate block
+        let mut tenure = vec![];
+        let mut cursor = block.header.parent_block_id.clone();
+        tenure.push(block);
+        loop {
+            let Some((block, _)) = self.get_nakamoto_block(&cursor)? else {
+                return Ok(None);
+            };
+
+            let is_tenure_start = block.is_wellformed_tenure_start_block().map_err(|e| {
+                ChainstateError::InvalidStacksBlock("Malformed tenure-start block".into())
+            })?;
+            cursor = block.header.parent_block_id.clone();
+            tenure.push(block);
+
+            if is_tenure_start {
+                break;
+            }
+        }
+        tenure.reverse();
+        Ok(Some(tenure))
+    }
+
     /// Get the size of a Nakamoto block, given its index block hash
     /// Returns Ok(Some(size)) if the block was present
     /// Returns Ok(None) if there was no such block

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -4183,6 +4183,9 @@ pub mod test {
             all_blocks: Vec<NakamotoBlock>,
             expected_siblings: usize,
         ) {
+            if !self.mine_malleablized_blocks {
+                return;
+            }
             for block in all_blocks.iter() {
                 let sighash = block.header.signer_signature_hash();
                 let siblings = self


### PR DESCRIPTION
This adds test coverage for #5274.  #5274 is not a bug -- the downloader works correctly.  This PR just adds test coverage to make sure.