### PR TITLE
chore: Apply new lints in Clippy 1.78 (version 2)

### DIFF
--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [ "stacks", "stx", "bitcoin", "crypto", "blockstack", "decentralized"
 readme = "README.md"
 resolver = "2"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.80"
 
 [lib]
 name = "blockstack_lib"

--- a/stackslib/src/chainstate/nakamoto/test_signers.rs
+++ b/stackslib/src/chainstate/nakamoto/test_signers.rs
@@ -264,7 +264,7 @@ impl TestSigners {
 
         let aggregate_public_key: Vec<u8> =
             rand::thread_rng().sample_iter(Standard).take(33).collect();
-        self.aggregate_public_key = aggregate_public_key.clone();
+        self.aggregate_public_key.clone_from(&aggregate_public_key);
         aggregate_public_key
     }
 }

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -444,14 +444,14 @@ impl StacksBlock {
         let mut txids = HashMap::new();
         for (i, tx) in txs.iter().enumerate() {
             let txid = tx.txid();
-            if txids.get(&txid).is_some() {
+            if txids.contains_key(&txid) {
                 warn!(
                     "Duplicate tx {}: at index {} and {}",
                     txid,
                     txids.get(&txid).unwrap(),
                     i
                 );
-                test_debug!("{:?}", &tx);
+                test_debug!("{tx:?}");
                 return false;
             }
             txids.insert(txid, i);

--- a/stackslib/src/chainstate/stacks/index/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/trie.rs
@@ -281,7 +281,7 @@ impl Trie {
             )));
         }
 
-        value.path = cur_leaf.path_bytes().clone();
+        value.path.clone_from(cur_leaf.path_bytes());
 
         let leaf_hash = get_leaf_hash(value);
 

--- a/stackslib/src/chainstate/stacks/tests/chain_histories.rs
+++ b/stackslib/src/chainstate/stacks/tests/chain_histories.rs
@@ -2857,7 +2857,7 @@ pub fn mine_invalid_token_transfers_block(
     );
     builder.force_mine_tx(clarity_tx, &tx1).unwrap();
 
