### PR TITLE
chore: Apply Clippy lint `bind-instead-of-map`

### DIFF
--- a/stackslib/src/burnchains/bitcoin/blocks.rs
+++ b/stackslib/src/burnchains/bitcoin/blocks.rs
@@ -150,9 +150,7 @@ impl BitcoinMessageHandler for BitcoinBlockDownloader {
             None => panic!("No block header set"),
             Some(ref ipc_header) => {
                 let block_hash = ipc_header.block_header.header.bitcoin_hash().clone();
-                indexer
-                    .send_getdata(&vec![block_hash])
-                    .and_then(|_r| Ok(true))
+                indexer.send_getdata(&vec![block_hash]).map(|_r| true)
             }
         }
     }

--- a/stackslib/src/burnchains/bitcoin/indexer.rs
+++ b/stackslib/src/burnchains/bitcoin/indexer.rs
@@ -458,7 +458,7 @@ impl BitcoinIndexer {
         }
         spv_client
             .run(self)
-            .and_then(|_r| Ok(spv_client.end_block_height.unwrap()))
+            .map(|_r| spv_client.end_block_height.unwrap())
     }
 
     #[cfg(test)]

--- a/stackslib/src/burnchains/bitcoin/network.rs
+++ b/stackslib/src/burnchains/bitcoin/network.rs
@@ -127,16 +127,16 @@ impl BitcoinIndexer {
         // classify the message here, so we can pass it along to the handler explicitly
         match message {
             btc_message::NetworkMessage::Version(..) => {
-                return self.handle_version(message).and_then(|_r| Ok(true));
+                return self.handle_version(message).map(|_r| true);
             }
             btc_message::NetworkMessage::Verack => {
-                return self.handle_verack(message).and_then(|_r| Ok(true));
+                return self.handle_verack(message).map(|_r| true);
             }
             btc_message::NetworkMessage::Ping(..) => {
-                return self.handle_ping(message).and_then(|_r| Ok(true));
+                return self.handle_ping(message).map(|_r| true);
             }
             btc_message::NetworkMessage::Pong(..) => {
-                return self.handle_pong(message).and_then(|_r| Ok(true));
+                return self.handle_pong(message).map(|_r| true);
             }
             _ => match handler {
                 Some(custom_handler) => custom_handler.handle_message(self, message),

--- a/stackslib/src/burnchains/bitcoin/spv.rs
+++ b/stackslib/src/burnchains/bitcoin/spv.rs
@@ -274,7 +274,7 @@ impl SpvClient {
         tx.execute("UPDATE db_config SET version = ?1", &[version])
             .map_err(db_error::SqliteError)
             .map_err(|e| e.into())
-            .and_then(|_| Ok(()))
+            .map(|_| ())
     }
 
     #[cfg(test)]
@@ -354,7 +354,7 @@ impl SpvClient {
     pub fn is_initialized(&self) -> Result<(), btc_error> {
         fs::metadata(&self.headers_path)
             .map_err(btc_error::FilesystemError)
-            .and_then(|_m| Ok(()))
+            .map(|_m| ())
     }
 
     /// Get the block range to scan
@@ -762,7 +762,7 @@ impl SpvClient {
 
         tx.execute(sql, args)
             .map_err(|e| btc_error::DBError(db_error::SqliteError(e)))
-            .and_then(|_x| Ok(()))
+            .map(|_x| ())
     }
 
     /// Initialize the block headers file with the genesis block hash.
@@ -1231,7 +1231,7 @@ impl BitcoinMessageHandler for SpvClient {
 
         indexer.runtime.last_getheaders_send_time = get_epoch_time_secs();
         self.send_next_getheaders(indexer, start_height)
-            .and_then(|_r| Ok(true))
+            .map(|_r| true)
     }
 
     /// Trait message handler
@@ -1298,7 +1298,7 @@ impl BitcoinMessageHandler for SpvClient {
                     );
                 }
                 self.send_next_getheaders(indexer, block_height)
-                    .and_then(|_| Ok(true))
+                    .map(|_| true)
             }
             x => Err(btc_error::UnhandledMessage(x)),
         }

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -3936,7 +3936,7 @@ impl SortitionDBConn<'_> {
             tip,
             reward_cycle_id,
         )
