### PR TITLE
fix: disable `tests::epoch_25::microblocks_disabled`

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -54,6 +54,7 @@ jobs:
           # - tests::neon_integrations::size_overflow_unconfirmed_microblocks_integration_test
           # - tests::neon_integrations::size_overflow_unconfirmed_stream_microblocks_integration_test
           # - tests::neon_integrations::runtime_overflow_unconfirmed_microblocks_integration_test
+          # - tests::epoch_25::microblocks_disabled
           # Disable this flaky test. Microblocks are no longer supported anyways.
           # - tests::neon_integrations::microblock_large_tx_integration_test_FLAKY
           - tests::neon_integrations::miner_submit_twice
@@ -80,7 +81,6 @@ jobs:
           - tests::neon_integrations::bitcoin_reorg_flap
           - tests::neon_integrations::bitcoin_reorg_flap_with_follower
           - tests::neon_integrations::start_stop_bitcoind
-          - tests::epoch_25::microblocks_disabled
           - tests::should_succeed_handling_malformed_and_valid_txs
           - tests::nakamoto_integrations::simple_neon_integration
           - tests::nakamoto_integrations::flash_blocks_on_epoch_3


### PR DESCRIPTION
This test is flaky on CI and is not relevant any more.