### PR TITLE
Add timestamp calculation to all block responses

### DIFF
--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Changed
 
 - Add tenure extend timestamp to signer block responses
+- Added tenure_idle_timeout_secs configuration option for determining when a tenure extend will be accepted
 
 ## [3.0.0.0.1.0]
 

--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -122,6 +122,8 @@ pub struct ProposalEvalConfig {
     /// Time to wait for the last block of a tenure to be globally accepted or rejected before considering
     /// a new miner's block at the same height as valid.
     pub tenure_last_block_proposal_timeout: Duration,
+    /// How much idle time must pass before allowing a tenure extend
+    pub tenure_idle_timeout: Duration,
 }
 
 impl From<&SignerConfig> for ProposalEvalConfig {
@@ -130,6 +132,7 @@ impl From<&SignerConfig> for ProposalEvalConfig {
             first_proposal_burn_block_timing: value.first_proposal_burn_block_timing,
             block_proposal_timeout: value.block_proposal_timeout,
             tenure_last_block_proposal_timeout: value.tenure_last_block_proposal_timeout,
+            tenure_idle_timeout: value.tenure_idle_timeout,
         }
     }
 }

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -413,6 +413,7 @@ pub(crate) mod tests {
             block_proposal_timeout: config.block_proposal_timeout,
             tenure_last_block_proposal_timeout: config.tenure_last_block_proposal_timeout,
             block_proposal_validation_timeout: config.block_proposal_validation_timeout,
+            tenure_idle_timeout: config.tenure_idle_timeout,
         }
     }
 

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -38,6 +38,7 @@ const BLOCK_PROPOSAL_TIMEOUT_MS: u64 = 600_000;
 const BLOCK_PROPOSAL_VALIDATION_TIMEOUT_MS: u64 = 120_000;
 const DEFAULT_FIRST_PROPOSAL_BURN_BLOCK_TIMING_SECS: u64 = 60;
 const DEFAULT_TENURE_LAST_BLOCK_PROPOSAL_TIMEOUT_SECS: u64 = 30;
+const TENURE_IDLE_TIMEOUT_SECS: u64 = 300;
 
 #[derive(thiserror::Error, Debug)]
 /// An error occurred parsing the provided configuration
@@ -135,6 +136,8 @@ pub struct SignerConfig {
     pub tenure_last_block_proposal_timeout: Duration,
     /// How much time to wait for a block proposal validation response before marking the block invalid
     pub block_proposal_validation_timeout: Duration,
+    /// How much idle tie must pass before allowing a tenure extend
+    pub tenure_idle_timeout: Duration,
 }
 
 /// The parsed configuration for the signer
@@ -171,6 +174,8 @@ pub struct GlobalConfig {
     /// How long to wait for a response from a block proposal validation response from the node
     /// before marking that block as invalid and rejecting it
     pub block_proposal_validation_timeout: Duration,
+    /// How much idle time must pass before allowing a tenure extend
+    pub tenure_idle_timeout: Duration,
 }
 
 /// Internal struct for loading up the config file
@@ -206,6 +211,8 @@ struct RawConfigFile {
     /// How long to wait (in millisecs) for a response from a block proposal validation response from the node
     /// before marking that block as invalid and rejecting it
     pub block_proposal_validation_timeout_ms: Option<u64>,
+    /// How much idle time (in seconds) must pass before a tenure extend is allowed
+    pub tenure_idle_timeout_secs: Option<u64>,
 }
 
 impl RawConfigFile {
@@ -297,6 +304,12 @@ impl TryFrom<RawConfigFile> for GlobalConfig {
                 .unwrap_or(BLOCK_PROPOSAL_VALIDATION_TIMEOUT_MS),
         );
 
+        let tenure_idle_timeout = Duration::from_secs(
+            raw_data
+                .tenure_idle_timeout_secs
+                .unwrap_or(TENURE_IDLE_TIMEOUT_SECS),
+        );
+
         Ok(Self {
             node_host: raw_data.node_host,
             endpoint,
@@ -312,6 +325,7 @@ impl TryFrom<RawConfigFile> for GlobalConfig {
             chain_id: raw_data.chain_id,
             tenure_last_block_proposal_timeout,
             block_proposal_validation_timeout,
+            tenure_idle_timeout,
         })
     }
 }

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -136,7 +136,7 @@ pub struct SignerConfig {
     pub tenure_last_block_proposal_timeout: Duration,
     /// How much time to wait for a block proposal validation response before marking the block invalid
     pub block_proposal_validation_timeout: Duration,
-    /// How much idle tie must pass before allowing a tenure extend
+    /// How much idle time must pass before allowing a tenure extend
     pub tenure_idle_timeout: Duration,
 }
 

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -285,6 +285,7 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
             block_proposal_timeout: self.config.block_proposal_timeout,
             tenure_last_block_proposal_timeout: self.config.tenure_last_block_proposal_timeout,
             block_proposal_validation_timeout: self.config.block_proposal_validation_timeout,
