### PR TITLE
Fix mistaken 0 as u32 replacement with 0_u8 in delegate_stx.rs serial…

### DIFF
--- a/stackslib/src/chainstate/burn/operations/delegate_stx.rs
+++ b/stackslib/src/chainstate/burn/operations/delegate_stx.rs
@@ -237,7 +237,7 @@ impl StacksMessageCodec for DelegateStxOp {
         } else {
             fd.write_all(&0_u8.to_be_bytes())
                 .map_err(|e| codec_error::WriteError(e))?;
-            fd.write_all(&0_u8.to_be_bytes())
+            fd.write_all(&0_u32.to_be_bytes())
                 .map_err(|e| codec_error::WriteError(e))?;
         }
 


### PR DESCRIPTION
I introduced this here: https://github.com/stacks-network/stacks-core/pull/5624/files#r1902272931

This was caught by a test but among the plethora of flakey CI tests I missed the new one and failed to properly verify it!

