### PR TITLE
Do not process block validation responses for the wrong reward cycle

### DIFF
--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -8,9 +8,16 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ## [Unreleased]
 
 ## Added
-- Prevent old reward cycle signers from processing block validation response messages that do not apply to blocks from their cycle.
 
 ## Changed
+
+# [3.1.0.0.2.1]
+
+## Added
+
+## Changed
+
+- Prevent old reward cycle signers from processing block validation response messages that do not apply to blocks from their cycle.
 
 ## [3.1.0.0.2.0]
 

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ## [Unreleased]
 
 ## Added
+- Prevent old reward cycle signers from processing block validation response messages that do not apply to blocks from their cycle.
 
 ## Changed
 

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -564,6 +564,14 @@ impl Signer {
         // For mutability reasons, we need to take the block_info out of the map and add it back after processing
         let mut block_info = match self.signer_db.block_lookup(&signer_signature_hash) {
             Ok(Some(block_info)) => {
+                if block_info.reward_cycle != self.reward_cycle {
+                    // We are not signing for this reward cycle. Ignore the block.
+                    debug!(
+                        "{self}: Received a block validation response for a different reward cycle. Ignore it.";
+                        "requested_reward_cycle" => block_info.reward_cycle,
+                    );
+                    return None;
+                }
                 if block_info.is_locally_finalized() {
                     debug!("{self}: Received block validation for a block that is already marked as {}. Ignoring...", block_info.state);
                     return None;
@@ -635,6 +643,14 @@ impl Signer {
         }
         let mut block_info = match self.signer_db.block_lookup(&signer_signature_hash) {
             Ok(Some(block_info)) => {
+                if block_info.reward_cycle != self.reward_cycle {
+                    // We are not signing for this reward cycle. Ignore the block.
+                    debug!(
+                        "{self}: Received a block validation response for a different reward cycle. Ignore it.";
+                        "requested_reward_cycle" => block_info.reward_cycle,
+                    );
+                    return None;
+                }
                 if block_info.is_locally_finalized() {
                     debug!("{self}: Received block validation for a block that is already marked as {}. Ignoring...", block_info.state);
                     return None;


### PR DESCRIPTION
@obycode discovered that the recent stall was due to the WRONG signer (one from prior reward cycle) processing a block validation response and attempting to broadcast when it thought it had enough signatures. The block proposal itself was already reward cycle gated but not the block validationr esponse. This caused some inifite looping in a signer that tried to broadcast a signed block that met its own reward cycle threshold but not the actual reward cycle threshold of the current reward cycle. 

This should be fixed in the event parity check but that would require changes to the node. This is just a hotfix for the signers only. 

This only became an issue now because of a change I made to the signer db: we no longer query the db based on reward_cycle (this never was a problem before because when we would go to query for a block using its signer signature hash, we would also pass in our own reward cycle. This would then never return a matching block info and then the block validation request would not apply)