### PR TITLE
Refactor: StacksAddress and PrincipalData cleanup

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -167,6 +167,7 @@ jobs:
           - tests::nakamoto_integrations::sip029_coinbase_change
           - tests::nakamoto_integrations::clarity_cost_spend_down
           - tests::nakamoto_integrations::v3_blockbyheight_api_endpoint
+          - tests::nakamoto_integrations::mine_invalid_principal_from_consensus_buff
           - tests::nakamoto_integrations::test_tenure_extend_from_flashblocks
           # TODO: enable these once v1 signer is supported by a new nakamoto epoch
           # - tests::signer::v1::dkg

--- a/clarity/src/libclarity.rs
+++ b/clarity/src/libclarity.rs
@@ -60,7 +60,8 @@ pub mod boot_util {
     pub fn boot_code_id(name: &str, mainnet: bool) -> QualifiedContractIdentifier {
         let addr = boot_code_addr(mainnet);
         QualifiedContractIdentifier::new(
-            addr.into(),
+            addr.try_into()
+                .expect("FATAL: boot contract addr is not a legal principal"),
             ContractName::try_from(name.to_string())
                 .expect("FATAL: boot contract name is not a legal ContractName"),
         )

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -2134,20 +2134,14 @@ mod test {
         mut tl_env_factory: TopLevelMemoryEnvironmentGenerator,
     ) {
         let mut env = tl_env_factory.get_env(epoch);
-        let u1 = StacksAddress {
-            version: 0,
-            bytes: Hash160([1; 20]),
-        };
-        let u2 = StacksAddress {
-            version: 0,
-            bytes: Hash160([2; 20]),
-        };
+        let u1 = StacksAddress::new(0, Hash160([1; 20])).unwrap();
+        let u2 = StacksAddress::new(0, Hash160([2; 20])).unwrap();
         // insufficient balance must be a non-includable transaction. it must error here,
         //  not simply rollback the tx and squelch the error as includable.
         let e = env
             .stx_transfer(
-                &PrincipalData::from(u1),
-                &PrincipalData::from(u2),
+                &PrincipalData::try_from(u1).unwrap(),
+                &PrincipalData::try_from(u2).unwrap(),
                 1000,
                 &BuffData::empty(),
             )

--- a/clarity/src/vm/functions/conversions.rs
+++ b/clarity/src/vm/functions/conversions.rs
@@ -20,6 +20,7 @@ use crate::vm::errors::{
     check_argument_count, CheckErrors, InterpreterError, InterpreterResult as Result,
 };
 use crate::vm::representations::SymbolicExpression;
+use crate::vm::types::serialization::SerializationError;
 use crate::vm::types::SequenceSubtype::BufferType;
 use crate::vm::types::TypeSignature::SequenceType;
 use crate::vm::types::{
@@ -276,6 +277,9 @@ pub fn from_consensus_buff(
         env.epoch().value_sanitizing(),
     ) {
         Ok(value) => value,
+        Err(SerializationError::UnexpectedSerialization) => {
+            return Err(CheckErrors::Expects("UnexpectedSerialization".into()).into())
+        }
         Err(_) => return Ok(Value::none()),
     };
     if !type_arg.admits(env.epoch(), &result)? {

--- a/clarity/src/vm/functions/crypto.rs
+++ b/clarity/src/vm/functions/crypto.rs
@@ -27,10 +27,7 @@ use crate::vm::errors::{
     check_argument_count, CheckErrors, InterpreterError, InterpreterResult as Result,
 };
 use crate::vm::representations::SymbolicExpression;
-use crate::vm::types::{
-    BuffData, SequenceData, StacksAddressExtensions, TypeSignature, Value, BUFF_32, BUFF_33,
-    BUFF_65,
-};
+use crate::vm::types::{BuffData, SequenceData, TypeSignature, Value, BUFF_32, BUFF_33, BUFF_65};
 use crate::vm::{eval, ClarityVersion, Environment, LocalContext};
 
 macro_rules! native_hash_func {
@@ -120,7 +117,7 @@ pub fn special_principal_of(
         } else {
             pubkey_to_address_v1(pub_key)?
         };
-        let principal = addr.to_account_principal();
+        let principal = addr.into();
         Ok(Value::okay(Value::Principal(principal))
             .map_err(|_| InterpreterError::Expect("Failed to construct ok".into()))?)
     } else {

--- a/clarity/src/vm/test_util/mod.rs
+++ b/clarity/src/vm/test_util/mod.rs
@@ -108,7 +108,7 @@ impl From<&StacksPrivateKey> for StandardPrincipalData {
             &vec![StacksPublicKey::from_private(o)],
         )
         .unwrap();
-        StandardPrincipalData::from(stacks_addr)
+        StandardPrincipalData::try_from(stacks_addr).unwrap()
     }
 }
 

--- a/clarity/src/vm/tests/principals.rs
+++ b/clarity/src/vm/tests/principals.rs
@@ -668,7 +668,7 @@ fn test_principal_construct_good() {
         Value::Response(ResponseData {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Standard(
-                StandardPrincipalData(22, transfer_buffer)
+                StandardPrincipalData::new(22, transfer_buffer).unwrap()
             )))
         }),
         execute_with_parameters(
@@ -688,7 +688,7 @@ fn test_principal_construct_good() {
         Value::Response(ResponseData {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Standard(
-                StandardPrincipalData(20, transfer_buffer)
+                StandardPrincipalData::new(20, transfer_buffer).unwrap()
             )))
         }),
         execute_with_parameters(
@@ -710,7 +710,7 @@ fn test_principal_construct_good() {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Contract(
                 QualifiedContractIdentifier::new(
-                    StandardPrincipalData(22, transfer_buffer),
+                    StandardPrincipalData::new(22, transfer_buffer).unwrap(),
                     "hello-world".into()
                 )
             )))
@@ -734,7 +734,7 @@ fn test_principal_construct_good() {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Contract(
                 QualifiedContractIdentifier::new(
-                    StandardPrincipalData(20, transfer_buffer),
+                    StandardPrincipalData::new(20, transfer_buffer).unwrap(),
                     "hello-world".into()
                 )
             )))
@@ -756,7 +756,7 @@ fn test_principal_construct_good() {
         Value::Response(ResponseData {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Standard(
-                StandardPrincipalData(26, transfer_buffer)
+                StandardPrincipalData::new(26, transfer_buffer).unwrap()
             )))
         }),
         execute_with_parameters(
@@ -776,7 +776,7 @@ fn test_principal_construct_good() {
         Value::Response(ResponseData {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Standard(
-                StandardPrincipalData(21, transfer_buffer)
+                StandardPrincipalData::new(21, transfer_buffer).unwrap()
             )))
         }),
         execute_with_parameters(
@@ -798,7 +798,7 @@ fn test_principal_construct_good() {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Contract(
                 QualifiedContractIdentifier::new(
-                    StandardPrincipalData(26, transfer_buffer),
+                    StandardPrincipalData::new(26, transfer_buffer).unwrap(),
                     "hello-world".into()
                 )
             )))
@@ -822,7 +822,7 @@ fn test_principal_construct_good() {
             committed: true,
             data: Box::new(Value::Principal(PrincipalData::Contract(
                 QualifiedContractIdentifier::new(
-                    StandardPrincipalData(21, transfer_buffer),
+                    StandardPrincipalData::new(21, transfer_buffer).unwrap(),
                     "hello-world".into()
                 )
             )))
@@ -853,15 +853,14 @@ fn create_principal_from_strings(
     if let Some(name) = name {
         // contract principal requested
         Value::Principal(PrincipalData::Contract(QualifiedContractIdentifier::new(
-            StandardPrincipalData(version_array[0], principal_array),
+            StandardPrincipalData::new(version_array[0], principal_array).unwrap(),
             name.into(),
         )))
     } else {
         // standard principal requested
-        Value::Principal(PrincipalData::Standard(StandardPrincipalData(
-            version_array[0],
-            principal_array,
-        )))
+        Value::Principal(PrincipalData::Standard(
+            StandardPrincipalData::new(version_array[0], principal_array).unwrap(),
+        ))
     }
 }
 

--- a/clarity/src/vm/tests/simple_apply_eval.rs
+++ b/clarity/src/vm/tests/simple_apply_eval.rs
@@ -430,7 +430,7 @@ fn test_secp256k1() {
     )
     .unwrap();
     eprintln!("addr from privk {:?}", &addr);
-    let principal = addr.to_account_principal();
+    let principal = addr.try_into().unwrap();
     if let PrincipalData::Standard(data) = principal {
         eprintln!("test_secp256k1 principal {:?}", data.to_address());
     }
@@ -446,7 +446,7 @@ fn test_secp256k1() {
     )
     .unwrap();
     eprintln!("addr from hex {:?}", addr);
-    let principal = addr.to_account_principal();
+    let principal: PrincipalData = addr.try_into().unwrap();
     if let PrincipalData::Standard(data) = principal.clone() {
         eprintln!("test_secp256k1 principal {:?}", data.to_address());
     }
@@ -491,8 +491,9 @@ fn test_principal_of_fix() {
         .unwrap()],
     )
     .unwrap()
-    .to_account_principal();
-    let testnet_principal = StacksAddress::from_public_keys(
+    .try_into()
+    .unwrap();
+    let testnet_principal: PrincipalData = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
         1,
@@ -502,7 +503,8 @@ fn test_principal_of_fix() {
         .unwrap()],
     )
     .unwrap()
-    .to_account_principal();
+    .try_into()
+    .unwrap();
 
     // Clarity2, mainnet, should have a mainnet principal.
     assert_eq!(

--- a/clarity/src/vm/types/mod.rs
+++ b/clarity/src/vm/types/mod.rs
@@ -66,15 +66,72 @@ pub struct ListData {
     pub type_signature: ListTypeData,
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub struct StandardPrincipalData(pub u8, pub [u8; 20]);
+pub use self::std_principals::StandardPrincipalData;
 
-impl StandardPrincipalData {
-    pub fn transient() -> StandardPrincipalData {
-        Self(
-            1,
-            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-        )
+mod std_principals {
+    use std::fmt;
+
+    use stacks_common::address::c32;
+
+    use crate::vm::errors::InterpreterError;
+
+    #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+    pub struct StandardPrincipalData(u8, pub [u8; 20]);
+
+    impl StandardPrincipalData {
+        pub fn transient() -> StandardPrincipalData {
+            Self(
+                1,
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            )
+        }
+    }
+
+    impl StandardPrincipalData {
+        pub fn new(version: u8, bytes: [u8; 20]) -> Result<Self, InterpreterError> {
+            if version >= 32 {
+                return Err(InterpreterError::Expect("Unexpected principal data".into()));
+            }
+            Ok(Self(version, bytes))
+        }
+
+        /// NEVER, EVER use this in ANY production code.
+        /// `version` must NEVER be greater than 31.
+        #[cfg(any(test, feature = "testing"))]
+        pub fn new_unsafe(version: u8, bytes: [u8; 20]) -> Self {
+            Self(version, bytes)
+        }
+
+        pub fn null_principal() -> Self {
+            Self::new(0, [0; 20]).unwrap()
+        }
+
+        pub fn version(&self) -> u8 {
+            self.0
+        }
+
+        pub fn to_address(&self) -> String {
+            c32::c32_address(self.0, &self.1[..]).unwrap_or_else(|_| "INVALID_C32_ADD".to_string())
+        }
+
+        pub fn destruct(self) -> (u8, [u8; 20]) {
+            let Self(version, bytes) = self;
+            (version, bytes)
+        }
+    }
+
+    impl fmt::Display for StandardPrincipalData {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let c32_str = self.to_address();
+            write!(f, "{}", c32_str)
+        }
+    }
+
+    impl fmt::Debug for StandardPrincipalData {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let c32_str = self.to_address();
+            write!(f, "StandardPrincipalData({})", c32_str)
+        }
     }
 }
 
@@ -169,7 +226,9 @@ pub trait StacksAddressExtensions {
 
 impl StacksAddressExtensions for StacksAddress {
     fn to_account_principal(&self) -> PrincipalData {
-        PrincipalData::Standard(StandardPrincipalData(self.version, *self.bytes.as_bytes()))
+        PrincipalData::Standard(
+            StandardPrincipalData::new(self.version(), *self.bytes().as_bytes()).unwrap(),
+        )
     }
 }
 
@@ -1372,9 +1431,18 @@ impl fmt::Display for Value {
 impl PrincipalData {
     pub fn version(&self) -> u8 {
         match self {
-            PrincipalData::Standard(StandardPrincipalData(version, _)) => *version,
-            PrincipalData::Contract(QualifiedContractIdentifier { issuer, name: _ }) => issuer.0,
+            PrincipalData::Standard(ref p) => p.version(),
+            PrincipalData::Contract(QualifiedContractIdentifier { issuer, name: _ }) => {
+                issuer.version()
+            }
         }
+    }
+
+    /// A version is only valid if it fits into 5 bits.
+    /// This is enforced by the constructor, but it was historically possible to assemble invalid
+    /// addresses.  This function is used to validate historic addresses.
+    pub fn has_valid_version(&self) -> bool {
+        self.version() < 32
     }
 
     pub fn parse(literal: &str) -> Result<PrincipalData> {
@@ -1405,27 +1473,7 @@ impl PrincipalData {
         }
         let mut fixed_data = [0; 20];
         fixed_data.copy_from_slice(&data[..20]);
-        Ok(StandardPrincipalData(version, fixed_data))
-    }
-}
-
-impl StandardPrincipalData {
-    pub fn to_address(&self) -> String {
-        c32::c32_address(self.0, &self.1[..]).unwrap_or_else(|_| "INVALID_C32_ADD".to_string())
-    }
-}
-
-impl fmt::Display for StandardPrincipalData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let c32_str = self.to_address();
-        write!(f, "{}", c32_str)
-    }
-}
-
-impl fmt::Debug for StandardPrincipalData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let c32_str = self.to_address();
-        write!(f, "StandardPrincipalData({})", c32_str)
+        Ok(StandardPrincipalData::new(version, fixed_data)?)
     }
 }
 
@@ -1463,23 +1511,29 @@ impl fmt::Display for TraitIdentifier {
 }
 
 impl From<StacksAddress> for StandardPrincipalData {
-    fn from(addr: StacksAddress) -> StandardPrincipalData {
-        StandardPrincipalData(addr.version, addr.bytes.0)
+    fn from(addr: StacksAddress) -> Self {
+        let (version, bytes) = addr.destruct();
+
+        // should be infallible because it's impossible to construct a StacksAddress with an
+        // unsupported version byte
+        Self::new(version, bytes.0)
+            .expect("FATAL: could not convert StacksAddress to StandardPrincipalData")
     }
 }
 
 impl From<StacksAddress> for PrincipalData {
-    fn from(addr: StacksAddress) -> PrincipalData {
+    fn from(addr: StacksAddress) -> Self {
         PrincipalData::from(StandardPrincipalData::from(addr))
     }
 }
 
 impl From<StandardPrincipalData> for StacksAddress {
     fn from(o: StandardPrincipalData) -> StacksAddress {
-        StacksAddress {
-            version: o.0,
-            bytes: hash::Hash160(o.1),
-        }
+        // should be infallible because it's impossible to construct a StandardPrincipalData with
+        // an unsupported version byte
+        StacksAddress::new(o.version(), hash::Hash160(o.1)).unwrap_or_else(|_| {
+            panic!("FATAL: could not convert a StandardPrincipalData to StacksAddress")
+        })
     }
 }
 

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -50,7 +50,7 @@ impl AssetIdentifier {
     pub fn STX() -> AssetIdentifier {
         AssetIdentifier {
             contract_identifier: QualifiedContractIdentifier::new(
-                StandardPrincipalData(0, [0u8; 20]),
+                StandardPrincipalData::null_principal(),
                 ContractName::try_from("STX".to_string()).unwrap(),
             ),
             asset_name: ClarityName::try_from("STX".to_string()).unwrap(),
@@ -61,7 +61,7 @@ impl AssetIdentifier {
     pub fn STX_burned() -> AssetIdentifier {
         AssetIdentifier {
             contract_identifier: QualifiedContractIdentifier::new(
-                StandardPrincipalData(0, [0u8; 20]),
+                StandardPrincipalData::null_principal(),
                 ContractName::try_from("BURNED".to_string()).unwrap(),
             ),
             asset_name: ClarityName::try_from("BURNED".to_string()).unwrap(),

--- a/libstackerdb/src/libstackerdb.rs
+++ b/libstackerdb/src/libstackerdb.rs
@@ -186,7 +186,7 @@ impl SlotMetadata {
             .map_err(|ve| Error::VerifyingError(ve.to_string()))?;
 
         let pubkh = Hash160::from_node_public_key(&pubk);
-        Ok(pubkh == principal.bytes)
+        Ok(pubkh == *principal.bytes())
     }
 }
 

--- a/libstackerdb/src/tests/mod.rs
+++ b/libstackerdb/src/tests/mod.rs
@@ -32,10 +32,7 @@ fn test_stackerdb_slot_metadata_sign_verify() {
         &vec![StacksPublicKey::from_private(&pk)],
     )
     .unwrap();
-    let bad_addr = StacksAddress {
-        version: 0x01,
-        bytes: Hash160([0x01; 20]),
-    };
+    let bad_addr = StacksAddress::new(0x01, Hash160([0x01; 20])).unwrap();
 
     let chunk_data = StackerDBChunkData {
         slot_id: 0,

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -591,23 +591,16 @@ impl PartialOrd for StacksAddress {
 
 impl Ord for StacksAddress {
     fn cmp(&self, other: &StacksAddress) -> Ordering {
-        match self.version.cmp(&other.version) {
-            Ordering::Equal => self.bytes.cmp(&other.bytes),
+        match self.version().cmp(&other.version()) {
+            Ordering::Equal => self.bytes().cmp(&other.bytes()),
             inequality => inequality,
         }
     }
 }
 
 impl StacksAddress {
-    pub fn new(version: u8, hash: Hash160) -> StacksAddress {
-        StacksAddress {
-            version,
-            bytes: hash,
-        }
-    }
-
     pub fn is_mainnet(&self) -> bool {
-        match self.version {
+        match self.version() {
             C32_ADDRESS_VERSION_MAINNET_MULTISIG | C32_ADDRESS_VERSION_MAINNET_SINGLESIG => true,
             C32_ADDRESS_VERSION_TESTNET_MULTISIG | C32_ADDRESS_VERSION_TESTNET_SINGLESIG => false,
             _ => false,
@@ -615,14 +608,16 @@ impl StacksAddress {
     }
 
     pub fn burn_address(mainnet: bool) -> StacksAddress {
-        StacksAddress {
-            version: if mainnet {
+        Self::new(
+            if mainnet {
                 C32_ADDRESS_VERSION_MAINNET_SINGLESIG
             } else {
                 C32_ADDRESS_VERSION_TESTNET_SINGLESIG
             },
-            bytes: Hash160([0u8; 20]),
-        }
+            Hash160([0u8; 20]),
+        )
+        .unwrap_or_else(|_| panic!("FATAL: constant address versions are invalid"))
+        // infallible
     }
 
     /// Generate an address from a given address hash mode, signature threshold, and list of public
@@ -663,7 +658,7 @@ impl StacksAddress {
         }
 
         let hash_bits = public_keys_to_address_hash(hash_mode, num_sigs, pubkeys);
-        Some(StacksAddress::new(version, hash_bits))
+        StacksAddress::new(version, hash_bits).ok()
     }
 
     /// Make a P2PKH StacksAddress
@@ -679,16 +674,17 @@ impl StacksAddress {
         } else {
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG
         };
-        Self {
-            version,
-            bytes: hash,
-        }
+        Self::new(version, hash)
+            .unwrap_or_else(|_| panic!("FATAL: constant address versions are invalid"))
+        // infallible
     }
 }
 
 impl std::fmt::Display for StacksAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        c32_address(self.version, self.bytes.as_bytes())
+        // the .unwrap_or_else() should be unreachable since StacksAddress is constructed to only
+        // accept a 5-bit value for its version
+        c32_address(self.version(), self.bytes().as_bytes())
             .expect("Stacks version is not C32-encodable")
             .fmt(f)
     }
@@ -696,7 +692,7 @@ impl std::fmt::Display for StacksAddress {
 
 impl Address for StacksAddress {
     fn to_bytes(&self) -> Vec<u8> {
-        self.bytes.as_bytes().to_vec()
+        self.bytes().as_bytes().to_vec()
     }
 
     fn from_string(s: &str) -> Option<StacksAddress> {
@@ -708,14 +704,11 @@ impl Address for StacksAddress {
 
         let mut hash_bytes = [0u8; 20];
         hash_bytes.copy_from_slice(&bytes[..]);
-        Some(StacksAddress {
-            version,
-            bytes: Hash160(hash_bytes),
-        })
+        StacksAddress::new(version, Hash160(hash_bytes)).ok()
     }
 
     fn is_burn(&self) -> bool {
-        self.bytes == Hash160([0u8; 20])
+        self.bytes() == &Hash160([0u8; 20])
     }
 }
 

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -340,14 +340,14 @@ pub fn parse_pox_addr(pox_address_literal: &str) -> Result<PoxAddress, String> {
         Ok,
     );
     match parsed_addr {
-        Ok(PoxAddress::Standard(addr, None)) => match addr.version {
+        Ok(PoxAddress::Standard(addr, None)) => match addr.version() {
             C32_ADDRESS_VERSION_MAINNET_MULTISIG | C32_ADDRESS_VERSION_TESTNET_MULTISIG => Ok(
                 PoxAddress::Standard(addr, Some(AddressHashMode::SerializeP2SH)),
             ),
             C32_ADDRESS_VERSION_MAINNET_SINGLESIG | C32_ADDRESS_VERSION_TESTNET_SINGLESIG => Ok(
                 PoxAddress::Standard(addr, Some(AddressHashMode::SerializeP2PKH)),
             ),
-            _ => Err(format!("Invalid address version: {}", addr.version)),
+            _ => Err(format!("Invalid address version: {}", addr.version())),
         },
         _ => parsed_addr,
     }
@@ -451,7 +451,7 @@ mod tests {
         );
         match pox_addr {
             PoxAddress::Standard(stacks_addr, hash_mode) => {
-                assert_eq!(stacks_addr.version, 22);
+                assert_eq!(stacks_addr.version(), 22);
                 assert_eq!(hash_mode, Some(AddressHashMode::SerializeP2PKH));
             }
             _ => panic!("Invalid parsed address"),
@@ -467,7 +467,7 @@ mod tests {
         make_message_hash(&pox_addr);
         match pox_addr {
             PoxAddress::Standard(stacks_addr, hash_mode) => {
-                assert_eq!(stacks_addr.version, 20);
+                assert_eq!(stacks_addr.version(), 20);
                 assert_eq!(hash_mode, Some(AddressHashMode::SerializeP2SH));
             }
             _ => panic!("Invalid parsed address"),
@@ -483,7 +483,7 @@ mod tests {
         make_message_hash(&pox_addr);
         match pox_addr {
             PoxAddress::Standard(stacks_addr, hash_mode) => {
-                assert_eq!(stacks_addr.version, C32_ADDRESS_VERSION_TESTNET_SINGLESIG);
+                assert_eq!(stacks_addr.version(), C32_ADDRESS_VERSION_TESTNET_SINGLESIG);
                 assert_eq!(hash_mode, Some(AddressHashMode::SerializeP2PKH));
             }
             _ => panic!("Invalid parsed address"),

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -985,7 +985,7 @@ impl Signer {
         // authenticate the signature -- it must be signed by one of the stacking set
         let is_valid_sig = self.signer_addresses.iter().any(|addr| {
             // it only matters that the address hash bytes match
-            signer_address.bytes == addr.bytes
+            signer_address.bytes() == addr.bytes()
         });
 
         if !is_valid_sig {
@@ -1081,7 +1081,7 @@ impl Signer {
             let stacker_address = StacksAddress::p2pkh(self.mainnet, &public_key);
 
             // it only matters that the address hash bytes match
-            stacker_address.bytes == addr.bytes
+            stacker_address.bytes() == addr.bytes()
         });
 
         if !is_valid_sig {

--- a/stackslib/src/blockstack_cli.rs
+++ b/stackslib/src/blockstack_cli.rs
@@ -633,7 +633,7 @@ fn get_addresses(args: &[String], version: TransactionVersion) -> Result<String,
 
     let mut b58_addr_slice = [0u8; 21];
     b58_addr_slice[0] = b58_version;
-    b58_addr_slice[1..].copy_from_slice(&stx_address.bytes.0);
+    b58_addr_slice[1..].copy_from_slice(&stx_address.bytes().0);
     let b58_address_string = b58::check_encode_slice(&b58_addr_slice);
     Ok(format!(
         "{{

--- a/stackslib/src/burnchains/tests/db.rs
+++ b/stackslib/src/burnchains/tests/db.rs
@@ -1353,7 +1353,10 @@ fn test_classify_delegate_stx() {
     if let BlockstackOperationType::DelegateStx(op) = &processed_ops_1[0] {
         assert_eq!(&op.sender, &expected_pre_delegate_addr);
         assert_eq!(op.delegated_ustx, u128::from_be_bytes([1; 16]));
-        assert_eq!(op.delegate_to, StacksAddress::new(22, Hash160([2u8; 20])));
+        assert_eq!(
+            op.delegate_to,
+            StacksAddress::new(22, Hash160([2u8; 20])).unwrap()
+        );
         assert_eq!(&op.reward_addr, &expected_reward_addr);
         assert_eq!(op.until_burn_height, Some(u64::from_be_bytes([1; 8])));
     } else {

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -10698,8 +10698,8 @@ pub mod tests {
 
         let good_ops = vec![
             BlockstackOperationType::TransferStx(TransferStxOp {
-                sender: StacksAddress::new(1, Hash160([1u8; 20])),
-                recipient: StacksAddress::new(2, Hash160([2u8; 20])),
+                sender: StacksAddress::new(1, Hash160([1u8; 20])).unwrap(),
+                recipient: StacksAddress::new(2, Hash160([2u8; 20])).unwrap(),
                 transfered_ustx: 123,
                 memo: vec![0x00, 0x01, 0x02, 0x03, 0x04],
 
@@ -10709,8 +10709,11 @@ pub mod tests {
                 burn_header_hash: first_burn_hash.clone(),
             }),
             BlockstackOperationType::StackStx(StackStxOp {
-                sender: StacksAddress::new(3, Hash160([3u8; 20])),
-                reward_addr: PoxAddress::Standard(StacksAddress::new(4, Hash160([4u8; 20])), None),
+                sender: StacksAddress::new(3, Hash160([3u8; 20])).unwrap(),
+                reward_addr: PoxAddress::Standard(
+                    StacksAddress::new(4, Hash160([4u8; 20])).unwrap(),
+                    None,
+                ),
                 stacked_ustx: 456,
                 num_cycles: 6,
                 signer_key: Some(StacksPublicKeyBuffer([0x02; 33])),
@@ -10723,12 +10726,12 @@ pub mod tests {
                 burn_header_hash: first_burn_hash.clone(),
             }),
             BlockstackOperationType::DelegateStx(DelegateStxOp {
-                sender: StacksAddress::new(6, Hash160([6u8; 20])),
-                delegate_to: StacksAddress::new(7, Hash160([7u8; 20])),
+                sender: StacksAddress::new(6, Hash160([6u8; 20])).unwrap(),
+                delegate_to: StacksAddress::new(7, Hash160([7u8; 20])).unwrap(),
                 reward_addr: Some((
                     123,
                     PoxAddress::Standard(
-                        StacksAddress::new(8, Hash160([8u8; 20])),
+                        StacksAddress::new(8, Hash160([8u8; 20])).unwrap(),
                         Some(AddressHashMode::SerializeP2PKH),
                     ),
                 )),
@@ -10741,7 +10744,7 @@ pub mod tests {
                 burn_header_hash: first_burn_hash.clone(),
             }),
             BlockstackOperationType::VoteForAggregateKey(VoteForAggregateKeyOp {
-                sender: StacksAddress::new(6, Hash160([6u8; 20])),
+                sender: StacksAddress::new(6, Hash160([6u8; 20])).unwrap(),
                 aggregate_key: vote_key,
                 signer_key: vote_key,
                 round: 1,
@@ -10793,8 +10796,8 @@ pub mod tests {
         // if the same ops get mined in a different burnchain block, they will still be available
         let good_ops_2 = vec![
             BlockstackOperationType::TransferStx(TransferStxOp {
-                sender: StacksAddress::new(1, Hash160([1u8; 20])),
-                recipient: StacksAddress::new(2, Hash160([2u8; 20])),
+                sender: StacksAddress::new(1, Hash160([1u8; 20])).unwrap(),
+                recipient: StacksAddress::new(2, Hash160([2u8; 20])).unwrap(),
                 transfered_ustx: 123,
                 memo: vec![0x00, 0x01, 0x02, 0x03, 0x04],
 
@@ -10804,8 +10807,11 @@ pub mod tests {
                 burn_header_hash: fork_burn_hash.clone(),
             }),
             BlockstackOperationType::StackStx(StackStxOp {
-                sender: StacksAddress::new(3, Hash160([3u8; 20])),
-                reward_addr: PoxAddress::Standard(StacksAddress::new(4, Hash160([4u8; 20])), None),
+                sender: StacksAddress::new(3, Hash160([3u8; 20])).unwrap(),
+                reward_addr: PoxAddress::Standard(
+                    StacksAddress::new(4, Hash160([4u8; 20])).unwrap(),
+                    None,
+                ),
                 stacked_ustx: 456,
                 num_cycles: 6,
                 signer_key: None,
@@ -10818,11 +10824,11 @@ pub mod tests {
                 burn_header_hash: fork_burn_hash.clone(),
             }),
             BlockstackOperationType::DelegateStx(DelegateStxOp {
-                sender: StacksAddress::new(6, Hash160([6u8; 20])),
-                delegate_to: StacksAddress::new(7, Hash160([7u8; 20])),
+                sender: StacksAddress::new(6, Hash160([6u8; 20])).unwrap(),
+                delegate_to: StacksAddress::new(7, Hash160([7u8; 20])).unwrap(),
                 reward_addr: Some((
                     123,
-                    PoxAddress::Standard(StacksAddress::new(8, Hash160([8u8; 20])), None),
+                    PoxAddress::Standard(StacksAddress::new(8, Hash160([8u8; 20])).unwrap(), None),
                 )),
                 delegated_ustx: 789,
                 until_burn_height: Some(1000),
@@ -10833,7 +10839,7 @@ pub mod tests {
                 burn_header_hash: fork_burn_hash.clone(),
             }),
             BlockstackOperationType::VoteForAggregateKey(VoteForAggregateKeyOp {
-                sender: StacksAddress::new(6, Hash160([6u8; 20])),
+                sender: StacksAddress::new(6, Hash160([6u8; 20])).unwrap(),
                 aggregate_key: StacksPublicKeyBuffer([0x01; 33]),
                 signer_key: StacksPublicKeyBuffer([0x02; 33]),
                 round: 1,

--- a/stackslib/src/chainstate/burn/operations/delegate_stx.rs
+++ b/stackslib/src/chainstate/burn/operations/delegate_stx.rs
@@ -331,10 +331,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let op = DelegateStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -357,7 +354,10 @@ mod tests {
             ))
         );
         assert_eq!(op.delegated_ustx, u128::from_be_bytes([1; 16]));
-        assert_eq!(op.delegate_to, StacksAddress::new(22, Hash160([2u8; 20])));
+        assert_eq!(
+            op.delegate_to,
+            StacksAddress::new(22, Hash160([2u8; 20])).unwrap()
+        );
         assert_eq!(op.until_burn_height, None);
     }
 
@@ -402,10 +402,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let op = DelegateStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -417,7 +414,10 @@ mod tests {
         assert_eq!(&op.sender, &sender);
         assert_eq!(&op.reward_addr, &None);
         assert_eq!(op.delegated_ustx, u128::from_be_bytes([1; 16]));
-        assert_eq!(op.delegate_to, StacksAddress::new(22, Hash160([2u8; 20])));
+        assert_eq!(
+            op.delegate_to,
+            StacksAddress::new(22, Hash160([2u8; 20])).unwrap()
+        );
         assert_eq!(op.until_burn_height, Some(u64::from_be_bytes([1; 8])));
     }
 
@@ -449,10 +449,7 @@ mod tests {
             }],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let err = DelegateStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -491,10 +488,7 @@ mod tests {
             }],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let err = DelegateStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -537,10 +531,7 @@ mod tests {
             }],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let err = DelegateStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -576,10 +567,7 @@ mod tests {
             outputs: vec![],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let err = DelegateStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -648,10 +636,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let op = DelegateStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -674,7 +659,10 @@ mod tests {
             ))
         );
         assert_eq!(op.delegated_ustx, u128::from_be_bytes([1; 16]));
-        assert_eq!(op.delegate_to, StacksAddress::new(22, Hash160([2u8; 20])));
+        assert_eq!(
+            op.delegate_to,
+            StacksAddress::new(22, Hash160([2u8; 20])).unwrap()
+        );
         assert_eq!(op.until_burn_height, Some(u64::from_be_bytes([1; 8])));
     }
 }

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1208,17 +1208,17 @@ mod tests {
     }
 
     fn stacks_address_to_bitcoin_tx_out(addr: &StacksAddress, value: u64) -> TxOut {
-        let btc_version = to_b58_version_byte(addr.version)
+        let btc_version = to_b58_version_byte(addr.version())
             .expect("BUG: failed to decode Stacks version byte to Bitcoin version byte");
         let btc_addr_type = legacy_version_byte_to_address_type(btc_version)
             .expect("BUG: failed to decode Bitcoin version byte")
             .0;
         match btc_addr_type {
             LegacyBitcoinAddressType::PublicKeyHash => {
-                LegacyBitcoinAddress::to_p2pkh_tx_out(&addr.bytes, value)
+                LegacyBitcoinAddress::to_p2pkh_tx_out(addr.bytes(), value)
             }
             LegacyBitcoinAddressType::ScriptHash => {
-                LegacyBitcoinAddress::to_p2sh_tx_out(&addr.bytes, value)
+                LegacyBitcoinAddress::to_p2sh_tx_out(addr.bytes(), value)
             }
         }
     }
@@ -1764,8 +1764,8 @@ mod tests {
                     memo: vec![0x1f],
 
                     commit_outs: vec![
-                        PoxAddress::Standard( StacksAddress { version: 26, bytes: Hash160::empty() }, None ),
-                        PoxAddress::Standard( StacksAddress { version: 26, bytes: Hash160::empty() }, None ),
+                        PoxAddress::Standard( StacksAddress::new(26, Hash160::empty()).unwrap(), None ),
+                        PoxAddress::Standard( StacksAddress::new(26, Hash160::empty()).unwrap(), None ),
                     ],
 
                     burn_fee: 24690,
@@ -3260,7 +3260,7 @@ mod tests {
         let anchor_block_hash = BlockHeaderHash([0xaa; 32]);
 
         fn reward_addrs(i: usize) -> PoxAddress {
-            let addr = StacksAddress::new(1, Hash160::from_data(&i.to_be_bytes()));
+            let addr = StacksAddress::new(1, Hash160::from_data(&i.to_be_bytes())).unwrap();
             PoxAddress::Standard(addr, None)
         }
         let burn_addr_0 = PoxAddress::Standard(StacksAddress::burn_address(false), None);

--- a/stackslib/src/chainstate/burn/operations/mod.rs
+++ b/stackslib/src/chainstate/burn/operations/mod.rs
@@ -369,8 +369,8 @@ pub fn stacks_addr_serialize(addr: &StacksAddress) -> serde_json::Value {
     let addr_str = addr.to_string();
     json!({
         "address": addr_str,
-        "address_hash_bytes": format!("0x{}", addr.bytes),
-        "address_version": addr.version
+        "address_hash_bytes": format!("0x{}", addr.bytes()),
+        "address_version": addr.version()
     })
 }
 

--- a/stackslib/src/chainstate/burn/operations/stack_stx.rs
+++ b/stackslib/src/chainstate/burn/operations/stack_stx.rs
@@ -507,10 +507,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let op = PreStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -571,10 +568,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
 
         // pre-2.1 this fails
         let op_err = PreStxOp::parse_from_tx(
@@ -652,10 +646,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let op = StackStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -726,10 +717,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let op = StackStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
@@ -798,10 +786,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
 
         // pre-2.1: this fails
         let op_err = StackStxOp::parse_from_tx(
@@ -849,10 +834,7 @@ mod tests {
         let sender_addr = "ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2";
         let sender = StacksAddress::from_string(sender_addr).unwrap();
         let reward_addr = PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                bytes: Hash160([0x01; 20]),
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20])).unwrap(),
             None,
         );
         let op = StackStxOp {

--- a/stackslib/src/chainstate/burn/operations/test/serialization.rs
+++ b/stackslib/src/chainstate/burn/operations/test/serialization.rs
@@ -61,10 +61,7 @@ fn test_serialization_stack_stx_op() {
     let sender_addr = "ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2";
     let sender = StacksAddress::from_string(sender_addr).unwrap();
     let reward_addr = PoxAddress::Standard(
-        StacksAddress {
-            version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-            bytes: Hash160([0x01; 20]),
-        },
+        StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20])).unwrap(),
         None,
     );
 
@@ -110,10 +107,7 @@ fn test_serialization_stack_stx_op_with_signer_key() {
     let sender_addr = "ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2";
     let sender = StacksAddress::from_string(sender_addr).unwrap();
     let reward_addr = PoxAddress::Standard(
-        StacksAddress {
-            version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-            bytes: Hash160([0x01; 20]),
-        },
+        StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20])).unwrap(),
         None,
     );
 
@@ -191,10 +185,7 @@ fn test_serialization_delegate_stx_op() {
     let delegate_to_addr = "SP24ZBZ8ZE6F48JE9G3F3HRTG9FK7E2H6K2QZ3Q1K";
     let delegate_to = StacksAddress::from_string(delegate_to_addr).unwrap();
     let pox_addr = PoxAddress::Standard(
-        StacksAddress {
-            version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-            bytes: Hash160([0x01; 20]),
-        },
+        StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20])).unwrap(),
         None,
     );
     let op = DelegateStxOp {

--- a/stackslib/src/chainstate/burn/operations/transfer_stx.rs
+++ b/stackslib/src/chainstate/burn/operations/transfer_stx.rs
@@ -304,10 +304,7 @@ mod tests {
             ],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let op = TransferStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),

--- a/stackslib/src/chainstate/burn/operations/vote_for_aggregate_key.rs
+++ b/stackslib/src/chainstate/burn/operations/vote_for_aggregate_key.rs
@@ -268,10 +268,7 @@ mod tests {
             }],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let vote_op = VoteForAggregateKeyOp::parse_from_tx(
             1000,
             &BurnchainHeaderHash([0; 32]),
@@ -324,10 +321,7 @@ mod tests {
             }],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let vote_op = VoteForAggregateKeyOp::parse_from_tx(
             1000,
             &BurnchainHeaderHash([0; 32]),
@@ -369,10 +363,7 @@ mod tests {
             }],
         };
 
-        let sender = StacksAddress {
-            version: 0,
-            bytes: Hash160([0; 20]),
-        };
+        let sender = StacksAddress::new(0, Hash160([0; 20])).unwrap();
         let vote_op = VoteForAggregateKeyOp::parse_from_tx(
             1000,
             &BurnchainHeaderHash([0; 32]),

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -110,7 +110,7 @@ fn advance_to_nakamoto(
     )
     .unwrap();
     let default_pox_addr =
-        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone());
+        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes().clone());
 
     let mut tip = None;
     for sortition_height in 0..11 {
@@ -825,7 +825,8 @@ fn block_descendant() {
                 StacksAddress::new(
                     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                     Hash160::from_data(&index.to_be_bytes()),
-                ),
+                )
+                .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH),
             )),
         })
@@ -914,7 +915,8 @@ fn block_info_tests(use_primary_testnet: bool) {
                 StacksAddress::new(
                     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                     Hash160::from_data(&index.to_be_bytes()),
-                ),
+                )
+                .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH),
             )),
             max_amount: None,
@@ -1342,7 +1344,8 @@ fn pox_treatment() {
                 StacksAddress::new(
                     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                     Hash160::from_data(&index.to_be_bytes()),
-                ),
+                )
+                .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH),
             )),
             max_amount: None,
@@ -3093,7 +3096,8 @@ fn process_next_nakamoto_block_deadlock() {
                 StacksAddress::new(
                     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                     Hash160::from_data(&index.to_be_bytes()),
-                ),
+                )
+                .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH),
             )),
             max_amount: None,

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -4807,10 +4807,10 @@ impl NakamotoChainState {
             .map(|hash160|
                 // each miner gets two slots
                 (
-                    StacksAddress {
-                        version: 1, // NOTE: the version is ignored in stackerdb; we only care about the hashbytes
-                        bytes: hash160
-                    },
+                    StacksAddress::new(
+                        1, // NOTE: the version is ignored in stackerdb; we only care about the hashbytes
+                        hash160
+                    ).expect("FATAL: infallible: 1 is not a valid address version byte"),
                     MINER_SLOT_COUNT,
                 ))
             .collect();

--- a/stackslib/src/chainstate/nakamoto/test_signers.rs
+++ b/stackslib/src/chainstate/nakamoto/test_signers.rs
@@ -165,10 +165,11 @@ impl TestSigners {
                 weight: 1,
             };
             let pox_addr = PoxAddress::Standard(
-                StacksAddress {
-                    version: AddressHashMode::SerializeP2PKH.to_version_testnet(),
-                    bytes: Hash160::from_data(&nakamoto_signer_entry.signing_key),
-                },
+                StacksAddress::new(
+                    AddressHashMode::SerializeP2PKH.to_version_testnet(),
+                    Hash160::from_data(&nakamoto_signer_entry.signing_key),
+                )
+                .expect("FATAL: constant testnet address version is not supported"),
                 Some(AddressHashMode::SerializeP2PKH),
             );
             signer_entries.push(nakamoto_signer_entry);

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -2063,10 +2063,7 @@ fn test_make_miners_stackerdb_config() {
         .collect();
     let miner_addrs: Vec<_> = miner_hash160s
         .iter()
-        .map(|miner_hash160| StacksAddress {
-            version: 1,
-            bytes: miner_hash160.clone(),
-        })
+        .map(|miner_hash160| StacksAddress::new(1, miner_hash160.clone()).unwrap())
         .collect();
 
     debug!("miners = {:#?}", &miner_hash160s);
@@ -2268,8 +2265,8 @@ fn test_make_miners_stackerdb_config() {
         .iter()
         .map(|config| {
             (
-                config.signers[0].0.bytes.clone(),
-                config.signers[1].0.bytes.clone(),
+                config.signers[0].0.bytes().clone(),
+                config.signers[1].0.bytes().clone(),
             )
         })
         .collect();

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -149,7 +149,7 @@ impl TestStacker {
                 let pox_key = StacksPrivateKey::from_seed(&[*key_seed, *key_seed]);
                 let addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&pox_key));
                 let pox_addr =
-                    PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone());
+                    PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes().clone());
 
                 TestStacker {
                     signer_private_key: signing_key.clone(),

--- a/stackslib/src/chainstate/stacks/address.rs
+++ b/stackslib/src/chainstate/stacks/address.rs
@@ -131,7 +131,7 @@ impl PoxAddress {
     #[cfg(any(test, feature = "testing"))]
     pub fn hash160(&self) -> Hash160 {
         match *self {
-            PoxAddress::Standard(addr, _) => addr.bytes.clone(),
+            PoxAddress::Standard(addr, _) => addr.bytes().clone(),
             _ => panic!("Called hash160 on a non-standard PoX address"),
         }
     }
@@ -140,7 +140,7 @@ impl PoxAddress {
     /// version.
     pub fn bytes(&self) -> Vec<u8> {
         match *self {
-            PoxAddress::Standard(addr, _) => addr.bytes.0.to_vec(),
+            PoxAddress::Standard(addr, _) => addr.bytes().0.to_vec(),
             PoxAddress::Addr20(_, _, bytes) => bytes.to_vec(),
             PoxAddress::Addr32(_, _, bytes) => bytes.to_vec(),
         }
@@ -171,7 +171,7 @@ impl PoxAddress {
         };
 
         Some(PoxAddress::Standard(
-            StacksAddress { version, bytes },
+            StacksAddress::new(version, bytes).ok()?,
             Some(hashmode),
         ))
     }
@@ -293,7 +293,7 @@ impl PoxAddress {
     pub fn to_burnchain_repr(&self) -> String {
         match *self {
             PoxAddress::Standard(ref addr, _) => {
-                format!("{:02x}-{}", &addr.version, &addr.bytes)
+                format!("{:02x}-{}", &addr.version(), &addr.bytes())
             }
             PoxAddress::Addr20(_, ref addrtype, ref addrbytes) => {
                 format!("{:02x}-{}", addrtype.to_u8(), to_hex(addrbytes))
@@ -328,7 +328,7 @@ impl PoxAddress {
                     }
                 };
                 let version = Value::buff_from_byte(*hm as u8);
-                let hashbytes = Value::buff_from(Vec::from(addr.bytes.0.clone()))
+                let hashbytes = Value::buff_from(Vec::from(addr.bytes().0.clone()))
                     .expect("FATAL: hash160 does not fit into a Clarity value");
 
                 let tuple_data = TupleData::from_data(vec![
@@ -376,7 +376,7 @@ impl PoxAddress {
     pub fn coerce_hash_mode(self) -> PoxAddress {
         match self {
             PoxAddress::Standard(addr, _) => {
-                let hm = AddressHashMode::from_version(addr.version);
+                let hm = AddressHashMode::from_version(addr.version());
                 PoxAddress::Standard(addr, Some(hm))
             }
             _ => self,
@@ -429,7 +429,7 @@ impl PoxAddress {
         match *self {
             PoxAddress::Standard(addr, _) => {
                 // legacy Bitcoin address
-                let btc_version = to_b58_version_byte(addr.version).expect(
+                let btc_version = to_b58_version_byte(addr.version()).expect(
                     "BUG: failed to decode Stacks version byte to legacy Bitcoin version byte",
                 );
                 let btc_addr_type = legacy_version_byte_to_address_type(btc_version)
@@ -437,10 +437,10 @@ impl PoxAddress {
                     .0;
                 match btc_addr_type {
                     LegacyBitcoinAddressType::PublicKeyHash => {
-                        LegacyBitcoinAddress::to_p2pkh_tx_out(&addr.bytes, value)
+                        LegacyBitcoinAddress::to_p2pkh_tx_out(addr.bytes(), value)
                     }
                     LegacyBitcoinAddressType::ScriptHash => {
-                        LegacyBitcoinAddress::to_p2sh_tx_out(&addr.bytes, value)
+                        LegacyBitcoinAddress::to_p2sh_tx_out(addr.bytes(), value)
                     }
                 }
             }
@@ -500,10 +500,7 @@ impl PoxAddress {
     #[cfg(any(test, feature = "testing"))]
     pub fn from_legacy(hash_mode: AddressHashMode, hash_bytes: Hash160) -> PoxAddress {
         PoxAddress::Standard(
-            StacksAddress {
-                version: hash_mode.to_version_testnet(),
-                bytes: hash_bytes,
-            },
+            StacksAddress::new(hash_mode.to_version_testnet(), hash_bytes).unwrap(),
             Some(hash_mode),
         )
     }
@@ -524,14 +521,12 @@ impl StacksAddressExtensions for StacksAddress {
         // should not fail by construction
         let version = to_c32_version_byte(btc_version)
             .expect("Failed to decode Bitcoin version byte to Stacks version byte");
-        StacksAddress {
-            version,
-            bytes: addr.bytes.clone(),
-        }
+        StacksAddress::new(version, addr.bytes.clone())
+            .expect("FATAL: failed to convert bitcoin address type to stacks address version byte")
     }
 
     fn to_b58(self) -> String {
-        let StacksAddress { version, bytes } = self;
+        let (version, bytes) = self.destruct();
         let btc_version = to_b58_version_byte(version)
             // fallback to version
             .unwrap_or(version);
@@ -556,10 +551,7 @@ mod test {
 
     #[test]
     fn tx_stacks_address_codec() {
-        let addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
         let addr_bytes = [
             // version
             0x01, // bytes
@@ -574,7 +566,7 @@ mod test {
     fn tx_stacks_address_valid_p2pkh() {
         // p2pkh should accept compressed or uncompressed
         assert_eq!(StacksAddress::from_public_keys(1, &AddressHashMode::SerializeP2PKH, 1, &vec![PubKey::from_hex("04b7c7cbe36a1aed38c6324b143584a1e822bbf0c4435b102f0497ccb592baf8e964a5a270f9348285595b78855c3e33dc36708e34f9abdeeaad4d2977cb81e3a1").unwrap()]),
-                   Some(StacksAddress { version: 1, bytes: Hash160::from_hex("560ee9d7f5694dd4dbeddf55eff16bcc05409fef").unwrap() }));
+                   Some(StacksAddress::new(1, Hash160::from_hex("560ee9d7f5694dd4dbeddf55eff16bcc05409fef").unwrap()).unwrap()));
 
         assert_eq!(
             StacksAddress::from_public_keys(
@@ -586,10 +578,13 @@ mod test {
                 )
                 .unwrap()]
             ),
-            Some(StacksAddress {
-                version: 2,
-                bytes: Hash160::from_hex("e3771b5724d9a8daca46052bab5d0f533cd1e619").unwrap()
-            })
+            Some(
+                StacksAddress::new(
+                    2,
+                    Hash160::from_hex("e3771b5724d9a8daca46052bab5d0f533cd1e619").unwrap()
+                )
+                .unwrap()
+            )
         );
 
         // should fail if we have too many signatures
@@ -623,10 +618,13 @@ mod test {
                 )
                 .unwrap()]
             ),
-            Some(StacksAddress {
-                version: 4,
-                bytes: Hash160::from_hex("384d172898686fd0337fba27843add64cbe684f1").unwrap()
-            })
+            Some(
+                StacksAddress::new(
+                    4,
+                    Hash160::from_hex("384d172898686fd0337fba27843add64cbe684f1").unwrap()
+                )
+                .unwrap()
+            )
         );
     }
 
@@ -653,16 +651,19 @@ mod test {
                     .unwrap()
                 ]
             ),
-            Some(StacksAddress {
-                version: 5,
-                bytes: Hash160::from_hex("b01162ecda72c57ed419f7966ec4e8dd7987c704").unwrap()
-            })
+            Some(
+                StacksAddress::new(
+                    5,
+                    Hash160::from_hex("b01162ecda72c57ed419f7966ec4e8dd7987c704").unwrap()
+                )
+                .unwrap()
+            )
         );
 
         assert_eq!(StacksAddress::from_public_keys(6, &AddressHashMode::SerializeP2SH, 2, &vec![PubKey::from_hex("04b30fafab3a12372c5d150d567034f37d60a91168009a779498168b0e9d8ec7f259fc6bc2f317febe245344d9e11912427cee095b64418719207ac502e8cff0ce").unwrap(),
                                                                                                 PubKey::from_hex("04ce61f1d155738a5e434fc8a61c3e104f891d1ec71576e8ad85abb68b34670d35c61aec8a973b3b7d68c7325b03c1d18a82e88998b8307afeaa491c1e45e46255").unwrap(),
                                                                                                 PubKey::from_hex("04ef2340518b5867b23598a9cf74611f8b98064f7d55cdb8c107c67b5efcbc5c771f112f919b00a6c6c5f51f7c63e1762fe9fac9b66ec75a053db7f51f4a52712b").unwrap()]),
-                   Some(StacksAddress { version: 6, bytes: Hash160::from_hex("1003ab7fc0ba18a343da2818c560109c170cdcbb").unwrap() }));
+                   Some(StacksAddress::new(6, Hash160::from_hex("1003ab7fc0ba18a343da2818c560109c170cdcbb").unwrap()).unwrap()));
     }
 
     #[test]
@@ -688,10 +689,13 @@ mod test {
                     .unwrap()
                 ]
             ),
-            Some(StacksAddress {
-                version: 7,
-                bytes: Hash160::from_hex("57130f08a480e7518c1d685e8bb88008d90a0a60").unwrap()
-            })
+            Some(
+                StacksAddress::new(
+                    7,
+                    Hash160::from_hex("57130f08a480e7518c1d685e8bb88008d90a0a60").unwrap()
+                )
+                .unwrap()
+            )
         );
 
         assert_eq!(StacksAddress::from_public_keys(8, &AddressHashMode::SerializeP2PKH, 2, &vec![PubKey::from_hex("04b30fafab3a12372c5d150d567034f37d60a91168009a779498168b0e9d8ec7f259fc6bc2f317febe245344d9e11912427cee095b64418719207ac502e8cff0ce").unwrap(),
@@ -721,10 +725,8 @@ mod test {
         assert_eq!(
             PoxAddress::try_from_pox_tuple(true, &make_pox_addr_raw(0x00, vec![0x01; 20])).unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH)
             )
         );
@@ -732,20 +734,16 @@ mod test {
             PoxAddress::try_from_pox_tuple(false, &make_pox_addr_raw(0x00, vec![0x02; 20]))
                 .unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-                    bytes: Hash160([0x02; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0x02; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH)
             )
         );
         assert_eq!(
             PoxAddress::try_from_pox_tuple(true, &make_pox_addr_raw(0x01, vec![0x03; 20])).unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x03; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x03; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2SH)
             )
         );
@@ -753,20 +751,16 @@ mod test {
             PoxAddress::try_from_pox_tuple(false, &make_pox_addr_raw(0x01, vec![0x04; 20]))
                 .unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                    bytes: Hash160([0x04; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x04; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2SH)
             )
         );
         assert_eq!(
             PoxAddress::try_from_pox_tuple(true, &make_pox_addr_raw(0x02, vec![0x05; 20])).unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x05; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x05; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WPKH)
             )
         );
@@ -774,20 +768,16 @@ mod test {
             PoxAddress::try_from_pox_tuple(false, &make_pox_addr_raw(0x02, vec![0x06; 20]))
                 .unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                    bytes: Hash160([0x06; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x06; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WPKH)
             )
         );
         assert_eq!(
             PoxAddress::try_from_pox_tuple(true, &make_pox_addr_raw(0x03, vec![0x07; 20])).unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x07; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x07; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WSH)
             )
         );
@@ -795,10 +785,8 @@ mod test {
             PoxAddress::try_from_pox_tuple(false, &make_pox_addr_raw(0x03, vec![0x08; 20]))
                 .unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                    bytes: Hash160([0x08; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x08; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WSH)
             )
         );
@@ -943,10 +931,8 @@ mod test {
     fn test_as_clarity_tuple() {
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH)
             )
             .as_clarity_tuple()
@@ -957,10 +943,8 @@ mod test {
         );
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-                    bytes: Hash160([0x02; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0x02; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH)
             )
             .as_clarity_tuple()
@@ -970,19 +954,13 @@ mod test {
                 .unwrap()
         );
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                bytes: Hash160([0x01; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
         .is_none());
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-                bytes: Hash160([0x02; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0x02; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
@@ -990,10 +968,8 @@ mod test {
 
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2SH)
             )
             .as_clarity_tuple()
@@ -1004,10 +980,8 @@ mod test {
         );
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                    bytes: Hash160([0x02; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x02; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2SH)
             )
             .as_clarity_tuple()
@@ -1017,19 +991,13 @@ mod test {
                 .unwrap()
         );
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                bytes: Hash160([0x01; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
         .is_none());
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                bytes: Hash160([0x02; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x02; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
@@ -1037,10 +1005,8 @@ mod test {
 
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WPKH)
             )
             .as_clarity_tuple()
@@ -1051,10 +1017,8 @@ mod test {
         );
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                    bytes: Hash160([0x02; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x02; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WPKH)
             )
             .as_clarity_tuple()
@@ -1064,19 +1028,13 @@ mod test {
                 .unwrap()
         );
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                bytes: Hash160([0x01; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
         .is_none());
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                bytes: Hash160([0x02; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x02; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
@@ -1084,10 +1042,8 @@ mod test {
 
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WSH)
             )
             .as_clarity_tuple()
@@ -1098,10 +1054,8 @@ mod test {
         );
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                    bytes: Hash160([0x02; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x02; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WSH)
             )
             .as_clarity_tuple()
@@ -1111,19 +1065,13 @@ mod test {
                 .unwrap()
         );
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                bytes: Hash160([0x01; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
         .is_none());
         assert!(PoxAddress::Standard(
-            StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-                bytes: Hash160([0x02; 20])
-            },
+            StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, Hash160([0x02; 20])).unwrap(),
             None
         )
         .as_clarity_tuple()
@@ -1185,10 +1133,8 @@ mod test {
     fn test_to_bitcoin_tx_out() {
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH)
             )
             .to_bitcoin_tx_out(123)
@@ -1198,10 +1144,8 @@ mod test {
         );
         assert_eq!(
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH)
             )
             .to_bitcoin_tx_out(123)
@@ -1239,10 +1183,8 @@ mod test {
         // representative test PoxAddresses
         let pox_addrs: Vec<PoxAddress> = vec![
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                    bytes: Hash160([0x01; 20]),
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2PKH),
             ),
             PoxAddress::Addr20(true, PoxAddressType20::P2WPKH, [0x01; 20]),
@@ -1252,31 +1194,23 @@ mod test {
             PoxAddress::Addr32(true, PoxAddressType32::P2TR, [0x01; 32]),
             PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0x01; 32]),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20]),
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2SH),
             ),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                    bytes: Hash160([0x01; 20]),
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2SH),
             ),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20]),
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WSH),
             ),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20]),
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 Some(AddressHashMode::SerializeP2WPKH),
             ),
         ];
@@ -1304,10 +1238,8 @@ mod test {
             })
             .unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_SINGLESIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 None
             )
         );
@@ -1322,10 +1254,8 @@ mod test {
             })
             .unwrap(),
             PoxAddress::Standard(
-                StacksAddress {
-                    version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-                    bytes: Hash160([0x01; 20])
-                },
+                StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, Hash160([0x01; 20]))
+                    .unwrap(),
                 None
             )
         );

--- a/stackslib/src/chainstate/stacks/auth.rs
+++ b/stackslib/src/chainstate/stacks/auth.rs
@@ -222,17 +222,13 @@ impl MultisigSpendingCondition {
     }
 
     pub fn address_mainnet(&self) -> StacksAddress {
-        StacksAddress {
-            version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-            bytes: self.signer.clone(),
-        }
+        StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, self.signer.clone())
+            .expect("FATAL: infallible: constant is not a valid address byte")
     }
 
     pub fn address_testnet(&self) -> StacksAddress {
-        StacksAddress {
-            version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-            bytes: self.signer.clone(),
-        }
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, self.signer.clone())
+            .expect("FATAL: infallible: constant is not a valid address byte")
     }
 
     /// Authenticate a spending condition against an initial sighash.
