### PR TITLE
Add version to signer messages

### DIFF
--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -49,8 +49,10 @@ use std::cmp::Eq;
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use blockstack_lib::version_string;
 use clarity::codec::StacksMessageCodec;
 use clarity::vm::types::QualifiedContractIdentifier;
+use lazy_static::lazy_static;
 
 pub use crate::error::{EventError, RPCError};
 pub use crate::events::{
@@ -73,4 +75,12 @@ pub trait MessageSlotID: Sized + Eq + Hash + Debug + Copy {
 pub trait SignerMessage<T: MessageSlotID>: StacksMessageCodec {
     /// The contract identifier for the message slot in stacker db
     fn msg_id(&self) -> Option<T>;
+}
+
+lazy_static! {
+    /// The version string for the signer
+    pub static ref VERSION_STRING: String = {
+        let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        version_string("stacks-signer", pkg_version)
+    };
 }

--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -1254,14 +1254,9 @@ mod test {
             SignerMessage::BlockResponse(BlockResponse::Rejected(BlockRejection {
                 reason_code: RejectCode::ValidationFailed(ValidateRejectCode::NoSuchTenure),
                 reason: "Block is not a tenure-start block, and has an unrecognized tenure consensus hash".to_string(),
-                signer_signature_hash: Sha512Trunc256Sum([145, 249, 95, 132, 183, 4, 95, 125, 206, 119, 87, 5, 44, 170, 152, 110, 240, 66, 203, 88, 247, 223, 80, 49, 163, 181, 181, 208, 227, 221, 166, 62]),
+                signer_signature_hash: Sha512Trunc256Sum::from_hex("91f95f84b7045f7dce7757052caa986ef042cb58f7df5031a3b5b5d0e3dda63e").unwrap(),
                 chain_id: CHAIN_ID_TESTNET,
-                signature: MessageSignature([
-                    0, 111, 179, 73, 33, 46, 26, 26, 241, 163, 199, 18, 135, 141, 81, 89, 181, 236,
-                    20, 99, 106, 219, 111, 112, 190, 0, 166, 218, 74, 212, 248, 138, 153, 52, 216,
-                    169, 171, 178, 41, 98, 13, 216, 224, 242, 37, 214, 52, 1, 227, 108, 100, 129,
-                    127, 178, 158, 108, 5, 89, 29, 203, 233, 92, 81, 45, 243,
-                ]),
+                signature: MessageSignature::from_hex("006fb349212e1a1af1a3c712878d5159b5ec14636adb6f70be00a6da4ad4f88a9934d8a9abb229620dd8e0f225d63401e36c64817fb29e6c05591dcbe95c512df3").unwrap(),
                 metadata: SignerMessageMetadata::empty(),
             }))
         );
@@ -1269,17 +1264,12 @@ mod test {
         assert_eq!(
             block_accepted,
             SignerMessage::BlockResponse(BlockResponse::Accepted(BlockAccepted {
-                signer_signature_hash: Sha512Trunc256Sum([
-                    17, 113, 113, 73, 103, 124, 42, 201, 125, 21, 174, 89, 84, 247, 167, 22, 241,
-                    1, 0, 185, 203, 129, 162, 191, 39, 85, 27, 47, 46, 84, 239, 25
-                ]),
+                signer_signature_hash: Sha512Trunc256Sum::from_hex(
+                    "11717149677c2ac97d15ae5954f7a716f10100b9cb81a2bf27551b2f2e54ef19"
+                )
+                .unwrap(),
                 metadata: SignerMessageMetadata::empty(),
-                signature: MessageSignature([
-                    0, 28, 105, 79, 129, 52, 197, 201, 15, 47, 43, 205, 51, 14, 159, 66, 50, 4,
-                    136, 79, 0, 27, 93, 240, 5, 15, 54, 162, 196, 255, 121, 221, 147, 82, 43, 178,
-                    174, 57, 94, 168, 125, 228, 150, 72, 134, 68, 117, 7, 193, 131, 116, 183, 164,
-                    110, 226, 227, 113, 233, 191, 51, 47, 7, 6, 163, 232
-                ]),
+                signature: MessageSignature::from_hex("001c694f8134c5c90f2f2bcd330e9f423204884f001b5df0050f36a2c4ff79dd93522bb2ae395ea87de4964886447507c18374b7a46ee2e371e9bf332f0706a3e8").unwrap(),
             }))
         );
     }
@@ -1300,14 +1290,9 @@ mod test {
             SignerMessage::BlockResponse(BlockResponse::Rejected(BlockRejection {
                 reason_code: RejectCode::ValidationFailed(ValidateRejectCode::NoSuchTenure),
                 reason: "Block is not a tenure-start block, and has an unrecognized tenure consensus hash".to_string(),
-                signer_signature_hash: Sha512Trunc256Sum([145, 249, 95, 132, 183, 4, 95, 125, 206, 119, 87, 5, 44, 170, 152, 110, 240, 66, 203, 88, 247, 223, 80, 49, 163, 181, 181, 208, 227, 221, 166, 62]),
+                signer_signature_hash: Sha512Trunc256Sum::from_hex("91f95f84b7045f7dce7757052caa986ef042cb58f7df5031a3b5b5d0e3dda63e").unwrap(),
                 chain_id: CHAIN_ID_TESTNET,
-                signature: MessageSignature([
-                    0, 111, 179, 73, 33, 46, 26, 26, 241, 163, 199, 18, 135, 141, 81, 89, 181, 236,
-                    20, 99, 106, 219, 111, 112, 190, 0, 166, 218, 74, 212, 248, 138, 153, 52, 216,
-                    169, 171, 178, 41, 98, 13, 216, 224, 242, 37, 214, 52, 1, 227, 108, 100, 129,
-                    127, 178, 158, 108, 5, 89, 29, 203, 233, 92, 81, 45, 243,
-                ]),
+                signature: MessageSignature::from_hex("006fb349212e1a1af1a3c712878d5159b5ec14636adb6f70be00a6da4ad4f88a9934d8a9abb229620dd8e0f225d63401e36c64817fb29e6c05591dcbe95c512df3").unwrap(),
                 metadata: SignerMessageMetadata {
                     server_version: "Hello world".to_string(),
                 },
@@ -1317,19 +1302,14 @@ mod test {
         assert_eq!(
             block_accepted,
             SignerMessage::BlockResponse(BlockResponse::Accepted(BlockAccepted {
-                signer_signature_hash: Sha512Trunc256Sum([
-                    17, 113, 113, 73, 103, 124, 42, 201, 125, 21, 174, 89, 84, 247, 167, 22, 241,
-                    1, 0, 185, 203, 129, 162, 191, 39, 85, 27, 47, 46, 84, 239, 25
-                ]),
+                signer_signature_hash: Sha512Trunc256Sum::from_hex(
+                    "11717149677c2ac97d15ae5954f7a716f10100b9cb81a2bf27551b2f2e54ef19"
+                )
+                .unwrap(),
                 metadata: SignerMessageMetadata {
                     server_version: "Hello world".to_string(),
                 },
-                signature: MessageSignature([
-                    0, 28, 105, 79, 129, 52, 197, 201, 15, 47, 43, 205, 51, 14, 159, 66, 50, 4,
-                    136, 79, 0, 27, 93, 240, 5, 15, 54, 162, 196, 255, 121, 221, 147, 82, 43, 178,
-                    174, 57, 94, 168, 125, 228, 150, 72, 134, 68, 117, 7, 193, 131, 116, 183, 164,
-                    110, 226, 227, 113, 233, 191, 51, 47, 7, 6, 163, 232
-                ]),
+                signature: MessageSignature::from_hex("001c694f8134c5c90f2f2bcd330e9f423204884f001b5df0050f36a2c4ff79dd93522bb2ae395ea87de4964886447507c18374b7a46ee2e371e9bf332f0706a3e8").unwrap(),
             }))
         );
     }

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -29,6 +29,7 @@ use clarity::util::hash::Sha256Sum;
 use clarity::util::secp256k1::MessageSignature;
 use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
 use clarity::vm::Value;
+use libsigner::VERSION_STRING;
 use serde::{Deserialize, Serialize};
 use stacks_common::address::{
     b58, AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG,
@@ -37,8 +38,6 @@ use stacks_common::address::{
 };
 use stacks_common::define_u8_enum;
 use stacks_common::types::chainstate::StacksPrivateKey;
-
-use crate::VERSION_STRING;
 
 extern crate alloc;
 

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -235,7 +235,9 @@ mod tests {
     use blockstack_lib::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader};
     use clarity::util::hash::{MerkleTree, Sha512Trunc256Sum};
     use clarity::util::secp256k1::MessageSignature;
-    use libsigner::v0::messages::{BlockRejection, BlockResponse, RejectCode, SignerMessage};
+    use libsigner::v0::messages::{
+        BlockRejection, BlockResponse, RejectCode, SignerMessage, SignerMessageMetadata,
+    };
     use rand::{thread_rng, RngCore};
 
     use super::*;
@@ -283,6 +285,7 @@ mod tests {
             signer_signature_hash: block.header.signer_signature_hash(),
             chain_id: thread_rng().next_u32(),
             signature: MessageSignature::empty(),
+            metadata: SignerMessageMetadata::empty(),
         };
         let signer_message = SignerMessage::BlockResponse(BlockResponse::Rejected(block_reject));
         let ack = StackerDBChunkAckData {

--- a/stacks-signer/src/lib.rs
+++ b/stacks-signer/src/lib.rs
@@ -48,11 +48,9 @@ mod tests;
 use std::fmt::{Debug, Display};
 use std::sync::mpsc::{channel, Receiver, Sender};
 
-use blockstack_lib::version_string;
 use chainstate::SortitionsView;
 use config::GlobalConfig;
-use lazy_static::lazy_static;
-use libsigner::{SignerEvent, SignerEventReceiver, SignerEventTrait};
+use libsigner::{SignerEvent, SignerEventReceiver, SignerEventTrait, VERSION_STRING};
 use runloop::SignerResult;
 use slog::{slog_info, slog_warn};
 use stacks_common::{info, warn};
@@ -60,14 +58,6 @@ use stacks_common::{info, warn};
 use crate::client::StacksClient;
 use crate::config::SignerConfig;
 use crate::runloop::RunLoop;
-
-lazy_static! {
-    /// The version string for the signer
-    pub static ref VERSION_STRING: String = {
-        let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-        version_string("stacks-signer", pkg_version)
-    };
-}
 
 /// A trait which provides a common `Signer` interface for `v0` and `v1`
 pub trait Signer<T: SignerEventTrait>: Debug + Display {

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -32,7 +32,7 @@ use blockstack_lib::util_lib::signed_structured_data::pox4::make_pox_4_signer_ke
 use clap::Parser;
 use clarity::types::chainstate::StacksPublicKey;
 use clarity::util::sleep_ms;
-use libsigner::SignerSession;
+use libsigner::{SignerSession, VERSION_STRING};
 use libstackerdb::StackerDBChunkData;
 use slog::{slog_debug, slog_error};
 use stacks_common::util::hash::to_hex;
@@ -47,7 +47,6 @@ use stacks_signer::config::GlobalConfig;
 use stacks_signer::monitor_signers::SignerMonitor;
 use stacks_signer::utils::stackerdb_session;
 use stacks_signer::v0::SpawnedSigner;
-use stacks_signer::VERSION_STRING;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 

--- a/stacks-signer/src/monitoring/server.rs
+++ b/stacks-signer/src/monitoring/server.rs
@@ -19,6 +19,7 @@ use std::time::Instant;
 
 use clarity::util::hash::to_hex;
 use clarity::util::secp256k1::Secp256k1PublicKey;
+use libsigner::VERSION_STRING;
 use slog::{slog_debug, slog_error, slog_info, slog_warn};
 use stacks_common::{debug, error, info, warn};
 use tiny_http::{Response as HttpResponse, Server as HttpServer};
@@ -28,7 +29,6 @@ use crate::client::{ClientError, StacksClient};
 use crate::config::{GlobalConfig, Network};
 use crate::monitoring::prometheus::gather_metrics_string;
 use crate::monitoring::{update_signer_nonce, update_stacks_tip_height};
-use crate::VERSION_STRING;
 
 #[derive(thiserror::Error, Debug)]
 /// Monitoring server errors

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -25,14 +25,13 @@ use clarity::types::{PrivateKey, StacksEpochId};
 use clarity::util::hash::MerkleHashFunc;
 use clarity::util::secp256k1::Secp256k1PublicKey;
 use libsigner::v0::messages::{
-    BlockRejection, BlockResponse, MessageSlotID, MockProposal, MockSignature, RejectCode,
-    SignerMessage,
+    BlockAccepted, BlockRejection, BlockResponse, MessageSlotID, MockProposal, MockSignature,
+    RejectCode, SignerMessage,
 };
 use libsigner::{BlockProposal, SignerEvent};
 use slog::{slog_debug, slog_error, slog_info, slog_warn};
 use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::util::get_epoch_time_secs;
-use stacks_common::util::hash::Sha512Trunc256Sum;
 use stacks_common::util::secp256k1::MessageSignature;
 use stacks_common::{debug, error, info, warn};
 
@@ -494,8 +493,8 @@ impl Signer {
         block_response: &BlockResponse,
     ) {
         match block_response {
-            BlockResponse::Accepted((block_hash, signature)) => {
-                self.handle_block_signature(stacks_client, block_hash, signature);
+            BlockResponse::Accepted(accepted) => {
+                self.handle_block_signature(stacks_client, accepted);
             }
             BlockResponse::Rejected(block_rejection) => {
                 self.handle_block_rejection(block_rejection);
@@ -547,13 +546,13 @@ impl Signer {
         self.signer_db
             .insert_block(&block_info)
             .unwrap_or_else(|_| panic!("{self}: Failed to insert block in DB"));
+        let accepted = BlockAccepted {
+            signer_signature_hash: block_info.signer_signature_hash(),
+            signature,
+        };
         // have to save the signature _after_ the block info
-        self.handle_block_signature(
-            stacks_client,
-            &block_info.signer_signature_hash(),
-            &signature,
-        );
-        Some(BlockResponse::accepted(signer_signature_hash, signature))
+        self.handle_block_signature(stacks_client, &accepted);
+        Some(BlockResponse::Accepted(accepted))
     }
 
     /// Handle the block validate reject response. Returns our block response if we have one
@@ -739,12 +738,11 @@ impl Signer {
     }
 
     /// Handle an observed signature from another signer
-    fn handle_block_signature(
-        &mut self,
-        stacks_client: &StacksClient,
-        block_hash: &Sha512Trunc256Sum,
-        signature: &MessageSignature,
-    ) {
+    fn handle_block_signature(&mut self, stacks_client: &StacksClient, accepted: &BlockAccepted) {
+        let BlockAccepted {
+            signer_signature_hash: block_hash,
+            signature,
+        } = accepted;
         debug!("{self}: Received a block-accept signature: ({block_hash}, {signature})");
 
         // Have we already processed this block?

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -546,10 +546,7 @@ impl Signer {
         self.signer_db
             .insert_block(&block_info)
             .unwrap_or_else(|_| panic!("{self}: Failed to insert block in DB"));
-        let accepted = BlockAccepted {
-            signer_signature_hash: block_info.signer_signature_hash(),
-            signature,
-        };
+        let accepted = BlockAccepted::new(block_info.signer_signature_hash(), signature);
         // have to save the signature _after_ the block info
         self.handle_block_signature(stacks_client, &accepted);
         Some(BlockResponse::Accepted(accepted))
@@ -742,8 +739,12 @@ impl Signer {
         let BlockAccepted {
             signer_signature_hash: block_hash,
             signature,
+            metadata,
         } = accepted;
-        debug!("{self}: Received a block-accept signature: ({block_hash}, {signature})");
+        debug!(
+            "{self}: Received a block-accept signature: ({block_hash}, {signature}, {})",
+            metadata.server_version
+        );
 
         // Have we already processed this block?
         match self

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use hashbrown::{HashMap, HashSet};
-use libsigner::v0::messages::{BlockResponse, MinerSlotID, SignerMessage as SignerMessageV0};
+use libsigner::v0::messages::{
+    BlockAccepted, BlockResponse, MinerSlotID, SignerMessage as SignerMessageV0,
+};
 use libsigner::{BlockProposal, SignerEntries, SignerEvent, SignerSession, StackerDBSession};
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
@@ -450,10 +452,11 @@ impl SignCoordinator {
                 }
 
                 match message {
-                    SignerMessageV0::BlockResponse(BlockResponse::Accepted((
-                        response_hash,
-                        signature,
-                    ))) => {
+                    SignerMessageV0::BlockResponse(BlockResponse::Accepted(accepted)) => {
+                        let BlockAccepted {
+                            signer_signature_hash: response_hash,
+                            signature,
+                        } = accepted;
                         let block_sighash = block.header.signer_signature_hash();
                         if block_sighash != response_hash {
                             warn!(

--- a/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
+++ b/testnet/stacks-node/src/nakamoto_node/sign_coordinator.rs
@@ -456,6 +456,7 @@ impl SignCoordinator {
                         let BlockAccepted {
                             signer_signature_hash: response_hash,
                             signature,
+                            metadata,
                         } = accepted;
                         let block_sighash = block.header.signer_signature_hash();
                         if block_sighash != response_hash {
@@ -466,7 +467,8 @@ impl SignCoordinator {
                                 "response_hash" => %response_hash,
                                 "slot_id" => slot_id,
                                 "reward_cycle_id" => reward_cycle_id,
-                                "response_hash" => %response_hash
+                                "response_hash" => %response_hash,
+                                "server_version" => %metadata.server_version
                             );
                             continue;
                         }
@@ -514,7 +516,8 @@ impl SignCoordinator {
                             "signer_weight" => signer_entry.weight,
                             "total_weight_signed" => total_weight_signed,
                             "stacks_block_hash" => %block.header.block_hash(),
-                            "stacks_block_id" => %block.header.block_id()
+                            "stacks_block_id" => %block.header.block_id(),
+                            "server_version" => metadata.server_version,
                         );
                         gathered_signatures.insert(slot_id, signature);
                         responded_signers.insert(signer_pubkey);

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -36,7 +36,7 @@ use std::time::{Duration, Instant};
 
 use clarity::boot_util::boot_code_id;
 use clarity::vm::types::PrincipalData;
-use libsigner::v0::messages::{BlockAccepted, BlockResponse, SignerMessage};
+use libsigner::v0::messages::{BlockResponse, SignerMessage};
 use libsigner::{SignerEntries, SignerEventTrait};
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::nakamoto::signer_set::NakamotoSigners;
@@ -579,17 +579,16 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
                         .expect("Failed to deserialize SignerMessage");
                     match message {
                         SignerMessage::BlockResponse(BlockResponse::Accepted(accepted)) => {
-                            let BlockAccepted {
-                                signer_signature_hash: hash,
-                                signature,
-                            } = accepted;
-                            if hash == *signer_signature_hash
+                            if accepted.signer_signature_hash == *signer_signature_hash
                                 && expected_signers.iter().any(|pk| {
-                                    pk.verify(hash.bits(), &signature)
-                                        .expect("Failed to verify signature")
+                                    pk.verify(
+                                        accepted.signer_signature_hash.bits(),
+                                        &accepted.signature,
+                                    )
+                                    .expect("Failed to verify signature")
                                 })
                             {
-                                Some(signature)
+                                Some(accepted.signature)
                             } else {
                                 None
                             }

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -36,7 +36,7 @@ use std::time::{Duration, Instant};
 
 use clarity::boot_util::boot_code_id;
 use clarity::vm::types::PrincipalData;
-use libsigner::v0::messages::{BlockResponse, SignerMessage};
+use libsigner::v0::messages::{BlockAccepted, BlockResponse, SignerMessage};
 use libsigner::{SignerEntries, SignerEventTrait};
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::nakamoto::signer_set::NakamotoSigners;
@@ -578,10 +578,11 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
                     let message = SignerMessage::consensus_deserialize(&mut chunk.data.as_slice())
                         .expect("Failed to deserialize SignerMessage");
                     match message {
-                        SignerMessage::BlockResponse(BlockResponse::Accepted((
-                            hash,
-                            signature,
-                        ))) => {
+                        SignerMessage::BlockResponse(BlockResponse::Accepted(accepted)) => {
+                            let BlockAccepted {
+                                signer_signature_hash: hash,
+                                signature,
+                            } = accepted;
                             if hash == *signer_signature_hash
                                 && expected_signers.iter().any(|pk| {
                                     pk.verify(hash.bits(), &signature)

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -25,7 +25,7 @@ use clarity::vm::StacksEpoch;
 use libsigner::v0::messages::{
     BlockRejection, BlockResponse, MessageSlotID, MinerSlotID, RejectCode, SignerMessage,
 };
-use libsigner::{BlockProposal, SignerSession, StackerDBSession};
+use libsigner::{BlockProposal, SignerSession, StackerDBSession, VERSION_STRING};
 use stacks::address::AddressHashMode;
 use stacks::burnchains::Txid;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
@@ -2567,10 +2567,12 @@ fn empty_sortition() {
             };
             if let SignerMessage::BlockResponse(BlockResponse::Rejected(BlockRejection {
                 reason_code,
+                metadata,
                 ..
             })) = latest_msg
             {
                 assert!(matches!(reason_code, RejectCode::SortitionViewMismatch));
+                assert_eq!(metadata.server_version, VERSION_STRING.to_string());
                 found_rejections.push(*slot_id);
             } else {
                 info!("Latest message from slot #{slot_id} isn't a block rejection, will wait to see if the signer updates to a rejection");

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -3411,7 +3411,7 @@ fn duplicate_signers() {
             })
             .filter_map(|message| match message {
                 SignerMessage::BlockResponse(BlockResponse::Accepted(m)) => {
-                    info!("Message(accepted): {message:?}");
+                    info!("Message(accepted): {:?}", &m);
                     Some(m)
                 }
                 _ => {
@@ -3425,20 +3425,23 @@ fn duplicate_signers() {
     info!("------------------------- Assert there are {unique_signers} unique signatures and recovered pubkeys -------------------------");
 
     // Pick a message hash
-    let (selected_sighash, _) = signer_accepted_responses
+    let accepted = signer_accepted_responses
         .iter()
-        .min_by_key(|(sighash, _)| *sighash)
-        .copied()
+        .min_by_key(|accepted| accepted.signer_signature_hash)
         .expect("No `BlockResponse::Accepted` messages recieved");
+    let selected_sighash = accepted.signer_signature_hash;
 
     // Filter only resonses for selected block and collect unique pubkeys and signatures
     let (pubkeys, signatures): (HashSet<_>, HashSet<_>) = signer_accepted_responses
         .into_iter()
-        .filter(|(hash, _)| *hash == selected_sighash)
-        .map(|(msg, sig)| {
-            let pubkey = Secp256k1PublicKey::recover_to_pubkey(msg.bits(), &sig)
-                .expect("Failed to recover pubkey");
-            (pubkey, sig)
+        .filter(|accepted| accepted.signer_signature_hash == selected_sighash)
+        .map(|accepted| {
+            let pubkey = Secp256k1PublicKey::recover_to_pubkey(
+                accepted.signer_signature_hash.bits(),
+                &accepted.signature,
+            )
+            .expect("Failed to recover pubkey");
+            (pubkey, accepted.signature)
         })
         .unzip();
 
@@ -4652,10 +4655,11 @@ fn reorg_locally_accepted_blocks_across_tenures_succeeds() {
                 let message = SignerMessage::consensus_deserialize(&mut chunk.data.as_slice())
                     .expect("Failed to deserialize SignerMessage");
                 match message {
-                    SignerMessage::BlockResponse(BlockResponse::Accepted((hash, signature))) => {
-                        ignoring_signers
-                            .iter()
-                            .find(|key| key.verify(hash.bits(), &signature).is_ok())
+                    SignerMessage::BlockResponse(BlockResponse::Accepted(accepted)) => {
+                        ignoring_signers.iter().find(|key| {
+                            key.verify(accepted.signer_signature_hash.bits(), &accepted.signature)
+                                .is_ok()
+                        })
                     }
                     _ => None,
                 }
@@ -4896,12 +4900,11 @@ fn miner_recovers_when_broadcast_block_delay_across_tenures_occurs() {
                     let message = SignerMessage::consensus_deserialize(&mut chunk.data.as_slice())
                         .expect("Failed to deserialize SignerMessage");
                     match message {
-                        SignerMessage::BlockResponse(BlockResponse::Accepted((
-                            hash,
-                            signature,
-                        ))) => {
-                            if block.header.signer_signature_hash() == hash {
-                                Some(signature)
+                        SignerMessage::BlockResponse(BlockResponse::Accepted(accepted)) => {
+                            if block.header.signer_signature_hash()
+                                == accepted.signer_signature_hash
+                            {
+                                Some(accepted.signature)
                             } else {
                                 None
                             }


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/5332

This adds the signer's version string to signer messages. To ensure backwards compatibility, I've added a light `SignerMessageMetadata` struct. Right now it only has the `server_version` string, but it's mainly used to implement special-case decoding if there are no bytes left to read.