### PR TITLE
Remove signers older than the current reward cycle if they have no more blocks to process

### DIFF
--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ## Added
 
 ## Changed
+- Improvements to the stale signer cleanup logic: deletes the prior signer if it has no remaining unprocessed blocks in its database
 
 ## [3.1.0.0.1.0]
 

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -423,23 +423,15 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
         let mut to_delete = Vec::new();
         for (idx, signer) in &mut self.stacks_signers {
             let reward_cycle = signer.reward_cycle();
-            let next_reward_cycle = reward_cycle.wrapping_add(1);
-            let stale = match next_reward_cycle.cmp(&current_reward_cycle) {
-                std::cmp::Ordering::Less => true, // We are more than one reward cycle behind, so we are stale
-                std::cmp::Ordering::Equal => {
-                    // We are the next reward cycle, so check if we were registered and have any pending blocks to process
-                    match signer {
-                        ConfiguredSigner::RegisteredSigner(signer) => {
-                            !signer.has_unprocessed_blocks()
-                        }
-                        _ => true,
-                    }
+            if current_reward_cycle >= reward_cycle {
+                // We are either the current or a future reward cycle, so we are not stale.
+                continue;
+            }
+            if let ConfiguredSigner::RegisteredSigner(signer) = signer {
+                if !signer.has_unprocessed_blocks() {
+                    debug!("{signer}: Signer's tenure has completed.");
+                    to_delete.push(*idx);
                 }
-                std::cmp::Ordering::Greater => false, // We are the current reward cycle, so we are not stale
-            };
-            if stale {
-                debug!("{signer}: Signer's tenure has completed.");
-                to_delete.push(*idx);
             }
         }
         for idx in to_delete {

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -423,7 +423,7 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
         let mut to_delete = Vec::new();
         for (idx, signer) in &mut self.stacks_signers {
             let reward_cycle = signer.reward_cycle();
-            if current_reward_cycle >= reward_cycle {
+            if reward_cycle >= current_reward_cycle {
                 // We are either the current or a future reward cycle, so we are not stale.
                 continue;
             }


### PR DESCRIPTION
We used to keep reward cycle signers for an extra reward cycle in prep for potentially the fallback scenario where signers would continue signing blocks/sbtc transactions if the incoming signers failed to initialize. However, this is really confusing our partners who don't understand why their logs report stale signers as operating. Also this old logic was flawed anyway as we only ever kept 2 signers around anyway (the hashmap of signers is keyed by the reward_cycle % 2). The cleanup function as it was essentially was a no-op. 

This code change makes the function delete anything that has no unprocessed blocks in its database and that is for a reward cycle older than the current reward cycle. We can always revert or add additional logic about when to delete them when we start giving potential responsibilities to "stale" signers. 