### PR TITLE
Fix/bitcoind forking test signerdb state

### DIFF
--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -539,7 +539,7 @@ impl SortitionsView {
     ///
     /// The rationale here is that the signer DB can be out-of-sync with the node.  For example,
     /// the signer may have been added to an already-running node.
-    fn check_tenure_change_confirms_parent(
+    pub fn check_tenure_change_confirms_parent(
         tenure_change: &TenureChangePayload,
         block: &NakamotoBlock,
         signer_db: &mut SignerDb,

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -582,45 +582,38 @@ impl Signer {
         }
     }
 
-    /// WARNING: Do NOT call this function PRIOR to check_proposal or block_proposal validation succeeds.
+    /// WARNING: This is an incomplete check. Do NOT call this function PRIOR to check_proposal or block_proposal validation succeeds.
     ///
     /// Re-verify a block's chain length against the last signed block within signerdb.
     /// This is required in case a block has been approved since the initial checks of the block validation endpoint.
     fn check_block_against_signer_db_state(
-        &self,
+        &mut self,
+        stacks_client: &StacksClient,
         proposed_block: &NakamotoBlock,
     ) -> Option<BlockResponse> {
         let signer_signature_hash = proposed_block.header.signer_signature_hash();
         let proposed_block_consensus_hash = proposed_block.header.consensus_hash;
         // If the tenure change block confirms the expected parent block, it should confirm at least one more block than the last accepted block in the parent tenure.
         if let Some(tenure_change) = proposed_block.get_tenure_change_tx_payload() {
-            match SortitionsView::get_tenure_last_block_info(
-                &tenure_change.prev_tenure_consensus_hash,
-                &self.signer_db,
+            // Ensure that the tenure change block confirms the expected parent block
+            match SortitionsView::check_tenure_change_confirms_parent(
+                tenure_change,
+                proposed_block,
+                &mut self.signer_db,
+                stacks_client,
                 self.proposal_config.tenure_last_block_proposal_timeout,
             ) {
-                Ok(Some(last_block_info)) => {
-                    if proposed_block.header.chain_length
-                        <= last_block_info.block.header.chain_length
-                    {
-                        warn!(
-                            "Miner's block proposal does not confirm as many blocks as we expect";
-                            "proposed_block_consensus_hash" => %proposed_block_consensus_hash,
-                            "proposed_block_signer_sighash" => %signer_signature_hash,
-                            "proposed_chain_length" => proposed_block.header.chain_length,
-                            "expected_at_least" => last_block_info.block.header.chain_length + 1,
-                        );
-                        return Some(self.create_block_rejection(
+                Ok(true) => {}
+                Ok(false) => {
+                    return Some(
+                        self.create_block_rejection(
                             RejectCode::SortitionViewMismatch,
                             proposed_block,
-                        ));
-                    }
-                }
-                Ok(_) => {
-                    // We have no information about the parent consensus hash. Just assume its valid.
+                        ),
+                    )
                 }
                 Err(e) => {
-                    warn!("{self}: Failed to check block against signer db: {e}";
+                    warn!("{self}: Error checking block proposal: {e}";
                         "signer_sighash" => %signer_signature_hash,
                         "block_id" => %proposed_block.block_id()
                     );
@@ -631,8 +624,7 @@ impl Signer {
             }
         }
 
-        // Ensure that the block proposal confirms the expected number of blocks in the current tenure
-        // (This may be redundant for a tenure change block, but we could have had two valid tenure change blocks in a row)
+        // Ensure that the block is the last block in the chain of its current tenure.
         match self
             .signer_db
             .get_last_accepted_block(&proposed_block_consensus_hash)
@@ -712,7 +704,9 @@ impl Signer {
             }
         };
 
-        if let Some(block_response) = self.check_block_against_signer_db_state(&block_info.block) {
+        if let Some(block_response) =
+            self.check_block_against_signer_db_state(stacks_client, &block_info.block)
+        {
             // The signer db state has changed. We no longer view this block as valid. Override the validation response.
             if let Err(e) = block_info.mark_locally_rejected() {
                 if !block_info.has_reached_consensus() {

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -593,7 +593,7 @@ impl Signer {
     ) -> Option<BlockResponse> {
         let signer_signature_hash = proposed_block.header.signer_signature_hash();
         let proposed_block_consensus_hash = proposed_block.header.consensus_hash;
-        // If the tenure change block confirms the expected parent block, it should confirm at least one more block than the last accepted block in the parent tenure.
+        // If this is a tenure change block, ensure that it confirms the correct number of blocks from the parent tenure.
         if let Some(tenure_change) = proposed_block.get_tenure_change_tx_payload() {
             // Ensure that the tenure change block confirms the expected parent block
             match SortitionsView::check_tenure_change_confirms_parent(


### PR DESCRIPTION
Closes https://github.com/stacks-network/stacks-core/issues/5673

This check_block_against_signer_db_state is meant to be a minimal check post other validation checks in case some block got approved between our block proposal submission for validation and its return. It was incorrectly querying signer db purely based on height and state and ignoring consensus hash. This check makes it use bare minimum checks to include both a check against the parent consensus hash in the case of a tenure change and a check against the current cosnensus hash to ensure the proposed height is acceptable. 