### PR TITLE
Add clippy to CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,40 @@
+## Perform Clippy checks - currently set to defaults
+##   https://github.com/rust-lang/rust-clippy#usage
+##   https://rust-lang.github.io/rust-clippy/master/index.html
+##
+name: Clippy Checks
+
+# Only run when:
+#   - PRs are (re)opened against develop branch
+on:
+  pull_request:
+    branches:
+      - develop
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  clippy_check:
+    name: Clippy Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        id: git_checkout
+        uses: actions/checkout@v3
+      - name: Define Rust Toolchain
+        id: define_rust_toolchain
+        run: echo "RUST_TOOLCHAIN=$(cat ./rust-toolchain)" >> $GITHUB_ENV
+      - name: Setup Rust Toolchain
+        id: setup_rust_toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: clippy
+      - name: Clippy
+        id: clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -p libstackerdb -p stacks-signer -p pox-locking --no-deps --tests --all-features -- -D warnings

--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -176,7 +176,7 @@ enum ProposedBy<'a> {
     CurrentSortition(&'a SortitionState),
 }
 
-impl<'a> ProposedBy<'a> {
+impl ProposedBy<'_> {
     pub fn state(&self) -> &SortitionState {
         match self {
             ProposedBy::LastSortition(x) => x,

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -41,11 +41,9 @@ use stacks_common::types::chainstate::StacksPrivateKey;
 
 extern crate alloc;
 
-#[derive(Parser, Debug)]
-#[command(author, version, about)]
-#[command(long_version = VERSION_STRING.as_str())]
-
 /// The CLI arguments for the stacks signer
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_version = VERSION_STRING.as_str())]
 pub struct Cli {
     /// Subcommand action to take
     #[command(subcommand)]


### PR DESCRIPTION
Add clippy to CI.

Somehow this was deleted from CI...I am just in the process of adding back the existing libs and fixing the subsequent warnings, but please take a look in case you think there is something wrong with adding this back...