@@ -290,24 +286,21 @@ impl MultisigSpendingCondition {
             ));
         }
 
-        let addr_bytes = match StacksAddress::from_public_keys(
+        let addr = StacksAddress::from_public_keys(
             0,
             &self.hash_mode.to_address_hash_mode(),
             self.signatures_required as usize,
             &pubkeys,
-        ) {
-            Some(a) => a.bytes,
-            None => {
-                return Err(net_error::VerifyingError(
-                    "Failed to generate address from public keys".to_string(),
-                ));
-            }
-        };
+        )
+        .ok_or_else(|| {
+            net_error::VerifyingError("Failed to generate address from public keys".to_string())
+        })?;
 
-        if addr_bytes != self.signer {
+        if *addr.bytes() != self.signer {
             return Err(net_error::VerifyingError(format!(
                 "Signer hash does not equal hash of public key(s): {} != {}",
-                addr_bytes, self.signer
+                addr.bytes(),
+                self.signer
             )));
         }
 
@@ -419,17 +412,13 @@ impl OrderIndependentMultisigSpendingCondition {
     }
 
     pub fn address_mainnet(&self) -> StacksAddress {
-        StacksAddress {
-            version: C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-            bytes: self.signer.clone(),
-        }
+        StacksAddress::new(C32_ADDRESS_VERSION_MAINNET_MULTISIG, self.signer.clone())
+            .expect("FATAL: infallible: constant address byte is not supported")
     }
 
     pub fn address_testnet(&self) -> StacksAddress {
-        StacksAddress {
-            version: C32_ADDRESS_VERSION_TESTNET_MULTISIG,
-            bytes: self.signer.clone(),
-        }
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_MULTISIG, self.signer.clone())
+            .expect("FATAL: infallible: constant address byte is not supported")
     }
 
     /// Authenticate a spending condition against an initial sighash.
