### PR TITLE
Fix: explicit burnchain checks in miner thread

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -143,6 +143,8 @@ jobs:
           - tests::signer::v0::outgoing_signers_ignore_block_proposals
           - tests::signer::v0::injected_signatures_are_ignored_across_boundaries
           - tests::signer::v0::fast_sortition
+          - tests::signer::v0::single_miner_empty_sortition
+          - tests::signer::v0::multiple_miners_empty_sortition
           - tests::nakamoto_integrations::burn_ops_integration_test
           - tests::nakamoto_integrations::check_block_heights
           - tests::nakamoto_integrations::clarity_burn_state

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -360,8 +360,6 @@ impl BlockMinerThread {
             self.burnchain.pox_constants.clone(),
         )
         .expect("FATAL: could not open sortition DB");
-        let burn_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
-            .expect("FATAL: failed to query sortition DB for canonical burn chain tip");
 
         // Start the signer coordinator
         let mut coordinator = SignerCoordinator::new(

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -443,6 +443,11 @@ impl BlockMinerThread {
                     "Failed to open chainstate DB. Cannot mine! {e:?}"
                 ))
             })?;
+        // Late block tenures are initiated only to issue the BlockFound
+        //  tenure change tx (because they can be immediately extended to
+        //  the next burn view). This checks whether or not we're in such a
+        //  tenure and have produced a block already. If so, it exits the
+        //  mining thread to allow the tenure extension thread to take over.
         if self.last_block_mined.is_some() && self.reason.is_late_block() {
             info!("Miner: finished mining a late tenure");
             return Err(NakamotoNodeError::StacksTipChanged);

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -451,7 +451,8 @@ impl RelayerThread {
                       "winning_sortition" => %sn.consensus_hash);
                 return Some(MinerDirective::BeginTenure {
                     parent_tenure_start: committed_index_hash,
-                    burnchain_tip: sn,
+                    burnchain_tip: sn.clone(),
+                    election_block: sn,
                     late: false,
                 });
             }
@@ -589,7 +590,8 @@ impl RelayerThread {
                     parent_tenure_start: StacksBlockId(
                         last_winning_snapshot.winning_stacks_block_hash.clone().0,
                     ),
-                    burnchain_tip: last_winning_snapshot,
+                    burnchain_tip: sn,
+                    election_block: last_winning_snapshot,
                     late: true,
                 });
             }
