### PR TITLE
Add changlog for epoch 3.1 and revert block version (5538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ### Added
 
+### Changed
+
+## [3.1.0.0.0]
+
+### Added
+
+- **SIP-029 consensus rules, activating in epoch 3.1 at block 875,000** (see [SIP-029](https://github.com/will-corcoran/sips/blob/feat/sip-029-halving-alignment/sips/sip-029/sip-029-halving-alignment.md) for details)
 - New RPC endpoints
   - `/v2/clarity/marf/:marf_key_hash`
   - `/v2/clarity/metadata/:principal/:contract_name/:clarity_metadata_key`

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ### Changed
 
+## [3.1.0.0.0.0]
+
+### Added
+
+- **SIP-029 consensus rules, activating in epoch 3.1 at block 875,000** (see [SIP-029](https://github.com/will-corcoran/sips/blob/feat/sip-029-halving-alignment/sips/sip-029/sip-029-halving-alignment.md) for details)
+
+### Changed
+
 ## [3.0.0.0.4.0]
 
 ### Added

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -131,7 +131,7 @@ pub use self::staging_blocks::{
     NakamotoStagingBlocksConn, NakamotoStagingBlocksConnRef, NakamotoStagingBlocksTx,
 };
 
-pub const NAKAMOTO_BLOCK_VERSION: u8 = 1;
+pub const NAKAMOTO_BLOCK_VERSION: u8 = 0;
 
 define_named_enum!(HeaderTypeNames {
     Nakamoto("nakamoto"),


### PR DESCRIPTION
Changelog for 3.1 (sip-029) and cherry-pick from #5538 