@@ -486,24 +475,21 @@ impl OrderIndependentMultisigSpendingCondition {
             ));
         }
 
-        let addr_bytes = match StacksAddress::from_public_keys(
+        let addr = StacksAddress::from_public_keys(
             0,
             &self.hash_mode.to_address_hash_mode(),
             self.signatures_required as usize,
             &pubkeys,
-        ) {
-            Some(a) => a.bytes,
-            None => {
-                return Err(net_error::VerifyingError(
-                    "Failed to generate address from public keys".to_string(),
-                ));
-            }
-        };
+        )
+        .ok_or_else(|| {
+            net_error::VerifyingError("Failed to generate address from public keys".to_string())
+        })?;
 
-        if addr_bytes != self.signer {
+        if *addr.bytes() != self.signer {
             return Err(net_error::VerifyingError(format!(
                 "Signer hash does not equal hash of public key(s): {} != {}",
-                addr_bytes, self.signer
+                addr.bytes(),
+                self.signer
             )));
         }
 
@@ -590,10 +576,8 @@ impl SinglesigSpendingCondition {
             SinglesigHashMode::P2PKH => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
             SinglesigHashMode::P2WPKH => C32_ADDRESS_VERSION_MAINNET_MULTISIG,
         };
-        StacksAddress {
-            version,
-            bytes: self.signer.clone(),
-        }
+        StacksAddress::new(version, self.signer.clone())
+            .expect("FATAL: infallible: supported address constant is not valid")
     }
 
     pub fn address_testnet(&self) -> StacksAddress {
@@ -601,10 +585,8 @@ impl SinglesigSpendingCondition {
             SinglesigHashMode::P2PKH => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             SinglesigHashMode::P2WPKH => C32_ADDRESS_VERSION_TESTNET_MULTISIG,
         };
-        StacksAddress {
-            version,
-            bytes: self.signer.clone(),
-        }
+        StacksAddress::new(version, self.signer.clone())
+            .expect("FATAL: infallible: supported address constant is not valid")
     }
 
     /// Authenticate a spending condition against an initial sighash.
@@ -624,24 +606,22 @@ impl SinglesigSpendingCondition {
             &self.key_encoding,
             &self.signature,
         )?;
-        let addr_bytes = match StacksAddress::from_public_keys(
+
+        let addr = StacksAddress::from_public_keys(
             0,
             &self.hash_mode.to_address_hash_mode(),
             1,
             &vec![pubkey],
-        ) {
-            Some(a) => a.bytes,
-            None => {
-                return Err(net_error::VerifyingError(
-                    "Failed to generate address from public key".to_string(),
-                ));
-            }
-        };
+        )
+        .ok_or_else(|| {
+            net_error::VerifyingError("Failed to generate address from public key".to_string())
+        })?;
 
