### PR TITLE
Improvements to event dispatcher retry logic

### DIFF
--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -460,7 +460,7 @@ impl EventObserver {
                     warn!(
                         "Event dispatcher: connection or request failed to {}:{} - {:?}",
                         &host, &port, err;
-                        "backoff" => backoff,
+                        "backoff" => ?backoff,
                         "attempts" => attempts
                     );
                 }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -455,7 +455,8 @@ impl EventObserver {
                 Err(err) => {
                     warn!(
                         "Event dispatcher: connection or request failed to {}:{} - {:?}",
-                        &host, &port, err
+                        &host, &port, err;
+                        "backoff" => backoff
                     );
                 }
             }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -434,16 +434,16 @@ impl EventObserver {
         // Cap the backoff at 3x the timeout
         let max_backoff = timeout.saturating_mul(3);
 
-        let mut request = StacksHttpRequest::new_for_peer(
-            peerhost.clone(),
-            "POST".into(),
-            url.path().into(),
-            HttpRequestContents::new().payload_json(payload.clone()),
-        )
-        .unwrap_or_else(|_| panic!("FATAL: failed to encode infallible data as HTTP request"));
-        request.add_header("Connection".into(), "close".into());
         loop {
-            match send_http_request(host, port, request.clone(), timeout) {
+            let mut request = StacksHttpRequest::new_for_peer(
+                peerhost.clone(),
+                "POST".into(),
+                url.path().into(),
+                HttpRequestContents::new().payload_json(payload.clone()),
+            )
+            .unwrap_or_else(|_| panic!("FATAL: failed to encode infallible data as HTTP request"));
+            request.add_header("Connection".into(), "close".into());
+            match send_http_request(host, port, request, timeout) {
                 Ok(response) => {
                     if response.preamble().status_code == 200 {
                         debug!(

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -429,6 +429,7 @@ impl EventObserver {
             .unwrap_or(PeerHost::DNS(host.to_string(), port));
 
         let mut backoff = Duration::from_millis(100);
+        let max_backoff = timeout.saturating_mul(3);
         loop {
             let mut request = StacksHttpRequest::new_for_peer(
                 peerhost.clone(),
@@ -472,7 +473,7 @@ impl EventObserver {
             }
 
             sleep(backoff);
-            backoff *= 2;
+            backoff = std::cmp::min(backoff.saturating_mul(2), max_backoff);
         }
     }
 

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -443,7 +443,7 @@ impl EventObserver {
         .unwrap_or_else(|_| panic!("FATAL: failed to encode infallible data as HTTP request"));
         request.add_header("Connection".into(), "close".into());
         loop {
-            match send_http_request(host, port, request, timeout) {
+            match send_http_request(host, port, request.clone(), timeout) {
                 Ok(response) => {
                     if response.preamble().status_code == 200 {
                         debug!(


### PR DESCRIPTION
While debugging an issue with stacks-node -> API communication, I realized we could do some things better in this retry code. They are all pretty minor changes.