### PR TITLE
fix: increase timeout for waiting for signer set calculation

### DIFF
--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -249,7 +249,7 @@ impl SignerTest<SpawnedSigner> {
         // Make sure the signer set is calculated before continuing or signers may not
         // recognize that they are registered signers in the subsequent burn block event
         let reward_cycle = self.get_current_reward_cycle() + 1;
-        wait_for(30, || {
+        wait_for(120, || {
             Ok(self
                 .stacks_client
                 .get_reward_set_signers(reward_cycle)


### PR DESCRIPTION
For tests with a follower node, where some signers are listening to the follower node, this can take longer than 30s to run in CI.