-        if addr_bytes != self.signer {
+        if *addr.bytes() != self.signer {
             return Err(net_error::VerifyingError(format!(
                 "Signer hash does not equal hash of public key(s): {} != {}",
-                &addr_bytes, &self.signer
+                addr.bytes(),
+                &self.signer
             )));
         }
 
@@ -708,7 +688,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Singlesig(
             SinglesigSpendingCondition {
-                signer: signer_addr.bytes,
+                signer: signer_addr.destruct().1,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: SinglesigHashMode::P2PKH,
@@ -728,7 +708,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Singlesig(
             SinglesigSpendingCondition {
-                signer: signer_addr.bytes,
+                signer: signer_addr.destruct().1,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: SinglesigHashMode::P2WPKH,
@@ -751,7 +731,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Multisig(
             MultisigSpendingCondition {
-                signer: signer_addr.bytes,
+                signer: signer_addr.destruct().1,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: MultisigHashMode::P2SH,
@@ -774,7 +754,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::OrderIndependentMultisig(
             OrderIndependentMultisigSpendingCondition {
-                signer: signer_addr.bytes,
+                signer: signer_addr.destruct().1,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: OrderIndependentMultisigHashMode::P2SH,
@@ -797,7 +777,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::OrderIndependentMultisig(
             OrderIndependentMultisigSpendingCondition {
-                signer: signer_addr.bytes,
+                signer: signer_addr.destruct().1,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: OrderIndependentMultisigHashMode::P2WSH,
@@ -820,7 +800,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Multisig(
             MultisigSpendingCondition {
-                signer: signer_addr.bytes,
+                signer: signer_addr.destruct().1,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: MultisigHashMode::P2WSH,

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -1466,10 +1466,7 @@ mod test {
         let mut tx_invalid_coinbase = tx_coinbase.clone();
         tx_invalid_coinbase.anchor_mode = TransactionAnchorMode::OffChainOnly;
 
-        let stx_address = StacksAddress {
-            version: 0,
-            bytes: Hash160([0u8; 20]),
-        };
+        let stx_address = StacksAddress::new(0, Hash160([0u8; 20])).unwrap();
         let mut tx_invalid_anchor = StacksTransaction::new(
             TransactionVersion::Testnet,
             origin_auth.clone(),
@@ -1594,10 +1591,7 @@ mod test {
         let mut tx_coinbase_offchain = tx_coinbase.clone();
         tx_coinbase_offchain.anchor_mode = TransactionAnchorMode::OffChainOnly;
 
-        let stx_address = StacksAddress {
-            version: 0,
-            bytes: Hash160([0u8; 20]),
-        };
+        let stx_address = StacksAddress::new(0, Hash160([0u8; 20])).unwrap();
         let mut tx_invalid_anchor = StacksTransaction::new(
             TransactionVersion::Testnet,
             origin_auth.clone(),
@@ -1803,10 +1797,7 @@ mod test {
             microblock_pubkey_hash: Hash160([9u8; 20]),
         };
 
-        let stx_address = StacksAddress {
-            version: 0,
-            bytes: Hash160([0u8; 20]),
-        };
+        let stx_address = StacksAddress::new(0, Hash160([0u8; 20])).unwrap();
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -1973,10 +1964,7 @@ mod test {
             TransactionPayload::Coinbase(CoinbasePayload([0u8; 32]), None, Some(proof)),
         );
 
-        let stx_address = StacksAddress {
-            version: 0,
-            bytes: Hash160([0u8; 20]),
-        };
+        let stx_address = StacksAddress::new(0, Hash160([0u8; 20])).unwrap();
         let tx_transfer = StacksTransaction::new(
             TransactionVersion::Testnet,
             origin_auth.clone(),

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -1790,10 +1790,8 @@ fn test_deploy_smart_contract(
 fn max_stackerdb_list() {
     let signers_list: Vec<_> = (0..SIGNERS_MAX_LIST_SIZE)
         .map(|signer_ix| {
-            let signer_address = StacksAddress {
-                version: 0,
-                bytes: Hash160::from_data(&signer_ix.to_be_bytes()),
-            };
+            let signer_address =
+                StacksAddress::new(0, Hash160::from_data(&signer_ix.to_be_bytes())).unwrap();
             Value::Tuple(
                 TupleData::from_data(vec![
                     (

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -2464,7 +2464,7 @@ pub mod test {
         make_tx(sender_key, nonce, 0, payload)
     }
 
-    fn make_tx(
+    pub fn make_tx(
         key: &StacksPrivateKey,
         nonce: u64,
         tx_fee: u64,
@@ -3031,7 +3031,7 @@ pub mod test {
                 ];
 
                 if tenure_id == 1 {
-                    let alice_lockup_1 = make_pox_lockup(&alice, 0, 512 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).bytes, 1, tip.block_height);
+                    let alice_lockup_1 = make_pox_lockup(&alice, 0, 512 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).destruct().1, 1, tip.block_height);
                     block_txs.push(alice_lockup_1);
                 }
                 if tenure_id == 2 {
@@ -3269,7 +3269,7 @@ pub mod test {
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             12,
                             tip.block_height,
                         );
@@ -3409,7 +3409,7 @@ pub mod test {
                     );
                     assert_eq!(
                         (reward_addrs[0].0).hash160(),
-                        key_to_stacks_addr(&alice).bytes
+                        key_to_stacks_addr(&alice).destruct().1,
                     );
                     assert_eq!(reward_addrs[0].1, 1024 * POX_THRESHOLD_STEPS_USTX);
 
@@ -3485,7 +3485,7 @@ pub mod test {
                                 0,
                                 1024 * POX_THRESHOLD_STEPS_USTX,
                                 AddressHashMode::SerializeP2PKH,
-                                key_to_stacks_addr(key).bytes,
+                                key_to_stacks_addr(key).destruct().1,
                                 12,
                                 tip.block_height,
                             );
@@ -3653,7 +3653,7 @@ pub mod test {
                     assert_eq!(reward_addrs.len(), 4);
                     let mut all_addrbytes = HashSet::new();
                     for key in keys.iter() {
-                        all_addrbytes.insert(key_to_stacks_addr(&key).bytes);
+                        all_addrbytes.insert(key_to_stacks_addr(&key).destruct().1);
                     }
 
                     for key in keys.iter() {
@@ -3665,8 +3665,8 @@ pub mod test {
                             (reward_addrs[0].0).version(),
                             AddressHashMode::SerializeP2PKH as u8
                         );
-                        assert!(all_addrbytes.contains(&key_to_stacks_addr(&key).bytes));
-                        all_addrbytes.remove(&key_to_stacks_addr(&key).bytes);
+                        assert!(all_addrbytes.contains(&key_to_stacks_addr(&key).destruct().1));
+                        all_addrbytes.remove(&key_to_stacks_addr(&key).destruct().1);
                         assert_eq!(reward_addrs[0].1, 1024 * POX_THRESHOLD_STEPS_USTX);
 
                         // Lock-up is consistent with stacker state
@@ -3746,7 +3746,7 @@ pub mod test {
                             "do-lockup",
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             1,
                         );
                         block_txs.push(alice_stack);
@@ -3899,7 +3899,7 @@ pub mod test {
                         );
                         assert_eq!(
                             (reward_addrs[0].0).hash160(),
-                            key_to_stacks_addr(&alice).bytes
+                            key_to_stacks_addr(&alice).destruct().1,
                         );
                         assert_eq!(reward_addrs[0].1, 1024 * POX_THRESHOLD_STEPS_USTX);
 
@@ -4008,7 +4008,7 @@ pub mod test {
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             12,
                             tip.block_height,
                         );
@@ -4020,7 +4020,7 @@ pub mod test {
                             0,
                             (4 * 1024 * POX_THRESHOLD_STEPS_USTX) / 5,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&bob).bytes,
+                            key_to_stacks_addr(&bob).destruct().1,
                             12,
                             tip.block_height,
                         );
@@ -4156,7 +4156,7 @@ pub mod test {
                     );
                     assert_eq!(
                         (reward_addrs[1].0).hash160(),
-                        key_to_stacks_addr(&alice).bytes
+                        key_to_stacks_addr(&alice).destruct().1,
                     );
                     assert_eq!(reward_addrs[1].1, 1024 * POX_THRESHOLD_STEPS_USTX);
 
@@ -4166,7 +4166,7 @@ pub mod test {
                     );
                     assert_eq!(
                         (reward_addrs[0].0).hash160(),
-                        key_to_stacks_addr(&bob).bytes
+                        key_to_stacks_addr(&bob).destruct().1,
                     );
                     assert_eq!(reward_addrs[0].1, (4 * 1024 * POX_THRESHOLD_STEPS_USTX) / 5);
                 } else {
@@ -4216,11 +4216,11 @@ pub mod test {
                 if tenure_id == 1 {
                     // Alice locks up exactly 12.5% of the liquid STX supply, twice.
                     // Only the first one succeeds.
-                    let alice_lockup_1 = make_pox_lockup(&alice, 0, 512 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).bytes, 12, tip.block_height);
+                    let alice_lockup_1 = make_pox_lockup(&alice, 0, 512 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).destruct().1, 12, tip.block_height);
                     block_txs.push(alice_lockup_1);
 
                     // will be rejected
-                    let alice_lockup_2 = make_pox_lockup(&alice, 1, 512 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).bytes, 12, tip.block_height);
+                    let alice_lockup_2 = make_pox_lockup(&alice, 1, 512 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).destruct().1, 12, tip.block_height);
                     block_txs.push(alice_lockup_2);
 
                     // let's make some allowances for contract-calls through smart contracts
@@ -4437,7 +4437,7 @@ pub mod test {
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             1,
                             tip.block_height,
                         );
@@ -4570,7 +4570,7 @@ pub mod test {
                         );
                         assert_eq!(
                             (reward_addrs[0].0).hash160(),
-                            key_to_stacks_addr(&alice).bytes
+                            key_to_stacks_addr(&alice).destruct().1,
                         );
                         assert_eq!(reward_addrs[0].1, 1024 * POX_THRESHOLD_STEPS_USTX);
 
@@ -4686,7 +4686,7 @@ pub mod test {
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             1,
                             tip.block_height,
                         );
@@ -4703,7 +4703,7 @@ pub mod test {
                             "do-lockup",
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&charlie).bytes,
+                            key_to_stacks_addr(&charlie).destruct().1,
                             1,
                         );
                         block_txs.push(charlie_stack);
@@ -4723,7 +4723,7 @@ pub mod test {
                             1,
                             512 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             1,
                             tip.block_height,
                         );
@@ -4737,7 +4737,7 @@ pub mod test {
                             "do-lockup",
                             512 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&charlie).bytes,
+                            key_to_stacks_addr(&charlie).destruct().1,
                             1,
                         );
                         block_txs.push(charlie_stack);
@@ -4907,7 +4907,7 @@ pub mod test {
                     );
                     assert_eq!(
                         (reward_addrs[1].0).hash160(),
-                        key_to_stacks_addr(&alice).bytes
+                        key_to_stacks_addr(&alice).destruct().1,
                     );
                     assert_eq!(reward_addrs[1].1, 1024 * POX_THRESHOLD_STEPS_USTX);
 
@@ -4917,7 +4917,7 @@ pub mod test {
                     );
                     assert_eq!(
                         (reward_addrs[0].0).hash160(),
-                        key_to_stacks_addr(&charlie).bytes
+                        key_to_stacks_addr(&charlie).destruct().1,
                     );
                     assert_eq!(reward_addrs[0].1, 1024 * POX_THRESHOLD_STEPS_USTX);
 
@@ -5035,7 +5035,7 @@ pub mod test {
                     );
                     assert_eq!(
                         (reward_addrs[1].0).hash160(),
-                        key_to_stacks_addr(&alice).bytes
+                        key_to_stacks_addr(&alice).destruct().1,
                     );
                     assert_eq!(reward_addrs[1].1, 512 * POX_THRESHOLD_STEPS_USTX);
 
@@ -5045,7 +5045,7 @@ pub mod test {
                     );
                     assert_eq!(
                         (reward_addrs[0].0).hash160(),
-                        key_to_stacks_addr(&charlie).bytes
+                        key_to_stacks_addr(&charlie).destruct().1,
                     );
                     assert_eq!(reward_addrs[0].1, 512 * POX_THRESHOLD_STEPS_USTX);
 
@@ -5208,7 +5208,7 @@ pub mod test {
                             0,
                             512 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             1,
                             tip.block_height,
                         );
@@ -5219,7 +5219,7 @@ pub mod test {
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&bob).bytes,
+                            key_to_stacks_addr(&bob).destruct().1,
                             1,
                             tip.block_height,
                         );
@@ -5230,7 +5230,7 @@ pub mod test {
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&charlie).bytes,
+                            key_to_stacks_addr(&charlie).destruct().1,
                             1,
                             tip.block_height,
                         );
@@ -5241,7 +5241,7 @@ pub mod test {
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2PKH,
-                            key_to_stacks_addr(&danielle).bytes,
+                            key_to_stacks_addr(&danielle).destruct().1,
                             1,
                             tip.block_height,
                         );
@@ -5257,7 +5257,7 @@ pub mod test {
                             "do-lockup",
                             512 * POX_THRESHOLD_STEPS_USTX,
                             AddressHashMode::SerializeP2SH,
-                            key_to_stacks_addr(&alice).bytes,
+                            key_to_stacks_addr(&alice).destruct().1,
                             1,
                         );
                         block_txs.push(alice_stack);
@@ -5367,23 +5367,23 @@ pub mod test {
             let expected_pox_addrs: Vec<(u8, Hash160)> = vec![
                 (
                     AddressHashMode::SerializeP2PKH as u8,
-                    key_to_stacks_addr(&alice).bytes,
+                    key_to_stacks_addr(&alice).destruct().1,
                 ),
                 (
                     AddressHashMode::SerializeP2PKH as u8,
-                    key_to_stacks_addr(&bob).bytes,
+                    key_to_stacks_addr(&bob).destruct().1,
                 ),
                 (
                     AddressHashMode::SerializeP2PKH as u8,
-                    key_to_stacks_addr(&charlie).bytes,
+                    key_to_stacks_addr(&charlie).destruct().1,
                 ),
                 (
                     AddressHashMode::SerializeP2PKH as u8,
-                    key_to_stacks_addr(&danielle).bytes,
+                    key_to_stacks_addr(&danielle).destruct().1,
                 ),
                 (
                     AddressHashMode::SerializeP2SH as u8,
-                    key_to_stacks_addr(&alice).bytes,
+                    key_to_stacks_addr(&alice).destruct().1,
                 ),
             ];
 
@@ -5645,7 +5645,7 @@ pub mod test {
 
                 if tenure_id == 1 {
                     // Alice locks up exactly 25% of the liquid STX supply, so this should succeed.
-                    let alice_lockup = make_pox_lockup(&alice, 0, 1024 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).bytes, 12, tip.block_height);
+                    let alice_lockup = make_pox_lockup(&alice, 0, 1024 * POX_THRESHOLD_STEPS_USTX, AddressHashMode::SerializeP2PKH, key_to_stacks_addr(&alice).destruct().1, 12, tip.block_height);
                     block_txs.push(alice_lockup);
 
                     // Bob rejects with exactly 25% of the liquid STX supply (shouldn't affect
@@ -5851,7 +5851,7 @@ pub mod test {
                         );
                         assert_eq!(
                             (reward_addrs[0].0).hash160(),
-                            key_to_stacks_addr(&alice).bytes
+                            key_to_stacks_addr(&alice).destruct().1,
                         );
                         assert_eq!(reward_addrs[0].1, 1024 * POX_THRESHOLD_STEPS_USTX);
                     }

--- a/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -775,7 +775,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
             );
             assert_eq!(
                 (reward_addrs[0].0).hash160(),
-                key_to_stacks_addr(&alice).bytes
+                key_to_stacks_addr(&alice).destruct().1
             );
             assert_eq!(reward_addrs[0].1, 1024 * POX_THRESHOLD_STEPS_USTX);
         } else {
@@ -787,7 +787,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
             );
             assert_eq!(
                 (reward_addrs[0].0).hash160(),
-                key_to_stacks_addr(&bob).bytes
+                key_to_stacks_addr(&bob).destruct().1
             );
             assert_eq!(reward_addrs[0].1, 512 * POX_THRESHOLD_STEPS_USTX);
 
@@ -797,7 +797,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
             );
             assert_eq!(
                 (reward_addrs[1].0).hash160(),
-                key_to_stacks_addr(&alice).bytes
+                key_to_stacks_addr(&alice).destruct().1
             );
             assert_eq!(reward_addrs[1].1, 512 * POX_THRESHOLD_STEPS_USTX);
         }
@@ -828,7 +828,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
         0,
         1024 * POX_THRESHOLD_STEPS_USTX,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         4,
         tip.block_height,
     );
@@ -916,7 +916,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
         512 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         6,
         tip.block_height,
@@ -939,7 +939,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
         1,
         512 * POX_THRESHOLD_STEPS_USTX,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&bob).bytes,
+        key_to_stacks_addr(&bob).destruct().1,
         4,
         tip.block_height,
     );
@@ -971,7 +971,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
         512 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         12,
         tip.block_height,
@@ -1001,7 +1001,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
         2,
         512 * POX_THRESHOLD_STEPS_USTX,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         12,
         tip.block_height,
     );
@@ -1210,7 +1210,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
         1024 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
         tip.block_height,
@@ -1222,7 +1222,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
         1 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         6,
         tip.block_height,
@@ -1246,11 +1246,11 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
         assert_eq!(reward_set_entries.len(), 2);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&bob).bytes.0.to_vec()
+            key_to_stacks_addr(&bob).bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
     }
 
@@ -1285,7 +1285,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
     }
 
@@ -1486,7 +1486,7 @@ fn delegate_stack_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes.clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
     let mut alice_nonce = 0;
     let mut bob_nonce = 0;
 
@@ -1866,7 +1866,7 @@ fn stack_increase() {
         first_lockup_amt,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
         tip.block_height,
@@ -1898,7 +1898,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1918,7 +1918,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1963,7 +1963,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1978,7 +1978,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[0].amount_stacked,
@@ -2111,7 +2111,7 @@ fn test_lock_period_invariant_extend_transition() {
         0,
         ALICE_LOCKUP,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         4,
         tip.block_height,
     );
@@ -2177,7 +2177,7 @@ fn test_lock_period_invariant_extend_transition() {
         1,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
     );
@@ -2290,7 +2290,7 @@ fn test_pox_extend_transition_pox_2() {
         );
         assert_eq!(
             (reward_addrs[0].0).hash160(),
-            key_to_stacks_addr(&alice).bytes
+            key_to_stacks_addr(&alice).destruct().1,
         );
         assert_eq!(reward_addrs[0].1, ALICE_LOCKUP);
     };
@@ -2326,7 +2326,7 @@ fn test_pox_extend_transition_pox_2() {
         );
         assert_eq!(
             (reward_addrs[0].0).hash160(),
-            key_to_stacks_addr(&bob).bytes
+            key_to_stacks_addr(&bob).destruct().1,
         );
         assert_eq!(reward_addrs[0].1, BOB_LOCKUP);
 
@@ -2336,7 +2336,7 @@ fn test_pox_extend_transition_pox_2() {
         );
         assert_eq!(
             (reward_addrs[1].0).hash160(),
-            key_to_stacks_addr(&alice).bytes
+            key_to_stacks_addr(&alice).destruct().1,
         );
         assert_eq!(reward_addrs[1].1, ALICE_LOCKUP);
     };
@@ -2363,7 +2363,7 @@ fn test_pox_extend_transition_pox_2() {
         0,
         ALICE_LOCKUP,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         4,
         tip.block_height,
     );
@@ -2431,7 +2431,7 @@ fn test_pox_extend_transition_pox_2() {
         BOB_LOCKUP,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         3,
         tip.block_height,
@@ -2443,7 +2443,7 @@ fn test_pox_extend_transition_pox_2() {
         1,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
     );
@@ -2461,7 +2461,7 @@ fn test_pox_extend_transition_pox_2() {
         1,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         1,
     );
@@ -2509,7 +2509,7 @@ fn test_pox_extend_transition_pox_2() {
         2,
         512 * POX_THRESHOLD_STEPS_USTX,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         12,
         tip.block_height,
     );
@@ -2727,7 +2727,7 @@ fn test_delegate_extend_transition_pox_2() {
             (reward_addrs[0].0).version(),
             AddressHashMode::SerializeP2PKH as u8
         );
-        assert_eq!(&(reward_addrs[0].0).hash160(), &charlie_address.bytes);
+        assert_eq!(&(reward_addrs[0].0).hash160(), charlie_address.bytes());
         // 1 lockup was done between alice's first cycle and the start of v2 cycles
         assert_eq!(reward_addrs[0].1, 1 * LOCKUP_AMT);
     };
@@ -2761,7 +2761,7 @@ fn test_delegate_extend_transition_pox_2() {
             (reward_addrs[0].0).version(),
             AddressHashMode::SerializeP2PKH as u8
         );
-        assert_eq!(&(reward_addrs[0].0).hash160(), &charlie_address.bytes);
+        assert_eq!(&(reward_addrs[0].0).hash160(), charlie_address.bytes());
         // 2 lockups were performed in v2 cycles
         assert_eq!(reward_addrs[0].1, 2 * LOCKUP_AMT);
     };
@@ -2804,7 +2804,7 @@ fn test_delegate_extend_transition_pox_2() {
             Value::UInt(LOCKUP_AMT),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(tip.block_height as u128),
             Value::UInt(4),
@@ -2819,7 +2819,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(EXPECTED_ALICE_FIRST_REWARD_CYCLE),
         ],
@@ -2832,7 +2832,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(EXPECTED_ALICE_FIRST_REWARD_CYCLE + 1),
         ],
@@ -2845,7 +2845,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(EXPECTED_ALICE_FIRST_REWARD_CYCLE + 2),
         ],
@@ -2858,7 +2858,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(EXPECTED_ALICE_FIRST_REWARD_CYCLE + 3),
         ],
@@ -2964,7 +2964,7 @@ fn test_delegate_extend_transition_pox_2() {
             Value::UInt(LOCKUP_AMT),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(tip.block_height as u128),
             Value::UInt(3),
@@ -2980,7 +2980,7 @@ fn test_delegate_extend_transition_pox_2() {
             PrincipalData::from(alice_address.clone()).into(),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(6),
         ],
@@ -2996,7 +2996,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v2_cycle as u128),
         ],
@@ -3009,7 +3009,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v2_cycle as u128 + 1),
         ],
@@ -3022,7 +3022,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v2_cycle as u128 + 2),
         ],
@@ -3089,7 +3089,7 @@ fn test_delegate_extend_transition_pox_2() {
             PrincipalData::from(bob_address.clone()).into(),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(1),
         ],
@@ -3102,7 +3102,7 @@ fn test_delegate_extend_transition_pox_2() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v2_cycle as u128 + 3),
         ],
@@ -3171,7 +3171,7 @@ fn test_delegate_extend_transition_pox_2() {
             PrincipalData::from(bob_address.clone()).into(),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(1),
         ],
@@ -3236,7 +3236,7 @@ fn test_delegate_extend_transition_pox_2() {
         2,
         512 * POX_THRESHOLD_STEPS_USTX,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         12,
         tip.block_height,
     );
@@ -3461,7 +3461,7 @@ fn test_pox_2_getters() {
         LOCKUP_AMT,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         4,
         tip.block_height,
@@ -3490,7 +3490,7 @@ fn test_pox_2_getters() {
             Value::UInt(LOCKUP_AMT),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(tip.block_height as u128),
             Value::UInt(4),
@@ -3504,7 +3504,7 @@ fn test_pox_2_getters() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(cur_reward_cycle as u128),
         ],
@@ -3517,7 +3517,7 @@ fn test_pox_2_getters() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(cur_reward_cycle as u128 + 1),
         ],
@@ -3530,7 +3530,7 @@ fn test_pox_2_getters() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(cur_reward_cycle as u128 + 2),
         ],
@@ -3578,10 +3578,10 @@ fn test_pox_2_getters() {
     }}", &alice_address,
         &bob_address,
         &bob_address, &format!("{}.hello-world", &charlie_address), cur_reward_cycle + 1,
-        &charlie_address.bytes, cur_reward_cycle + 0, &charlie_address,
-        &charlie_address.bytes, cur_reward_cycle + 1, &charlie_address,
-        &charlie_address.bytes, cur_reward_cycle + 2, &charlie_address,
-        &charlie_address.bytes, cur_reward_cycle + 3, &charlie_address,
+        charlie_address.bytes(), cur_reward_cycle + 0, &charlie_address,
+        charlie_address.bytes(), cur_reward_cycle + 1, &charlie_address,
+        charlie_address.bytes(), cur_reward_cycle + 2, &charlie_address,
+        charlie_address.bytes(), cur_reward_cycle + 3, &charlie_address,
         cur_reward_cycle,
         cur_reward_cycle + 1,
         cur_reward_cycle + 2,
@@ -3769,7 +3769,10 @@ fn test_get_pox_addrs() {
                             key,
                             0,
                             1024 * POX_THRESHOLD_STEPS_USTX,
-                            PoxAddress::from_legacy(*hash_mode, key_to_stacks_addr(key).bytes),
+                            PoxAddress::from_legacy(
+                                *hash_mode,
+                                key_to_stacks_addr(key).destruct().1,
+                            ),
                             2,
                             tip.block_height,
                         );
@@ -4270,10 +4273,7 @@ fn test_stack_with_segwit() {
         PoxAddress::Addr32(false, PoxAddressType32::P2WSH, [0x02; 32]),
         PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0x03; 32]),
         PoxAddress::Standard(
-            StacksAddress {
-                version: 26,
-                bytes: Hash160([0x04; 20]),
-            },
+            StacksAddress::new(26, Hash160([0x04; 20])).unwrap(),
             Some(AddressHashMode::SerializeP2PKH),
         ),
     ];
@@ -4357,7 +4357,7 @@ fn test_pox_2_delegate_stx_addr_validation() {
             Value::none(),
             Value::some(make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                alice_address.bytes.clone(),
+                alice_address.bytes().clone(),
             ))
             .unwrap(),
         ],
@@ -4372,7 +4372,7 @@ fn test_pox_2_delegate_stx_addr_validation() {
             (
                 ClarityName::try_from("hashbytes".to_owned()).unwrap(),
                 Value::Sequence(SequenceData::Buffer(BuffData {
-                    data: bob_address.bytes.as_bytes().to_vec(),
+                    data: bob_address.bytes().as_bytes().to_vec(),
                 })),
             ),
         ])
@@ -4461,7 +4461,10 @@ fn test_pox_2_delegate_stx_addr_validation() {
 
     assert_eq!(
         alice_pox_addr,
-        make_pox_addr(AddressHashMode::SerializeP2PKH, alice_address.bytes.clone(),)
+        make_pox_addr(
+            AddressHashMode::SerializeP2PKH,
+            alice_address.bytes().clone(),
+        )
     );
 }
 
@@ -4521,17 +4524,17 @@ fn stack_aggregation_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes.clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
     let charlie = keys.pop().unwrap();
     let charlie_address = key_to_stacks_addr(&charlie);
     let charlie_pox_addr = make_pox_addr(
         AddressHashMode::SerializeP2PKH,
-        charlie_address.bytes.clone(),
+        charlie_address.bytes().clone(),
     );
     let dan = keys.pop().unwrap();
     let dan_address = key_to_stacks_addr(&dan);
     let dan_principal = PrincipalData::from(dan_address.clone());
-    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, dan_address.bytes.clone());
+    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, dan_address.bytes().clone());
     let alice_nonce = 0;
     let mut bob_nonce = 0;
     let mut charlie_nonce = 0;
@@ -4585,7 +4588,7 @@ fn stack_aggregation_increase() {
         &dan,
         dan_nonce,
         dan_stack_amount,
-        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, dan_address.bytes.clone()),
+        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, dan_address.bytes().clone()),
         12,
         tip.block_height,
     );
@@ -4967,12 +4970,14 @@ fn stack_in_both_pox1_and_pox2() {
 
     let alice = keys.pop().unwrap();
     let alice_address = key_to_stacks_addr(&alice);
-    let alice_pox_addr =
-        make_pox_addr(AddressHashMode::SerializeP2PKH, alice_address.bytes.clone());
+    let alice_pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2PKH,
+        alice_address.bytes().clone(),
+    );
 
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes.clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
 
     let mut alice_nonce = 0;
     let mut bob_nonce = 0;
@@ -4999,7 +5004,7 @@ fn stack_in_both_pox1_and_pox2() {
         alice_nonce,
         alice_first_lock_amount,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         12,
         tip.block_height,
     );
@@ -5033,7 +5038,7 @@ fn stack_in_both_pox1_and_pox2() {
         bob_nonce,
         bob_first_lock_amount,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&bob).bytes,
+        key_to_stacks_addr(&bob).destruct().1,
         12,
         tip.block_height,
     );

--- a/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
@@ -238,7 +238,7 @@ fn simple_pox_lockup_transition_pox_2() {
         0,
         1024 * POX_THRESHOLD_STEPS_USTX,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         4,
         tip.block_height,
     );
@@ -322,7 +322,7 @@ fn simple_pox_lockup_transition_pox_2() {
         512 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         6,
         tip.block_height,
@@ -348,7 +348,7 @@ fn simple_pox_lockup_transition_pox_2() {
         1,
         512 * POX_THRESHOLD_STEPS_USTX,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&bob).bytes,
+        key_to_stacks_addr(&bob).destruct().1,
         4,
         tip.block_height,
     );
