### PR TITLE
Chore: Use thiserror throughout stacks-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "serde_stacker",
  "slog",
  "stacks-common",
+ "thiserror",
  "time 0.2.27",
 ]
 
@@ -1886,6 +1887,7 @@ dependencies = [
  "serde_stacker",
  "sha2 0.10.8",
  "stacks-common",
+ "thiserror",
 ]
 
 [[package]]
@@ -3291,6 +3293,7 @@ dependencies = [
  "slog",
  "slog-json",
  "slog-term",
+ "thiserror",
  "time 0.2.27",
  "winapi 0.3.9",
 ]
@@ -3328,6 +3331,7 @@ dependencies = [
  "stackslib",
  "stx-genesis",
  "tempfile",
+ "thiserror",
  "tikv-jemallocator",
  "tiny_http",
  "tokio",
@@ -3418,6 +3422,7 @@ dependencies = [
  "stacks-common",
  "stdext",
  "stx-genesis",
+ "thiserror",
  "tikv-jemallocator",
  "time 0.2.27",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8"
 rand_chacha = "0.3.1"
 tikv-jemallocator = "0.5.4"
 rusqlite = { version = "0.31.0", features = ["blob", "serde_json", "i128_blob", "bundled", "trace"] }
+thiserror = { version = "1.0" }
 
 # Use a bit more than default optimization for
 #  dev builds to speed up test execution

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -31,7 +31,8 @@ stacks_common = { package = "stacks-common", path = "../stacks-common", optional
 rstest = "0.17.0"
 rstest_reuse = "0.5.0"
 hashbrown = { workspace = true }
-rusqlite = { workspace = true, optional = true}
+rusqlite = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [dependencies.serde_json]
 version = "1.0"

--- a/clarity/src/vm/analysis/arithmetic_checker/mod.rs
+++ b/clarity/src/vm/analysis/arithmetic_checker/mod.rs
@@ -47,25 +47,19 @@ pub struct ArithmeticOnlyChecker<'a> {
     clarity_version: &'a ClarityVersion,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+/// Errors originating from the arithmetic checker
 pub enum Error {
+    #[error("Define type forbidden: {0}")]
     DefineTypeForbidden(DefineFunctions),
+    #[error("Variable forbidden: {0}")]
     VariableForbidden(NativeVariables),
+    #[error("Function not permitted: {0}")]
     FunctionNotPermitted(NativeFunctions),
+    #[error("Trait references forbidden")]
     TraitReferencesForbidden,
+    #[error("Unexpected contract structure")]
     UnexpectedContractStructure,
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
 }
 
 impl<'a> ArithmeticOnlyChecker<'a> {

--- a/libsigner/Cargo.toml
+++ b/libsigner/Cargo.toml
@@ -30,7 +30,7 @@ slog-term = "2.6.0"
 slog-json = { version = "2.3.0", optional = true }
 stacks-common = { path = "../stacks-common" }
 stackslib = { path = "../stackslib"}
-thiserror = "1.0"
+thiserror = { workspace = true }
 tiny_http = "0.12"
 
 [dev-dependencies]

--- a/libstackerdb/Cargo.toml
+++ b/libstackerdb/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = "1"
 serde_stacker = "0.1"
 stacks-common = { path = "../stacks-common" }
 clarity = { path = "../clarity" }
+thiserror = { workspace = true }
 
 [dependencies.secp256k1]
 version = "0.24.3"

--- a/libstackerdb/src/libstackerdb.rs
+++ b/libstackerdb/src/libstackerdb.rs
@@ -19,8 +19,8 @@ extern crate serde;
 extern crate sha2;
 extern crate stacks_common;
 
+use std::fmt;
 use std::io::{Read, Write};
-use std::{error, fmt};
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use serde::{Deserialize, Serialize};
@@ -41,30 +41,14 @@ pub const SIGNERS_STACKERDB_CHUNK_SIZE: usize = 2 * 1024 * 1024; // 2MB
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error signing a message
+    #[error("{0}")]
     SigningError(String),
     /// Error verifying a message
+    #[error("{0}")]
     VerifyingError(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::SigningError(ref s) => fmt::Display::fmt(s, f),
-            Error::VerifyingError(ref s) => fmt::Display::fmt(s, f),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::SigningError(ref _s) => None,
-            Error::VerifyingError(ref _s) => None,
-        }
-    }
 }
 
 /// Slot metadata from the DB.

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -33,6 +33,7 @@ chrono = "0.4.19"
 libc = "0.2.82"
 hashbrown = { workspace = true }
 rusqlite = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"

--- a/stacks-common/src/address/mod.rs
+++ b/stacks-common/src/address/mod.rs
@@ -33,60 +33,31 @@ pub const C32_ADDRESS_VERSION_MAINNET_MULTISIG: u8 = 20; // M
 pub const C32_ADDRESS_VERSION_TESTNET_SINGLESIG: u8 = 26; // T
 pub const C32_ADDRESS_VERSION_TESTNET_MULTISIG: u8 = 21; // N
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Invalid crockford 32 string")]
     InvalidCrockford32,
+    #[error("Invalid version {0}")]
     InvalidVersion(u8),
+    #[error("Empty data")]
     EmptyData,
     /// Invalid character encountered
+    #[error("invalid base58 character 0x{0:x}")]
     BadByte(u8),
     /// Checksum was not correct (expected, actual)
+    #[error("base58ck checksum 0x{1:x} does not match expected 0x{0:x}")]
     BadChecksum(u32, u32),
     /// The length (in bytes) of the object was not correct
     /// Note that if the length is excessively long the provided length may be
     /// an estimate (and the checksum step may be skipped).
+    #[error("length {0} invalid for this base58 type")]
     InvalidLength(usize),
     /// Checked data was less than 4 bytes
+    #[error("base58ck data not even long enough for a checksum")]
     TooShort(usize),
     /// Any other error
+    #[error("{0}")]
     Other(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::InvalidCrockford32 => write!(f, "Invalid crockford 32 string"),
-            Error::InvalidVersion(ref v) => write!(f, "Invalid version {}", v),
-            Error::EmptyData => f.write_str("Empty data"),
-            Error::BadByte(b) => write!(f, "invalid base58 character 0x{:x}", b),
-            Error::BadChecksum(exp, actual) => write!(
-                f,
-                "base58ck checksum 0x{:x} does not match expected 0x{:x}",
-                actual, exp
-            ),
-            Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
-            Error::TooShort(_) => write!(f, "base58ck data not even long enough for a checksum"),
-            Error::Other(ref s) => f.write_str(s),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-    fn description(&self) -> &'static str {
-        match *self {
-            Error::InvalidCrockford32 => "Invalid crockford 32 string",
-            Error::InvalidVersion(_) => "Invalid version",
-            Error::EmptyData => "Empty data",
-            Error::BadByte(_) => "invalid b58 character",
-            Error::BadChecksum(_, _) => "invalid b58ck checksum",
-            Error::InvalidLength(_) => "invalid length for b58 type",
-            Error::TooShort(_) => "b58ck data less than 4 bytes",
-            Error::Other(_) => "unknown b58 error",
-        }
-    }
 }
 
 /// Serialization modes for public keys to addresses.  These apply to Stacks addresses, which

--- a/stacks-common/src/codec/mod.rs
+++ b/stacks-common/src/codec/mod.rs
@@ -9,58 +9,35 @@ use crate::util::secp256k1::MESSAGE_SIGNATURE_ENCODED_SIZE;
 #[macro_use]
 pub mod macros;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Failed to encode
+    #[error("{0}")]
     SerializeError(String),
     /// Failed to read
+    #[error("{0}")]
     ReadError(io::Error),
     /// Failed to decode
+    #[error("{0}")]
     DeserializeError(String),
     /// Failed to write
+    #[error("{0}")]
     WriteError(io::Error),
     /// Underflow -- not enough bytes to form the message
+    #[error("{0}")]
     UnderflowError(String),
     /// Overflow -- message too big
+    #[error("{0}")]
     OverflowError(String),
     /// Array is too big
+    #[error("Array too long")]
     ArrayTooLong,
     /// Failed to sign
+    #[error("{0}")]
     SigningError(String),
     /// Generic error
+    #[error("{0}")]
     GenericError(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::SerializeError(ref s) => fmt::Display::fmt(s, f),
-            Error::DeserializeError(ref s) => fmt::Display::fmt(s, f),
-            Error::ReadError(ref io) => fmt::Display::fmt(io, f),
-            Error::WriteError(ref io) => fmt::Display::fmt(io, f),
-            Error::UnderflowError(ref s) => fmt::Display::fmt(s, f),
-            Error::OverflowError(ref s) => fmt::Display::fmt(s, f),
-            Error::ArrayTooLong => write!(f, "Array too long"),
-            Error::SigningError(ref s) => fmt::Display::fmt(s, f),
-            Error::GenericError(ref s) => fmt::Display::fmt(s, f),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::SerializeError(ref _s) => None,
-            Error::ReadError(ref io) => Some(io),
-            Error::DeserializeError(ref _s) => None,
-            Error::WriteError(ref io) => Some(io),
-            Error::UnderflowError(ref _s) => None,
-            Error::OverflowError(ref _s) => None,
-            Error::ArrayTooLong => None,
-            Error::SigningError(ref _s) => None,
-            Error::GenericError(ref _s) => None,
-        }
-    }
 }
 
 /// Helper trait for various primitive types that make up Stacks messages

