### PR TITLE
fix: when validating a block, clone the blocks version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - New RPC endpoints
   - `/v2/clarity/marf/:marf_key_hash`
   - `/v2/clarity/metadata/:principal/:contract_name/:clarity_metadata_key`
+- When a proposed block is validated by a node, the block can be validated even when the block version is different than the node's default ([#5539](https://github.com/stacks-network/stacks-core/pull/5539))
 
 ### Changed
 

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -538,6 +538,9 @@ impl NakamotoBlockProposal {
         }
 
         let mut block = builder.mine_nakamoto_block(&mut tenure_tx);
+        // Override the block version with the one from the proposal. This must be
+        // done before computing the block hash, because the block hash includes the
+        // version in its computation.
         block.header.version = self.block.header.version;
         let size = builder.get_bytes_so_far();
         let cost = builder.tenure_finish(tenure_tx)?;

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -538,6 +538,7 @@ impl NakamotoBlockProposal {
         }
 
         let mut block = builder.mine_nakamoto_block(&mut tenure_tx);
+        block.header.version = self.block.header.version;
         let size = builder.get_bytes_so_far();
         let cost = builder.tenure_finish(tenure_tx)?;
 


### PR DESCRIPTION
When nodes change their `NAKAMOTO_BLOCK_VERSION`, unupgraded signers reject the block, because the unupgraded signers use the old version when trying to clone (and compare the block hash) of the proposed block.

This change has the block validation endpoint clone the version of the proposed block to the local block, so that the block hash will match.

We may need more validation here about what a valid block version is - for example, I believe it needs to be <128, or it is treated as a shadow block. Thus, opening as a draft.