### PR TITLE
Feat/miner key node seed

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -835,7 +835,7 @@ impl Config {
         let miner = match config_file.miner {
             Some(mut miner) => {
                 miner.mining_key = match String::from_utf8(node.seed.clone()) {
-                    OK(res) => Some(res),
+                    Ok(res) => Some(res),
                     Err(_) => None,
                 };
                 miner.into_config_default(miner_default_config)?

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -833,7 +833,13 @@ impl Config {
         }
 
         let miner = match config_file.miner {
-            Some(miner) => miner.into_config_default(miner_default_config)?,
+            Some(mut miner) => {
+                miner.mining_key = match String::from_utf8(node.seed.clone()) {
+                    OK(res) => Some(res),
+                    Err(_) => None,
+                };
+                miner.into_config_default(miner_default_config)?
+            }
             None => miner_default_config,
         };
 
@@ -2546,6 +2552,13 @@ pub struct MinerConfigFile {
 
 impl MinerConfigFile {
     fn into_config_default(self, miner_default_config: MinerConfig) -> Result<MinerConfig, String> {
+        match &self.mining_key {
+            Some(_) => {}
+            None => {
+                panic!("mining key not set");
+            }
+        }
+
         let mining_key = self
             .mining_key
             .as_ref()

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -836,8 +836,8 @@ impl Config {
             Some(mut miner) => {
                 if miner.mining_key == None {
                     info!("Mining key found!";
-                        "Mining key" => %miner.mining_key,
-                    "Node seed" => %node.seed);
+                        "Mining key" => ?miner.mining_key,
+                    "Node seed" => ?node.seed);
                     miner.mining_key = match String::from_utf8(node.seed.clone()) {
                         Ok(res) => Some(res),
                         Err(_) => None,
@@ -2558,7 +2558,7 @@ pub struct MinerConfigFile {
 impl MinerConfigFile {
     fn into_config_default(self, miner_default_config: MinerConfig) -> Result<MinerConfig, String> {
         info!("into config default function!";
-            "Mining key" => %self.mining_key);
+            "Mining key" => ?self.mining_key);
         match &self.mining_key {
             Some(_) => {}
             None => {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -53,6 +53,7 @@ use stacks::net::connection::ConnectionOptions;
 use stacks::net::{Neighbor, NeighborKey};
 use stacks::types::chainstate::BurnchainHeaderHash;
 use stacks::types::EpochList;
+use stacks::util::hash::to_hex;
 use stacks::util_lib::boot::boot_code_id;
 use stacks::util_lib::db::Error as DBError;
 use stacks_common::consts::SIGNER_SLOTS_PER_USER;
@@ -834,14 +835,11 @@ impl Config {
 
         let miner = match config_file.miner {
             Some(mut miner) => {
-                if miner.mining_key == None {
+                if miner.mining_key.is_none() && !node.seed.is_empty() {
                     info!("Mining key found!";
                         "Mining key" => ?miner.mining_key,
                     "Node seed" => ?node.seed);
-                    miner.mining_key = match String::from_utf8(node.seed.clone()) {
-                        Ok(res) => Some(res),
-                        Err(_) => None,
-                    };
+                    miner.mining_key = Some(to_hex(&node.seed));
                 }
                 miner.into_config_default(miner_default_config)?
             }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -834,10 +834,15 @@ impl Config {
 
         let miner = match config_file.miner {
             Some(mut miner) => {
-                miner.mining_key = match String::from_utf8(node.seed.clone()) {
-                    Ok(res) => Some(res),
-                    Err(_) => None,
-                };
+                if miner.mining_key == None {
+                    info!("Mining key found!";
+                        "Mining key" => %miner.mining_key,
+                    "Node seed" => %node.seed);
+                    miner.mining_key = match String::from_utf8(node.seed.clone()) {
+                        Ok(res) => Some(res),
+                        Err(_) => None,
+                    };
+                }
                 miner.into_config_default(miner_default_config)?
             }
             None => miner_default_config,
@@ -2552,6 +2557,8 @@ pub struct MinerConfigFile {
 
 impl MinerConfigFile {
     fn into_config_default(self, miner_default_config: MinerConfig) -> Result<MinerConfig, String> {
+        info!("into config default function!";
+            "Mining key" => %self.mining_key);
         match &self.mining_key {
             Some(_) => {}
             None => {


### PR DESCRIPTION
- fixes https://github.com/stacks-network/stacks-core/issues/5473

Also, if `node.seed` is specified, the miner will use that as the `miner.mining_key` 