### PR TITLE
chore: Apply Clippy lint `iter_with_drain`

### DIFF
--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -1035,13 +1035,13 @@ fn mine_10_stacks_blocks_2_forks_disjoint() {
     let mut miners_1 = vec![];
     let mut miners_2 = vec![];
 
-    let mut miners_drain = miners.drain(..);
+    let mut miners_iter = miners.into_iter();
     for i in 0..5 {
-        let m = miners_drain.next().unwrap();
+        let m = miners_iter.next().unwrap();
         miners_1.push(m);
     }
     for i in 0..5 {
-        let m = miners_drain.next().unwrap();
+        let m = miners_iter.next().unwrap();
         miners_2.push(m);
     }
 
@@ -1150,13 +1150,13 @@ fn mine_10_stacks_blocks_2_forks_disjoint_same_blocks() {
     let mut miners_1 = vec![];
     let mut miners_2 = vec![];
 
-    let mut miners_drain = miners.drain(..);
+    let mut miners_iter = miners.into_iter();
     for i in 0..5 {
-        let m = miners_drain.next().unwrap();
+        let m = miners_iter.next().unwrap();
         miners_1.push(m);
     }
     for i in 0..5 {
-        let m = miners_drain.next().unwrap();
+        let m = miners_iter.next().unwrap();
         miners_2.push(m);
     }
 

--- a/stackslib/src/chainstate/nakamoto/shadow.rs
+++ b/stackslib/src/chainstate/nakamoto/shadow.rs
@@ -506,7 +506,7 @@ impl NakamotoBlockBuilder {
         chainstate_handle: &StacksChainState,
         burn_dbconn: &SortitionHandleConn,
         tenure_id_consensus_hash: &ConsensusHash,
-        mut txs: Vec<StacksTransaction>,
+        txs: Vec<StacksTransaction>,
     ) -> Result<(NakamotoBlock, u64, ExecutionCost), Error> {
         use clarity::vm::ast::ASTRules;
 
@@ -532,7 +532,7 @@ impl NakamotoBlockBuilder {
             &mut miner_tenure_info,
             tenure_id_consensus_hash,
         )?;
-        for tx in txs.drain(..) {
+        for tx in txs.into_iter() {
             let tx_len = tx.tx_len();
             match builder.try_mine_tx_with_len(
                 &mut tenure_tx,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -1016,7 +1016,7 @@ impl TestStacksNode {
         mut builder: NakamotoBlockBuilder,
         chainstate_handle: &StacksChainState,
         burn_dbconn: &SortitionHandleConn,
-        mut txs: Vec<StacksTransaction>,
+        txs: Vec<StacksTransaction>,
     ) -> Result<(NakamotoBlock, u64, ExecutionCost), ChainstateError> {
         use clarity::vm::ast::ASTRules;
 
@@ -1035,7 +1035,7 @@ impl TestStacksNode {
         let mut miner_tenure_info =
             builder.load_tenure_info(&mut chainstate, burn_dbconn, tenure_cause)?;
         let mut tenure_tx = builder.tenure_begin(burn_dbconn, &mut miner_tenure_info)?;
-        for tx in txs.drain(..) {
+        for tx in txs.into_iter() {
             let tx_len = tx.tx_len();
             match builder.try_mine_tx_with_len(
                 &mut tenure_tx,

--- a/stackslib/src/chainstate/stacks/index/test/marf.rs
+++ b/stackslib/src/chainstate/stacks/index/test/marf.rs
@@ -1351,7 +1351,7 @@ fn marf_insert_random_10485760_4096_file_storage() {
         start_time = get_epoch_time_ms();
 
         let values = values
-            .drain(..)
+            .into_iter()
             .map(|x| MARFValue::from_value(&x))
             .collect();
 
@@ -1772,7 +1772,7 @@ fn marf_insert_get_128_fork_256() {
                 }
 
                 let values = values
-                    .drain(..)
+                    .into_iter()
                     .map(|x| MARFValue::from_value(&x))
                     .collect();
 

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -2073,7 +2073,7 @@ impl StacksBlockBuilder {
         mut builder: StacksBlockBuilder,
         chainstate_handle: &StacksChainState,
         burn_dbconn: &SortitionHandleConn,
-        mut txs: Vec<StacksTransaction>,
+        txs: Vec<StacksTransaction>,
         mut mblock_txs: Vec<StacksTransaction>,
     ) -> Result<(StacksBlock, u64, ExecutionCost, Option<StacksMicroblock>), Error> {
         debug!("Build anchored block from {} transactions", txs.len());
@@ -2081,7 +2081,7 @@ impl StacksBlockBuilder {
         let mut miner_epoch_info = builder.pre_epoch_begin(&mut chainstate, burn_dbconn, true)?;
         let ast_rules = miner_epoch_info.ast_rules;
         let (mut epoch_tx, _) = builder.epoch_begin(burn_dbconn, &mut miner_epoch_info)?;
-        for tx in txs.drain(..) {
+        for tx in txs.into_iter() {
             match builder.try_mine_tx(&mut epoch_tx, &tx, ast_rules.clone()) {
                 Ok(_) => {
                     debug!("Included {}", &tx.txid());

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -1572,7 +1572,7 @@ pub mod test {
 
         tx_coinbase.anchor_mode = TransactionAnchorMode::OnChainOnly;
 
-        let mut all_txs = codec_all_transactions(
+        let all_txs = codec_all_transactions(
             &TransactionVersion::Testnet,
             0x80000000,
             &TransactionAnchorMode::OnChainOnly,
@@ -1589,7 +1589,7 @@ pub mod test {
             txs_anchored.push(tx_coinbase);
         }
 
-        for tx in all_txs.drain(..) {
+        for tx in all_txs.into_iter() {
             match tx.payload {
                 TransactionPayload::Coinbase(..) => {
                     continue;

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -1397,7 +1397,7 @@ fn mempool_db_load_store_replace_tx(#[case] behavior: MempoolCollectionBehavior)
     let chainstate_path = chainstate_path(&path_name);
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let mut txs = codec_all_transactions(
+    let txs = codec_all_transactions(
         &TransactionVersion::Testnet,
         0x80000000,
         &TransactionAnchorMode::Any,
@@ -1409,7 +1409,7 @@ fn mempool_db_load_store_replace_tx(#[case] behavior: MempoolCollectionBehavior)
     let mut mempool_tx = mempool.tx_begin().unwrap();
 
     eprintln!("add all txs");
-    for (i, mut tx) in txs.drain(..).enumerate() {
+    for (i, mut tx) in txs.into_iter().enumerate() {
         // make sure each address is unique per tx (not the case in codec_all_transactions)
         let origin_address = StacksAddress {
             version: 22,

--- a/stackslib/src/net/dns.rs
+++ b/stackslib/src/net/dns.rs
@@ -277,7 +277,7 @@ impl DNSClient {
                 to_remove.push(req.clone());
             }
         }
-        for req in to_remove.drain(..) {
+        for req in to_remove.into_iter() {
             self.requests.insert(
                 req.clone(),
                 Some(DNSResponse::error(req, "DNS lookup timed out".to_string())),

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -687,11 +687,11 @@ impl NakamotoTenureDownloaderSet {
                 self.clear_downloader(naddr);
             }
         }
-        for done_naddr in finished.drain(..) {
+        for done_naddr in finished.into_iter() {
             debug!("Remove finished downloader for {done_naddr}");
             self.clear_downloader(&done_naddr);
         }
-        for done_tenure in finished_tenures.drain(..) {
+        for done_tenure in finished_tenures.into_iter() {
             self.completed_tenures.insert(done_tenure);
         }
 

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -291,7 +291,7 @@ impl RelayerStats {
                         }
                         to_remove.push(*ts);
                     }
-                    for ts in to_remove.drain(..) {
+                    for ts in to_remove.into_iter() {
                         self.relay_updates.remove(&ts);
                     }
                 }
@@ -3354,7 +3354,7 @@ impl PeerNetwork {
         availability_data: BlocksAvailableMap,
         blocks: HashMap<ConsensusHash, StacksBlock>,
     ) -> Result<(usize, usize), net_error> {
-        let (mut outbound_recipients, mut inbound_recipients) =
+        let (outbound_recipients, inbound_recipients) =
             self.find_block_recipients(&availability_data)?;
         debug!(
             "{:?}: Advertize {} blocks to {} inbound peers, {} outbound peers",
@@ -3367,7 +3367,7 @@ impl PeerNetwork {
         let num_inbound = inbound_recipients.len();
         let num_outbound = outbound_recipients.len();
 
-        for recipient in outbound_recipients.drain(..) {
+        for recipient in outbound_recipients.into_iter() {
             debug!(
                 "{:?}: Advertize {} blocks to outbound peer {}",
                 &self.local_peer,
@@ -3380,7 +3380,7 @@ impl PeerNetwork {
                 &blocks,
             )?;
         }
-        for recipient in inbound_recipients.drain(..) {
+        for recipient in inbound_recipients.into_iter() {
             debug!(
                 "{:?}: Advertize {} blocks to inbound peer {}",
                 &self.local_peer,
@@ -3405,14 +3405,14 @@ impl PeerNetwork {
         availability_data: BlocksAvailableMap,
         microblocks: HashMap<ConsensusHash, (StacksBlockId, Vec<StacksMicroblock>)>,
     ) -> Result<(usize, usize), net_error> {
-        let (mut outbound_recipients, mut inbound_recipients) =
+        let (outbound_recipients, inbound_recipients) =
             self.find_block_recipients(&availability_data)?;
         debug!("{:?}: Advertize {} confirmed microblock streams to {} inbound peers, {} outbound peers", &self.local_peer, availability_data.len(), outbound_recipients.len(), inbound_recipients.len());
 
         let num_inbound = inbound_recipients.len();
         let num_outbound = outbound_recipients.len();
 
-        for recipient in outbound_recipients.drain(..) {
+        for recipient in outbound_recipients.into_iter() {
             debug!(
                 "{:?}: Advertize {} confirmed microblock streams to outbound peer {}",
                 &self.local_peer,
@@ -3425,7 +3425,7 @@ impl PeerNetwork {
                 &microblocks,
             )?;
         }
-        for recipient in inbound_recipients.drain(..) {
+        for recipient in inbound_recipients.into_iter() {
             debug!(
                 "{:?}: Advertize {} confirmed microblock streams to inbound peer {}",
                 &self.local_peer,

--- a/stackslib/src/net/server.rs
+++ b/stackslib/src/net/server.rs
@@ -338,7 +338,7 @@ impl HttpPeer {
             }
         }
 
-        for event_id in to_remove.drain(0..) {
+        for event_id in to_remove.into_iter() {
             self.deregister_http(network_state, event_id);
         }
     }


### PR DESCRIPTION
### Description

Apply Clippy lint `iter_with_drain`, which finds places where `.drain(..)` can be replaced with `.into_iter()` (there are still a couple false positives in the code)

This is more efficient because `into_iter()` does not clear the `Vec`