@@ -975,6 +977,7 @@ impl RelayerThread {
         burn_tip: BlockSnapshot,
         parent_tenure_id: StacksBlockId,
         reason: MinerReason,
+        burn_tip_at_start: &ConsensusHash,
     ) -> Result<BlockMinerThread, NakamotoNodeError> {
         if fault_injection_skip_mining(&self.config.node.rpc_bind, burn_tip.block_height) {
             debug!(
@@ -991,14 +994,8 @@ impl RelayerThread {
 
         let burn_chain_tip = burn_chain_sn.burn_header_hash;
 
-        let allow_late = if let MinerReason::BlockFound { late } = &reason {
-            *late
-        } else {
-            false
-        };
-
-        if burn_chain_tip != burn_header_hash && !allow_late {
-            debug!(
+        if &burn_chain_sn.consensus_hash != burn_tip_at_start {
+            info!(
                 "Relayer: Drop stale RunTenure for {burn_header_hash}: current sortition is for {burn_chain_tip}"
             );
             self.globals.counters.bump_missed_tenures();
@@ -1021,6 +1018,7 @@ impl RelayerThread {
             burn_election_block,
             burn_tip,
             parent_tenure_id,
+            burn_tip_at_start,
             reason,
         );
         Ok(miner_thread_state)
@@ -1032,6 +1030,7 @@ impl RelayerThread {
         block_election_snapshot: BlockSnapshot,
         burn_tip: BlockSnapshot,
         reason: MinerReason,
+        burn_tip_at_start: &ConsensusHash,
     ) -> Result<(), NakamotoNodeError> {
         // when starting a new tenure, block the mining thread if its currently running.
         // the new mining thread will join it (so that the new mining thread stalls, not the relayer)
@@ -1052,6 +1051,7 @@ impl RelayerThread {
             burn_tip.clone(),
             parent_tenure_start,
             reason,
+            burn_tip_at_start,
         )?;
 
         debug!("Relayer: starting new tenure thread");
@@ -1372,7 +1372,7 @@ impl RelayerThread {
             StacksBlockId::new(&canonical_stacks_tip_ch, &canonical_stacks_tip_bh);
 
         let reason = MinerReason::Extended {
-            burn_view_consensus_hash: new_burn_view,
+            burn_view_consensus_hash: new_burn_view.clone(),
         };
 
         if let Err(e) = self.start_new_tenure(
@@ -1380,6 +1380,7 @@ impl RelayerThread {
             canonical_stacks_tip_election_snapshot.clone(),
             burn_tip.clone(),
             reason.clone(),
+            &new_burn_view,
         ) {
             error!("Relayer: Failed to start new tenure: {e:?}");
         } else {
@@ -1415,12 +1416,14 @@ impl RelayerThread {
             MinerDirective::BeginTenure {
                 parent_tenure_start,
                 burnchain_tip,
+                election_block,
                 late,
             } => match self.start_new_tenure(
                 parent_tenure_start,
-                burnchain_tip.clone(),
-                burnchain_tip.clone(),
+                election_block.clone(),
+                election_block.clone(),
                 MinerReason::BlockFound { late },
+                &burnchain_tip.consensus_hash,
             ) {
                 Ok(()) => {
                     debug!("Relayer: successfully started new tenure.";

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -7074,7 +7074,8 @@ fn continue_tenure_extend() {
     wait_for(60, || {
         let nonce = get_account(&http_origin, &to_addr(&sender_sk)).nonce;
         Ok(nonce > transfer_nonce)
-    }).unwrap();
+    })
+    .unwrap();
 
     let blocks_processed_before = coord_channel
         .lock()

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -7068,6 +7068,14 @@ fn continue_tenure_extend() {
         )
         .unwrap();
 
+    // wait for the extended miner to include the tx in a block
+    //  before we produce the next bitcoin block (this test will assert
+    //  that this is the case at the end of the test).
+    wait_for(60, || {
+        let nonce = get_account(&http_origin, &to_addr(&sender_sk)).nonce;
+        Ok(nonce > transfer_nonce)
+    }).unwrap();
+
     let blocks_processed_before = coord_channel
         .lock()
         .expect("Mutex poisoned")

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -84,7 +84,8 @@ use crate::tests::nakamoto_integrations::{
     POX_4_DEFAULT_STACKER_BALANCE, POX_4_DEFAULT_STACKER_STX_AMT,
 };
 use crate::tests::neon_integrations::{
-    get_account, get_chain_info, get_chain_info_opt, get_sortition_info, get_sortition_info_ch, next_block_and_wait, run_until_burnchain_height, submit_tx, submit_tx_fallible, test_observer
+    get_account, get_chain_info, get_chain_info_opt, get_sortition_info, get_sortition_info_ch,
+    next_block_and_wait, run_until_burnchain_height, submit_tx, submit_tx_fallible, test_observer,
 };
 use crate::tests::{
     self, gen_random_port, make_contract_call, make_contract_publish, make_stacks_transfer,
@@ -11446,18 +11447,20 @@ fn multiple_miners_empty_sortition() {
             .unwrap();
         }
 
-
         let last_active_sortition = get_sortition_info(&conf);
         assert!(last_active_sortition.was_sortition);
 
         // lets mine a btc flash block
         let rl2_commits_before = rl2_commits.load(Ordering::SeqCst);
         let rl1_commits_before = rl1_commits.load(Ordering::SeqCst);
-        signer_test.running_nodes.btc_regtest_controller.build_next_block(2);
+        signer_test
+            .running_nodes
+            .btc_regtest_controller
+            .build_next_block(2);
 
         wait_for(60, || {
-            Ok(rl2_commits.load(Ordering::SeqCst) > rl2_commits_before &&
-               rl1_commits.load(Ordering::SeqCst) > rl1_commits_before)
+            Ok(rl2_commits.load(Ordering::SeqCst) > rl2_commits_before
+                && rl1_commits.load(Ordering::SeqCst) > rl1_commits_before)
         })
         .unwrap();
 
@@ -11520,7 +11523,6 @@ fn multiple_miners_empty_sortition() {
         "The last two transactions after the flash block must be included in a block"
     );
 
-
     rl2_coord_channels
         .lock()
         .expect("Mutex poisoned")
@@ -11528,5 +11530,168 @@ fn multiple_miners_empty_sortition() {
     run_loop_stopper_2.store(false, Ordering::SeqCst);
     run_loop_2_thread.join().unwrap();
     signer_test.shutdown();
+}
 
+#[test]
+#[ignore]
+/// This test spins up two nakamoto nodes, both configured to mine.
+/// After Nakamoto blocks are mined, it waits for a normal tenure, then issues
+///  two bitcoin blocks in quick succession -- the first will contain block commits,
+///  and the second "flash block" will contain no block commits.
+/// The test checks if the winner of the first block is different than the previous tenure.
+/// If so, it performs the actual test: asserting that the miner wakes up and produces valid blocks.
+/// This test uses the burn-block-height to ensure consistent calculation of the burn view between
+///   the miner thread and the block processor
+fn single_miner_empty_sortition() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+    let num_signers = 5;
+    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_addr = tests::to_addr(&sender_sk);
+    let send_fee = 180;
+
+    let btc_miner_1_seed = vec![1, 1, 1, 1];
+    let btc_miner_1_pk = Keychain::default(btc_miner_1_seed.clone()).get_pub_key();
+
+    let node_1_rpc = gen_random_port();
+    let node_1_p2p = gen_random_port();
+
+    let localhost = "127.0.0.1";
+    let node_1_rpc_bind = format!("{localhost}:{node_1_rpc}");
+
+    let max_nakamoto_tenures = 30;
+    // partition the signer set so that ~half are listening and using node 1 for RPC and events,
+    //  and the rest are using node 2
+
+    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender_addr, send_fee * 2 * 60 + 1000)],
+        |signer_config| {
+            let node_host = &node_1_rpc_bind;
+            signer_config.node_host = node_host.to_string();
+        },
+        |config| {
+            config.node.rpc_bind = format!("{localhost}:{node_1_rpc}");
+            config.node.p2p_bind = format!("{localhost}:{node_1_p2p}");
+            config.node.data_url = format!("http://{localhost}:{node_1_rpc}");
+            config.node.p2p_address = format!("{localhost}:{node_1_p2p}");
+            config.miner.wait_on_interim_blocks = Duration::from_secs(5);
+            config.node.pox_sync_sample_secs = 30;
+            config.burnchain.pox_reward_length = Some(max_nakamoto_tenures);
+
+            config.node.seed = btc_miner_1_seed.clone();
+            config.node.local_peer_seed = btc_miner_1_seed.clone();
+            config.burnchain.local_mining_public_key = Some(btc_miner_1_pk.to_hex());
+            config.miner.mining_key = Some(Secp256k1PrivateKey::from_seed(&[1]));
+        },
+        Some(vec![btc_miner_1_pk]),
+        None,
+    );
+    let conf = signer_test.running_nodes.conf.clone();
+
+    let node_1_sk = Secp256k1PrivateKey::from_seed(&conf.node.local_peer_seed);
+    let node_1_pk = StacksPublicKey::from_private(&node_1_sk);
+
+    signer_test.boot_to_epoch_3();
+
+    let pre_nakamoto_peer_1_height = get_chain_info(&conf).stacks_tip_height;
+
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let burn_height_contract = "
+       (define-data-var local-burn-block-ht uint u0)
+       (define-public (run-update)
+          (ok (var-set local-burn-block-ht burn-block-height)))
+    ";
+
+    let contract_tx = make_contract_publish(
+        &sender_sk,
+        0,
+        1000,
+        conf.burnchain.chain_id,
+        "burn-height-local",
+        burn_height_contract,
+    );
+    submit_tx(&conf.node.data_url, &contract_tx);
+
+    let rl1_coord_channels = signer_test.running_nodes.coord_channel.clone();
+    let rl1_commits = signer_test.running_nodes.commits_submitted.clone();
+
+    for _i in 0..3 {
+        // Mine 1 nakamoto tenures
+        info!("Mining tenure...");
+        let rl1_commits_before = rl1_commits.load(Ordering::SeqCst);
+
+        signer_test.mine_block_wait_on_processing(
+            &[&rl1_coord_channels],
+            &[&rl1_commits],
+            Duration::from_secs(30),
+        );
+
+        // mine the interim blocks
+        for _ in 0..2 {
+            let sender_nonce = get_account(&conf.node.data_url, &sender_addr).nonce;
+            // check if the burn contract is already produced, if not wait for it to be included in
+            //  an interim block
+            if sender_nonce >= 1 {
+                let contract_call_tx = make_contract_call(
+                    &sender_sk,
+                    sender_nonce,
+                    send_fee,
+                    conf.burnchain.chain_id,
+                    &sender_addr,
+                    "burn-height-local",
+                    "run-update",
+                    &[],
+                );
+                submit_tx(&conf.node.data_url, &contract_call_tx);
+            }
+
+            // make sure the sender's tx gets included (whether it was the contract publish or call)
+            wait_for(60, || {
+                let next_sender_nonce = get_account(&conf.node.data_url, &sender_addr).nonce;
+                Ok(next_sender_nonce > sender_nonce)
+            })
+            .unwrap();
+        }
+
+        let last_active_sortition = get_sortition_info(&conf);
+        assert!(last_active_sortition.was_sortition);
+
+        // lets mine a btc flash block
+        let rl1_commits_before = rl1_commits.load(Ordering::SeqCst);
+        signer_test
+            .running_nodes
+            .btc_regtest_controller
+            .build_next_block(2);
+
+        wait_for(60, || {
+            Ok(rl1_commits.load(Ordering::SeqCst) > rl1_commits_before)
+        })
+        .unwrap();
+
+        let cur_empty_sortition = get_sortition_info(&conf);
+        assert!(!cur_empty_sortition.was_sortition);
+        let inactive_sortition = get_sortition_info_ch(
+            &conf,
+            cur_empty_sortition.last_sortition_ch.as_ref().unwrap(),
+        );
+        assert!(inactive_sortition.was_sortition);
+        assert_eq!(
+            inactive_sortition.burn_block_height,
+            last_active_sortition.burn_block_height + 1
+        );
+
+        info!("==================== Mined a flash block ====================");
+        info!("Flash block sortition info";
+              "last_active_winner" => ?last_active_sortition.miner_pk_hash160,
+              "last_winner" => ?inactive_sortition.miner_pk_hash160,
+              "last_active_ch" => %last_active_sortition.consensus_hash,
+              "last_winner_ch" => %inactive_sortition.consensus_hash,
+              "cur_empty_sortition" => %cur_empty_sortition.consensus_hash,
+        );
+    }
+
+    signer_test.shutdown();
 }


### PR DESCRIPTION
### Description

This fixes an issue in #5515 where a `BlockFound { late: true }` mining thread would stay alive after a new burn block arrived (this caused flake in a previous test I wrote for that PR). This PR includes a test that consistently fails (I think I saw it pass once though?) in #5515, but passes with the changeset.


This changeset adds a new instance variable to the mining thread which records what burn block initiated the mining thread (so this is the chain tip even in the case of a late block found). If the burn tip ever doesn't match that, it closes the miner.