+            tenure_idle_timeout: self.config.tenure_idle_timeout,
         }))
     }
 

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -157,7 +157,7 @@ pub struct BlockInfo {
     pub signed_group: Option<u64>,
     /// The block state relative to the signer's view of the stacks blockchain
     pub state: BlockState,
-    /// Amount of validation time in milliseconds
+    /// Consumed processing time in milliseconds to validate this block
     pub validation_time_ms: Option<u64>,
     /// Extra data specific to v0, v1, etc.
     pub ext: ExtraBlockInfo,

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -157,10 +157,10 @@ pub struct BlockInfo {
     pub signed_group: Option<u64>,
     /// The block state relative to the signer's view of the stacks blockchain
     pub state: BlockState,
+    /// Amount of validation time in milliseconds
+    pub validation_time_ms: Option<u64>,
     /// Extra data specific to v0, v1, etc.
     pub ext: ExtraBlockInfo,
-    /// Time at which the proposal was processed (epoch time in seconds)
-    pub processed_time: Option<u64>,
 }
 
 impl From<BlockProposal> for BlockInfo {
@@ -177,7 +177,7 @@ impl From<BlockProposal> for BlockInfo {
             signed_group: None,
             ext: ExtraBlockInfo::default(),
             state: BlockState::Unprocessed,
-            processed_time: None,
+            validation_time_ms: None,
         }
     }
 }
@@ -193,7 +193,6 @@ impl BlockInfo {
         } else {
             self.signed_self.get_or_insert(get_epoch_time_secs());
         }
-        self.processed_time = Some(get_epoch_time_secs());
         Ok(())
     }
 
