### PR TITLE
feat(wasm): use only one `Engine` per global context

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -399,6 +399,7 @@ pub fn initialize_contract(
     let mut call_stack = CallStack::new();
     let epoch = global_context.epoch_id;
     let clarity_version = *contract_context.get_clarity_version();
+    let engine = global_context.engine.clone();
     let init_context = ClarityWasmContext::new_init(
         global_context,
         contract_context,
@@ -408,7 +409,6 @@ pub fn initialize_contract(
         sponsor.clone(),
         Some(contract_analysis),
     );
-    let engine = Engine::default();
     let module = init_context
         .contract_context()
         .with_wasm_module(|wasm_module| {
@@ -485,6 +485,7 @@ pub fn call_function<'a>(
 ) -> Result<Value, Error> {
     let epoch = global_context.epoch_id;
     let clarity_version = *contract_context.get_clarity_version();
+    let engine = global_context.engine.clone();
     let context = ClarityWasmContext::new_run(
         global_context,
         contract_context,
@@ -499,7 +500,6 @@ pub fn call_function<'a>(
         .contract_context()
         .lookup_function(function_name)
         .ok_or(CheckErrors::UndefinedFunction(function_name.to_string()))?;
-    let engine = Engine::default();
     let module = context
         .contract_context()
         .with_wasm_module(|wasm_module| unsafe {

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -24,10 +24,11 @@ use serde_json::json;
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::StacksEpochId;
+use wasmtime::{Engine, Linker};
 
 use super::analysis::{self, ContractAnalysis};
 #[cfg(feature = "clarity-wasm")]
-use super::clarity_wasm::call_function;
+use super::clarity_wasm::{call_function, ClarityWasmContext};
 use super::EvalHook;
 use crate::vm::ast::{ASTRules, ContractAST};
 use crate::vm::callables::{DefinedFunction, FunctionIdentifier};
@@ -206,6 +207,7 @@ pub struct GlobalContext<'a> {
     /// This is the chain ID of the transaction
     pub chain_id: u32,
     pub eval_hooks: Option<Vec<&'a mut dyn EvalHook>>,
+    pub engine: Engine,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -1653,6 +1655,8 @@ impl<'a> GlobalContext<'a> {
         cost_track: LimitedCostTracker,
         epoch_id: StacksEpochId,
     ) -> GlobalContext {
+        let engine = Engine::default();
+
         GlobalContext {
             database,
             cost_track,
@@ -1663,6 +1667,7 @@ impl<'a> GlobalContext<'a> {
             epoch_id,
             chain_id,
             eval_hooks: None,
+            engine,
         }
     }
 


### PR DESCRIPTION
Instantiating a `wasmtime::Engine` is an expensive operation, so it is best to do it only once for the duration of a `GlobalContext`. Cloning an engine is, however, not an expensive operation (just an `Arc::clone`) and we use it to avoid referring to the global context already referred to by the instantiated `ClarityWasmContext`.

See-also: https://github.com/stacks-network/clarity-wasm/issues/468