-        .and_then(|(reward_cycle_info, _anchor_sortition_id)| Ok(reward_cycle_info))
+        .map(|(reward_cycle_info, _anchor_sortition_id)| reward_cycle_info)
     }
 
     /// Get the prepare phase start sortition ID of a reward cycle.  This is the first prepare

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -2411,11 +2411,11 @@ impl<
             // burnchain has not yet advanced to epoch 3.0
             return self
                 .handle_new_epoch2_burnchain_block(&mut HashSet::new())
-                .and_then(|block_hash_opt| {
+                .map(|block_hash_opt| {
                     if let Some(block_hash) = block_hash_opt {
-                        Ok(NewBurnchainBlockStatus::WaitForPox2x(block_hash))
+                        NewBurnchainBlockStatus::WaitForPox2x(block_hash)
                     } else {
-                        Ok(NewBurnchainBlockStatus::Ready)
+                        NewBurnchainBlockStatus::Ready
                     }
                 });
         }
@@ -2444,12 +2444,12 @@ impl<
 
         // proceed to process sortitions in epoch 3.0
         self.handle_new_nakamoto_burnchain_block()
-            .and_then(|can_proceed| {
+            .map(|can_proceed| {
                 if can_proceed {
-                    Ok(NewBurnchainBlockStatus::Ready)
+                    NewBurnchainBlockStatus::Ready
                 } else {
                     // missing PoX anchor block, but unlike in 2.x, we don't know what it is!
-                    Ok(NewBurnchainBlockStatus::WaitForPoxNakamoto)
+                    NewBurnchainBlockStatus::WaitForPoxNakamoto
                 }
             })
     }

--- a/stackslib/src/chainstate/stacks/auth.rs
+++ b/stackslib/src/chainstate/stacks/auth.rs
@@ -1371,7 +1371,7 @@ impl TransactionAuth {
             TransactionAuth::Standard(_) => Ok(()),
             TransactionAuth::Sponsored(_, ref sponsor_condition) => sponsor_condition
                 .verify(&origin_sighash, &TransactionAuthFlags::AuthSponsored)
-                .and_then(|_sigh| Ok(())),
+                .map(|_sigh| ()),
         }
     }
 

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -2780,9 +2780,9 @@ pub mod test {
     ) -> Result<Vec<RawRewardSetEntry>, Error> {
         state
             .get_reward_addresses(burnchain, sortdb, burn_block_height, block_id)
-            .and_then(|mut addrs| {
+            .map(|mut addrs| {
                 addrs.sort_by_key(|k| k.reward_address.bytes());
-                Ok(addrs)
+                addrs
             })
     }
 

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -1459,9 +1459,9 @@ impl StacksChainState {
             seq,
             seq,
         )
-        .and_then(|list_opt| match list_opt {
-            Some(mut list) => Ok(list.pop()),
-            None => Ok(None),
+        .map(|list_opt| match list_opt {
+            Some(mut list) => list.pop(),
+            None => None,
         })
     }
 
@@ -2786,8 +2786,7 @@ impl StacksChainState {
         parent_index_block_hash: &StacksBlockId,
         min_seq: u16,
     ) -> Result<bool, Error> {
-        StacksChainState::read_i64s(&self.db(), "SELECT processed FROM staging_microblocks WHERE index_block_hash = ?1 AND sequence >= ?2 LIMIT 1", &[&parent_index_block_hash, &min_seq])
-            .and_then(|processed| Ok(!processed.is_empty()))
+        StacksChainState::read_i64s(&self.db(), "SELECT processed FROM staging_microblocks WHERE index_block_hash = ?1 AND sequence >= ?2 LIMIT 1", &[&parent_index_block_hash, &min_seq]).map(|processed| !processed.is_empty())
     }
 
     /// Do we have a given microblock as a descendant of a given anchored block?
@@ -2799,8 +2798,7 @@ impl StacksChainState {
         parent_index_block_hash: &StacksBlockId,
         microblock_hash: &BlockHeaderHash,
     ) -> Result<bool, Error> {
-        StacksChainState::read_i64s(&self.db(), "SELECT processed FROM staging_microblocks WHERE index_block_hash = ?1 AND microblock_hash = ?2 LIMIT 1", &[parent_index_block_hash, microblock_hash])
-            .and_then(|processed| Ok(!processed.is_empty()))
+        StacksChainState::read_i64s(&self.db(), "SELECT processed FROM staging_microblocks WHERE index_block_hash = ?1 AND microblock_hash = ?2 LIMIT 1", &[parent_index_block_hash, microblock_hash]).map(|processed| !processed.is_empty())
     }
 
     /// Do we have any microblock available to serve in any capacity, given its parent anchored block's
@@ -2815,7 +2813,7 @@ impl StacksChainState {
             "SELECT processed FROM staging_microblocks WHERE index_block_hash = ?1 LIMIT 1",
             &[&parent_index_block_hash],
         )
-        .and_then(|processed| Ok(!processed.is_empty()))
+        .map(|processed| !processed.is_empty())
     }
 
     /// Given an index block hash, get the consensus hash and block hash

--- a/stackslib/src/chainstate/stacks/index/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/trie.rs
@@ -907,10 +907,10 @@ impl Trie {
             if cfg!(test) && is_trace() {
                 let node_hash = my_hash.clone();
                 let _ = Trie::get_trie_root_ancestor_hashes_bytes(storage, &node_hash)
-                    .and_then(|_hs| {
+                    .map(|_hs| {
                         storage.clear_cached_ancestor_hashes_bytes();
                         trace!("update_root_hash: Updated {:?} with {:?} from {} to {} + {:?} = {} (fixed root)", &node, &child_ptr, &_cur_hash, &node_hash, &_hs[1..].to_vec(), &h);
-                        Ok(())
+                        ()
                     });
             }
 
@@ -971,10 +971,10 @@ impl Trie {
 
                         if cfg!(test) && is_trace() {
                             let _ = Trie::get_trie_root_ancestor_hashes_bytes(storage, &content_hash)
-                                        .and_then(|_hs| {
+                                        .map(|_hs| {
                                             storage.clear_cached_ancestor_hashes_bytes();
                                             trace!("update_root_hash: Updated {:?} with {:?} from {:?} to {:?} + {:?} = {:?}", &node, &child_ptr, &_cur_hash, &content_hash, &_hs[1..].to_vec(), &h);
-                                            Ok(())
+                                            ()
                                         });
                         }
 

--- a/stackslib/src/chainstate/stacks/index/trie_sql.rs
+++ b/stackslib/src/chainstate/stacks/index/trie_sql.rs
@@ -569,7 +569,7 @@ pub fn set_migrated(conn: &Connection) -> Result<(), Error> {
         &[&u64_to_sql(SQL_MARF_SCHEMA_VERSION)?],
     )
     .map_err(|e| e.into())
-    .and_then(|_| Ok(()))
+    .map(|_| ())
 }
 
 pub fn get_node_hash_bytes(

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -1792,7 +1792,7 @@ impl ClarityTransactionConnection<'_, '_> {
             },
             |_, _| false,
         )
-        .and_then(|(value, ..)| Ok(value))
+        .map(|(value, ..)| value)
     }
 
     pub fn is_mainnet(&self) -> bool {

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -1972,7 +1972,7 @@ impl MemPoolDB {
 
     pub fn db_has_tx(conn: &DBConn, txid: &Txid) -> Result<bool, db_error> {
         query_row(conn, "SELECT 1 FROM mempool WHERE txid = ?1", params![txid])
-            .and_then(|row_opt: Option<i64>| Ok(row_opt.is_some()))
+            .map(|row_opt: Option<i64>| row_opt.is_some())
     }
 
     pub fn get_tx(conn: &DBConn, txid: &Txid) -> Result<Option<MemPoolTxInfo>, db_error> {

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -2138,7 +2138,7 @@ impl ConversationP2P {
             );
             return self
                 .reply_nack(local_peer, chain_view, preamble, NackErrorCodes::Throttled)
-                .and_then(|handle| Ok(Some(handle)));
+                .map(|handle| Some(handle));
         }
         Ok(None)
     }
@@ -2176,7 +2176,7 @@ impl ConversationP2P {
             debug!("{:?}: Neighbor {:?} exceeded max microblocks-push bandwidth of {} bytes/sec (currently at {})", self, &self.to_neighbor_key(), self.connection.options.max_microblocks_push_bandwidth, self.stats.get_microblocks_push_bandwidth());
             return self
                 .reply_nack(local_peer, chain_view, preamble, NackErrorCodes::Throttled)
-                .and_then(|handle| Ok(Some(handle)));
+                .map(|handle| Some(handle));
         }
         Ok(None)
     }
@@ -2213,7 +2213,7 @@ impl ConversationP2P {
             debug!("{:?}: Neighbor {:?} exceeded max transaction-push bandwidth of {} bytes/sec (currently at {})", self, &self.to_neighbor_key(), self.connection.options.max_transaction_push_bandwidth, self.stats.get_transaction_push_bandwidth());
             return self
                 .reply_nack(local_peer, chain_view, preamble, NackErrorCodes::Throttled)
-                .and_then(|handle| Ok(Some(handle)));
+                .map(|handle| Some(handle));
         }
         Ok(None)
     }
@@ -2251,7 +2251,7 @@ impl ConversationP2P {
             debug!("{:?}: Neighbor {:?} exceeded max stackerdb-push bandwidth of {} bytes/sec (currently at {})", self, &self.to_neighbor_key(), self.connection.options.max_stackerdb_push_bandwidth, self.stats.get_stackerdb_push_bandwidth());
             return self
                 .reply_nack(local_peer, chain_view, preamble, NackErrorCodes::Throttled)
-                .and_then(|handle| Ok(Some(handle)));
+                .map(|handle| Some(handle));
         }
 
         Ok(None)
@@ -2290,7 +2290,7 @@ impl ConversationP2P {
             debug!("{:?}: Neighbor {:?} exceeded max Nakamoto block push bandwidth of {} bytes/sec (currently at {})", self, &self.to_neighbor_key(), self.connection.options.max_nakamoto_block_push_bandwidth, self.stats.get_nakamoto_block_push_bandwidth());
             return self
                 .reply_nack(local_peer, chain_view, preamble, NackErrorCodes::Throttled)
-                .and_then(|handle| Ok(Some(handle)));
+                .map(|handle| Some(handle));
         }
 
         Ok(None)
@@ -2568,7 +2568,7 @@ impl ConversationP2P {
             StacksMessageType::HandshakeAccept(ref data) => {
                 debug!("{:?}: Got HandshakeAccept", &self);
                 self.handle_handshake_accept(network.get_chain_view(), &msg.preamble, data, None)
-                    .and_then(|_| Ok(None))
+                    .map(|_| None)
             }
             StacksMessageType::StackerDBHandshakeAccept(ref data, ref db_data) => {
                 debug!("{:?}: Got StackerDBHandshakeAccept", &self);
@@ -2578,7 +2578,7 @@ impl ConversationP2P {
                     data,
                     Some(db_data),
                 )
-                .and_then(|_| Ok(None))
+                .map(|_| None)
             }
             StacksMessageType::Ping(_) => {
                 debug!("{:?}: Got Ping", &self);
@@ -2652,7 +2652,7 @@ impl ConversationP2P {
                         data,
                         None,
                     )
-                    .and_then(|_| Ok(None))
+                    .map(|_| None)
                 } else {
                     debug!("{:?}: Unsolicited unauthenticated HandshakeAccept", &self);
 
@@ -2670,7 +2670,7 @@ impl ConversationP2P {
                         data,
                         Some(db_data),
                     )
-                    .and_then(|_| Ok(None))
+                    .map(|_| None)
                 } else {
                     debug!(
                         "{:?}: Unsolicited unauthenticated StackerDBHandshakeAccept",

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -1493,8 +1493,7 @@ impl StacksMessage {
         self.payload.consensus_serialize(&mut message_bits)?;
 
         let mut p = self.preamble.clone();
-        p.verify(&message_bits, &secp256k1_pubkey)
-            .and_then(|_m| Ok(()))
+        p.verify(&message_bits, &secp256k1_pubkey).map(|_m| ())
     }
 }
 
@@ -1583,7 +1582,7 @@ impl ProtocolFamily for StacksP2P {
         preamble
             .clone()
             .verify(&bytes[0..(preamble.payload_len as usize)], key)
-            .and_then(|_m| Ok(()))
+            .map(|_m| ())
     }
 
     fn write_message<W: Write>(

--- a/stackslib/src/net/inv/epoch2x.rs
+++ b/stackslib/src/net/inv/epoch2x.rs
@@ -1768,9 +1768,8 @@ impl PeerNetwork {
     ) -> Result<Option<(u64, GetBlocksInv)>, net_error> {
         if stats.block_reward_cycle <= stats.inv.num_reward_cycles {
             self.make_getblocksinv(sortdb, nk, stats, stats.block_reward_cycle)
-                .and_then(|getblocksinv_opt| {
-                    Ok(getblocksinv_opt
-                        .map(|getblocksinv| (stats.block_reward_cycle, getblocksinv)))
+                .map(|getblocksinv_opt| {
+                    getblocksinv_opt.map(|getblocksinv| (stats.block_reward_cycle, getblocksinv))
                 })
         } else {
             Ok(None)
@@ -2167,13 +2166,13 @@ impl PeerNetwork {
             let again = match stats.state {
                 InvWorkState::GetPoxInvBegin => self
                     .inv_getpoxinv_begin(pins, sortdb, nk, stats, request_timeout)
-                    .and_then(|_| Ok(true))?,
+                    .map(|_| true)?,
                 InvWorkState::GetPoxInvFinish => {
                     self.inv_getpoxinv_try_finish(sortdb, nk, stats, ibd)?
                 }
                 InvWorkState::GetBlocksInvBegin => self
                     .inv_getblocksinv_begin(pins, sortdb, nk, stats, request_timeout)
-                    .and_then(|_| Ok(true))?,
+                    .map(|_| true)?,
                 InvWorkState::GetBlocksInvFinish => {
                     self.inv_getblocksinv_try_finish(nk, stats, ibd)?
                 }

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -3239,7 +3239,7 @@ pub mod test {
             self.network.chain_view = chain_view;
 
             for n in self.config.initial_neighbors.iter() {
-                self.network.connect_peer(&n.addr).and_then(|e| Ok(()))?;
+                self.network.connect_peer(&n.addr).map(|e| ())?;
             }
             Ok(())
         }
@@ -3382,7 +3382,7 @@ pub mod test {
             self.coord.handle_new_stacks_block().unwrap();
             self.coord.handle_new_nakamoto_stacks_block().unwrap();
 
-            receipts_res.and_then(|receipts| Ok((net_result, receipts)))
+            receipts_res.map(|receipts| (net_result, receipts))
         }
 
         pub fn step_dns(&mut self, dns_client: &mut DNSClient) -> Result<NetworkResult, net_error> {

--- a/stackslib/src/net/neighbors/comms.rs
+++ b/stackslib/src/net/neighbors/comms.rs
@@ -145,7 +145,7 @@ pub trait NeighborComms {
             self.remove_connecting(network, &nk);
             return self
                 .neighbor_handshake(network, &nk)
-                .and_then(|handle| Ok(Some(handle)));
+                .map(|handle| Some(handle));
         }
 
         if let Some(event_id) = self.get_connecting(network, &nk) {
@@ -201,7 +201,7 @@ pub trait NeighborComms {
                 self.remove_connecting(network, &alt_nk);
                 return self
                     .neighbor_handshake(network, &alt_nk)
-                    .and_then(|handle| Ok(Some(handle)));
+                    .map(|handle| Some(handle));
             }
             Err(e) => {
                 info!(
@@ -247,7 +247,7 @@ pub trait NeighborComms {
                         self.remove_connecting(network, &nk);
                         return self
                             .neighbor_handshake(network, &nk)
-                            .and_then(|handle| Ok(Some(handle)));
+                            .map(|handle| Some(handle));
                     }
                     test_debug!(
                         "{:?}: Already connected to {:?} on event {} (address: {:?})",

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -1400,9 +1400,9 @@ impl PeerNetwork {
                 }
                 Ok(())
             }
-            NetworkRequest::Relay(neighbor_key, msg) => self
-                .relay_signed_message(&neighbor_key, msg)
-                .and_then(|_| Ok(())),
+            NetworkRequest::Relay(neighbor_key, msg) => {
+                self.relay_signed_message(&neighbor_key, msg).map(|_| ())
+            }
             NetworkRequest::Broadcast(relay_hints, msg) => {
                 // pick some neighbors. Note that only some messages can be broadcasted.
                 let neighbor_keys = match msg {

--- a/stackslib/src/net/tests/relay/nakamoto.rs
+++ b/stackslib/src/net/tests/relay/nakamoto.rs
@@ -138,7 +138,7 @@ impl ExitedPeer {
         self.mempool = Some(mempool);
         self.indexer = Some(indexer);
 
-        receipts_res.and_then(|receipts| Ok((net_result, receipts)))
+        receipts_res.map(|receipts| (net_result, receipts))
     }
 }
 

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -550,7 +550,7 @@ fn inner_sql_pragma(
 pub fn sql_vacuum(conn: &Connection) -> Result<(), Error> {
     conn.execute("VACUUM", NO_PARAMS)
         .map_err(Error::SqliteError)
-        .and_then(|_| Ok(()))
+        .map(|_| ())
 }
 
 /// Returns true if the database table `table_name` exists in the active


### PR DESCRIPTION
### Description

Apply Clippy lint `bind-instead-of-map`, which replaces unnecessary `.and_then()` calls. For example, replace:

```rust
.and_then(|x| Ok(x+1))
```

with:

```rust
.map(|x| x+1)
```