-    if miner.spent_at_nonce.get(&1).is_none() {
+    if !miner.spent_at_nonce.contains_key(&1) {
         miner.spent_at_nonce.insert(1, 11111);
     }
 
@@ -2871,7 +2871,7 @@ pub fn mine_invalid_token_transfers_block(
     );
     builder.force_mine_tx(clarity_tx, &tx2).unwrap();
 
-    if miner.spent_at_nonce.get(&2).is_none() {
+    if !miner.spent_at_nonce.contains_key(&2) {
         miner.spent_at_nonce.insert(2, 22222);
     }
 

--- a/stackslib/src/chainstate/stacks/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/tests/mod.rs
@@ -214,7 +214,7 @@ impl TestMinerTrace {
         let mut num_blocks = 0;
         for p in self.points.iter() {
             for miner_id in p.stacks_blocks.keys() {
-                if p.stacks_blocks.get(miner_id).is_some() {
+                if p.stacks_blocks.contains_key(miner_id) {
                     num_blocks += 1;
                 }
             }
@@ -227,7 +227,7 @@ impl TestMinerTrace {
         let mut num_sortitions = 0;
         for p in self.points.iter() {
             for miner_id in p.fork_snapshots.keys() {
-                if p.fork_snapshots.get(miner_id).is_some() {
+                if p.fork_snapshots.contains_key(miner_id) {
                     num_sortitions += 1;
                 }
             }

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -1438,7 +1438,7 @@ impl BurnchainConfigFile {
             // check magic bytes and set if not defined
             let mainnet_magic = ConfigFile::mainnet().burnchain.unwrap().magic_bytes;
             if self.magic_bytes.is_none() {
-                self.magic_bytes = mainnet_magic.clone();
+                self.magic_bytes.clone_from(&mainnet_magic);
             }
             if self.magic_bytes != mainnet_magic {
                 return Err(format!(

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -1266,7 +1266,7 @@ fn test_iterate_candidates_concurrent_write_lock() {
     assert_eq!(all_addr_nonces.len(), expected_addr_nonces.len());
 
     for (addr, nonce) in all_addr_nonces {
-        assert!(expected_addr_nonces.get(&addr).is_some());
+        assert!(expected_addr_nonces.contains_key(&addr));
         assert_eq!(nonce, 24);
     }
 }

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -562,7 +562,10 @@ impl NakamotoBlockProposal {
         // Clone signatures from block proposal
         // These have already been validated by `validate_nakamoto_block_burnchain()``
         block.header.miner_signature = self.block.header.miner_signature.clone();
-        block.header.signer_signature = self.block.header.signer_signature.clone();
+        block
+            .header
+            .signer_signature
+            .clone_from(&self.block.header.signer_signature);
 
         // Clone the timestamp from the block proposal, which has already been validated
         block.header.timestamp = self.block.header.timestamp;

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -1181,7 +1181,8 @@ impl ConversationP2P {
         &mut self,
         stacker_db_data: &StackerDBHandshakeData,
     ) {
-        self.db_smart_contracts = stacker_db_data.smart_contracts.clone();
+        self.db_smart_contracts
+            .clone_from(&stacker_db_data.smart_contracts);
     }
 
     /// Forget about this peer's stacker DB replication state

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -316,7 +316,7 @@ impl HttpRequestContentsExtensions for HttpRequestContents {
     /// Use a particular tip request
     fn for_tip(mut self, tip_req: TipRequest) -> Self {
         if tip_req != TipRequest::UseLatestAnchoredTip {
-            self.query_arg("tip".to_string(), format!("{}", &tip_req.to_string()))
+            self.query_arg("tip".to_string(), tip_req.to_string())
         } else {
             let _ = self.take_query_arg(&"tip".to_string());
             self

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -80,12 +80,12 @@ pub enum TipRequest {
 
 impl TipRequest {}
 
-impl ToString for TipRequest {
-    fn to_string(&self) -> String {
+impl fmt::Display for TipRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::UseLatestAnchoredTip => "".to_string(),
-            Self::UseLatestUnconfirmedTip => "latest".to_string(),
-            Self::SpecificTip(ref tip) => format!("{}", tip),
+            Self::UseLatestAnchoredTip => write!(f, ""),
+            Self::UseLatestUnconfirmedTip => write!(f, "latest"),
+            Self::SpecificTip(ref tip) => write!(f, "{tip}"),
         }
     }
 }

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -81,7 +81,7 @@ pub enum TipRequest {
 impl TipRequest {}
 
 impl fmt::Display for TipRequest {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::UseLatestAnchoredTip => write!(f, ""),
             Self::UseLatestUnconfirmedTip => write!(f, "latest"),

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -241,7 +241,7 @@ impl InvGenerator {
         tenure_id_consensus_hash: &ConsensusHash,
     ) -> Result<Option<InvTenureInfo>, NetError> {
         let tip_block_id = StacksBlockId::new(tip_block_ch, tip_block_bh);
-        if self.processed_tenures.get(&tip_block_id).is_none() {
+        if !self.processed_tenures.contains_key(&tip_block_id) {
             // this tip has no known table.
             // does it have an ancestor with a table? If so, then move its ancestor's table to this
             // tip. Otherwise, make a new table.

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -474,7 +474,7 @@ impl PeerNetwork {
         );
         let pub_ip = connection_opts.public_ip_address.clone();
         let pub_ip_learned = pub_ip.is_none();
-        local_peer.public_ip_address = pub_ip.clone();
+        local_peer.public_ip_address.clone_from(&pub_ip);
 
         if connection_opts.disable_inbound_handshakes {
             debug!("{:?}: disable inbound handshakes", &local_peer);
@@ -4119,7 +4119,8 @@ impl PeerNetwork {
     /// Get the local peer from the peer DB, but also preserve the public IP address
     pub fn load_local_peer(&self) -> Result<LocalPeer, net_error> {
         let mut lp = PeerDB::get_local_peer(&self.peerdb.conn())?;
-        lp.public_ip_address = self.local_peer.public_ip_address.clone();
+        lp.public_ip_address
+            .clone_from(&self.local_peer.public_ip_address);
         Ok(lp)
     }
 

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -406,7 +406,7 @@ impl RelayerStats {
         // look up ASNs
         let mut asns = HashMap::new();
         for nk in neighbors.iter() {
-            if asns.get(nk).is_none() {
+            if !asns.contains_key(nk) {
                 match PeerDB::asn_lookup(conn, &nk.addrbytes)? {
                     Some(asn) => asns.insert((*nk).clone(), asn),
                     None => asns.insert((*nk).clone(), 0),
@@ -1150,7 +1150,7 @@ impl Relayer {
 
         for (anchored_block_hash, (relayers, mblocks_map)) in new_microblocks.into_iter() {
             for (_, mblock) in mblocks_map.into_iter() {
-                if mblocks_data.get(&anchored_block_hash).is_none() {
+                if !mblocks_data.contains_key(&anchored_block_hash) {
                     mblocks_data.insert(anchored_block_hash.clone(), vec![]);
                 }
 

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -1182,7 +1182,7 @@ fn test_tenure_start_end_from_inventory() {
         for (i, wt) in wanted_tenures.iter().enumerate() {
             if i >= (rc_len - 1).into() {
                 // nothing here
-                assert!(available.get(&wt.tenure_id_consensus_hash).is_none());
+                assert!(!available.contains_key(&wt.tenure_id_consensus_hash));
                 continue;
             }
 

--- a/stackslib/src/net/tests/httpcore.rs
+++ b/stackslib/src/net/tests/httpcore.rs
@@ -767,11 +767,11 @@ fn test_http_response_type_codec() {
         match preamble {
             StacksHttpPreamble::Response(ref mut req) => {
                 assert_eq!(req.headers.len(), 5);
-                assert!(req.headers.get("access-control-allow-headers").is_some());
-                assert!(req.headers.get("access-control-allow-methods").is_some());
-                assert!(req.headers.get("access-control-allow-origin").is_some());
-                assert!(req.headers.get("server").is_some());
-                assert!(req.headers.get("date").is_some());
+                assert!(req.headers.contains_key("access-control-allow-headers"));
+                assert!(req.headers.contains_key("access-control-allow-methods"));
+                assert!(req.headers.contains_key("access-control-allow-origin"));
+                assert!(req.headers.contains_key("server"));
+                assert!(req.headers.contains_key("date"));
                 req.headers.clear();
             }
             StacksHttpPreamble::Request(_) => {

--- a/stackslib/src/net/tests/mempool/mod.rs
+++ b/stackslib/src/net/tests/mempool/mod.rs
@@ -307,7 +307,7 @@ fn test_mempool_sync_2_peers() {
     // peer 2 has none of the old ones
     for tx in peer_2_mempool_txs {
         assert_eq!(&tx.tx, txs.get(&tx.tx.txid()).unwrap());
-        assert!(old_txs.get(&tx.tx.txid()).is_none());
+        assert!(!old_txs.contains_key(&tx.tx.txid()));
     }
 }
 

--- a/stackslib/src/net/tests/neighbors.rs
+++ b/stackslib/src/net/tests/neighbors.rs
@@ -581,7 +581,7 @@ fn test_step_walk_1_neighbor_bootstrapping() {
                     assert_eq!(w.result.replaced_neighbors.len(), 0);
 
                     // peer 2 never gets added to peer 1's frontier
-                    assert!(w.frontier.get(&neighbor_2.addr).is_none());
+                    assert!(!w.frontier.contains_key(&neighbor_2.addr));
                 }
                 None => {}
             };
@@ -597,7 +597,7 @@ fn test_step_walk_1_neighbor_bootstrapping() {
             i += 1;
         }
 
-        debug!("Completed walk round {} step(s)", i);
+        debug!("Completed walk round {i} step(s)");
 
         // peer 1 contacted peer 2
         let stats_1 = peer_1
@@ -673,7 +673,7 @@ fn test_step_walk_1_neighbor_behind() {
                     assert_eq!(w.result.replaced_neighbors.len(), 0);
 
                     // peer 1 never gets added to peer 2's frontier
-                    assert!(w.frontier.get(&neighbor_1.addr).is_none());
+                    assert!(!w.frontier.contains_key(&neighbor_1.addr));
                 }
                 None => {}
             };


### PR DESCRIPTION
### Description

Apply the following lints introduced in Clippy 1.78:
- `unnecessary_get_then_check`: Replace `.get().is_some()` with `contains_key()`
- `assigning_clones`: Use possibly more efficient `clone_from()` instead of `clone()` where available
- `to_string_trait_impl`: Implement `std::fmt::Display` instead of `ToString`
- `incompatible_msrv`: Use correct MSRV in Cargo.toml

This is a newer version of #4780 made by re-applying changes on latest `develop`

### Applicable issues

- #4780 