### PR TITLE
Signers: Use tenure extend timestamp to determine if enough time has passed for a tenure extend

### DIFF
--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -814,7 +814,7 @@ impl SignerDb {
         ))
     }
 
-    /// Return the all globally accepted block in a tenure (identified by its consensus hash).
+    /// Return the all globally accepted block in a tenure (identified by its consensus hash) in stacks height descending order
     fn get_globally_accepted_blocks(
         &self,
         tenure: &ConsensusHash,

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -829,7 +829,7 @@ impl SignerDb {
     }
 
     /// Compute the tenure extend timestamp based on the tenure start and already consumed idle time of the
-    /// globally accepted blocks of the provided tenure (identified by the cosnensus hash)
+    /// globally accepted blocks of the provided tenure (identified by the consensus hash)
     pub fn get_tenure_extend_timestamp(
         &self,
         tenure_idle_timeout: Duration,

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -16,9 +16,10 @@
 
 use std::fmt::Display;
 use std::path::Path;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::chainstate::stacks::TransactionPayload;
 use blockstack_lib::util_lib::db::{
     query_row, query_rows, sqlite_open, table_exists, tx_begin_immediate, u64_to_sql,
     Error as DBError,
@@ -814,7 +815,7 @@ impl SignerDb {
     }
 
     /// Return the all globally accepted block in a tenure (identified by its consensus hash).
-    pub fn get_globally_accepted_blocks(
+    fn get_globally_accepted_blocks(
         &self,
         tenure: &ConsensusHash,
     ) -> Result<Vec<BlockInfo>, DBError> {
@@ -825,6 +826,47 @@ impl SignerDb {
             .iter()
             .map(|info| serde_json::from_str(info).map_err(DBError::from))
             .collect()
+    }
+
+    /// Compute the tenure extend timestamp based on the tenure start and already consumed idle time of the
+    /// globally accepted blocks of the provided tenure (identified by the cosnensus hash)
+    pub fn get_tenure_extend_timestamp(
+        &self,
+        tenure_idle_timeout: Duration,
+        consensus_hash: &ConsensusHash,
+    ) -> u64 {
+        // We do not know our tenure start timestamp until we find the last processed tenure change transaction for the given consensus hash.
+        // We may not even have it in our database, in which case, we should use the oldest known block in the tenure.
+        // If we have no blocks known for this tenure, we will assume it has only JUST started and calculate
+        // our tenure extend timestamp based on the epoch time in secs.
+        let mut tenure_start_timestamp = None;
+        let mut tenure_process_time_ms = 0;
+        // Note that the globally accepted blocks are already returned in descending order of stacks height, therefore by newest block to oldest block
+        for block_info in self
+            .get_globally_accepted_blocks(consensus_hash)
+            .unwrap_or_default()
+            .iter()
+        {
+            // Always use the oldest block as our tenure start timestamp
+            tenure_start_timestamp = Some(block_info.proposed_time);
+            tenure_process_time_ms += block_info.validation_time_ms.unwrap_or(0);
+
+            if block_info
+                .block
+                .txs
+                .first()
+                .map(|tx| matches!(tx.payload, TransactionPayload::TenureChange(_)))
+                .unwrap_or(false)
+            {
+                // Tenure change found. No more blocks should count towards this tenure's processing time.
+                break;
+            }
+        }
+
+        tenure_start_timestamp
+            .unwrap_or(get_epoch_time_secs())
+            .saturating_add(tenure_idle_timeout.as_secs())
+            .saturating_sub(tenure_process_time_ms / 1000)
     }
 }
 


### PR DESCRIPTION
I think it made the most sense to put the calculate tenure extend timestamp code inside the signer db code but I could also put it in the utils if preferred. 