### PR TITLE
fix: revert stack block version change

### DIFF
--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -131,7 +131,7 @@ pub use self::staging_blocks::{
     NakamotoStagingBlocksConn, NakamotoStagingBlocksConnRef, NakamotoStagingBlocksTx,
 };
 
-pub const NAKAMOTO_BLOCK_VERSION: u8 = 1;
+pub const NAKAMOTO_BLOCK_VERSION: u8 = 0;
 
 define_named_enum!(HeaderTypeNames {
     Nakamoto("nakamoto"),


### PR DESCRIPTION
Due to an issue with how signers validate block proposals, unupgraded signers reject blocks that have a different default version than their node. Thus, this change reverts the default version until we have a fix for the block validation endpoint (which will come in a different PR).