### PR TITLE
Fix default mainnet burnchain peer details

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -187,10 +187,9 @@ impl ConfigFile {
             mode: Some("mainnet".to_string()),
             rpc_port: Some(8332),
             peer_port: Some(8333),
-            peer_host: Some("bitcoin.blockstack.com".to_string()),
-            username: Some("blockstack".to_string()),
-            password: Some("blockstacksystem".to_string()),
-            magic_bytes: Some("X2".to_string()),
+            peer_host: Some("bitcoin.mainnet.stacks.org".to_string()),
+            username: Some("stacks".to_string()),
+            password: Some("foundation".to_string()),
             ..BurnchainConfigFile::default()
         };
 


### PR DESCRIPTION
### Description
On 19th December 2024, the default burnchain peer referenced in the 'mainnet' config of the stacks-node program was taken down. As a result, stacks-node programs run with the 'mainnet' command (i.e. those using the config produced by `ConfigFile::mainnet()`) no longer sync.

This PR fixes the default mainnet burnchain peer details by updating them to match those in the stacks-blockchain-docker repo.

### Applicable issues

(none currently open)

### Additional info (benefits, drawbacks, caveats)

To confirm the current configuration doesn't work, you can inspect the DNS result (NXDOMAIN) of running:
`dig bitcoin.blockstack.com`

Here's the matching stacks-blockchain-docker sample config for mainnet: https://github.com/stacks-network/stacks-blockchain-docker/blob/master/conf/mainnet/Config.toml.sample#L12-L14

The stacks-blockchain-docker config works at the time of writing; confirmed using bitcoin-cli.


### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
