### PR TITLE
Update Argument Count Checking for type_checker

### DIFF
--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/maps.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/maps.rs
@@ -18,7 +18,7 @@ use stacks_common::types::StacksEpochId;
 
 use super::check_special_tuple_cons;
 use crate::vm::analysis::type_checker::v2_1::{
-    check_arguments_at_least, CheckError, CheckErrors, TypeChecker, TypeResult, TypingContext,
+    check_argument_count, CheckError, CheckErrors, TypeChecker, TypeResult, TypingContext,
 };
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::{analysis_typecheck_cost, cost_functions, runtime_cost};
@@ -31,7 +31,7 @@ pub fn check_special_fetch_entry(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(2, args)?;
+    check_argument_count(2, args)?;
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::BadMapName)?;
 
@@ -71,7 +71,7 @@ pub fn check_special_delete_entry(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(2, args)?;
+    check_argument_count(2, args)?;
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::BadMapName)?;
 
@@ -104,7 +104,7 @@ fn check_set_or_insert_entry(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(3, args)?;
+    check_argument_count(3, args)?;
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::BadMapName)?;
 

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
@@ -346,7 +346,7 @@ fn check_special_set_var(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(2, args)?;
+    check_argument_count(2, args)?;
 
     let var_name = args[0].match_atom().ok_or(CheckErrors::BadMapName)?;
 
@@ -715,7 +715,7 @@ fn check_get_block_info(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(2, args)?;
+    check_argument_count(2, args)?;
 
     let block_info_prop_str = args[0]
         .match_atom()


### PR DESCRIPTION
[WIP]

This has the role to update the argument count checkers of the `type_checker` specific to the clarity functions expected number of arguments.

Not sure if this would create any backwards incompatibility, but I think they should be updated to match the required length of arguments accordingly.

Update: The typechecker cannot be changed. The contracts that were already deployed "exploiting" this bug should still deploy with the compiled version. A new version of the typechecker will be rewritten in the future.