### PR TITLE
feat: remove panic in DB busy handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ### Changed
 - Add index for StacksBlockId to nakamoto block headers table (improves node performance)
+- Remove the panic for reporting DB deadlocks (just error and continue waiting)
 
 ## [3.0.0.0.0]
 


### PR DESCRIPTION
Instead of panicking after 5m, just print an error with a backtrace every 5 minutes. This is sufficient to detect the situation without the need to crash the node and potentially corrupt chainstate.