### PR TITLE
fix: New lifetime warnings in Rust 1.83

### DIFF
--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -499,7 +499,7 @@ impl EventBatch {
 
 impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
     #[cfg(any(test, feature = "testing"))]
-    pub fn new(database: ClarityDatabase<'a>, epoch: StacksEpochId) -> OwnedEnvironment<'a, '_> {
+    pub fn new(database: ClarityDatabase<'a>, epoch: StacksEpochId) -> OwnedEnvironment<'a, 'a> {
         OwnedEnvironment {
             context: GlobalContext::new(
                 false,
@@ -513,7 +513,7 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
     }
 
     #[cfg(any(test, feature = "testing"))]
-    pub fn new_toplevel(mut database: ClarityDatabase<'a>) -> OwnedEnvironment<'a, '_> {
+    pub fn new_toplevel(mut database: ClarityDatabase<'a>) -> OwnedEnvironment<'a, 'a> {
         database.begin();
         let epoch = database.get_clarity_epoch_version().unwrap();
         let version = ClarityVersion::default_for_epoch(epoch);
@@ -540,7 +540,7 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
         mut database: ClarityDatabase<'a>,
         epoch: StacksEpochId,
         use_mainnet: bool,
-    ) -> OwnedEnvironment<'a, '_> {
+    ) -> OwnedEnvironment<'a, 'a> {
         use crate::vm::tests::test_only_mainnet_to_chain_id;
         let cost_track = LimitedCostTracker::new_max_limit(&mut database, epoch, use_mainnet)
             .expect("FAIL: problem instantiating cost tracking");
@@ -557,7 +557,7 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
         chain_id: u32,
         database: ClarityDatabase<'a>,
         epoch_id: StacksEpochId,
-    ) -> OwnedEnvironment<'a, '_> {
+    ) -> OwnedEnvironment<'a, 'a> {
         OwnedEnvironment {
             context: GlobalContext::new(
                 mainnet,
@@ -576,7 +576,7 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
         database: ClarityDatabase<'a>,
         cost_tracker: LimitedCostTracker,
         epoch_id: StacksEpochId,
-    ) -> OwnedEnvironment<'a, '_> {
+    ) -> OwnedEnvironment<'a, 'a> {
         OwnedEnvironment {
             context: GlobalContext::new(mainnet, chain_id, database, cost_tracker, epoch_id),
             call_stack: CallStack::new(),
@@ -1546,7 +1546,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
         database: ClarityDatabase<'a>,
         cost_track: LimitedCostTracker,
         epoch_id: StacksEpochId,
-    ) -> GlobalContext {
+    ) -> GlobalContext<'a, 'hooks> {
         GlobalContext {
             database,
             cost_track,

--- a/clarity/src/vm/database/key_value_wrapper.rs
+++ b/clarity/src/vm/database/key_value_wrapper.rs
@@ -205,7 +205,7 @@ where
 }
 
 impl<'a> RollbackWrapper<'a> {
-    pub fn new(store: &'a mut dyn ClarityBackingStore) -> RollbackWrapper {
+    pub fn new(store: &'a mut dyn ClarityBackingStore) -> RollbackWrapper<'a> {
         RollbackWrapper {
             store,
             lookup_map: HashMap::new(),
@@ -218,7 +218,7 @@ impl<'a> RollbackWrapper<'a> {
     pub fn from_persisted_log(
         store: &'a mut dyn ClarityBackingStore,
         log: RollbackWrapperPersistedLog,
-    ) -> RollbackWrapper {
+    ) -> RollbackWrapper<'a> {
         RollbackWrapper {
             store,
             lookup_map: log.lookup_map,

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -355,7 +355,7 @@ impl NakamotoBootPlan {
     fn boot_nakamoto_peers<'a>(
         mut self,
         observer: Option<&'a TestEventObserver>,
-    ) -> (TestPeer<'a>, Vec<TestPeer>) {
+    ) -> (TestPeer<'a>, Vec<TestPeer<'a>>) {
         let mut peer_config = TestPeerConfig::new(&self.test_name, 0, 0);
         peer_config.network_id = self.network_id;
         peer_config.private_key = self.private_key.clone();
@@ -666,7 +666,7 @@ impl NakamotoBootPlan {
         self,
         boot_plan: Vec<NakamotoBootTenure>,
         observer: Option<&'a TestEventObserver>,
-    ) -> (TestPeer<'a>, Vec<TestPeer>) {
+    ) -> (TestPeer<'a>, Vec<TestPeer<'a>>) {
         let test_signers = self.test_signers.clone();
         let pox_constants = self.pox_constants.clone();
         let test_stackers = self.test_stackers.clone();


### PR DESCRIPTION
### Description

Rust 1.83 seems to be more strict about declaring lifetimes and now generates warnings for certain cases in which they are elided. Example:

```
   Compiling clarity v0.0.1 (/home/jbencin/git/stacks-core/clarity)
warning: elided lifetime has a name
   --> clarity/./src/vm/contexts.rs:560:31
    |
500 | impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
    |      -- lifetime `'a` declared here
...
560 |     ) -> OwnedEnvironment<'a, '_> {
    |                               ^^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
```

This PR fixes the warnings by explicitly declaring the lifetimes