--- a/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
@@ -164,33 +164,18 @@ display_from_debug!(Builder);
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, thiserror::Error)]
 pub enum Error {
     /// Something did a non-minimal push; for more information see
     /// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`
+    #[error("non-minimal datapush")]
     NonMinimalPush,
     /// Some opcode expected a parameter, but it was missing or truncated
+    #[error("unexpected end of script")]
     EarlyEndOfScript,
     /// Tried to read an array off the stack as a number when it was more than 4 bytes
+    #[error("numeric overflow (number on stack larger than 4 bytes)")]
     NumericOverflow,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::NonMinimalPush => write!(f, "non-minimal datapush"),
-            Error::EarlyEndOfScript => write!(f, "unexpected end of script"),
-            Error::NumericOverflow => {
-                write!(f, "numeric overflow (number on stack larger than 4 bytes)")
-            }
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
 }
 
 /// Helper to encode an integer in script format

--- a/stacks-common/src/deps_common/bitcoin/network/mod.rs
+++ b/stacks-common/src/deps_common/bitcoin/network/mod.rs
@@ -30,31 +30,15 @@ pub mod message_blockdata;
 pub mod message_network;
 
 /// Network error
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// And I/O error
-    Io(io::Error),
+    #[error("{0}")]
+    Io(#[from] io::Error),
     /// Socket mutex was poisoned
+    #[error("socket mutex was poisoned")]
     SocketMutexPoisoned,
     /// Not connected to peer
+    #[error("not connected to peer")]
     SocketNotConnectedToPeer,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Io(ref e) => fmt::Display::fmt(e, f),
-            Error::SocketMutexPoisoned => write!(f, "socket mutex was poisoned"),
-            Error::SocketNotConnectedToPeer => write!(f, "not connected to peer"),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Io(ref e) => Some(e),
-            Error::SocketMutexPoisoned | Error::SocketNotConnectedToPeer => None,
-        }
-    }
 }

