### PR TITLE
Fix/stackerdb audit coinfabrik

### DIFF
--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::ops::{Deref, DerefMut};
 use std::sync::mpsc::{
@@ -24,7 +24,7 @@ use std::time::Duration;
 use std::{io, net};
 
 use clarity::vm::costs::ExecutionCost;
-use clarity::vm::types::BOUND_VALUE_SERIALIZATION_HEX;
+use clarity::vm::types::{QualifiedContractIdentifier, BOUND_VALUE_SERIALIZATION_HEX};
 use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
 use stacks_common::types::net::PeerAddress;
 use stacks_common::util::hash::to_hex;
@@ -44,7 +44,8 @@ use crate::net::neighbors::{
     WALK_SEED_PROBABILITY, WALK_STATE_TIMEOUT,
 };
 use crate::net::{
-    Error as net_error, MessageSequence, Preamble, ProtocolFamily, RelayData, StacksHttp, StacksP2P,
+    Error as net_error, MessageSequence, NeighborAddress, Preamble, ProtocolFamily, RelayData,
+    StacksHttp, StacksP2P,
 };
 
 /// Receiver notification handle.
@@ -433,6 +434,8 @@ pub struct ConnectionOptions {
     pub nakamoto_unconfirmed_downloader_interval_ms: u128,
     /// The authorization token to enable privileged RPC endpoints
     pub auth_token: Option<String>,
+    /// StackerDB replicas to talk to for a particular smart contract
+    pub stackerdb_hint_replicas: HashMap<QualifiedContractIdentifier, Vec<NeighborAddress>>,
 
     // fault injection
     /// Disable neighbor walk and discovery
@@ -565,6 +568,7 @@ impl std::default::Default for ConnectionOptions {
             nakamoto_inv_sync_burst_interval_ms: 1_000, // wait 1 second after a sortition before running inventory sync
             nakamoto_unconfirmed_downloader_interval_ms: 5_000, // run unconfirmed downloader once every 5 seconds
             auth_token: None,
+            stackerdb_hint_replicas: HashMap::new(),
 
             // no faults on by default
             disable_neighbor_walk: false,

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -3141,7 +3141,7 @@ pub mod test {
                     &mut stacks_node.chainstate,
                     &sortdb,
                     old_stackerdb_configs,
-                    config.connection_opts.num_neighbors,
+                    &config.connection_opts,
                 )
                 .expect("Failed to refresh stackerdb configs");
 

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -841,6 +841,9 @@ impl PeerNetwork {
     ) -> usize {
         let mut count = 0;
         for (_, convo) in self.peers.iter() {
+            if !convo.is_authenticated() {
+                continue;
+            }
             if !convo.is_outbound() {
                 continue;
             }
@@ -4158,7 +4161,7 @@ impl PeerNetwork {
             chainstate,
             sortdb,
             stacker_db_configs,
-            self.connection_opts.num_neighbors,
+            &self.connection_opts,
         )?;
         Ok(())
     }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -2370,16 +2370,7 @@ impl ConnectionOptionsFile {
                     hint_replicas_res
                 })
                 .transpose()?
-                .and_then(|stackerdb_replicas_list| {
-                    // coalesce to a hashmap, but don't worry about duplicate entries
-                    // (garbage in, garbage out)
-                    let stackerdb_hint_replicas: HashMap<
-                        QualifiedContractIdentifier,
-                        Vec<NeighborAddress>,
-                    > = stackerdb_replicas_list.into_iter().collect();
-
-                    Some(stackerdb_hint_replicas)
-                })
+                .map(HashMap::from_iter)
                 .unwrap_or(default.stackerdb_hint_replicas),
             ..default
         })

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -4810,7 +4810,7 @@ impl StacksNode {
                 &mut chainstate,
                 &sortdb,
                 stackerdb_configs,
-                config.connection_options.num_neighbors,
+                &config.connection_options,
             )
             .unwrap();
 


### PR DESCRIPTION
This implements all of Coinfabrik's StackerDB audit recommendations.

Nothing major was found.  The only changes are:

* Allow `hint-replicas` to be locally overridden, so a StackerDB smart contract can't force subscribed nodes to connect to non-replicas (such as hosts on a private network, or a DoS target)

* Set `private_neighbors` to `false` by default (cc @CharlieC3 @deantchi @wileyj so you're aware of this config default)

* Only count authenticated outbound StackerDB replicas when calculating the broadcast probability for a StackerDB inventory or chunk

cc @will-corcoran 