### PR TITLE
feat: add build-time git info

### DIFF
--- a/stacks-common/build.rs
+++ b/stacks-common/build.rs
@@ -1,7 +1,63 @@
 use std::path::Path;
+use std::process::Command;
 use std::{env, fs};
 
 use toml::Value;
+
+fn current_git_hash() -> Option<String> {
+    if option_env!("GIT_COMMIT") == None {
+        let commit = Command::new("git")
+            .arg("log")
+            .arg("-1")
+            .arg("--pretty=format:%h") // Abbreviated commit hash
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .output();
+
+        if let Ok(commit) = commit {
+            if let Ok(commit) = String::from_utf8(commit.stdout) {
+                return Some(commit.trim().to_string());
+            }
+        }
+    } else {
+        return option_env!("GIT_COMMIT").map(String::from);
+    }
+
+    None
+}
+
+fn current_git_branch() -> Option<String> {
+    if option_env!("GIT_BRANCH") == None {
+        let commit = Command::new("git")
+            .arg("rev-parse")
+            .arg("--abbrev-ref")
+            .arg("HEAD")
+            .output();
+        if let Ok(commit) = commit {
+            if let Ok(commit) = String::from_utf8(commit.stdout) {
+                return Some(commit.trim().to_string());
+            }
+        }
+    } else {
+        return option_env!("GIT_BRANCH").map(String::from);
+    }
+
+    None
+}
+
+fn is_working_tree_clean() -> bool {
+    let status = Command::new("git")
+        .arg("diff")
+        .arg("--quiet")
+        .arg("--exit-code")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status();
+
+    if let Ok(status) = status {
+        status.code() == Some(0)
+    } else {
+        true
+    }
+}
 
 fn main() {
     let toml_content =
@@ -32,6 +88,40 @@ fn main() {
         _ => {
             panic!("Invalid value type in versions.toml: {:?}", config);
         }
+    }
+
+    if let Some(git) = current_git_hash() {
+        // println!("git commit: {}", git);
+        rust_code.push_str(&format!(
+            "pub const GIT_COMMIT: Option<&'static str> = Some(\"{}\");\n",
+            git
+        ));
+        println!("cargo:rustc-env=GIT_COMMIT={}", git);
+    } else {
+        rust_code.push_str(&format!(
+            "pub const GIT_COMMIT: Option<&'static str> = None;\n"
+        ));
+    }
+    if let Some(git) = current_git_branch() {
+        rust_code.push_str(&format!(
+            "pub const GIT_BRANCH: Option<&'static str> = Some(\"{}\");\n",
+            git
+        ));
+        println!("cargo:rustc-env=GIT_BRANCH={}", git);
+    } else {
+        rust_code.push_str(&format!(
+            "pub const GIT_BRANCH: Option<&'static str> = None;\n"
+        ));
+    }
+    if !is_working_tree_clean() {
+        rust_code.push_str(&format!(
+            "pub const GIT_TREE_CLEAN: Option<&'static str> = Some(\"\");\n"
+        ));
+        println!("cargo:rustc-env=GIT_TREE_CLEAN=+");
+    } else {
+        rust_code.push_str(&format!(
+            "pub const GIT_TREE_CLEAN: Option<&'static str> = Some(\"+\");\n"
+        ));
     }
 
     let out_dir = env::var_os("OUT_DIR").unwrap();

--- a/stackslib/src/lib.rs
+++ b/stackslib/src/lib.rs
@@ -45,7 +45,7 @@ extern crate stacks_common;
 #[macro_use]
 pub extern crate clarity;
 
-use stacks_common::versions::STACKS_NODE_VERSION;
+use stacks_common::versions::{GIT_BRANCH, GIT_COMMIT, GIT_TREE_CLEAN, STACKS_NODE_VERSION};
 pub use stacks_common::{address, codec, types, util};
 
 #[macro_use]
@@ -71,9 +71,9 @@ pub mod deps;
 pub mod monitoring;
 
 // set via _compile-time_ envars
-const GIT_BRANCH: Option<&'static str> = option_env!("GIT_BRANCH");
-const GIT_COMMIT: Option<&'static str> = option_env!("GIT_COMMIT");
-const GIT_TREE_CLEAN: Option<&'static str> = option_env!("GIT_TREE_CLEAN");
+const GIT_BRANCH_ENV: Option<&'static str> = option_env!("GIT_BRANCH");
+const GIT_COMMIT_ENV: Option<&'static str> = option_env!("GIT_COMMIT");
+const GIT_TREE_CLEAN_ENV: Option<&'static str> = option_env!("GIT_TREE_CLEAN");
 
 #[cfg(debug_assertions)]
 const BUILD_TYPE: &'static str = "debug";
@@ -82,11 +82,9 @@ const BUILD_TYPE: &'static str = "release";
 
 pub fn version_string(pkg_name: &str, pkg_version: Option<&str>) -> String {
     let pkg_version = pkg_version.unwrap_or(STACKS_NODE_VERSION);
-    let git_branch = GIT_BRANCH
-        .map(|x| format!("{}", x))
-        .unwrap_or("".to_string());
-    let git_commit = GIT_COMMIT.unwrap_or("");
-    let git_tree_clean = GIT_TREE_CLEAN.unwrap_or("");
+    let git_branch = GIT_BRANCH_ENV.unwrap_or(GIT_BRANCH.unwrap_or(""));
+    let git_commit = GIT_COMMIT_ENV.unwrap_or(GIT_COMMIT.unwrap_or(""));
+    let git_tree_clean = GIT_TREE_CLEAN_ENV.unwrap_or(GIT_TREE_CLEAN.unwrap_or(""));
 
     format!(
         "{} {} ({}:{}{}, {} build, {} [{}])",


### PR DESCRIPTION
While working on #5399, I noticed that we have a root-level `build.rs` file that gets git info, but we weren't using that.

Because 5399 introduces a build-time constants file, I figured I'd open this PR to also include Git info without needing to specify `GIT_COMMIT` and `GIT_BRANCH` ENV variables. This way, you always get the "full version string" regardless of how you run `cargo build`. This, along with 5399, means we can be rid of the unhelpful `0.0.1` version strings when people do custom builds.

I'm relatively ambivalent about this change - let me know what you think.