### PR TITLE
fix: don not use rusqlite in clarity-vm without default features

### DIFF
--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -19,6 +19,7 @@ pub mod log;
 #[macro_use]
 pub mod macros;
 pub mod chunked_encoding;
+#[cfg(feature = "canonical")]
 pub mod db;
 pub mod hash;
 pub mod pair;


### PR DESCRIPTION
Rusqlite is only enabled with the `canonical`  feature
