### PR TITLE
Clippy: static lifetime for consts

### DIFF
--- a/stacks-common/src/util/macros.rs
+++ b/stacks-common/src/util/macros.rs
@@ -47,8 +47,8 @@ macro_rules! define_named_enum {
             $($Variant),*,
         }
         impl $Name {
-            pub const ALL: &[$Name] = &[$($Name::$Variant),*];
-            pub const ALL_NAMES: &[&str] = &[$($VarName),*];
+            pub const ALL: &'static [$Name] = &[$($Name::$Variant),*];
+            pub const ALL_NAMES: &'static [&'static str] = &[$($VarName),*];
 
             pub fn lookup_by_name(name: &str) -> Option<Self> {
                 match name {
@@ -113,8 +113,8 @@ macro_rules! define_versioned_named_enum_internal {
         }
 
         impl $Name {
-            pub const ALL: &[$Name] = &[$($Name::$Variant),*];
-            pub const ALL_NAMES: &[&str] = &[$($VarName),*];
+            pub const ALL: &'static [$Name] = &[$($Name::$Variant),*];
+            pub const ALL_NAMES: &'static [&'static str] = &[$($VarName),*];
 
             pub fn lookup_by_name(name: &str) -> Option<Self> {
                 match name {

--- a/stackslib/src/chainstate/burn/mod.rs
+++ b/stackslib/src/chainstate/burn/mod.rs
@@ -183,17 +183,17 @@ impl SortitionHash {
 }
 
 impl Opcodes {
-    const HTTP_BLOCK_COMMIT: &str = "block_commit";
-    const HTTP_KEY_REGISTER: &str = "key_register";
-    const HTTP_BURN_SUPPORT: &str = "burn_support";
-    const HTTP_STACK_STX: &str = "stack_stx";
-    const HTTP_PRE_STX: &str = "pre_stx";
-    const HTTP_TRANSFER_STX: &str = "transfer_stx";
-    const HTTP_DELEGATE_STX: &str = "delegate_stx";
-    const HTTP_PEG_IN: &str = "peg_in";
-    const HTTP_PEG_OUT_REQUEST: &str = "peg_out_request";
-    const HTTP_PEG_OUT_FULFILL: &str = "peg_out_fulfill";
-    const HTTP_VOTE_FOR_AGGREGATE_KEY: &str = "vote_for_aggregate_key";
+    const HTTP_BLOCK_COMMIT: &'static str = "block_commit";
+    const HTTP_KEY_REGISTER: &'static str = "key_register";
+    const HTTP_BURN_SUPPORT: &'static str = "burn_support";
+    const HTTP_STACK_STX: &'static str = "stack_stx";
+    const HTTP_PRE_STX: &'static str = "pre_stx";
+    const HTTP_TRANSFER_STX: &'static str = "transfer_stx";
+    const HTTP_DELEGATE_STX: &'static str = "delegate_stx";
+    const HTTP_PEG_IN: &'static str = "peg_in";
+    const HTTP_PEG_OUT_REQUEST: &'static str = "peg_out_request";
+    const HTTP_PEG_OUT_FULFILL: &'static str = "peg_out_fulfill";
+    const HTTP_VOTE_FOR_AGGREGATE_KEY: &'static str = "vote_for_aggregate_key";
 
     pub fn to_http_str(&self) -> &'static str {
         match self {

--- a/stackslib/src/net/api/getstackers.rs
+++ b/stackslib/src/net/api/getstackers.rs
@@ -57,8 +57,8 @@ pub enum GetStackersErrors {
 }
 
 impl GetStackersErrors {
-    pub const NOT_AVAILABLE_ERR_TYPE: &str = "not_available_try_again";
-    pub const OTHER_ERR_TYPE: &str = "other";
+    pub const NOT_AVAILABLE_ERR_TYPE: &'static str = "not_available_try_again";
+    pub const OTHER_ERR_TYPE: &'static str = "other";
 
     pub fn error_type_string(&self) -> &'static str {
         match self {


### PR DESCRIPTION
This fixes some clippy warnings about not specifying explicit lifetimes for constants.