### PR TITLE
fix: Signer networking setup docs link

### DIFF
--- a/stacks-signer/src/lib.rs
+++ b/stacks-signer/src/lib.rs
@@ -121,7 +121,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SpawnedSigner
             as this could potentially expose sensitive data or functionalities to security risks \
             if additional proper security checks are not integrated in place. \
             For more information, check the documentation at \
-            https://docs.stacks.co/nakamoto-upgrade/signing-and-stacking/faq#what-should-the-networking-setup-for-my-signer-look-like."
+            https://docs.stacks.co/guides-and-tutorials/running-a-signer#preflight-setup"
         );
         let (res_send, res_recv) = channel();
         let ev = SignerEventReceiver::new(config.network.is_mainnet());


### PR DESCRIPTION
### Description

Found and fixed a stale link. 

I am afraid this might break again though. To improve, we could:

1. Have a "well-known" doc URI that we ensure never changes. It can redirect the user to the most appropriate place.
2. Show the warning only if the signer is not bound to a loopback address (core already has [code to check that](https://github.com/stacks-network/stacks-core/blob/a2dcd4c3ffdb625a6478bb2c0b23836bc9c72f9f/stacks-common/src/types/net.rs#L225) that could be used as inspiration).