### PR TITLE
Feat: block info handling in Clarity 2 contracts post-3.0

### DIFF
--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -927,6 +927,14 @@ impl<'a> ClarityDatabase<'a> {
         }
     }
 
+    /// Return the block height for a given tenure height
+    ///   if the block information is queryable for the tenure height.
+    /// The block information for a given tenure height is queryable iff:
+    ///  * `tenure_height` falls in 2.x, and `tenure_height` < `current_height`
+    ///  * `tenure_height` falls in 3.x, and the first block of the tenure
+    ///    at `tenure_height` has a stacks block height less than `current_height`
+    ///
+    /// If the block information isn't queryable, return `Ok(None)`
     pub fn get_block_height_for_tenure_height(
         &mut self,
         tenure_height: u32,

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -935,10 +935,14 @@ impl<'a> ClarityDatabase<'a> {
         if current_tenure_height < tenure_height {
             return Ok(None);
         }
-        if current_tenure_height == tenure_height {
-            return Ok(Some(self.get_current_block_height()));
-        }
         let current_height = self.get_current_block_height();
+        // check if we're querying a 2.x block
+        let id_bhh = self.get_index_block_header_hash(tenure_height)?;
+        let epoch = self.get_stacks_epoch_for_block(&id_bhh)?;
+        if !epoch.uses_nakamoto_blocks() {
+            return Ok(Some(tenure_height));
+        }
+
         // query from the parent
         let query_tip = self.get_index_block_header_hash(current_height.saturating_sub(1))?;
         Ok(self

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -936,13 +936,15 @@ impl<'a> ClarityDatabase<'a> {
             return Ok(None);
         }
         let current_height = self.get_current_block_height();
+        if current_height <= tenure_height {
+            return Ok(None);
+        }
         // check if we're querying a 2.x block
         let id_bhh = self.get_index_block_header_hash(tenure_height)?;
         let epoch = self.get_stacks_epoch_for_block(&id_bhh)?;
         if !epoch.uses_nakamoto_blocks() {
             return Ok(Some(tenure_height));
         }
-
         // query from the parent
         let query_tip = self.get_index_block_header_hash(current_height.saturating_sub(1))?;
         Ok(self

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2863,6 +2863,14 @@ mod test {
         ) -> Option<u128> {
             Some(12000)
         }
+
+        fn get_stacks_height_for_tenure_height(
+            &self,
+            _tip: &StacksBlockId,
+            tenure_height: u32,
+        ) -> Option<u32> {
+            Some(tenure_height)
+        }
     }
 
     struct DocBurnStateDB {}

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -769,6 +769,24 @@ pub fn special_get_block_info(
         _ => return Ok(Value::none()),
     };
 
+    let height_value = if env.contract_context.get_clarity_version() < &ClarityVersion::Clarity3 {
+        if env.global_context.epoch_id < StacksEpochId::Epoch30 {
+            height_value
+        } else {
+            // interpretting height_value as a tenure height
+            let height_opt = env
+                .global_context
+                .database
+                .get_block_height_for_tenure_height(height_value)?;
+            match height_opt {
+                Some(x) => x,
+                None => return Ok(Value::none()),
+            }
+        }
+    } else {
+        height_value
+    };
+
     let current_block_height = env.global_context.database.get_current_block_height();
     if height_value >= current_block_height {
         return Ok(Value::none());

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -16,6 +16,7 @@
 
 use std::cmp;
 
+use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::StacksEpochId;
 
@@ -769,22 +770,27 @@ pub fn special_get_block_info(
         _ => return Ok(Value::none()),
     };
 
-    let height_value = if env.contract_context.get_clarity_version() < &ClarityVersion::Clarity3 {
-        if env.global_context.epoch_id < StacksEpochId::Epoch30 {
-            height_value
-        } else {
-            // interpretting height_value as a tenure height
-            let height_opt = env
-                .global_context
-                .database
-                .get_block_height_for_tenure_height(height_value)?;
-            match height_opt {
-                Some(x) => x,
-                None => return Ok(Value::none()),
-            }
-        }
-    } else {
+    // interpret height as a tenure height IFF
+    // * clarity version is less than Clarity3
+    // * the evaluated epoch is geq 3.0
+    // * we are not on (classic) primary testnet
+    let interpret_height_as_tenure_height = env.contract_context.get_clarity_version()
+        < &ClarityVersion::Clarity3
+        && env.global_context.epoch_id >= StacksEpochId::Epoch30
+        && env.global_context.chain_id != CHAIN_ID_TESTNET;
+
+    let height_value = if !interpret_height_as_tenure_height {
         height_value
+    } else {
+        // interpretting height_value as a tenure height
+        let height_opt = env
+            .global_context
+            .database
+            .get_block_height_for_tenure_height(height_value)?;
+        match height_opt {
+            Some(x) => x,
+            None => return Ok(Value::none()),
+        }
     };
 
     let current_block_height = env.global_context.database.get_current_block_height();

--- a/clarity/src/vm/test_util/mod.rs
+++ b/clarity/src/vm/test_util/mod.rs
@@ -229,6 +229,14 @@ impl HeadersDB for UnitTestHeaderDB {
         // if the block is defined at all, then return a constant
         self.get_burn_block_height_for_block(id_bhh).map(|_| 3000)
     }
+
+    fn get_stacks_height_for_tenure_height(
+        &self,
+        _tip: &StacksBlockId,
+        tenure_height: u32,
+    ) -> Option<u32> {
+        Some(tenure_height)
+    }
 }
 
 impl BurnStateDB for UnitTestBurnStateDB {

--- a/clarity/src/vm/tests/contracts.rs
+++ b/clarity/src/vm/tests/contracts.rs
@@ -139,7 +139,7 @@ fn test_get_block_info_eval(
             .unwrap();
 
         let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
-
+        eprintln!("{}", contracts[i]);
         let eval_result = env.eval_read_only(&contract_identifier, "(test-func)");
         match expected[i] {
             // any (some UINT) is okay for checking get-block-info? time

--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -123,11 +123,13 @@ pub struct TestMiner {
     pub nonce: u64,
     pub spent_at_nonce: HashMap<u64, u128>, // how much uSTX this miner paid in a given tx's nonce
     pub test_with_tx_fees: bool, // set to true to make certain helper methods attach a pre-defined tx fee
+    pub chain_id: u32,
 }
 
 pub struct TestMinerFactory {
     pub key_seed: [u8; 32],
     pub next_miner_id: usize,
+    pub chain_id: u32,
 }
 
 impl TestMiner {
@@ -136,6 +138,7 @@ impl TestMiner {
         privks: &Vec<StacksPrivateKey>,
         num_sigs: u16,
         hash_mode: &AddressHashMode,
+        chain_id: u32,
     ) -> TestMiner {
         TestMiner {
             burnchain: burnchain.clone(),
@@ -150,6 +153,7 @@ impl TestMiner {
             nonce: 0,
             spent_at_nonce: HashMap::new(),
             test_with_tx_fees: true,
+            chain_id,
         }
     }
 
@@ -314,15 +318,7 @@ impl TestMinerFactory {
         TestMinerFactory {
             key_seed: [0u8; 32],
             next_miner_id: 1,
-        }
-    }
-
-    pub fn from_u16(seed: u16) -> TestMinerFactory {
-        let mut bytes = [0u8; 32];
-        (&mut bytes[0..2]).copy_from_slice(&seed.to_be_bytes());
-        TestMinerFactory {
-            key_seed: bytes,
-            next_miner_id: seed as usize,
+            chain_id: CHAIN_ID_TESTNET,
         }
     }
 
@@ -346,7 +342,7 @@ impl TestMinerFactory {
         }
 
         test_debug!("New miner: {:?} {}:{:?}", &hash_mode, num_sigs, &keys);
-        let mut m = TestMiner::new(burnchain, &keys, num_sigs, &hash_mode);
+        let mut m = TestMiner::new(burnchain, &keys, num_sigs, &hash_mode, self.chain_id);
         m.id = self.next_miner_id;
         self.next_miner_id += 1;
         m

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -302,7 +302,7 @@ pub fn make_token_transfer(
     stx_transfer_signed
 }
 
-/// Make a token-transfer from a private key
+/// Make contract publish
 pub fn make_contract(
     chainstate: &mut StacksChainState,
     name: &str,

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -17,9 +17,12 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
+use clarity::consts::CHAIN_ID_TESTNET;
 use clarity::vm::clarity::ClarityConnection;
-use clarity::vm::types::PrincipalData;
-use clarity::vm::Value;
+use clarity::vm::costs::ExecutionCost;
+use clarity::vm::database::clarity_db::NullBurnStateDB;
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
+use clarity::vm::{ClarityVersion, Value};
 use rand::prelude::SliceRandom;
 use rand::{thread_rng, Rng, RngCore};
 use stacks_common::address::{AddressHashMode, C32_ADDRESS_VERSION_TESTNET_SINGLESIG};
@@ -35,6 +38,7 @@ use stacks_common::util::hash::Hash160;
 use stacks_common::util::secp256k1::Secp256k1PrivateKey;
 use stacks_common::util::vrf::VRFProof;
 
+use crate::burnchains::tests::TestMiner;
 use crate::burnchains::{PoxConstants, Txid};
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandle};
 use crate::chainstate::burn::operations::{
@@ -64,7 +68,7 @@ use crate::chainstate::stacks::events::TransactionOrigin;
 use crate::chainstate::stacks::{
     CoinbasePayload, Error as ChainstateError, StacksTransaction, StacksTransactionSigner,
     TenureChangeCause, TokenTransferMemo, TransactionAnchorMode, TransactionAuth,
-    TransactionPayload, TransactionVersion,
+    TransactionPayload, TransactionSmartContract, TransactionVersion,
 };
 use crate::clarity::vm::types::StacksAddressExtensions;
 use crate::core::StacksEpochExtension;
@@ -76,6 +80,7 @@ use crate::stacks_common::codec::StacksMessageCodec;
 use crate::util_lib::boot::boot_code_id;
 use crate::util_lib::db::{query_rows, u64_to_sql};
 use crate::util_lib::signed_structured_data::pox4::Pox4SignatureTopic;
+use crate::util_lib::strings::StacksString;
 
 impl<'a> NakamotoStagingBlocksConnRef<'a> {
     pub fn get_blocks_at_height(&self, height: u64) -> Vec<NakamotoBlock> {
@@ -285,7 +290,7 @@ pub fn make_token_transfer(
             TokenTransferMemo([0x00; 34]),
         ),
     );
-    stx_transfer.chain_id = 0x80000000;
+    stx_transfer.chain_id = chainstate.chain_id;
     stx_transfer.anchor_mode = TransactionAnchorMode::OnChainOnly;
     stx_transfer.set_tx_fee(fee);
     stx_transfer.auth.set_origin_nonce(nonce);
@@ -295,6 +300,37 @@ pub fn make_token_transfer(
     let stx_transfer_signed = tx_signer.get_tx().unwrap();
 
     stx_transfer_signed
+}
+
+/// Make a token-transfer from a private key
+pub fn make_contract(
+    chainstate: &mut StacksChainState,
+    name: &str,
+    code: &str,
+    private_key: &StacksPrivateKey,
+    version: ClarityVersion,
+    nonce: u64,
+    fee: u64,
+) -> StacksTransaction {
+    let mut stx_tx = StacksTransaction::new(
+        TransactionVersion::Testnet,
+        TransactionAuth::from_p2pkh(private_key).unwrap(),
+        TransactionPayload::SmartContract(
+            TransactionSmartContract {
+                name: name.into(),
+                code_body: StacksString::from_str(code).unwrap(),
+            },
+            Some(version),
+        ),
+    );
+    stx_tx.chain_id = chainstate.chain_id;
+    stx_tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
+    stx_tx.set_tx_fee(fee);
+    stx_tx.auth.set_origin_nonce(nonce);
+
+    let mut tx_signer = StacksTransactionSigner::new(&stx_tx);
+    tx_signer.sign_origin(&private_key).unwrap();
+    tx_signer.get_tx().unwrap()
 }
 
 /// Given the blocks and block-commits for a reward cycle, replay the sortitions on the given
@@ -612,6 +648,67 @@ impl<'a> TestPeer<'a> {
         block
     }
 
+    pub fn mine_tenure<F>(&mut self, block_builder: F) -> Vec<(NakamotoBlock, u64, ExecutionCost)>
+    where
+        F: FnMut(
+            &mut TestMiner,
+            &mut StacksChainState,
+            &SortitionDB,
+            &[(NakamotoBlock, u64, ExecutionCost)],
+        ) -> Vec<StacksTransaction>,
+    {
+        let (burn_ops, mut tenure_change, miner_key) =
+            self.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
+        let (burn_height, _, consensus_hash) = self.next_burnchain_block(burn_ops.clone());
+        let pox_constants = self.sortdb().pox_constants.clone();
+        let first_burn_height = self.sortdb().first_block_height;
+        let mut test_signers = self.config.test_signers.clone().unwrap();
+
+        info!(
+            "Burnchain block produced: {burn_height}, in_prepare_phase?: {}, first_reward_block?: {}",
+            pox_constants.is_in_prepare_phase(first_burn_height, burn_height),
+            pox_constants.is_naka_signing_cycle_start(first_burn_height, burn_height)
+        );
+        let vrf_proof = self.make_nakamoto_vrf_proof(miner_key);
+
+        tenure_change.tenure_consensus_hash = consensus_hash.clone();
+        tenure_change.burn_view_consensus_hash = consensus_hash.clone();
+
+        let nakamoto_tip =
+            if let Some(nakamoto_parent_tenure) = self.nakamoto_parent_tenure_opt.as_ref() {
+                nakamoto_parent_tenure.last().as_ref().unwrap().block_id()
+            } else {
+                let tip = {
+                    let chainstate = &mut self.stacks_node.as_mut().unwrap().chainstate;
+                    let sort_db = self.sortdb.as_mut().unwrap();
+                    NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
+                        .unwrap()
+                        .unwrap()
+                };
+                tip.index_block_hash()
+            };
+
+        let miner_addr = self.miner.origin_address().unwrap();
+        let miner_acct = self.get_account(&nakamoto_tip, &miner_addr.to_account_principal());
+
+        let tenure_change_tx = self
+            .miner
+            .make_nakamoto_tenure_change_with_nonce(tenure_change.clone(), miner_acct.nonce);
+
+        let coinbase_tx =
+            self.miner
+                .make_nakamoto_coinbase_with_nonce(None, vrf_proof, miner_acct.nonce + 1);
+
+        self.make_nakamoto_tenure_and(
+            tenure_change_tx,
+            coinbase_tx,
+            &mut test_signers,
+            |_| {},
+            block_builder,
+            |_| true,
+        )
+    }
+
     pub fn single_block_tenure<S, F, G>(
         &mut self,
         sender_key: &StacksPrivateKey,
@@ -762,6 +859,439 @@ fn block_descendant() {
         first_reward_block.header.parent_block_id,
         naka_anchor_block.block_id()
     );
+}
+
+#[test]
+fn block_info_primary_testnet() {
+    block_info_tests(true)
+}
+
+#[test]
+fn block_info_other_testnet() {
+    block_info_tests(false)
+}
+
+fn block_info_tests(use_primary_testnet: bool) {
+    let private_key = StacksPrivateKey::from_seed(&[2]);
+    let addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&private_key));
+
+    let num_stackers: u32 = 4;
+    let mut signing_key_seed = num_stackers.to_be_bytes().to_vec();
+    signing_key_seed.extend_from_slice(&[1, 1, 1, 1]);
+    let signing_key = StacksPrivateKey::from_seed(signing_key_seed.as_slice());
+    let test_stackers = (0..num_stackers)
+        .map(|index| TestStacker {
+            signer_private_key: signing_key.clone(),
+            stacker_private_key: StacksPrivateKey::from_seed(&index.to_be_bytes()),
+            amount: u64::MAX as u128 - 10000,
+            pox_addr: Some(PoxAddress::Standard(
+                StacksAddress::new(
+                    C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+                    Hash160::from_data(&index.to_be_bytes()),
+                ),
+                Some(AddressHashMode::SerializeP2PKH),
+            )),
+            max_amount: None,
+        })
+        .collect::<Vec<_>>();
+    let test_signers = TestSigners::new(vec![signing_key]);
+    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    pox_constants.reward_cycle_length = 10;
+    pox_constants.v2_unlock_height = 21;
+    pox_constants.pox_3_activation_height = 26;
+    pox_constants.v3_unlock_height = 27;
+    pox_constants.pox_4_activation_height = 28;
+
+    let chain_id = if use_primary_testnet {
+        CHAIN_ID_TESTNET
+    } else {
+        CHAIN_ID_TESTNET + 1
+    };
+    let mut boot_plan =
+        NakamotoBootPlan::new(&format!("{}.{use_primary_testnet}", function_name!()))
+            .with_test_stackers(test_stackers.clone())
+            .with_test_signers(test_signers.clone())
+            .with_private_key(private_key)
+            .with_network_id(chain_id);
+    boot_plan.pox_constants = pox_constants;
+
+    // Supply an empty vec to make sure we have no nakamoto blocks when this test begins
+    let mut peer = boot_plan.boot_into_nakamoto_peer(vec![], None);
+
+    let clar1_contract = "
+       (define-read-only (get-info (height uint)) (get-block-info? id-header-hash height))
+    ";
+    let clar3_contract = "
+       (define-read-only (get-info (height uint)) (get-stacks-block-info? id-header-hash height))
+    ";
+
+    let clar1_contract_name = "clar1";
+    let clar3_contract_name = "clar3";
+
+    let clar1_contract_id = QualifiedContractIdentifier {
+        issuer: addr.clone().into(),
+        name: clar1_contract_name.into(),
+    };
+    let clar3_contract_id = QualifiedContractIdentifier {
+        issuer: addr.clone().into(),
+        name: clar3_contract_name.into(),
+    };
+
+    let get_tip_info = |peer: &mut TestPeer| {
+        peer.with_db_state(|sortdb, _, _, _| {
+            let (tip_ch, tip_bh, tip_height) =
+                SortitionDB::get_canonical_stacks_chain_tip_hash_and_height(sortdb.conn()).unwrap();
+            let tip_block_id = StacksBlockId::new(&tip_ch, &tip_bh);
+            Ok((tip_block_id, tip_height))
+        })
+        .unwrap()
+    };
+
+    let get_info = |peer: &mut TestPeer,
+                    version: ClarityVersion,
+                    query_ht: u64,
+                    tip_block_id: &StacksBlockId| {
+        let contract_id = match version {
+            ClarityVersion::Clarity1 => &clar1_contract_id,
+            ClarityVersion::Clarity2 => panic!(),
+            ClarityVersion::Clarity3 => &clar3_contract_id,
+        };
+        peer.with_db_state(|sortdb, chainstate, _, _| {
+            let sortdb_handle = sortdb.index_handle_at_tip();
+            let output = chainstate
+                .clarity_eval_read_only(
+                    &sortdb_handle,
+                    &tip_block_id,
+                    contract_id,
+                    &format!("(get-info u{query_ht})"),
+                )
+                .expect_optional()
+                .unwrap()
+                .map(|value| StacksBlockId::from_vec(&value.expect_buff(32).unwrap()).unwrap());
+
+            info!("At stacks block {tip_block_id}, {contract_id} returned {output:?}");
+
+            Ok(output)
+        })
+        .unwrap()
+    };
+
+    let (last_2x_block_id, last_2x_block_ht) = get_tip_info(&mut peer);
+
+    peer.mine_tenure(|miner, chainstate, sortdb, blocks_so_far| {
+        if blocks_so_far.len() > 0 {
+            return vec![];
+        }
+        info!("Producing first nakamoto block, publishing our three contracts");
+        let account = get_account(chainstate, sortdb, &addr);
+        let tx_0 = make_contract(
+            chainstate,
+            clar1_contract_name,
+            clar1_contract,
+            &private_key,
+            ClarityVersion::Clarity1,
+            account.nonce,
+            1000,
+        );
+        let tx_1 = make_contract(
+            chainstate,
+            clar3_contract_name,
+            clar3_contract,
+            &private_key,
+            ClarityVersion::Clarity3,
+            account.nonce + 1,
+            1000,
+        );
+
+        vec![tx_0, tx_1]
+    });
+
+    let (tenure_1_start_block_id, tenure_1_block_ht) = get_tip_info(&mut peer);
+    assert_eq!(
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            last_2x_block_ht,
+            &tenure_1_start_block_id
+        )
+        .unwrap(),
+        last_2x_block_id,
+    );
+    assert_eq!(
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity3,
+            last_2x_block_ht,
+            &tenure_1_start_block_id
+        )
+        .unwrap(),
+        last_2x_block_id,
+    );
+    assert!(get_info(
+        &mut peer,
+        ClarityVersion::Clarity1,
+        tenure_1_block_ht,
+        &tenure_1_start_block_id
+    )
+    .is_none());
+    assert!(get_info(
+        &mut peer,
+        ClarityVersion::Clarity3,
+        tenure_1_block_ht,
+        &tenure_1_start_block_id
+    )
+    .is_none());
+
+    let recipient_addr = StacksAddress::p2pkh(
+        false,
+        &StacksPublicKey::from_private(&StacksPrivateKey::from_seed(&[2, 1, 2])),
+    );
+
+    let tenure_2_blocks: Vec<_> = peer
+        .mine_tenure(|miner, chainstate, sortdb, blocks_so_far| {
+            if blocks_so_far.len() > 3 {
+                return vec![];
+            }
+            info!("Producing block #{} in Tenure #2", blocks_so_far.len());
+            let account = get_account(chainstate, sortdb, &addr);
+            let tx_0 = make_token_transfer(
+                chainstate,
+                sortdb,
+                &private_key,
+                account.nonce,
+                100,
+                1,
+                &recipient_addr,
+            );
+
+            vec![tx_0]
+        })
+        .into_iter()
+        .map(|(block, ..)| block.header.block_id())
+        .collect();
+
+    let (tenure_2_last_block_id, tenure_2_last_block_ht) = get_tip_info(&mut peer);
+
+    assert_eq!(&tenure_2_last_block_id, tenure_2_blocks.last().unwrap());
+
+    let c3_tenure1_from_tenure2 = get_info(
+        &mut peer,
+        ClarityVersion::Clarity3,
+        tenure_1_block_ht,
+        &tenure_2_blocks[0],
+    )
+    .unwrap();
+    let c1_tenure1_from_tenure2 = get_info(
+        &mut peer,
+        ClarityVersion::Clarity1,
+        tenure_1_block_ht,
+        &tenure_2_blocks[0],
+    )
+    .unwrap();
+
+    // note, since tenure_1 only has one block in it, tenure_1_block_ht is *also* the tenure height, so this should return the
+    // same value regardless of the `primary_tesnet` flag
+    assert_eq!(c1_tenure1_from_tenure2, c3_tenure1_from_tenure2);
+    assert_eq!(c1_tenure1_from_tenure2, tenure_1_start_block_id);
+
+    let tenure_2_start_block_ht = tenure_1_block_ht + 1;
+    let tenure_2_tenure_ht = tenure_1_block_ht + 1;
+
+    // make sure we can't look up block info from the block we're evaluating at
+    if use_primary_testnet {
+        assert!(get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_2_start_block_ht,
+            &tenure_2_blocks[0]
+        )
+        .is_none());
+    } else {
+        assert!(get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_2_tenure_ht,
+            &tenure_2_blocks[0]
+        )
+        .is_none());
+    }
+    assert!(get_info(
+        &mut peer,
+        ClarityVersion::Clarity3,
+        tenure_2_start_block_ht,
+        &tenure_2_blocks[0]
+    )
+    .is_none());
+
+    // but we can from the next block in the tenure
+    let c1_tenure_2_start_block = if use_primary_testnet {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_2_start_block_ht,
+            &tenure_2_blocks[1],
+        )
+        .unwrap()
+    } else {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_2_tenure_ht,
+            &tenure_2_blocks[1],
+        )
+        .unwrap()
+    };
+    let c3_tenure_2_start_block = get_info(
+        &mut peer,
+        ClarityVersion::Clarity3,
+        tenure_2_start_block_ht,
+        &tenure_2_blocks[1],
+    )
+    .unwrap();
+    assert_eq!(c1_tenure_2_start_block, c3_tenure_2_start_block);
+    assert_eq!(&c1_tenure_2_start_block, &tenure_2_blocks[0]);
+
+    // try to query the middle block from the last block in the tenure
+    let c1_tenure_2_mid_block = if use_primary_testnet {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_2_start_block_ht + 1,
+            &tenure_2_blocks[2],
+        )
+    } else {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_2_start_block_ht + 1,
+            &tenure_2_blocks[2],
+        )
+    };
+    let c3_tenure_2_mid_block = get_info(
+        &mut peer,
+        ClarityVersion::Clarity3,
+        tenure_2_start_block_ht + 1,
+        &tenure_2_blocks[2],
+    )
+    .unwrap();
+    assert_eq!(&c3_tenure_2_mid_block, &tenure_2_blocks[1]);
+    if use_primary_testnet {
+        assert_eq!(c1_tenure_2_mid_block.unwrap(), c3_tenure_2_mid_block);
+    } else {
+        // if interpreted as a tenure-height, this will return none, because there's no tenure at height +1 yet
+        assert!(c1_tenure_2_mid_block.is_none());
+
+        // query the tenure height again from the latest block for good measure
+        let start_block_result = get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_2_tenure_ht,
+            &tenure_2_blocks[2],
+        )
+        .unwrap();
+        assert_eq!(&start_block_result, &tenure_2_blocks[0]);
+    }
+
+    let tenure_3_tenure_ht = tenure_2_tenure_ht + 1;
+    let tenure_3_start_block_ht =
+        tenure_2_start_block_ht + u64::try_from(tenure_2_blocks.len()).unwrap();
+
+    let tenure_3_blocks: Vec<_> = peer
+        .mine_tenure(|miner, chainstate, sortdb, blocks_so_far| {
+            if blocks_so_far.len() > 3 {
+                return vec![];
+            }
+            info!("Producing block #{} in Tenure #3", blocks_so_far.len());
+            let account = get_account(chainstate, sortdb, &addr);
+            let tx_0 = make_token_transfer(
+                chainstate,
+                sortdb,
+                &private_key,
+                account.nonce,
+                100,
+                1,
+                &recipient_addr,
+            );
+
+            vec![tx_0]
+        })
+        .into_iter()
+        .map(|(block, ..)| block.header.block_id())
+        .collect();
+
+    let (tenure_3_last_block_id, tenure_3_last_block_ht) = get_tip_info(&mut peer);
+
+    assert_eq!(&tenure_3_last_block_id, tenure_3_blocks.last().unwrap());
+    assert_eq!(tenure_3_start_block_ht, tenure_2_last_block_ht + 1);
+
+    // query the current tenure information from the middle block
+    let c1_tenure_3_start_block = if use_primary_testnet {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_3_start_block_ht,
+            &tenure_3_blocks[1],
+        )
+        .unwrap()
+    } else {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_3_tenure_ht,
+            &tenure_3_blocks[1],
+        )
+        .unwrap()
+    };
+    let c3_tenure_3_start_block = get_info(
+        &mut peer,
+        ClarityVersion::Clarity3,
+        tenure_3_start_block_ht,
+        &tenure_3_blocks[1],
+    )
+    .unwrap();
+    assert_eq!(c1_tenure_3_start_block, c3_tenure_3_start_block);
+    assert_eq!(&c1_tenure_3_start_block, &tenure_3_blocks[0]);
+
+    // try to query the middle block from the last block in the tenure
+    let c1_tenure_3_mid_block = if use_primary_testnet {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_3_start_block_ht + 1,
+            &tenure_3_blocks[2],
+        )
+    } else {
+        get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_3_start_block_ht + 1,
+            &tenure_3_blocks[2],
+        )
+    };
+    let c3_tenure_3_mid_block = get_info(
+        &mut peer,
+        ClarityVersion::Clarity3,
+        tenure_3_start_block_ht + 1,
+        &tenure_3_blocks[2],
+    )
+    .unwrap();
+    assert_eq!(&c3_tenure_3_mid_block, &tenure_3_blocks[1]);
+    if use_primary_testnet {
+        assert_eq!(c1_tenure_3_mid_block.unwrap(), c3_tenure_3_mid_block);
+    } else {
+        // if interpreted as a tenure-height, this will return none, because there's no tenure at height +1 yet
+        assert!(c1_tenure_3_mid_block.is_none());
+
+        // query the tenure height again from the latest block for good measure
+        let start_block_result = get_info(
+            &mut peer,
+            ClarityVersion::Clarity1,
+            tenure_3_tenure_ht,
+            &tenure_3_blocks[2],
+        )
+        .unwrap();
+        assert_eq!(&start_block_result, &tenure_3_blocks[0]);
+    }
 }
 
 #[test]