--- a/stacks-common/src/deps_common/bitcoin/util/mod.rs
+++ b/stacks-common/src/deps_common/bitcoin/util/mod.rs
@@ -48,60 +48,21 @@ pub trait BitArray {
 
 /// A general error code, other errors should implement conversions to/from this
 /// if appropriate.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// secp-related error
-    Secp256k1(secp256k1::Error),
+    #[error("{0}")]
+    Secp256k1(#[from] secp256k1::Error),
     /// Serialization error
-    Serialize(serialize::Error),
+    #[error("{0}")]
+    Serialize(#[from] serialize::Error),
     /// Network error
-    Network(network::Error),
+    #[error("{0}")]
+    Network(#[from] network::Error),
     /// The header hash is not below the target
+    #[error("target correct but not attained")]
     SpvBadProofOfWork,
     /// The `target` field of a block header did not match the expected difficulty
+    #[error("target incorrect")]
     SpvBadTarget,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
-            Error::Serialize(ref e) => fmt::Display::fmt(e, f),
-            Error::Network(ref e) => fmt::Display::fmt(e, f),
-            Error::SpvBadProofOfWork => f.write_str("target correct but not attained"),
-            Error::SpvBadTarget => f.write_str("target incorrect"),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Secp256k1(ref e) => Some(e),
-            Error::Serialize(ref e) => Some(e),
-            Error::Network(ref e) => Some(e),
-            Error::SpvBadProofOfWork | Error::SpvBadTarget => None,
-        }
-    }
-}
-
-#[doc(hidden)]
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error {
-        Error::Secp256k1(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<serialize::Error> for Error {
-    fn from(e: serialize::Error) -> Error {
-        Error::Serialize(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<network::Error> for Error {
-    fn from(e: network::Error) -> Error {
-        Error::Network(e)
-    }
 }

--- a/stacks-common/src/deps_common/ctrlc/error.rs
+++ b/stacks-common/src/deps_common/ctrlc/error.rs
@@ -3,45 +3,19 @@ use std::fmt;
 use crate::deps_common::ctrlc::platform;
 
 /// Ctrl-C error.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Ctrl-C signal handler already registered.
+    #[error("Ctrl-C error: Ctrl-C signal handler already registered")]
     MultipleHandlers,
     /// Unexpected system error.
+    #[error("Ctrl-C error: Unexpected system error")]
     System(std::io::Error),
-}
-
-impl Error {
-    fn describe(&self) -> &str {
-        match *self {
-            Error::MultipleHandlers => "Ctrl-C signal handler already registered",
-            Error::System(_) => "Unexpected system error",
-        }
-    }
 }
 
 impl From<platform::Error> for Error {
     fn from(e: platform::Error) -> Error {
         let system_error = std::io::Error::new(std::io::ErrorKind::Other, e);
         Error::System(system_error)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Ctrl-C error: {}", self.describe())
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        self.describe()
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match *self {
-            Error::System(ref e) => Some(e),
-            _ => None,
-        }
     }
 }

--- a/stacks-common/src/deps_common/httparse/mod.rs
+++ b/stacks-common/src/deps_common/httparse/mod.rs
@@ -325,55 +325,33 @@ fn is_header_value_token(b: u8) -> bool {
 }
 
 /// An error in parsing.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, thiserror::Error)]
 pub enum Error {
     /// Invalid byte in header name.
+    #[error("invalid header name")]
     HeaderName,
     /// Invalid byte in header value.
+    #[error("invalid header value")]
     HeaderValue,
     /// Invalid byte in new line.
+    #[error("invalid new line")]
     NewLine,
     /// Invalid byte in Response status.
+    #[error("invalid response status")]
     Status,
     /// Invalid byte where token is required.
+    #[error("invalid token")]
     Token,
     /// Parsed more headers than provided buffer can contain.
+    #[error("too many headers")]
     TooManyHeaders,
     /// Invalid byte in HTTP version.
+    #[error("invalid HTTP version")]
     Version,
     /// Invalid chunk size
+    #[error("invalid chunk size")]
     ChunkSize,
 }
-
-impl Error {
-    #[inline]
-    fn description_str(&self) -> &'static str {
-        match *self {
-            Error::HeaderName => "invalid header name",
-            Error::HeaderValue => "invalid header value",
-            Error::NewLine => "invalid new line",
-            Error::Status => "invalid response status",
-            Error::Token => "invalid token",
-            Error::TooManyHeaders => "too many headers",
-            Error::Version => "invalid HTTP version",
-            Error::ChunkSize => "invalid chunk size",
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description_str())
-    }
-}
-
-/*
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        self.description_str()
-    }
-}
-*/
 
 /// A Result of any parsing action.
 ///
@@ -1285,6 +1263,6 @@ mod tests {
 
         use super::Error;
         let err = Error::HeaderName;
-        assert_eq!(err.to_string(), err.description_str());
+        assert_eq!(err.to_string(), format!("{err}"));
     }
 }

--- a/stacks-common/src/types/net.rs
+++ b/stacks-common/src/types/net.rs
@@ -24,25 +24,10 @@ use serde::ser::Serialize;
 
 use crate::util::hash::to_bin;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("{0}")]
     DecodeError(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::DecodeError(msg) => write!(f, "{}", &msg),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match self {
-            Error::DecodeError(_) => None,
-        }
-    }
 }
 
 /// A container for an IPv4 or IPv6 address.

--- a/stacks-common/src/util/chunked_encoding.rs
+++ b/stacks-common/src/util/chunked_encoding.rs
@@ -22,28 +22,12 @@ use crate::deps_common::httparse;
 
 /// NOTE: it is imperative that the given Read and Write impls here _never_ fail with EWOULDBLOCK.
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ChunkedError {
+    #[error("{0}")]
     DeserializeError(String),
+    #[error("{0}")]
     OverflowError(String),
-}
-
-impl fmt::Display for ChunkedError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ChunkedError::DeserializeError(ref s) => fmt::Display::fmt(s, f),
-            ChunkedError::OverflowError(ref s) => fmt::Display::fmt(s, f),
-        }
-    }
-}
-
-impl error::Error for ChunkedError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            ChunkedError::DeserializeError(..) => None,
-            ChunkedError::OverflowError(..) => None,
-        }
-    }
 }
 
 #[allow(clippy::upper_case_acronyms)]

