### PR TITLE
Increased mining timeout in mock_mining and partial_tenure_fork integration tests

### DIFF
--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -8838,7 +8838,8 @@ fn mock_mining() {
 
     info!("Booting follower-thread, waiting for the follower to sync to the chain tip");
 
-    wait_for(120, || {
+    // use a high timeout for avoiding problem with github workflow
+    wait_for(600, || {
         let Some(miner_node_info) = get_chain_info_opt(&naka_conf) else {
             return Ok(false);
         };

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -4971,7 +4971,8 @@ fn partial_tenure_fork() {
     info!("-------- Waiting miner 2 to catch up to miner 1 --------");
 
     // Wait for miner 2 to catch up to miner 1
-    wait_for(60, || {
+    // (note: use a high timeout to avoid potential failing on github workflow)
+    wait_for(600, || {
         let info_1 = get_chain_info(&conf);
         let info_2 = get_chain_info(&conf_node_2);
         Ok(info_1.stacks_tip_height == info_2.stacks_tip_height)


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This patch increases mining timeout for 2 integration tests for allowing the CI to not fail on them.

The tests are:

```
tests::nakamoto_integrations::mock_mining
tests::signer::v0::partial_tenure_fork
```

### Applicable issues

- fixes #5556

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
