### PR TITLE
locally_accepted_blocks_overriden_by_global_rejection fix: Store the rejected block in the database in testing directive case

### DIFF
--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -428,30 +428,8 @@ impl Signer {
         };
 
         #[cfg(any(test, feature = "testing"))]
-        let block_response = match &*TEST_REJECT_ALL_BLOCK_PROPOSAL.lock().unwrap() {
-            Some(public_keys) => {
-                if public_keys.contains(
-                    &stacks_common::types::chainstate::StacksPublicKey::from_private(
-                        &self.private_key,
-                    ),
-                ) {
-                    warn!("{self}: Rejecting block proposal automatically due to testing directive";
-                        "block_id" => %block_proposal.block.block_id(),
-                        "height" => block_proposal.block.header.chain_length,
-                        "consensus_hash" => %block_proposal.block.header.consensus_hash
-                    );
-                    Some(BlockResponse::rejected(
-                        block_proposal.block.header.signer_signature_hash(),
-                        RejectCode::TestingDirective,
-                        &self.private_key,
-                        self.mainnet,
-                    ))
-                } else {
-                    None
-                }
-            }
-            None => block_response,
-        };
+        let block_response =
+            self.test_reject_block_proposal(block_proposal, &mut block_info, block_response);
 
         if let Some(block_response) = block_response {
             // We know proposal is invalid. Send rejection message, do not do further validation
@@ -933,6 +911,44 @@ impl Signer {
             return true;
         }
         false
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    fn test_reject_block_proposal(
+        &mut self,
+        block_proposal: &BlockProposal,
+        block_info: &mut BlockInfo,
+        block_response: Option<BlockResponse>,
+    ) -> Option<BlockResponse> {
+        let Some(public_keys) = &*TEST_REJECT_ALL_BLOCK_PROPOSAL.lock().unwrap() else {
+            return block_response;
+        };
+        if public_keys.contains(
+            &stacks_common::types::chainstate::StacksPublicKey::from_private(&self.private_key),
+        ) {
+            warn!("{self}: Rejecting block proposal automatically due to testing directive";
+                "block_id" => %block_proposal.block.block_id(),
+                "height" => block_proposal.block.header.chain_length,
+                "consensus_hash" => %block_proposal.block.header.consensus_hash
+            );
+            if let Err(e) = block_info.mark_locally_rejected() {
+                warn!("{self}: Failed to mark block as locally rejected: {e:?}",);
+            };
+            // We must insert the block into the DB to prevent subsequent repeat proposals being accepted (should reject
+            // as invalid since we rejected in a prior round if this crops up again)
+            // in case this is the first time we saw this block. Safe to do since this is testing case only.
+            self.signer_db
+                .insert_block(block_info)
+                .unwrap_or_else(|_| panic!("{self}: Failed to insert block in DB"));
+            Some(BlockResponse::rejected(
+                block_proposal.block.header.signer_signature_hash(),
+                RejectCode::TestingDirective,
+                &self.private_key,
+                self.mainnet,
+            ))
+        } else {
+            None
+        }
     }
 
     /// Send a mock signature to stackerdb to prove we are still alive

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -4246,6 +4246,8 @@ fn locally_accepted_blocks_overriden_by_global_rejection() {
         .unwrap()
         .replace(rejecting_signers.clone());
     test_observer::clear();
+    // Make a new stacks transaction to create a different block signature, but make sure to propose it
+    // AFTER the signers are unfrozen so they don't inadvertently prevent the new block being accepted
     let transfer_tx = make_stacks_transfer(
         &sender_sk,
         sender_nonce,


### PR DESCRIPTION
Fixes https://github.com/stacks-network/stacks-core/issues/5389

