### PR TITLE
*''Update docs to reflect segwit support in Stacks 2.1. ''*

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/docs.rs
+++ b/stackslib/src/chainstate/stacks/boot/docs.rs
@@ -33,7 +33,7 @@ This is the self-service interface.  tx-sender will be the Stacker.
 * You will need the minimum uSTX threshold. This isn't determined until the reward cycle begins, but this
    method still requires stacking over the _absolute minimum_ amount, which can be obtained by calling `get-stacking-minimum`.
 * The pox-addr argument must represent a valid reward address.  Right now, this must be a Bitcoin
-p2pkh or p2sh address.  It cannot be a native Segwit address, but it may be a p2wpkh-p2sh or p2wsh-p2sh address.
+p2pkh or p2sh address.  // Native Segwit addresses are now supported as of Stacks 2.1. but it may be a p2wpkh-p2sh or p2wsh-p2sh address.
 
 The tokens will unlock and be returned to the Stacker (tx-sender) automatically."),
         ("revoke-delegate-stx", "Revoke a Stacking delegate relationship. A particular Stacker may only have one delegate,


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description: This pull request updates the documentation regarding Segwit address support in the Stacks project. The current documentation stated that "It cannot be a native Segwit address," which was accurate before Stacks 2.1. However, with the release of Stacks 2.1, native Segwit addresses are now supported, and this change has been reflected in the documentation.

### Applicable issues
N/A
- fixes #
- Outdated documentation regarding native Segwit address support.

The statement "It cannot be a native Segwit address" was incorrect after Stacks 2.1. It is now corrected to reflect the current capabilities.

### Additional info (benefits, drawbacks, caveats)
This change ensures the documentation accurately reflects the capabilities of Stacks 2.1, providing clarity for developers using Segwit addresses.

### Checklist
[ ] My code follows the project's style guidelines.

[ ] I have updated the documentation accordingly.

[ ] I have reviewed the contribution guidelines for this project.

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
