### PR TITLE
 Fix/http stall on invalid message

### DIFF
--- a/.github/workflows/p2p-tests.yml
+++ b/.github/workflows/p2p-tests.yml
@@ -43,6 +43,10 @@ jobs:
           - net::tests::convergence::test_walk_star_15_org_biased
           - net::tests::convergence::test_walk_inbound_line_15
           - net::api::tests::postblock_proposal::test_try_make_response
+          - net::server::tests::test_http_10_threads_getinfo
+          - net::server::tests::test_http_10_threads_getblock
+          - net::server::tests::test_http_too_many_clients
+          - net::server::tests::test_http_slow_client
     steps:
       ## Setup test environment
       - name: Setup Test Environment

--- a/stackslib/src/net/server.rs
+++ b/stackslib/src/net/server.rs
@@ -288,6 +288,7 @@ impl HttpPeer {
     /// Deregister a socket/event pair
     #[cfg_attr(test, mutants::skip)]
     pub fn deregister_http(&mut self, network_state: &mut NetworkState, event_id: usize) -> () {
+        test_debug!("Remove HTTP event {}", event_id);
         self.peers.remove(&event_id);
 
         match self.sockets.remove(&event_id) {
@@ -456,7 +457,7 @@ impl HttpPeer {
                                         "Failed to flush HTTP 400 to socket {:?}: {:?}",
                                         &client_sock, &e
                                     );
-                                    convo_dead = true;
+                                    // convo_dead = true;
                                 }
                             }
                             Err(e) => {
@@ -559,19 +560,11 @@ impl HttpPeer {
         let mut to_remove = vec![];
         let mut msgs = vec![];
         for event_id in &poll_state.ready {
-            if !self.sockets.contains_key(&event_id) {
+            let Some(client_sock) = self.sockets.get_mut(&event_id) else {
                 debug!("Rogue socket event {}", event_id);
                 to_remove.push(*event_id);
                 continue;
-            }
-
-            let client_sock_opt = self.sockets.get_mut(&event_id);
-            if client_sock_opt.is_none() {
-                debug!("No such socket event {}", event_id);
-                to_remove.push(*event_id);
-                continue;
-            }
-            let client_sock = client_sock_opt.unwrap();
+            };
 
             match self.peers.get_mut(event_id) {
                 Some(ref mut convo) => {


### PR DESCRIPTION
This fixes #5490, and fixes the problem we were seeing in #5296 and #4997.  The fundamental problem was that the HTTP session state machine was not correctly treating server-generated HTTP error responses as having completed once they were flushed.  This PR fixes this, and removes some now-needless (and buggy) code that had earlier attempted (and failed) to address this problem.

Let's get this into `develop` so we can turn around and fix #5296 and #4997.