### PR TITLE
feat: better exposing of signer version

### DIFF
--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -29,7 +29,6 @@ use clarity::util::hash::Sha256Sum;
 use clarity::util::secp256k1::MessageSignature;
 use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
 use clarity::vm::Value;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use stacks_common::address::{
     b58, AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG,
@@ -39,31 +38,9 @@ use stacks_common::address::{
 use stacks_common::define_u8_enum;
 use stacks_common::types::chainstate::StacksPrivateKey;
 
+use crate::VERSION_STRING;
+
 extern crate alloc;
-
-const GIT_BRANCH: Option<&'static str> = option_env!("GIT_BRANCH");
-const GIT_COMMIT: Option<&'static str> = option_env!("GIT_COMMIT");
-#[cfg(debug_assertions)]
-const BUILD_TYPE: &str = "debug";
-#[cfg(not(debug_assertions))]
-const BUILD_TYPE: &str = "release";
-
-lazy_static! {
-    static ref VERSION_STRING: String = {
-        let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-        let git_branch = GIT_BRANCH.unwrap_or("");
-        let git_commit = GIT_COMMIT.unwrap_or("");
-        format!(
-            "{} ({}:{}, {} build, {} [{}])",
-            pkg_version,
-            git_branch,
-            git_commit,
-            BUILD_TYPE,
-            std::env::consts::OS,
-            std::env::consts::ARCH
-        )
-    };
-}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]

--- a/stacks-signer/src/lib.rs
+++ b/stacks-signer/src/lib.rs
@@ -48,8 +48,10 @@ mod tests;
 use std::fmt::{Debug, Display};
 use std::sync::mpsc::{channel, Receiver, Sender};
 
+use blockstack_lib::version_string;
 use chainstate::SortitionsView;
 use config::GlobalConfig;
+use lazy_static::lazy_static;
 use libsigner::{SignerEvent, SignerEventReceiver, SignerEventTrait};
 use runloop::SignerResult;
 use slog::{slog_info, slog_warn};
@@ -58,6 +60,14 @@ use stacks_common::{info, warn};
 use crate::client::StacksClient;
 use crate::config::SignerConfig;
 use crate::runloop::RunLoop;
+
+lazy_static! {
+    /// The version string for the signer
+    pub static ref VERSION_STRING: String = {
+        let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        version_string("stacks-signer", pkg_version)
+    };
+}
 
 /// A trait which provides a common `Signer` interface for `v0` and `v1`
 pub trait Signer<T: SignerEventTrait>: Debug + Display {
@@ -113,6 +123,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SpawnedSigner
     /// Create a new spawned signer
     pub fn new(config: GlobalConfig) -> Self {
         let endpoint = config.endpoint;
+        info!("Stacks signer version {:?}", VERSION_STRING.as_str());
         info!("Starting signer with config: {:?}", config);
         warn!(
             "Reminder: The signer is primarily designed for use with a local or subnet network stacks node. \

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -47,6 +47,7 @@ use stacks_signer::config::GlobalConfig;
 use stacks_signer::monitor_signers::SignerMonitor;
 use stacks_signer::utils::stackerdb_session;
 use stacks_signer::v0::SpawnedSigner;
+use stacks_signer::VERSION_STRING;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
@@ -157,7 +158,11 @@ fn handle_generate_stacking_signature(
 
 fn handle_check_config(args: RunSignerArgs) {
     let config = GlobalConfig::try_from(&args.config).unwrap();
-    println!("Config: {}", config);
+    println!(
+        "Signer version: {}\nConfig: \n{}",
+        VERSION_STRING.to_string(),
+        config
+    );
 }
 
 fn handle_generate_vote(args: GenerateVoteArgs, do_print: bool) -> MessageSignature {

--- a/stacks-signer/src/monitoring/server.rs
+++ b/stacks-signer/src/monitoring/server.rs
@@ -28,6 +28,7 @@ use crate::client::{ClientError, StacksClient};
 use crate::config::{GlobalConfig, Network};
 use crate::monitoring::prometheus::gather_metrics_string;
 use crate::monitoring::{update_signer_nonce, update_stacks_tip_height};
+use crate::VERSION_STRING;
 
 #[derive(thiserror::Error, Debug)]
 /// Monitoring server errors
@@ -215,6 +216,7 @@ impl MonitoringServer {
             "signerPublicKey": to_hex(&self.public_key.to_bytes_compressed()),
             "network": self.network.to_string(),
             "stxAddress": self.stacks_client.get_signer_address().to_string(),
+            "version": VERSION_STRING.to_string(),
         }))
         .expect("Failed to serialize JSON")
     }


### PR DESCRIPTION
We previously had a `VERSION_STRING` that you could use with `stacks-signer --version`. This PR does a few things:

- Use the `version_string` helper to improve code re-use (it was the same exact code anyways)
- When starting the signer, print the version
- Add version to `check-config` CLI command
- Add version to the `/info` endpoint on the metrics server