### PR TITLE
Fix/observer filters

### DIFF
--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -1998,10 +1998,7 @@ mod test {
         let timeout = Duration::from_secs(5);
 
         // Create a mock server
-        let mut server = mockito::Server::new_with_opts(mockito::ServerOpts {
-            port: 0,
-            ..Default::default()
-        });
+        let mut server = mockito::Server::new();
         let _m = server
             .mock("POST", "/api")
             .match_header("content-type", Matcher::Regex("application/json.*".into()))
@@ -2069,10 +2066,7 @@ mod test {
         let payload = json!({"key": "value"});
 
         // Create a mock server
-        let mut server = mockito::Server::new_with_opts(mockito::ServerOpts {
-            port: 0,
-            ..Default::default()
-        });
+        let mut server = mockito::Server::new();
         let _m = server
             .mock("POST", "/test")
             .match_header("content-type", Matcher::Regex("application/json.*".into()))
@@ -2108,10 +2102,7 @@ mod test {
         let payload = json!({"key": "value"});
 
         // Create a mock server
-        let mut server = mockito::Server::new_with_opts(mockito::ServerOpts {
-            port: 0,
-            ..Default::default()
-        });
+        let mut server = mockito::Server::new();
         let _m = server
             .mock("POST", "/test")
             .match_header("content-type", Matcher::Regex("application/json.*".into()))

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -67,7 +68,6 @@ use stacks_common::types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, Sta
 use stacks_common::types::net::PeerHost;
 use stacks_common::util::hash::{bytes_to_hex, Hash160, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::MessageSignature;
-use std::cell::RefCell;
 use url::Url;
 
 use super::config::{EventKeyType, EventObserverConfig};

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#[cfg(test)]
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -48,8 +49,7 @@ use stacks::chainstate::stacks::events::{
 };
 use stacks::chainstate::stacks::miner::TransactionEvent;
 use stacks::chainstate::stacks::{
-    SinglesigHashMode, StacksBlock, StacksMicroblock, StacksTransaction, TransactionPayload,
-    TransactionPublicKeyEncoding,
+    StacksBlock, StacksMicroblock, StacksTransaction, TransactionPayload,
 };
 use stacks::core::mempool::{MemPoolDropReason, MemPoolEventDispatcher, ProposalCallbackReceiver};
 use stacks::libstackerdb::StackerDBChunkData;
@@ -66,7 +66,7 @@ use stacks_common::bitvec::BitVec;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockId};
 use stacks_common::types::net::PeerHost;
-use stacks_common::util::hash::{bytes_to_hex, Hash160, Sha512Trunc256Sum};
+use stacks_common::util::hash::{bytes_to_hex, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::MessageSignature;
 use url::Url;
 
@@ -1709,13 +1709,14 @@ mod test {
     use stacks::chainstate::stacks::db::{StacksBlockHeaderTypes, StacksHeaderInfo};
     use stacks::chainstate::stacks::events::StacksBlockEventData;
     use stacks::chainstate::stacks::{
-        SinglesigSpendingCondition, StacksBlock, TransactionAuth, TransactionSpendingCondition,
-        TransactionVersion,
+        SinglesigHashMode, SinglesigSpendingCondition, StacksBlock, TransactionAuth,
+        TransactionPublicKeyEncoding, TransactionSpendingCondition, TransactionVersion,
     };
     use stacks::types::chainstate::BlockHeaderHash;
     use stacks::util::secp256k1::MessageSignature;
     use stacks_common::bitvec::BitVec;
     use stacks_common::types::chainstate::{BurnchainHeaderHash, StacksBlockId};
+    use stacks_common::util::hash::Hash160;
     use tempfile::tempdir;
     use tiny_http::{Method, Response, Server, StatusCode};
 

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -2492,7 +2492,7 @@ mod test {
         // Create a mock server
         let mut server = mockito::Server::new();
         let _m = server
-            .mock("POST", "/new_mempool_tx")
+            .mock("POST", "/new_block")
             .with_status(200)
             .expect_at_most(1)
             .create();


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This patch fixes the observer filtering system and adds tests for it.

Note that the patch includes a little change for fixing a race condition with 3 of the tests using the TEST_EVENT_OBSERVER_SKIP_RETRY variable (that was static and now is a thread local one)

### Applicable issues

- fixes #5558

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