--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -57,33 +57,14 @@ pub fn sleep_ms(millis: u64) {
 }
 
 /// Hex deserialization error
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, thiserror::Error)]
 pub enum HexError {
     /// Length was not 64 characters
+    #[error("bad length {0} for hex string")]
     BadLength(usize),
     /// Non-hex character in string
+    #[error("bad character {0} for hex string")]
     BadCharacter(char),
-}
-
-impl fmt::Display for HexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            HexError::BadLength(n) => write!(f, "bad length {} for hex string", n),
-            HexError::BadCharacter(c) => write!(f, "bad character {} for hex string", c),
-        }
-    }
-}
-
-impl error::Error for HexError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-    fn description(&self) -> &str {
-        match *self {
-            HexError::BadLength(_) => "hex string non-64 length",
-            HexError::BadCharacter(_) => "bad hex character",
-        }
-    }
 }
 
 /// Write any `serde_json` object directly to a file

--- a/stacks-common/src/util/vrf.rs
+++ b/stacks-common/src/util/vrf.rs
@@ -185,31 +185,14 @@ impl VRFPublicKey {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Invalid public key")]
     InvalidPublicKey,
+    #[error("No data could be found")]
     InvalidDataError,
+    #[error("{0}")]
     OSRNGError(rand::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::InvalidPublicKey => write!(f, "Invalid public key"),
-            Error::InvalidDataError => write!(f, "No data could be found"),
-            Error::OSRNGError(ref e) => fmt::Display::fmt(e, f),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::InvalidPublicKey => None,
-            Error::InvalidDataError => None,
-            Error::OSRNGError(ref e) => Some(e),
-        }
-    }
 }
 
 pub const SUITE: u8 = 0x03;

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -38,7 +38,7 @@ slog-json = { version = "2.3.0", optional = true }
 slog-term = "2.6.0"
 stacks-common = { path = "../stacks-common" }
 stackslib = { path = "../stackslib" }
-thiserror = "1.0"
+thiserror = { workspace = true }
 tiny_http = { version = "0.12", optional = true }
 toml = "0.5.6"
 tracing = "0.1.37"

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -58,6 +58,7 @@ libstackerdb = { path = "../libstackerdb" }
 siphasher = "0.3.7"
 hashbrown = { workspace = true }
 rusqlite = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(not(any(target_os = "macos",target_os="windows", target_arch = "arm" )))'.dependencies]
 tikv-jemallocator = {workspace = true}

