### PR TITLE
feat: add chain_id to signer config

### DIFF
--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -255,6 +255,7 @@ mod tests {
             Some(100_000),
             None,
             Some(9000),
+            None,
         );
         let config = GlobalConfig::load_from_str(&signer_config[0]).unwrap();
         let signer_config = generate_signer_config(&config, 5);

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -121,7 +121,7 @@ fn handle_generate_stacking_signature(
         &private_key, //
         args.reward_cycle.into(),
         args.method.topic(),
-        config.network.to_chain_id(),
+        config.to_chain_id(),
         args.period.into(),
         args.max_amount,
         args.auth_id,

--- a/stacks-signer/src/tests/chainstate.rs
+++ b/stacks-signer/src/tests/chainstate.rs
@@ -32,6 +32,7 @@ use clarity::util::vrf::VRFProof;
 use libsigner::BlockProposal;
 use slog::slog_info;
 use stacks_common::bitvec::BitVec;
+use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::info;
 use stacks_common::types::chainstate::{
     ConsensusHash, StacksBlockId, StacksPrivateKey, StacksPublicKey, TrieHash,
@@ -96,6 +97,7 @@ fn setup_test_environment(
         SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 10000).to_string(),
         "FOO".into(),
         false,
+        CHAIN_ID_TESTNET,
     );
 
     let signer_db_dir = "/tmp/stacks-node-tests/signer-units/";

--- a/stacks-signer/src/tests/conf/signer-custom-chain-id.toml
+++ b/stacks-signer/src/tests/conf/signer-custom-chain-id.toml
@@ -1,0 +1,7 @@
+stacks_private_key = "126e916e77359ccf521e168feea1fcb9626c59dc375cae00c7464303381c7dff01"
+node_host = "127.0.0.1:20444"
+endpoint = "localhost:30001"
+network = "testnet"
+auth_password = "12345"
+db_path = ":memory:"
+chain_id = 0x80000100

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -78,7 +78,7 @@ use stacks::util_lib::signed_structured_data::pox4::{
 use stacks_common::address::AddressHashMode;
 use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
-use stacks_common::consts::STACKS_EPOCH_MAX;
+use stacks_common::consts::{CHAIN_ID_TESTNET, STACKS_EPOCH_MAX};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, StacksAddress, StacksPrivateKey, StacksPublicKey,
     TrieHash,
@@ -6400,6 +6400,7 @@ fn signer_chainstate() {
             .clone()
             .unwrap_or("".into()),
         false,
+        CHAIN_ID_TESTNET,
     );
 
     wait_for_first_naka_block_commit(60, &commits_submitted);

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -173,6 +173,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
             Some(100_000),
             None,
             Some(9000),
+            None,
         )
         .into_iter()
         .map(|toml| {

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -2990,6 +2990,7 @@ fn signer_set_rollover() {
         Some(100_000),
         None,
         Some(9000 + num_signers),
+        None,
     );
 
     let new_spawned_signers: Vec<_> = (0..new_num_signers)


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/5313

This adds an optional `chain_id` field to the signer's config. If present, it is used in the `/v3/block_proposal` endpoint.