### PR TITLE
Miner can continue mining after an empty tenure followed by empty sortition

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -120,6 +120,7 @@ jobs:
           - tests::signer::v0::signing_in_0th_tenure_of_reward_cycle
           - tests::signer::v0::continue_after_tenure_extend
           - tests::signer::v0::multiple_miners_with_custom_chain_id
+          - tests::signer::v0::continue_after_fast_block_no_sortition
           - tests::nakamoto_integrations::burn_ops_integration_test
           - tests::nakamoto_integrations::check_block_heights
           - tests::nakamoto_integrations::clarity_burn_state

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -922,25 +922,22 @@ impl BlockMinerThread {
     fn make_vrf_proof(&mut self) -> Option<VRFProof> {
         // if we're a mock miner, then make sure that the keychain has a keypair for the mocked VRF
         // key
-        let sortition_hash = if matches!(self.reason, MinerReason::EmptyTenure) {
-            self.burn_election_block.sortition_hash
-        } else {
-            self.burn_block.sortition_hash
-        };
         let vrf_proof = if self.config.get_node_config(false).mock_mining {
-            self.keychain
-                .generate_proof(VRF_MOCK_MINER_KEY, sortition_hash.as_bytes())
+            self.keychain.generate_proof(
+                VRF_MOCK_MINER_KEY,
+                self.burn_election_block.sortition_hash.as_bytes(),
+            )
         } else {
             self.keychain.generate_proof(
                 self.registered_key.target_block_height,
-                sortition_hash.as_bytes(),
+                self.burn_election_block.sortition_hash.as_bytes(),
             )
         };
 
         debug!(
             "Generated VRF Proof: {} over {} ({},{}) with key {}",
             vrf_proof.to_hex(),
-            &sortition_hash,
+            &self.burn_election_block.sortition_hash,
             &self.burn_block.block_height,
             &self.burn_block.burn_header_hash,
             &self.registered_key.vrf_public_key.to_hex()

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -109,6 +109,8 @@ pub enum MinerReason {
         /// sortition.
         burn_view_consensus_hash: ConsensusHash,
     },
+    /// The miner thread was spawned to initialize a prior empty tenure
+    EmptyTenure,
 }
 
 impl std::fmt::Display for MinerReason {
@@ -121,6 +123,7 @@ impl std::fmt::Display for MinerReason {
                 f,
                 "Extended: burn_view_consensus_hash = {burn_view_consensus_hash:?}",
             ),
+            MinerReason::EmptyTenure => write!(f, "EmptyTenure"),
         }
     }
 }