--- a/stackslib/src/blockstack_cli.rs
+++ b/stackslib/src/blockstack_cli.rs
@@ -181,52 +181,23 @@ raw binary microblocks will be read from stdin.
 N.B. Stacks microblocks are not stored as files in the Stacks chainstate -- they are stored in
 block's sqlite database.";
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 enum CliError {
-    ClarityRuntimeError(RuntimeErrorType),
-    ClarityGeneralError(ClarityError),
+    #[error("Clarity error: {0}")]
+    ClarityRuntimeError(#[from] RuntimeErrorType),
+    #[error("Clarity error: {0}")]
+    ClarityGeneralError(#[from] ClarityError),
+    #[error("{0}")]
     Message(String),
+    #[error("{}", USAGE)]
     Usage,
+    #[error("Invalid chain ID: {0}")]
     InvalidChainId(std::num::ParseIntError),
-}
-
-impl std::error::Error for CliError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CliError::ClarityRuntimeError(e) => Some(e),
-            CliError::ClarityGeneralError(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl std::fmt::Display for CliError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CliError::ClarityRuntimeError(e) => write!(f, "Clarity error: {:?}", e),
-            CliError::ClarityGeneralError(e) => write!(f, "Clarity error: {}", e),
-            CliError::Message(e) => write!(f, "{}", e),
-            CliError::Usage => write!(f, "{}", USAGE),
-            CliError::InvalidChainId(e) => write!(f, "Invalid chain ID: {}", e),
-        }
-    }
 }
 
 impl From<&str> for CliError {
     fn from(value: &str) -> Self {
         CliError::Message(value.into())
-    }
-}
-
-impl From<RuntimeErrorType> for CliError {
-    fn from(value: RuntimeErrorType) -> Self {
-        CliError::ClarityRuntimeError(value)
-    }
-}
-
-impl From<ClarityError> for CliError {
-    fn from(value: ClarityError) -> Self {
-        CliError::ClarityGeneralError(value)
     }
 }
 

--- a/stackslib/src/burnchains/bitcoin/mod.rs
+++ b/stackslib/src/burnchains/bitcoin/mod.rs
@@ -45,108 +45,68 @@ pub type PeerMessage = stacks_common::deps_common::bitcoin::network::message::Ne
 // Borrowed from Andrew Poelstra's rust-bitcoin
 
 /// Network error
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// I/O error
+    #[error("{0}")]
     Io(io::Error),
     /// Not connected to peer
+    #[error("Not connected to peer")]
     SocketNotConnectedToPeer,
     /// Serialization error
+    #[error("{0}")]
     SerializationError(btc_serialize_error),
-    /// Invalid Message to peer
+    /// Invalid message to peer
+    #[error("Invalid message to send")]
     InvalidMessage(PeerMessage),
-    /// Invalid Reply from peer
+    /// Invalid reply from peer
+    #[error("Invalid reply for given message")]
     InvalidReply,
     /// Invalid magic
+    #[error("Invalid network magic")]
     InvalidMagic,
     /// Unhandled message
+    #[error("Unhandled message")]
     UnhandledMessage(PeerMessage),
     /// Connection is broken and ought to be re-established
+    #[error("Connection to peer node is broken")]
     ConnectionBroken,
     /// Connection could not be (re-)established
+    #[error("Connection to peer could not be (re-)established")]
     ConnectionError,
-    /// general filesystem error
+    /// General filesystem error
+    #[error("{0}")]
     FilesystemError(io::Error),
     /// Database error
