### PR TITLE
refactor: add serde default to symbolic expression struct

### DIFF
--- a/clarity/src/vm/representations.rs
+++ b/clarity/src/vm/representations.rs
@@ -459,13 +459,13 @@ pub struct SymbolicExpression {
     pub span: Span,
 
     #[cfg(feature = "developer-mode")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pre_comments: Vec<(String, Span)>,
     #[cfg(feature = "developer-mode")]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_line_comment: Option<String>,
-    #[serde(default)]
     #[cfg(feature = "developer-mode")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub post_comments: Vec<(String, Span)>,
 }
 

--- a/clarity/src/vm/representations.rs
+++ b/clarity/src/vm/representations.rs
@@ -455,12 +455,16 @@ pub struct SymbolicExpression {
     pub id: u64,
 
     #[cfg(feature = "developer-mode")]
+    #[serde(default)]
     pub span: Span,
 
     #[cfg(feature = "developer-mode")]
+    #[serde(default)]
     pub pre_comments: Vec<(String, Span)>,
     #[cfg(feature = "developer-mode")]
+    #[serde(default)]
     pub end_line_comment: Option<String>,
+    #[serde(default)]
     #[cfg(feature = "developer-mode")]
     pub post_comments: Vec<(String, Span)>,
 }


### PR DESCRIPTION
## Context

Clarinet uses `clarity` with the developer-mode feature enabled.

It also needs to fetch some data from the RPC endpoints from the stacks-nodes (such as contract metadata, including contract body, as SymbolicExpressions).
The response from the stacks-node don't include the SymbolicExpression span and other `developer-mode` properties.
As a result, Clarinet can not parse the response of the api call.

## Fix

By adding the `#[serde(default)]` directive, it enables Clarinet to parse the response. It's important to note that n this context, we don't care about the actual values of this properties