--- a/stackslib/src/chainstate/nakamoto/keys.rs
+++ b/stackslib/src/chainstate/nakamoto/keys.rs
@@ -23,7 +23,7 @@ pub fn ongoing_tenure_id() -> &'static str {
     "nakamoto::tenures::ongoing_tenure_id"
 }
 
-/// MARF key to map the coinbase height of a tenure to its consensus hash
+/// MARF key to map the coinbase height of a tenure to its first block ID
 pub fn ongoing_tenure_coinbase_height(coinbase_height: u64) -> String {
     format!(
         "nakamoto::tenures::ongoing_tenure_coinbase_height::{}",

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -3886,7 +3886,7 @@ impl NakamotoChainState {
 
     /// Append a Nakamoto Stacks block to the Stacks chain state.
     /// NOTE: This does _not_ set the block as processed!  The caller must do this.
-    fn append_block<'a>(
+    pub(crate) fn append_block<'a>(
         chainstate_tx: &mut ChainstateTx,
         clarity_instance: &'a mut ClarityInstance,
         burn_dbconn: &mut SortitionHandleConn,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -231,7 +231,7 @@ impl TestMiner {
                 Some(vrf_proof),
             ),
         );
-        tx_coinbase.chain_id = 0x80000000;
+        tx_coinbase.chain_id = self.chain_id;
         tx_coinbase.anchor_mode = TransactionAnchorMode::OnChainOnly;
         tx_coinbase.auth.set_origin_nonce(nonce);
 
@@ -258,7 +258,7 @@ impl TestMiner {
             self.as_transaction_auth().unwrap(),
             TransactionPayload::TenureChange(tenure_change),
         );
-        tx_tenure_change.chain_id = 0x80000000;
+        tx_tenure_change.chain_id = self.chain_id;
         tx_tenure_change.anchor_mode = TransactionAnchorMode::OnChainOnly;
         tx_tenure_change.auth.set_origin_nonce(nonce);
 

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -649,6 +649,14 @@ impl HeadersDB for TestSimHeadersDB {
         // if the block is defined at all, then return a constant
         self.get_burn_block_height_for_block(id_bhh).map(|_| 3000)
     }
+
+    fn get_stacks_height_for_tenure_height(
+        &self,
+        _tip: &StacksBlockId,
+        tenure_height: u32,
+    ) -> Option<u32> {
+        Some(tenure_height)
+    }
 }
 
 #[test]

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1998,6 +1998,44 @@ pub mod test {
         make_tx(key, nonce, 0, payload)
     }
 
+    pub fn make_pox_4_lockup_chain_id(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        amount: u128,
+        addr: &PoxAddress,
+        lock_period: u128,
+        signer_key: &StacksPublicKey,
+        burn_ht: u64,
+        signature_opt: Option<Vec<u8>>,
+        max_amount: u128,
+        auth_id: u128,
+        chain_id: u32,
+    ) -> StacksTransaction {
+        let addr_tuple = Value::Tuple(addr.as_clarity_tuple().unwrap());
+        let signature = match signature_opt {
+            Some(sig) => Value::some(Value::buff_from(sig).unwrap()).unwrap(),
+            None => Value::none(),
+        };
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            "pox-4",
+            "stack-stx",
+            vec![
+                Value::UInt(amount),
+                addr_tuple,
+                Value::UInt(burn_ht as u128),
+                Value::UInt(lock_period),
+                signature,
+                Value::buff_from(signer_key.to_bytes_compressed()).unwrap(),
+                Value::UInt(max_amount),
+                Value::UInt(auth_id),
+            ],
+        )
+        .unwrap();
+
+        make_tx_chain_id(key, nonce, 0, payload, chain_id)
+    }
+
     pub fn make_pox_2_or_3_lockup(
         key: &StacksPrivateKey,
         nonce: u64,
@@ -2451,10 +2489,20 @@ pub mod test {
         tx_fee: u64,
         payload: TransactionPayload,
     ) -> StacksTransaction {
+        make_tx_chain_id(key, nonce, tx_fee, payload, CHAIN_ID_TESTNET)
+    }
+
+    fn make_tx_chain_id(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        tx_fee: u64,
+        payload: TransactionPayload,
+        chain_id: u32,
+    ) -> StacksTransaction {
         let auth = TransactionAuth::from_p2pkh(key).unwrap();
         let addr = auth.origin().address_testnet();
         let mut tx = StacksTransaction::new(TransactionVersion::Testnet, auth, payload);
-        tx.chain_id = 0x80000000;
+        tx.chain_id = chain_id;
         tx.auth.set_origin_nonce(nonce);
         tx.set_post_condition_mode(TransactionPostConditionMode::Allow);
         tx.set_tx_fee(tx_fee);

--- a/stackslib/src/chainstate/stacks/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/tests/mod.rs
@@ -1050,7 +1050,7 @@ pub fn make_coinbase_with_nonce(
             None,
         ),
     );
-    tx_coinbase.chain_id = 0x80000000;
+    tx_coinbase.chain_id = miner.chain_id;
     tx_coinbase.anchor_mode = TransactionAnchorMode::OnChainOnly;
     tx_coinbase.auth.set_origin_nonce(nonce);
 
@@ -1147,7 +1147,7 @@ pub fn make_contract_call(
         .unwrap(),
     );
 
-    tx_contract_call.chain_id = 0x80000000;
+    tx_contract_call.chain_id = miner.chain_id;
     tx_contract_call.auth.set_origin_nonce(miner.get_nonce());
 
     if miner.test_with_tx_fees {
@@ -1179,7 +1179,7 @@ pub fn make_token_transfer(
         TransactionPayload::TokenTransfer((*recipient).clone().into(), amount, (*memo).clone()),
     );
 
-    tx_stx_transfer.chain_id = 0x80000000;
+    tx_stx_transfer.chain_id = miner.chain_id;
     tx_stx_transfer
         .auth
         .set_origin_nonce(nonce.unwrap_or(miner.get_nonce()));

--- a/stackslib/src/clarity_cli.rs
+++ b/stackslib/src/clarity_cli.rs
@@ -766,6 +766,14 @@ impl HeadersDB for CLIHeadersDB {
         // if the block is defined at all, then return a constant
         get_cli_block_height(&self.conn(), id_bhh).map(|_| 3000)
     }
+
+    fn get_stacks_height_for_tenure_height(
+        &self,
+        _tip: &StacksBlockId,
+        tenure_height: u32,
+    ) -> Option<u32> {
+        Some(tenure_height)
+    }
 }
 
 fn get_eval_input(invoked_by: &str, args: &[String]) -> EvalInput {

--- a/stackslib/src/clarity_vm/database/mod.rs
+++ b/stackslib/src/clarity_vm/database/mod.rs
@@ -47,6 +47,9 @@ pub trait GetTenureStartId {
         tip: &StacksBlockId,
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Option<TenureBlockId>, DBError>;
+    /// Return the StacksBlockId of the tenure start block for the
+    ///  tenure with coinbase height `coinbase_height` in the fork
+    ///  referenced by `tip`.
     fn get_tenure_block_id_at_cb_height(
         &self,
         tip: &StacksBlockId,

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2379,6 +2379,7 @@ pub mod test {
         ) -> TestPeer<'a> {
             let test_path = TestPeer::make_test_path(&config);
             let mut miner_factory = TestMinerFactory::new();
+            miner_factory.chain_id = config.network_id;
             let mut miner =
                 miner_factory.next_miner(&config.burnchain, 1, 1, AddressHashMode::SerializeP2PKH);
             // manually set fees

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -7230,14 +7230,14 @@ fn get_block_times(
     let contract1_name = "test-contract-1";
     let contract3_name = "test-contract-3";
 
-    info!("Getting block times at block {block_height}, {tenure_height}...");
+    info!("Getting block times at block {block_height}, tenure {tenure_height}...");
 
     let time0_value = call_read_only(
         &naka_conf,
         &sender_addr,
         contract0_name,
         "get-time",
-        vec![&clarity::vm::Value::UInt(block_height)],
+        vec![&clarity::vm::Value::UInt(tenure_height)],
     );
     let time0 = time0_value
         .expect_optional()
@@ -7265,7 +7265,7 @@ fn get_block_times(
         &sender_addr,
         contract1_name,
         "get-time",
-        vec![&clarity::vm::Value::UInt(block_height)],
+        vec![&clarity::vm::Value::UInt(tenure_height)],
     );
     let time1 = time1_value
         .expect_optional()

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -7374,6 +7374,7 @@ fn check_block_times() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
+    naka_conf.burnchain.chain_id = CHAIN_ID_TESTNET + 1;
     let sender_sk = Secp256k1PrivateKey::new();
     let sender_signer_sk = Secp256k1PrivateKey::new();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
@@ -7771,6 +7772,8 @@ fn check_block_info() {
 
     let mut signers = TestSigners::default();
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
+    // change the chain id so that it isn't the same as primary testnet
+    naka_conf.burnchain.chain_id = CHAIN_ID_TESTNET + 1;
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let sender_sk = Secp256k1PrivateKey::new();
@@ -8362,6 +8365,7 @@ fn check_block_info_rewards() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
+    naka_conf.burnchain.chain_id = CHAIN_ID_TESTNET + 1;
     let sender_sk = Secp256k1PrivateKey::new();
     let sender_signer_sk = Secp256k1PrivateKey::new();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);


### PR DESCRIPTION
This PR makes get-block-info interpret block heights as tenure heights in Clarity 2 contracts.
