### PR TITLE
fix: moving and adding to unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
   cases: when a bitcoin block is produced before the previous bitcoin block's Stacks tenure started.
   Previously, the miner had difficulty restarting their missed tenure and extending into the new
   bitcoin block, leading to 1-2 bitcoin blocks of missed Stacks block production.
+- The event dispatcher now includes `consensus_hash` in the `/new_block` and `/new_burn_block` payloads. ([#5677](https://github.com/stacks-network/stacks-core/pull/5677))
 
 ## [3.1.0.0.3]
 

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ## Added
 
+- When a new block proposal is received while the signer is waiting for an existing proposal to be validated, the signer will wait until the existing block is done validating before submitting the new one for validating. ([#5453](https://github.com/stacks-network/stacks-core/pull/5453))
+- Introduced two new prometheus metrics:
+  - `stacks_signer_block_validation_latencies_histogram`: the validation_time_ms reported by the node when validating a block proposal
+  - `stacks_signer_block_response_latencies_histogram`: the "end-to-end" time it takes for the signer to issue a block response
+
 ## Changed
 
 ## [3.1.0.0.3.0]
@@ -16,10 +21,6 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ## Added
 
 - Introduced the `block_proposal_max_age_secs` configuration option for signers, enabling them to automatically ignore block proposals that exceed the specified age in seconds.
-- When a new block proposal is received while the signer is waiting for an existing proposal to be validated, the signer will wait until the existing block is done validating before submitting the new one for validating. ([#5453](https://github.com/stacks-network/stacks-core/pull/5453))
-- Introduced two new prometheus metrics:
-  - `stacks_signer_block_validation_latencies_histogram`: the validation_time_ms reported by the node when validating a block proposal
-  - `stacks_signer_block_response_latencies_histogram`: the "end-to-end" time it takes for the signer to issue a block response
 
 ## Changed
 - Improvements to the stale signer cleanup logic: deletes the prior signer if it has no remaining unprocessed blocks in its database


### PR DESCRIPTION
A few things occurred:

- After a merge, one changelog entry was moved from "unreleased" to "3.1.0.0.3" even though it's not in that release
- I accidentally added a changelog entry to 3.1.0.0.3 instead of "unreleased"
- I forgot to add a changelog entry 