@@ -819,7 +818,7 @@ impl SignerDb {
         &self,
         tenure: &ConsensusHash,
     ) -> Result<Vec<BlockInfo>, DBError> {
-        let query = "SELECT block_info FROM blocks WHERE consensus_hash = ?1 AND json_extract(block_info, '$.state') = ?2";
+        let query = "SELECT block_info FROM blocks WHERE consensus_hash = ?1 AND json_extract(block_info, '$.state') = ?2 ORDER BY stacks_height DESC";
         let args = params![tenure, &BlockState::GloballyAccepted.to_string()];
         let result: Vec<String> = query_rows(&self.db, query, args)?;
         result
@@ -1365,14 +1364,12 @@ mod tests {
 
         // Verify tenure consensus_hash_1
         let block_infos = db.get_globally_accepted_blocks(&consensus_hash_1).unwrap();
-        assert_eq!(block_infos.len(), 2);
-        assert!(block_infos.contains(&block_info_1));
-        assert!(block_infos.contains(&block_info_3));
+        assert_eq!(block_infos, vec![block_info_3, block_info_1]);
 
         // Verify tenure consensus_hash_2
         let block_infos = db.get_globally_accepted_blocks(&consensus_hash_2).unwrap();
         assert_eq!(block_infos.len(), 1);
-        assert!(block_infos.contains(&block_info_4));
+        assert_eq!(block_infos, vec![block_info_4]);
 
         // Verify tenure consensus_hash_3
         assert!(db

--- a/stacks-signer/src/tests/chainstate.rs
+++ b/stacks-signer/src/tests/chainstate.rs
@@ -90,6 +90,7 @@ fn setup_test_environment(
             first_proposal_burn_block_timing: Duration::from_secs(30),
             block_proposal_timeout: Duration::from_secs(5),
             tenure_last_block_proposal_timeout: Duration::from_secs(30),
+            tenure_idle_timeout: Duration::from_secs(300),
         },
     };
 

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -22,7 +22,7 @@ use blockstack_lib::chainstate::stacks::TransactionPayload;
 use blockstack_lib::net::api::postblock_proposal::{
     BlockValidateOk, BlockValidateReject, BlockValidateResponse,
 };
-use clarity::types::chainstate::StacksPrivateKey;
+use clarity::types::chainstate::{ConsensusHash, StacksPrivateKey};
 use clarity::types::{PrivateKey, StacksEpochId};
 use clarity::util::hash::MerkleHashFunc;
 use clarity::util::secp256k1::Secp256k1PublicKey;
@@ -134,7 +134,7 @@ impl SignerTrait<SignerMessage> for Signer {
         if event_parity == Some(other_signer_parity) {
             return;
         }
-        self.check_submitted_block_proposal(stacks_client, sortition_state);
+        self.check_submitted_block_proposal();
         debug!("{self}: Processing event: {event:?}");
         let Some(event) = event else {
             // No event. Do nothing.
@@ -144,11 +144,7 @@ impl SignerTrait<SignerMessage> for Signer {
         match event {
             SignerEvent::BlockValidationResponse(block_validate_response) => {
                 debug!("{self}: Received a block proposal result from the stacks node...");
-                self.handle_block_validate_response(
-                    stacks_client,
-                    block_validate_response,
-                    sortition_state,
-                )
+                self.handle_block_validate_response(stacks_client, block_validate_response)
             }
             SignerEvent::SignerMessages(_signer_set, messages) => {
                 debug!(
@@ -296,12 +292,7 @@ impl Signer {
     /// Determine this signers response to a proposed block
     /// Returns a BlockResponse if we have already validated the block
     /// Returns None otherwise
-    fn determine_response(
-        &self,
-        block_info: &BlockInfo,
-        stacks_client: &StacksClient,
-        sortition_state: &mut Option<SortitionsView>,
-    ) -> Option<BlockResponse> {
+    fn determine_response(&self, block_info: &BlockInfo) -> Option<BlockResponse> {
         let valid = block_info.valid?;
         let response = if valid {
             debug!("{self}: Accepting block {}", block_info.block.block_id());
@@ -312,7 +303,7 @@ impl Signer {
             BlockResponse::accepted(
                 block_info.signer_signature_hash(),
                 signature,
-                self.calculate_tenure_extend_timestamp(stacks_client, sortition_state),
+                self.calculate_tenure_extend_timestamp(&block_info.block.header.consensus_hash),
             )
         } else {
             debug!("{self}: Rejecting block {}", block_info.block.block_id());
@@ -321,7 +312,7 @@ impl Signer {
                 RejectCode::RejectedInPriorRound,
                 &self.private_key,
                 self.mainnet,
-                self.calculate_tenure_extend_timestamp(stacks_client, sortition_state),
+                self.calculate_tenure_extend_timestamp(&block_info.block.header.consensus_hash),
             )
         };
         Some(response)
@@ -353,9 +344,7 @@ impl Signer {
             .block_lookup(self.reward_cycle, &signer_signature_hash)
             .expect("Failed to connect to signer DB")
         {
-            let Some(block_response) =
-                self.determine_response(&block_info, stacks_client, sortition_state)
-            else {
+            let Some(block_response) = self.determine_response(&block_info) else {
                 // We are still waiting for a response for this block. Do nothing.
                 debug!("{self}: Received a block proposal for a block we are already validating.";
                     "signer_sighash" => %signer_signature_hash,
@@ -404,8 +393,6 @@ impl Signer {
                     .ok();
         }
 
-        let tenure_extend_timestamp =
-            self.calculate_tenure_extend_timestamp(stacks_client, sortition_state);
         // Check if proposal can be rejected now if not valid against sortition view
         let block_response = if let Some(sortition_state) = sortition_state {
             match sortition_state.check_proposal(
@@ -428,7 +415,9 @@ impl Signer {
                         RejectCode::ConnectivityIssues,
                         &self.private_key,
                         self.mainnet,
-                        tenure_extend_timestamp,
+                        self.calculate_tenure_extend_timestamp(
+                            &block_proposal.block.header.consensus_hash,
+                        ),
                     ))
                 }
                 // Block proposal is bad
@@ -443,7 +432,9 @@ impl Signer {
                         RejectCode::SortitionViewMismatch,
                         &self.private_key,
                         self.mainnet,
-                        tenure_extend_timestamp,
+                        self.calculate_tenure_extend_timestamp(
+                            &block_proposal.block.header.consensus_hash,
+                        ),
                     ))
                 }
                 // Block proposal passed check, still don't know if valid
@@ -460,7 +451,7 @@ impl Signer {
                 RejectCode::NoSortitionView,
                 &self.private_key,
                 self.mainnet,
-                tenure_extend_timestamp,
+                self.calculate_tenure_extend_timestamp(&block_proposal.block.header.consensus_hash),
             ))
         };
 
@@ -488,7 +479,7 @@ impl Signer {
             }
         } else {
             // Just in case check if the last block validation submission timed out.
-            self.check_submitted_block_proposal(stacks_client, sortition_state);
+            self.check_submitted_block_proposal();
             if self.submitted_block_proposal.is_none() {
                 // We don't know if proposal is valid, submit to stacks-node for further checks and store it locally.
                 info!(
@@ -542,7 +533,6 @@ impl Signer {
         &mut self,
         stacks_client: &StacksClient,
         block_validate_ok: &BlockValidateOk,
-        sortition_state: &mut Option<SortitionsView>,
     ) -> Option<BlockResponse> {
         crate::monitoring::increment_block_validation_responses(true);
         let signer_signature_hash = block_validate_ok.signer_signature_hash;
@@ -598,7 +588,7 @@ impl Signer {
         let accepted = BlockAccepted::new(
             block_info.signer_signature_hash(),
             signature,
-            self.calculate_tenure_extend_timestamp(stacks_client, sortition_state),
+            self.calculate_tenure_extend_timestamp(&block_info.block.header.consensus_hash),
         );
         // have to save the signature _after_ the block info
         self.handle_block_signature(stacks_client, &accepted);
@@ -608,9 +598,7 @@ impl Signer {
     /// Handle the block validate reject response. Returns our block response if we have one
     fn handle_block_validate_reject(
         &mut self,
-        stacks_client: &StacksClient,
         block_validate_reject: &BlockValidateReject,
-        sortition_state: &mut Option<SortitionsView>,
     ) -> Option<BlockResponse> {
         crate::monitoring::increment_block_validation_responses(false);
         let signer_signature_hash = block_validate_reject.signer_signature_hash;
@@ -655,7 +643,7 @@ impl Signer {
             block_validate_reject.clone(),
             &self.private_key,
             self.mainnet,
-            self.calculate_tenure_extend_timestamp(stacks_client, sortition_state),
+            self.calculate_tenure_extend_timestamp(&block_info.block.header.consensus_hash),
         );
         self.signer_db
             .insert_block(&block_info)
@@ -669,19 +657,15 @@ impl Signer {
         &mut self,
         stacks_client: &StacksClient,
         block_validate_response: &BlockValidateResponse,
-        sortition_state: &mut Option<SortitionsView>,
     ) {
         info!("{self}: Received a block validate response: {block_validate_response:?}");
         let block_response = match block_validate_response {
             BlockValidateResponse::Ok(block_validate_ok) => {
-                self.handle_block_validate_ok(stacks_client, block_validate_ok, sortition_state)
+                self.handle_block_validate_ok(stacks_client, block_validate_ok)
             }
-            BlockValidateResponse::Reject(block_validate_reject) => self
-                .handle_block_validate_reject(
-                    stacks_client,
-                    block_validate_reject,
-                    sortition_state,
-                ),
+            BlockValidateResponse::Reject(block_validate_reject) => {
+                self.handle_block_validate_reject(block_validate_reject)
+            }
         };
         let Some(response) = block_response else {
             return;
@@ -706,11 +690,7 @@ impl Signer {
 
     /// Check the current tracked submitted block proposal to see if it has timed out.
     /// Broadcasts a rejection and marks the block locally rejected if it has.
-    fn check_submitted_block_proposal(
-        &mut self,
-        stacks_client: &StacksClient,
-        sortition_state: &mut Option<SortitionsView>,
-    ) {
+    fn check_submitted_block_proposal(&mut self) {
         let Some((block_proposal, block_submission)) = self.submitted_block_proposal.take() else {
             // Nothing to check.
             return;
@@ -761,7 +741,7 @@ impl Signer {
             RejectCode::ConnectivityIssues,
             &self.private_key,
             self.mainnet,
-            self.calculate_tenure_extend_timestamp(stacks_client, sortition_state),
+            self.calculate_tenure_extend_timestamp(&block_proposal.block.header.consensus_hash),
         );
         if let Err(e) = block_info.mark_locally_rejected() {
             warn!("{self}: Failed to mark block as locally rejected: {e:?}",);
@@ -1165,36 +1145,17 @@ impl Signer {
     }
 
     /// Calculate the tenure extend timestamp based on the tenure start and already consumed idle time.
-    fn calculate_tenure_extend_timestamp(
-        &self,
-        stacks_client: &StacksClient,
-        sortition_state: &mut Option<SortitionsView>,
-    ) -> u64 {
-        if sortition_state.is_none() {
-            *sortition_state =
-                SortitionsView::fetch_view(self.proposal_config.clone(), stacks_client)
-                    .inspect_err(|e| {
-                        warn!(
-                            "{self}: Failed to update sortition view: {e:?}";
-                        )
-                    })
-                    .ok();
-        }
-        let Some(sortition_state) = sortition_state else {
-            warn!("{self}: No sortition state known. Unable to determine tenure extend timestamp for current tenure.");
-            return get_epoch_time_secs()
-                .saturating_add(self.proposal_config.tenure_idle_timeout.as_secs());
-        };
-        // We do not know our tenure start timestamp until we find the last processed tenure change transaction.
-        // We may not even have it in our database, in which case, we should use the oldest known block in this tenure.
-        // If we have no blocks known for this tenure, we will assume it has only just started and calculate
+    fn calculate_tenure_extend_timestamp(&self, consensus_hash: &ConsensusHash) -> u64 {
+        // We do not know our tenure start timestamp until we find the last processed tenure change transaction for the given consensus hash.
+        // We may not even have it in our database, in which case, we should use the oldest known block in the tenure.
+        // If we have no blocks known for this tenure, we will assume it has only JUST started and calculate
         // our tenure extend timestamp based on the epoch time in secs.
         let mut tenure_start_timestamp = None;
         let mut tenure_process_time_ms = 0;
         // Note that the globally accepted blocks are already returned in descending order of stacks height, therefore by newest block to oldest block
         for block_info in self
             .signer_db
-            .get_globally_accepted_blocks(&sortition_state.cur_sortition.consensus_hash)
+            .get_globally_accepted_blocks(consensus_hash)
             .unwrap_or_default()
             .iter()
         {

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -1124,7 +1124,7 @@ impl Signer {
                 RejectCode::TestingDirective,
                 &self.private_key,
                 self.mainnet,
-                u64::MAX,
+                self.calculate_tenure_extend_timestamp(&block_proposal.block.header.consensus_hash),
             ))
         } else {
             None

--- a/testnet/stacks-node/src/tests/epoch_25.rs
+++ b/testnet/stacks-node/src/tests/epoch_25.rs
@@ -23,7 +23,7 @@ use stacks_common::types::chainstate::StacksPrivateKey;
 
 use crate::config::InitialBalance;
 use crate::tests::bitcoin_regtest::BitcoinCoreController;
-use crate::tests::nakamoto_integrations::{next_block_and, wait_for};
+use crate::tests::nakamoto_integrations::wait_for;
 use crate::tests::neon_integrations::{
     get_account, get_chain_info, neon_integration_test_conf, next_block_and_wait, submit_tx,
     test_observer, wait_for_runloop,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -6459,7 +6459,7 @@ fn signer_chainstate() {
                 signed_group: None,
                 ext: ExtraBlockInfo::None,
                 state: BlockState::Unprocessed,
-                processed_time: None,
+                validation_time_ms: None,
             })
             .unwrap();
 
@@ -6549,7 +6549,7 @@ fn signer_chainstate() {
                 signed_group: Some(get_epoch_time_secs()),
                 ext: ExtraBlockInfo::None,
                 state: BlockState::GloballyAccepted,
-                processed_time: Some(get_epoch_time_secs()),
+                validation_time_ms: Some(1000),
             })
             .unwrap();
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -6369,6 +6369,7 @@ fn signer_chainstate() {
             first_proposal_burn_block_timing: Duration::from_secs(0),
             block_proposal_timeout: Duration::from_secs(100),
             tenure_last_block_proposal_timeout: Duration::from_secs(30),
+            tenure_idle_timeout: Duration::from_secs(300),
         };
         let mut sortitions_view =
             SortitionsView::fetch_view(proposal_conf, &signer_client).unwrap();
@@ -6458,6 +6459,7 @@ fn signer_chainstate() {
                 signed_group: None,
                 ext: ExtraBlockInfo::None,
                 state: BlockState::Unprocessed,
+                processed_time: None,
             })
             .unwrap();
 
@@ -6508,6 +6510,7 @@ fn signer_chainstate() {
             first_proposal_burn_block_timing: Duration::from_secs(0),
             block_proposal_timeout: Duration::from_secs(100),
             tenure_last_block_proposal_timeout: Duration::from_secs(30),
+            tenure_idle_timeout: Duration::from_secs(300),
         };
         let burn_block_height = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
             .unwrap()
@@ -6546,6 +6549,7 @@ fn signer_chainstate() {
                 signed_group: Some(get_epoch_time_secs()),
                 ext: ExtraBlockInfo::None,
                 state: BlockState::GloballyAccepted,
+                processed_time: Some(get_epoch_time_secs()),
             })
             .unwrap();
 
@@ -6586,6 +6590,7 @@ fn signer_chainstate() {
         first_proposal_burn_block_timing: Duration::from_secs(0),
         block_proposal_timeout: Duration::from_secs(100),
         tenure_last_block_proposal_timeout: Duration::from_secs(30),
+        tenure_idle_timeout: Duration::from_secs(300),
     };
     let mut sortitions_view = SortitionsView::fetch_view(proposal_conf, &signer_client).unwrap();
     let burn_block_height = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -457,6 +457,7 @@ fn block_proposal_rejection() {
         first_proposal_burn_block_timing: Duration::from_secs(0),
         block_proposal_timeout: Duration::from_secs(100),
         tenure_last_block_proposal_timeout: Duration::from_secs(30),
+        tenure_idle_timeout: Duration::from_secs(300),
     };
     let mut block = NakamotoBlock {
         header: NakamotoBlockHeader::empty(),
@@ -6949,6 +6950,7 @@ fn block_validation_response_timeout() {
         first_proposal_burn_block_timing: Duration::from_secs(0),
         tenure_last_block_proposal_timeout: Duration::from_secs(30),
         block_proposal_timeout: Duration::from_secs(100),
+        tenure_idle_timeout: Duration::from_secs(300),
     };
     let mut block = NakamotoBlock {
         header: NakamotoBlockHeader::empty(),

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -510,10 +510,16 @@ fn block_proposal_rejection() {
             {
                 if signer_signature_hash == block_signer_signature_hash_1 {
                     found_signer_signature_hash_1 = true;
-                    assert!(matches!(reason_code, RejectCode::SortitionViewMismatch));
+                    assert!(
+                        matches!(reason_code, RejectCode::SortitionViewMismatch),
+                        "Expected sortition view mismatch rejection. Got: {reason_code}"
+                    );
                 } else if signer_signature_hash == block_signer_signature_hash_2 {
                     found_signer_signature_hash_2 = true;
-                    assert!(matches!(reason_code, RejectCode::ValidationFailed(_)));
+                    assert!(
+                        matches!(reason_code, RejectCode::ValidationFailed(_)),
+                        "Expected validation failed rejection. Got: {reason_code}"
+                    );
                 } else {
                     continue;
                 }


### PR DESCRIPTION
First pass. Haven't tested this at all and this was just first thoughts. EDIT: Initially way over-complicating things and assumed that we should respond to a block proposal based on who the current sortition winner is. However, if a miner proposes a block proposal that does not link to the correct consensus hash (odds are it will be rejected first off), it does not actually really matter. We will simply let the proposing miner know that the tenure extend for that timestamp has passed or not. It only matters that a valid sortition winner knows this for a valid proposal/valid attempt to tenure change. This simplified things a lot as I could just respond to every block proposal based on its provided consensus hash.