### PR TITLE
Fix/stackerdb sync for 3.0-rc3

### DIFF
--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -4998,7 +4998,7 @@ impl PeerNetwork {
     /// Log our neighbors.
     /// Used for testing and debuggin
     fn log_neighbors(&mut self) {
-        if self.get_connection_opts().log_neighbors_freq == 0 {
+        if !cfg!(test) && self.get_connection_opts().log_neighbors_freq == 0 {
             return;
         }
 

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -443,6 +443,8 @@ pub struct StackerDBSync<NC: NeighborComms> {
     rounds: u128,
     /// Round when we last pushed
     push_round: u128,
+    /// time we last deliberately evicted a peer
+    last_eviction_time: u64,
 }
 
 impl StackerDBSyncResult {

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -79,6 +79,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             num_attempted_connections: 0,
             rounds: 0,
             push_round: 0,
+            last_eviction_time: get_epoch_time_secs(),
         };
         dbsync.reset(None, config);
         dbsync
@@ -217,10 +218,32 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
         self.expected_versions.clear();
         self.downloaded_chunks.clear();
 
-        // reset comms, but keep all connected replicas pinned
+        // reset comms, but keep all connected replicas pinned.
+        // Randomly evict one every so often.
         self.comms.reset();
         if let Some(network) = network {
-            for naddr in self.replicas.iter() {
+            let mut eviction_index = None;
+            if self.last_eviction_time + 60 < get_epoch_time_secs() {
+                self.last_eviction_time = get_epoch_time_secs();
+                if self.replicas.len() > 0 {
+                    eviction_index = Some(thread_rng().gen::<usize>() % self.replicas.len());
+                }
+            }
+
+            let mut remove_naddr = None;
+            for (i, naddr) in self.replicas.iter().enumerate() {
+                if let Some(eviction_index) = eviction_index.as_ref() {
+                    if *eviction_index == i {
+                        debug!(
+                            "{:?}: {}: don't reuse connection for replica {:?}",
+                            network.get_local_peer(),
+                            &self.smart_contract_id,
+                            &naddr,
+                        );
+                        remove_naddr = Some(naddr.clone());
+                        continue;
+                    }
+                }
                 if let Some(event_id) = network.get_event_id(&naddr.to_neighbor_key(network)) {
                     self.comms.pin_connection(event_id);
                     debug!(
@@ -231,6 +254,9 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                         event_id
                     );
                 }
+            }
+            if let Some(naddr) = remove_naddr.take() {
+                self.replicas.remove(&naddr);
             }
         }
 
@@ -668,7 +694,8 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
     /// We might not be connected to any yet.
     /// Clears self.replicas, and fills in self.connected_replicas with already-connected neighbors
     /// Returns Ok(true) if we can proceed to sync
-    /// Returns Ok(false) if we have no known peers
+    /// Returns Ok(false) if we should try this again
+    /// Returns Err(NoSuchNeighbor) if we don't have anyone to talk to
     /// Returns Err(..) on DB query error
     pub fn connect_begin(&mut self, network: &mut PeerNetwork) -> Result<bool, net_error> {
         if self.replicas.len() == 0 {
@@ -686,7 +713,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
         );
         if self.replicas.len() == 0 {
             // nothing to do
-            return Ok(false);
+            return Err(net_error::NoSuchNeighbor);
         }
 
         let naddrs = mem::replace(&mut self.replicas, HashSet::new());
@@ -729,11 +756,12 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                     );
                     self.num_attempted_connections += 1;
                     self.num_connections += 1;
+                    self.connected_replicas.insert(naddr);
                 }
                 Ok(false) => {
                     // need to retry
-                    self.replicas.insert(naddr);
                     self.num_attempted_connections += 1;
+                    self.replicas.insert(naddr);
                 }
                 Err(_e) => {
                     debug!(
@@ -746,7 +774,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                 }
             }
         }
-        Ok(self.replicas.len() == 0)
+        Ok(self.connected_replicas.len() > 0)
     }
 
     /// Finish up connecting to our replicas.
@@ -1154,7 +1182,8 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
         );
 
         // fill up our comms with $capacity requests
