### PR TITLE
chore: add consensus hash to signer's new proposal log

### DIFF
--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -487,6 +487,7 @@ impl Signer {
             "block_id" => %block_proposal.block.block_id(),
             "block_height" => block_proposal.block.header.chain_length,
             "burn_height" => block_proposal.burn_height,
+            "consensus_hash" => %block_proposal.block.header.consensus_hash,
         );
         crate::monitoring::increment_block_proposals_received();
         #[cfg(any(test, feature = "testing"))]


### PR DESCRIPTION
This will allow us to easily identify which signer the proposal came from when reviewing logs.