### PR TITLE
Fix boot to epoch 3 calls to retrieve the stacker set and fix multple miners test 

### DIFF
--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -53,7 +53,6 @@ use stacks::net::api::getaccount::AccountEntryResponse;
 use stacks::net::api::getcontractsrc::ContractSrcResponse;
 use stacks::net::api::getinfo::RPCPeerInfoData;
 use stacks::net::api::getpoxinfo::RPCPoxInfoData;
-use stacks::net::api::getstackers::GetStackersResponse;
 use stacks::net::api::gettransaction_unconfirmed::UnconfirmedTransactionResponse;
 use stacks::net::api::postblock::StacksBlockAcceptedData;
 use stacks::net::api::postfeerate::RPCFeeEstimateResponse;
@@ -1435,16 +1434,6 @@ pub fn get_contract_src(
         let err_str = res.text().unwrap();
         Err(err_str)
     }
-}
-
-pub fn get_stacker_set(http_origin: &str, reward_cycle: u64) -> GetStackersResponse {
-    let client = reqwest::blocking::Client::new();
-    let path = format!("{}/v3/stacker_set/{}", http_origin, reward_cycle);
-    let res = client.get(&path).send().unwrap();
-
-    info!("Got stacker_set response {:?}", &res);
-    let res = res.json::<GetStackersResponse>().unwrap();
-    res
 }
 
 #[test]


### PR DESCRIPTION
Forgot to set pox_sync_sample_secs to a positive integer in multiple_miners and was getting lots of crashes in various tests about the stacker set not being calculated yet. This will just advance one more block into the prepare phase to ensure the stacker set is calculated and put the call to the endpoint on a retry in case there is some sort of delay. 