@@ -365,7 +365,7 @@ fn simple_pox_lockup_transition_pox_2() {
         512 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         12,
         tip.block_height,
@@ -409,7 +409,7 @@ fn simple_pox_lockup_transition_pox_2() {
         512 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         6,
         tip,
@@ -421,7 +421,7 @@ fn simple_pox_lockup_transition_pox_2() {
         512 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
         tip,
@@ -630,7 +630,7 @@ fn pox_auto_unlock(alice_first: bool) {
         1024 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
         tip.block_height,
@@ -642,7 +642,7 @@ fn pox_auto_unlock(alice_first: bool) {
         1 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         6,
         tip.block_height,
@@ -663,11 +663,11 @@ fn pox_auto_unlock(alice_first: bool) {
         assert_eq!(reward_set_entries.len(), 2);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&bob).bytes.0.to_vec()
+            key_to_stacks_addr(&bob).bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
     }
 
@@ -697,7 +697,7 @@ fn pox_auto_unlock(alice_first: bool) {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
     }
 
@@ -791,7 +791,7 @@ fn pox_auto_unlock(alice_first: bool) {
         1024 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
         tip.block_height,
@@ -803,7 +803,7 @@ fn pox_auto_unlock(alice_first: bool) {
         1 * POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         6,
         tip.block_height,
@@ -824,11 +824,11 @@ fn pox_auto_unlock(alice_first: bool) {
         assert_eq!(reward_set_entries.len(), 2);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&bob).bytes.0.to_vec()
+            key_to_stacks_addr(&bob).bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
     }
 
@@ -857,7 +857,7 @@ fn pox_auto_unlock(alice_first: bool) {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
     }
 
@@ -1045,7 +1045,7 @@ fn delegate_stack_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes.clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
     let mut alice_nonce = 0;
     let mut bob_nonce = 0;
 
@@ -1691,7 +1691,7 @@ fn stack_increase() {
         first_lockup_amt,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
         tip.block_height,
@@ -1715,7 +1715,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1735,7 +1735,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1773,7 +1773,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1793,7 +1793,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[0].amount_stacked,
@@ -1859,7 +1859,7 @@ fn stack_increase() {
         first_lockup_amt,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
         tip.block_height,
@@ -1882,7 +1882,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1902,7 +1902,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1950,7 +1950,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, first_lockup_amt,);
     }
@@ -1965,7 +1965,7 @@ fn stack_increase() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[0].amount_stacked,
@@ -2138,7 +2138,7 @@ fn pox_extend_transition() {
         );
         assert_eq!(
             (reward_addrs[0].0).hash160(),
-            key_to_stacks_addr(&alice).bytes
+            key_to_stacks_addr(&alice).destruct().1,
         );
         assert_eq!(reward_addrs[0].1, ALICE_LOCKUP);
     };
@@ -2174,7 +2174,7 @@ fn pox_extend_transition() {
         );
         assert_eq!(
             (reward_addrs[0].0).hash160(),
-            key_to_stacks_addr(&bob).bytes
+            key_to_stacks_addr(&bob).destruct().1,
         );
         assert_eq!(reward_addrs[0].1, BOB_LOCKUP);
 
@@ -2184,7 +2184,7 @@ fn pox_extend_transition() {
         );
         assert_eq!(
             (reward_addrs[1].0).hash160(),
-            key_to_stacks_addr(&alice).bytes
+            key_to_stacks_addr(&alice).destruct().1,
         );
         assert_eq!(reward_addrs[1].1, ALICE_LOCKUP);
     };
@@ -2204,7 +2204,7 @@ fn pox_extend_transition() {
         0,
         ALICE_LOCKUP,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         4,
         tip.block_height,
     );
@@ -2267,7 +2267,7 @@ fn pox_extend_transition() {
         BOB_LOCKUP,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         3,
         tip.block_height,
@@ -2279,7 +2279,7 @@ fn pox_extend_transition() {
         1,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
     );
@@ -2293,7 +2293,7 @@ fn pox_extend_transition() {
         1,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         1,
     );
@@ -2358,7 +2358,7 @@ fn pox_extend_transition() {
         ALICE_LOCKUP,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         4,
         tip.block_height,
@@ -2377,7 +2377,7 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, ALICE_LOCKUP,);
     }
@@ -2406,7 +2406,7 @@ fn pox_extend_transition() {
         BOB_LOCKUP,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         3,
         tip.block_height,
@@ -2418,7 +2418,7 @@ fn pox_extend_transition() {
         3,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
     );
@@ -2436,7 +2436,7 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, ALICE_LOCKUP,);
     }
@@ -2447,12 +2447,12 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 2);
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[1].amount_stacked, ALICE_LOCKUP,);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&bob).bytes.0.to_vec()
+            key_to_stacks_addr(&bob).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, BOB_LOCKUP,);
     }
@@ -2463,7 +2463,7 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, ALICE_LOCKUP,);
     }
@@ -2668,7 +2668,7 @@ fn delegate_extend_pox_3() {
             Value::UInt(LOCKUP_AMT),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(tip.block_height as u128),
             Value::UInt(3),
@@ -2689,7 +2689,7 @@ fn delegate_extend_pox_3() {
             Value::UInt(LOCKUP_AMT),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(tip.block_height as u128),
             Value::UInt(6),
@@ -2708,7 +2708,7 @@ fn delegate_extend_pox_3() {
             vec![
                 make_pox_addr(
                     AddressHashMode::SerializeP2PKH,
-                    charlie_address.bytes.clone(),
+                    charlie_address.bytes().clone(),
                 ),
                 Value::UInt(first_v3_cycle as u128 + ix),
             ],
@@ -2733,7 +2733,7 @@ fn delegate_extend_pox_3() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&charlie).bytes.0.to_vec()
+            key_to_stacks_addr(&charlie).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, 2 * LOCKUP_AMT);
     }
@@ -2791,7 +2791,7 @@ fn delegate_extend_pox_3() {
             PrincipalData::from(bob_address.clone()).into(),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(1),
         ],
@@ -2808,7 +2808,7 @@ fn delegate_extend_pox_3() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v3_cycle as u128 + 3),
         ],
@@ -2860,7 +2860,7 @@ fn delegate_extend_pox_3() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&charlie).bytes.0.to_vec()
+            key_to_stacks_addr(&charlie).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, 2 * LOCKUP_AMT);
     }
@@ -2884,7 +2884,7 @@ fn delegate_extend_pox_3() {
             PrincipalData::from(bob_address.clone()).into(),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(3),
         ],
@@ -3112,7 +3112,7 @@ fn pox_3_getters() {
         LOCKUP_AMT,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         4,
         tip.block_height,
@@ -3141,7 +3141,7 @@ fn pox_3_getters() {
             Value::UInt(LOCKUP_AMT),
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(tip.block_height as u128),
             Value::UInt(4),
@@ -3155,7 +3155,7 @@ fn pox_3_getters() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v3_cycle as u128),
         ],
@@ -3168,7 +3168,7 @@ fn pox_3_getters() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v3_cycle as u128 + 1),
         ],
@@ -3181,7 +3181,7 @@ fn pox_3_getters() {
         vec![
             make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes.clone(),
+                charlie_address.bytes().clone(),
             ),
             Value::UInt(first_v3_cycle as u128 + 2),
         ],
@@ -3229,10 +3229,10 @@ fn pox_3_getters() {
     }}", &alice_address,
         &bob_address,
         &bob_address, &format!("{}.hello-world", &charlie_address), first_v3_cycle + 1,
-        &charlie_address.bytes, first_v3_cycle + 0, &charlie_address,
-        &charlie_address.bytes, first_v3_cycle + 1, &charlie_address,
-        &charlie_address.bytes, first_v3_cycle + 2, &charlie_address,
-        &charlie_address.bytes, first_v3_cycle + 3, &charlie_address,
+        charlie_address.bytes(), first_v3_cycle + 0, &charlie_address,
+        charlie_address.bytes(), first_v3_cycle + 1, &charlie_address,
+        charlie_address.bytes(), first_v3_cycle + 2, &charlie_address,
+        charlie_address.bytes(), first_v3_cycle + 3, &charlie_address,
         first_v3_cycle,
         first_v3_cycle + 1,
         first_v3_cycle + 2,
@@ -3523,7 +3523,7 @@ fn get_pox_addrs() {
             AddressHashMode::SerializeP2WSH,
         ])
         .map(|(key, hash_mode)| {
-            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).bytes);
+            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).destruct().1);
             txs.push(make_pox_3_lockup(
                 key,
                 0,
@@ -3870,17 +3870,17 @@ fn stack_aggregation_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes.clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
     let charlie = keys.pop().unwrap();
     let charlie_address = key_to_stacks_addr(&charlie);
     let charlie_pox_addr = make_pox_addr(
         AddressHashMode::SerializeP2PKH,
-        charlie_address.bytes.clone(),
+        charlie_address.bytes().clone(),
     );
     let dan = keys.pop().unwrap();
     let dan_address = key_to_stacks_addr(&dan);
     let dan_principal = PrincipalData::from(dan_address.clone());
-    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, dan_address.bytes.clone());
+    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, dan_address.bytes().clone());
     let alice_nonce = 0;
     let mut bob_nonce = 0;
     let mut charlie_nonce = 0;
@@ -3937,7 +3937,7 @@ fn stack_aggregation_increase() {
         &dan,
         dan_nonce,
         dan_stack_amount,
-        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, dan_address.bytes.clone()),
+        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, dan_address.bytes().clone()),
         12,
         tip.block_height,
     );
@@ -4333,7 +4333,7 @@ fn pox_3_delegate_stx_addr_validation() {
             Value::none(),
             Value::some(make_pox_addr(
                 AddressHashMode::SerializeP2PKH,
-                alice_address.bytes.clone(),
+                alice_address.bytes().clone(),
             ))
             .unwrap(),
         ],
@@ -4348,7 +4348,7 @@ fn pox_3_delegate_stx_addr_validation() {
             (
                 ClarityName::try_from("hashbytes".to_owned()).unwrap(),
                 Value::Sequence(SequenceData::Buffer(BuffData {
-                    data: bob_address.bytes.as_bytes().to_vec(),
+                    data: bob_address.bytes().as_bytes().to_vec(),
                 })),
             ),
         ])
@@ -4437,6 +4437,9 @@ fn pox_3_delegate_stx_addr_validation() {
 
     assert_eq!(
         alice_pox_addr,
-        make_pox_addr(AddressHashMode::SerializeP2PKH, alice_address.bytes.clone(),)
+        make_pox_addr(
+            AddressHashMode::SerializeP2PKH,
+            alice_address.bytes().clone(),
+        )
     );
 }

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -111,7 +111,7 @@ fn make_simple_pox_4_lock(
     lock_period: u128,
 ) -> StacksTransaction {
     let addr = key_to_stacks_addr(key);
-    let pox_addr = PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone());
+    let pox_addr = PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes().clone());
     let signer_pk = StacksPublicKey::from_private(&key);
     let tip = get_tip(peer.sortdb.as_ref());
     let next_reward_cycle = peer
@@ -343,7 +343,7 @@ fn pox_extend_transition() {
         );
         assert_eq!(
             (reward_addrs[0].0).hash160(),
-            key_to_stacks_addr(&alice).bytes
+            key_to_stacks_addr(&alice).destruct().1
         );
         assert_eq!(reward_addrs[0].1, ALICE_LOCKUP);
     };
@@ -379,7 +379,7 @@ fn pox_extend_transition() {
         );
         assert_eq!(
             (reward_addrs[0].0).hash160(),
-            key_to_stacks_addr(&bob).bytes
+            key_to_stacks_addr(&bob).destruct().1,
         );
         assert_eq!(reward_addrs[0].1, BOB_LOCKUP);
 
@@ -389,7 +389,7 @@ fn pox_extend_transition() {
         );
         assert_eq!(
             (reward_addrs[1].0).hash160(),
-            key_to_stacks_addr(&alice).bytes
+            key_to_stacks_addr(&alice).destruct().1,
         );
         assert_eq!(reward_addrs[1].1, ALICE_LOCKUP);
     };
@@ -409,7 +409,7 @@ fn pox_extend_transition() {
         0,
         ALICE_LOCKUP,
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
         4,
         tip.block_height,
     );
@@ -472,7 +472,7 @@ fn pox_extend_transition() {
         BOB_LOCKUP,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         3,
         tip.block_height,
@@ -484,7 +484,7 @@ fn pox_extend_transition() {
         1,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         6,
     );
@@ -498,7 +498,7 @@ fn pox_extend_transition() {
         1,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&bob).bytes,
+            key_to_stacks_addr(&bob).destruct().1,
         ),
         1,
     );
@@ -564,7 +564,7 @@ fn pox_extend_transition() {
 
     let alice_pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&alice).bytes,
+        key_to_stacks_addr(&alice).destruct().1,
     );
     let auth_id = 1;
 
@@ -585,7 +585,7 @@ fn pox_extend_transition() {
         ALICE_LOCKUP,
         &PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            key_to_stacks_addr(&alice).bytes,
+            key_to_stacks_addr(&alice).destruct().1,
         ),
         4,
         &alice_signer_key,
@@ -614,7 +614,7 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, ALICE_LOCKUP,);
     }
@@ -642,7 +642,7 @@ fn pox_extend_transition() {
 
     let bob_pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(&bob).bytes,
+        key_to_stacks_addr(&bob).destruct().1,
     );
 
     let bob_signature = make_signer_key_signature(
@@ -708,7 +708,7 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, ALICE_LOCKUP);
     }
@@ -719,12 +719,12 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 2);
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[1].amount_stacked, ALICE_LOCKUP);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&bob).bytes.0.to_vec()
+            key_to_stacks_addr(&bob).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, BOB_LOCKUP);
     }
@@ -736,7 +736,7 @@ fn pox_extend_transition() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            key_to_stacks_addr(&alice).bytes.0.to_vec()
+            key_to_stacks_addr(&alice).bytes().0.to_vec()
         );
         assert_eq!(reward_set_entries[0].amount_stacked, ALICE_LOCKUP);
     }
@@ -960,7 +960,7 @@ fn pox_lock_unlock() {
         ])
         .enumerate()
         .map(|(ix, (key, hash_mode))| {
-            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).bytes);
+            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).destruct().1);
             let lock_period = if ix == 3 { 12 } else { lock_period };
             let signer_key = key;
             let signature = make_signer_key_signature(
@@ -1139,7 +1139,7 @@ fn pox_3_defunct() {
             AddressHashMode::SerializeP2WSH,
         ])
         .map(|(key, hash_mode)| {
-            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).bytes);
+            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).destruct().1);
             txs.push(make_pox_3_lockup(
                 key,
                 0,
@@ -1269,7 +1269,7 @@ fn pox_3_unlocks() {
             AddressHashMode::SerializeP2WSH,
         ])
         .map(|(key, hash_mode)| {
-            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).bytes);
+            let pox_addr = PoxAddress::from_legacy(hash_mode, key_to_stacks_addr(key).destruct().1);
             txs.push(make_pox_3_lockup(
                 key,
                 0,
@@ -1417,8 +1417,10 @@ fn pox_4_check_cycle_id_range_in_print_events_pool() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val =
-        make_pox_addr(AddressHashMode::SerializeP2PKH, steph_address.bytes.clone());
+    let steph_pox_addr_val = make_pox_addr(
+        AddressHashMode::SerializeP2PKH,
+        steph_address.bytes().clone(),
+    );
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -1806,8 +1808,10 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val =
-        make_pox_addr(AddressHashMode::SerializeP2PKH, steph_address.bytes.clone());
+    let steph_pox_addr_val = make_pox_addr(
+        AddressHashMode::SerializeP2PKH,
+        steph_address.bytes().clone(),
+    );
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -2450,8 +2454,10 @@ fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val =
-        make_pox_addr(AddressHashMode::SerializeP2PKH, steph_address.bytes.clone());
+    let steph_pox_addr_val = make_pox_addr(
+        AddressHashMode::SerializeP2PKH,
+        steph_address.bytes().clone(),
+    );
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -2571,8 +2577,10 @@ fn pox_4_check_cycle_id_range_in_print_events_in_prepare_phase() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val =
-        make_pox_addr(AddressHashMode::SerializeP2PKH, steph_address.bytes.clone());
+    let steph_pox_addr_val = make_pox_addr(
+        AddressHashMode::SerializeP2PKH,
+        steph_address.bytes().clone(),
+    );
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -2807,8 +2815,10 @@ fn pox_4_revoke_delegate_stx_events() {
     let steph = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr =
-        make_pox_addr(AddressHashMode::SerializeP2PKH, steph_address.bytes.clone());
+    let steph_pox_addr = make_pox_addr(
+        AddressHashMode::SerializeP2PKH,
+        steph_address.bytes().clone(),
+    );
 
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -3053,9 +3063,12 @@ fn verify_signer_key_signatures() {
 
     let expected_error = Value::error(Value::Int(35)).unwrap();
 
-    let alice_pox_addr =
-        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, alice_address.bytes.clone());
-    let bob_pox_addr = PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, bob_address.bytes);
+    let alice_pox_addr = PoxAddress::from_legacy(
+        AddressHashMode::SerializeP2PKH,
+        alice_address.bytes().clone(),
+    );
+    let bob_pox_addr =
+        PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
 
     let period = 1_u128;
 
@@ -3323,7 +3336,7 @@ fn stack_stx_verify_signer_sig(use_nakamoto: bool) {
     let second_stacker_addr = key_to_stacks_addr(second_stacker);
     let second_stacker_pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        second_stacker_addr.bytes.clone(),
+        second_stacker_addr.bytes().clone(),
     );
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
@@ -4224,7 +4237,7 @@ impl StackerSignerInfo {
         let public_key = StacksPublicKey::from_private(&private_key);
         let address = key_to_stacks_addr(&private_key);
         let pox_address =
-            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, address.bytes.clone());
+            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, address.bytes().clone());
         let principal = PrincipalData::from(address.clone());
         let nonce = 0;
         Self {
@@ -6151,7 +6164,7 @@ fn delegate_stack_stx_extend_signer_key(use_nakamoto: bool) {
 
     let pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(bob_delegate_private_key).bytes,
+        key_to_stacks_addr(bob_delegate_private_key).destruct().1,
     );
 
     let delegate_stx = make_pox_4_delegate_stx(
@@ -6356,7 +6369,7 @@ fn stack_increase(use_nakamoto: bool) {
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
     let pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(alice_stacking_private_key).bytes,
+        key_to_stacks_addr(alice_stacking_private_key).destruct().1,
     );
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
@@ -6535,7 +6548,7 @@ fn delegate_stack_increase(use_nakamoto: bool) {
 
     let pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(bob_delegate_key).bytes,
+        key_to_stacks_addr(bob_delegate_key).destruct().1,
     );
 
     let next_reward_cycle = 1 + burnchain
@@ -7274,6 +7287,344 @@ fn test_scenario_one(use_nakamoto: bool) {
         .expect_result_err()
         .unwrap();
     assert_eq!(bob_tx_result, Value::Int(19));
+}
+
+#[test]
+// In this test two solo stacker-signers Alice & Bob sign & stack
+//  for two reward cycles. Alice provides a signature, Bob uses
+//  'set-signer-key-authorizations' to authorize. Two cycles later,
+//  when no longer stacked, they both try replaying their auths.
+fn test_deser_abort() {
+    // Alice solo stacker-signer setup
+    let mut alice = StackerSignerInfo::new();
+    // Bob solo stacker-signer setup
+    let mut bob = StackerSignerInfo::new();
+    let default_initial_balances: u64 = 1_000_000_000_000_000_000;
+    let initial_balances = vec![
+        (alice.principal.clone(), default_initial_balances),
+        (bob.principal.clone(), default_initial_balances),
+    ];
+
+    let observer = TestEventObserver::new();
+    let (
+        mut peer,
+        mut peer_nonce,
+        burn_block_height,
+        reward_cycle,
+        next_reward_cycle,
+        min_ustx,
+        peer_config,
+        mut test_signers,
+    ) = pox_4_scenario_test_setup("test_scenario_one", &observer, initial_balances, true);
+
+    // Add alice and bob to test_signers
+    if let Some(ref mut test_signers) = test_signers.as_mut() {
+        test_signers
+            .signer_keys
+            .extend(vec![alice.private_key.clone(), bob.private_key.clone()]);
+    }
+
+    // Alice Signatures
+    let amount = (default_initial_balances / 2).wrapping_sub(1000) as u128;
+    let lock_period = 1;
+    let alice_signature = make_signer_key_signature(
+        &alice.pox_address,
+        &alice.private_key,
+        reward_cycle,
+        &Pox4SignatureTopic::StackStx,
+        lock_period,
+        u128::MAX,
+        1,
+    );
+    let alice_signature_err = make_signer_key_signature(
+        &alice.pox_address,
+        &alice.private_key,
+        reward_cycle - 1,
+        &Pox4SignatureTopic::StackStx,
+        lock_period,
+        100,
+        2,
+    );
+
+    // Bob Authorizations
+    let bob_authorization_low = make_pox_4_set_signer_key_auth(
+        &bob.pox_address,
+        &bob.private_key,
+        reward_cycle,
+        &Pox4SignatureTopic::StackStx,
+        lock_period,
+        true,
+        bob.nonce,
+        Some(&bob.private_key),
+        100,
+        2,
+    );
+    bob.nonce += 1;
+    let bob_authorization = make_pox_4_set_signer_key_auth(
+        &bob.pox_address,
+        &bob.private_key,
+        reward_cycle,
+        &Pox4SignatureTopic::StackStx,
+        lock_period,
+        true,
+        bob.nonce,
+        Some(&bob.private_key),
+        u128::MAX,
+        3,
+    );
+    bob.nonce += 1;
+
+    // Alice stacks
+    let alice_err_nonce = alice.nonce;
+    let alice_stack_err = make_pox_4_lockup(
+        &alice.private_key,
+        alice_err_nonce,
+        amount,
+        &alice.pox_address,
+        lock_period,
+        &alice.public_key,
+        burn_block_height,
+        Some(alice_signature_err),
+        100,
+        1,
+    );
+
+    let alice_stack_nonce = alice_err_nonce + 1;
+    let alice_stack = make_pox_4_lockup(
+        &alice.private_key,
+        alice_stack_nonce,
+        amount,
+        &alice.pox_address,
+        lock_period,
+        &alice.public_key,
+        burn_block_height,
+        Some(alice_signature.clone()),
+        u128::MAX,
+        1,
+    );
+    alice.nonce = alice_stack_nonce + 1;
+
+    // Bob stacks
+    let bob_nonce_stack_err = bob.nonce;
+    let bob_stack_err = make_pox_4_lockup(
+        &bob.private_key,
+        bob_nonce_stack_err,
+        amount,
+        &bob.pox_address,
+        lock_period,
+        &bob.public_key,
+        burn_block_height,
+        None,
+        100,
+        2,
+    );
+    let bob_nonce_stack = bob_nonce_stack_err + 1;
+    let bob_stack = make_pox_4_lockup(
+        &bob.private_key,
+        bob_nonce_stack,
+        amount,
+        &bob.pox_address,
+        lock_period,
+        &bob.public_key,
+        burn_block_height,
+        None,
+        u128::MAX,
+        3,
+    );
+    bob.nonce = bob_nonce_stack + 1;
+
+    let txs = vec![
+        bob_authorization_low,
+        bob_authorization,
+        alice_stack_err,
+        alice_stack,
+        bob_stack_err,
+        bob_stack,
+    ];
+
+    // Commit tx & advance to the reward set calculation height (2nd block of the prepare phase)
+    let target_height = peer
+        .config
+        .burnchain
+        .reward_cycle_to_block_height(next_reward_cycle as u64)
+        .saturating_sub(peer.config.burnchain.pox_constants.prepare_length as u64)
+        .wrapping_add(2);
+    let (latest_block, tx_block, receipts) = advance_to_block_height(
+        &mut peer,
+        &observer,
+        &txs,
+        &mut peer_nonce,
+        target_height,
+        &mut test_signers,
+    );
+
+    // Verify Alice stacked
+    let (pox_address, first_reward_cycle, lock_period, _indices) =
+        get_stacker_info_pox_4(&mut peer, &alice.principal)
+            .expect("Failed to find alice initial stack-stx");
+    assert_eq!(first_reward_cycle, next_reward_cycle);
+    assert_eq!(pox_address, alice.pox_address);
+
+    // Verify Bob stacked
+    let (pox_address, first_reward_cycle, lock_period, _indices) =
+        get_stacker_info_pox_4(&mut peer, &bob.principal)
+            .expect("Failed to find bob initial stack-stx");
+    assert_eq!(first_reward_cycle, next_reward_cycle);
+    assert_eq!(pox_address, bob.pox_address);
+
+    // 1. Check bob's low authorization transaction
+    let bob_tx_result_low = receipts
+        .get(1)
+        .unwrap()
+        .result
+        .clone()
+        .expect_result_ok()
+        .unwrap();
+    assert_eq!(bob_tx_result_low, Value::Bool(true));
+
+    // 2. Check bob's expected authorization transaction
+    let bob_tx_result_ok = receipts
+        .get(2)
+        .unwrap()
+        .result
+        .clone()
+        .expect_result_ok()
+        .unwrap();
+    assert_eq!(bob_tx_result_ok, Value::Bool(true));
+
+    // 3. Check alice's low stack transaction
+    let alice_tx_result_err = receipts
+        .get(3)
+        .unwrap()
+        .result
+        .clone()
+        .expect_result_err()
+        .unwrap();
+    assert_eq!(alice_tx_result_err, Value::Int(38));
+
+    // Get alice's expected stack transaction
+    let alice_tx_result_ok = receipts
+        .get(4)
+        .unwrap()
+        .result
+        .clone()
+        .expect_result_ok()
+        .unwrap()
+        .expect_tuple()
+        .unwrap();
+
+    // 4.1 Check amount locked
+    let amount_locked_expected = Value::UInt(amount);
+    let amount_locked_actual = alice_tx_result_ok
+        .data_map
+        .get("lock-amount")
+        .unwrap()
+        .clone();
+    assert_eq!(amount_locked_actual, amount_locked_expected);
+
+    // 4.2 Check signer key
+    let signer_key_expected = Value::buff_from(alice.public_key.to_bytes_compressed()).unwrap();
+    let signer_key_actual = alice_tx_result_ok
+        .data_map
+        .get("signer-key")
+        .unwrap()
+        .clone();
+    assert_eq!(signer_key_expected, signer_key_actual);
+
+    // 4.3 Check unlock height
+    let unlock_height_expected = Value::UInt(
+        peer.config
+            .burnchain
+            .reward_cycle_to_block_height(next_reward_cycle as u64 + lock_period as u64)
+            .wrapping_sub(1) as u128,
+    );
+    let unlock_height_actual = alice_tx_result_ok
+        .data_map
+        .get("unlock-burn-height")
+        .unwrap()
+        .clone();
+    assert_eq!(unlock_height_expected, unlock_height_actual);
+
+    // 5. Check bob's error stack transaction
+    let bob_tx_result_err = receipts
+        .get(5)
+        .unwrap()
+        .result
+        .clone()
+        .expect_result_err()
+        .unwrap();
+    assert_eq!(bob_tx_result_err, Value::Int(38));
+
+    // Get bob's expected stack transaction
+    let bob_tx_result_ok = receipts
+        .get(6)
+        .unwrap()
+        .result
+        .clone()
+        .expect_result_ok()
+        .unwrap()
+        .expect_tuple()
+        .unwrap();
+
+    // 6.1 Check amount locked
+    let amount_locked_expected = Value::UInt(amount);
+    let amount_locked_actual = bob_tx_result_ok
+        .data_map
+        .get("lock-amount")
+        .unwrap()
+        .clone();
+    assert_eq!(amount_locked_actual, amount_locked_expected);
+
+    // 6.2 Check signer key
+    let signer_key_expected = Value::buff_from(bob.public_key.to_bytes_compressed()).unwrap();
+    let signer_key_actual = bob_tx_result_ok.data_map.get("signer-key").unwrap().clone();
+    assert_eq!(signer_key_expected, signer_key_actual);
+
+    // 6.3 Check unlock height (end of cycle 7 - block 140)
+    let unlock_height_expected = Value::UInt(
+        peer.config
+            .burnchain
+            .reward_cycle_to_block_height((next_reward_cycle + lock_period) as u64)
+            .wrapping_sub(1) as u128,
+    );
+    let unlock_height_actual = bob_tx_result_ok
+        .data_map
+        .get("unlock-burn-height")
+        .unwrap()
+        .clone();
+    assert_eq!(unlock_height_expected, unlock_height_actual);
+
+    // Now starting create vote txs
+    // Fetch signer indices in reward cycle 6
+    // Alice vote
+    let contract = "
+      (define-private (sample)
+         (from-consensus-buff? principal 0x062011deadbeef11ababffff11deadbeef11ababffff0461626364))
+      (sample)
+    ";
+
+    let tx_payload = TransactionPayload::new_smart_contract(
+        &format!("hello-world"),
+        &contract.to_string(),
+        Some(ClarityVersion::Clarity2),
+    )
+    .unwrap();
+
+    let alice_tx = super::test::make_tx(&alice.private_key, alice.nonce, 1000, tx_payload);
+    alice.nonce += 1;
+    let alice_txid = alice_tx.txid();
+    let txs = vec![alice_tx];
+
+    info!("Submitting block with test txs");
+
+    let e = tenure_with_txs_fallible(&mut peer, &txs, &mut peer_nonce, &mut test_signers)
+        .expect_err("Should not have produced a valid block with this tx");
+    match e {
+        ChainstateError::ProblematicTransaction(txid) => {
+            assert_eq!(txid, alice_txid);
+        }
+        _ => panic!("Expected a problematic transaction result"),
+    }
 }
 
 // In this test two solo service signers, Alice & Bob, provide auth
@@ -8510,7 +8861,7 @@ fn delegate_stack_increase_err(use_nakamoto: bool) {
 
     let pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        key_to_stacks_addr(bob_delegate_key).bytes,
+        key_to_stacks_addr(bob_delegate_key).destruct().1,
     );
 
     let next_reward_cycle = 1 + burnchain
@@ -8901,6 +9252,60 @@ pub fn prepare_pox4_test<'a>(
     }
 }
 
+use crate::chainstate::stacks::Error as ChainstateError;
+pub fn tenure_with_txs_fallible(
+    peer: &mut TestPeer,
+    txs: &[StacksTransaction],
+    coinbase_nonce: &mut usize,
+    test_signers: &mut Option<TestSigners>,
+) -> Result<StacksBlockId, ChainstateError> {
+    if let Some(test_signers) = test_signers {
+        let (burn_ops, mut tenure_change, miner_key) =
+            peer.begin_nakamoto_tenure(TenureChangeCause::BlockFound);
+        let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+        let vrf_proof = peer.make_nakamoto_vrf_proof(miner_key);
+
+        tenure_change.tenure_consensus_hash = consensus_hash.clone();
+        tenure_change.burn_view_consensus_hash = consensus_hash.clone();
+
+        let tenure_change_tx = peer
+            .miner
+            .make_nakamoto_tenure_change(tenure_change.clone());
+        let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+
+        let blocks_and_sizes = peer.make_nakamoto_tenure_and(
+            tenure_change_tx,
+            coinbase_tx,
+            test_signers,
+            |_| {},
+            |_miner, _chainstate, _sort_dbconn, _blocks| {
+                info!("Building nakamoto block. Blocks len {}", _blocks.len());
+                if _blocks.is_empty() {
+                    txs.to_vec()
+                } else {
+                    vec![]
+                }
+            },
+            |_| true,
+        )?;
+        let blocks: Vec<_> = blocks_and_sizes
+            .into_iter()
+            .map(|(block, _, _)| block)
+            .collect();
+
+        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.sortdb.as_mut().unwrap();
+        let latest_block = sort_db
+            .index_handle_at_tip()
+            .get_nakamoto_tip_block_id()
+            .unwrap()
+            .unwrap();
+        Ok(latest_block)
+    } else {
+        Ok(peer.tenure_with_txs(txs, coinbase_nonce))
+    }
+}
+
 pub fn tenure_with_txs(
     peer: &mut TestPeer,
     txs: &[StacksTransaction],
@@ -9044,11 +9449,11 @@ fn missed_slots_no_unlock() {
         );
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            bob_address.bytes.0.to_vec()
+            bob_address.bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            alice_address.bytes.0.to_vec()
+            alice_address.bytes().0.to_vec()
         );
     }
 
@@ -9076,11 +9481,11 @@ fn missed_slots_no_unlock() {
         assert_eq!(reward_set_entries.len(), 2);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            bob_address.bytes.0.to_vec()
+            bob_address.bytes().0.to_vec()
         );
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            alice_address.bytes.0.to_vec()
+            alice_address.bytes().0.to_vec()
         );
     }
 