@@ -919,22 +922,25 @@ impl BlockMinerThread {
     fn make_vrf_proof(&mut self) -> Option<VRFProof> {
         // if we're a mock miner, then make sure that the keychain has a keypair for the mocked VRF
         // key
+        let sortition_hash = if matches!(self.reason, MinerReason::EmptyTenure) {
+            self.burn_election_block.sortition_hash
+        } else {
+            self.burn_block.sortition_hash
+        };
         let vrf_proof = if self.config.get_node_config(false).mock_mining {
-            self.keychain.generate_proof(
-                VRF_MOCK_MINER_KEY,
-                self.burn_block.sortition_hash.as_bytes(),
-            )
+            self.keychain
+                .generate_proof(VRF_MOCK_MINER_KEY, sortition_hash.as_bytes())
         } else {
             self.keychain.generate_proof(
                 self.registered_key.target_block_height,
-                self.burn_block.sortition_hash.as_bytes(),
+                sortition_hash.as_bytes(),
             )
         };
 
         debug!(
             "Generated VRF Proof: {} over {} ({},{}) with key {}",
             vrf_proof.to_hex(),
-            &self.burn_block.sortition_hash,
+            &sortition_hash,
             &self.burn_block.block_height,
             &self.burn_block.burn_header_hash,
             &self.registered_key.vrf_public_key.to_hex()
@@ -1155,7 +1161,7 @@ impl BlockMinerThread {
         };
 
         let (tenure_change_tx, coinbase_tx) = match &self.reason {
-            MinerReason::BlockFound => {
+            MinerReason::BlockFound | MinerReason::EmptyTenure => {
                 let tenure_change_tx =
                     self.generate_tenure_change_tx(current_miner_nonce, payload)?;
                 let coinbase_tx =

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -1003,13 +1003,7 @@ impl RelayerThread {
 
     #[cfg(test)]
     fn fault_injection_skip_block_commit(&self) -> bool {
-        self.globals
-            .counters
-            .naka_skip_commit_op
-            .0
-            .lock()
-            .unwrap()
-            .unwrap_or(false)
+        self.globals.counters.naka_skip_commit_op.get()
     }
 
     #[cfg(not(test))]

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -930,7 +930,7 @@ impl RelayerThread {
             if !won_last_non_empty_sortition_snapshot {
                 debug!("Relayer: Failed to issue a tenure change payload in our last tenure. Issue a new tenure change payload.");
                 (
-                    canonical_stacks_tip, // TODO: what should this be? is this correct?
+                    canonical_stacks_tip,
                     last_block_election_snapshot,
                     MinerReason::EmptyTenure,
                 )

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -93,6 +93,19 @@ impl Default for TestFlag {
     }
 }
 
+#[cfg(test)]
+impl TestFlag {
+    /// Set the test flag to the given value
+    pub fn set(&self, value: bool) {
+        *self.0.lock().unwrap() = Some(value);
+    }
+
+    /// Get the test flag value. Defaults to false if the flag is not set.
+    pub fn get(&self) -> bool {
+        self.0.lock().unwrap().unwrap_or(false)
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct Counters {
     pub blocks_processed: RunLoopCounter,
@@ -1034,7 +1047,7 @@ impl RunLoop {
     /// This function will block by looping infinitely.
     /// It will start the burnchain (separate thread), set-up a channel in
     /// charge of coordinating the new blocks coming from the burnchain and
-    /// the nodes, taking turns on tenures.  
+    /// the nodes, taking turns on tenures.
     ///
     /// Returns `Option<NeonGlobals>` so that data can be passed to `NakamotoNode`
     pub fn start(

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -5051,7 +5051,7 @@ fn forked_tenure_is_ignored() {
 
     // Unpause the broadcast of Tenure B's block, do not submit commits, and do not allow blocks to
     // be processed
-    test_skip_commit_op.0.lock().unwrap().replace(true);
+    test_skip_commit_op.set(true);
     TEST_BROADCAST_STALL.lock().unwrap().replace(false);
 
     // Wait for a stacks block to be broadcasted.
@@ -5104,7 +5104,7 @@ fn forked_tenure_is_ignored() {
         .expect("Mutex poisoned")
         .get_stacks_blocks_processed();
     next_block_and(&mut btc_regtest_controller, 60, || {
-        test_skip_commit_op.0.lock().unwrap().replace(false);
+        test_skip_commit_op.set(false);
         TEST_BLOCK_ANNOUNCE_STALL.lock().unwrap().replace(false);
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         let blocks_count = mined_blocks.load(Ordering::SeqCst);
@@ -7054,7 +7054,7 @@ fn continue_tenure_extend() {
         .get_stacks_blocks_processed();
 
     info!("Pausing commit ops to trigger a tenure extend.");
-    test_skip_commit_op.0.lock().unwrap().replace(true);
+    test_skip_commit_op.set(true);
 
     next_block_and(&mut btc_regtest_controller, 60, || Ok(true)).unwrap();
 
@@ -7153,7 +7153,7 @@ fn continue_tenure_extend() {
     }
 
     info!("Resuming commit ops to mine regular tenures.");
-    test_skip_commit_op.0.lock().unwrap().replace(false);
+    test_skip_commit_op.set(false);
 
     // Mine 15 more regular nakamoto tenures
     for _i in 0..15 {

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -5176,8 +5176,12 @@ fn continue_after_fast_block_no_sortition() {
     })
     .expect("Timed out waiting for boostrapped node to catch up to the miner");
 
-    let mining_pkh_1 = Hash160::from_node_public_key(&StacksPublicKey::from_private(&conf.miner.mining_key.unwrap()));
-    let mining_pkh_2 = Hash160::from_node_public_key(&StacksPublicKey::from_private(&conf_node_2.miner.mining_key.unwrap()));
+    let mining_pkh_1 = Hash160::from_node_public_key(&StacksPublicKey::from_private(
+        &conf.miner.mining_key.unwrap(),
+    ));
+    let mining_pkh_2 = Hash160::from_node_public_key(&StacksPublicKey::from_private(
+        &conf_node_2.miner.mining_key.unwrap(),
+    ));
     debug!("The miner key for miner 1 is {mining_pkh_1}");
     debug!("The miner key for miner 2 is {mining_pkh_2}");
 
@@ -5233,7 +5237,10 @@ fn continue_after_fast_block_no_sortition() {
             .get_peer_info()
             .expect("Failed to get peer info")
             .stacks_tip_height;
-        Ok(blocks_mined1.load(Ordering::SeqCst) > blocks_processed_before_1 && stacks_height > stacks_height_before)
+        Ok(
+            blocks_mined1.load(Ordering::SeqCst) > blocks_processed_before_1
+                && stacks_height > stacks_height_before,
+        )
     })
     .unwrap();
 

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -5952,13 +5952,13 @@ fn continue_after_fast_block_no_sortition() {
         let commits_before_1 = rl1_commits.load(Ordering::SeqCst);
         let commits_before_2 = rl2_commits.load(Ordering::SeqCst);
 
-        signer_test
-            .running_nodes
-            .btc_regtest_controller
-            .build_next_block(1);
+        next_block_and(
+            &mut signer_test.running_nodes.btc_regtest_controller,
+            30,
+            || Ok(get_burn_height() > burn_height_before),
+        )
+        .unwrap();
         btc_blocks_mined += 1;
-
-        wait_for(30, || Ok(get_burn_height() > burn_height_before)).unwrap();
 
         assert_eq!(rl1_commits.load(Ordering::SeqCst), commits_before_1);
         assert_eq!(rl2_commits.load(Ordering::SeqCst), commits_before_2);

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -1003,10 +1003,7 @@ fn forked_tenure_testing(
     signer_test
         .running_nodes
         .nakamoto_test_skip_commit_op
-        .0
-        .lock()
-        .unwrap()
-        .replace(true);
+        .set(true);
     TEST_BROADCAST_STALL.lock().unwrap().replace(false);
 
     // Wait for a stacks block to be broadcasted
@@ -1083,10 +1080,7 @@ fn forked_tenure_testing(
             signer_test
                 .running_nodes
                 .nakamoto_test_skip_commit_op
-                .0
-                .lock()
-                .unwrap()
-                .replace(false);
+                .set(false);
 
             let commits_count = commits_submitted.load(Ordering::SeqCst);
             if commits_count > commits_before {
@@ -1850,7 +1844,7 @@ fn miner_forking() {
 
     let pre_nakamoto_peer_1_height = get_chain_info(&conf).stacks_tip_height;
 
-    naka_skip_commit_op.0.lock().unwrap().replace(false);
+    naka_skip_commit_op.set(true);
     info!("------------------------- Reached Epoch 3.0 -------------------------");
 
     let mut sortitions_seen = Vec::new();
@@ -1868,7 +1862,7 @@ fn miner_forking() {
             .running_nodes
             .btc_regtest_controller
             .build_next_block(1);
-        naka_skip_commit_op.0.lock().unwrap().replace(false);
+        naka_skip_commit_op.set(false);
 
         // wait until a commit is submitted by run_loop_2
         wait_for(60, || {
@@ -1892,7 +1886,7 @@ fn miner_forking() {
 
         // block commits from RL2 -- this will block until the start of the next iteration
         //  in this loop.
-        naka_skip_commit_op.0.lock().unwrap().replace(true);
+        naka_skip_commit_op.set(true);
         // ensure RL1 performs an RBF after unblock block broadcast
         let rl1_commits_before = signer_test
             .running_nodes
@@ -2499,10 +2493,7 @@ fn empty_sortition() {
     signer_test
         .running_nodes
         .nakamoto_test_skip_commit_op
-        .0
-        .lock()
-        .unwrap()
-        .replace(true);
+        .set(true);
 
     let blocks_after = signer_test
         .running_nodes
@@ -5120,10 +5111,7 @@ fn continue_after_tenure_extend() {
     signer_test
         .running_nodes
         .nakamoto_test_skip_commit_op
-        .0
-        .lock()
-        .unwrap()
-        .replace(true);
+        .set(true);
 
     // It's possible that we have a pending block commit already.
     // Mine two BTC blocks to "flush" this commit.

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -5019,10 +5019,13 @@ fn miner_recovers_when_broadcast_block_delay_across_tenures_occurs() {
 }
 
 /// Test a scenario where:
-/// We have one miner. During block A, there is a sortition and a TenureChange.
-/// Block B is mined, but it does not contain a TenureChange (ie because a
-/// new burn block was mined too quickly).
-/// Then block C occurs, which does not have a sortition.
+/// Two miners boot to Nakamoto.
+/// Miner 1 wins the first Nakamoto tenure A. Miner 1 mines a regular stacks block N.
+/// Miner 2 wins the second Nakamoto tenure B and proposes block N+1, but it is rejected by the signers.
+/// An empty burn block is mined
+/// Miner 2 wins the third Nakamoto tenure C. Miner 2 proposes a block N+1' which all signers accept.
+/// Asserts:
+/// - The stacks tip advances to N+1'
 #[test]
 #[ignore]
 fn continue_after_fast_block_no_sortition() {

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -5044,7 +5044,7 @@ fn continue_after_fast_block_no_sortition() {
     let send_fee = 180;
     let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
         num_signers,
-        vec![(sender_addr.clone(), (send_amt + send_fee) * 5)],
+        vec![(sender_addr, (send_amt + send_fee) * 5)],
     );
     let timeout = Duration::from_secs(200);
     let _coord_channel = signer_test.running_nodes.coord_channel.clone();
@@ -5056,7 +5056,7 @@ fn continue_after_fast_block_no_sortition() {
     let sortdb = burnchain.open_sortition_db(true).unwrap();
 
     let get_burn_height = || {
-        SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn())
+        SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
             .unwrap()
             .block_height
     };
@@ -5093,7 +5093,7 @@ fn continue_after_fast_block_no_sortition() {
     .expect("Timed out waiting for a new block commit");
 
     // Make all signers ignore block proposals
-    let ignoring_signers: Vec<_> = all_signers.iter().cloned().collect();
+    let ignoring_signers = all_signers.to_vec();
     TEST_REJECT_ALL_BLOCK_PROPOSAL
         .lock()
         .unwrap()
@@ -5126,7 +5126,7 @@ fn continue_after_fast_block_no_sortition() {
     .unwrap();
 
     // assure we have a sortition
-    let tip = SortitionDB::get_canonical_burn_chain_tip(&sortdb.conn()).unwrap();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
     assert!(tip.sortition);
 
     let burn_height_before = signer_test


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/5400

(hopefully eventually)

This PR currently just contains an integration test to try and reproduce the scenario described in #5400.

The basic flow of the test is:

- boot to nakamoto
- mine a regular block (A) (burn block with TenureChange)
- Have signers reject all new block proposals
- Mine a new BTC block (B) with a sortition
- Wait for the signers to reject it
- Mine a new BTC block (C) **without** a sortition
- Turn off the block rejection flag

I thought this would reproduce the issue, but things seem fine - the miner creates a `TenureExtend` off of block A and signers approve it.

**JACINTA EDIT:**

So I modified the logic to check during continue_tenure to see if we failed to produce any blocks in our tenure which means we really never issued a tenure extend. Now we issue one. I verified this works with multiple empty sortitions, and that we can build off this tenure change payload that shows up late essentially. I also ensured that we do issue a traditional tenure extend in the case where we successfully issued the tenure extend payload. This did require me to chagne the vrf proof generation to use the block election snapshot and not the current burn block to verify. I also found a bug in the way we were passing the election snapshot along (caused miners to never issue a block proposal at all because it would attempt to write to the wrong slot).

Now I know @kantai you wanted the miner to issue a continue tenure after the successful tenure change but I think this is a lot more complicated and has more edge cases that I don't like...Now I can continue to try this though if you think this fix is insufficient / or if there are edge cases that already exist that I am just not seeing.

Will see what CI does...hopefully haven't broken anything 
