### PR TITLE
Include `tenure_height` in `/new_block` event payload

### DIFF
--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -180,6 +180,7 @@ pub trait BlockEventDispatcher {
         reward_set_data: &Option<RewardSetData>,
         signer_bitvec: &Option<BitVec<4000>>,
         block_timestamp: Option<u64>,
+        coinbase_height: u64,
     );
 
     /// called whenever a burn block is about to be

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -431,6 +431,7 @@ impl BlockEventDispatcher for NullEventDispatcher {
         _reward_set_data: &Option<RewardSetData>,
         _signer_bitvec: &Option<BitVec<4000>>,
         _block_timestamp: Option<u64>,
+        _coinbase_height: u64,
     ) {
         assert!(
             false,

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2118,6 +2118,7 @@ impl NakamotoChainState {
                 &reward_set_data,
                 &Some(signer_bitvec),
                 Some(block_timestamp),
+                receipt.coinbase_height,
             );
         }
 
@@ -4382,6 +4383,7 @@ impl NakamotoChainState {
             evaluated_epoch,
             epoch_transition: applied_epoch_transition,
             signers_updated,
+            coinbase_height,
         };
 
         Ok((epoch_receipt, clarity_commit, reward_set_data))

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -230,6 +230,7 @@ pub struct StacksEpochReceipt {
     pub epoch_transition: bool,
     /// Was .signers updated during this block?
     pub signers_updated: bool,
+    pub coinbase_height: u64,
 }
 
 /// Headers we serve over the network

--- a/stackslib/src/cost_estimates/tests/common.rs
+++ b/stackslib/src/cost_estimates/tests/common.rs
@@ -52,5 +52,6 @@ pub fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksE
         evaluated_epoch: StacksEpochId::Epoch20,
         epoch_transition: false,
         signers_updated: false,
+        coinbase_height: 1234,
     }
 }

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2037,6 +2037,7 @@ pub mod test {
             reward_set_data: &Option<RewardSetData>,
             _signer_bitvec: &Option<BitVec<4000>>,
             _block_timestamp: Option<u64>,
+            _coinbase_height: u64,
         ) {
             self.blocks.lock().unwrap().push(TestEventObserverBlock {
                 block: block.clone(),

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -748,6 +748,7 @@ impl EventObserver {
         reward_set_data: &Option<RewardSetData>,
         signer_bitvec_opt: &Option<BitVec<4000>>,
         block_timestamp: Option<u64>,
+        coinbase_height: u64,
     ) -> serde_json::Value {
         // Serialize events to JSON
         let serialized_events: Vec<serde_json::Value> = filtered_events
@@ -809,6 +810,7 @@ impl EventObserver {
             "signer_bitvec": signer_bitvec_value,
             "reward_set": reward_set_value,
             "cycle_number": cycle_number_value,
+            "tenure_height": coinbase_height,
         });
 
         let as_object_mut = payload.as_object_mut().unwrap();
@@ -1008,6 +1010,7 @@ impl BlockEventDispatcher for EventDispatcher {
         reward_set_data: &Option<RewardSetData>,
         signer_bitvec: &Option<BitVec<4000>>,
         block_timestamp: Option<u64>,
+        coinbase_height: u64,
     ) {
         self.process_chain_tip(
             block,
@@ -1026,6 +1029,7 @@ impl BlockEventDispatcher for EventDispatcher {
             reward_set_data,
             signer_bitvec,
             block_timestamp,
+            coinbase_height,
         );
     }
 
@@ -1209,6 +1213,7 @@ impl EventDispatcher {
         reward_set_data: &Option<RewardSetData>,
         signer_bitvec: &Option<BitVec<4000>>,
         block_timestamp: Option<u64>,
+        coinbase_height: u64,
     ) {
         let all_receipts = receipts.to_owned();
         let (dispatch_matrix, events) = self.create_dispatch_matrix_and_event_vector(&all_receipts);
@@ -1261,6 +1266,7 @@ impl EventDispatcher {
                         reward_set_data,
                         signer_bitvec,
                         block_timestamp,
+                        coinbase_height,
                     );
 
                 // Send payload
@@ -1669,6 +1675,7 @@ mod test {
         let pox_constants = PoxConstants::testnet_default();
         let signer_bitvec = BitVec::zeros(2).expect("Failed to create BitVec with length 2");
         let block_timestamp = Some(123456);
+        let coinbase_height = 1234;
 
         let payload = observer.make_new_block_processed_payload(
             filtered_events,
@@ -1687,6 +1694,7 @@ mod test {
             &None,
             &Some(signer_bitvec.clone()),
             block_timestamp,
+            coinbase_height,
         );
         assert_eq!(
             payload
@@ -1737,6 +1745,7 @@ mod test {
         let pox_constants = PoxConstants::testnet_default();
         let signer_bitvec = BitVec::zeros(2).expect("Failed to create BitVec with length 2");
         let block_timestamp = Some(123456);
+        let coinbase_height = 1234;
 
         let payload = observer.make_new_block_processed_payload(
             filtered_events,
@@ -1755,6 +1764,7 @@ mod test {
             &None,
             &Some(signer_bitvec.clone()),
             block_timestamp,
+            coinbase_height,
         );
 
         let event_signer_signature = payload

--- a/testnet/stacks-node/src/run_loop/mod.rs
+++ b/testnet/stacks-node/src/run_loop/mod.rs
@@ -198,5 +198,6 @@ pub fn announce_boot_receipts(
         &None,
         &None,
         None,
+        0,
     );
 }

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -8328,7 +8328,9 @@ fn check_block_info() {
         "Contract 3 should be able to fetch the StacksBlockId of the tip"
     );
 
-    let blocks = test_observer::get_blocks();
+    let mut blocks = test_observer::get_blocks();
+    blocks.sort_by_key(|block| block["block_height"].as_u64().unwrap());
+
     let mut last_tenture_height = 0;
     for block in blocks.iter() {
         let transactions = block.get("transactions").unwrap().as_array().unwrap();
@@ -8346,10 +8348,14 @@ fn check_block_info() {
             }
         }
         // if `signer_bitvec` is set on a block, then it's a nakamoto block
-        let is_nakamoto_block = block.get("signer_bitvec").is_some();
-
+        let is_nakamoto_block = block.get("signer_bitvec").map_or(false, |v| !v.is_null());
         let tenure_height = block.get("tenure_height").unwrap().as_u64().unwrap();
         let block_height = block.get("block_height").unwrap().as_u64().unwrap();
+
+        if block_height == 0 {
+            // genesis block
+            continue;
+        }
 
         if is_nakamoto_block {
             if block_has_tenure_change {

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -4866,6 +4866,45 @@ fn burn_ops_integration_test() {
         "Stack-stx tx without a signer_key shouldn't have been submitted"
     );
     assert!(transfer_stx_found, "Expected transfer STX op");
+
+    let mut last_tenture_height = 0;
+    for block in blocks.iter() {
+        let transactions = block.get("transactions").unwrap().as_array().unwrap();
+        let mut block_has_tenure_change = false;
+        for tx in transactions.iter().rev() {
+            let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+            if raw_tx != "0x00" {
+                let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+                let parsed =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
+                if let TransactionPayload::TenureChange(_tenure_change) = parsed.payload {
+                    block_has_tenure_change = true;
+                }
+            }
+        }
+        // if `signer_bitvec` is set on a block, then it's a nakamoto block
+        let is_nakamoto_block = block.get("signer_bitvec").is_some();
+
+        let tenure_height = block.get("tenure_height").unwrap().as_u64().unwrap();
+        let block_height = block.get("block_height").unwrap().as_u64().unwrap();
+
+        if is_nakamoto_block {
+            if block_has_tenure_change {
+                // tenure change block should have tenure height 1 more than the last tenure height
+                assert_eq!(last_tenture_height + 1, tenure_height);
+                last_tenture_height = tenure_height;
+            } else {
+                // tenure extend block should have the same tenure height as the last tenure height
+                assert_eq!(last_tenture_height, tenure_height);
+            }
+            last_tenture_height = block.get("block_height").unwrap().as_u64().unwrap();
+        } else {
+            // epoch2.x block tenure height is the same as the block height
+            assert_eq!(tenure_height, block_height);
+            last_tenture_height = block_height;
+        }
+    }
+
     assert!(delegate_stx_found, "Expected delegate STX op");
     let sortdb = btc_regtest_controller.sortdb_mut();
     let sortdb_conn = sortdb.conn();

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -4879,6 +4879,7 @@ fn burn_ops_integration_test() {
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 if let TransactionPayload::TenureChange(_tenure_change) = parsed.payload {
                     block_has_tenure_change = true;
+                    continue;
                 }
             }
         }
@@ -4897,7 +4898,6 @@ fn burn_ops_integration_test() {
                 // tenure extend block should have the same tenure height as the last tenure height
                 assert_eq!(last_tenture_height, tenure_height);
             }
-            last_tenture_height = block.get("block_height").unwrap().as_u64().unwrap();
         } else {
             // epoch2.x block tenure height is the same as the block height
             assert_eq!(tenure_height, block_height);


### PR DESCRIPTION
Closes https://github.com/stacks-network/stacks-core/issues/5318

Part of https://github.com/hirosystems/explorer/issues/1624 and https://github.com/hirosystems/stacks-blockchain-api/issues/2124

Adds a `tenure_height` (AKA `coinbase_height`) to the `/new_block` event payload.

In epoch2.x this is the same value as `block_height`.