### PR TITLE
Fix/use cargo workspace

### DIFF
--- a/stackslib/src/clarity_cli.rs
+++ b/stackslib/src/clarity_cli.rs
@@ -35,7 +35,7 @@ use stacks_common::types::chainstate::{
 };
 use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::hash::{bytes_to_hex, Hash160, Sha512Trunc256Sum};
-use stacks_common::util::{cargo_workspace, get_epoch_time_ms, log};
+use stacks_common::util::{get_epoch_time_ms, log};
 
 use crate::burnchains::{Address, PoxConstants, Txid};
 use crate::chainstate::stacks::boot::{
@@ -1949,6 +1949,8 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
 #[cfg(test)]
 mod test {
     use std::path::Path;
+
+    use stacks_common::util::cargo_workspace;
 
     use super::*;
 


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This patch fixes the use of the cargo_workspace function in clarity_cli.rs.

This function is marked as "test only"  in stacks_common::util so the use fails out of the testing context:

```
 Compiling stackslib v0.0.1 (/home/roberto/STACKS/STACKS_TESTS/stacks-core/stackslib)
error[E0432]: unresolved import `stacks_common::util::cargo_workspace`
  --> stackslib/src/clarity_cli.rs:38:27
   |
38 | use stacks_common::util::{cargo_workspace, get_epoch_time_ms, log};
   |                           ^^^^^^^^^^^^^^^ no `cargo_workspace` in `util`
   |
```

### Applicable issues

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
