### PR TITLE
Fix/nakamoto downloader at reward cycle boundary

### DIFF
--- a/stackslib/src/net/download/nakamoto/tenure.rs
+++ b/stackslib/src/net/download/nakamoto/tenure.rs
@@ -325,15 +325,12 @@ impl TenureStartEnd {
                 wt_start.winning_block_id.clone(),
                 wt_end.winning_block_id.clone(),
                 rc,
-                downloader_block_height_to_reward_cycle(
-                    pox_constants,
-                    first_burn_height,
-                    wt_start.burn_height,
-                )
-                .expect(&format!(
-                    "FATAL: tenure from before system start ({} <= {})",
-                    wt_start.burn_height, first_burn_height
-                )),
+                pox_constants
+                    .block_height_to_reward_cycle(first_burn_height, wt_start.burn_height)
+                    .expect(&format!(
+                        "FATAL: tenure from before system start ({} <= {})",
+                        wt_start.burn_height, first_burn_height
+                    )),
                 wt.processed,
             );
             tenure_start_end.fetch_end_block = true;

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -407,6 +407,12 @@ impl NakamotoTenureDownloaderSet {
                 continue;
             };
 
+            info!("Download tenure {}", &ch;
+                "tenure_start_block" => %tenure_info.start_block_id,
+                "tenrue_end_block" => %tenure_info.end_block_id,
+                "tenure_start_reward_cycle" => tenure_info.start_reward_cycle,
+                "tenure_end_reward_cycle" => tenure_info.end_reward_cycle);
+
             debug!(
                 "Download tenure {} (start={}, end={}) (rc {},{})",
                 &ch,

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -409,7 +409,7 @@ impl NakamotoTenureDownloaderSet {
 
             info!("Download tenure {}", &ch;
                 "tenure_start_block" => %tenure_info.start_block_id,
-                "tenrue_end_block" => %tenure_info.end_block_id,
+                "tenure_end_block" => %tenure_info.end_block_id,
                 "tenure_start_reward_cycle" => tenure_info.start_reward_cycle,
                 "tenure_end_reward_cycle" => tenure_info.end_reward_cycle);
 

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -679,6 +679,7 @@ impl NakamotoTenureInv {
             }
             StacksMessageType::Nack(nack_data) => {
                 info!("{:?}: remote peer NACKed our GetNakamotoInv", network.get_local_peer();
+                      "remote_peer" => %self.neighbor_address,
                       "error_code" => nack_data.error_code);
 
                 if nack_data.error_code != NackErrorCodes::NoSuchBurnchainBlock {


### PR DESCRIPTION
This fixes an off-by-one bug in which we load the wrong reward set to validate the tenure-end block of the last tenure of a reward set.