@@ -9173,7 +9578,7 @@ fn missed_slots_no_unlock() {
             assert_eq!(rewarded_addrs.len(), 1);
             assert_eq!(
                 reward_set_data.reward_set.rewarded_addresses[0].bytes(),
-                alice_address.bytes.0.to_vec(),
+                alice_address.bytes().0.to_vec(),
             );
             reward_cycles_in_2_5 += 1;
             eprintln!("{:?}", b.reward_set_data)
@@ -9292,7 +9697,7 @@ fn no_lockups_2_5() {
         );
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            bob_address.bytes.0.to_vec()
+            bob_address.bytes().0.to_vec()
         );
     }
 

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -1219,10 +1219,7 @@ mod test {
 
         // dummy reward
         let mut tip_reward = make_dummy_miner_payment_schedule(
-            &StacksAddress {
-                version: 0,
-                bytes: Hash160([0u8; 20]),
-            },
+            &StacksAddress::new(0, Hash160([0u8; 20])).unwrap(),
             0,
             0,
             0,
@@ -1294,10 +1291,7 @@ mod test {
 
         // dummy reward
         let mut tip_reward = make_dummy_miner_payment_schedule(
-            &StacksAddress {
-                version: 0,
-                bytes: Hash160([0u8; 20]),
-            },
+            &StacksAddress::new(0, Hash160([0u8; 20])).unwrap(),
             0,
             0,
             0,
@@ -1344,10 +1338,7 @@ mod test {
 
         // dummy reward
         let mut tip_reward = make_dummy_miner_payment_schedule(
-            &StacksAddress {
-                version: 0,
-                bytes: Hash160([0u8; 20]),
-            },
+            &StacksAddress::new(0, Hash160([0u8; 20])).unwrap(),
             0,
             0,
             0,

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -6860,7 +6860,7 @@ impl StacksChainState {
                 // version byte matches?
                 if !StacksChainState::is_valid_address_version(
                     chainstate_config.mainnet,
-                    address.version,
+                    address.version(),
                 ) {
                     return Err(MemPoolRejection::BadAddressVersionByte);
                 }

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -1414,7 +1414,6 @@ impl StacksChainState {
                 Ok(receipt)
             }
             TransactionPayload::Coinbase(..) => {
-                // no-op; not handled here
                 // NOTE: technically, post-conditions are allowed (even if they're non-sensical).
 
                 let receipt = StacksTransactionReceipt::from_coinbase(tx.clone());
@@ -1605,16 +1604,35 @@ pub mod test {
         epoch_id: StacksEpochId::Epoch21,
         ast_rules: ASTRules::PrecheckSize,
     };
+    pub const TestBurnStateDB_25: UnitTestBurnStateDB = UnitTestBurnStateDB {
+        epoch_id: StacksEpochId::Epoch25,
+        ast_rules: ASTRules::PrecheckSize,
+    };
+    pub const TestBurnStateDB_30: UnitTestBurnStateDB = UnitTestBurnStateDB {
+        epoch_id: StacksEpochId::Epoch30,
+        ast_rules: ASTRules::PrecheckSize,
+    };
+    pub const TestBurnStateDB_31: UnitTestBurnStateDB = UnitTestBurnStateDB {
+        epoch_id: StacksEpochId::Epoch31,
+        ast_rules: ASTRules::PrecheckSize,
+    };
 
     pub const ALL_BURN_DBS: &[&dyn BurnStateDB] = &[
         &TestBurnStateDB_20 as &dyn BurnStateDB,
         &TestBurnStateDB_2_05 as &dyn BurnStateDB,
         &TestBurnStateDB_21 as &dyn BurnStateDB,
+        &TestBurnStateDB_30 as &dyn BurnStateDB,
+        &TestBurnStateDB_31 as &dyn BurnStateDB,
     ];
 
     pub const PRE_21_DBS: &[&dyn BurnStateDB] = &[
         &TestBurnStateDB_20 as &dyn BurnStateDB,
         &TestBurnStateDB_2_05 as &dyn BurnStateDB,
+    ];
+
+    pub const NAKAMOTO_DBS: &[&dyn BurnStateDB] = &[
+        &TestBurnStateDB_30 as &dyn BurnStateDB,
+        &TestBurnStateDB_31 as &dyn BurnStateDB,
     ];
 
     #[test]
@@ -1703,10 +1721,7 @@ pub mod test {
         .unwrap();
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
-        let recv_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
         let mut tx_stx_transfer = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -1770,11 +1785,7 @@ pub mod test {
 
             let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
             let recv_addr = PrincipalData::from(QualifiedContractIdentifier {
-                issuer: StacksAddress {
-                    version: 1,
-                    bytes: Hash160([0xfe; 20]),
-                }
-                .into(),
+                issuer: StacksAddress::new(1, Hash160([0xfe; 20])).unwrap().into(),
                 name: "contract-hellow".into(),
             });
 
@@ -2046,10 +2057,7 @@ pub mod test {
         let addr = auth.origin().address_testnet();
         let addr_sponsor = auth.sponsor().unwrap().address_testnet();
 
-        let recv_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
         let mut tx_stx_transfer = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -2380,7 +2388,7 @@ pub mod test {
 
                 // Verify that the syntax error is recorded in the receipt
                 let expected_error =
-                    if burn_db.get_stacks_epoch(0).unwrap().epoch_id == StacksEpochId::Epoch21 {
+                    if burn_db.get_stacks_epoch(0).unwrap().epoch_id >= StacksEpochId::Epoch21 {
                         expected_errors_2_1[i].to_string()
                     } else {
                         expected_errors[i].to_string()
@@ -5046,14 +5054,8 @@ pub mod test {
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
         let origin = addr.to_account_principal();
-        let recv_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
-        let contract_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0x01; 20]),
-        };
+        let recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
+        let contract_addr = StacksAddress::new(1, Hash160([0x01; 20])).unwrap();
 
         let asset_info_1 = AssetInfo {
             contract_address: contract_addr.clone(),
@@ -6898,14 +6900,8 @@ pub mod test {
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
         let origin = addr.to_account_principal();
-        let _recv_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
-        let contract_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0x01; 20]),
-        };
+        let _recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
+        let contract_addr = StacksAddress::new(1, Hash160([0x01; 20])).unwrap();
 
         let asset_info = AssetInfo {
             contract_address: contract_addr.clone(),
@@ -7252,10 +7248,7 @@ pub mod test {
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
         let origin = addr.to_account_principal();
-        let _recv_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let _recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
         // stx-transfer for 123 microstx
         let mut stx_asset_map = AssetMap::new();
@@ -8748,10 +8741,7 @@ pub mod test {
         .unwrap();
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
-        let recv_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
         let smart_contract = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -8962,10 +8952,7 @@ pub mod test {
         .unwrap();
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let addr = auth.origin().address_testnet();
-        let recv_addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
         let smart_contract = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -11400,5 +11387,439 @@ pub mod test {
         }
 
         conn.commit_block();
+    }
+
+    /// Verify that transactions with bare PrincipalDatas in them cannot decode if the version byte
+    /// is inappropriate.
+    #[test]
+    fn test_invalid_address_prevents_tx_decode() {
+        // token transfer
+        let bad_payload_bytes = vec![
+            TransactionPayloadID::TokenTransfer as u8,
+            // Clarity value type (StandardPrincipalData)
+            0x05,
+            // bad address (version byte 32)
+            0x20,
+            // address body (0x00000000000000000000)
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            // amount (1 uSTX)
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            // memo
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+        ];
+
+        let mut good_payload_bytes = bad_payload_bytes.clone();
+
+        // only diff is the address version
+        good_payload_bytes[2] = 0x1f;
+
+        let bad_payload: Result<TransactionPayload, _> =
+            TransactionPayload::consensus_deserialize(&mut &bad_payload_bytes[..]);
+        assert!(bad_payload.is_err());
+
+        let _: TransactionPayload =
+            TransactionPayload::consensus_deserialize(&mut &good_payload_bytes[..]).unwrap();
+
+        // contract-call with bad contract address
+        let bad_payload_bytes = vec![
+            TransactionPayloadID::ContractCall as u8,
+            // Stacks address
+            // bad version byte
+            0x20,
+            // address body (0x00000000000000000000)
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            // contract name ("hello")
+            0x05,
+            0x68,
+            0x65,
+            0x6c,
+            0x6c,
+            0x6f,
+            // function name ("world")
+            0x05,
+            0x77,
+            0x6f,
+            0x72,
+            0x6c,
+            0x64,
+            // arguments (good address)
+            // length (1)
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            // StandardPrincipalData
+            0x05,
+            // address version (1)
+            0x01,
+            // address body (0x00000000000000000000)
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ];
+
+        let mut good_payload_bytes = bad_payload_bytes.clone();
+
+        // only diff is the address version
+        good_payload_bytes[1] = 0x1f;
+
+        let bad_payload: Result<TransactionPayload, _> =
+            TransactionPayload::consensus_deserialize(&mut &bad_payload_bytes[..]);
+        assert!(bad_payload.is_err());
+
+        let _: TransactionPayload =
+            TransactionPayload::consensus_deserialize(&mut &good_payload_bytes[..]).unwrap();
+
+        // contract-call with bad Principal argument
+        let bad_payload_bytes = vec![
+            TransactionPayloadID::ContractCall as u8,
+            // Stacks address
+            0x01,
+            // address body (0x00000000000000000000)
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            // contract name ("hello")
+            0x05,
+            0x68,
+            0x65,
+            0x6c,
+            0x6c,
+            0x6f,
+            // function name ("world")
+            0x05,
+            0x77,
+            0x6f,
+            0x72,
+            0x6c,
+            0x64,
+            // arguments (good address)
+            // length (1)
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            // StandardPrincipalData
+            0x05,
+            // address version (32 -- bad)
+            0x20,
+            // address body (0x00000000000000000000)
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ];
+
+        let mut good_payload_bytes = bad_payload_bytes.clone();
+        good_payload_bytes[39] = 0x1f;
+
+        let bad_payload: Result<TransactionPayload, _> =
+            TransactionPayload::consensus_deserialize(&mut &bad_payload_bytes[..]);
+        assert!(bad_payload.is_err());
+
+        let _: TransactionPayload =
+            TransactionPayload::consensus_deserialize(&mut &good_payload_bytes[..]).unwrap();
+
+        let bad_payload_bytes = vec![
+            // payload type ID
+            TransactionPayloadID::NakamotoCoinbase as u8,
+            // buffer
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            0x12,
+            // have contract recipient, so Some(..)
+            0x0a,
+            // contract address type
+            0x06,
+            // address (bad version)
+            0x20,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            // name length
+            0x0c,
+            // name ('foo-contract')
+            0x66,
+            0x6f,
+            0x6f,
+            0x2d,
+            0x63,
+            0x6f,
+            0x6e,
+            0x74,
+            0x72,
+            0x61,
+            0x63,
+            0x74,
+            // proof bytes
+            0x92,
+            0x75,
+            0xdf,
+            0x67,
+            0xa6,
+            0x8c,
+            0x87,
+            0x45,
+            0xc0,
+            0xff,
+            0x97,
+            0xb4,
+            0x82,
+            0x01,
+            0xee,
+            0x6d,
+            0xb4,
+            0x47,
+            0xf7,
+            0xc9,
+            0x3b,
+            0x23,
+            0xae,
+            0x24,
+            0xcd,
+            0xc2,
+            0x40,
+            0x0f,
+            0x52,
+            0xfd,
+            0xb0,
+            0x8a,
+            0x1a,
+            0x6a,
+            0xc7,
+            0xec,
+            0x71,
+            0xbf,
+            0x9c,
+            0x9c,
+            0x76,
+            0xe9,
+            0x6e,
+            0xe4,
+            0x67,
+            0x5e,
+            0xbf,
+            0xf6,
+            0x06,
+            0x25,
+            0xaf,
+            0x28,
+            0x71,
+            0x85,
+            0x01,
+            0x04,
+            0x7b,
+            0xfd,
+            0x87,
+            0xb8,
+            0x10,
+            0xc2,
+            0xd2,
+            0x13,
+            0x9b,
+            0x73,
+            0xc2,
+            0x3b,
+            0xd6,
+            0x9d,
+            0xe6,
+            0x63,
+            0x60,
+            0x95,
+            0x3a,
+            0x64,
+            0x2c,
+            0x2a,
+            0x33,
+            0x0a,
+        ];
+
+        let mut good_payload_bytes = bad_payload_bytes.clone();
+        debug!(
+            "index is {:?}",
+            good_payload_bytes.iter().find(|x| **x == 0x20)
+        );
+        good_payload_bytes[35] = 0x1f;
+
+        let bad_payload: Result<TransactionPayload, _> =
+            TransactionPayload::consensus_deserialize(&mut &bad_payload_bytes[..]);
+        assert!(bad_payload.is_err());
+
+        let _: TransactionPayload =
+            TransactionPayload::consensus_deserialize(&mut &good_payload_bytes[..]).unwrap();
     }
 }

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -669,8 +669,7 @@ pub struct TransactionContractCall {
 
 impl TransactionContractCall {
     pub fn contract_identifier(&self) -> QualifiedContractIdentifier {
-        let standard_principal =
-            StandardPrincipalData(self.address.version, self.address.bytes.0.clone());
+        let standard_principal = StandardPrincipalData::from(self.address.clone());
         QualifiedContractIdentifier::new(standard_principal, self.contract_name.clone())
     }
 }
@@ -1126,10 +1125,7 @@ pub mod test {
         post_condition_mode: &TransactionPostConditionMode,
         epoch_id: StacksEpochId,
     ) -> Vec<StacksTransaction> {
-        let addr = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
         let asset_name = ClarityName::try_from("hello-asset").unwrap();
         let asset_value = Value::buff_from(vec![0, 1, 2, 3]).unwrap();
         let contract_name = ContractName::try_from("hello-world").unwrap();
@@ -1276,15 +1272,9 @@ pub mod test {
 
         let tx_post_condition_principals = vec![
             PostConditionPrincipal::Origin,
-            PostConditionPrincipal::Standard(StacksAddress {
-                version: 1,
-                bytes: Hash160([1u8; 20]),
-            }),
+            PostConditionPrincipal::Standard(StacksAddress::new(1, Hash160([1u8; 20])).unwrap()),
             PostConditionPrincipal::Contract(
-                StacksAddress {
-                    version: 2,
-                    bytes: Hash160([2u8; 20]),
-                },
+                StacksAddress::new(2, Hash160([2u8; 20])).unwrap(),
                 ContractName::try_from("hello-world").unwrap(),
             ),
         ];
@@ -1403,10 +1393,7 @@ pub mod test {
             ]);
         }
 
-        let stx_address = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let stx_address = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
         let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
         let mut tx_payloads = vec![
@@ -1424,10 +1411,7 @@ pub mod test {
                 TokenTransferMemo([0u8; 34]),
             ),
             TransactionPayload::ContractCall(TransactionContractCall {
-                address: StacksAddress {
-                    version: 4,
-                    bytes: Hash160([0xfc; 20]),
-                },
+                address: StacksAddress::new(4, Hash160([0xfc; 20])).unwrap(),
                 contract_name: ContractName::try_from("hello-contract-name").unwrap(),
                 function_name: ClarityName::try_from("hello-contract-call").unwrap(),
                 function_args: vec![Value::Int(0)],
@@ -1481,9 +1465,9 @@ pub mod test {
                 ),
                 TransactionPayload::Coinbase(
                     CoinbasePayload([0x12; 32]),
-                    Some(PrincipalData::Standard(StandardPrincipalData(
-                        0x01, [0x02; 20],
-                    ))),
+                    Some(PrincipalData::Standard(
+                        StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
+                    )),
                     Some(proof.clone()),
                 ),
             ])
@@ -1499,9 +1483,9 @@ pub mod test {
                 ),
                 TransactionPayload::Coinbase(
                     CoinbasePayload([0x12; 32]),
-                    Some(PrincipalData::Standard(StandardPrincipalData(
-                        0x01, [0x02; 20],
-                    ))),
+                    Some(PrincipalData::Standard(
+                        StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
+                    )),
                     None,
                 ),
             ])
@@ -1649,10 +1633,7 @@ pub mod test {
         )
         .unwrap();
 
-        let stx_address = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let stx_address = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
         let payload = TransactionPayload::TokenTransfer(
             stx_address.into(),
             123,

--- a/stackslib/src/chainstate/stacks/tests/chain_histories.rs
+++ b/stackslib/src/chainstate/stacks/tests/chain_histories.rs
@@ -2846,7 +2846,8 @@ pub fn mine_invalid_token_transfers_block(
         .try_mine_tx(clarity_tx, &tx_coinbase_signed, ASTRules::PrecheckSize)
         .unwrap();
 
-    let recipient = StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0xff; 20]));
+    let recipient =
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0xff; 20])).unwrap();
     let tx1 = make_token_transfer(
         miner,
         burnchain_height,

--- a/stackslib/src/config/chain_data.rs
+++ b/stackslib/src/config/chain_data.rs
@@ -794,13 +794,14 @@ EOF
                     ]
                 ),
                 PoxAddress::Standard(
-                    StacksAddress {
-                        version: 20,
-                        bytes: Hash160([
+                    StacksAddress::new(
+                        20,
+                        Hash160([
                             0x18, 0xc4, 0x20, 0x80, 0xa1, 0xe8, 0x7f, 0xd0, 0x2d, 0xd3, 0xfc, 0xa9,
                             0x4c, 0x45, 0x13, 0xf9, 0xec, 0xfe, 0x74, 0x14
                         ])
-                    },
+                    )
+                    .unwrap(),
                     None
                 )
             ]

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -215,14 +215,9 @@ fn mempool_walk_over_fork() {
         let block = &blocks_to_broadcast_in[ix];
         let good_tx = &txs[ix];
 
-        let origin_address = StacksAddress {
-            version: 22,
-            bytes: Hash160::from_data(&[ix as u8; 32]),
-        };
-        let sponsor_address = StacksAddress {
-            version: 22,
-            bytes: Hash160::from_data(&[0x80 | (ix as u8); 32]),
-        };
+        let origin_address = StacksAddress::new(22, Hash160::from_data(&[ix as u8; 32])).unwrap();
+        let sponsor_address =
+            StacksAddress::new(22, Hash160::from_data(&[0x80 | (ix as u8); 32])).unwrap();
 
         let txid = good_tx.txid();
         let tx_bytes = good_tx.serialize_to_vec();
@@ -469,14 +464,8 @@ fn mempool_walk_over_fork() {
     let mut mempool_tx = mempool.tx_begin().unwrap();
     let block = &b_1;
     let tx = &txs[1];
-    let origin_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&[1; 32]),
-    };
-    let sponsor_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&[0x81; 32]),
-    };
+    let origin_address = StacksAddress::new(22, Hash160::from_data(&[1; 32])).unwrap();
+    let sponsor_address = StacksAddress::new(22, Hash160::from_data(&[0x81; 32])).unwrap();
 
     let txid = tx.txid();
     let tx_bytes = tx.serialize_to_vec();
@@ -523,14 +512,8 @@ fn mempool_walk_over_fork() {
     let mut mempool_tx = mempool.tx_begin().unwrap();
     let block = &b_4;
     let tx = &txs[1];
-    let origin_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&[0; 32]),
-    };
-    let sponsor_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&[1; 32]),
-    };
+    let origin_address = StacksAddress::new(22, Hash160::from_data(&[0; 32])).unwrap();
+    let sponsor_address = StacksAddress::new(22, Hash160::from_data(&[1; 32])).unwrap();
 
     let txid = tx.txid();
     let tx_bytes = tx.serialize_to_vec();
@@ -1307,14 +1290,8 @@ fn mempool_do_not_replace_tx() {
     let mut mempool_tx = mempool.tx_begin().unwrap();
 
     // do an initial insert
-    let origin_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&[0; 32]),
-    };
-    let sponsor_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&[1; 32]),
-    };
+    let origin_address = StacksAddress::new(22, Hash160::from_data(&[0; 32])).unwrap();
+    let sponsor_address = StacksAddress::new(22, Hash160::from_data(&[1; 32])).unwrap();
 
     tx.set_tx_fee(123);
 
@@ -1411,14 +1388,9 @@ fn mempool_db_load_store_replace_tx(#[case] behavior: MempoolCollectionBehavior)
     eprintln!("add all txs");
     for (i, mut tx) in txs.into_iter().enumerate() {
         // make sure each address is unique per tx (not the case in codec_all_transactions)
-        let origin_address = StacksAddress {
-            version: 22,
-            bytes: Hash160::from_data(&i.to_be_bytes()),
-        };
-        let sponsor_address = StacksAddress {
-            version: 22,
-            bytes: Hash160::from_data(&(i + 1).to_be_bytes()),
-        };
+        let origin_address = StacksAddress::new(22, Hash160::from_data(&i.to_be_bytes())).unwrap();
+        let sponsor_address =
+            StacksAddress::new(22, Hash160::from_data(&(i + 1).to_be_bytes())).unwrap();
 
         tx.set_tx_fee(123);
 
@@ -1668,10 +1640,7 @@ fn mempool_db_test_rbf() {
         tx_fee: 456,
         signature: MessageSignature::from_raw(&[0xff; 65]),
     });
-    let stx_address = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let stx_address = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let payload = TransactionPayload::TokenTransfer(
         PrincipalData::from(QualifiedContractIdentifier {
             issuer: stx_address.into(),
@@ -1691,14 +1660,9 @@ fn mempool_db_test_rbf() {
     };
 
     let i: usize = 0;
-    let origin_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&i.to_be_bytes()),
-    };
-    let sponsor_address = StacksAddress {
-        version: 22,
-        bytes: Hash160::from_data(&(i + 1).to_be_bytes()),
-    };
+    let origin_address = StacksAddress::new(22, Hash160::from_data(&i.to_be_bytes())).unwrap();
+    let sponsor_address =
+        StacksAddress::new(22, Hash160::from_data(&(i + 1).to_be_bytes())).unwrap();
 
     tx.set_tx_fee(123);
     let txid = tx.txid();
@@ -1807,10 +1771,7 @@ fn test_add_txs_bloom_filter() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
     let mut all_txids: Vec<Vec<Txid>> = vec![];
 
@@ -1916,10 +1877,7 @@ fn test_txtags() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
     let mut seed = [0u8; 32];
     thread_rng().fill_bytes(&mut seed);
@@ -2015,10 +1973,7 @@ fn test_make_mempool_sync_data() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
     let mut txids = vec![];
     let mut nonrecent_fp_rates = vec![];
@@ -2192,10 +2147,7 @@ fn test_find_next_missing_transactions() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
     let block_height = 10;
     let mut txids = vec![];
@@ -2463,10 +2415,7 @@ fn test_drop_and_blacklist_txs_by_time() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let mut txs = vec![];
     let block_height = 10;
 
@@ -2583,10 +2532,7 @@ fn test_drop_and_blacklist_txs_by_size() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let mut txs = vec![];
     let block_height = 10;
 
@@ -2686,10 +2632,7 @@ fn test_filter_txs_by_type() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let mut txs = vec![];
     let block_height = 10;
     let mut total_len = 0;

--- a/stackslib/src/cost_estimates/tests/cost_estimators.rs
+++ b/stackslib/src/cost_estimates/tests/cost_estimators.rs
@@ -81,7 +81,7 @@ fn make_dummy_coinbase_tx() -> StacksTransactionReceipt {
 
 fn make_dummy_transfer_payload() -> TransactionPayload {
     TransactionPayload::TokenTransfer(
-        PrincipalData::Standard(StandardPrincipalData(0, [0; 20])),
+        PrincipalData::Standard(StandardPrincipalData::new(0, [0; 20]).unwrap()),
         1,
         TokenTransferMemo([0; 34]),
     )
@@ -92,7 +92,7 @@ fn make_dummy_transfer_tx() -> StacksTransactionReceipt {
         TransactionVersion::Mainnet,
         TransactionAuth::Standard(TransactionSpendingCondition::new_initial_sighash()),
         TransactionPayload::TokenTransfer(
-            PrincipalData::Standard(StandardPrincipalData(0, [0; 20])),
+            PrincipalData::Standard(StandardPrincipalData::new(0, [0; 20]).unwrap()),
             1,
             TokenTransferMemo([0; 34]),
         ),
@@ -128,7 +128,7 @@ fn make_dummy_cc_tx(
 
 fn make_dummy_cc_payload(contract_name: &str, function_name: &str) -> TransactionPayload {
     TransactionPayload::ContractCall(TransactionContractCall {
-        address: StacksAddress::new(0, Hash160([0; 20])),
+        address: StacksAddress::new(0, Hash160([0; 20])).unwrap(),
         contract_name: contract_name.into(),
         function_name: function_name.into(),
         function_args: vec![],
@@ -254,13 +254,13 @@ fn test_pessimistic_cost_estimator_declining_average() {
 fn pessimistic_estimator_contract_owner_separation() {
     let mut estimator = instantiate_test_db();
     let cc_payload_0 = TransactionPayload::ContractCall(TransactionContractCall {
-        address: StacksAddress::new(0, Hash160([0; 20])),
+        address: StacksAddress::new(0, Hash160([0; 20])).unwrap(),
         contract_name: "contract-1".into(),
         function_name: "func1".into(),
         function_args: vec![],
     });
     let cc_payload_1 = TransactionPayload::ContractCall(TransactionContractCall {
-        address: StacksAddress::new(0, Hash160([1; 20])),
+        address: StacksAddress::new(0, Hash160([1; 20])).unwrap(),
         contract_name: "contract-1".into(),
         function_name: "func1".into(),
         function_args: vec![],

--- a/stackslib/src/cost_estimates/tests/fee_medians.rs
+++ b/stackslib/src/cost_estimates/tests/fee_medians.rs
@@ -65,7 +65,7 @@ fn make_dummy_cc_tx(fee: u64, execution_cost: &ExecutionCost) -> StacksTransacti
         TransactionVersion::Mainnet,
         TransactionAuth::Standard(TransactionSpendingCondition::new_initial_sighash()),
         TransactionPayload::ContractCall(TransactionContractCall {
-            address: StacksAddress::new(0, Hash160([0; 20])),
+            address: StacksAddress::new(0, Hash160([0; 20])).unwrap(),
             contract_name: "cc-dummy".into(),
             function_name: "func-name".into(),
             function_args: vec![],

--- a/stackslib/src/cost_estimates/tests/fee_scalar.rs
+++ b/stackslib/src/cost_estimates/tests/fee_scalar.rs
@@ -83,7 +83,7 @@ fn make_dummy_transfer_tx(fee: u64) -> StacksTransactionReceipt {
         TransactionVersion::Mainnet,
         TransactionAuth::Standard(TransactionSpendingCondition::new_initial_sighash()),
         TransactionPayload::TokenTransfer(
-            PrincipalData::Standard(StandardPrincipalData(0, [0; 20])),
+            PrincipalData::Standard(StandardPrincipalData::new(0, [0; 20]).unwrap()),
             1,
             TokenTransferMemo([0; 34]),
         ),
@@ -103,7 +103,7 @@ fn make_dummy_cc_tx(fee: u64) -> StacksTransactionReceipt {
         TransactionVersion::Mainnet,
         TransactionAuth::Standard(TransactionSpendingCondition::new_initial_sighash()),
         TransactionPayload::ContractCall(TransactionContractCall {
-            address: StacksAddress::new(0, Hash160([0; 20])),
+            address: StacksAddress::new(0, Hash160([0; 20])).unwrap(),
             contract_name: "cc-dummy".into(),
             function_name: "func-name".into(),
             function_args: vec![],

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -260,10 +260,7 @@ fn test_try_make_response() {
         )
         .unwrap();
 
-        let stx_address = StacksAddress {
-            version: 1,
-            bytes: Hash160([0xff; 20]),
-        };
+        let stx_address = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
         let payload = TransactionPayload::TokenTransfer(
             stx_address.into(),
             123,

--- a/stackslib/src/net/api/tests/postmempoolquery.rs
+++ b/stackslib/src/net/api/tests/postmempoolquery.rs
@@ -131,10 +131,7 @@ fn test_stream_mempool_txs() {
     let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let mut txs = vec![];
     let block_height = 10;
     let mut total_len = 0;
@@ -351,10 +348,7 @@ fn test_stream_mempool_txs() {
 
 #[test]
 fn test_decode_tx_stream() {
-    let addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let mut txs = vec![];
     for _i in 0..10 {
         let pk = StacksPrivateKey::new();

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -774,7 +774,7 @@ fn contract_id_consensus_serialize<W: Write>(
 ) -> Result<(), codec_error> {
     let addr = &cid.issuer;
     let name = &cid.name;
-    write_next(fd, &addr.0)?;
+    write_next(fd, &addr.version())?;
     write_next(fd, &addr.1)?;
     write_next(fd, name)?;
     Ok(())
@@ -787,11 +787,13 @@ fn contract_id_consensus_deserialize<R: Read>(
     let bytes: [u8; 20] = read_next(fd)?;
     let name: ContractName = read_next(fd)?;
     let qn = QualifiedContractIdentifier::new(
-        StacksAddress {
-            version,
-            bytes: Hash160(bytes),
-        }
-        .into(),
+        StacksAddress::new(version, Hash160(bytes))
+            .map_err(|_| {
+                codec_error::DeserializeError(
+                    "Failed to make StacksAddress with given version".into(),
+                )
+            })?
+            .into(),
         name,
     );
     Ok(qn)

--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -1924,11 +1924,11 @@ mod test {
 
         let mut stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x01, [0x02; 20]),
+                StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
                 "db-1".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x02, [0x03; 20]),
+                StandardPrincipalData::new(0x02, [0x03; 20]).unwrap(),
                 "db-2".into(),
             ),
         ];
@@ -2097,11 +2097,11 @@ mod test {
         // basic storage and retrieval
         let mut stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x01, [0x02; 20]),
+                StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
                 "db-1".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x02, [0x03; 20]),
+                StandardPrincipalData::new(0x02, [0x03; 20]).unwrap(),
                 "db-2".into(),
             ),
         ];
@@ -2127,11 +2127,11 @@ mod test {
         // adding DBs to the same slot just grows the total list
         let mut new_stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x03, [0x04; 20]),
+                StandardPrincipalData::new(0x03, [0x04; 20]).unwrap(),
                 "db-3".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x04, [0x05; 20]),
+                StandardPrincipalData::new(0x04, [0x05; 20]).unwrap(),
                 "db-5".into(),
             ),
         ];
@@ -2332,11 +2332,11 @@ mod test {
 
         let mut stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x01, [0x02; 20]),
+                StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
                 "db-1".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x02, [0x03; 20]),
+                StandardPrincipalData::new(0x02, [0x03; 20]).unwrap(),
                 "db-2".into(),
             ),
         ];
@@ -2369,11 +2369,11 @@ mod test {
         // insert new stacker DBs -- keep one the same, and add a different one
         let mut changed_stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x01, [0x02; 20]),
+                StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
                 "db-1".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x03, [0x04; 20]),
+                StandardPrincipalData::new(0x03, [0x04; 20]).unwrap(),
                 "db-3".into(),
             ),
         ];
@@ -2409,11 +2409,11 @@ mod test {
         // add back stacker DBs
         let mut new_stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x04, [0x05; 20]),
+                StandardPrincipalData::new(0x04, [0x05; 20]).unwrap(),
                 "db-4".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x05, [0x06; 20]),
+                StandardPrincipalData::new(0x05, [0x06; 20]).unwrap(),
                 "db-5".into(),
             ),
         ];
@@ -2437,11 +2437,11 @@ mod test {
         for _ in 0..2 {
             let mut replace_stackerdbs = vec![
                 QualifiedContractIdentifier::new(
-                    StandardPrincipalData(0x06, [0x07; 20]),
+                    StandardPrincipalData::new(0x06, [0x07; 20]).unwrap(),
                     "db-6".into(),
                 ),
                 QualifiedContractIdentifier::new(
-                    StandardPrincipalData(0x07, [0x08; 20]),
+                    StandardPrincipalData::new(0x07, [0x08; 20]).unwrap(),
                     "db-7".into(),
                 ),
             ];
@@ -2533,11 +2533,11 @@ mod test {
 
         let mut stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x01, [0x02; 20]),
+                StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
                 "db-1".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x02, [0x03; 20]),
+                StandardPrincipalData::new(0x02, [0x03; 20]).unwrap(),
                 "db-2".into(),
             ),
         ];
@@ -2572,11 +2572,11 @@ mod test {
         // insert new stacker DBs -- keep one the same, and add a different one
         let mut changed_stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x01, [0x02; 20]),
+                StandardPrincipalData::new(0x01, [0x02; 20]).unwrap(),
                 "db-1".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x03, [0x04; 20]),
+                StandardPrincipalData::new(0x03, [0x04; 20]).unwrap(),
                 "db-3".into(),
             ),
         ];
@@ -2666,11 +2666,11 @@ mod test {
 
         let mut replace_stackerdbs = vec![
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x06, [0x07; 20]),
+                StandardPrincipalData::new(0x06, [0x07; 20]).unwrap(),
                 "db-6".into(),
             ),
             QualifiedContractIdentifier::new(
-                StandardPrincipalData(0x07, [0x08; 20]),
+                StandardPrincipalData::new(0x07, [0x08; 20]).unwrap(),
                 "db-7".into(),
             ),
         ];

--- a/stackslib/src/net/stackerdb/tests/config.rs
+++ b/stackslib/src/net/stackerdb/tests/config.rs
@@ -142,11 +142,11 @@ fn test_valid_and_invalid_stackerdb_configs() {
             Some(StackerDBConfig {
                 chunk_size: 123,
                 signers: vec![(
-                    StacksAddress {
-                        version: 26,
-                        bytes: Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b")
-                            .unwrap(),
-                    },
+                    StacksAddress::new(
+                        26,
+                        Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b").unwrap(),
+                    )
+                    .unwrap(),
                     3,
                 )],
                 write_freq: 4,
@@ -183,11 +183,11 @@ fn test_valid_and_invalid_stackerdb_configs() {
             Some(StackerDBConfig {
                 chunk_size: 123,
                 signers: vec![(
-                    StacksAddress {
-                        version: 26,
-                        bytes: Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b")
-                            .unwrap(),
-                    },
+                    StacksAddress::new(
+                        26,
+                        Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b").unwrap(),
+                    )
+                    .unwrap(),
                     3,
                 )],
                 write_freq: 4,
@@ -485,11 +485,11 @@ fn test_valid_and_invalid_stackerdb_configs() {
             Some(StackerDBConfig {
                 chunk_size: 123,
                 signers: vec![(
-                    StacksAddress {
-                        version: 26,
-                        bytes: Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b")
-                            .unwrap(),
-                    },
+                    StacksAddress::new(
+                        26,
+                        Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b").unwrap(),
+                    )
+                    .unwrap(),
                     3,
                 )],
                 write_freq: 4,
@@ -634,10 +634,11 @@ fn test_hint_replicas_override() {
     let expected_config = StackerDBConfig {
         chunk_size: 123,
         signers: vec![(
-            StacksAddress {
-                version: 26,
-                bytes: Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b").unwrap(),
-            },
+            StacksAddress::new(
+                26,
+                Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b").unwrap(),
+            )
+            .unwrap(),
             3,
         )],
         write_freq: 4,

--- a/stackslib/src/net/stackerdb/tests/db.rs
+++ b/stackslib/src/net/stackerdb/tests/db.rs
@@ -62,67 +62,37 @@ fn test_stackerdb_create_list_delete() {
     let mut db = StackerDBs::connect(path, true).unwrap();
     let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
 
-    let slots = [(
-        StacksAddress {
-            version: 0x02,
-            bytes: Hash160([0x02; 20]),
-        },
-        1,
-    )];
+    let slots = [(StacksAddress::new(0x02, Hash160([0x02; 20])).unwrap(), 1)];
 
     // databases with one chunk
     tx.create_stackerdb(
         &QualifiedContractIdentifier::new(
-            StacksAddress {
-                version: 0x01,
-                bytes: Hash160([0x01; 20]),
-            }
-            .into(),
+            StacksAddress::new(0x01, Hash160([0x01; 20]))
+                .unwrap()
+                .into(),
             ContractName::try_from("db1").unwrap(),
         ),
-        &[(
-            StacksAddress {
-                version: 0x01,
-                bytes: Hash160([0x01; 20]),
-            },
-            1,
-        )],
+        &[(StacksAddress::new(0x01, Hash160([0x01; 20])).unwrap(), 1)],
     )
     .unwrap();
     tx.create_stackerdb(
         &QualifiedContractIdentifier::new(
-            StacksAddress {
-                version: 0x02,
-                bytes: Hash160([0x02; 20]),
-            }
-            .into(),
+            StacksAddress::new(0x02, Hash160([0x02; 20]))
+                .unwrap()
+                .into(),
             ContractName::try_from("db2").unwrap(),
         ),
-        &[(
-            StacksAddress {
-                version: 0x02,
-                bytes: Hash160([0x02; 20]),
-            },
-            1,
-        )],
+        &[(StacksAddress::new(0x02, Hash160([0x02; 20])).unwrap(), 1)],
     )
     .unwrap();
     tx.create_stackerdb(
         &QualifiedContractIdentifier::new(
-            StacksAddress {
-                version: 0x03,
-                bytes: Hash160([0x03; 20]),
-            }
-            .into(),
+            StacksAddress::new(0x03, Hash160([0x03; 20]))
+                .unwrap()
+                .into(),
             ContractName::try_from("db3").unwrap(),
         ),
-        &[(
-            StacksAddress {
-                version: 0x03,
-                bytes: Hash160([0x03; 20]),
-            },
-            1,
-        )],
+        &[(StacksAddress::new(0x03, Hash160([0x03; 20])).unwrap(), 1)],
     )
     .unwrap();
 
@@ -135,27 +105,21 @@ fn test_stackerdb_create_list_delete() {
         dbs,
         vec![
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x01,
-                    bytes: Hash160([0x01; 20])
-                }
-                .into(),
+                StacksAddress::new(0x01, Hash160([0x01; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db1").unwrap()
             ),
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x02,
-                    bytes: Hash160([0x02; 20])
-                }
-                .into(),
+                StacksAddress::new(0x02, Hash160([0x02; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db2").unwrap()
             ),
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x03,
-                    bytes: Hash160([0x03; 20])
-                }
-                .into(),
+                StacksAddress::new(0x03, Hash160([0x03; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db3").unwrap()
             ),
         ]
@@ -166,11 +130,9 @@ fn test_stackerdb_create_list_delete() {
     if let net_error::StackerDBExists(..) = tx
         .create_stackerdb(
             &QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x01,
-                    bytes: Hash160([0x01; 20]),
-                }
-                .into(),
+                StacksAddress::new(0x01, Hash160([0x01; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db1").unwrap(),
             ),
             &[],
@@ -189,27 +151,21 @@ fn test_stackerdb_create_list_delete() {
         dbs,
         vec![
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x01,
-                    bytes: Hash160([0x01; 20])
-                }
-                .into(),
+                StacksAddress::new(0x01, Hash160([0x01; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db1").unwrap()
             ),
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x02,
-                    bytes: Hash160([0x02; 20])
-                }
-                .into(),
+                StacksAddress::new(0x02, Hash160([0x02; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db2").unwrap()
             ),
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x03,
-                    bytes: Hash160([0x03; 20])
-                }
-                .into(),
+                StacksAddress::new(0x03, Hash160([0x03; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db3").unwrap()
             ),
         ]
@@ -223,11 +179,9 @@ fn test_stackerdb_create_list_delete() {
     // remove a db
     let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
     tx.delete_stackerdb(&QualifiedContractIdentifier::new(
-        StacksAddress {
-            version: 0x01,
-            bytes: Hash160([0x01; 20]),
-        }
-        .into(),
+        StacksAddress::new(0x01, Hash160([0x01; 20]))
+            .unwrap()
+            .into(),
         ContractName::try_from("db1").unwrap(),
     ))
     .unwrap();
@@ -240,19 +194,15 @@ fn test_stackerdb_create_list_delete() {
         dbs,
         vec![
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x02,
-                    bytes: Hash160([0x02; 20])
-                }
-                .into(),
+                StacksAddress::new(0x02, Hash160([0x02; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db2").unwrap()
             ),
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x03,
-                    bytes: Hash160([0x03; 20])
-                }
-                .into(),
+                StacksAddress::new(0x03, Hash160([0x03; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db3").unwrap()
             ),
         ]
@@ -266,11 +216,9 @@ fn test_stackerdb_create_list_delete() {
     // deletion is idempotent
     let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
     tx.delete_stackerdb(&QualifiedContractIdentifier::new(
-        StacksAddress {
-            version: 0x01,
-            bytes: Hash160([0x01; 20]),
-        }
-        .into(),
+        StacksAddress::new(0x01, Hash160([0x01; 20]))
+            .unwrap()
+            .into(),
         ContractName::try_from("db1").unwrap(),
     ))
     .unwrap();
@@ -283,19 +231,15 @@ fn test_stackerdb_create_list_delete() {
         dbs,
         vec![
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x02,
-                    bytes: Hash160([0x02; 20])
-                }
-                .into(),
+                StacksAddress::new(0x02, Hash160([0x02; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db2").unwrap()
             ),
             QualifiedContractIdentifier::new(
-                StacksAddress {
-                    version: 0x03,
-                    bytes: Hash160([0x03; 20])
-                }
-                .into(),
+                StacksAddress::new(0x03, Hash160([0x03; 20]))
+                    .unwrap()
+                    .into(),
                 ContractName::try_from("db3").unwrap()
             ),
         ]
@@ -313,11 +257,9 @@ fn test_stackerdb_prepare_clear_slots() {
     setup_test_path(path);
 
     let sc = QualifiedContractIdentifier::new(
-        StacksAddress {
-            version: 0x01,
-            bytes: Hash160([0x01; 20]),
-        }
-        .into(),
+        StacksAddress::new(0x01, Hash160([0x01; 20]))
+            .unwrap()
+            .into(),
         ContractName::try_from("db1").unwrap(),
     );
 
@@ -327,27 +269,9 @@ fn test_stackerdb_prepare_clear_slots() {
     tx.create_stackerdb(
         &sc,
         &[
-            (
-                StacksAddress {
-                    version: 0x02,
-                    bytes: Hash160([0x02; 20]),
-                },
-                2,
-            ),
-            (
-                StacksAddress {
-                    version: 0x03,
-                    bytes: Hash160([0x03; 20]),
-                },
-                3,
-            ),
-            (
-                StacksAddress {
-                    version: 0x04,
-                    bytes: Hash160([0x04; 20]),
-                },
-                4,
-            ),
+            (StacksAddress::new(0x02, Hash160([0x02; 20])).unwrap(), 2),
+            (StacksAddress::new(0x03, Hash160([0x03; 20])).unwrap(), 3),
+            (StacksAddress::new(0x04, Hash160([0x04; 20])).unwrap(), 4),
         ],
     )
     .unwrap();
@@ -363,28 +287,19 @@ fn test_stackerdb_prepare_clear_slots() {
             // belongs to 0x02
             assert_eq!(
                 slot_validation.signer,
-                StacksAddress {
-                    version: 0x02,
-                    bytes: Hash160([0x02; 20])
-                }
+                StacksAddress::new(0x02, Hash160([0x02; 20])).unwrap()
             );
         } else if slot_id >= 2 && slot_id < 2 + 3 {
             // belongs to 0x03
             assert_eq!(
                 slot_validation.signer,
-                StacksAddress {
-                    version: 0x03,
-                    bytes: Hash160([0x03; 20])
-                }
+                StacksAddress::new(0x03, Hash160([0x03; 20])).unwrap()
             );
         } else if slot_id >= 2 + 3 && slot_id < 2 + 3 + 4 {
             // belongs to 0x03
             assert_eq!(
                 slot_validation.signer,
-                StacksAddress {
-                    version: 0x04,
-                    bytes: Hash160([0x04; 20])
-                }
+                StacksAddress::new(0x04, Hash160([0x04; 20])).unwrap()
             );
         } else {
             unreachable!()
@@ -424,11 +339,9 @@ fn test_stackerdb_insert_query_chunks() {
     setup_test_path(path);
 
     let sc = QualifiedContractIdentifier::new(
-        StacksAddress {
-            version: 0x01,
-            bytes: Hash160([0x01; 20]),
-        }
-        .into(),
+        StacksAddress::new(0x01, Hash160([0x01; 20]))
+            .unwrap()
+            .into(),
         ContractName::try_from("db1").unwrap(),
     );
 
@@ -579,11 +492,9 @@ fn test_reconfigure_stackerdb() {
     setup_test_path(path);
 
     let sc = QualifiedContractIdentifier::new(
-        StacksAddress {
-            version: 0x01,
-            bytes: Hash160([0x01; 20]),
-        }
-        .into(),
+        StacksAddress::new(0x01, Hash160([0x01; 20]))
+            .unwrap()
+            .into(),
         ContractName::try_from("db1").unwrap(),
     );
 

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -69,10 +69,11 @@ impl StackerDBConfig {
 /// `setup_stackerdb()`
 fn add_stackerdb(config: &mut TestPeerConfig, stackerdb_config: Option<StackerDBConfig>) -> usize {
     let name = ContractName::try_from(format!("db-{}", config.stacker_dbs.len())).unwrap();
-    let addr = StacksAddress {
-        version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-        bytes: Hash160::from_data(&config.stacker_dbs.len().to_be_bytes()),
-    };
+    let addr = StacksAddress::new(
+        C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+        Hash160::from_data(&config.stacker_dbs.len().to_be_bytes()),
+    )
+    .unwrap();
 
     let stackerdb_config = stackerdb_config.unwrap_or(StackerDBConfig::noop());
 
@@ -110,10 +111,11 @@ fn setup_stackerdb(peer: &mut TestPeer, idx: usize, fill: bool, num_slots: usize
             }
         };
         let pubk = StacksPublicKey::from_private(&pk);
-        let addr = StacksAddress {
-            version: C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-            bytes: Hash160::from_node_public_key(&pubk),
-        };
+        let addr = StacksAddress::new(
+            C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+            Hash160::from_node_public_key(&pubk),
+        )
+        .unwrap();
 
         pks.push(pk);
         slots.push((addr, 1u32));

--- a/stackslib/src/net/tests/convergence.rs
+++ b/stackslib/src/net/tests/convergence.rs
@@ -39,7 +39,7 @@ fn setup_rlimit_nofiles() {
 
 fn stacker_db_id(i: usize) -> QualifiedContractIdentifier {
     QualifiedContractIdentifier::new(
-        StandardPrincipalData(0x01, [i as u8; 20]),
+        StandardPrincipalData::new(0x01, [i as u8; 20]).unwrap(),
         format!("db-{}", i).as_str().into(),
     )
 }

--- a/stackslib/src/net/tests/httpcore.rs
+++ b/stackslib/src/net/tests/httpcore.rs
@@ -151,10 +151,7 @@ fn make_test_transaction() -> StacksTransaction {
     .unwrap();
     let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
     let addr = auth.origin().address_testnet();
-    let recv_addr = StacksAddress {
-        version: 1,
-        bytes: Hash160([0xff; 20]),
-    };
+    let recv_addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
 
     let mut tx_stx_transfer = StacksTransaction::new(
         TransactionVersion::Testnet,

--- a/stackslib/src/net/tests/mempool/mod.rs
+++ b/stackslib/src/net/tests/mempool/mod.rs
@@ -86,10 +86,8 @@ fn test_mempool_sync_2_peers() {
         peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
     }
 
-    let addr = StacksAddress {
-        version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr =
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0xff; 20])).unwrap();
 
     let stacks_tip_ch = peer_1.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bhh = peer_1.network.stacks_tip.block_hash.clone();
@@ -354,10 +352,8 @@ fn test_mempool_sync_2_peers_paginated() {
         peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
     }
 
-    let addr = StacksAddress {
-        version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr =
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0xff; 20])).unwrap();
 
     let stacks_tip_ch = peer_1.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bhh = peer_1.network.stacks_tip.block_hash.clone();
@@ -545,10 +541,8 @@ fn test_mempool_sync_2_peers_blacklisted() {
         peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
     }
 
-    let addr = StacksAddress {
-        version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr =
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0xff; 20])).unwrap();
 
     let stacks_tip_ch = peer_1.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bhh = peer_1.network.stacks_tip.block_hash.clone();
@@ -756,10 +750,8 @@ fn test_mempool_sync_2_peers_problematic() {
         peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
     }
 
-    let addr = StacksAddress {
-        version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr =
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0xff; 20])).unwrap();
 
     let stacks_tip_ch = peer_1.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bhh = peer_1.network.stacks_tip.block_hash.clone();
@@ -1143,10 +1135,8 @@ fn test_mempool_sync_2_peers_nakamoto_paginated() {
 
     debug!("Peers are connected");
 
-    let addr = StacksAddress {
-        version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        bytes: Hash160([0xff; 20]),
-    };
+    let addr =
+        StacksAddress::new(C32_ADDRESS_VERSION_TESTNET_SINGLESIG, Hash160([0xff; 20])).unwrap();
 
     let stacks_tip_ch = peer_1.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bhh = peer_1.network.stacks_tip.block_hash.clone();

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -443,7 +443,7 @@ impl NakamotoBootPlan {
         let mut other_peer_nonces = vec![0; other_peers.len()];
         let addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&self.private_key));
         let default_pox_addr =
-            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes.clone());
+            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes().clone());
 
         let mut sortition_height = peer.get_burn_block_height();
         debug!("\n\n======================");

--- a/stackslib/src/util_lib/boot.rs
+++ b/stackslib/src/util_lib/boot.rs
@@ -25,7 +25,7 @@ pub fn boot_code_addr(mainnet: bool) -> StacksAddress {
 pub fn boot_code_tx_auth(boot_code_address: StacksAddress) -> TransactionAuth {
     TransactionAuth::Standard(TransactionSpendingCondition::Singlesig(
         SinglesigSpendingCondition {
-            signer: boot_code_address.bytes.clone(),
+            signer: boot_code_address.bytes().clone(),
             hash_mode: SinglesigHashMode::P2PKH,
             key_encoding: TransactionPublicKeyEncoding::Uncompressed,
             nonce: 0,

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -300,7 +300,9 @@ pub mod pox4 {
             // Test 2: invalid pox address
             let other_pox_address = PoxAddress::from_legacy(
                 AddressHashMode::SerializeP2PKH,
-                StacksAddress::p2pkh(false, &Secp256k1PublicKey::new()).bytes,
+                StacksAddress::p2pkh(false, &Secp256k1PublicKey::new())
+                    .destruct()
+                    .1,
             );
             let result = call_get_signer_message_hash(
                 &mut sim,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -546,7 +546,7 @@ fn transition_fixes_bitcoin_rigidity() {
     let _spender_btc_addr = BitcoinAddress::from_bytes_legacy(
         BitcoinNetworkType::Regtest,
         LegacyBitcoinAddressType::PublicKeyHash,
-        &spender_stx_addr.bytes.0,
+        &spender_stx_addr.bytes().0,
     )
     .unwrap();
 

--- a/testnet/stacks-node/src/tests/epoch_22.rs
+++ b/testnet/stacks-node/src/tests/epoch_22.rs
@@ -444,22 +444,23 @@ fn disable_pox() {
     let reward_cycle_max = *reward_cycle_pox_addrs.keys().max().unwrap();
 
     let pox_addr_1 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_2 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_3 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let burn_pox_addr = PoxAddress::Standard(
         StacksAddress::new(
             26,
             Hash160::from_hex("0000000000000000000000000000000000000000").unwrap(),
-        ),
+        )
+        .unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
 
@@ -1110,22 +1111,23 @@ fn pox_2_unlock_all() {
     let reward_cycle_max = *reward_cycle_pox_addrs.keys().max().unwrap();
 
     let pox_addr_1 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_2 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_3 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let burn_pox_addr = PoxAddress::Standard(
         StacksAddress::new(
             26,
             Hash160::from_hex("0000000000000000000000000000000000000000").unwrap(),
-        ),
+        )
+        .unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
 

--- a/testnet/stacks-node/src/tests/epoch_24.rs
+++ b/testnet/stacks-node/src/tests/epoch_24.rs
@@ -540,22 +540,23 @@ fn fix_to_pox_contract() {
     let reward_cycle_max = *reward_cycle_pox_addrs.keys().max().unwrap();
 
     let pox_addr_1 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_2 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_3 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let burn_pox_addr = PoxAddress::Standard(
         StacksAddress::new(
             26,
             Hash160::from_hex("0000000000000000000000000000000000000000").unwrap(),
-        ),
+        )
+        .unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
 
@@ -1088,7 +1089,7 @@ fn verify_auto_unlock_behavior() {
         info!("reward set entries: {reward_set_entries:?}");
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            pox_pubkey_2_stx_addr.bytes.0.to_vec()
+            pox_pubkey_2_stx_addr.bytes().0
         );
         assert_eq!(
             reward_set_entries[0].amount_stacked,
@@ -1096,7 +1097,7 @@ fn verify_auto_unlock_behavior() {
         );
         assert_eq!(
             reward_set_entries[1].reward_address.bytes(),
-            pox_pubkey_3_stx_addr.bytes.0.to_vec()
+            pox_pubkey_3_stx_addr.bytes().0
         );
         assert_eq!(reward_set_entries[1].amount_stacked, small_stacked as u128);
     }
@@ -1165,7 +1166,7 @@ fn verify_auto_unlock_behavior() {
         assert_eq!(reward_set_entries.len(), 1);
         assert_eq!(
             reward_set_entries[0].reward_address.bytes(),
-            pox_pubkey_2_stx_addr.bytes.0.to_vec()
+            pox_pubkey_2_stx_addr.bytes().0
         );
         assert_eq!(
             reward_set_entries[0].amount_stacked,
@@ -1244,22 +1245,23 @@ fn verify_auto_unlock_behavior() {
     let reward_cycle_max = *reward_cycle_pox_addrs.keys().max().unwrap();
 
     let pox_addr_1 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_1).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_2 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_2).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let pox_addr_3 = PoxAddress::Standard(
-        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()),
+        StacksAddress::new(26, Hash160::from_hex(&pox_pubkey_hash_3).unwrap()).unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
     let burn_pox_addr = PoxAddress::Standard(
         StacksAddress::new(
             26,
             Hash160::from_hex("0000000000000000000000000000000000000000").unwrap(),
-        ),
+        )
+        .unwrap(),
         Some(AddressHashMode::SerializeP2PKH),
     );
 

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -328,7 +328,7 @@ fn mempool_setup_chainstate() {
 
                 // mismatched network on contract-call!
                 let bad_addr = StacksAddress::from_public_keys(
-                    88,
+                    18,
                     &AddressHashMode::SerializeP2PKH,
                     1,
                     &vec![StacksPublicKey::from_private(&other_sk)],
@@ -470,8 +470,12 @@ fn mempool_setup_chainstate() {
                 });
 
                 // recipient must be testnet
-                let mut mainnet_recipient = to_addr(&other_sk);
-                mainnet_recipient.version = C32_ADDRESS_VERSION_MAINNET_SINGLESIG;
+                let testnet_recipient = to_addr(&other_sk);
+                let mainnet_recipient = StacksAddress::new(
+                    C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+                    testnet_recipient.destruct().1,
+                )
+                .unwrap();
                 let mainnet_princ = mainnet_recipient.into();
                 let tx_bytes = make_stacks_transfer(
                     &contract_sk,

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -488,10 +488,11 @@ pub fn get_latest_block_proposal(
     )
     .map_err(|e| e.to_string())?;
     let miner_signed_addr = StacksAddress::p2pkh(false, &pubkey);
-    if miner_signed_addr.bytes != miner_addr.bytes {
+    if miner_signed_addr.bytes() != miner_addr.bytes() {
         return Err(format!(
             "Invalid miner signature on proposal. Found {}, expected {}",
-            miner_signed_addr.bytes, miner_addr.bytes
+            miner_signed_addr.bytes(),
+            miner_addr.bytes()
         ));
     }
 
@@ -911,7 +912,7 @@ pub fn boot_to_epoch_3(
     for (stacker_sk, signer_sk) in stacker_sks.iter().zip(signer_sks.iter()) {
         let pox_addr = PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            tests::to_addr(stacker_sk).bytes,
+            tests::to_addr(stacker_sk).bytes().clone(),
         );
         let pox_addr_tuple: clarity::vm::Value =
             pox_addr.clone().as_clarity_tuple().unwrap().into();
@@ -1073,7 +1074,7 @@ pub fn boot_to_pre_epoch_3_boundary(
     for (stacker_sk, signer_sk) in stacker_sks.iter().zip(signer_sks.iter()) {
         let pox_addr = PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            tests::to_addr(stacker_sk).bytes,
+            tests::to_addr(stacker_sk).bytes().clone(),
         );
         let pox_addr_tuple: clarity::vm::Value =
             pox_addr.clone().as_clarity_tuple().unwrap().into();
@@ -1312,7 +1313,7 @@ pub fn setup_epoch_3_reward_set(
     for (stacker_sk, signer_sk) in stacker_sks.iter().zip(signer_sks.iter()) {
         let pox_addr = PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            tests::to_addr(stacker_sk).bytes,
+            tests::to_addr(stacker_sk).bytes().clone(),
         );
         let pox_addr_tuple: clarity::vm::Value =
             pox_addr.clone().as_clarity_tuple().unwrap().into();
@@ -2559,7 +2560,7 @@ fn correct_burn_outs() {
 
             let pox_addr = PoxAddress::from_legacy(
                 AddressHashMode::SerializeP2PKH,
-                tests::to_addr(account.0).bytes,
+                tests::to_addr(account.0).bytes().clone(),
             );
             let pox_addr_tuple: clarity::vm::Value =
                 pox_addr.clone().as_clarity_tuple().unwrap().into();
@@ -11122,4 +11123,120 @@ fn test_tenure_extend_from_flashblocks() {
     follower_run_loop_stopper.store(false, Ordering::SeqCst);
 
     follower_thread.join().unwrap();
+}
+
+/// Mine a smart contract transaction with a call to `from-consensus-buff?` that would decode to an
+/// invalid Principal. Verify that this transaction is dropped from the mempool.
+#[test]
+#[ignore]
+fn mine_invalid_principal_from_consensus_buff() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (mut conf, _miner_account) = naka_neon_integration_conf(None);
+    let password = "12345".to_string();
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    conf.connection_options.auth_token = Some(password.clone());
+    conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
+    let stacker_sk = setup_stacker(&mut conf);
+    let signer_sk = Secp256k1PrivateKey::new();
+    let signer_addr = tests::to_addr(&signer_sk);
+    let sender_sk = Secp256k1PrivateKey::new();
+    // setup sender + recipient for some test stx transfers
+    // these are necessary for the interim blocks to get mined at all
+    let sender_addr = tests::to_addr(&sender_sk);
+    conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1000000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+
+    test_observer::spawn();
+    test_observer::register(&mut conf, &[EventKeyType::AnyEvent]);
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .expect("Failed starting bitcoind");
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    btc_regtest_controller.bootstrap_chain(201);
+
+    let mut run_loop = boot_nakamoto::BootRunLoop::new(conf.clone()).unwrap();
+    let run_loop_stopper = run_loop.get_termination_switch();
+    let Counters {
+        blocks_processed,
+        naka_submitted_commits: commits_submitted,
+        naka_proposed_blocks: proposals_submitted,
+        naka_mined_blocks: mined_blocks,
+        ..
+    } = run_loop.counters();
+
+    let coord_channel = run_loop.coordinator_channels();
+
+    let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
+    let mut signers = TestSigners::new(vec![signer_sk]);
+    wait_for_runloop(&blocks_processed);
+    boot_to_epoch_3(
+        &conf,
+        &blocks_processed,
+        &[stacker_sk],
+        &[signer_sk],
+        &mut Some(&mut signers),
+        &mut btc_regtest_controller,
+    );
+
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    blind_signer(&conf, &signers, proposals_submitted);
+
+    wait_for_first_naka_block_commit(60, &commits_submitted);
+
+    // submit faulty contract
+    let contract = "(print (from-consensus-buff? principal 0x062011deadbeef11ababffff11deadbeef11ababffff0461626364))";
+
+    let contract_tx_bytes = make_contract_publish(
+        &sender_sk,
+        0,
+        1024,
+        conf.burnchain.chain_id,
+        "contract",
+        &contract,
+    );
+    submit_tx(&http_origin, &contract_tx_bytes);
+
+    let contract_tx =
+        StacksTransaction::consensus_deserialize(&mut &contract_tx_bytes[..]).unwrap();
+
+    // mine one more block
+    let blocks_before = mined_blocks.load(Ordering::SeqCst);
+    let blocks_processed_before = coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .get_stacks_blocks_processed();
+    let commits_before = commits_submitted.load(Ordering::SeqCst);
+    next_block_and(&mut btc_regtest_controller, 60, || {
+        let blocks_count = mined_blocks.load(Ordering::SeqCst);
+        let blocks_processed = coord_channel
+            .lock()
+            .expect("Mutex poisoned")
+            .get_stacks_blocks_processed();
+        Ok(blocks_count > blocks_before
+            && blocks_processed > blocks_processed_before
+            && commits_submitted.load(Ordering::SeqCst) > commits_before)
+    })
+    .unwrap();
+
+    let dropped_txs = test_observer::get_memtx_drops();
+
+    // we identified and dropped the offending tx as problematic
+    debug!("dropped_txs: {:?}", &dropped_txs);
+    assert_eq!(dropped_txs.len(), 1);
+    assert_eq!(dropped_txs[0].0, format!("0x{}", &contract_tx.txid()));
+    assert_eq!(dropped_txs[0].1.as_str(), "Problematic");
+
+    coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    run_loop_stopper.store(false, Ordering::SeqCst);
+
+    run_loop_thread.join().unwrap();
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1909,7 +1909,7 @@ fn stx_transfer_btc_integration_test() {
     let _spender_btc_addr = BitcoinAddress::from_bytes_legacy(
         BitcoinNetworkType::Regtest,
         LegacyBitcoinAddressType::PublicKeyHash,
-        &spender_stx_addr.bytes.0,
+        &spender_stx_addr.bytes().0,
     )
     .unwrap();
 

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -128,7 +128,7 @@ impl SignerTest<SpawnedSigner> {
         for stacker_sk in self.signer_stacks_private_keys.iter() {
             let pox_addr = PoxAddress::from_legacy(
                 AddressHashMode::SerializeP2PKH,
-                tests::to_addr(stacker_sk).bytes,
+                tests::to_addr(stacker_sk).bytes().clone(),
             );
             let pox_addr_tuple: clarity::vm::Value =
                 pox_addr.clone().as_clarity_tuple().unwrap().into();
@@ -4193,7 +4193,7 @@ fn signer_set_rollover() {
     for stacker_sk in new_signer_private_keys.iter() {
         let pox_addr = PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
-            tests::to_addr(stacker_sk).bytes,
+            tests::to_addr(stacker_sk).bytes().clone(),
         );
         let pox_addr_tuple: clarity::vm::Value =
             pox_addr.clone().as_clarity_tuple().unwrap().into();
@@ -10923,7 +10923,7 @@ fn injected_signatures_are_ignored_across_boundaries() {
     // Stack the new signer
     let pox_addr = PoxAddress::from_legacy(
         AddressHashMode::SerializeP2PKH,
-        tests::to_addr(&new_signer_private_key).bytes,
+        tests::to_addr(&new_signer_private_key).bytes().clone(),
     );
     let pox_addr_tuple: clarity::vm::Value = pox_addr.clone().as_clarity_tuple().unwrap().into();
     let signature = make_pox_4_signer_key_signature(


### PR DESCRIPTION
This refactor makes it easier to use StacksAddress and PrincipalData.