### PR TITLE
DRAFT - POC for managing version across binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,6 +3062,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,6 +3299,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_stacker",
+ "serde_yaml",
  "sha2 0.10.8",
  "sha3",
  "slog",
@@ -3971,6 +3985,12 @@ dependencies = [
  "generic-array 0.14.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -53,6 +53,8 @@ use blockstack_lib::version_string;
 use clarity::codec::StacksMessageCodec;
 use clarity::vm::types::QualifiedContractIdentifier;
 use lazy_static::lazy_static;
+use stacks_common::util::versions::get_long_version;
+
 
 pub use crate::error::{EventError, RPCError};
 pub use crate::events::{
@@ -80,7 +82,6 @@ pub trait SignerMessage<T: MessageSlotID>: StacksMessageCodec {
 lazy_static! {
     /// The version string for the signer
     pub static ref VERSION_STRING: String = {
-        let pkg_version = option_env!("STACKS_NODE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-        version_string("stacks-signer", pkg_version)
+        get_long_version("stacks-signer")
     };
 }

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -1,14 +1,25 @@
 [package]
 name = "stacks-common"
 version = "0.0.1"
-authors = [ "Jude Nelson <jude@stacks.org>",
-            "Aaron Blankstein <aaron@blockstack.com>",
-            "Ludo Galabru <ludovic@blockstack.com>" ]
+authors = [
+    "Jude Nelson <jude@stacks.org>",
+    "Aaron Blankstein <aaron@blockstack.com>",
+    "Ludo Galabru <ludovic@blockstack.com>",
+]
 license = "GPLv3"
 homepage = "https://github.com/blockstack/stacks-blockchain"
 repository = "https://github.com/blockstack/stacks-blockchain"
 description = "Common modules for blockstack_lib, libclarity"
-keywords = [ "stacks", "stx", "bitcoin", "crypto", "blockstack", "decentralized", "dapps", "blockchain" ]
+keywords = [
+    "stacks",
+    "stx",
+    "bitcoin",
+    "crypto",
+    "blockstack",
+    "decentralized",
+    "dapps",
+    "blockchain",
+]
 readme = "README.md"
 resolver = "2"
 edition = "2021"
@@ -22,11 +33,12 @@ rand = { workspace = true }
 serde = "1"
 serde_derive = "1"
 serde_stacker = "0.1"
+serde_yaml = "0.9"
 sha3 = "0.10.1"
 ripemd = "0.1.1"
 lazy_static = "1.4.0"
 percent-encoding = "2.1.0"
-slog = { version = "2.5.2", features = [ "max_level_trace" ] }
+slog = { version = "2.5.2", features = ["max_level_trace"] }
 slog-term = "2.6.0"
 slog-json = { version = "2.3.0", optional = true }
 chrono = "0.4.19"
@@ -34,11 +46,21 @@ libc = "0.2.82"
 hashbrown = { workspace = true }
 rusqlite = { workspace = true, optional = true }
 
+[build-dependencies]
+serde = "1"
+serde_derive = "1"
+serde_yaml = "0.9"
+
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }
+winapi = { version = "0.3", features = [
+    "consoleapi",
+    "handleapi",
+    "synchapi",
+    "winbase",
+] }
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3", features = ["fileapi", "processenv", "winnt"] }

--- a/stacks-common/build.rs
+++ b/stacks-common/build.rs
@@ -1,0 +1,60 @@
+use serde_derive::Serialize;
+use serde_derive::Deserialize;
+use std::fs::File;
+use std::io::Write;
+use std::env;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Versions {
+    stacks_node: String,
+    stacks_signer: String,
+    blockstack_cli: String,
+    clarity_cli: String,
+    relay_server: String,
+    stacks_inspect: String,
+}
+
+// get Versions struct from versions.yaml
+fn get_build_versions() -> Versions {
+    let file = File::open("versions.yaml").expect("Unable to open file");
+    let versions: Versions = serde_yaml::from_reader(file).expect("Unable to read file");
+    versions
+}
+
+// override build versions with environment variables if they exist otherwise use passed in Versions struct
+fn set_build_versions() {
+
+    let mut versions = get_build_versions();
+
+    if let Ok(val) = env::var("STACKS_NODE_VERSION") {
+        versions.stacks_node = val;
+    }
+    if let Ok(val) = env::var("STACKS_SIGNER_VERSION") {
+        versions.stacks_signer = val;
+    }
+    if let Ok(val) = env::var("BLOCKSTACK_CLI_VERSION") {
+        versions.blockstack_cli = val;
+    }
+    if let Ok(val) = env::var("CLARITY_CLI_VERSION") {
+        versions.clarity_cli = val;
+    }
+    if let Ok(val) = env::var("RELAY_SERVER_VERSION") {
+        versions.relay_server = val;
+    }
+    if let Ok(val) = env::var("STACKS_INSPECT_VERSION") {
+        versions.stacks_inspect = val;
+    }
+    write_build_versions(&versions, "versions.yaml");
+}
+
+
+
+fn write_build_versions(versions: &Versions, path: &str) {
+    let yaml_string = serde_yaml::to_string(&versions).unwrap();
+    let mut file = File::create(path).expect("Unable to create file");
+    file.write_all(yaml_string.as_bytes()).expect("Unable to write data to path");
+}
+
+fn main() {
+    set_build_versions();
+}

--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -26,6 +26,7 @@ pub mod pipe;
 pub mod retry;
 pub mod secp256k1;
 pub mod uint;
+pub mod versions;
 pub mod vrf;
 
 use std::collections::HashMap;

--- a/stacks-common/src/util/versions.rs
+++ b/stacks-common/src/util/versions.rs
@@ -1,0 +1,32 @@
+use serde::Serialize;
+use serde::Deserialize;
+use std::fs::File;
+
+#[derive(Serialize, Deserialize)]
+struct Versions {
+    stacks_node: String,
+    stacks_signer: String,
+    blockstack_cli: String,
+    clarity_cli: String,
+    relay_server: String,
+    stacks_inspect: String,
+}
+
+pub fn get_build_version(binary: &str) -> String {
+    let versions = get_build_versions();
+    match binary {
+        "stacks-node" => versions.stacks_node,
+        "stacks-signer" => versions.stacks_signer,
+        "blockstack-cli" => versions.blockstack_cli,
+        "clarity-cli" => versions.clarity_cli,
+        "relay-server" => versions.relay_server,
+        "stacks-inspect" => versions.stacks_inspect,
+        _ => panic!("Binary not found"),
+    }
+}
+
+fn get_build_versions() -> Versions {
+    let file = File::open("../../versions.yaml").expect("Unable to open versions.yaml");
+    let versions: Versions = serde_yaml::from_reader(file).expect("Unable to read versions.yaml");
+    versions
+}

--- a/stacks-common/src/util/versions.rs
+++ b/stacks-common/src/util/versions.rs
@@ -25,8 +25,58 @@ pub fn get_build_version(binary: &str) -> String {
     }
 }
 
+pub fn get_long_version(binary: &str) -> String {
+    let build_version = get_build_version(binary);
+    format!("{} ({}, {}, {})", build_version, get_target_build_type(), get_target_os(), get_target_arch())
+}
+
+fn get_target_arch() -> String {
+    let architecture = if cfg!(target_arch = "x86") { 
+        "x86" 
+    } 
+    else if cfg!(target_arch = "x86_64") { 
+        "x86_64" 
+    } 
+    else if cfg!(target_arch = "arm") {
+         "ARM" 
+    } 
+    else if cfg!(target_arch = "aarch64") {
+         "AArch64" 
+    } 
+    else { 
+        "unknown"
+    };
+    architecture.to_string()
+}
+
+fn get_target_os() -> String {
+    let os = if cfg!(target_os = "linux") { 
+        "Linux" 
+    } 
+    else if cfg!(target_os = "macos") { 
+        "macOS" 
+    } 
+    else if cfg!(target_os = "windows") {
+         "Windows" 
+    } 
+    else { 
+        "unknown"
+    };
+    os.to_string()
+}
+
+fn get_target_build_type() -> String {
+    let build_type = if cfg!(debug_assertions) { 
+        "Debug" 
+    } 
+    else { 
+        "Release" 
+    };
+    build_type.to_string()
+}
+
 fn get_build_versions() -> Versions {
-    let file = File::open("../../versions.yaml").expect("Unable to open versions.yaml");
-    let versions: Versions = serde_yaml::from_reader(file).expect("Unable to read versions.yaml");
+    let versions_content = include_str!("../../versions.yaml");
+    let versions: Versions = serde_yaml::from_str(versions_content).expect("Unable to read versions.yaml");
     versions
 }

--- a/stacks-common/versions.yaml
+++ b/stacks-common/versions.yaml
@@ -1,0 +1,6 @@
+stacks_node: 3.0.0.0
+stacks_signer: 3.0.0.0.2
+blockstack_cli: 3.0.0.0.2
+clarity_cli: 3.0.0.0.2
+relay_server: 3.0.0.0.2
+stacks_inspect: 3.0.0.0.2

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -75,8 +75,6 @@ pub enum Command {
     VerifyVote(VerifyVoteArgs),
     /// Verify signer signatures by checking stackerdb slots contain the correct data
     MonitorSigners(MonitorSignersArgs),
-    /// Show custom version string
-    Version(VersionArgs),
 }
 
 /// Basic arguments for all cyrptographic and stacker-db functionality

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -75,6 +75,8 @@ pub enum Command {
     VerifyVote(VerifyVoteArgs),
     /// Verify signer signatures by checking stackerdb slots contain the correct data
     MonitorSigners(MonitorSignersArgs),
+    /// Show custom version string
+    Version(VersionArgs),
 }
 
 /// Basic arguments for all cyrptographic and stacker-db functionality
@@ -248,6 +250,11 @@ pub struct MonitorSignersArgs {
     /// Max age in seconds before a signer message is considered stale.
     #[arg(long, short, default_value = "1200")]
     pub max_age: u64,
+}
+
+#[derive(Parser, Debug, Clone)]
+/// Arguments for the Version command
+pub struct VersionArgs {
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -37,6 +37,7 @@ use libstackerdb::StackerDBChunkData;
 use slog::{slog_debug, slog_error};
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::MessageSignature;
+use stacks_common::util::versions::get_build_version;
 use stacks_common::{debug, error};
 use stacks_signer::cli::{
     Cli, Command, GenerateStackingSignatureArgs, GenerateVoteArgs, GetChunkArgs,
@@ -240,6 +241,9 @@ fn main() {
         }
         Command::MonitorSigners(args) => {
             handle_monitor_signers(args);
+        }
+        Command::Version(args) => {
+            println!("stacks-signer {}", get_build_version("stacks-signer"));
         }
     }
 }

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -204,6 +204,7 @@ fn handle_monitor_signers(args: MonitorSignersArgs) {
 }
 
 fn main() {
+
     let cli = Cli::parse();
 
     tracing_subscriber::registry()
@@ -241,9 +242,6 @@ fn main() {
         }
         Command::MonitorSigners(args) => {
             handle_monitor_signers(args);
-        }
-        Command::Version(args) => {
-            println!("stacks-signer {}", get_build_version("stacks-signer"));
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `stacks-common` and `stacks-signer` modules to enhance version handling and improve code organization. The most important changes include the addition of a new `versions` module, updates to the `Cargo.toml` file, and modifications to the `build.rs` file to handle version information more efficiently.

Enhancements to version handling:

* [`stacks-common/src/util/versions.rs`](diffhunk://#diff-a6339761e0575727f115a09e1f5a7593f09e3552352d6d5649a4a67729d65cccR1-R82): Added a new `versions` module that includes functions to retrieve and format build versions for different binaries.
* [`stacks-common/build.rs`](diffhunk://#diff-f17e7f7be40eb7b4ff9249e9c0aac6dd078ad0d5654d72784251efcfccaa04dcR1-R60): Introduced a new `Versions` struct and functions to read version information from a `versions.yaml` file and override it with environment variables if they exist.

Code organization improvements:

* [`stacks-common/Cargo.toml`](diffhunk://#diff-d6073b2cc665ed957bc8cbe850b26831d54dc3d44977867691a2835e942f6825L4-R22): Reformatted the `authors` and `keywords` fields for better readability and added new dependencies for `serde` and `serde_yaml`. [[1]](diffhunk://#diff-d6073b2cc665ed957bc8cbe850b26831d54dc3d44977867691a2835e942f6825L4-R22) [[2]](diffhunk://#diff-d6073b2cc665ed957bc8cbe850b26831d54dc3d44977867691a2835e942f6825R36) [[3]](diffhunk://#diff-d6073b2cc665ed957bc8cbe850b26831d54dc3d44977867691a2835e942f6825R49-R63)
* [`stacks-common/src/util/mod.rs`](diffhunk://#diff-fa401a6f5cd0b77011fc893a6d4cdd2f9d5a69f83df307b0f28885aadbe09d5dR29): Added the newly created `versions` module to the list of public modules.

Updates to `stacks-signer`:

* [`stacks-signer/src/libsigner.rs`](diffhunk://#diff-5003638492fc91ab51df9cf907489b01197135920df7424bd3b69112fded5e4fL83-R85): Replaced the manual version string construction with the new `get_long_version` function from the `versions` module.
* [`stacks-signer/src/main.rs`](diffhunk://#diff-d94456f1e25e610a1b7d4a3ade3219476fd571ac77eb2c29fffe2889e74761e1R40): Integrated the `get_build_version` function from the `versions` module to retrieve build version information.
 
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
