### PR TITLE
Do not issue a BurnchainTipChanged error unless there is a new sortition

### DIFF
--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -1201,11 +1201,14 @@ impl BlockMinerThread {
     }
 
     /// Check if the tenure needs to change -- if so, return a BurnchainTipChanged error
+    /// The tenure should change if there is a new burnchain tip with a valid sortition
     fn check_burn_tip_changed(&self, sortdb: &SortitionDB) -> Result<(), NakamotoNodeError> {
         let cur_burn_chain_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
             .expect("FATAL: failed to query sortition DB for canonical burn chain tip");
 
-        if cur_burn_chain_tip.consensus_hash != self.burn_block.consensus_hash {
+        if cur_burn_chain_tip.consensus_hash != self.burn_block.consensus_hash
+            && cur_burn_chain_tip.sortition_id != self.burn_block.sortition_id
+        {
             info!("Miner: Cancel block assembly; burnchain tip has changed");
             self.globals.counters.bump_missed_tenures();
             Err(NakamotoNodeError::BurnchainTipChanged)


### PR DESCRIPTION
We should only be issuing a BurnchainTIpChanged error to abort waiting for a block if a valid sortition has also occured to properly handle tenure extends.

Still need to add a test.