### PR TITLE
Filter out phantom txs from test_observer::parse_transaction fn

### DIFF
--- a/stackslib/src/chainstate/stacks/transaction.rs
+++ b/stackslib/src/chainstate/stacks/transaction.rs
@@ -34,6 +34,7 @@ use crate::chainstate::stacks::{TransactionPayloadID, *};
 use crate::codec::Error as CodecError;
 use crate::core::*;
 use crate::net::Error as net_error;
+use crate::util_lib::boot::boot_code_addr;
 
 impl StacksMessageCodec for TransactionContractCall {
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), codec_error> {
@@ -1029,6 +1030,16 @@ impl StacksTransaction {
         match self.version {
             TransactionVersion::Mainnet => true,
             _ => false,
+        }
+    }
+
+    /// Is this a phantom transaction?
+    pub fn is_phantom(&self) -> bool {
+        let boot_address = boot_code_addr(self.is_mainnet()).into();
+        if let TransactionPayload::TokenTransfer(address, amount, _) = &self.payload {
+            *address == boot_address && *amount == 0
+        } else {
+            false
         }
     }
 }

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -241,7 +241,7 @@ impl TestSigningChannel {
 
 /// Assert that the block events captured by the test observer
 ///  all match the miner heuristic of *exclusively* including the
-///  tenure change transaction in tenure changing blocks.
+///  tenure change transaction and token transfers in tenure changing blocks.
 pub fn check_nakamoto_empty_block_heuristics() {
     let blocks = test_observer::get_blocks();
     for block in blocks.iter() {
@@ -257,10 +257,12 @@ pub fn check_nakamoto_empty_block_heuristics() {
             let only_coinbase_and_tenure_change = txs.iter().all(|tx| {
                 matches!(
                     tx.payload,
-                    TransactionPayload::TenureChange(_) | TransactionPayload::Coinbase(..)
+                    TransactionPayload::TenureChange(_)
+                        | TransactionPayload::Coinbase(..)
+                        | TransactionPayload::TokenTransfer(..)
                 )
             });
-            assert!(only_coinbase_and_tenure_change, "Nakamoto blocks with a tenure change in them should only have coinbase or tenure changes");
+            assert!(only_coinbase_and_tenure_change, "Nakamoto blocks with a tenure change in them should only have coinbase, tenure changes, or token transfers.");
         }
     }
 }

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -241,7 +241,7 @@ impl TestSigningChannel {
 
 /// Assert that the block events captured by the test observer
 ///  all match the miner heuristic of *exclusively* including the
-///  tenure change transaction and token transfers in tenure changing blocks.
+///  tenure change transaction in tenure changing blocks.
 pub fn check_nakamoto_empty_block_heuristics() {
     let blocks = test_observer::get_blocks();
     for block in blocks.iter() {
@@ -257,12 +257,10 @@ pub fn check_nakamoto_empty_block_heuristics() {
             let only_coinbase_and_tenure_change = txs.iter().all(|tx| {
                 matches!(
                     tx.payload,
-                    TransactionPayload::TenureChange(_)
-                        | TransactionPayload::Coinbase(..)
-                        | TransactionPayload::TokenTransfer(..)
+                    TransactionPayload::TenureChange(_) | TransactionPayload::Coinbase(..)
                 )
             });
-            assert!(only_coinbase_and_tenure_change, "Nakamoto blocks with a tenure change in them should only have coinbase, tenure changes, or token transfers.");
+            assert!(only_coinbase_and_tenure_change, "Nakamoto blocks with a tenure change in them should only have coinbase or tenure changes");
         }
     }
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -200,6 +200,7 @@ pub mod test_observer {
     use stacks::chainstate::stacks::{StacksTransaction, TransactionPayload};
     use stacks::codec::StacksMessageCodec;
     use stacks::config::{EventKeyType, EventObserverConfig};
+    use stacks::core::CHAIN_ID_MAINNET;
     use stacks::net::api::postblock_proposal::BlockValidateResponse;
     use stacks::util::hash::hex_bytes;
     use stacks_common::types::chainstate::StacksBlockId;
@@ -599,10 +600,9 @@ pub mod test_observer {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
 
-                let mainnet_address = boot_code_addr(true).into();
-                let testnet_address = boot_code_addr(false).into();
+                let boot_address = boot_code_addr(tx.chain_id == CHAIN_ID_MAINNET).into();
                 if let TransactionPayload::TokenTransfer(address, amount, _) = &tx.payload {
-                    if *address == mainnet_address || *address == testnet_address && *amount == 0 {
+                    if *address == boot_address && *amount == 0 {
                         return None;
                     }
                 }


### PR DESCRIPTION
Closes https://github.com/stacks-network/stacks-core/issues/5634

We now generate phantom unlock txs and include them in tenure change blocks. These really are actually only tx receipts though not actual transactions. I attempt to filter them out from the test_observer call. I could prevent them being added to the transaction list but I feel like maybe that its better to include them and just not parse them out from the final test_observer end.