### PR TITLE
feat: added access modifier restrictions on clarity trait definitions

### DIFF
--- a/clarity/src/vm/analysis/analysis_db.rs
+++ b/clarity/src/vm/analysis/analysis_db.rs
@@ -24,7 +24,7 @@ use crate::vm::database::{
     ClarityBackingStore, ClarityDeserializable, ClaritySerializable, RollbackWrapper,
 };
 use crate::vm::representations::ClarityName;
-use crate::vm::types::signatures::FunctionSignature;
+use crate::vm::types::signatures::{FunctionSignature, MethodSignature};
 use crate::vm::types::{FunctionType, QualifiedContractIdentifier, TraitIdentifier, TypeSignature};
 use crate::vm::ClarityVersion;
 
@@ -207,7 +207,7 @@ impl<'a> AnalysisDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         trait_name: &str,
         epoch: &StacksEpochId,
-    ) -> CheckResult<Option<BTreeMap<ClarityName, FunctionSignature>>> {
+    ) -> CheckResult<Option<BTreeMap<ClarityName, MethodSignature>>> {
         // TODO: this function loads the whole contract to obtain the function type.
         //         but it doesn't need to -- rather this information can just be
         //         stored as its own entry. the analysis cost tracking currently only

--- a/clarity/src/vm/analysis/type_checker/v2_05/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/contexts.rs
@@ -22,7 +22,7 @@ use crate::vm::analysis::errors::{CheckError, CheckErrors, CheckResult};
 use crate::vm::analysis::types::ContractAnalysis;
 use crate::vm::contexts::MAX_CONTEXT_DEPTH;
 use crate::vm::representations::{ClarityName, SymbolicExpression};
-use crate::vm::types::signatures::FunctionSignature;
+use crate::vm::types::signatures::{FunctionSignature, MethodSignature};
 use crate::vm::types::{FunctionType, TraitIdentifier, TypeSignature};
 
 pub struct ContractContext {
@@ -34,7 +34,7 @@ pub struct ContractContext {
     persisted_variable_types: HashMap<ClarityName, TypeSignature>,
     fungible_tokens: HashSet<ClarityName>,
     non_fungible_tokens: HashMap<ClarityName, TypeSignature>,
-    traits: HashMap<ClarityName, BTreeMap<ClarityName, FunctionSignature>>,
+    traits: HashMap<ClarityName, BTreeMap<ClarityName, MethodSignature>>,
     pub implemented_traits: HashSet<TraitIdentifier>,
 }
 
@@ -170,7 +170,7 @@ impl ContractContext {
     pub fn add_trait(
         &mut self,
         trait_name: ClarityName,
-        trait_signature: BTreeMap<ClarityName, FunctionSignature>,
+        trait_signature: BTreeMap<ClarityName, MethodSignature>,
     ) -> CheckResult<()> {
         self.traits.insert(trait_name, trait_signature);
         Ok(())
@@ -181,7 +181,7 @@ impl ContractContext {
         Ok(())
     }
 
-    pub fn get_trait(&self, trait_name: &str) -> Option<&BTreeMap<ClarityName, FunctionSignature>> {
+    pub fn get_trait(&self, trait_name: &str) -> Option<&BTreeMap<ClarityName, MethodSignature>> {
         self.traits.get(trait_name)
     }
 

--- a/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
@@ -44,7 +44,7 @@ use crate::vm::representations::SymbolicExpressionType::{
     Atom, AtomValue, Field, List, LiteralValue, TraitReference,
 };
 use crate::vm::representations::{depth_traverse, ClarityName, SymbolicExpression};
-use crate::vm::types::signatures::{FunctionSignature, BUFF_20};
+use crate::vm::types::signatures::{FunctionSignature, MethodSignature, BUFF_20};
 use crate::vm::types::{
     parse_name_type_pairs, FixedFunction, FunctionArg, FunctionType, PrincipalData,
     QualifiedContractIdentifier, TupleTypeSignature, TypeSignature, Value,
@@ -299,7 +299,7 @@ impl FunctionType {
     }
 }
 
-fn trait_type_size(trait_sig: &BTreeMap<ClarityName, FunctionSignature>) -> CheckResult<u64> {
+fn trait_type_size(trait_sig: &BTreeMap<ClarityName, MethodSignature>) -> CheckResult<u64> {
     let mut total_size = 0;
     for (_func_name, value) in trait_sig.iter() {
         total_size = total_size.cost_overflow_add(value.total_type_size()?)?;
@@ -808,7 +808,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         trait_name: &ClarityName,
         function_types: &[SymbolicExpression],
         _context: &mut TypingContext,
-    ) -> CheckResult<(ClarityName, BTreeMap<ClarityName, FunctionSignature>)> {
+    ) -> CheckResult<(ClarityName, BTreeMap<ClarityName, MethodSignature>)> {
         let trait_signature = TypeSignature::parse_trait_type_repr(
             function_types,
             &mut (),

--- a/clarity/src/vm/analysis/type_checker/v2_05/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/natives/mod.rs
@@ -413,13 +413,16 @@ fn check_contract_call(
             let trait_signature = checker.contract_context.get_trait(&trait_id.name).ok_or(
                 CheckErrors::TraitReferenceUnknown(trait_id.name.to_string()),
             )?;
-            let func_signature =
-                trait_signature
+            let func_signature = {
+                let method_sign = trait_signature
                     .get(func_name)
                     .ok_or(CheckErrors::TraitMethodUnknown(
                         trait_id.name.to_string(),
                         func_name.to_string(),
                     ))?;
+
+                    FunctionSignature { args: method_sign.args.clone(), returns: method_sign.returns.clone() }
+                };
 
             runtime_cost(
                 ClarityCostFunction::AnalysisLookupFunctionTypes,
@@ -427,7 +430,7 @@ fn check_contract_call(
                 func_signature.total_type_size()?,
             )?;
 
-            func_signature.clone()
+            func_signature
         }
         _ => return Err(CheckError::new(CheckErrors::ContractCallExpectName)),
     };

--- a/clarity/src/vm/analysis/type_checker/v2_1/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/contexts.rs
@@ -23,19 +23,19 @@ use crate::vm::analysis::type_checker::is_reserved_word;
 use crate::vm::analysis::types::ContractAnalysis;
 use crate::vm::contexts::MAX_CONTEXT_DEPTH;
 use crate::vm::representations::{ClarityName, SymbolicExpression};
-use crate::vm::types::signatures::{CallableSubtype, FunctionSignature};
+use crate::vm::types::signatures::{CallableSubtype, FunctionSignature, MethodSignature};
 use crate::vm::types::{FunctionType, QualifiedContractIdentifier, TraitIdentifier, TypeSignature};
 use crate::vm::ClarityVersion;
 
 enum TraitContext {
     /// Traits stored in this context use the trait type-checking behavior defined in Clarity1
-    Clarity1(HashMap<ClarityName, BTreeMap<ClarityName, FunctionSignature>>),
+    Clarity1(HashMap<ClarityName, BTreeMap<ClarityName, MethodSignature>>),
     /// Traits stored in this context use the new trait type-checking behavior defined in Clarity2
     Clarity2 {
         /// Aliases for locally defined traits and traits imported with `use-trait`
         defined: HashSet<ClarityName>,
         /// All traits which are defined or used in a contract
-        all: HashMap<TraitIdentifier, BTreeMap<ClarityName, FunctionSignature>>,
+        all: HashMap<TraitIdentifier, BTreeMap<ClarityName, MethodSignature>>,
     },
 }
 
@@ -61,7 +61,7 @@ impl TraitContext {
         &mut self,
         contract_identifier: QualifiedContractIdentifier,
         trait_name: ClarityName,
-        trait_signature: BTreeMap<ClarityName, FunctionSignature>,
+        trait_signature: BTreeMap<ClarityName, MethodSignature>,
     ) -> CheckResult<()> {
         match self {
             Self::Clarity1(map) => {
@@ -85,7 +85,7 @@ impl TraitContext {
         &mut self,
         alias: ClarityName,
         trait_id: TraitIdentifier,
-        trait_signature: BTreeMap<ClarityName, FunctionSignature>,
+        trait_signature: BTreeMap<ClarityName, MethodSignature>,
     ) -> CheckResult<()> {
         match self {
             Self::Clarity1(map) => {
@@ -102,7 +102,7 @@ impl TraitContext {
     pub fn get_trait(
         &self,
         trait_id: &TraitIdentifier,
-    ) -> Option<&BTreeMap<ClarityName, FunctionSignature>> {
+    ) -> Option<&BTreeMap<ClarityName, MethodSignature>> {
         match self {
             Self::Clarity1(map) => map.get(&trait_id.name),
             Self::Clarity2 { defined: _, all } => all.get(trait_id),
@@ -284,7 +284,7 @@ impl ContractContext {
     pub fn add_defined_trait(
         &mut self,
         trait_name: ClarityName,
-        trait_signature: BTreeMap<ClarityName, FunctionSignature>,
+        trait_signature: BTreeMap<ClarityName, MethodSignature>,
     ) -> CheckResult<()> {
         if self.clarity_version >= ClarityVersion::Clarity3 {
             self.check_name_used(&trait_name)?;
@@ -301,7 +301,7 @@ impl ContractContext {
         &mut self,
         alias: ClarityName,
         trait_id: TraitIdentifier,
-        trait_signature: BTreeMap<ClarityName, FunctionSignature>,
+        trait_signature: BTreeMap<ClarityName, MethodSignature>,
     ) -> CheckResult<()> {
         if self.clarity_version >= ClarityVersion::Clarity3 {
             self.check_name_used(&alias)?;
@@ -318,7 +318,7 @@ impl ContractContext {
     pub fn get_trait(
         &self,
         trait_id: &TraitIdentifier,
-    ) -> Option<&BTreeMap<ClarityName, FunctionSignature>> {
+    ) -> Option<&BTreeMap<ClarityName, MethodSignature>> {
         self.traits.get_trait(trait_id)
     }
 

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -45,7 +45,7 @@ use crate::vm::representations::SymbolicExpressionType::{
 };
 use crate::vm::representations::{depth_traverse, ClarityName, SymbolicExpression};
 use crate::vm::types::signatures::{
-    CallableSubtype, FunctionArgSignature, FunctionReturnsSignature, FunctionSignature, BUFF_20,
+    CallableSubtype, FunctionArgSignature, FunctionReturnsSignature, FunctionSignature, MethodSignature, BUFF_20
 };
 use crate::vm::types::{
     parse_name_type_pairs, CallableData, FixedFunction, FunctionArg, FunctionType, ListData,
@@ -647,8 +647,8 @@ fn check_function_arg_signature<T: CostTracker>(
 fn clarity2_check_functions_compatible<T: CostTracker>(
     db: &mut AnalysisDatabase,
     contract_context: Option<&ContractContext>,
-    expected_sig: &FunctionSignature,
-    actual_sig: &FunctionSignature,
+    expected_sig: &MethodSignature,
+    actual_sig: &MethodSignature,
     tracker: &mut T,
 ) -> bool {
     if expected_sig.args.len() != actual_sig.args.len() {
@@ -692,9 +692,9 @@ pub fn clarity2_trait_check_trait_compliance<T: CostTracker>(
     db: &mut AnalysisDatabase,
     contract_context: Option<&ContractContext>,
     actual_trait_identifier: &TraitIdentifier,
-    actual_trait: &BTreeMap<ClarityName, FunctionSignature>,
+    actual_trait: &BTreeMap<ClarityName, MethodSignature>,
     expected_trait_identifier: &TraitIdentifier,
-    expected_trait: &BTreeMap<ClarityName, FunctionSignature>,
+    expected_trait: &BTreeMap<ClarityName, MethodSignature>,
     tracker: &mut T,
 ) -> CheckResult<()> {
     // Shortcut for the simple case when the two traits are the same.
@@ -910,7 +910,7 @@ fn clarity2_lookup_trait<T: CostTracker>(
     contract_context: Option<&ContractContext>,
     trait_id: &TraitIdentifier,
     tracker: &mut T,
-) -> CheckResult<BTreeMap<ClarityName, FunctionSignature>> {
+) -> CheckResult<BTreeMap<ClarityName, MethodSignature>> {
     if let Some(contract_context) = contract_context {
         // If the trait is from this contract, then it must be in the context or it doesn't exist.
         if contract_context.is_contract(&trait_id.contract_identifier) {
@@ -956,7 +956,7 @@ fn clarity2_lookup_trait<T: CostTracker>(
     }
 }
 
-fn trait_type_size(trait_sig: &BTreeMap<ClarityName, FunctionSignature>) -> CheckResult<u64> {
+fn trait_type_size(trait_sig: &BTreeMap<ClarityName, MethodSignature>) -> CheckResult<u64> {
     let mut total_size = 0;
     for (_func_name, value) in trait_sig.iter() {
         total_size = total_size.cost_overflow_add(value.total_type_size()?)?;
@@ -1610,7 +1610,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         trait_name: &ClarityName,
         function_types: &[SymbolicExpression],
         _context: &mut TypingContext,
-    ) -> CheckResult<(ClarityName, BTreeMap<ClarityName, FunctionSignature>)> {
+    ) -> CheckResult<(ClarityName, BTreeMap<ClarityName, MethodSignature>)> {
         let trait_signature = TypeSignature::parse_trait_type_repr(
             function_types,
             &mut (),

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
@@ -499,21 +499,23 @@ fn check_contract_call(
                 let trait_signature = checker.contract_context.get_trait(trait_id).ok_or(
                     CheckErrors::TraitReferenceUnknown(trait_id.name.to_string()),
                 )?;
-                let func_signature =
-                    trait_signature
+                let func_signature = {
+                    let method_sign = trait_signature
                         .get(func_name)
                         .ok_or(CheckErrors::TraitMethodUnknown(
                             trait_id.name.to_string(),
                             func_name.to_string(),
                         ))?;
 
+                        FunctionSignature { args: method_sign.args.clone(), returns: method_sign.returns.clone() }
+                    };
                 runtime_cost(
                     ClarityCostFunction::AnalysisLookupFunctionTypes,
                     &mut checker.cost_track,
                     func_signature.total_type_size()?,
                 )?;
 
-                func_signature.clone()
+                func_signature
             } else {
                 // Clarity2+
                 match checker.contract_context.get_variable_type(trait_instance) {
@@ -577,12 +579,16 @@ fn check_contract_call(
                         let trait_signature = checker.contract_context.get_trait(trait_id).ok_or(
                             CheckErrors::TraitReferenceUnknown(trait_id.name.to_string()),
                         )?;
-                        let func_signature = trait_signature.get(func_name).ok_or(
-                            CheckErrors::TraitMethodUnknown(
-                                trait_id.name.to_string(),
-                                func_name.to_string(),
-                            ),
-                        )?;
+                        let func_signature = {
+                            let method_sign = trait_signature
+                                .get(func_name)
+                                .ok_or(CheckErrors::TraitMethodUnknown(
+                                    trait_id.name.to_string(),
+                                    func_name.to_string(),
+                                ))?;
+        
+                                FunctionSignature { args: method_sign.args.clone(), returns: method_sign.returns.clone() }
+                            };
 
                         runtime_cost(
                             ClarityCostFunction::AnalysisLookupFunctionTypes,
@@ -590,7 +596,7 @@ fn check_contract_call(
                             func_signature.total_type_size()?,
                         )?;
 
-                        func_signature.clone()
+                        func_signature
                     }
                 }
             }

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -25,6 +25,7 @@ use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::StacksEpochId;
 
+use super::types::signatures::MethodSignature;
 use super::EvalHook;
 use crate::vm::ast::{ASTRules, ContractAST};
 use crate::vm::callables::{DefinedFunction, FunctionIdentifier};
@@ -210,7 +211,7 @@ pub struct ContractContext {
     pub contract_identifier: QualifiedContractIdentifier,
     pub variables: HashMap<ClarityName, Value>,
     pub functions: HashMap<ClarityName, DefinedFunction>,
-    pub defined_traits: HashMap<ClarityName, BTreeMap<ClarityName, FunctionSignature>>,
+    pub defined_traits: HashMap<ClarityName, BTreeMap<ClarityName, MethodSignature>>,
     pub implemented_traits: HashSet<TraitIdentifier>,
     // tracks the names of NFTs, FTs, Maps, and Data Vars.
     //  used for ensuring that they never are defined twice.
@@ -1805,7 +1806,7 @@ impl ContractContext {
     pub fn lookup_trait_definition(
         &self,
         name: &str,
-    ) -> Option<BTreeMap<ClarityName, FunctionSignature>> {
+    ) -> Option<BTreeMap<ClarityName, MethodSignature>> {
         self.defined_traits.get(name).cloned()
     }
 
@@ -1974,7 +1975,7 @@ mod test {
     use crate::vm::tests::{
         test_epochs, tl_env_factory, MemoryEnvironmentGenerator, TopLevelMemoryEnvironmentGenerator,
     };
-    use crate::vm::types::signatures::CallableSubtype;
+    use crate::vm::types::signatures::{CallableSubtype, MethodType};
     use crate::vm::types::{FixedFunction, FunctionArg, FunctionType, StandardPrincipalData};
 
     #[test]
@@ -2186,12 +2187,13 @@ mod test {
         let mut trait_functions = BTreeMap::new();
         trait_functions.insert(
             "alpha".into(),
-            FunctionSignature {
+            MethodSignature {
                 args: vec![TypeSignature::TraitReferenceType(trait_id.clone())],
                 returns: TypeSignature::ResponseType(Box::new((
                     TypeSignature::UIntType,
                     TypeSignature::UIntType,
                 ))),
+                define_type: MethodType::NotDefined,
             },
         );
         contract_context

--- a/clarity/src/vm/functions/define.rs
+++ b/clarity/src/vm/functions/define.rs
@@ -27,7 +27,7 @@ use crate::vm::representations::SymbolicExpressionType::{
     Atom, AtomValue, Field, List, LiteralValue,
 };
 use crate::vm::representations::{ClarityName, SymbolicExpression};
-use crate::vm::types::signatures::FunctionSignature;
+use crate::vm::types::signatures::{FunctionSignature, MethodSignature};
 use crate::vm::types::{
     parse_name_type_pairs, PrincipalData, QualifiedContractIdentifier, TraitIdentifier,
     TupleTypeSignature, TypeSignature, Value,
@@ -105,7 +105,7 @@ pub enum DefineResult {
     PersistedVariable(ClarityName, TypeSignature, Value),
     FungibleToken(ClarityName, Option<u128>),
     NonFungibleAsset(ClarityName, TypeSignature),
-    Trait(ClarityName, BTreeMap<ClarityName, FunctionSignature>),
+    Trait(ClarityName, BTreeMap<ClarityName, MethodSignature>),
     UseTrait(ClarityName, TraitIdentifier),
     ImplTrait(TraitIdentifier),
     NoDefine,

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -262,6 +262,20 @@ pub struct FunctionSignature {
     pub returns: TypeSignature,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MethodType {
+    ReadOnly,
+    Public,
+    NotDefined,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MethodSignature {
+    pub args: Vec<TypeSignature>,
+    pub returns: TypeSignature,
+    pub define_type: MethodType,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FixedFunction {
     pub args: Vec<FunctionArg>,
@@ -1025,6 +1039,48 @@ impl FunctionSignature {
     }
 }
 
+impl MethodSignature {
+    pub fn total_type_size(&self) -> Result<u64> {
+        let mut function_type_size = u64::from(self.returns.type_size()?);
+        for arg in self.args.iter() {
+            function_type_size =
+                function_type_size.cost_overflow_add(u64::from(arg.type_size()?))?;
+        }
+        Ok(function_type_size)
+    }
+
+    pub fn check_args_trait_compliance(
+        &self,
+        epoch: &StacksEpochId,
+        args: Vec<TypeSignature>,
+    ) -> Result<bool> {
+        if args.len() != self.args.len() {
+            return Ok(false);
+        }
+        let args_iter = self.args.iter().zip(args.iter());
+        for (expected_arg, arg) in args_iter {
+            if !arg.admits_type(epoch, expected_arg)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    pub fn canonicalize(&self, epoch: &StacksEpochId) -> Self {
+        let canonicalized_args = self
+            .args
+            .iter()
+            .map(|arg| arg.canonicalize(epoch))
+            .collect();
+
+        Self {
+            args: canonicalized_args,
+            returns: self.returns.canonicalize(epoch),
+            define_type: self.define_type.clone(),
+        }
+    }
+}
+
 impl FunctionArg {
     pub fn new(signature: TypeSignature, name: ClarityName) -> FunctionArg {
         FunctionArg { signature, name }
@@ -1654,8 +1710,8 @@ impl TypeSignature {
         accounting: &mut A,
         epoch: StacksEpochId,
         clarity_version: ClarityVersion,
-    ) -> Result<BTreeMap<ClarityName, FunctionSignature>> {
-        let mut trait_signature: BTreeMap<ClarityName, FunctionSignature> = BTreeMap::new();
+    ) -> Result<BTreeMap<ClarityName, MethodSignature>> {
+        let mut trait_signature: BTreeMap<ClarityName, MethodSignature> = BTreeMap::new();
         let functions_types = type_args
             .get(0)
             .ok_or_else(|| CheckErrors::InvalidTypeDescription)?
@@ -1666,40 +1722,22 @@ impl TypeSignature {
             let args = function_type
                 .match_list()
                 .ok_or(CheckErrors::DefineTraitBadSignature)?;
-            if args.len() != 3 {
+
+            let (fn_name, fn_args, fn_return, method_type) = if args.len() == 3 {
+                TypeSignature::parse_method(args, epoch, accounting)?
+            } else if args.len() == 4 {
+                TypeSignature::parse_method_access_modifier(args, epoch, accounting)?
+            } else {
                 return Err(CheckErrors::InvalidTypeDescription);
-            }
-
-            // Extract function's name
-            let fn_name = args[0]
-                .match_atom()
-                .ok_or(CheckErrors::DefineTraitBadSignature)?;
-
-            // Extract function's arguments
-            let fn_args_exprs = args[1]
-                .match_list()
-                .ok_or(CheckErrors::DefineTraitBadSignature)?;
-            let mut fn_args = Vec::with_capacity(fn_args_exprs.len());
-            for arg_type in fn_args_exprs.into_iter() {
-                let arg_t = TypeSignature::parse_type_repr(epoch, arg_type, accounting)?;
-                fn_args.push(arg_t);
-            }
-
-            // Extract function's type return - must be a response
-            let fn_return = match TypeSignature::parse_type_repr(epoch, &args[2], accounting) {
-                Ok(response) => match response {
-                    TypeSignature::ResponseType(_) => Ok(response),
-                    _ => Err(CheckErrors::DefineTraitBadSignature),
-                },
-                _ => Err(CheckErrors::DefineTraitBadSignature),
-            }?;
+            };
 
             if trait_signature
                 .insert(
                     fn_name.clone(),
-                    FunctionSignature {
+                    MethodSignature {
                         args: fn_args,
                         returns: fn_return,
+                        define_type: method_type,
                     },
                 )
                 .is_some()
@@ -1709,6 +1747,82 @@ impl TypeSignature {
             }
         }
         Ok(trait_signature)
+    }
+
+    fn parse_method<'a, A: CostTracker>(
+        args: &'a [SymbolicExpression],
+        epoch:StacksEpochId,
+        accounting: &'a mut A, 
+    ) -> Result<(&'a ClarityName, Vec<TypeSignature>, TypeSignature, MethodType)> {
+        // Extract function's name
+        let fn_name = args[0]
+        .match_atom()
+        .ok_or(CheckErrors::DefineTraitBadSignature)?;
+
+        // Extract function's arguments
+        let fn_args_exprs = args[1]
+            .match_list()
+            .ok_or(CheckErrors::DefineTraitBadSignature)?;
+        let mut fn_args = Vec::with_capacity(fn_args_exprs.len());
+        for arg_type in fn_args_exprs.into_iter() {
+            let arg_t = TypeSignature::parse_type_repr(epoch, arg_type, accounting)?;
+            fn_args.push(arg_t);
+        }
+
+        // Extract function's type return - must be a response
+        let fn_return = match TypeSignature::parse_type_repr(epoch, &args[2], accounting) {
+            Ok(response) => match response {
+                TypeSignature::ResponseType(_) => Ok(response),
+                _ => Err(CheckErrors::DefineTraitBadSignature),
+            },
+            _ => Err(CheckErrors::DefineTraitBadSignature),
+        }?;
+
+        Ok((fn_name, fn_args, fn_return, MethodType::NotDefined))
+    }
+
+    fn parse_method_access_modifier<'a, A: CostTracker>(
+        args: &'a [SymbolicExpression],
+        epoch:StacksEpochId,
+        accounting: &'a mut A, 
+    ) -> Result<(&'a ClarityName, Vec<TypeSignature>, TypeSignature, MethodType)> {
+
+        // Extract acccess modifier type
+        let access_modifier = args[0].
+        match_atom()
+        .ok_or(CheckErrors::DefineTraitBadSignature)?;
+
+        let method_type = match access_modifier.as_str() {
+            "public" => Ok(MethodType::Public),
+            "read-only" => Ok(MethodType::ReadOnly),
+            _ => Err(CheckErrors::DefineTraitBadSignature)
+        }?;
+
+        // Extract function's name
+        let fn_name = args[1]
+        .match_atom()
+        .ok_or(CheckErrors::DefineTraitBadSignature)?;
+
+        // Extract function's arguments
+        let fn_args_exprs = args[2]
+            .match_list()
+            .ok_or(CheckErrors::DefineTraitBadSignature)?;
+        let mut fn_args = Vec::with_capacity(fn_args_exprs.len());
+        for arg_type in fn_args_exprs.into_iter() {
+            let arg_t = TypeSignature::parse_type_repr(epoch, arg_type, accounting)?;
+            fn_args.push(arg_t);
+        }
+
+        // Extract function's type return - must be a response
+        let fn_return = match TypeSignature::parse_type_repr(epoch, &args[3], accounting) {
+            Ok(response) => match response {
+                TypeSignature::ResponseType(_) => Ok(response),
+                _ => Err(CheckErrors::DefineTraitBadSignature),
+            },
+            _ => Err(CheckErrors::DefineTraitBadSignature),
+        }?;
+
+        Ok((fn_name, fn_args, fn_return, method_type))
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Was working on [this issue in the clarinet repo](https://github.com/hirosystems/clarinet/pull/1592) and felt need of more data from the clarity virtual machine.

Upon further investigation, noticed that there is something wrong about how traits are handle in the virtual machine.

for eg. if we take the standard nft trait SIP009, it has methods like `(get-last-token-id () (response uint uint))` and `(transfer (uint principal principal) (response bool uint))`, it should be intuitive but if not according to the standard definition first one should be implemented as a read-only function and the latter should be public.

In current scenario, this access modifier like assertion is not stored in the trait definitions. Any contract implementing the trait can implement those methods howsoever it likes as there is no safe-guard about it. Currently, the virtual machine only checks if the name and the signature is a match.

It should be assumed that the average end-user doesn't know about these kind of things. A getter function can be implemented as public one and can easily change the state of the chain. While similarly, a transfer like function is expected to change the state of the chain and consequently should be public but contracts are free to implement it however they like.

In my opinion, this is quite a vulnerability.

This pr should help.