-        for _i in 0..self.request_capacity {
+        let mut num_sent = 0;
+        for _i in 0..self.chunk_push_priorities.len() {
             if self.comms.count_inflight() >= self.request_capacity {
                 break;
             }
@@ -1173,6 +1202,9 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
                     chunk_push.chunk_data.slot_id,
                     chunk_push.chunk_data.slot_version,
                 );
+
+                // next-prioritized chunk
+                cur_priority = (cur_priority + 1) % self.chunk_push_priorities.len();
                 continue;
             };
 
@@ -1213,6 +1245,11 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
 
             // next-prioritized chunk
             cur_priority = (cur_priority + 1) % self.chunk_push_priorities.len();
+
+            num_sent += 1;
+            if num_sent > self.request_capacity {
+                break;
+            }
         }
         self.next_chunk_push_priority = cur_priority;
         Ok(self
@@ -1370,14 +1407,22 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             let mut blocked = true;
             match self.state {
                 StackerDBSyncState::ConnectBegin => {
-                    let done = self.connect_begin(network)?;
+                    let done = match self.connect_begin(network) {
+                        Ok(done) => done,
+                        Err(net_error::NoSuchNeighbor) => {
+                            // nothing to do
+                            self.state = StackerDBSyncState::Finished;
+                            blocked = false;
+                            false
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    };
                     if done {
                         self.state = StackerDBSyncState::ConnectFinish;
-                    } else {
-                        // no replicas; try again
-                        self.state = StackerDBSyncState::Finished;
+                        blocked = false;
                     }
-                    blocked = false;
                 }
                 StackerDBSyncState::ConnectFinish => {
                     let done = self.connect_try_finish(network)?;

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -199,7 +199,14 @@ fn test_reconnect(network: &mut PeerNetwork) {
         .expect("FATAL: did not replace stacker dbs");
 
     for (_sc, stacker_db_sync) in stacker_db_syncs.iter_mut() {
-        stacker_db_sync.connect_begin(network).unwrap();
+        match stacker_db_sync.connect_begin(network) {
+            Ok(x) => {}
+            Err(net_error::PeerNotConnected) => {}
+            Err(net_error::NoSuchNeighbor) => {}
+            Err(e) => {
+                panic!("Failed to connect_begin: {:?}", &e);
+            }
+        }
     }
 
     network.stacker_db_syncs = Some(stacker_db_syncs);

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -183,7 +183,12 @@ fn load_stackerdb(peer: &TestPeer, idx: usize) -> Vec<(SlotMetadata, Vec<u8>)> {
 
 fn check_sync_results(network_sync: &NetworkResult) {
     for res in network_sync.stacker_db_sync_results.iter() {
-        assert!(res.num_connections >= res.num_attempted_connections);
+        assert!(
+            res.num_connections <= res.num_attempted_connections,
+            "{} < {}",
+            res.num_connections,
+            res.num_attempted_connections
+        );
     }
 }
 


### PR DESCRIPTION
This fixes a bug in StackerDB sync present in 3.0-rc3 whereby the state machine never completes, causing it to miss StackerDB updates.  This was due to a flaw in the success condition of `connect_begin()` -- we would either fail to complete it in a timely manner if some nodes weren't routable, or we would always fail if all replicas have been connected to or attempted to be connected to (which was meant at one point to mean "there are no more replicas to try", but that had since changed).  The fix is to treat `connect_begin()` as successful if there is at least one _connected_ replica, and rely on the fact that `connect_begin()` will connect to subsequent replicas in subsequent passes.  To prevent ossification, the node will deliberately forget about one connected replica at random once per minute (allowing the pruner to garbage-collect it).

This also fixes a bug in StackerDB sync whereby the node wouldn't attempt to push chunks to every peer that needs them.  Instead of only considering `request_capacity` chunks, including ones that are needed by no one, we now instead track the number of sent chunks separately and try to send chunks to each and every peer represented in the chunk push schedule.

There were a few false starts to this PR that would have been much more tedious (e.g. I aborted an attempt to give each replica its own state machine, so they could independently make progress on syncing), but this isn't something we have time for right now.  While I think this refactoring is desirable, it can wait until after Nakamoto is released.