### PR TITLE
chore: add allow(clippy::needless_as_bytes) for some Clarity codecs

### DIFF
--- a/clarity/src/vm/representations.rs
+++ b/clarity/src/vm/representations.rs
@@ -84,6 +84,7 @@ guarded_string!(
 );
 
 impl StacksMessageCodec for ClarityName {
+    #[allow(clippy::needless_as_bytes)] // as_bytes isn't necessary, but verbosity is preferable in the codec impls
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), codec_error> {
         // ClarityName can't be longer than vm::representations::MAX_STRING_LEN, which itself is
         // a u8, so we should be good here.
@@ -124,6 +125,7 @@ impl StacksMessageCodec for ClarityName {
 }
 
 impl StacksMessageCodec for ContractName {
+    #[allow(clippy::needless_as_bytes)] // as_bytes isn't necessary, but verbosity is preferable in the codec impls
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), codec_error> {
         if self.as_bytes().len() < CONTRACT_MIN_NAME_LENGTH
             || self.as_bytes().len() > CONTRACT_MAX_NAME_LENGTH

--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -283,6 +283,7 @@ pub struct PeerInfo {
 }
 
 impl StacksMessageCodec for PeerInfo {
+    #[allow(clippy::needless_as_bytes)] // as_bytes isn't necessary, but verbosity is preferable in the codec impls
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError> {
         write_next(fd, &self.burn_block_height)?;
         write_next(fd, self.stacks_tip_consensus_hash.as_bytes())?;

--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -20,10 +20,10 @@ use clarity::vm::costs::LimitedCostTracker;
 use clarity::vm::errors::Error as ClarityError;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, ResponseData, TupleData};
 use clarity::vm::Value;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 use slog::slog_debug;
 use slog::slog_error;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 use stacks_common::debug;
 use stacks_common::types::StacksEpochId;
 use stacks_common::{error, test_debug};

--- a/pox-locking/src/events_24.rs
+++ b/pox-locking/src/events_24.rs
@@ -19,10 +19,10 @@ use clarity::vm::contexts::GlobalContext;
 use clarity::vm::errors::Error as ClarityError;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, TupleData};
 use clarity::vm::Value;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 use slog::slog_debug;
 use slog::slog_error;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 use stacks_common::debug;
 use stacks_common::{error, test_debug};
 


### PR DESCRIPTION
This just adds `allow` decorators to some message codec implementations. The `as_bytes()` invocations are indeed needless, but I think the verbosity is preferable in the codec (so that its very clear to readers that we're concerned with byte length, rather than character length).

This should fix two checks in CI.