-    DBError(db_error),
+    #[error("{0}")]
+    DBError(#[from] db_error),
     /// Hashing error
+    #[error("{0}")]
     HashError(btc_hex_error),
     /// Non-contiguous header
+    #[error("Non-contiguous header")]
     NoncontiguousHeader,
     /// Missing header
+    #[error("Missing header")]
     MissingHeader,
-    /// Invalid header proof-of-work (i.e. due to a bad timestamp or a bad `bits` field)
+    /// Invalid header proof-of-work
+    #[error("Invalid proof of work")]
     InvalidPoW,
     /// Chainwork would decrease by including a given header
+    #[error("Chain difficulty cannot decrease")]
     InvalidChainWork,
     /// Wrong number of bytes for constructing an address
+    #[error("Invalid sequence of bytes")]
     InvalidByteSequence,
     /// Configuration error
+    #[error("{0}")]
     ConfigError(String),
     /// Tried to synchronize to a point above the chain tip
+    #[error("Value is beyond the end of the blockchain")]
     BlockchainHeight,
     /// Request timed out
+    #[error("Request timed out")]
     TimedOut,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Io(ref e) => fmt::Display::fmt(e, f),
-            Error::SocketNotConnectedToPeer => write!(f, "not connected to peer"),
-            Error::SerializationError(ref e) => fmt::Display::fmt(e, f),
-            Error::InvalidMessage(ref _msg) => write!(f, "Invalid message to send"),
-            Error::InvalidReply => write!(f, "invalid reply for given message"),
-            Error::InvalidMagic => write!(f, "invalid network magic"),
-            Error::UnhandledMessage(ref _msg) => write!(f, "Unhandled message"),
-            Error::ConnectionBroken => write!(f, "connection to peer node is broken"),
-            Error::ConnectionError => write!(f, "connection to peer could not be (re-)established"),
-            Error::FilesystemError(ref e) => fmt::Display::fmt(e, f),
-            Error::DBError(ref e) => fmt::Display::fmt(e, f),
-            Error::HashError(ref e) => fmt::Display::fmt(e, f),
-            Error::NoncontiguousHeader => write!(f, "Non-contiguous header"),
-            Error::MissingHeader => write!(f, "Missing header"),
-            Error::InvalidPoW => write!(f, "Invalid proof of work"),
-            Error::InvalidChainWork => write!(f, "Chain difficulty cannot decrease"),
-            Error::InvalidByteSequence => write!(f, "Invalid sequence of bytes"),
-            Error::ConfigError(ref e_str) => fmt::Display::fmt(e_str, f),
-            Error::BlockchainHeight => write!(f, "Value is beyond the end of the blockchain"),
-            Error::TimedOut => write!(f, "Request timed out"),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Io(ref e) => Some(e),
-            Error::SocketNotConnectedToPeer => None,
-            Error::SerializationError(ref e) => Some(e),
-            Error::InvalidMessage(ref _msg) => None,
-            Error::InvalidReply => None,
-            Error::InvalidMagic => None,
-            Error::UnhandledMessage(ref _msg) => None,
-            Error::ConnectionBroken => None,
-            Error::ConnectionError => None,
-            Error::FilesystemError(ref e) => Some(e),
-            Error::DBError(ref e) => Some(e),
-            Error::HashError(ref e) => Some(e),
-            Error::NoncontiguousHeader => None,
-            Error::MissingHeader => None,
-            Error::InvalidPoW => None,
-            Error::InvalidChainWork => None,
-            Error::InvalidByteSequence => None,
-            Error::ConfigError(ref _e_str) => None,
-            Error::BlockchainHeight => None,
-            Error::TimedOut => None,
-        }
-    }
-}
-
-impl From<db_error> for Error {
-    fn from(e: db_error) -> Error {
-        Error::DBError(e)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/stackslib/src/chainstate/burn/operations/mod.rs
+++ b/stackslib/src/chainstate/burn/operations/mod.rs
@@ -51,123 +51,64 @@ pub mod vote_for_aggregate_key;
 mod test;
 
 /// This module contains all burn-chain operations
-
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Failed to parse the operation from the burnchain transaction
+    #[error("Failed to parse transaction into Blockstack operation")]
     ParseError,
     /// Invalid input data
+    #[error("Invalid input")]
     InvalidInput,
     /// Database error
-    DBError(db_error),
-
-    // block commits related errors
+    #[error("{0}")]
+    DBError(#[from] db_error),
+    // Block commits related errors
+    #[error("Block commit predates genesis block")]
     BlockCommitPredatesGenesis,
+    #[error("Block commit commits to an already-seen block")]
     BlockCommitAlreadyExists,
+    #[error("Block commit has no matching register key")]
     BlockCommitNoLeaderKey,
+    #[error("Block commit parent does not exist")]
     BlockCommitNoParent,
+    #[error("Block commit tx input does not match register key tx output")]
     BlockCommitBadInput,
-    BlockCommitBadOutputs,
+    #[error("Failure checking PoX anchor block for commit")]
     BlockCommitAnchorCheck,
+    #[error("Block commit included a bad commitment output")]
+    BlockCommitBadOutputs,
+    #[error("Block commit included a bad burn block height modulus")]
     BlockCommitBadModulus,
+    #[error("Block commit has an invalid epoch")]
     BlockCommitBadEpoch,
+    #[error("Block commit missed its target sortition height by too much")]
     BlockCommitMissDistanceTooBig,
+    #[error("Block commit included in a burn block that was not intended")]
     MissedBlockCommit(MissedBlockCommit),
-
-    // leader key register related errors
+    // Leader key register related errors
+    #[error("Leader key has already been registered")]
     LeaderKeyAlreadyRegistered,
-
-    // transfer stx related errors
+    // Transfer STX related errors
+    #[error("Transfer STX must be positive amount")]
     TransferStxMustBePositive,
+    #[error("Transfer STX must not send to self")]
     TransferStxSelfSend,
-
-    // stack stx related errors
+    // Stack STX related errors
+    #[error("Stack STX must be positive amount")]
     StackStxMustBePositive,
+    #[error("Stack STX must set num cycles between 1 and max num cycles")]
     StackStxInvalidCycles,
+    #[error("Signer key is invalid")]
     StackStxInvalidKey,
-
-    // errors associated with delegate stx
+    // Errors associated with delegate STX
+    #[error("Delegate STX must be positive amount")]
     DelegateStxMustBePositive,
-
     // sBTC errors
+    #[error("Peg in amount must be positive")]
     AmountMustBePositive,
-
-    // vote-for-aggregate-public-key errors
+    // Vote-for-aggregate-public-key errors
+    #[error("Aggregate key is invalid")]
     VoteForAggregateKeyInvalidKey,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::ParseError => write!(f, "Failed to parse transaction into Blockstack operation"),
-            Error::InvalidInput => write!(f, "Invalid input"),
-            Error::DBError(ref e) => fmt::Display::fmt(e, f),
-
-            Error::BlockCommitPredatesGenesis => write!(f, "Block commit predates genesis block"),
-            Error::BlockCommitAlreadyExists => {
-                write!(f, "Block commit commits to an already-seen block")
-            }
-            Error::BlockCommitNoLeaderKey => write!(f, "Block commit has no matching register key"),
-            Error::BlockCommitNoParent => write!(f, "Block commit parent does not exist"),
-            Error::BlockCommitBadInput => write!(
-                f,
-                "Block commit tx input does not match register key tx output"
-            ),
-            Error::BlockCommitAnchorCheck => {
-                write!(f, "Failure checking PoX anchor block for commit")
-            }
-            Error::BlockCommitBadOutputs => {
-                write!(f, "Block commit included a bad commitment output")
-            }
-            Error::BlockCommitBadModulus => {
-                write!(f, "Block commit included a bad burn block height modulus")
-            }
-            Error::BlockCommitBadEpoch => {
-                write!(f, "Block commit has an invalid epoch")
-            }
-            Error::BlockCommitMissDistanceTooBig => {
-                write!(
-                    f,
-                    "Block commit missed its target sortition height by too much"
-                )
-            }
-            Error::MissedBlockCommit(_) => write!(
-                f,
-                "Block commit included in a burn block that was not intended"
-            ),
-            Error::LeaderKeyAlreadyRegistered => {
-                write!(f, "Leader key has already been registered")
-            }
-            Error::TransferStxMustBePositive => write!(f, "Transfer STX must be positive amount"),
-            Error::TransferStxSelfSend => write!(f, "Transfer STX must not send to self"),
-            Error::StackStxMustBePositive => write!(f, "Stack STX must be positive amount"),
-            Error::StackStxInvalidCycles => write!(
-                f,
-                "Stack STX must set num cycles between 1 and max num cycles"
-            ),
-            Error::StackStxInvalidKey => write!(f, "Signer key is invalid"),
-            Error::DelegateStxMustBePositive => write!(f, "Delegate STX must be positive amount"),
-            Error::VoteForAggregateKeyInvalidKey => {
-                write!(f, "Aggregate key is invalid")
-            }
-            Self::AmountMustBePositive => write!(f, "Peg in amount must be positive"),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::DBError(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<db_error> for Error {
-    fn from(e: db_error) -> Error {
-        Error::DBError(e)
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]

--- a/stackslib/src/chainstate/stacks/index/node.rs
+++ b/stackslib/src/chainstate/stacks/index/node.rs
@@ -36,27 +36,14 @@ use crate::chainstate::stacks::index::{
     TrieLeaf, MARF_VALUE_ENCODED_SIZE,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum CursorError {
+    #[error("Path diverged")]
     PathDiverged,
+    #[error("Back-pointer encountered")]
     BackptrEncountered(TriePtr),
+    #[error("Node child not found")]
     ChrNotFound,
-}
-
-impl fmt::Display for CursorError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            CursorError::PathDiverged => write!(f, "Path diverged"),
-            CursorError::BackptrEncountered(_) => write!(f, "Back-pointer encountered"),
-            CursorError::ChrNotFound => write!(f, "Node child not found"),
-        }
-    }
-}
-
-impl error::Error for CursorError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
 }
 
 // All numeric values of a Trie node when encoded.

--- a/stackslib/src/cost_estimates/mod.rs
+++ b/stackslib/src/cost_estimates/mod.rs
@@ -181,32 +181,12 @@ pub trait CostEstimator: Send {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum EstimatorError {
+    #[error("No estimate available for the provided payload.")]
     NoEstimateAvailable,
-    SqliteError(SqliteError),
-}
-
-impl Error for EstimatorError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            EstimatorError::SqliteError(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl Display for EstimatorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EstimatorError::NoEstimateAvailable => {
-                write!(f, "No estimate available for the provided payload.")
-            }
-            EstimatorError::SqliteError(e) => {
-                write!(f, "Sqlite error from estimator: {}", e)
-            }
-        }
-    }
+    #[error("Sqlite error from estimator: {0}")]
+    SqliteError(#[from] SqliteError),
 }
 
 impl EstimatorError {

--- a/stackslib/src/cost_estimates/pessimistic.rs
+++ b/stackslib/src/cost_estimates/pessimistic.rs
@@ -246,12 +246,6 @@ impl PessimisticEstimator {
     }
 }
 
-impl From<SqliteError> for EstimatorError {
-    fn from(e: SqliteError) -> Self {
-        EstimatorError::SqliteError(e)
-    }
-}
-
 impl CostEstimator for PessimisticEstimator {
     fn notify_event(
         &mut self,

--- a/stackslib/src/net/api/getstackers.rs
+++ b/stackslib/src/net/api/getstackers.rs
@@ -51,8 +51,11 @@ pub struct GetStackersResponse {
     pub stacker_set: RewardSet,
 }
 
+#[derive(thiserror::Error, Debug)]
 pub enum GetStackersErrors {
+    #[error("Could not read reward set. Prepare phase may not have started for this cycle yet. Err = {0:?}")]
     NotAvailableYet(crate::chainstate::coordinator::Error),
+    #[error("{0}")]
     Other(String),
 }
 
@@ -71,15 +74,6 @@ impl GetStackersErrors {
 impl From<&str> for GetStackersErrors {
     fn from(value: &str) -> Self {
         GetStackersErrors::Other(value.into())
-    }
-}
-
-impl std::fmt::Display for GetStackersErrors {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GetStackersErrors::NotAvailableYet(e) => write!(f, "Could not read reward set. Prepare phase may not have started for this cycle yet. Err = {e:?}"),
-            GetStackersErrors::Other(msg) => write!(f, "{msg}")
-        }
     }
 }
 

--- a/stackslib/src/net/http/mod.rs
+++ b/stackslib/src/net/http/mod.rs
@@ -49,66 +49,32 @@ pub use crate::net::http::response::{
 };
 pub use crate::net::http::stream::HttpChunkGenerator;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Serde failed to serialize or deserialize
-    JsonError(serde_json::Error),
+    #[error("{0}")]
+    JsonError(#[from] serde_json::Error),
     /// We failed to decode something
+    #[error("{0}")]
     DecodeError(String),
     /// The underlying StacksMessageCodec failed
-    CodecError(CodecError),
+    #[error("{0}")]
+    CodecError(#[from] CodecError),
     /// Failed to write()
+    #[error("{0}")]
     WriteError(io::Error),
     /// Failed to read()
+    #[error("{0}")]
     ReadError(io::Error),
     /// Not enough bytes to parse
+    #[error("{0}")]
     UnderflowError(String),
     /// Http error response
+    #[error("code={0}, msg={1}")]
     Http(u16, String),
     /// Application error
+    #[error("{0}")]
     AppError(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::JsonError(json_error) => fmt::Display::fmt(&json_error, f),
-            Error::DecodeError(msg) => write!(f, "{}", &msg),
-            Error::CodecError(codec_error) => fmt::Display::fmt(&codec_error, f),
-            Error::WriteError(io_error) => fmt::Display::fmt(&io_error, f),
-            Error::ReadError(io_error) => fmt::Display::fmt(&io_error, f),
-            Error::UnderflowError(msg) => write!(f, "{}", msg),
-            Error::Http(code, msg) => write!(f, "code={}, msg={}", code, msg),
-            Error::AppError(msg) => write!(f, "{}", &msg),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match self {
-            Error::JsonError(json_error) => Some(json_error),
-            Error::DecodeError(_) => None,
-            Error::CodecError(codec_error) => Some(codec_error),
-            Error::WriteError(io_error) => Some(io_error),
-            Error::ReadError(io_error) => Some(io_error),
-            Error::UnderflowError(_) => None,
-            Error::Http(..) => None,
-            Error::AppError(_) => None,
-        }
-    }
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(e: serde_json::Error) -> Error {
-        Error::JsonError(e)
-    }
-}
-
-impl From<CodecError> for Error {
-    fn from(e: CodecError) -> Error {
-        Error::CodecError(e)
-    }
 }
 
 impl Error {

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -32,6 +32,7 @@ rusqlite = { workspace = true }
 async-h1 = { version = "2.3.2", optional = true }
 async-std = { version = "1.6", optional = true, features = ["attributes"] }
 http-types = { version = "2.12", optional = true }
+thiserror = { workspace = true }
 
 [target.'cfg(not(any(target_os = "macos", target_os="windows", target_arch = "arm")))'.dependencies]
 tikv-jemallocator = {workspace = true}

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -1,7 +1,6 @@
 pub mod bitcoin_regtest_controller;
 pub mod mocknet_controller;
 
-use std::fmt;
 use std::time::Instant;
 
 use stacks::burnchains;
@@ -16,39 +15,24 @@ pub use self::bitcoin_regtest_controller::{make_bitcoin_indexer, BitcoinRegtestC
 pub use self::mocknet_controller::MocknetController;
 use super::operations::BurnchainOpSigner;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("ChainsCoordinator closed")]
     CoordinatorClosed,
-    IndexerError(burnchains::Error),
+    #[error("Indexer error: {0}")]
+    IndexerError(#[from] burnchains::Error),
+    #[error("Burnchain error")]
     BurnchainError,
+    #[error("Max fee rate exceeded")]
     MaxFeeRateExceeded,
+    #[error("Identical operation, not submitting")]
     IdenticalOperation,
+    #[error("No UTXOs available")]
     NoUTXOs,
+    #[error("Transaction submission failed: {0}")]
     TransactionSubmissionFailed(String),
+    #[error("Serializer error: {0}")]
     SerializerError(CodecError),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::CoordinatorClosed => write!(f, "ChainsCoordinator closed"),
-            Error::IndexerError(ref e) => write!(f, "Indexer error: {:?}", e),
-            Error::BurnchainError => write!(f, "Burnchain error"),
-            Error::MaxFeeRateExceeded => write!(f, "Max fee rate exceeded"),
-            Error::IdenticalOperation => write!(f, "Identical operation, not submitting"),
-            Error::NoUTXOs => write!(f, "No UTXOs available"),
-            Error::TransactionSubmissionFailed(e) => {
-                write!(f, "Transaction submission failed: {e}")
-            }
-            Error::SerializerError(e) => write!(f, "Serializer error: {e}"),
-        }
-    }
-}
-
-impl From<burnchains::Error> for Error {
-    fn from(e: burnchains::Error) -> Self {
-        Error::IndexerError(e)
-    }
 }
 
 pub trait BurnchainController {

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -17,19 +17,12 @@ use crate::helium::RunLoop;
 use crate::tests::to_addr;
 use crate::Config;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum BitcoinCoreError {
+    #[error("bitcoind spawn failed: {0}")]
     SpawnFailed(String),
+    #[error("bitcoind stop failed: {0}")]
     StopFailed(String),
-}
-
-impl std::fmt::Display for BitcoinCoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SpawnFailed(msg) => write!(f, "bitcoind spawn failed: {msg}"),
-            Self::StopFailed(msg) => write!(f, "bitcoind stop failed: {msg}"),
-        }
-    }
 }
 
 type BitcoinResult<T> = Result<T, BitcoinCoreError>;


### PR DESCRIPTION
There is only one instance of custom fmt display I didn't modify because it was feature gated so figured shoudln't mess with it. In general though description() is deprecated so should really be replaced. Welcome to revert any unwanted error modifications/or to take feedback on better error messages.