### PR TITLE
feat: add serialize to cost synthesis

### DIFF
--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -127,7 +127,7 @@ pub struct ExecutionResult {
     pub diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CostSynthesis {
     pub total: ExecutionCost,
     pub limit: ExecutionCost,


### PR DESCRIPTION
Serializing `CostSynthesis` is needed in Clarinet.

Is it ok to add it here even though it's not used internally in stacks-core?
The alternative would be to create a identical struct in Clarinet that can be Serialized and has a `from<CostSynthesis>`, adding a bit of complexity but I'm fine with it to