### PR TITLE
Apply `clippy::unnecesary_to_owned` and `clippy::unwrap_or_default` fixes throughout stacks core

### DIFF
--- a/libsigner/src/tests/mod.rs
+++ b/libsigner/src/tests/mod.rs
@@ -128,7 +128,7 @@ fn test_simple_signer() {
         reward_cycle: 1,
     };
     for i in 0..max_events {
-        let privk = Secp256k1PrivateKey::new();
+        let privk = Secp256k1PrivateKey::random();
         let message = SignerMessage::BlockProposal(block_proposal.clone());
         let message_bytes = message.serialize_to_vec();
         let mut chunk = StackerDBChunkData::new(i as u32, 1, message_bytes);

--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -1192,7 +1192,7 @@ mod test {
         let rejection = BlockRejection::new(
             Sha512Trunc256Sum([0u8; 32]),
             RejectCode::ValidationFailed(ValidateRejectCode::InvalidBlock),
-            &StacksPrivateKey::new(),
+            &StacksPrivateKey::random(),
             thread_rng().gen_bool(0.5),
             thread_rng().next_u64(),
         );
@@ -1204,7 +1204,7 @@ mod test {
         let rejection = BlockRejection::new(
             Sha512Trunc256Sum([1u8; 32]),
             RejectCode::ConnectivityIssues,
-            &StacksPrivateKey::new(),
+            &StacksPrivateKey::random(),
             thread_rng().gen_bool(0.5),
             thread_rng().next_u64(),
         );
@@ -1231,7 +1231,7 @@ mod test {
         let response = BlockResponse::Rejected(BlockRejection::new(
             Sha512Trunc256Sum([1u8; 32]),
             RejectCode::ValidationFailed(ValidateRejectCode::InvalidBlock),
-            &StacksPrivateKey::new(),
+            &StacksPrivateKey::random(),
             thread_rng().gen_bool(0.5),
             thread_rng().next_u64(),
         ));
@@ -1318,10 +1318,10 @@ mod test {
 
     #[test]
     fn verify_sign_mock_proposal() {
-        let private_key = StacksPrivateKey::new();
+        let private_key = StacksPrivateKey::random();
         let public_key = StacksPublicKey::from_private(&private_key);
 
-        let bad_private_key = StacksPrivateKey::new();
+        let bad_private_key = StacksPrivateKey::random();
         let bad_public_key = StacksPublicKey::from_private(&bad_private_key);
 
         let mut mock_proposal = random_mock_proposal();
@@ -1353,7 +1353,7 @@ mod test {
     #[test]
     fn serde_mock_proposal() {
         let mut mock_signature = random_mock_proposal();
-        mock_signature.sign(&StacksPrivateKey::new()).unwrap();
+        mock_signature.sign(&StacksPrivateKey::random()).unwrap();
         let serialized_signature = mock_signature.serialize_to_vec();
         let deserialized_signature = read_next::<MockProposal, _>(&mut &serialized_signature[..])
             .expect("Failed to deserialize MockSignature");
@@ -1368,7 +1368,7 @@ mod test {
             metadata: SignerMessageMetadata::default(),
         };
         mock_signature
-            .sign(&StacksPrivateKey::new())
+            .sign(&StacksPrivateKey::random())
             .expect("Failed to sign MockSignature");
         let serialized_signature = mock_signature.serialize_to_vec();
         let deserialized_signature = read_next::<MockSignature, _>(&mut &serialized_signature[..])
@@ -1379,8 +1379,10 @@ mod test {
     #[test]
     fn serde_mock_block() {
         let mock_proposal = random_mock_proposal();
-        let mock_signature_1 = MockSignature::new(mock_proposal.clone(), &StacksPrivateKey::new());
-        let mock_signature_2 = MockSignature::new(mock_proposal.clone(), &StacksPrivateKey::new());
+        let mock_signature_1 =
+            MockSignature::new(mock_proposal.clone(), &StacksPrivateKey::random());
+        let mock_signature_2 =
+            MockSignature::new(mock_proposal.clone(), &StacksPrivateKey::random());
         let mock_block = MockBlock {
             mock_proposal,
             mock_signatures: vec![mock_signature_1, mock_signature_2],

--- a/libstackerdb/src/tests/mod.rs
+++ b/libstackerdb/src/tests/mod.rs
@@ -24,7 +24,7 @@ use crate::*;
 
 #[test]
 fn test_stackerdb_slot_metadata_sign_verify() {
-    let pk = StacksPrivateKey::new();
+    let pk = StacksPrivateKey::random();
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,

--- a/stacks-common/src/util/secp256k1.rs
+++ b/stacks-common/src/util/secp256k1.rs
@@ -123,7 +123,7 @@ impl Default for Secp256k1PublicKey {
 impl Secp256k1PublicKey {
     #[cfg(any(test, feature = "testing"))]
     pub fn new() -> Secp256k1PublicKey {
-        Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new())
+        Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random())
     }
 
     pub fn from_hex(hex_string: &str) -> Result<Secp256k1PublicKey, &'static str> {
@@ -249,14 +249,8 @@ impl PublicKey for Secp256k1PublicKey {
     }
 }
 
-impl Default for Secp256k1PrivateKey {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Secp256k1PrivateKey {
-    pub fn new() -> Secp256k1PrivateKey {
+    pub fn random() -> Secp256k1PrivateKey {
         let mut rng = rand::thread_rng();
         loop {
             // keep trying to generate valid bytes
@@ -460,7 +454,7 @@ mod tests {
 
     #[test]
     fn test_parse_serialize_compressed() {
-        let mut t1 = Secp256k1PrivateKey::new();
+        let mut t1 = Secp256k1PrivateKey::random();
         t1.set_compress_public(true);
         let h_comp = t1.to_hex();
         t1.set_compress_public(false);
@@ -654,7 +648,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         for i in 0..100 {
-            let privk = Secp256k1PrivateKey::new();
+            let privk = Secp256k1PrivateKey::random();
             let pubk = Secp256k1PublicKey::from_private(&privk);
 
             let mut msg = [0u8; 32];

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -302,7 +302,7 @@ pub(crate) mod tests {
         pox_consensus_hash: Option<ConsensusHash>,
     ) -> (String, RPCPeerInfoData) {
         // Generate some random info
-        let private_key = StacksPrivateKey::new();
+        let private_key = StacksPrivateKey::random();
         let public_key = StacksPublicKey::from_private(&private_key);
         let public_key_buf = StacksPublicKeyBuffer::from_public_key(&public_key);
         let public_key_hash = Hash160::from_node_public_key(&public_key);
@@ -376,7 +376,7 @@ pub(crate) mod tests {
             let private_key = if signer_id == 0 {
                 config.stacks_private_key
             } else {
-                StacksPrivateKey::new()
+                StacksPrivateKey::random()
             };
             let public_key = StacksPublicKey::from_private(&private_key);
 

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn send_signer_message_should_succeed() {
         let signer_config = build_signer_config_tomls(
-            &[StacksPrivateKey::new()],
+            &[StacksPrivateKey::random()],
             "localhost:20443",
             Some(Duration::from_millis(128)), // Timeout defaults to 5 seconds. Let's override it to 128 milliseconds.
             &Network::Testnet,

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -1197,7 +1197,7 @@ mod tests {
     #[test]
     fn get_reward_set_should_succeed() {
         let mock = MockServerClient::new();
-        let private_key = StacksPrivateKey::new();
+        let private_key = StacksPrivateKey::random();
         let public_key = StacksPublicKey::from_private(&private_key);
         let mut bytes = [0u8; 33];
         bytes.copy_from_slice(&public_key.to_bytes_compressed());

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -409,10 +409,10 @@ pub mod tests {
     #[test]
     fn test_verify_vote() {
         let mut rand = rand::thread_rng();
-        let private_key = Secp256k1PrivateKey::new();
+        let private_key = Secp256k1PrivateKey::random();
         let public_key = StacksPublicKey::from_private(&private_key);
 
-        let invalid_private_key = Secp256k1PrivateKey::new();
+        let invalid_private_key = Secp256k1PrivateKey::random();
         let invalid_public_key = StacksPublicKey::from_private(&invalid_private_key);
 
         let sip = rand.next_u32();

--- a/stacks-signer/src/monitor_signers.rs
+++ b/stacks-signer/src/monitor_signers.rs
@@ -55,7 +55,7 @@ impl SignerMonitor {
     pub fn new(args: MonitorSignersArgs) -> Self {
         url::Url::parse(&format!("http://{}", args.host)).expect("Failed to parse node host");
         let stacks_client = StacksClient::try_from_host(
-            StacksPrivateKey::new(), // We don't need a private key to read
+            StacksPrivateKey::random(), // We don't need a private key to read
             args.host.clone(),
             "FOO".to_string(), // We don't care about authorized paths. Just accessing public info
         )

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -544,7 +544,8 @@ mod tests {
         let weight = 10;
         let mut signer_entries = Vec::with_capacity(nmb_signers);
         for _ in 0..nmb_signers {
-            let key = StacksPublicKey::from_private(&StacksPrivateKey::new()).to_bytes_compressed();
+            let key =
+                StacksPublicKey::from_private(&StacksPrivateKey::random()).to_bytes_compressed();
             let mut signing_key = [0u8; 33];
             signing_key.copy_from_slice(&key);
             signer_entries.push(NakamotoSignerEntry {

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -1674,13 +1674,13 @@ mod tests {
             previous_tenure_blocks: 1,
             cause: TenureChangeCause::BlockFound,
             pubkey_hash: Hash160::from_node_public_key(&StacksPublicKey::from_private(
-                &StacksPrivateKey::new(),
+                &StacksPrivateKey::random(),
             )),
         };
         let tenure_change_tx_payload = TransactionPayload::TenureChange(tenure_change_payload);
         let tenure_change_tx = StacksTransaction::new(
             TransactionVersion::Testnet,
-            TransactionAuth::from_p2pkh(&StacksPrivateKey::new()).unwrap(),
+            TransactionAuth::from_p2pkh(&StacksPrivateKey::random()).unwrap(),
             tenure_change_tx_payload,
         );
 

--- a/stacks-signer/src/tests/chainstate.rs
+++ b/stacks-signer/src/tests/chainstate.rs
@@ -95,7 +95,7 @@ fn setup_test_environment(
     };
 
     let stacks_client = StacksClient::new(
-        StacksPrivateKey::new(),
+        StacksPrivateKey::random(),
         SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 10000).to_string(),
         "FOO".into(),
         false,

--- a/stackslib/src/blockstack_cli.rs
+++ b/stackslib/src/blockstack_cli.rs
@@ -579,7 +579,7 @@ fn generate_secret_key(args: &[String], version: TransactionVersion) -> Result<S
         return Err(CliError::Message(format!("USAGE:\n {}", GENERATE_USAGE)));
     }
 
-    let sk = StacksPrivateKey::new();
+    let sk = StacksPrivateKey::random();
     let pk = StacksPublicKey::from_private(&sk);
     let version = match version {
         TransactionVersion::Mainnet => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
@@ -1157,7 +1157,7 @@ mod test {
                 .contains("Failed to decode hex")
         );
 
-        let sk = StacksPrivateKey::new();
+        let sk = StacksPrivateKey::random();
         let s = format!(
             "{}",
             sign_transaction_single_sig_standard("01zz", &sk).unwrap_err()

--- a/stackslib/src/burnchains/bitcoin/blocks.rs
+++ b/stackslib/src/burnchains/bitcoin/blocks.rs
@@ -436,7 +436,7 @@ impl BitcoinBlockParser {
         match (inputs_opt, outputs_opt) {
             (Some(inputs), Some(outputs)) => {
                 Some(BitcoinTransaction {
-                    txid: Txid::from_vec_be(tx.txid().as_bytes().as_ref()).unwrap(), // this *should* panic if it fails
+                    txid: Txid::from_vec_be(tx.txid().as_bytes()).unwrap(), // this *should* panic if it fails
                     vtxindex: vtxindex as u32,
                     opcode,
                     data,

--- a/stackslib/src/burnchains/bitcoin/blocks.rs
+++ b/stackslib/src/burnchains/bitcoin/blocks.rs
@@ -437,7 +437,7 @@ impl BitcoinBlockParser {
         match (inputs_opt, outputs_opt) {
             (Some(inputs), Some(outputs)) => {
                 Some(BitcoinTransaction {
-                    txid: Txid::from_vec_be(&tx.txid().as_bytes().to_vec()).unwrap(), // this *should* panic if it fails
+                    txid: Txid::from_vec_be(tx.txid().as_bytes().as_ref()).unwrap(), // this *should* panic if it fails
                     vtxindex: vtxindex as u32,
                     opcode,
                     data,

--- a/stackslib/src/burnchains/bitcoin/indexer.rs
+++ b/stackslib/src/burnchains/bitcoin/indexer.rs
@@ -227,7 +227,7 @@ impl BitcoinIndexer {
 
         // instantiate headers DB
         let _ = SpvClient::new(
-            &working_dir_path.to_str().unwrap().to_string(),
+            working_dir_path.to_str().unwrap(),
             0,
             None,
             BitcoinNetworkType::Regtest,
@@ -236,7 +236,7 @@ impl BitcoinIndexer {
         )
         .expect(&format!(
             "Failed to open {:?}",
-            &working_dir_path.to_str().unwrap().to_string()
+            working_dir_path.to_str().unwrap()
         ));
 
         BitcoinIndexer {

--- a/stackslib/src/burnchains/tests/burnchain.rs
+++ b/stackslib/src/burnchains/tests/burnchain.rs
@@ -710,7 +710,7 @@ fn test_burn_snapshot_sequence() {
         let pubkey_hex = vrf_pubkey.to_hex();
         leader_public_keys.push(pubkey_hex);
 
-        let bitcoin_privkey = Secp256k1PrivateKey::new();
+        let bitcoin_privkey = Secp256k1PrivateKey::random();
         let bitcoin_publickey = BitcoinPublicKey::from_private(&bitcoin_privkey);
 
         leader_bitcoin_public_keys.push(to_hex(&bitcoin_publickey.to_bytes()));

--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -241,13 +241,15 @@ impl TestMiner {
         );
         match self.vrf_key_map.get(vrf_pubkey) {
             Some(ref prover_key) => {
-                let proof = VRF::prove(prover_key, &last_sortition_hash.as_bytes().to_vec());
-                let valid =
-                    match VRF::verify(vrf_pubkey, &proof, &last_sortition_hash.as_bytes().to_vec())
-                    {
-                        Ok(v) => v,
-                        Err(e) => false,
-                    };
+                let proof = VRF::prove(prover_key, last_sortition_hash.as_bytes().as_ref());
+                let valid = match VRF::verify(
+                    vrf_pubkey,
+                    &proof,
+                    last_sortition_hash.as_bytes().as_ref(),
+                ) {
+                    Ok(v) => v,
+                    Err(e) => false,
+                };
                 assert!(valid);
                 Some(proof)
             }

--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -241,12 +241,8 @@ impl TestMiner {
         );
         match self.vrf_key_map.get(vrf_pubkey) {
             Some(prover_key) => {
-                let proof = VRF::prove(prover_key, last_sortition_hash.as_bytes().as_ref());
-                let valid = match VRF::verify(
-                    vrf_pubkey,
-                    &proof,
-                    last_sortition_hash.as_bytes().as_ref(),
-                ) {
+                let proof = VRF::prove(prover_key, last_sortition_hash.as_bytes());
+                let valid = match VRF::verify(vrf_pubkey, &proof, last_sortition_hash.as_bytes()) {
                     Ok(v) => v,
                     Err(e) => false,
                 };

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -1013,10 +1013,10 @@ fn missed_block_commits_2_05() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
-    let stacker = p2pkh_from(&StacksPrivateKey::new());
-    let rewards = pox_addr_from(&StacksPrivateKey::new());
+    let stacker = p2pkh_from(&StacksPrivateKey::random());
+    let rewards = pox_addr_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let stacked_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![(stacker.clone().into(), balance)];
@@ -1333,10 +1333,10 @@ fn missed_block_commits_2_1() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
-    let stacker = p2pkh_from(&StacksPrivateKey::new());
-    let rewards = pox_addr_from(&StacksPrivateKey::new());
+    let stacker = p2pkh_from(&StacksPrivateKey::random());
+    let rewards = pox_addr_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let stacked_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![(stacker.clone().into(), balance)];
@@ -1677,10 +1677,10 @@ fn late_block_commits_2_1() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
-    let stacker = p2pkh_from(&StacksPrivateKey::new());
-    let rewards = pox_addr_from(&StacksPrivateKey::new());
+    let stacker = p2pkh_from(&StacksPrivateKey::random());
+    let rewards = pox_addr_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let stacked_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![(stacker.clone().into(), balance)];
@@ -2005,7 +2005,7 @@ fn test_simple_setup() {
     let _r = std::fs::remove_dir_all(path_blinded);
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
     setup_states(
         &[path, path_blinded],
@@ -2216,11 +2216,11 @@ fn test_sortition_with_reward_set() {
     let _r = std::fs::remove_dir_all(path);
 
     let mut vrf_keys: Vec<_> = (0..150).map(|_| VRFPrivateKey::new()).collect();
-    let mut committers: Vec<_> = (0..150).map(|_| StacksPrivateKey::new()).collect();
+    let mut committers: Vec<_> = (0..150).map(|_| StacksPrivateKey::random()).collect();
 
     let reward_set_size = 4;
     let reward_set: Vec<_> = (0..reward_set_size)
-        .map(|_| pox_addr_from(&StacksPrivateKey::new()))
+        .map(|_| pox_addr_from(&StacksPrivateKey::random()))
         .collect();
 
     setup_states(
@@ -2390,7 +2390,7 @@ fn test_sortition_with_reward_set() {
                 vec![(pox_addr_from(miner_wrong_out), 0)]
             } else {
                 (0..OUTPUTS_PER_COMMIT)
-                    .map(|ix| (pox_addr_from(&StacksPrivateKey::new()), ix as u16))
+                    .map(|ix| (pox_addr_from(&StacksPrivateKey::random()), ix as u16))
                     .collect()
             };
             let bad_block_recipients = Some(RewardSetInfo {
@@ -2487,13 +2487,13 @@ fn test_sortition_with_burner_reward_set() {
     let _r = std::fs::remove_dir_all(path);
 
     let mut vrf_keys: Vec<_> = (0..150).map(|_| VRFPrivateKey::new()).collect();
-    let mut committers: Vec<_> = (0..150).map(|_| StacksPrivateKey::new()).collect();
+    let mut committers: Vec<_> = (0..150).map(|_| StacksPrivateKey::random()).collect();
 
     let reward_set_size = 3;
     let mut reward_set: Vec<_> = (0..reward_set_size - 1)
         .map(|_| PoxAddress::standard_burn_address(false))
         .collect();
-    reward_set.push(pox_addr_from(&StacksPrivateKey::new()));
+    reward_set.push(pox_addr_from(&StacksPrivateKey::random()));
 
     setup_states(
         &[path],
@@ -2636,7 +2636,7 @@ fn test_sortition_with_burner_reward_set() {
                 vec![(pox_addr_from(miner_wrong_out), 0)]
             } else {
                 (0..OUTPUTS_PER_COMMIT)
-                    .map(|ix| (pox_addr_from(&StacksPrivateKey::new()), ix as u16))
+                    .map(|ix| (pox_addr_from(&StacksPrivateKey::random()), ix as u16))
                     .collect()
             };
             let bad_block_recipients = Some(RewardSetInfo {
@@ -2751,10 +2751,10 @@ fn test_pox_btc_ops() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
-    let stacker = p2pkh_from(&StacksPrivateKey::new());
-    let rewards = pox_addr_from(&StacksPrivateKey::new());
+    let stacker = p2pkh_from(&StacksPrivateKey::random());
+    let rewards = pox_addr_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let stacked_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![(stacker.clone().into(), balance)];
@@ -3043,10 +3043,10 @@ fn test_stx_transfer_btc_ops() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
-    let stacker = p2pkh_from(&StacksPrivateKey::new());
-    let recipient = p2pkh_from(&StacksPrivateKey::new());
+    let stacker = p2pkh_from(&StacksPrivateKey::random());
+    let recipient = p2pkh_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let transfer_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![(stacker.clone().into(), balance)];
@@ -3474,11 +3474,11 @@ fn test_delegate_stx_btc_ops() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
-    let first_del = p2pkh_from(&StacksPrivateKey::new());
-    let second_del = p2pkh_from(&StacksPrivateKey::new());
-    let delegator_addr = p2pkh_from(&StacksPrivateKey::new());
+    let first_del = p2pkh_from(&StacksPrivateKey::random());
+    let second_del = p2pkh_from(&StacksPrivateKey::random());
+    let delegator_addr = p2pkh_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let delegated_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![
@@ -3781,10 +3781,10 @@ fn test_initial_coinbase_reward_distributions() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..50).map(|_| StacksPrivateKey::random()).collect();
 
-    let stacker = p2pkh_from(&StacksPrivateKey::new());
-    let rewards = p2pkh_from(&StacksPrivateKey::new());
+    let stacker = p2pkh_from(&StacksPrivateKey::random());
+    let rewards = p2pkh_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let stacked_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![(stacker.clone().into(), balance)];
@@ -4022,7 +4022,7 @@ fn test_epoch_switch_cost_contract_instantiation() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..10).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
 
     setup_states(
         &[path],
@@ -4225,7 +4225,7 @@ fn test_epoch_switch_pox_2_contract_instantiation() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..15).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::random()).collect();
 
     setup_states(
         &[path],
@@ -4431,7 +4431,7 @@ fn test_epoch_switch_pox_3_contract_instantiation() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..25).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..25).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..25).map(|_| StacksPrivateKey::random()).collect();
 
     setup_states(
         &[path],
@@ -4653,9 +4653,9 @@ fn atlas_stop_start() {
     let atlas_name: clarity::vm::ContractName = "atlas-test".into();
 
     let vrf_keys: Vec<_> = (0..15).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::random()).collect();
 
-    let signer_sk = StacksPrivateKey::new();
+    let signer_sk = StacksPrivateKey::random();
     let signer_pk = p2pkh_from(&signer_sk);
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let stacked_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
@@ -4948,11 +4948,11 @@ fn test_epoch_verify_active_pox_contract() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..20).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..20).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..20).map(|_| StacksPrivateKey::random()).collect();
 
-    let stacker = p2pkh_from(&StacksPrivateKey::new());
-    let stacker_2 = p2pkh_from(&StacksPrivateKey::new());
-    let rewards = pox_addr_from(&StacksPrivateKey::new());
+    let stacker = p2pkh_from(&StacksPrivateKey::random());
+    let stacker_2 = p2pkh_from(&StacksPrivateKey::random());
+    let rewards = pox_addr_from(&StacksPrivateKey::random());
     let balance = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let stacked_amt = 1_000_000_000 * (core::MICROSTACKS_PER_STACKS as u128);
     let initial_balances = vec![
@@ -5250,12 +5250,12 @@ fn test_sortition_with_sunset() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let mut vrf_keys: Vec<_> = (0..200).map(|_| VRFPrivateKey::new()).collect();
-    let mut committers: Vec<_> = (0..200).map(|_| StacksPrivateKey::new()).collect();
+    let mut committers: Vec<_> = (0..200).map(|_| StacksPrivateKey::random()).collect();
 
     let reward_set_size = pox_consts.as_ref().unwrap().reward_slots() as usize;
     assert_eq!(reward_set_size, 6);
     let reward_set: Vec<_> = (0..reward_set_size)
-        .map(|_| pox_addr_from(&StacksPrivateKey::new()))
+        .map(|_| pox_addr_from(&StacksPrivateKey::random()))
         .collect();
 
     setup_states(
@@ -5562,12 +5562,12 @@ fn test_sortition_with_sunset_and_epoch_switch() {
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let mut vrf_keys: Vec<_> = (0..200).map(|_| VRFPrivateKey::new()).collect();
-    let mut committers: Vec<_> = (0..200).map(|_| StacksPrivateKey::new()).collect();
+    let mut committers: Vec<_> = (0..200).map(|_| StacksPrivateKey::random()).collect();
 
     let reward_set_size = pox_consts.as_ref().unwrap().reward_slots() as usize;
     assert_eq!(reward_set_size, 6);
     let reward_set: Vec<_> = (0..reward_set_size)
-        .map(|_| pox_addr_from(&StacksPrivateKey::new()))
+        .map(|_| pox_addr_from(&StacksPrivateKey::random()))
         .collect();
 
     setup_states_with_epochs(
@@ -5913,7 +5913,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
     let b_blind = get_burnchain(path_blinded, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..20).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..20).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..20).map(|_| StacksPrivateKey::random()).collect();
 
     setup_states_with_epochs(
         &[path, path_blinded],
@@ -6203,7 +6203,7 @@ fn test_pox_no_anchor_selected() {
     let _r = std::fs::remove_dir_all(path_blinded);
 
     let vrf_keys: Vec<_> = (0..10).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
 
     setup_states(
         &[path, path_blinded],
@@ -6418,7 +6418,7 @@ fn test_pox_fork_out_of_order() {
     let _r = std::fs::remove_dir_all(path_blinded);
 
     let vrf_keys: Vec<_> = (0..15).map(|_| VRFPrivateKey::new()).collect();
-    let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::new()).collect();
+    let committers: Vec<_> = (0..15).map(|_| StacksPrivateKey::random()).collect();
 
     setup_states(
         &[path, path_blinded],

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -369,7 +369,7 @@ pub fn setup_states_with_epochs(
     );
 
     let block_limit = ExecutionCost::max_value();
-    let initial_balances = initial_balances.unwrap_or(vec![]);
+    let initial_balances = initial_balances.unwrap_or_default();
     for path in paths.iter() {
         let burnchain = get_burnchain(path, pox_consts.clone());
 

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -237,7 +237,7 @@ pub fn make_replay_peer<'a>(peer: &mut TestPeer<'a>) -> TestPeer<'a> {
     replay_config.http_port = 0;
     replay_config.test_stackers = peer.config.test_stackers.clone();
 
-    let test_stackers = replay_config.test_stackers.clone().unwrap_or(vec![]);
+    let test_stackers = replay_config.test_stackers.clone().unwrap_or_default();
     let mut test_signers = replay_config.test_signers.clone().unwrap();
     let mut replay_peer = TestPeer::new(replay_config);
     let observer = TestEventObserver::new();

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -4123,7 +4123,7 @@ impl NakamotoChainState {
             .iter()
             .enumerate()
             .fold(HashMap::new(), |mut map, (ix, addr)| {
-                map.entry(addr).or_insert_with(Vec::new).push(ix);
+                map.entry(addr).or_default().push(ix);
                 map
             });
 
@@ -4524,7 +4524,7 @@ impl NakamotoChainState {
         let matured_rewards = matured_miner_rewards_opt
             .as_ref()
             .map(|matured_miner_rewards| matured_miner_rewards.consolidate())
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         let mut lockup_events =
             match Self::finish_block(&mut clarity_tx, matured_miner_rewards_opt.as_ref()) {

--- a/stackslib/src/chainstate/nakamoto/shadow.rs
+++ b/stackslib/src/chainstate/nakamoto/shadow.rs
@@ -643,7 +643,7 @@ impl NakamotoBlockBuilder {
         let coinbase_payload = CoinbasePayload(naka_tip_tenure_start_header.index_block_hash().0);
 
         // the miner key is irrelevant
-        let miner_key = StacksPrivateKey::new();
+        let miner_key = StacksPrivateKey::random();
         let miner_addr = StacksAddress::p2pkh(mainnet, &StacksPublicKey::from_private(&miner_key));
         let miner_tx_auth = TransactionAuth::from_p2pkh(&miner_key).ok_or_else(|| {
             Error::InvalidStacksBlock(

--- a/stackslib/src/chainstate/nakamoto/test_signers.rs
+++ b/stackslib/src/chainstate/nakamoto/test_signers.rs
@@ -86,7 +86,7 @@ impl Default for TestSigners {
 
         let mut signer_keys = Vec::<Secp256k1PrivateKey>::new();
         for _ in 0..num_signers {
-            signer_keys.push(Secp256k1PrivateKey::default());
+            signer_keys.push(Secp256k1PrivateKey::random());
         }
         Self {
             threshold,

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -259,7 +259,7 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
     };
 
     let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-    let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+    let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
     let coinbase_payload =
         TransactionPayload::Coinbase(CoinbasePayload([0x12; 32]), None, Some(proof.clone()));
@@ -591,10 +591,10 @@ pub fn test_load_store_update_nakamoto_blocks() {
 
     let private_key = StacksPrivateKey::new();
     let epoch2_proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-    let epoch2_proof = VRFProof::from_bytes(&epoch2_proof_bytes[..].to_vec()).unwrap();
+    let epoch2_proof = VRFProof::from_bytes(&epoch2_proof_bytes[..]).unwrap();
 
     let nakamoto_proof_bytes = hex_bytes("973c815ac3e81a4aff3243f3d8310d24ab9783acd6caa4dcfab20a3744584b2f966acf08140e1a7e1e685695d51b1b511f4f19260a21887244a6c47f7637b8bdeaf5eafe85c1975bab75bc0668fe8a0b").unwrap();
-    let nakamoto_proof = VRFProof::from_bytes(&nakamoto_proof_bytes[..].to_vec()).unwrap();
+    let nakamoto_proof = VRFProof::from_bytes(&nakamoto_proof_bytes[..]).unwrap();
 
     let coinbase_payload = TransactionPayload::Coinbase(
         CoinbasePayload([0x12; 32]),

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -210,7 +210,7 @@ fn codec_nakamoto_header() {
 
 #[test]
 pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
-    let private_key = StacksPrivateKey::new();
+    let private_key = StacksPrivateKey::random();
     let header = NakamotoBlockHeader {
         version: 1,
         chain_length: 2,
@@ -589,7 +589,7 @@ pub fn test_load_store_update_nakamoto_blocks() {
         Some(epochs),
     );
 
-    let private_key = StacksPrivateKey::new();
+    let private_key = StacksPrivateKey::random();
     let epoch2_proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
     let epoch2_proof = VRFProof::from_bytes(&epoch2_proof_bytes[..]).unwrap();
 
@@ -1664,8 +1664,8 @@ pub fn test_load_store_update_nakamoto_blocks() {
 /// * NakamotoBlockHeader::check_shadow_coinbase_tx
 #[test]
 fn test_nakamoto_block_static_verification() {
-    let private_key = StacksPrivateKey::new();
-    let private_key_2 = StacksPrivateKey::new();
+    let private_key = StacksPrivateKey::random();
+    let private_key_2 = StacksPrivateKey::random();
 
     let vrf_privkey = VRFPrivateKey::new();
     let vrf_pubkey = VRFPublicKey::from_private(&vrf_privkey);
@@ -2044,7 +2044,7 @@ fn test_make_miners_stackerdb_config() {
     );
 
     let naka_miner_hash160 = peer.miner.nakamoto_miner_hash160();
-    let miner_keys: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let miner_keys: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let miner_hash160s: Vec<_> = miner_keys
         .iter()
         .map(|miner_privkey| {
@@ -2312,7 +2312,7 @@ fn test_make_miners_stackerdb_config() {
 
 #[test]
 fn parse_vote_for_aggregate_public_key_valid() {
-    let signer_private_key = StacksPrivateKey::new();
+    let signer_private_key = StacksPrivateKey::random();
     let mainnet = false;
     let chainid = CHAIN_ID_TESTNET;
     let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
@@ -2359,7 +2359,7 @@ fn parse_vote_for_aggregate_public_key_valid() {
 
 #[test]
 fn parse_vote_for_aggregate_public_key_invalid() {
-    let signer_private_key = StacksPrivateKey::new();
+    let signer_private_key = StacksPrivateKey::random();
     let mainnet = false;
     let chainid = CHAIN_ID_TESTNET;
     let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
@@ -2542,7 +2542,7 @@ fn parse_vote_for_aggregate_public_key_invalid() {
 
 #[test]
 fn valid_vote_transaction() {
-    let signer_private_key = StacksPrivateKey::new();
+    let signer_private_key = StacksPrivateKey::random();
     let mainnet = false;
     let chainid = CHAIN_ID_TESTNET;
     let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
@@ -2592,7 +2592,7 @@ fn valid_vote_transaction() {
 
 #[test]
 fn valid_vote_transaction_malformed_transactions() {
-    let signer_private_key = StacksPrivateKey::new();
+    let signer_private_key = StacksPrivateKey::random();
     let mainnet = false;
     let chainid = CHAIN_ID_TESTNET;
     let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
@@ -2825,8 +2825,8 @@ fn valid_vote_transaction_malformed_transactions() {
 
 #[test]
 fn filter_one_transaction_per_signer_multiple_addresses() {
-    let signer_private_key_1 = StacksPrivateKey::new();
-    let signer_private_key_2 = StacksPrivateKey::new();
+    let signer_private_key_1 = StacksPrivateKey::random();
+    let signer_private_key_2 = StacksPrivateKey::random();
     let mainnet = false;
     let chainid = CHAIN_ID_TESTNET;
     let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
@@ -2954,7 +2954,7 @@ fn filter_one_transaction_per_signer_multiple_addresses() {
 
 #[test]
 fn filter_one_transaction_per_signer_duplicate_nonces() {
-    let signer_private_key = StacksPrivateKey::new();
+    let signer_private_key = StacksPrivateKey::random();
     let mainnet = false;
     let chainid = CHAIN_ID_TESTNET;
     let vote_contract_id = boot_code_id(SIGNERS_VOTING_NAME, mainnet);
@@ -3074,9 +3074,9 @@ pub mod nakamoto_block_signatures {
     // Test that signatures succeed with exactly 70% of the votes
     pub fn test_exactly_enough_votes() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 35),
-            (Secp256k1PrivateKey::default(), 35),
-            (Secp256k1PrivateKey::default(), 30),
+            (Secp256k1PrivateKey::random(), 35),
+            (Secp256k1PrivateKey::random(), 35),
+            (Secp256k1PrivateKey::random(), 30),
         ];
         let reward_set = make_reward_set(&signers);
 
@@ -3101,9 +3101,9 @@ pub mod nakamoto_block_signatures {
     /// Test that signatures fail with just under 70% of the votes
     pub fn test_just_not_enough_votes() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 3500),
-            (Secp256k1PrivateKey::default(), 3499),
-            (Secp256k1PrivateKey::default(), 3001),
+            (Secp256k1PrivateKey::random(), 3500),
+            (Secp256k1PrivateKey::random(), 3499),
+            (Secp256k1PrivateKey::random(), 3001),
         ];
         let reward_set = make_reward_set(&signers);
 
@@ -3132,9 +3132,9 @@ pub mod nakamoto_block_signatures {
     /// Base success case - 3 signers of equal weight, all signing the block
     pub fn test_nakamoto_block_verify_signatures() {
         let signers = [
-            Secp256k1PrivateKey::default(),
-            Secp256k1PrivateKey::default(),
-            Secp256k1PrivateKey::default(),
+            Secp256k1PrivateKey::random(),
+            Secp256k1PrivateKey::random(),
+            Secp256k1PrivateKey::random(),
         ];
 
         let reward_set =
@@ -3162,9 +3162,9 @@ pub mod nakamoto_block_signatures {
     /// Fully signed block, but not in order
     fn test_out_of_order_signer_signatures() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
         ];
         let reward_set = make_reward_set(&signers);
 
@@ -3193,9 +3193,9 @@ pub mod nakamoto_block_signatures {
     // Test with 3 equal signers, and only two sign
     fn test_insufficient_signatures() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
         ];
         let reward_set = make_reward_set(&signers);
 
@@ -3225,10 +3225,10 @@ pub mod nakamoto_block_signatures {
     // and the block is valid
     fn test_single_signature_threshold() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 75),
-            (Secp256k1PrivateKey::default(), 10),
-            (Secp256k1PrivateKey::default(), 5),
-            (Secp256k1PrivateKey::default(), 10),
+            (Secp256k1PrivateKey::random(), 75),
+            (Secp256k1PrivateKey::random(), 10),
+            (Secp256k1PrivateKey::random(), 5),
+            (Secp256k1PrivateKey::random(), 10),
         ];
         let reward_set = make_reward_set(&signers);
 
@@ -3252,7 +3252,7 @@ pub mod nakamoto_block_signatures {
     #[test]
     // Test with a signature that didn't come from the signer set
     fn test_invalid_signer() {
-        let signers = [(Secp256k1PrivateKey::default(), 100)];
+        let signers = [(Secp256k1PrivateKey::random(), 100)];
 
         let reward_set = make_reward_set(&signers);
 
@@ -3266,7 +3266,7 @@ pub mod nakamoto_block_signatures {
             .map(|(s, _)| s.sign(&message).expect("Failed to sign block sighash"))
             .collect::<Vec<_>>();
 
-        let invalid_signature = Secp256k1PrivateKey::default()
+        let invalid_signature = Secp256k1PrivateKey::random()
             .sign(&message)
             .expect("Failed to sign block sighash");
 
@@ -3286,9 +3286,9 @@ pub mod nakamoto_block_signatures {
     #[test]
     fn test_duplicate_signatures() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
         ];
         let reward_set = make_reward_set(&signers);
 
@@ -3326,10 +3326,10 @@ pub mod nakamoto_block_signatures {
     // Test where a signature used a different message
     fn test_signature_invalid_message() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
         ];
 
         let reward_set = make_reward_set(&signers);
@@ -3367,10 +3367,10 @@ pub mod nakamoto_block_signatures {
     // Test where a signature is not recoverable
     fn test_unrecoverable_signature() {
         let signers = [
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
-            (Secp256k1PrivateKey::default(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
+            (Secp256k1PrivateKey::random(), 100),
         ];
 
         let reward_set = make_reward_set(&signers);

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -969,7 +969,7 @@ mod test {
     #[test]
     fn codec_stacks_block_ecvrf_proof() {
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         check_codec_and_corruption::<VRFProof>(&proof, &proof_bytes);
     }
@@ -991,7 +991,7 @@ mod test {
     #[test]
     fn codec_stacks_block_header() {
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let header = StacksBlockHeader {
             version: 0x12,
@@ -1710,7 +1710,7 @@ mod test {
             tx_merkle_root
         };
         let mut block_header_dup_tx = header.clone();
-        block_header_dup_tx.tx_merkle_root = get_tx_root(&txs.to_vec());
+        block_header_dup_tx.tx_merkle_root = get_tx_root(txs);
 
         let block = StacksBlock {
             header: block_header_dup_tx,
@@ -1957,7 +1957,7 @@ mod test {
         );
 
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
         let tx_coinbase_proof = StacksTransaction::new(
             TransactionVersion::Testnet,
             origin_auth.clone(),

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -63,14 +63,14 @@ lazy_static! {
     pub static ref COST_VOTING_CONTRACT_TESTNET: QualifiedContractIdentifier =
         boot_code_id("cost-voting", false);
     pub static ref USER_KEYS: Vec<StacksPrivateKey> =
-        (0..50).map(|_| StacksPrivateKey::new()).collect();
+        (0..50).map(|_| StacksPrivateKey::random()).collect();
     pub static ref POX_ADDRS: Vec<Value> = (0..50u64)
         .map(|ix| execute(&format!(
             "{{ version: 0x00, hashbytes: 0x000000000000000000000000{} }}",
             &to_hex(&ix.to_le_bytes())
         )))
         .collect();
-    pub static ref MINER_KEY: StacksPrivateKey = StacksPrivateKey::new();
+    pub static ref MINER_KEY: StacksPrivateKey = StacksPrivateKey::random();
     pub static ref MINER_ADDR: StacksAddress = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -663,7 +663,7 @@ impl HeadersDB for TestSimHeadersDB {
 fn pox_2_contract_caller_units() {
     let mut sim = ClarityTestSim::new();
     sim.epoch_bounds = vec![0, 1, 2];
-    let delegator = StacksPrivateKey::new();
+    let delegator = StacksPrivateKey::random();
 
     let expected_unlock_height = POX_TESTNET_CYCLE_LENGTH * 4;
 
@@ -893,7 +893,7 @@ fn pox_2_contract_caller_units() {
 fn pox_2_lock_extend_units() {
     let mut sim = ClarityTestSim::new();
     sim.epoch_bounds = vec![0, 1, 2];
-    let delegator = StacksPrivateKey::new();
+    let delegator = StacksPrivateKey::random();
 
     let reward_cycle_len = 5;
     let expected_user_1_unlock = 4 * reward_cycle_len + 9 * reward_cycle_len;
@@ -1146,7 +1146,7 @@ fn pox_2_lock_extend_units() {
 fn pox_2_delegate_extend_units() {
     let mut sim = ClarityTestSim::new();
     sim.epoch_bounds = vec![0, 1, 2];
-    let delegator = StacksPrivateKey::new();
+    let delegator = StacksPrivateKey::random();
 
     // execute past 2.1 epoch initialization
     sim.execute_next_block(|_env| {});
@@ -1682,7 +1682,7 @@ fn pox_2_delegate_extend_units() {
 fn simple_epoch21_test() {
     let mut sim = ClarityTestSim::new();
     sim.epoch_bounds = vec![0, 1, 3];
-    let delegator = StacksPrivateKey::new();
+    let delegator = StacksPrivateKey::random();
 
     let clarity_2_0_id =
         QualifiedContractIdentifier::new(StandardPrincipalData::transient(), "contract-2-0".into());
@@ -1813,7 +1813,7 @@ fn max_stackerdb_list() {
 #[test]
 fn recency_tests() {
     let mut sim = ClarityTestSim::new();
-    let delegator = StacksPrivateKey::new();
+    let delegator = StacksPrivateKey::random();
 
     sim.execute_next_block(|env| {
         env.initialize_versioned_contract(
@@ -1890,7 +1890,7 @@ fn recency_tests() {
 #[test]
 fn delegation_tests() {
     let mut sim = ClarityTestSim::new();
-    let delegator = StacksPrivateKey::new();
+    let delegator = StacksPrivateKey::random();
     const REWARD_CYCLE_LENGTH: u128 = 1050;
 
     sim.execute_next_block(|env| {

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -1610,7 +1610,7 @@ pub mod test {
     }
 
     fn rand_addr() -> StacksAddress {
-        key_to_stacks_addr(&StacksPrivateKey::new())
+        key_to_stacks_addr(&StacksPrivateKey::random())
     }
 
     pub fn key_to_stacks_addr(key: &StacksPrivateKey) -> StacksAddress {
@@ -2820,7 +2820,7 @@ pub mod test {
         let mut missed_initial_blocks = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -2947,7 +2947,7 @@ pub mod test {
                     assert_eq!(bob_balance, 4000);
                 }
             }
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -3014,7 +3014,7 @@ pub mod test {
         let alice = keys.pop().unwrap();
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -3131,7 +3131,7 @@ pub mod test {
         let alice = keys.pop().unwrap();
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -3242,7 +3242,7 @@ pub mod test {
         let mut alice_reward_cycle = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -3453,7 +3453,7 @@ pub mod test {
         let mut rewarded = false;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -3714,7 +3714,7 @@ pub mod test {
         let mut alice_reward_cycle = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -3981,7 +3981,7 @@ pub mod test {
         let mut first_reward_cycle = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -4197,7 +4197,7 @@ pub mod test {
         let mut first_reward_cycle = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -4410,7 +4410,7 @@ pub mod test {
         let mut alice_reward_cycle = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -4659,7 +4659,7 @@ pub mod test {
         let mut test_after_second_reward_cycle = false;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -5181,7 +5181,7 @@ pub mod test {
         let mut test_between_reward_cycles = false;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =
@@ -5627,7 +5627,7 @@ pub mod test {
         let mut alice_reward_cycle = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
             let tip =

--- a/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -3724,7 +3724,7 @@ fn test_get_pox_addrs() {
     let mut all_reward_addrs = vec![];
 
     for tenure_id in 0..num_blocks {
-        let microblock_privkey = StacksPrivateKey::new();
+        let microblock_privkey = StacksPrivateKey::random();
         let microblock_pubkeyhash =
             Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
         let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
@@ -3997,7 +3997,7 @@ fn test_stack_with_segwit() {
     let mut all_reward_addrs = vec![];
 
     for tenure_id in 0..num_blocks {
-        let microblock_privkey = StacksPrivateKey::new();
+        let microblock_privkey = StacksPrivateKey::random();
         let microblock_pubkeyhash =
             Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
         let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -7592,8 +7592,8 @@ fn test_deser_abort() {
     ";
 
     let tx_payload = TransactionPayload::new_smart_contract(
-        &format!("hello-world"),
-        &contract.to_string(),
+        "hello-world",
+        contract,
         Some(ClarityVersion::Clarity2),
     )
     .unwrap();

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -557,7 +557,7 @@ fn pox_extend_transition() {
 
     let tip = get_tip(peer.sortdb.as_ref());
 
-    let alice_signer_private = Secp256k1PrivateKey::new();
+    let alice_signer_private = Secp256k1PrivateKey::random();
     let alice_signer_key = Secp256k1PublicKey::from_private(&alice_signer_private);
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
@@ -636,7 +636,7 @@ fn pox_extend_transition() {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let bob_signer_private = Secp256k1PrivateKey::new();
+    let bob_signer_private = Secp256k1PrivateKey::random();
 
     let reward_cycle = get_current_reward_cycle(&peer, &burnchain);
 
@@ -670,7 +670,7 @@ fn pox_extend_transition() {
     );
 
     // new signing key needed
-    let alice_signer_private = Secp256k1PrivateKey::default();
+    let alice_signer_private = Secp256k1PrivateKey::random();
     let alice_signer_key = StacksPublicKey::from_private(&alice_signer_private);
 
     let alice_signature = make_signer_key_signature(
@@ -3674,7 +3674,7 @@ fn stack_extend_verify_sig() {
     );
 
     // We need a new signer-key for the extend tx
-    let signer_key = Secp256k1PrivateKey::new();
+    let signer_key = Secp256k1PrivateKey::random();
     let signer_public_key = StacksPublicKey::from_private(&signer_key);
 
     // Test 1: invalid reward cycle
@@ -3702,7 +3702,7 @@ fn stack_extend_verify_sig() {
 
     // Test 2: invalid pox-addr
     stacker_nonce += 1;
-    let other_pox_addr = pox_addr_from(&Secp256k1PrivateKey::new());
+    let other_pox_addr = pox_addr_from(&Secp256k1PrivateKey::random());
     let signature = make_signer_key_signature(
         &other_pox_addr,
         &signer_key,
@@ -3726,7 +3726,7 @@ fn stack_extend_verify_sig() {
 
     // Test 3: invalid key used to sign
     stacker_nonce += 1;
-    let other_key = Secp256k1PrivateKey::new();
+    let other_key = Secp256k1PrivateKey::random();
     let signature = make_signer_key_signature(
         &pox_addr,
         &other_key,
@@ -3961,7 +3961,7 @@ fn stack_agg_commit_verify_sig() {
 
     // Test 2: invalid pox addr
     delegate_nonce += 1;
-    let other_pox_addr = pox_addr_from(&Secp256k1PrivateKey::new());
+    let other_pox_addr = pox_addr_from(&Secp256k1PrivateKey::random());
     let signature = make_signer_key_signature(
         &other_pox_addr,
         signer_sk,
@@ -4227,7 +4227,7 @@ struct StackerSignerInfo {
 
 impl StackerSignerInfo {
     fn new() -> Self {
-        let private_key = StacksPrivateKey::new();
+        let private_key = StacksPrivateKey::random();
         let public_key = StacksPublicKey::from_private(&private_key);
         let address = key_to_stacks_addr(&private_key);
         let pox_address =
@@ -4779,7 +4779,7 @@ fn stack_increase_verify_signer_key(use_nakamoto: bool) {
 
     // invalid pox addr
     stacker_nonce += 1;
-    let other_pox_addr = pox_addr_from(&Secp256k1PrivateKey::new());
+    let other_pox_addr = pox_addr_from(&Secp256k1PrivateKey::random());
     let signature = make_signer_key_signature(
         &other_pox_addr, // different than existing
         signer_sk,

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -1209,11 +1209,9 @@ mod test {
     fn get_tip_ancestor() {
         let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5").unwrap();
         let user_1 =
-            StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0").unwrap();
         let mut miner_reward = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
         let user_reward = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
 
@@ -1276,8 +1274,7 @@ mod test {
     fn load_store_miner_payment_schedule() {
         let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5").unwrap();
 
         let mut miner_reward = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
 
@@ -1322,8 +1319,7 @@ mod test {
     fn load_store_miner_payment_schedule_pay_contract() {
         let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5").unwrap();
 
         let mut miner_reward = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
         miner_reward.recipient = PrincipalData::Contract(QualifiedContractIdentifier::transient());
@@ -1368,8 +1364,7 @@ mod test {
     #[test]
     fn miner_reward_one_miner_no_tx_fees_no_users() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5").unwrap();
         let participant = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
 
         let (parent_reward, miner_reward) = StacksChainState::calculate_miner_reward(
@@ -1398,8 +1393,7 @@ mod test {
     #[test]
     fn miner_reward_one_miner_no_tx_fees_no_users_pay_contract() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5").unwrap();
         let mut participant = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 1000, 1000);
         participant.recipient = PrincipalData::Contract(QualifiedContractIdentifier::transient());
 
@@ -1437,11 +1431,9 @@ mod test {
     #[test]
     fn miner_reward_one_miner_one_user_no_tx_fees() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5").unwrap();
         let user_1 =
-            StacksAddress::from_string(&"SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP2837ZMC89J40K4YTS64B00M7065C6X46JX6ARG0").unwrap();
 
         let miner = make_dummy_miner_payment_schedule(&miner_1, 500, 0, 0, 250, 1000);
         let user = make_dummy_user_payment_schedule(&user_1, 500, 0, 0, 750, 1000, 1);
@@ -1485,12 +1477,10 @@ mod test {
     #[test]
     fn miner_reward_tx_fees() {
         let miner_1 =
-            StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5").unwrap();
 
         let parent_miner_1 =
-            StacksAddress::from_string(&"SP2QDF700V0FWXVNQJJ4XFGBWE6R2Y4APTSFQNBVE".to_string())
-                .unwrap();
+            StacksAddress::from_string("SP2QDF700V0FWXVNQJJ4XFGBWE6R2Y4APTSFQNBVE").unwrap();
 
         let participant = make_dummy_miner_payment_schedule(&miner_1, 500, 100, 105, 1000, 1000);
         let parent_participant =

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -475,7 +475,7 @@ impl StacksChainState {
 
         let _ = StacksChainState::mkdirs(&block_path)?;
 
-        block_path.push(to_hex(block_hash_bytes).to_string());
+        block_path.push(to_hex(block_hash_bytes));
         let blocks_path_str = block_path
             .to_str()
             .ok_or_else(|| Error::DBError(db_error::ParseError))?
@@ -996,7 +996,7 @@ impl StacksChainState {
                 // load up associated block data
                 staging_block.block_data =
                     StacksChainState::load_block_bytes(blocks_path, consensus_hash, block_hash)?
-                        .unwrap_or(vec![]);
+                        .unwrap_or_default();
                 Ok(Some(staging_block))
             }
             _ => {
@@ -1162,7 +1162,7 @@ impl StacksChainState {
                 // load associated block data
                 staging_microblock.block_data =
                     StacksChainState::load_staging_microblock_bytes(blocks_conn, microblock_hash)?
-                        .unwrap_or(vec![]);
+                        .unwrap_or_default();
                 Ok(Some(staging_microblock))
             }
             None => {
@@ -6980,7 +6980,7 @@ pub mod test {
         .unwrap();
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let mut tx_coinbase = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -7045,7 +7045,7 @@ pub mod test {
         .unwrap();
         let auth = TransactionAuth::from_p2pkh(&privk).unwrap();
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let mut tx_coinbase = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -8593,7 +8593,7 @@ pub mod test {
         let num_mblocks = microblocks.len();
 
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let child_block_header = StacksBlockHeader {
             version: 0x01,

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -9983,7 +9983,7 @@ pub mod test {
 
         for i in 0..32 {
             test_debug!("Making block {}", i);
-            let privk = StacksPrivateKey::new();
+            let privk = StacksPrivateKey::random();
             let block = make_empty_coinbase_block(&privk);
 
             blocks.push(block);
@@ -10198,7 +10198,7 @@ pub mod test {
     fn stacks_db_get_blocks_inventory_for_reward_cycle() {
         let mut peer_config = TestPeerConfig::new(function_name!(), 21313, 21314);
 
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -10290,7 +10290,7 @@ pub mod test {
                     let coinbase_tx =
                         make_coinbase_with_nonce(miner, tenure_id as usize, tenure_id, None);
 
-                    let microblock_privkey = StacksPrivateKey::new();
+                    let microblock_privkey = StacksPrivateKey::random();
                     let microblock_pubkeyhash = Hash160::from_node_public_key(
                         &StacksPublicKey::from_private(&microblock_privkey),
                     );
@@ -11008,13 +11008,13 @@ pub mod test {
                     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                     &AddressHashMode::SerializeP2PKH,
                     1,
-                    &vec![StacksPublicKey::from_private(&StacksPrivateKey::new())],
+                    &vec![StacksPublicKey::from_private(&StacksPrivateKey::random())],
                 )
                 .unwrap()
             })
             .collect();
 
-        let recipient_privk = StacksPrivateKey::new();
+        let recipient_privk = StacksPrivateKey::random();
         let recipient_addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -11333,13 +11333,13 @@ pub mod test {
                     C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                     &AddressHashMode::SerializeP2PKH,
                     1,
-                    &vec![StacksPublicKey::from_private(&StacksPrivateKey::new())],
+                    &vec![StacksPublicKey::from_private(&StacksPrivateKey::random())],
                 )
                 .unwrap()
             })
             .collect();
 
-        let recipient_privk = StacksPrivateKey::new();
+        let recipient_privk = StacksPrivateKey::random();
         let recipient_addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -2511,7 +2511,7 @@ impl StacksChainState {
                 Ok(txids)
             })
             .optional()?
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         Ok(txids)
     }

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -1673,7 +1673,7 @@ pub mod test {
         );
 
         let mut tx_conn = next_block.start_transaction_processing();
-        let sk = secp256k1::Secp256k1PrivateKey::new();
+        let sk = secp256k1::Secp256k1PrivateKey::random();
 
         let tx = StacksTransaction {
             version: TransactionVersion::Testnet,

--- a/stackslib/src/chainstate/stacks/db/unconfirmed.rs
+++ b/stackslib/src/chainstate/stacks/db/unconfirmed.rs
@@ -663,7 +663,7 @@ mod test {
 
     #[test]
     fn test_unconfirmed_refresh_one_microblock_stx_transfer() {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -691,7 +691,7 @@ mod test {
 
         let mut last_block: Option<StacksBlock> = None;
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
@@ -900,7 +900,7 @@ mod test {
 
     #[test]
     fn test_unconfirmed_refresh_10_microblocks_10_stx_transfers() {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -928,7 +928,7 @@ mod test {
 
         let mut last_block: Option<StacksBlock> = None;
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
@@ -1147,7 +1147,7 @@ mod test {
 
     #[test]
     fn test_unconfirmed_refresh_invalid_microblock() {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -1187,7 +1187,7 @@ mod test {
         let mut recv_balance = 0;
 
         for tenure_id in 0..num_blocks {
-            let microblock_privkey = StacksPrivateKey::new();
+            let microblock_privkey = StacksPrivateKey::random();
             let microblock_pubkeyhash =
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 

--- a/stackslib/src/chainstate/stacks/index/test/marf.rs
+++ b/stackslib/src/chainstate/stacks/index/test/marf.rs
@@ -77,8 +77,8 @@ fn marf_insert_different_leaf_same_block_100() {
         merkle_test_marf(
             &mut marf.borrow_storage_backend(),
             &block_header,
-            path_bytes.as_ref(),
-            [99; 40].as_ref(),
+            &path_bytes,
+            &[99; 40],
             None,
         );
 
@@ -151,8 +151,8 @@ fn marf_insert_different_leaf_different_path_different_block_100() {
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &block_header,
-                path_bytes.as_ref(),
-                [i; 40].as_ref(),
+                &path_bytes,
+                &[i; 40],
                 None,
             );
         }
@@ -232,8 +232,8 @@ fn marf_insert_same_leaf_different_block_100() {
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &next_block_header,
-                path_bytes.as_ref(),
-                [i; 40].as_ref(),
+                &path_bytes,
+                &[i; 40],
                 None,
             );
         }
@@ -312,8 +312,8 @@ fn marf_insert_leaf_sequence_2() {
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &last_block_header,
-                path_bytes.as_ref(),
-                [i; 40].as_ref(),
+                &path_bytes,
+                &[i; 40],
                 None,
             );
         }
@@ -380,13 +380,7 @@ fn marf_insert_leaf_sequence_100() {
 
             assert_eq!(leaf.data.to_vec(), [i; 40].to_vec());
 
-            merkle_test_marf(
-                &mut f,
-                &last_block_header,
-                path_bytes.as_ref(),
-                [i; 40].as_ref(),
-                None,
-            );
+            merkle_test_marf(&mut f, &last_block_header, &path_bytes, &[i; 40], None);
         }
         if let Some(root_hashes) = last_root_hashes.take() {
             let next_root_hashes = f.read_root_to_block_table().unwrap();
@@ -615,16 +609,14 @@ where
                     debug!("---------------------------------------");
                     debug!(
                         "MARF verify {:?} {:?} from current block header (immediate) {:?}",
-                        &prev_path,
-                        [j as u8; 40].as_ref(),
-                        &next_block_header
+                        &prev_path, &[j as u8; 40], &next_block_header
                     );
                     debug!("----------------------------------------");
                     merkle_test_marf(
                         &mut marf.borrow_storage_backend(),
                         &next_block_header,
-                        prev_path.as_ref(),
-                        [j as u8; 40].as_ref(),
+                        &prev_path,
+                        &[j as u8; 40],
                         None,
                     );
                 }
@@ -640,16 +632,14 @@ where
                     debug!("---------------------------------------");
                     debug!(
                         "MARF verify {:?} {:?} from current block header (deferred) {:?}",
-                        &prev_path,
-                        [j as u8; 40].as_ref(),
-                        &next_block_header
+                        &prev_path, &[j as u8; 40], &next_block_header
                     );
                     debug!("----------------------------------------");
                     merkle_test_marf(
                         &mut marf.borrow_storage_backend(),
                         &next_block_header,
-                        prev_path.as_ref(),
-                        [j as u8; 40].as_ref(),
+                        &prev_path,
+                        &[j as u8; 40],
                         None,
                     );
                 }
@@ -662,8 +652,8 @@ where
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &next_block_header,
-                next_path.as_ref(),
-                [i as u8; 40].as_ref(),
+                &next_path,
+                &[i as u8; 40],
                 None,
             );
         }
@@ -691,16 +681,14 @@ where
             debug!("---------------------------------------");
             debug!(
                 "MARF verify {:?} {:?} from last block header {:?}",
-                &next_path,
-                [i as u8; 40].as_ref(),
-                &last_block_header
+                &next_path, &[i as u8; 40], &last_block_header
             );
             debug!("----------------------------------------");
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &last_block_header,
-                next_path.as_ref(),
-                [i as u8; 40].as_ref(),
+                &next_path,
+                &[i as u8; 40],
                 None,
             );
         }
@@ -882,7 +870,7 @@ fn marf_merkle_verify_backptrs() {
                 &mut marf.borrow_storage_backend(),
                 &block_header_3,
                 &path_3,
-                [21; 40].as_ref(),
+                &[21; 40],
                 None,
             );
             if let Some(root_hashes) = last_root_hashes.take() {
@@ -957,7 +945,7 @@ where
                 root_table_cache = Some(merkle_test_marf(
                     &mut marf.borrow_storage_backend(),
                     &block_header,
-                    path.as_ref(),
+                    &path,
                     &value.data.to_vec(),
                     root_table_cache,
                 ));
@@ -1018,7 +1006,7 @@ where
                 root_table_cache = Some(merkle_test_marf(
                     &mut marf.borrow_storage_backend(),
                     &block_header,
-                    path.as_ref(),
+                    &path,
                     &value.data.to_vec(),
                     root_table_cache,
                 ));
@@ -1330,13 +1318,10 @@ fn marf_insert_random_10485760_4096_file_storage() {
             seed = path.clone();
 
             let key = to_hex(&path);
-            let value = to_hex(
-                [
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i0 as u8, i1 as u8, i2 as u8, i3 as u8,
-                ]
-                .as_ref(),
-            );
+            let value = to_hex(&[
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, i0 as u8, i1 as u8, i2 as u8, i3 as u8,
+            ]);
 
             keys.push(key);
             values.push(value);
@@ -1388,13 +1373,10 @@ fn marf_insert_random_10485760_4096_file_storage() {
             seed = path.clone();
 
             let key = to_hex(&path);
-            let value = to_hex(
-                [
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i0 as u8, i1 as u8, i2 as u8, i3 as u8,
-                ]
-                .as_ref(),
-            );
+            let value = to_hex(&[
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, i0 as u8, i1 as u8, i2 as u8, i3 as u8,
+            ]);
 
             keys.push(key);
             values.push(value);
@@ -1618,13 +1600,7 @@ fn marf_read_random_1048576_4096_file_storage() {
 
             // can make a merkle proof to each one
             if do_merkle_check {
-                merkle_test_marf(
-                    &mut f,
-                    &block_header,
-                    path.as_ref(),
-                    &value.data.to_vec(),
-                    None,
-                );
+                merkle_test_marf(&mut f, &block_header, &path, &value.data.to_vec(), None);
             }
             if i % 128 == 0 {
                 let end_time = get_epoch_time_ms();
@@ -1927,7 +1903,7 @@ fn marf_insert_flush_to_different_block() {
             root_table_cache = Some(merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &target_block,
-                path.as_ref(),
+                &path,
                 &value.data.to_vec(),
                 root_table_cache,
             ));
@@ -2047,7 +2023,7 @@ fn marf_insert_flush_to_different_block() {
         root_table_cache = Some(merkle_test_marf(
             &mut marf.borrow_storage_backend(),
             &read_from_block,
-            path.as_ref(),
+            &path,
             &value.data.to_vec(),
             root_table_cache,
         ));

--- a/stackslib/src/chainstate/stacks/index/test/marf.rs
+++ b/stackslib/src/chainstate/stacks/index/test/marf.rs
@@ -77,8 +77,8 @@ fn marf_insert_different_leaf_same_block_100() {
         merkle_test_marf(
             &mut marf.borrow_storage_backend(),
             &block_header,
-            &path_bytes.to_vec(),
-            &[99; 40].to_vec(),
+            path_bytes.as_ref(),
+            [99; 40].as_ref(),
             None,
         );
 
@@ -151,8 +151,8 @@ fn marf_insert_different_leaf_different_path_different_block_100() {
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &block_header,
-                &path_bytes.to_vec(),
-                &[i; 40].to_vec(),
+                path_bytes.as_ref(),
+                [i; 40].as_ref(),
                 None,
             );
         }
@@ -232,8 +232,8 @@ fn marf_insert_same_leaf_different_block_100() {
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &next_block_header,
-                &path_bytes.to_vec(),
-                &[i; 40].to_vec(),
+                path_bytes.as_ref(),
+                [i; 40].as_ref(),
                 None,
             );
         }
@@ -312,8 +312,8 @@ fn marf_insert_leaf_sequence_2() {
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &last_block_header,
-                &path_bytes.to_vec(),
-                &[i; 40].to_vec(),
+                path_bytes.as_ref(),
+                [i; 40].as_ref(),
                 None,
             );
         }
@@ -383,8 +383,8 @@ fn marf_insert_leaf_sequence_100() {
             merkle_test_marf(
                 &mut f,
                 &last_block_header,
-                &path_bytes.to_vec(),
-                &[i; 40].to_vec(),
+                path_bytes.as_ref(),
+                [i; 40].as_ref(),
                 None,
             );
         }
@@ -616,15 +616,15 @@ where
                     debug!(
                         "MARF verify {:?} {:?} from current block header (immediate) {:?}",
                         &prev_path,
-                        &[j as u8; 40].to_vec(),
+                        [j as u8; 40].as_ref(),
                         &next_block_header
                     );
                     debug!("----------------------------------------");
                     merkle_test_marf(
                         &mut marf.borrow_storage_backend(),
                         &next_block_header,
-                        &prev_path.to_vec(),
-                        &[j as u8; 40].to_vec(),
+                        prev_path.as_ref(),
+                        [j as u8; 40].as_ref(),
                         None,
                     );
                 }
@@ -641,15 +641,15 @@ where
                     debug!(
                         "MARF verify {:?} {:?} from current block header (deferred) {:?}",
                         &prev_path,
-                        &[j as u8; 40].to_vec(),
+                        [j as u8; 40].as_ref(),
                         &next_block_header
                     );
                     debug!("----------------------------------------");
                     merkle_test_marf(
                         &mut marf.borrow_storage_backend(),
                         &next_block_header,
-                        &prev_path.to_vec(),
-                        &[j as u8; 40].to_vec(),
+                        prev_path.as_ref(),
+                        [j as u8; 40].as_ref(),
                         None,
                     );
                 }
@@ -662,8 +662,8 @@ where
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &next_block_header,
-                &next_path.to_vec(),
-                &[i as u8; 40].to_vec(),
+                next_path.as_ref(),
+                [i as u8; 40].as_ref(),
                 None,
             );
         }
@@ -692,15 +692,15 @@ where
             debug!(
                 "MARF verify {:?} {:?} from last block header {:?}",
                 &next_path,
-                &[i as u8; 40].to_vec(),
+                [i as u8; 40].as_ref(),
                 &last_block_header
             );
             debug!("----------------------------------------");
             merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &last_block_header,
-                &next_path.to_vec(),
-                &[i as u8; 40].to_vec(),
+                next_path.as_ref(),
+                [i as u8; 40].as_ref(),
                 None,
             );
         }
@@ -882,7 +882,7 @@ fn marf_merkle_verify_backptrs() {
                 &mut marf.borrow_storage_backend(),
                 &block_header_3,
                 &path_3,
-                &[21; 40].to_vec(),
+                [21; 40].as_ref(),
                 None,
             );
             if let Some(root_hashes) = last_root_hashes.take() {
@@ -957,7 +957,7 @@ where
                 root_table_cache = Some(merkle_test_marf(
                     &mut marf.borrow_storage_backend(),
                     &block_header,
-                    &path.to_vec(),
+                    path.as_ref(),
                     &value.data.to_vec(),
                     root_table_cache,
                 ));
@@ -1018,7 +1018,7 @@ where
                 root_table_cache = Some(merkle_test_marf(
                     &mut marf.borrow_storage_backend(),
                     &block_header,
-                    &path.to_vec(),
+                    path.as_ref(),
                     &value.data.to_vec(),
                     root_table_cache,
                 ));
@@ -1331,11 +1331,11 @@ fn marf_insert_random_10485760_4096_file_storage() {
 
             let key = to_hex(&path);
             let value = to_hex(
-                &[
+                [
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i0 as u8, i1 as u8, i2 as u8, i3 as u8,
                 ]
-                .to_vec(),
+                .as_ref(),
             );
 
             keys.push(key);
@@ -1389,11 +1389,11 @@ fn marf_insert_random_10485760_4096_file_storage() {
 
             let key = to_hex(&path);
             let value = to_hex(
-                &[
+                [
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i0 as u8, i1 as u8, i2 as u8, i3 as u8,
                 ]
-                .to_vec(),
+                .as_ref(),
             );
 
             keys.push(key);
@@ -1621,7 +1621,7 @@ fn marf_read_random_1048576_4096_file_storage() {
                 merkle_test_marf(
                     &mut f,
                     &block_header,
-                    &path.to_vec(),
+                    path.as_ref(),
                     &value.data.to_vec(),
                     None,
                 );
@@ -1927,7 +1927,7 @@ fn marf_insert_flush_to_different_block() {
             root_table_cache = Some(merkle_test_marf(
                 &mut marf.borrow_storage_backend(),
                 &target_block,
-                &path.to_vec(),
+                path.as_ref(),
                 &value.data.to_vec(),
                 root_table_cache,
             ));
@@ -2047,7 +2047,7 @@ fn marf_insert_flush_to_different_block() {
         root_table_cache = Some(merkle_test_marf(
             &mut marf.borrow_storage_backend(),
             &read_from_block,
-            &path.to_vec(),
+            path.as_ref(),
             &value.data.to_vec(),
             root_table_cache,
         ));

--- a/stackslib/src/chainstate/stacks/index/test/node.rs
+++ b/stackslib/src/chainstate/stacks/index/test/node.rs
@@ -4251,10 +4251,7 @@ fn trie_cursor_walk_full() {
 
     let (ptr, node, hash) = fields_opt.unwrap();
     assert_eq!(ptr, node_ptrs[31]);
-    assert_eq!(
-        node,
-        TrieNodeType::Leaf(TrieLeaf::new(&[], [31u8; 40].as_ref()))
-    );
+    assert_eq!(node, TrieNodeType::Leaf(TrieLeaf::new(&[], &[31u8; 40])));
     assert_eq!(hash, hashes[31]);
 
     // cursor's last-visited node points at the penultimate node (the last node4),

--- a/stackslib/src/chainstate/stacks/index/test/node.rs
+++ b/stackslib/src/chainstate/stacks/index/test/node.rs
@@ -4253,7 +4253,7 @@ fn trie_cursor_walk_full() {
     assert_eq!(ptr, node_ptrs[31]);
     assert_eq!(
         node,
-        TrieNodeType::Leaf(TrieLeaf::new(&[], &[31u8; 40].to_vec()))
+        TrieNodeType::Leaf(TrieLeaf::new(&[], [31u8; 40].as_ref()))
     );
     assert_eq!(hash, hashes[31]);
 

--- a/stackslib/src/chainstate/stacks/index/test/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/test/trie.rs
@@ -172,7 +172,7 @@ fn trie_cursor_try_attach_leaf() {
                 assert!(leaf_opt.is_some());
 
                 let leaf = leaf_opt.unwrap();
-                assert_eq!(leaf, TrieLeaf::new(&path[i + 1..].to_vec(), &[i as u8; 40]));
+                assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[i as u8; 40]));
 
                 // without a MARF commit, merkle tests will fail in deferred mode
                 if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -1526,7 +1526,7 @@ impl StacksBlockBuilder {
                 &EMPTY_MICROBLOCK_PARENT_HASH,
                 &Sha512Trunc256Sum([0u8; 32]),
             ), // will be updated
-            miner_privkey: StacksPrivateKey::new(), // caller should overwrite this, or refrain from mining microblocks
+            miner_privkey: StacksPrivateKey::random(), // caller should overwrite this, or refrain from mining microblocks
             miner_payouts: None,
             miner_id,
         }

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -1395,7 +1395,7 @@ pub mod test {
 
         let stx_address = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
         let mut tx_payloads = vec![
             TransactionPayload::TokenTransfer(
                 stx_address.into(),
@@ -1531,7 +1531,7 @@ pub mod test {
 
     pub fn make_codec_test_block(num_txs: usize, epoch_id: StacksEpochId) -> StacksBlock {
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -1626,7 +1626,7 @@ pub mod test {
         miner_privk: &StacksPrivateKey,
     ) -> NakamotoBlock {
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",

--- a/stackslib/src/chainstate/stacks/tests/accounting.rs
+++ b/stackslib/src/chainstate/stacks/tests/accounting.rs
@@ -128,7 +128,7 @@ fn test_bad_microblock_fees_pre_v210() {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -196,7 +196,7 @@ fn test_bad_microblock_fees_pre_v210() {
                         make_coinbase(miner, tenure_id / 2)
                     }
                     else {
-                        let pk = StacksPrivateKey::new();
+                        let pk = StacksPrivateKey::random();
                         let mut tx_coinbase = StacksTransaction::new(
                             TransactionVersion::Testnet,
                             TransactionAuth::from_p2pkh(&pk).unwrap(),
@@ -451,7 +451,7 @@ fn test_bad_microblock_fees_fix_transition() {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -519,7 +519,7 @@ fn test_bad_microblock_fees_fix_transition() {
                         make_coinbase(miner, tenure_id / 2)
                     }
                     else {
-                        let pk = StacksPrivateKey::new();
+                        let pk = StacksPrivateKey::random();
                         let mut tx_coinbase = StacksTransaction::new(
                             TransactionVersion::Testnet,
                             TransactionAuth::from_p2pkh(&pk).unwrap(),
@@ -808,7 +808,7 @@ fn test_get_block_info_v210() {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -875,7 +875,7 @@ fn test_get_block_info_v210() {
                         make_coinbase(miner, tenure_id / 2)
                     }
                     else {
-                        let pk = StacksPrivateKey::new();
+                        let pk = StacksPrivateKey::random();
                         let mut tx_coinbase = StacksTransaction::new(
                             TransactionVersion::Testnet,
                             TransactionAuth::from_p2pkh(&pk).unwrap(),
@@ -1180,7 +1180,7 @@ fn test_get_block_info_v210_no_microblocks() {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -1247,7 +1247,7 @@ fn test_get_block_info_v210_no_microblocks() {
                         make_coinbase(miner, tenure_id / 2)
                     }
                     else {
-                        let pk = StacksPrivateKey::new();
+                        let pk = StacksPrivateKey::random();
                         let mut tx_coinbase = StacksTransaction::new(
                             TransactionVersion::Testnet,
                             TransactionAuth::from_p2pkh(&pk).unwrap(),
@@ -1414,7 +1414,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
         "f67c7437f948ca1834602b28595c12ac744f287a4efaf70d437042a6afed81bc01",
     )
     .unwrap();
-    let privk_recipient = StacksPrivateKey::new();
+    let privk_recipient = StacksPrivateKey::random();
 
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
@@ -1501,7 +1501,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -1613,7 +1613,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
                             make_coinbase(miner, tenure_id)
                         }
                     } else {
-                        let pk = StacksPrivateKey::new();
+                        let pk = StacksPrivateKey::random();
                         let addr = StacksAddress::from_public_keys(
                             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                             &AddressHashMode::SerializeP2PKH,

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -431,7 +431,7 @@ fn test_build_anchored_blocks_stx_transfers_multi() {
     let num_blocks = 10;
 
     for _ in 0..num_blocks {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -649,7 +649,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -885,7 +885,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -1152,7 +1152,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
 /// to consider an origin's "next" transaction immediately. Prior behavior would
 /// only do so after processing any other origin's transactions.
 fn test_build_anchored_blocks_incrementing_nonces() {
-    let private_keys: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let private_keys: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let addresses: Vec<_> = private_keys
         .iter()
         .map(|sk| {
@@ -1310,7 +1310,7 @@ fn test_build_anchored_blocks_skip_too_expensive() {
     let mut initial_balances = vec![];
     let num_blocks = 10;
     for i in 0..num_blocks {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -1762,7 +1762,7 @@ fn test_build_anchored_blocks_multiple_chaintips() {
     let num_blocks = 10;
 
     for _ in 0..num_blocks {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -1909,7 +1909,7 @@ fn test_build_anchored_blocks_empty_chaintips() {
     let num_blocks = 10;
 
     for _ in 0..num_blocks {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -2052,7 +2052,7 @@ fn test_build_anchored_blocks_too_expensive_transactions() {
     let num_blocks = 3;
 
     for _ in 0..num_blocks {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -2417,7 +2417,7 @@ fn test_build_anchored_blocks_bad_nonces() {
     let num_blocks = 10;
 
     for _ in 0..num_blocks {
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -2665,8 +2665,8 @@ fn test_build_microblock_stream_forks() {
     let initial_balance = 100000000;
 
     for _ in 0..num_blocks {
-        let privk = StacksPrivateKey::new();
-        let mblock_privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
+        let mblock_privk = StacksPrivateKey::random();
 
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
@@ -2965,8 +2965,8 @@ fn test_build_microblock_stream_forks_with_descendants() {
     let initial_balance = 100000000;
 
     for _ in 0..num_blocks {
-        let privk = StacksPrivateKey::new();
-        let mblock_privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
+        let mblock_privk = StacksPrivateKey::random();
 
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
@@ -3496,7 +3496,7 @@ fn test_contract_call_across_clarity_versions() {
 
     let mut mblock_privks = vec![];
     for _ in 0..num_blocks {
-        let mblock_privk = StacksPrivateKey::new();
+        let mblock_privk = StacksPrivateKey::random();
         mblock_privks.push(mblock_privk);
     }
 
@@ -3999,7 +3999,7 @@ fn test_is_tx_problematic() {
     let mut initial_balances = vec![];
     let num_blocks = 10;
     for i in 0..num_blocks {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let addr = StacksAddress::from_public_keys(
             C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
             &AddressHashMode::SerializeP2PKH,
@@ -4493,7 +4493,7 @@ fn test_is_tx_problematic() {
 fn mempool_incorporate_pox_unlocks() {
     let mut initial_balances = vec![];
     let total_balance = 10_000_000_000;
-    let pk = StacksPrivateKey::new();
+    let pk = StacksPrivateKey::random();
     let addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -4918,7 +4918,7 @@ fn paramaterized_mempool_walk_test(
 ) {
     let key_address_pairs: Vec<(Secp256k1PrivateKey, StacksAddress)> = (0..num_users)
         .map(|_user_index| {
-            let privk = StacksPrivateKey::new();
+            let privk = StacksPrivateKey::random();
             let addr = StacksAddress::from_public_keys(
                 C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                 &AddressHashMode::SerializeP2PKH,

--- a/stackslib/src/chainstate/stacks/tests/chain_histories.rs
+++ b/stackslib/src/chainstate/stacks/tests/chain_histories.rs
@@ -2634,7 +2634,7 @@ fn miner_trace_replay_randomized(miner_trace: &mut TestMinerTrace) {
 
             match stacks_block_opt {
                 Some(stacks_block) => {
-                    let mut microblocks = microblocks_opt.unwrap_or(vec![]);
+                    let mut microblocks = microblocks_opt.unwrap_or_default();
 
                     // "discover" the stacks block and its microblocks in all nodes
                     // TODO: randomize microblock discovery order too

--- a/stackslib/src/chainstate/stacks/transaction.rs
+++ b/stackslib/src/chainstate/stacks/transaction.rs
@@ -2160,7 +2160,7 @@ mod test {
     #[test]
     fn tx_stacks_transaction_payload_nakamoto_coinbase() {
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let coinbase_payload =
             TransactionPayload::Coinbase(CoinbasePayload([0x12; 32]), None, Some(proof));
@@ -2291,7 +2291,7 @@ mod test {
     #[test]
     fn tx_stacks_transaction_payload_nakamoto_coinbase_alt_recipient() {
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let recipient = PrincipalData::from(QualifiedContractIdentifier {
             issuer: StacksAddress::new(1, Hash160([0xff; 20])).unwrap().into(),

--- a/stackslib/src/chainstate/stacks/transaction.rs
+++ b/stackslib/src/chainstate/stacks/transaction.rs
@@ -4400,7 +4400,7 @@ mod test {
         )
         .unwrap();
 
-        let mut random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let mut random_sponsor = StacksPrivateKey::random(); // what the origin sees
         random_sponsor.set_compress_public(true);
 
         let auth = TransactionAuth::Sponsored(
@@ -4625,7 +4625,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -4867,7 +4867,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -5104,7 +5104,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -5300,7 +5300,7 @@ mod test {
         )
         .unwrap();
 
-        let random_sponsor = StacksPrivateKey::new();
+        let random_sponsor = StacksPrivateKey::random();
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -5522,7 +5522,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new();
+        let random_sponsor = StacksPrivateKey::random();
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -5852,7 +5852,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -6097,7 +6097,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -6496,7 +6496,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -6661,7 +6661,7 @@ mod test {
         let pubk_4 = StacksPublicKey::from_private(&privk_4);
         let pubk_5 = StacksPublicKey::from_private(&privk_5);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -7074,7 +7074,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -7250,7 +7250,7 @@ mod test {
         let pubk_6 = StacksPublicKey::from_private(&privk_6);
         let pubk_7 = StacksPublicKey::from_private(&privk_7);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -7892,7 +7892,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -8141,7 +8141,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(
@@ -8399,7 +8399,7 @@ mod test {
         let pubk_2 = StacksPublicKey::from_private(&privk_2);
         let pubk_3 = StacksPublicKey::from_private(&privk_3);
 
-        let random_sponsor = StacksPrivateKey::new(); // what the origin sees
+        let random_sponsor = StacksPrivateKey::random(); // what the origin sees
 
         let auth = TransactionAuth::Sponsored(
             TransactionSpendingCondition::new_singlesig_p2pkh(StacksPublicKey::from_private(

--- a/stackslib/src/cli.rs
+++ b/stackslib/src/cli.rs
@@ -453,7 +453,7 @@ pub fn command_try_mine(argv: &[String], conf: Option<&Config>) {
 
     let result = match &parent_stacks_header.anchored_header {
         StacksBlockHeaderTypes::Epoch2(..) => {
-            let sk = StacksPrivateKey::new();
+            let sk = StacksPrivateKey::random();
             let mut tx_auth = TransactionAuth::from_p2pkh(&sk).unwrap();
             tx_auth.set_origin_nonce(0);
 

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -2061,7 +2061,7 @@ impl NodeConfig {
         let sockaddr = deny_node.to_socket_addrs().unwrap().next().unwrap();
         let neighbor = NodeConfig::default_neighbor(
             sockaddr,
-            Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new()),
+            Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random()),
             chain_id,
             peer_version,
         );

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -1783,7 +1783,7 @@ fn test_add_txs_bloom_filter() {
         let bf = mempool.get_txid_bloom_filter().unwrap();
         let mut mempool_tx = mempool.tx_begin().unwrap();
         for i in 0..128 {
-            let pk = StacksPrivateKey::new();
+            let pk = StacksPrivateKey::random();
             let mut tx = StacksTransaction {
                 version: TransactionVersion::Testnet,
                 chain_id: 0x80000000,
@@ -1889,7 +1889,7 @@ fn test_txtags() {
 
         let mut mempool_tx = mempool.tx_begin().unwrap();
         for i in 0..128 {
-            let pk = StacksPrivateKey::new();
+            let pk = StacksPrivateKey::random();
             let mut tx = StacksTransaction {
                 version: TransactionVersion::Testnet,
                 chain_id: 0x80000000,
@@ -1981,7 +1981,7 @@ fn test_make_mempool_sync_data() {
         for i in 0..((MAX_BLOOM_COUNTER_TXS + 128) as usize) {
             let mut mempool_tx = mempool.tx_begin().unwrap();
             for j in 0..128 {
-                let pk = StacksPrivateKey::new();
+                let pk = StacksPrivateKey::random();
                 let mut tx = StacksTransaction {
                     version: TransactionVersion::Testnet,
                     chain_id: 0x80000000,
@@ -2154,7 +2154,7 @@ fn test_find_next_missing_transactions() {
 
     let mut mempool_tx = mempool.tx_begin().unwrap();
     for i in 0..(2 * MAX_BLOOM_COUNTER_TXS) {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let mut tx = StacksTransaction {
             version: TransactionVersion::Testnet,
             chain_id: 0x80000000,
@@ -2421,7 +2421,7 @@ fn test_drop_and_blacklist_txs_by_time() {
 
     let mut mempool_tx = mempool.tx_begin().unwrap();
     for i in 0..10 {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let mut tx = StacksTransaction {
             version: TransactionVersion::Testnet,
             chain_id: 0x80000000,
@@ -2538,7 +2538,7 @@ fn test_drop_and_blacklist_txs_by_size() {
 
     let mut mempool_tx = mempool.tx_begin().unwrap();
     for i in 0..10 {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let mut tx = StacksTransaction {
             version: TransactionVersion::Testnet,
             chain_id: 0x80000000,
@@ -2651,7 +2651,7 @@ fn test_filter_txs_by_type() {
 
     let mut mempool_tx = mempool.tx_begin().unwrap();
     for i in 0..10 {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let mut tx = StacksTransaction {
             version: TransactionVersion::Testnet,
             chain_id: 0x80000000,

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -211,7 +211,7 @@ impl P2PSession {
             peer_info.parent_network_id,
             PeerAddress::from_socketaddr(&peer_addr),
             peer_addr.port(),
-            Some(StacksPrivateKey::new()),
+            Some(StacksPrivateKey::random()),
             u64::MAX,
             UrlString::try_from(format!("http://127.0.0.1:{}", data_port).as_str()).unwrap(),
             vec![],
@@ -1811,7 +1811,7 @@ simulating a miner.
     .expect("Failed to load chain tip header info")
     .expect("Failed to load chain tip header info");
 
-    let sk = StacksPrivateKey::new();
+    let sk = StacksPrivateKey::random();
     let mut tx_auth = TransactionAuth::from_p2pkh(&sk).unwrap();
     tx_auth.set_origin_nonce(0);
 

--- a/stackslib/src/main.rs
+++ b/stackslib/src/main.rs
@@ -540,7 +540,7 @@ fn main() {
         let microblocks =
             StacksChainState::find_parent_microblock_stream(chainstate.db(), &block_info)
                 .unwrap()
-                .unwrap_or(vec![]);
+                .unwrap_or_default();
 
         let mut mblock_report = vec![];
         for mblock in microblocks.iter() {

--- a/stackslib/src/net/api/getneighbors.rs
+++ b/stackslib/src/net/api/getneighbors.rs
@@ -136,7 +136,7 @@ impl RPCNeighborsInfo {
             .into_iter()
             .map(|n| {
                 let stackerdb_contract_ids =
-                    PeerDB::static_get_peer_stacker_dbs(peerdb_conn, &n).unwrap_or(vec![]);
+                    PeerDB::static_get_peer_stacker_dbs(peerdb_conn, &n).unwrap_or_default();
                 RPCNeighbor::from_neighbor_key_and_pubkh(
                     n.addr.clone(),
                     Hash160::from_node_public_key(&n.public_key),
@@ -163,7 +163,7 @@ impl RPCNeighborsInfo {
             .into_iter()
             .map(|n| {
                 let stackerdb_contract_ids =
-                    PeerDB::static_get_peer_stacker_dbs(peerdb_conn, &n).unwrap_or(vec![]);
+                    PeerDB::static_get_peer_stacker_dbs(peerdb_conn, &n).unwrap_or_default();
                 RPCNeighbor::from_neighbor_key_and_pubkh(
                     n.addr.clone(),
                     Hash160::from_node_public_key(&n.public_key),

--- a/stackslib/src/net/api/tests/getsigner.rs
+++ b/stackslib/src/net/api/tests/getsigner.rs
@@ -48,7 +48,7 @@ fn make_preamble(query: &str) -> HttpRequestPreamble {
 fn test_try_parse_request() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
     let http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
-    let private_key = StacksPrivateKey::new();
+    let private_key = StacksPrivateKey::random();
     let signer_pubkey = StacksPublicKey::from_private(&private_key);
     let signer_pubkey_hex = signer_pubkey.to_hex();
     let cycle_num = thread_rng().next_u32() as u64;
@@ -108,7 +108,7 @@ fn test_try_make_response() {
     )
     .unwrap();
 
-    let random_private_key = StacksPrivateKey::new();
+    let random_private_key = StacksPrivateKey::random();
     let random_public_key = StacksPublicKey::from_private(&random_private_key);
 
     let nakamoto_chain_tip = rpc_test.canonical_tip.clone();

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -241,7 +241,7 @@ impl<'a> TestRPC<'a> {
             "94c319327cc5cd04da7147d32d836eb2e4c44f4db39aa5ede7314a761183d0c701",
         )
         .unwrap();
-        let microblock_privkey = StacksPrivateKey::new();
+        let microblock_privkey = StacksPrivateKey::random();
         let microblock_pubkeyhash =
             Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
@@ -561,7 +561,7 @@ impl<'a> TestRPC<'a> {
         let mut mempool_tx = mempool.tx_begin().unwrap();
         let mut sendable_txs = vec![];
         for i in 0..20 {
-            let pk = StacksPrivateKey::new();
+            let pk = StacksPrivateKey::random();
             let addr = StacksAddress::from_public_keys(
                 C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
                 &AddressHashMode::SerializeP2PKH,

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -61,7 +61,7 @@ fn test_try_parse_request() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
     let mut http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
 
-    let block = make_codec_test_nakamoto_block(StacksEpochId::Epoch30, &StacksPrivateKey::new());
+    let block = make_codec_test_nakamoto_block(StacksEpochId::Epoch30, &StacksPrivateKey::random());
     let proposal = NakamotoBlockProposal {
         block: block.clone(),
         chain_id: 0x80000000,

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -253,7 +253,7 @@ fn test_try_make_response() {
                 .unwrap();
 
         let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-        let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+        let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",

--- a/stackslib/src/net/api/tests/postmempoolquery.rs
+++ b/stackslib/src/net/api/tests/postmempoolquery.rs
@@ -138,7 +138,7 @@ fn test_stream_mempool_txs() {
 
     let mut mempool_tx = mempool.tx_begin().unwrap();
     for i in 0..10 {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let mut tx = StacksTransaction {
             version: TransactionVersion::Testnet,
             chain_id: 0x80000000,
@@ -351,7 +351,7 @@ fn test_decode_tx_stream() {
     let addr = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let mut txs = vec![];
     for _i in 0..10 {
-        let pk = StacksPrivateKey::new();
+        let pk = StacksPrivateKey::random();
         let mut tx = StacksTransaction {
             version: TransactionVersion::Testnet,
             chain_id: 0x80000000,

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -4474,7 +4474,7 @@ mod test {
         let old_peer_1_pubkey = Secp256k1PublicKey::from_private(&old_peer_1_privkey);
 
         // peer 1 updates their private key
-        local_peer_1.private_key = Secp256k1PrivateKey::new();
+        local_peer_1.private_key = Secp256k1PrivateKey::random();
 
         // peer 1 re-handshakes
         // convo_1 sends a handshake to convo_2
@@ -5058,7 +5058,7 @@ mod test {
             );
 
             // regenerate keys and expiries in peer 1
-            let new_privkey = Secp256k1PrivateKey::new();
+            let new_privkey = Secp256k1PrivateKey::random();
             {
                 let tx = peerdb_1.tx_begin().unwrap();
                 PeerDB::set_local_private_key(&tx, &new_privkey, (12350 + i) as u64).unwrap();
@@ -7045,7 +7045,7 @@ mod test {
 
         // mock a second local peer with a different private key
         let mut local_peer_2 = local_peer_1.clone();
-        local_peer_2.private_key = Secp256k1PrivateKey::new();
+        local_peer_2.private_key = Secp256k1PrivateKey::random();
 
         // NOTE: payload can be anything since we only look at premable length here
         let payload = StacksMessageType::Nack(NackData { error_code: 123 });
@@ -7174,7 +7174,7 @@ mod test {
 
         // mock a second local peer with a different private key
         let mut local_peer_2 = local_peer_1.clone();
-        local_peer_2.private_key = Secp256k1PrivateKey::new();
+        local_peer_2.private_key = Secp256k1PrivateKey::random();
 
         // NOTE: payload can be anything since we only look at premable length here
         let payload = StacksMessageType::Nack(NackData { error_code: 123 });
@@ -7303,7 +7303,7 @@ mod test {
 
         // mock a second local peer with a different private key
         let mut local_peer_2 = local_peer_1.clone();
-        local_peer_2.private_key = Secp256k1PrivateKey::new();
+        local_peer_2.private_key = Secp256k1PrivateKey::random();
 
         // NOTE: payload can be anything since we only look at premable length here
         let payload = StacksMessageType::Nack(NackData { error_code: 123 });
@@ -7432,7 +7432,7 @@ mod test {
 
         // mock a second local peer with a different private key
         let mut local_peer_2 = local_peer_1.clone();
-        local_peer_2.private_key = Secp256k1PrivateKey::new();
+        local_peer_2.private_key = Secp256k1PrivateKey::random();
 
         // NOTE: payload can be anything since we only look at premable length here
         let payload = StacksMessageType::Nack(NackData { error_code: 123 });

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -2776,7 +2776,7 @@ pub mod test {
 
     #[test]
     fn codec_sign_and_verify() {
-        let privkey = Secp256k1PrivateKey::new();
+        let privkey = Secp256k1PrivateKey::random();
         let pubkey_buf =
             StacksPublicKeyBuffer::from_public_key(&Secp256k1PublicKey::from_private(&privkey));
 
@@ -2797,7 +2797,7 @@ pub mod test {
     #[test]
     fn codec_stacks_public_key_roundtrip() {
         for i in 0..100 {
-            let privkey = Secp256k1PrivateKey::new();
+            let privkey = Secp256k1PrivateKey::random();
             let pubkey = Secp256k1PublicKey::from_private(&privkey);
 
             let pubkey_buf = StacksPublicKeyBuffer::from_public_key(&pubkey);

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -1873,7 +1873,7 @@ mod test {
             &BurnchainHeaderHash([0x22; 32]),
             StacksMessageType::Ping(PingData { nonce }),
         );
-        let privkey = Secp256k1PrivateKey::new();
+        let privkey = Secp256k1PrivateKey::random();
         ping.sign(request_id, &privkey).unwrap();
         ping
     }
@@ -1919,7 +1919,7 @@ mod test {
             StacksMessageType::Ping(PingData { nonce: 0x01020304 }),
         );
 
-        let privkey = Secp256k1PrivateKey::new();
+        let privkey = Secp256k1PrivateKey::random();
         ping.sign(1, &privkey).unwrap();
 
         let mut pipes = vec![]; // keep pipes in-scope
@@ -2041,7 +2041,7 @@ mod test {
 
     #[test]
     fn connection_relay_send_recv() {
-        let privkey = Secp256k1PrivateKey::new();
+        let privkey = Secp256k1PrivateKey::random();
         let pubkey = Secp256k1PublicKey::from_private(&privkey);
 
         let neighbor = Neighbor {
@@ -2139,7 +2139,7 @@ mod test {
     #[test]
     fn connection_send_recv() {
         with_timeout(100, || {
-            let privkey = Secp256k1PrivateKey::new();
+            let privkey = Secp256k1PrivateKey::random();
             let pubkey = Secp256k1PublicKey::from_private(&privkey);
 
             let neighbor = Neighbor {
@@ -2254,7 +2254,7 @@ mod test {
 
     #[test]
     fn connection_send_recv_timeout() {
-        let privkey = Secp256k1PrivateKey::new();
+        let privkey = Secp256k1PrivateKey::random();
         let pubkey = Secp256k1PublicKey::from_private(&privkey);
 
         let neighbor = Neighbor {

--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -140,7 +140,7 @@ impl LocalPeer {
         data_url: UrlString,
         stacker_dbs: Vec<QualifiedContractIdentifier>,
     ) -> LocalPeer {
-        let mut pkey = privkey.unwrap_or_default();
+        let mut pkey = privkey.unwrap_or(Secp256k1PrivateKey::random());
         pkey.set_compress_public(true);
 
         let mut rng = thread_rng();
@@ -880,7 +880,7 @@ impl PeerDB {
             return Err(db_error::Overflow);
         }
 
-        let new_key = Secp256k1PrivateKey::new();
+        let new_key = Secp256k1PrivateKey::random();
         {
             let tx = self.tx_begin()?;
 
@@ -1241,7 +1241,7 @@ impl PeerDB {
                 addrbytes: peer_addr.clone(),
                 port: peer_port,
             };
-            let empty_key = StacksPublicKey::from_private(&StacksPrivateKey::new());
+            let empty_key = StacksPublicKey::from_private(&StacksPrivateKey::random());
             let mut empty_neighbor = Neighbor::empty(&nk, &empty_key, 0);
 
             empty_neighbor.allowed = allow_deadline;
@@ -1287,7 +1287,7 @@ impl PeerDB {
                 addrbytes: peer_addr.clone(),
                 port: peer_port,
             };
-            let empty_key = StacksPublicKey::from_private(&StacksPrivateKey::new());
+            let empty_key = StacksPublicKey::from_private(&StacksPrivateKey::random());
             let mut empty_neighbor = Neighbor::empty(&nk, &empty_key, 0);
 
             empty_neighbor.denied = deny_deadline as i64;
@@ -2307,7 +2307,7 @@ mod test {
             out_degree: 1,
         };
 
-        let key1 = Secp256k1PrivateKey::new();
+        let key1 = Secp256k1PrivateKey::random();
 
         let path = "/tmp/test-peerdb-try_insert_peer_with_stackerdbs.db".to_string();
         if fs::metadata(&path).is_ok() {
@@ -2508,7 +2508,7 @@ mod test {
             out_degree: 1,
         };
 
-        let key1 = Secp256k1PrivateKey::new();
+        let key1 = Secp256k1PrivateKey::random();
 
         let path = "/tmp/test-peerdb-find_stacker_db_replicas.db".to_string();
         if fs::metadata(&path).is_ok() {
@@ -2800,7 +2800,7 @@ mod test {
                     addrbytes: PeerAddress([i as u8; 16]),
                     port: i,
                 },
-                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new()),
+                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random()),
                 expire_block: (i + 23456) as u64,
                 last_contact_time: (1552509642 + (i as u64)),
                 allowed: (now_secs + 600) as i64,
@@ -2820,7 +2820,7 @@ mod test {
                     addrbytes: PeerAddress([i as u8; 16]),
                     port: i,
                 },
-                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new()),
+                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random()),
                 expire_block: (i + 23456) as u64,
                 last_contact_time: (1552509642 + (i as u64)),
                 allowed: 0,
@@ -2901,7 +2901,7 @@ mod test {
                     addrbytes: PeerAddress([i as u8; 16]),
                     port: i,
                 },
-                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new()),
+                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random()),
                 expire_block: (i + 23456) as u64,
                 last_contact_time: (1552509642 + (i as u64)),
                 allowed: -1,
@@ -2922,7 +2922,7 @@ mod test {
                     addrbytes: PeerAddress([i as u8; 16]),
                     port: i,
                 },
-                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new()),
+                public_key: Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random()),
                 expire_block: (i + 23456) as u64,
                 last_contact_time: (1552509642 + (i as u64)),
                 allowed: -1,
@@ -3503,8 +3503,8 @@ mod test {
     /// latest key.
     #[test]
     fn test_connect_new_key() {
-        let key1 = Secp256k1PrivateKey::new();
-        let key2 = Secp256k1PrivateKey::new();
+        let key1 = Secp256k1PrivateKey::random();
+        let key2 = Secp256k1PrivateKey::random();
 
         let path = "/tmp/test-connect-new-key.db".to_string();
         if fs::metadata(&path).is_ok() {
@@ -3571,7 +3571,7 @@ mod test {
     /// Test DB instantiation -- it must work.
     #[test]
     fn test_db_instantiation() {
-        let key1 = Secp256k1PrivateKey::new();
+        let key1 = Secp256k1PrivateKey::random();
 
         let path = "/tmp/test-peerdb-instantiation.db".to_string();
         if fs::metadata(&path).is_ok() {
@@ -3598,7 +3598,7 @@ mod test {
     /// Test `public` setting in DB migration
     #[test]
     fn test_db_schema_3_public_ip_migration() {
-        let key = Secp256k1PrivateKey::new();
+        let key = Secp256k1PrivateKey::random();
 
         let path = "/tmp/test-peerdb-schema-3-public-ip-migration.db".to_string();
         if fs::metadata(&path).is_ok() {
@@ -3669,12 +3669,12 @@ mod test {
 
         for private in private_addrbytes.iter() {
             neighbor.addr.addrbytes = private.clone();
-            neighbor.public_key = Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new());
+            neighbor.public_key = Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random());
             assert!(PeerDB::try_insert_peer(&tx, &neighbor, &[]).unwrap());
         }
         for public in public_addrbytes.iter() {
             neighbor.addr.addrbytes = public.clone();
-            neighbor.public_key = Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::new());
+            neighbor.public_key = Secp256k1PublicKey::from_private(&Secp256k1PrivateKey::random());
             assert!(PeerDB::try_insert_peer(&tx, &neighbor, &[]).unwrap());
         }
         tx.execute("UPDATE frontier SET public = 1", params![])
@@ -3745,7 +3745,7 @@ mod test {
     /// Verify that multiple peers with the same public key are coalesced by last-contact-time
     #[test]
     fn test_query_peers() {
-        let key = Secp256k1PrivateKey::new();
+        let key = Secp256k1PrivateKey::random();
 
         let path = "/tmp/test-query-peers.db".to_string();
         if fs::metadata(&path).is_ok() {

--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -140,7 +140,7 @@ impl LocalPeer {
         data_url: UrlString,
         stacker_dbs: Vec<QualifiedContractIdentifier>,
     ) -> LocalPeer {
-        let mut pkey = privkey.unwrap_or(Secp256k1PrivateKey::new());
+        let mut pkey = privkey.unwrap_or_default();
         pkey.set_compress_public(true);
 
         let mut rng = thread_rng();
@@ -2869,10 +2869,7 @@ mod test {
 
         let n15_fresh =
             PeerDB::get_initial_neighbors(db.conn(), 0x9abcdef0, 0x78, 15, 23456 + 14).unwrap();
-        assert!(are_present(
-            &n15_fresh[10..15].to_vec(),
-            &initial_neighbors[10..20].to_vec()
-        ));
+        assert!(are_present(&n15_fresh[10..15], &initial_neighbors[10..20]));
         for n in &n15_fresh[10..15] {
             assert!(n.expire_block > 23456 + 14);
             assert!(n.allowed == 0);

--- a/stackslib/src/net/dns.rs
+++ b/stackslib/src/net/dns.rs
@@ -420,13 +420,14 @@ mod test {
             client.try_recv().unwrap();
 
             for name in names.iter() {
-                if resolved_addrs.contains_key(&name.to_string()) {
+                let name_string = name.to_string();
+                if resolved_addrs.contains_key(&name_string) {
                     continue;
                 }
                 match client.poll_lookup(name, 80).unwrap() {
                     Some(addrs) => {
-                        test_debug!("name {} addrs: {:?}", name, &addrs);
-                        resolved_addrs.insert(name.to_string(), addrs);
+                        test_debug!("name {name} addrs: {addrs:?}");
+                        resolved_addrs.insert(name_string, addrs);
                         break;
                     }
                     None => {}

--- a/stackslib/src/net/dns.rs
+++ b/stackslib/src/net/dns.rs
@@ -420,14 +420,13 @@ mod test {
             client.try_recv().unwrap();
 
             for name in names.iter() {
-                let name_string = name.to_string();
-                if resolved_addrs.contains_key(&name_string) {
+                if resolved_addrs.contains_key(*name) {
                     continue;
                 }
                 match client.poll_lookup(name, 80).unwrap() {
                     Some(addrs) => {
                         test_debug!("name {name} addrs: {addrs:?}");
-                        resolved_addrs.insert(name_string, addrs);
+                        resolved_addrs.insert(name.to_string(), addrs);
                         break;
                     }
                     None => {}

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -759,7 +759,7 @@ impl NakamotoDownloadStateMachine {
                     inventories.iter(),
                 )
             })
-            .unwrap_or(HashMap::new());
+            .unwrap_or_default();
 
         let mut available = Self::find_available_tenures(
             self.reward_cycle,
@@ -783,7 +783,7 @@ impl NakamotoDownloadStateMachine {
                     inventories.iter(),
                 )
             })
-            .unwrap_or(HashMap::new());
+            .unwrap_or_default();
 
         let mut tenure_block_ids = {
             debug!(
@@ -822,7 +822,7 @@ impl NakamotoDownloadStateMachine {
                         &available,
                     )
                 })
-                .unwrap_or(VecDeque::new());
+                .unwrap_or_default();
 
             let schedule = Self::make_ibd_download_schedule(
                 self.nakamoto_start_height,
@@ -843,7 +843,7 @@ impl NakamotoDownloadStateMachine {
                         &available,
                     )
                 })
-                .unwrap_or(VecDeque::new());
+                .unwrap_or_default();
 
             let schedule = Self::make_rarest_first_download_schedule(
                 self.nakamoto_start_height,

--- a/stackslib/src/net/http/request.rs
+++ b/stackslib/src/net/http/request.rs
@@ -543,7 +543,7 @@ impl HttpRequestContents {
                 }
                 kv
             })
-            .unwrap_or(HashMap::new())
+            .unwrap_or_default()
     }
 
     /// chain constructor -- add a query strings' values to the existing values, and also

--- a/stackslib/src/net/inv/epoch2x.rs
+++ b/stackslib/src/net/inv/epoch2x.rs
@@ -2275,7 +2275,7 @@ impl PeerNetwork {
 
             let bootstrap_peers: HashSet<_> =
                 PeerDB::get_bootstrap_peers(&network.peerdb.conn(), network.local_peer.network_id)
-                    .unwrap_or(vec![])
+                    .unwrap_or_default()
                     .into_iter()
                     .map(|neighbor| neighbor.addr)
                     .collect();
@@ -2717,7 +2717,7 @@ impl PeerNetwork {
         // in our inv state
         let always_allowed: HashSet<_> =
             PeerDB::get_always_allowed_peers(&self.peerdb.conn(), self.local_peer.network_id)
-                .unwrap_or(vec![])
+                .unwrap_or_default()
                 .into_iter()
                 .map(|neighbor| neighbor.addr)
                 .collect();

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2622,7 +2622,7 @@ pub mod test {
                 network_id: 0x80000000,
                 peer_version: 0x01020304,
                 current_block: start_block + (burnchain.consensus_hash_lifetime + 1) as u64,
-                private_key: Secp256k1PrivateKey::new(),
+                private_key: Secp256k1PrivateKey::random(),
                 private_key_expire: start_block + conn_opts.private_key_lifetime,
                 initial_neighbors: vec![],
                 asn4_entries: vec![],

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -3256,7 +3256,7 @@ impl PeerNetwork {
             .inv_state
             .as_ref()
             .map(|inv_state| inv_state.block_stats.keys().cloned().collect())
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         if self.antientropy_start_reward_cycle == 0 {
             debug!(
@@ -3680,7 +3680,7 @@ impl PeerNetwork {
                 );
                 e
             })
-            .unwrap_or(HashMap::new());
+            .unwrap_or_default();
 
         network_result.consume_nakamoto_blocks(new_blocks);
 

--- a/stackslib/src/net/prune.rs
+++ b/stackslib/src/net/prune.rs
@@ -423,7 +423,7 @@ impl PeerNetwork {
 
         let pruned_by_org = self
             .prune_frontier_outbound_orgs(preserve)
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         debug!(
             "{:?}: remove {} outbound peers by shared Org",

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -2608,8 +2608,8 @@ impl Relayer {
     ) {
         // have the p2p thread tell our neighbors about newly-discovered blocks
         let new_block_chs = new_blocks.keys().cloned().collect();
-        let available = Relayer::load_blocks_available_data(sortdb, new_block_chs)
-            .unwrap_or(BlocksAvailableMap::new());
+        let available =
+            Relayer::load_blocks_available_data(sortdb, new_block_chs).unwrap_or_default();
         if !available.is_empty() {
             debug!("{:?}: Blocks available: {}", &_local_peer, available.len());
             if let Err(e) = self.p2p.advertize_blocks(available, new_blocks) {
@@ -2619,8 +2619,8 @@ impl Relayer {
 
         // have the p2p thread tell our neighbors about newly-discovered confirmed microblock streams
         let new_mblock_chs = new_confirmed_microblocks.keys().cloned().collect();
-        let mblocks_available = Relayer::load_blocks_available_data(sortdb, new_mblock_chs)
-            .unwrap_or(BlocksAvailableMap::new());
+        let mblocks_available =
+            Relayer::load_blocks_available_data(sortdb, new_mblock_chs).unwrap_or_default();
         if !mblocks_available.is_empty() {
             debug!(
                 "{:?}: Confirmed microblock streams available: {}",
@@ -2929,7 +2929,7 @@ impl Relayer {
             mempool,
             event_observer.map(|obs| obs.as_mempool_event_dispatcher()),
         )
-        .unwrap_or(vec![]);
+        .unwrap_or_default();
 
         if !new_txs.is_empty() {
             debug!(

--- a/stackslib/src/net/stackerdb/tests/db.rs
+++ b/stackslib/src/net/stackerdb/tests/db.rs
@@ -353,7 +353,7 @@ fn test_stackerdb_insert_query_chunks() {
 
     let tx = db.tx_begin(db_config.clone()).unwrap();
 
-    let pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let addrs: Vec<_> = pks
         .iter()
         .map(|pk| {
@@ -506,7 +506,7 @@ fn test_reconfigure_stackerdb() {
 
     let tx = db.tx_begin(db_config).unwrap();
 
-    let pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let addrs: Vec<_> = pks
         .iter()
         .map(|pk| {
@@ -567,7 +567,7 @@ fn test_reconfigure_stackerdb() {
     }
 
     let tx = db.tx_begin(StackerDBConfig::noop()).unwrap();
-    let new_pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let new_pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let reconfigured_pks = vec![
         // first five slots are unchanged
         pks[0], pks[1], pks[2], pks[3], pks[4],
@@ -648,7 +648,7 @@ fn test_reconfigure_stackerdb() {
     }
 
     // reconfigure with fewer slots
-    let new_pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let new_pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let reconfigured_pks = vec![
         // first five slots are unchanged
         pks[0], pks[1], pks[2], pks[3], pks[4],

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -177,7 +177,7 @@ fn load_stackerdb(peer: &TestPeer, idx: usize) -> Vec<(SlotMetadata, Vec<u8>)> {
             .stackerdbs
             .get_latest_chunk(&peer.config.stacker_dbs[idx], i)
             .unwrap()
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         ret.push((chunk_metadata, chunk));
     }
     ret

--- a/stackslib/src/net/tests/download/epoch2x.rs
+++ b/stackslib/src/net/tests/download/epoch2x.rs
@@ -782,7 +782,7 @@ pub fn test_get_blocks_and_microblocks_2_peers_download_plain_100_blocks() {
                         4,
                     );
 
-                    let mblock_privkey = StacksPrivateKey::new();
+                    let mblock_privkey = StacksPrivateKey::random();
 
                     let mblock_pubkey_hash_bytes = Hash160::from_data(
                         &StacksPublicKey::from_private(&mblock_privkey).to_bytes(),

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -144,7 +144,7 @@ impl NakamotoStagingBlocksConnRef<'_> {
 #[test]
 fn test_nakamoto_tenure_downloader() {
     let ch = ConsensusHash([0x11; 20]);
-    let private_key = StacksPrivateKey::new();
+    let private_key = StacksPrivateKey::random();
     let mut test_signers = TestSigners::new(vec![]);
 
     let reward_set = test_signers.synthesize_reward_set();
@@ -2328,7 +2328,7 @@ fn test_nakamoto_unconfirmed_download_run_2_peers() {
 /// tenure _T + 1_.  The unconfirmed downloader should be able to handle this case.
 #[test]
 fn test_nakamoto_microfork_download_run_2_peers() {
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
 
@@ -2509,7 +2509,7 @@ fn test_nakamoto_microfork_download_run_2_peers() {
 #[test]
 fn test_nakamoto_download_run_2_peers_with_one_shadow_block() {
     let observer = TestEventObserver::new();
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
     let bitvecs = vec![vec![true, true, false, false]];
@@ -2689,7 +2689,7 @@ fn test_nakamoto_download_run_2_peers_with_one_shadow_block() {
 #[test]
 fn test_nakamoto_download_run_2_peers_shadow_prepare_phase() {
     let observer = TestEventObserver::new();
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
     let bitvecs = vec![vec![true, true]];
@@ -2892,7 +2892,7 @@ fn test_nakamoto_download_run_2_peers_shadow_prepare_phase() {
 #[test]
 fn test_nakamoto_download_run_2_peers_shadow_reward_cycles() {
     let observer = TestEventObserver::new();
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
     let bitvecs = vec![vec![true, true]];

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -173,7 +173,7 @@ fn test_nakamoto_tenure_downloader() {
         pubkey_hash: Hash160([0x02; 20]),
     };
     let proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
-    let proof = VRFProof::from_bytes(&proof_bytes[..].to_vec()).unwrap();
+    let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
 
     let coinbase_payload =
         TransactionPayload::Coinbase(CoinbasePayload([0x12; 32]), None, Some(proof));
@@ -2149,7 +2149,7 @@ fn test_nakamoto_download_run_2_peers() {
     for height in 25..tip.block_height {
         let ops = peer
             .get_burnchain_block_ops_at_height(height + 1)
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         let sn = {
             let ih = peer.sortdb().index_handle(&tip.sortition_id);
             let sn = ih.get_block_snapshot_by_height(height).unwrap().unwrap();
@@ -2256,7 +2256,7 @@ fn test_nakamoto_unconfirmed_download_run_2_peers() {
     for height in 25..tip.block_height {
         let ops = peer
             .get_burnchain_block_ops_at_height(height + 1)
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         let sn = {
             let ih = peer.sortdb().index_handle(&tip.sortition_id);
             let sn = ih.get_block_snapshot_by_height(height).unwrap().unwrap();
@@ -2436,7 +2436,7 @@ fn test_nakamoto_microfork_download_run_2_peers() {
     for height in 25..tip.block_height {
         let ops = peer
             .get_burnchain_block_ops_at_height(height + 1)
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         let sn = {
             let ih = peer.sortdb().index_handle(&tip.sortition_id);
             let sn = ih.get_block_snapshot_by_height(height).unwrap().unwrap();
@@ -2611,7 +2611,7 @@ fn test_nakamoto_download_run_2_peers_with_one_shadow_block() {
     for height in 25..tip.block_height {
         let ops = peer
             .get_burnchain_block_ops_at_height(height + 1)
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         let sn = {
             let ih = peer.sortdb().index_handle(&tip.sortition_id);
             let sn = ih.get_block_snapshot_by_height(height).unwrap().unwrap();
@@ -2813,7 +2813,7 @@ fn test_nakamoto_download_run_2_peers_shadow_prepare_phase() {
     for height in 25..tip.block_height {
         let ops = peer
             .get_burnchain_block_ops_at_height(height + 1)
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         let sn = {
             let ih = peer.sortdb().index_handle(&tip.sortition_id);
             let sn = ih.get_block_snapshot_by_height(height).unwrap().unwrap();
@@ -3018,7 +3018,7 @@ fn test_nakamoto_download_run_2_peers_shadow_reward_cycles() {
     for height in 25..tip.block_height {
         let ops = peer
             .get_burnchain_block_ops_at_height(height + 1)
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         let sn = {
             let ih = peer.sortdb().index_handle(&tip.sortition_id);
             let sn = ih.get_block_snapshot_by_height(height).unwrap().unwrap();

--- a/stackslib/src/net/tests/inv/nakamoto.rs
+++ b/stackslib/src/net/tests/inv/nakamoto.rs
@@ -60,7 +60,7 @@ pub fn peer_get_nakamoto_invs<'a>(
     mut peer: TestPeer<'a>,
     reward_cycles: &[u64],
 ) -> (TestPeer<'a>, Vec<StacksMessageType>) {
-    let privk = StacksPrivateKey::new();
+    let privk = StacksPrivateKey::random();
     let mut convo = peer.make_client_convo();
     let client_peer = peer.make_client_local_peer(privk.clone());
     let peer_addr = peer.p2p_socketaddr();
@@ -1122,7 +1122,7 @@ fn test_nakamoto_inv_sync_across_epoch_change() {
 
 #[test]
 fn test_nakamoto_make_tenure_inv_in_forks() {
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
 
@@ -1739,7 +1739,7 @@ fn test_nakamoto_make_tenure_inv_in_forks() {
 
 #[test]
 fn test_nakamoto_make_tenure_inv_in_many_reward_cycles() {
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
 
@@ -2187,7 +2187,7 @@ fn test_nakamoto_make_tenure_inv_in_many_reward_cycles() {
 
 #[test]
 fn test_nakamoto_make_tenure_inv_from_old_tips() {
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
 
@@ -2362,7 +2362,7 @@ fn test_nakamoto_make_tenure_inv_from_old_tips() {
 #[test]
 fn test_nakamoto_invs_shadow_blocks() {
     let observer = TestEventObserver::new();
-    let sender_key = StacksPrivateKey::new();
+    let sender_key = StacksPrivateKey::random();
     let sender_addr = to_addr(&sender_key);
     let initial_balances = vec![(sender_addr.to_account_principal(), 1000000000)];
     let mut bitvecs = vec![vec![

--- a/stackslib/src/net/tests/mempool/mod.rs
+++ b/stackslib/src/net/tests/mempool/mod.rs
@@ -53,7 +53,7 @@ fn test_mempool_sync_2_peers() {
     peer_2_config.connection_opts.mempool_sync_interval = 1;
 
     let num_txs = 10;
-    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::random()).collect();
     let addrs: Vec<_> = pks.iter().map(to_addr).collect();
     let initial_balances: Vec<_> = addrs
         .iter()
@@ -319,7 +319,7 @@ fn test_mempool_sync_2_peers_paginated() {
     peer_2_config.connection_opts.mempool_sync_interval = 1;
 
     let num_txs = 1024;
-    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::random()).collect();
     let addrs: Vec<_> = pks.iter().map(to_addr).collect();
     let initial_balances: Vec<_> = addrs
         .iter()
@@ -508,7 +508,7 @@ fn test_mempool_sync_2_peers_blacklisted() {
     peer_2_config.connection_opts.mempool_sync_interval = 1;
 
     let num_txs = 1024;
-    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::random()).collect();
     let addrs: Vec<_> = pks.iter().map(to_addr).collect();
     let initial_balances: Vec<_> = addrs
         .iter()
@@ -717,7 +717,7 @@ fn test_mempool_sync_2_peers_problematic() {
     peer_2_config.connection_opts.mempool_sync_interval = 1;
 
     let num_txs = 128;
-    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::random()).collect();
     let addrs: Vec<_> = pks.iter().map(to_addr).collect();
     let initial_balances: Vec<_> = addrs
         .iter()
@@ -1089,7 +1089,7 @@ fn test_mempool_sync_2_peers_nakamoto_paginated() {
         vec![true, true, true, true, true, true, true, true, true, true],
     ];
     let num_txs = 1024;
-    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+    let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::random()).collect();
     let addrs: Vec<_> = pks.iter().map(to_addr).collect();
     let initial_balances: Vec<_> = addrs
         .iter()

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -1216,16 +1216,16 @@ fn test_network_result_update() {
         &BurnchainHeaderHash([0x22; 32]),
         StacksMessageType::Ping(PingData { nonce: 2 }),
     );
-    msg2.sign(2, &StacksPrivateKey::new()).unwrap();
+    msg2.sign(2, &StacksPrivateKey::random()).unwrap();
 
-    let pkey_1 = StacksPrivateKey::new();
-    let pkey_2 = StacksPrivateKey::new();
+    let pkey_1 = StacksPrivateKey::random();
+    let pkey_2 = StacksPrivateKey::random();
 
-    let pushed_pkey_1 = StacksPrivateKey::new();
-    let pushed_pkey_2 = StacksPrivateKey::new();
+    let pushed_pkey_1 = StacksPrivateKey::random();
+    let pushed_pkey_2 = StacksPrivateKey::random();
 
-    let uploaded_pkey_1 = StacksPrivateKey::new();
-    let uploaded_pkey_2 = StacksPrivateKey::new();
+    let uploaded_pkey_1 = StacksPrivateKey::random();
+    let uploaded_pkey_2 = StacksPrivateKey::random();
 
     let blk1 = make_empty_coinbase_block(&pkey_1);
     let blk2 = make_empty_coinbase_block(&pkey_2);

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -515,7 +515,7 @@ impl NakamotoBootPlan {
             .config
             .test_stackers
             .clone()
-            .unwrap_or(vec![])
+            .unwrap_or_default()
             .iter()
             .map(|test_stacker| {
                 let pox_addr = test_stacker

--- a/stackslib/src/net/tests/relay/epoch2x.rs
+++ b/stackslib/src/net/tests/relay/epoch2x.rs
@@ -1944,7 +1944,7 @@ fn test_get_blocks_and_microblocks_peers_broadcast() {
         let sent_txs = RefCell::new(vec![]);
         let done = RefCell::new(false);
         let num_peers = 3;
-        let privk = StacksPrivateKey::new();
+        let privk = StacksPrivateKey::random();
 
         let peers = run_get_blocks_and_microblocks(
             "test_get_blocks_and_microblocks_peers_broadcast",
@@ -2642,9 +2642,9 @@ pub fn make_contract_tx(
 
 #[test]
 fn test_static_problematic_tests() {
-    let spender_sk_1 = StacksPrivateKey::new();
-    let spender_sk_2 = StacksPrivateKey::new();
-    let spender_sk_3 = StacksPrivateKey::new();
+    let spender_sk_1 = StacksPrivateKey::random();
+    let spender_sk_2 = StacksPrivateKey::random();
+    let spender_sk_3 = StacksPrivateKey::random();
 
     let edge_repeat_factor = AST_CALL_STACK_DEPTH_BUFFER + (MAX_CALL_STACK_DEPTH as u64) - 1;
     let tx_edge_body_start = "{ a : ".repeat(edge_repeat_factor as usize);
@@ -2814,7 +2814,7 @@ fn process_new_blocks_rejects_problematic_asts() {
     let tip =
         SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn()).unwrap();
 
-    let mblock_privk = StacksPrivateKey::new();
+    let mblock_privk = StacksPrivateKey::random();
 
     // make one tenure with a valid block, but problematic microblocks
     let (burn_ops, block, microblocks) = peer.make_tenure(

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -2301,7 +2301,7 @@ pub struct SerializedTx {
 
 impl SerializedTx {
     pub fn new(tx: Transaction) -> SerializedTx {
-        let txid = Txid::from_vec_be(&tx.txid().as_bytes().to_vec()).unwrap();
+        let txid = Txid::from_vec_be(tx.txid().as_bytes().as_ref()).unwrap();
         let mut encoder = RawEncoder::new(Cursor::new(vec![]));
         tx.consensus_encode(&mut encoder)
             .expect("BUG: failed to serialize to a vec");

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -2301,7 +2301,7 @@ pub struct SerializedTx {
 
 impl SerializedTx {
     pub fn new(tx: Transaction) -> SerializedTx {
-        let txid = Txid::from_vec_be(tx.txid().as_bytes().as_ref()).unwrap();
+        let txid = Txid::from_vec_be(tx.txid().as_bytes()).unwrap();
         let mut encoder = RawEncoder::new(Cursor::new(vec![]));
         tx.consensus_encode(&mut encoder)
             .expect("BUG: failed to serialize to a vec");

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -45,7 +45,7 @@ fn test_exact_block_costs() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = PrincipalData::from(to_addr(&spender_sk));
     let spender_addr_c32 = to_addr(&spender_sk);
 
@@ -280,7 +280,7 @@ fn test_dynamic_db_method_costs() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = PrincipalData::from(to_addr(&spender_sk));
     let spender_addr_c32 = to_addr(&spender_sk);
     let contract_name = "test-contract";
@@ -694,15 +694,15 @@ fn test_cost_limit_switch_version205() {
     .to_string();
 
     // Create three characters, `creator`, `alice` and `bob`.
-    let creator_sk = StacksPrivateKey::new();
+    let creator_sk = StacksPrivateKey::random();
     let creator_addr = to_addr(&creator_sk);
     let creator_pd: PrincipalData = creator_addr.into();
 
-    let alice_sk = StacksPrivateKey::new();
+    let alice_sk = StacksPrivateKey::random();
     let alice_addr = to_addr(&alice_sk);
     let alice_pd: PrincipalData = alice_addr.into();
 
-    let bob_sk = StacksPrivateKey::new();
+    let bob_sk = StacksPrivateKey::random();
     let bob_addr = to_addr(&bob_sk);
     let bob_pd: PrincipalData = bob_addr.into();
 
@@ -909,7 +909,7 @@ fn bigger_microblock_streams_in_2_05() {
         return;
     }
 
-    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
 
     let (mut conf, miner_account) = neon_integration_test_conf();

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -282,7 +282,7 @@ fn transition_adds_burn_block_height() {
     // very simple test to verify that after the 2.1 transition, get-burn-block-info? works as
     // expected
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = PrincipalData::from(to_addr(&spender_sk));
     let spender_addr_c32 = to_addr(&spender_sk);
 
@@ -682,7 +682,7 @@ fn transition_fixes_bitcoin_rigidity() {
     // applied, even though it's within 6 blocks of the next Stacks block, which will be in epoch
     // 2.1.  This verifies that the new burnchain consideration window only applies to sortitions
     // that happen in Stacks 2.1.
-    let recipient_sk = StacksPrivateKey::new();
+    let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
     let transfer_stx_op = TransferStxOp {
         sender: spender_stx_addr,
@@ -834,7 +834,7 @@ fn transition_fixes_bitcoin_rigidity() {
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
     // let's fire off our transfer op.
-    let recipient_sk = StacksPrivateKey::new();
+    let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
     let transfer_stx_op = TransferStxOp {
         sender: spender_stx_addr,
@@ -1052,7 +1052,7 @@ fn transition_adds_get_pox_addr_recipients() {
     let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
     for _i in 0..7 {
-        let spender_sk = StacksPrivateKey::new();
+        let spender_sk = StacksPrivateKey::random();
         let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
         spender_sks.push(spender_sk);
@@ -1360,7 +1360,7 @@ fn transition_adds_mining_from_segwit() {
     let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
     for _i in 0..7 {
-        let spender_sk = StacksPrivateKey::new();
+        let spender_sk = StacksPrivateKey::random();
         let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
         spender_sks.push(spender_sk);
@@ -1443,7 +1443,7 @@ fn transition_removes_pox_sunset() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
     let first_bal = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
@@ -2026,9 +2026,9 @@ fn test_pox_reorgs_three_flaps() {
     epochs[StacksEpochId::Epoch21].start_height = 151;
     conf_template.burnchain.epochs = Some(epochs);
 
-    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
-    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
     let balances: Vec<_> = privks
         .iter()
@@ -2059,7 +2059,7 @@ fn test_pox_reorgs_three_flaps() {
     let mut miner_status = vec![];
 
     for i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.clear();
@@ -2546,9 +2546,9 @@ fn test_pox_reorg_one_flap() {
     epochs[StacksEpochId::Epoch21].start_height = 151;
     conf_template.burnchain.epochs = Some(epochs);
 
-    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
-    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
     let balances: Vec<_> = privks
         .iter()
@@ -2579,7 +2579,7 @@ fn test_pox_reorg_one_flap() {
     let mut miner_status = vec![];
 
     for i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.clear();
@@ -2950,9 +2950,9 @@ fn test_pox_reorg_flap_duel() {
     epochs[StacksEpochId::Epoch21].start_height = 151;
     conf_template.burnchain.epochs = Some(epochs);
 
-    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
-    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
     let balances: Vec<_> = privks
         .iter()
@@ -2983,7 +2983,7 @@ fn test_pox_reorg_flap_duel() {
     let mut miner_status = vec![];
 
     for i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.clear();
@@ -3369,9 +3369,9 @@ fn test_pox_reorg_flap_reward_cycles() {
     epochs[StacksEpochId::Epoch21].start_height = 151;
     conf_template.burnchain.epochs = Some(epochs);
 
-    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
-    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
     let balances: Vec<_> = privks
         .iter()
@@ -3402,7 +3402,7 @@ fn test_pox_reorg_flap_reward_cycles() {
     let mut miner_status = vec![];
 
     for i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.clear();
@@ -3779,9 +3779,9 @@ fn test_pox_missing_five_anchor_blocks() {
     epochs[StacksEpochId::Epoch21].start_height = 151;
     conf_template.burnchain.epochs = Some(epochs);
 
-    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
-    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
     let balances: Vec<_> = privks
         .iter()
@@ -3812,7 +3812,7 @@ fn test_pox_missing_five_anchor_blocks() {
     let mut miner_status = vec![];
 
     for i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.clear();
@@ -4157,9 +4157,9 @@ fn test_sortition_divergence_pre_21() {
     epochs[StacksEpochId::Epoch21].start_height = 241;
     conf_template.burnchain.epochs = Some(epochs);
 
-    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
-    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
     let balances: Vec<_> = privks
         .iter()
@@ -4190,7 +4190,7 @@ fn test_sortition_divergence_pre_21() {
     let mut miner_status = vec![];
 
     for i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.clear();
@@ -4558,7 +4558,7 @@ fn trait_invocation_cross_epoch() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = PrincipalData::from(to_addr(&spender_sk));
     let spender_addr_c32 = to_addr(&spender_sk);
 
@@ -4812,7 +4812,7 @@ fn test_v1_unlock_height_with_current_stackers() {
 
     let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
     let mut initial_balances = vec![];
 
@@ -5065,7 +5065,7 @@ fn test_v1_unlock_height_with_delay_and_current_stackers() {
 
     let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
     let mut initial_balances = vec![];
 

--- a/testnet/stacks-node/src/tests/epoch_22.rs
+++ b/testnet/stacks-node/src/tests/epoch_22.rs
@@ -59,13 +59,13 @@ fn disable_pox() {
     let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let increase_by = 10_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
-    let spender_2_sk = StacksPrivateKey::new();
+    let spender_2_sk = StacksPrivateKey::random();
     let spender_2_addr: PrincipalData = to_addr(&spender_2_sk).into();
 
-    let spender_3_sk = StacksPrivateKey::new();
+    let spender_3_sk = StacksPrivateKey::random();
     let spender_3_addr: PrincipalData = to_addr(&spender_3_sk).into();
 
     let mut initial_balances = vec![];
@@ -580,13 +580,13 @@ fn pox_2_unlock_all() {
 
     let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
-    let spender_2_sk = StacksPrivateKey::new();
+    let spender_2_sk = StacksPrivateKey::random();
     let spender_2_addr: PrincipalData = to_addr(&spender_2_sk).into();
 
-    let spender_3_sk = StacksPrivateKey::new();
+    let spender_3_sk = StacksPrivateKey::random();
     let spender_3_addr: PrincipalData = to_addr(&spender_3_sk).into();
 
     let mut initial_balances = vec![];
@@ -1268,9 +1268,9 @@ fn test_pox_reorg_one_flap() {
     epochs.truncate_after(StacksEpochId::Epoch22);
     conf_template.burnchain.epochs = Some(epochs);
 
-    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
-    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let stack_privks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
 
     let balances: Vec<_> = privks
         .iter()
@@ -1301,7 +1301,7 @@ fn test_pox_reorg_one_flap() {
     let mut miner_status = vec![];
 
     for i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.clear();

--- a/testnet/stacks-node/src/tests/epoch_23.rs
+++ b/testnet/stacks-node/src/tests/epoch_23.rs
@@ -46,7 +46,7 @@ fn trait_invocation_behavior() {
     let epoch_2_2 = 235;
     let epoch_2_3 = 241;
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let contract_addr = to_addr(&spender_sk);
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 

--- a/testnet/stacks-node/src/tests/epoch_24.rs
+++ b/testnet/stacks-node/src/tests/epoch_24.rs
@@ -88,10 +88,10 @@ fn fix_to_pox_contract() {
     let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let increase_by = 10_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
-    let spender_2_sk = StacksPrivateKey::new();
+    let spender_2_sk = StacksPrivateKey::random();
     let spender_2_addr: PrincipalData = to_addr(&spender_2_sk).into();
 
     let mut initial_balances = vec![];
@@ -695,11 +695,11 @@ fn verify_auto_unlock_behavior() {
     let first_stacked_incr = 40_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let small_stacked = 17_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_stx_addr: StacksAddress = to_addr(&spender_sk);
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
-    let spender_2_sk = StacksPrivateKey::new();
+    let spender_2_sk = StacksPrivateKey::random();
     let spender_2_stx_addr: StacksAddress = to_addr(&spender_2_sk);
     let spender_2_addr: PrincipalData = to_addr(&spender_2_sk).into();
 

--- a/testnet/stacks-node/src/tests/epoch_25.rs
+++ b/testnet/stacks-node/src/tests/epoch_25.rs
@@ -52,10 +52,10 @@ fn microblocks_disabled() {
     let spender_1_bal = 10_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
     let spender_2_bal = 10_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
 
-    let spender_1_sk = StacksPrivateKey::new();
+    let spender_1_sk = StacksPrivateKey::random();
     let spender_1_addr: PrincipalData = to_addr(&spender_1_sk).into();
 
-    let spender_2_sk = StacksPrivateKey::new();
+    let spender_2_sk = StacksPrivateKey::random();
     let spender_2_addr: PrincipalData = to_addr(&spender_2_sk).into();
 
     let mut initial_balances = vec![];

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -61,7 +61,7 @@ pub fn make_bad_stacks_transfer(
 
     let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
 
-    tx_signer.sign_origin(&StacksPrivateKey::new()).unwrap();
+    tx_signer.sign_origin(&StacksPrivateKey::random()).unwrap();
 
     let mut buf = vec![];
     tx_signer

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -855,7 +855,7 @@ pub fn next_block_and_wait_for_commits(
 }
 
 pub fn setup_stacker(naka_conf: &mut Config) -> Secp256k1PrivateKey {
-    let stacker_sk = Secp256k1PrivateKey::new();
+    let stacker_sk = Secp256k1PrivateKey::random();
     let stacker_address = tests::to_addr(&stacker_sk);
     naka_conf.add_initial_balance(
         PrincipalData::from(stacker_address).to_string(),
@@ -1501,7 +1501,7 @@ fn simple_neon_integration() {
     let prom_bind = "127.0.0.1:6000".to_string();
     naka_conf.node.prometheus_bind = Some(prom_bind.clone());
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(5);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
@@ -1510,7 +1510,7 @@ fn simple_neon_integration() {
         PrincipalData::from(sender_addr).to_string(),
         send_amt * 2 + send_fee,
     );
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
@@ -1760,7 +1760,7 @@ fn flash_blocks_on_epoch_3() {
     let prom_bind = "127.0.0.1:6000".to_string();
     naka_conf.node.prometheus_bind = Some(prom_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
@@ -1769,7 +1769,7 @@ fn flash_blocks_on_epoch_3() {
         PrincipalData::from(sender_addr).to_string(),
         send_amt * 2 + send_fee,
     );
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
@@ -2015,8 +2015,8 @@ fn mine_multiple_per_tenure_integration() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
@@ -2200,8 +2200,8 @@ fn multiple_miners() {
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     naka_conf.node.pox_sync_sample_secs = 30;
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let tenure_count = 15;
     let inter_blocks_per_tenure = 6;
@@ -2469,7 +2469,7 @@ fn correct_burn_outs() {
     }
 
     let stacker_accounts = accounts[0..3].to_vec();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
 
@@ -2787,7 +2787,7 @@ fn block_proposal_api_endpoint() {
     conf.connection_options.auth_token = Some(password.clone());
     let account_keys = add_initial_balances(&mut conf, 10, 1_000_000);
     let stacker_sk = setup_stacker(&mut conf);
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
 
@@ -3150,7 +3150,7 @@ fn miner_writes_proposed_block_to_stackerdb() {
 
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1000);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
@@ -3161,7 +3161,7 @@ fn miner_writes_proposed_block_to_stackerdb() {
     );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
 
@@ -3273,7 +3273,7 @@ fn vote_for_aggregate_key_burn_op() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     let _http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let signer_sk = Secp256k1PrivateKey::new();
+    let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
 
     let mut signers = TestSigners::new(vec![signer_sk]);
@@ -3503,8 +3503,8 @@ fn follower_bootup_simple() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     let tenure_count = 5;
@@ -3824,8 +3824,8 @@ fn follower_bootup_across_multiple_cycles() {
     naka_conf.node.pox_sync_sample_secs = 180;
     naka_conf.burnchain.max_rbf = 10_000_000;
 
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     let tenure_count = 5;
@@ -4025,8 +4025,8 @@ fn follower_bootup_custom_chain_id() {
     naka_conf.burnchain.chain_id = 0x87654321;
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     let tenure_count = 5;
@@ -4363,16 +4363,16 @@ fn burn_ops_integration_test() {
     let signer_sk_1 = setup_stacker(&mut naka_conf);
     let signer_addr_1 = tests::to_addr(&signer_sk_1);
 
-    let signer_sk_2 = Secp256k1PrivateKey::new();
+    let signer_sk_2 = Secp256k1PrivateKey::random();
     let signer_addr_2 = tests::to_addr(&signer_sk_2);
 
-    let stacker_sk_1 = Secp256k1PrivateKey::new();
+    let stacker_sk_1 = Secp256k1PrivateKey::random();
     let stacker_addr_1 = tests::to_addr(&stacker_sk_1);
 
-    let stacker_sk_2 = Secp256k1PrivateKey::new();
+    let stacker_sk_2 = Secp256k1PrivateKey::random();
     let stacker_addr_2 = tests::to_addr(&stacker_sk_2);
 
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let mut sender_nonce = 0;
 
@@ -4972,7 +4972,7 @@ fn forked_tenure_is_ignored() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(10);
     naka_conf.miner.block_commit_delay = Duration::from_secs(0);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
@@ -4981,7 +4981,7 @@ fn forked_tenure_is_ignored() {
         PrincipalData::from(sender_addr).to_string(),
         send_amt + send_fee,
     );
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
@@ -5328,8 +5328,8 @@ fn check_block_heights() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
@@ -5755,11 +5755,11 @@ fn nakamoto_attempt_time() {
     naka_conf.miner.nakamoto_attempt_time_ms = nakamoto_attempt_time_ms;
     let stacker_sk = setup_stacker(&mut naka_conf);
 
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     naka_conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1_000_000_000);
 
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100_000);
 
@@ -6072,8 +6072,8 @@ fn clarity_burn_state() {
     let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
@@ -6344,7 +6344,7 @@ fn signer_chainstate() {
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.node.prometheus_bind = Some(prom_bind.clone());
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
@@ -6353,7 +6353,7 @@ fn signer_chainstate() {
         PrincipalData::from(sender_addr).to_string(),
         (send_amt + send_fee) * 20,
     );
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
@@ -6936,7 +6936,7 @@ fn continue_tenure_extend() {
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     naka_conf.connection_options.block_proposal_max_age_secs = u64::MAX;
     let http_origin = naka_conf.node.data_url.clone();
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
@@ -6945,7 +6945,7 @@ fn continue_tenure_extend() {
         PrincipalData::from(sender_addr).to_string(),
         (send_amt + send_fee) * 20,
     );
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
@@ -7431,8 +7431,8 @@ fn check_block_times() {
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     naka_conf.burnchain.chain_id = CHAIN_ID_TESTNET + 1;
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
 
     // setup sender + recipient for some test stx transfers
@@ -7830,8 +7830,8 @@ fn check_block_info() {
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     naka_conf.miner.tenure_cost_limit_per_block_percentage = None;
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
 
     // setup sender + recipient for some test stx transfers
@@ -8462,8 +8462,8 @@ fn check_block_info_rewards() {
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     naka_conf.burnchain.chain_id = CHAIN_ID_TESTNET + 1;
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
 
     // setup sender + recipient for some test stx transfers
@@ -8797,8 +8797,8 @@ fn mock_mining() {
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     naka_conf.node.pox_sync_sample_secs = 30;
     naka_conf.miner.tenure_cost_limit_per_block_percentage = None;
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     let tenure_count = 3;
@@ -9237,10 +9237,10 @@ fn v3_signer_api_endpoint() {
     conf.connection_options.auth_token = Some(password);
     conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let stacker_sk = setup_stacker(&mut conf);
-    let signer_sk = Secp256k1PrivateKey::new();
+    let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
     let signer_pubkey = Secp256k1PublicKey::from_private(&signer_sk);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);
@@ -9411,9 +9411,9 @@ fn v3_blockbyheight_api_endpoint() {
     conf.connection_options.auth_token = Some(password);
     conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let stacker_sk = setup_stacker(&mut conf);
-    let signer_sk = Secp256k1PrivateKey::new();
+    let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);
@@ -9536,10 +9536,10 @@ fn nakamoto_lockup_events() {
     conf.connection_options.auth_token = Some(password);
     conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let stacker_sk = setup_stacker(&mut conf);
-    let signer_sk = Secp256k1PrivateKey::new();
+    let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
     let _signer_pubkey = Secp256k1PublicKey::from_private(&signer_sk);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);
@@ -9725,7 +9725,7 @@ fn skip_mining_long_tx() {
         send_amt * 15 + send_fee * 15,
     );
     naka_conf.add_initial_balance(PrincipalData::from(sender_2_addr).to_string(), 10000);
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
@@ -10099,8 +10099,8 @@ fn sip029_coinbase_change() {
     naka_conf.node.pox_sync_sample_secs = 180;
     naka_conf.burnchain.max_rbf = 10_000_000;
 
-    let sender_sk = Secp256k1PrivateKey::new();
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     let tenure_count = 5;
@@ -10297,10 +10297,10 @@ fn clarity_cost_spend_down() {
     let num_signers = 30;
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let sender_sks: Vec<_> = (0..num_signers)
-        .map(|_| Secp256k1PrivateKey::new())
+        .map(|_| Secp256k1PrivateKey::random())
         .collect();
     let sender_signer_sks: Vec<_> = (0..num_signers)
-        .map(|_| Secp256k1PrivateKey::new())
+        .map(|_| Secp256k1PrivateKey::random())
         .collect();
     let sender_signer_addrs: Vec<_> = sender_signer_sks.iter().map(tests::to_addr).collect();
     let sender_addrs: Vec<_> = sender_sks.iter().map(tests::to_addr).collect();
@@ -10589,9 +10589,9 @@ fn consensus_hash_event_dispatcher() {
     conf.connection_options.auth_token = Some(password.clone());
     conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let stacker_sk = setup_stacker(&mut conf);
-    let signer_sk = Secp256k1PrivateKey::new();
+    let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);
@@ -11140,9 +11140,9 @@ fn mine_invalid_principal_from_consensus_buff() {
     conf.connection_options.auth_token = Some(password.clone());
     conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
     let stacker_sk = setup_stacker(&mut conf);
-    let signer_sk = Secp256k1PrivateKey::new();
+    let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1476,7 +1476,7 @@ fn deep_contract() {
         ")".repeat(stack_limit + 1)
     );
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
     let spender_princ: PrincipalData = spender_addr.into();
 
@@ -1656,7 +1656,7 @@ fn liquid_ustx_integration() {
        (ok stx-liquid-supply))
     ";
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
     let spender_princ: PrincipalData = spender_addr.into();
 
@@ -1987,7 +1987,7 @@ fn stx_transfer_btc_integration_test() {
 
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     // let's fire off our transfer op.
-    let recipient_sk = StacksPrivateKey::new();
+    let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
     let transfer_stx_op = TransferStxOp {
         sender: spender_stx_addr,
@@ -2128,7 +2128,7 @@ fn stx_delegate_btc_integration_test() {
     let spender_stx_addr: StacksAddress = to_addr(&spender_sk);
     let spender_addr: PrincipalData = spender_stx_addr.into();
 
-    let recipient_sk = StacksPrivateKey::new();
+    let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
     let pox_pubkey = Secp256k1PublicKey::from_hex(
         "02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede",
@@ -2383,7 +2383,7 @@ fn stack_stx_burn_op_test() {
     let spender_sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
     let spender_stx_addr_2: StacksAddress = to_addr(&spender_sk_2);
 
-    let recipient_sk = StacksPrivateKey::new();
+    let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
@@ -4193,7 +4193,7 @@ fn filter_low_fee_tx_integration_test() {
         return;
     }
 
-    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
 
     let (mut conf, _) = neon_integration_test_conf();
@@ -4292,7 +4292,7 @@ fn filter_long_runtime_tx_integration_test() {
         return;
     }
 
-    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
 
     let (mut conf, _) = neon_integration_test_conf();
@@ -4379,7 +4379,7 @@ fn miner_submit_twice() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
     let contract_content = "
        (define-public (foo (a int))
@@ -4487,7 +4487,7 @@ fn size_check_integration_test() {
         giant_contract.push(' ');
     }
 
-    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
 
     let (mut conf, miner_account) = neon_integration_test_conf();
@@ -4656,7 +4656,7 @@ fn size_overflow_unconfirmed_microblocks_integration_test() {
         small_contract.push(' ');
     }
 
-    let spender_sks: Vec<_> = (0..5).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..5).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
 
     let (mut conf, miner_account) = neon_integration_test_conf();
@@ -4860,7 +4860,7 @@ fn size_overflow_unconfirmed_stream_microblocks_integration_test() {
         small_contract.push(' ');
     }
 
-    let spender_sks: Vec<_> = (0..20).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..20).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
 
     let (mut conf, miner_account) = neon_integration_test_conf();
@@ -5042,7 +5042,7 @@ fn size_overflow_unconfirmed_invalid_stream_microblocks_integration_test() {
         small_contract.push(' ');
     }
 
-    let spender_sks: Vec<_> = (0..25).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..25).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
 
     let (mut conf, miner_account) = neon_integration_test_conf();
@@ -5198,7 +5198,7 @@ fn runtime_overflow_unconfirmed_microblocks_integration_test() {
         return;
     }
 
-    let spender_sks: Vec<_> = (0..4).map(|_| StacksPrivateKey::new()).collect();
+    let spender_sks: Vec<_> = (0..4).map(|_| StacksPrivateKey::random()).collect();
     let spender_addrs: Vec<PrincipalData> = spender_sks.iter().map(|x| to_addr(x).into()).collect();
     let spender_addrs_c32: Vec<StacksAddress> = spender_sks.iter().map(to_addr).collect();
 
@@ -5626,7 +5626,7 @@ fn cost_voting_integration() {
         (ok proposal-id)))
     ";
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
     let spender_princ: PrincipalData = spender_addr.into();
 
@@ -6221,11 +6221,11 @@ fn block_limit_hit_integration_test() {
             .join(" "),
     );
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let addr = to_addr(&spender_sk);
-    let second_spender_sk = StacksPrivateKey::new();
+    let second_spender_sk = StacksPrivateKey::random();
     let second_spender_addr: PrincipalData = to_addr(&second_spender_sk).into();
-    let third_spender_sk = StacksPrivateKey::new();
+    let third_spender_sk = StacksPrivateKey::random();
     let third_spender_addr: PrincipalData = to_addr(&third_spender_sk).into();
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
@@ -6432,11 +6432,11 @@ fn microblock_limit_hit_integration_test() {
             .join(" "),
     );
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let addr = to_addr(&spender_sk);
-    let second_spender_sk = StacksPrivateKey::new();
+    let second_spender_sk = StacksPrivateKey::random();
     let second_spender_addr: PrincipalData = to_addr(&second_spender_sk).into();
-    let third_spender_sk = StacksPrivateKey::new();
+    let third_spender_sk = StacksPrivateKey::random();
     let third_spender_addr: PrincipalData = to_addr(&third_spender_sk).into();
 
     let (mut conf, _) = neon_integration_test_conf();
@@ -6675,7 +6675,7 @@ fn block_large_tx_integration_test() {
             .join(" ")
     );
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
 
     let (mut conf, miner_account) = neon_integration_test_conf();
@@ -6807,7 +6807,7 @@ fn microblock_large_tx_integration_test_FLAKY() {
             .join(" ")
     );
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let addr = to_addr(&spender_sk);
 
     let (mut conf, miner_account) = neon_integration_test_conf();
@@ -6924,13 +6924,13 @@ fn pox_integration_test() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
-    let spender_2_sk = StacksPrivateKey::new();
+    let spender_2_sk = StacksPrivateKey::random();
     let spender_2_addr: PrincipalData = to_addr(&spender_2_sk).into();
 
-    let spender_3_sk = StacksPrivateKey::new();
+    let spender_3_sk = StacksPrivateKey::random();
     let spender_3_addr: PrincipalData = to_addr(&spender_3_sk).into();
 
     let pox_pubkey = Secp256k1PublicKey::from_hex(
@@ -6939,7 +6939,7 @@ fn pox_integration_test() {
     .unwrap();
     let pox_pubkey_hash = bytes_to_hex(&Hash160::from_node_public_key(&pox_pubkey).to_bytes());
 
-    let pox_2_pubkey = Secp256k1PublicKey::from_private(&StacksPrivateKey::new());
+    let pox_2_pubkey = Secp256k1PublicKey::from_private(&StacksPrivateKey::random());
     let pox_2_pubkey_hash = bytes_to_hex(&Hash160::from_node_public_key(&pox_2_pubkey).to_bytes());
 
     let pox_2_address = BitcoinAddress::from_bytes_legacy(
@@ -7449,7 +7449,7 @@ fn atlas_integration_test() {
         return;
     }
 
-    let user_1 = StacksPrivateKey::new();
+    let user_1 = StacksPrivateKey::random();
     let initial_balance_user_1 = InitialBalance {
         address: to_addr(&user_1).into(),
         amount: 1_000_000_000 * u64::from(core::MICROSTACKS_PER_STACKS),
@@ -7865,7 +7865,7 @@ fn atlas_integration_test() {
     // executing the transactions, once mined.
     let namespace = "passport";
     for i in 1..10 {
-        let user = StacksPrivateKey::new();
+        let user = StacksPrivateKey::random();
         let zonefile_hex = format!("facade0{i}");
         let hashed_zonefile = Hash160::from_data(&hex_bytes(&zonefile_hex).unwrap());
         let name = format!("johndoe{i}");
@@ -7968,7 +7968,7 @@ fn antientropy_integration_test() {
         return;
     }
 
-    let user_1 = StacksPrivateKey::new();
+    let user_1 = StacksPrivateKey::random();
     let initial_balance_user_1 = InitialBalance {
         address: to_addr(&user_1).into(),
         amount: 1_000_000_000 * u64::from(core::MICROSTACKS_PER_STACKS),
@@ -8248,7 +8248,7 @@ fn atlas_stress_integration_test() {
     let batch_size = 20;
 
     for _i in 0..(2 * batches * batch_size + 1) {
-        let user = StacksPrivateKey::new();
+        let user = StacksPrivateKey::random();
         let initial_balance_user = InitialBalance {
             address: to_addr(&user).into(),
             amount: 1_000_000_000 * u64::from(core::MICROSTACKS_PER_STACKS),
@@ -8993,7 +8993,7 @@ fn fuzzed_median_fee_rate_estimation_test(window_size: u64, expected_final_value
       (ok (var-get counter))))
     "#;
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
 
     let (mut conf, _) = neon_integration_test_conf();
@@ -11521,7 +11521,7 @@ fn test_competing_miners_build_on_same_chain(
         return;
     }
 
-    let privks: Vec<_> = (0..100).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..100).map(|_| StacksPrivateKey::random()).collect();
     let balances: Vec<_> = privks
         .iter()
         .map(|privk| {
@@ -11538,7 +11538,7 @@ fn test_competing_miners_build_on_same_chain(
     let mut blocks_processed = vec![];
 
     for _i in 0..num_miners {
-        let seed = StacksPrivateKey::new().to_bytes();
+        let seed = StacksPrivateKey::random().to_bytes();
         let (mut conf, _) = neon_integration_test_conf_with_seed(seed);
 
         conf.initial_balances.append(&mut balances.clone());
@@ -11777,7 +11777,7 @@ fn microblock_miner_multiple_attempts() {
     conf.burnchain.max_rbf = 1000000;
     conf.node.wait_time_for_blocks = 1_000;
 
-    let privks: Vec<_> = (0..100).map(|_| StacksPrivateKey::new()).collect();
+    let privks: Vec<_> = (0..100).map(|_| StacksPrivateKey::random()).collect();
     let balances: Vec<_> = privks
         .iter()
         .map(|privk| {
@@ -11859,7 +11859,7 @@ fn min_txs() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
     let spender_princ: PrincipalData = spender_addr.into();
 
@@ -11962,7 +11962,7 @@ fn filter_txs_by_type() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
     let spender_princ: PrincipalData = spender_addr.into();
 
@@ -12075,7 +12075,7 @@ fn filter_txs_by_origin() {
         return;
     }
 
-    let spender_sk = StacksPrivateKey::new();
+    let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
     let spender_princ: PrincipalData = spender_addr.into();
 

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -147,7 +147,11 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
                     "Number of private keys does not match number of signers"
                 )
             })
-            .unwrap_or_else(|| (0..num_signers).map(|_| StacksPrivateKey::new()).collect());
+            .unwrap_or_else(|| {
+                (0..num_signers)
+                    .map(|_| StacksPrivateKey::random())
+                    .collect()
+            });
 
         let (mut naka_conf, _miner_account) = naka_neon_integration_conf(None);
 
@@ -729,7 +733,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     pub fn get_latest_block_response(&self, slot_id: u32) -> BlockResponse {
         let mut stackerdb = StackerDB::new(
             &self.running_nodes.conf.node.rpc_bind,
-            StacksPrivateKey::new(), // We are just reading so don't care what the key is
+            StacksPrivateKey::random(), // We are just reading so don't care what the key is
             false,
             self.get_current_reward_cycle(),
             SignerSlotID(0), // We are just reading so again, don't care about index.

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -825,7 +825,7 @@ fn reloads_signer_set_in() {
         .init();
 
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -941,7 +941,7 @@ fn forked_tenure_testing(
         .init();
 
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -1279,7 +1279,7 @@ fn bitcoind_forking_test() {
     }
 
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -1511,7 +1511,7 @@ fn multiple_miners() {
     }
 
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -1784,7 +1784,7 @@ fn miner_forking() {
     }
 
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2248,7 +2248,7 @@ fn end_of_tenure() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2396,7 +2396,7 @@ fn retry_on_rejection() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2528,7 +2528,7 @@ fn signers_broadcast_signed_blocks() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2623,7 +2623,7 @@ fn tenure_extend_after_idle_signers() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2675,7 +2675,7 @@ fn tenure_extend_after_idle_miner() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2751,7 +2751,7 @@ fn tenure_extend_succeeds_after_rejected_attempt() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2841,7 +2841,7 @@ fn stx_transfers_dont_effect_idle_timeout() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -2964,9 +2964,9 @@ fn idle_tenure_extend_active_mining() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
-    let deployer_sk = Secp256k1PrivateKey::new();
+    let deployer_sk = Secp256k1PrivateKey::random();
     let deployer_addr = tests::to_addr(&deployer_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -3224,7 +3224,7 @@ fn empty_sortition() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -3332,7 +3332,7 @@ fn empty_sortition() {
     let reward_cycle = signer_test.get_current_reward_cycle();
     let mut stackerdb = StackerDB::new(
         &signer_test.running_nodes.conf.node.rpc_bind,
-        StacksPrivateKey::new(), // We are just reading so don't care what the key is
+        StacksPrivateKey::random(), // We are just reading so don't care what the key is
         false,
         reward_cycle,
         SignerSlotID(0), // We are just reading so again, don't care about index.
@@ -3408,7 +3408,7 @@ fn empty_sortition_before_approval() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -3563,7 +3563,7 @@ fn empty_sortition_before_proposal() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -3715,7 +3715,7 @@ fn mock_sign_epoch_25() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -3839,7 +3839,7 @@ fn multiple_miners_mock_sign_epoch_25() {
     }
 
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -4046,14 +4046,14 @@ fn signer_set_rollover() {
     let new_num_signers = 4;
 
     let new_signer_private_keys: Vec<_> = (0..new_num_signers)
-        .map(|_| StacksPrivateKey::new())
+        .map(|_| StacksPrivateKey::random())
         .collect();
     let new_signer_public_keys: Vec<_> = new_signer_private_keys
         .iter()
         .map(|sk| Secp256k1PublicKey::from_private(sk).to_bytes_compressed())
         .collect();
     let new_signer_addresses: Vec<_> = new_signer_private_keys.iter().map(tests::to_addr).collect();
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -4342,7 +4342,7 @@ fn min_gap_between_blocks() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -4463,7 +4463,7 @@ fn duplicate_signers() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let mut signer_stacks_private_keys = (0..num_signers)
-        .map(|_| StacksPrivateKey::new())
+        .map(|_| StacksPrivateKey::random())
         .collect::<Vec<_>>();
 
     // First two signers have same private key
@@ -4558,7 +4558,7 @@ fn multiple_miners_with_nakamoto_blocks() {
     let inter_blocks_per_tenure = 5;
 
     // setup sender + recipient for a test stx transfer
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
     let send_fee = 180;
@@ -4826,7 +4826,7 @@ fn partial_tenure_fork() {
     let inter_blocks_per_tenure = 5;
 
     // setup sender + recipient for a test stx transfer
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
     let send_fee = 180;
@@ -5306,7 +5306,7 @@ fn locally_accepted_blocks_overriden_by_global_rejection() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -5487,7 +5487,7 @@ fn locally_rejected_blocks_overriden_by_global_acceptance() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -5705,7 +5705,7 @@ fn reorg_locally_accepted_blocks_across_tenures_succeeds() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -5925,7 +5925,7 @@ fn reorg_locally_accepted_blocks_across_tenures_fails() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -6141,7 +6141,7 @@ fn miner_recovers_when_broadcast_block_delay_across_tenures_occurs() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -6460,7 +6460,7 @@ fn continue_after_fast_block_no_sortition() {
 
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -7006,7 +7006,7 @@ fn continue_after_tenure_extend() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let send_amt = 100;
@@ -7238,7 +7238,7 @@ fn multiple_miners_with_custom_chain_id() {
     let inter_blocks_per_tenure = 5;
 
     // setup sender + recipient for a test stx transfer
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
     let send_fee = 180;
@@ -7639,7 +7639,7 @@ fn block_validation_response_timeout() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let timeout = Duration::from_secs(30);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -7814,7 +7814,7 @@ fn block_validation_pending_table() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let timeout = Duration::from_secs(30);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -7974,7 +7974,7 @@ fn new_tenure_while_validating_previous_scenario() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let timeout = Duration::from_secs(30);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -8141,7 +8141,7 @@ fn tenure_extend_after_failed_miner() {
 
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -8503,7 +8503,7 @@ fn tenure_extend_after_bad_commit() {
 
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -8985,7 +8985,7 @@ fn tenure_extend_after_2_bad_commits() {
 
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -9676,7 +9676,7 @@ fn global_acceptance_depends_on_block_announcement() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -9931,7 +9931,7 @@ fn no_reorg_due_to_successive_block_validation_ok() {
 
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -10464,7 +10464,7 @@ fn incoming_signers_ignore_block_proposals() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -10526,7 +10526,7 @@ fn incoming_signers_ignore_block_proposals() {
     let blocks_before = mined_blocks.load(Ordering::SeqCst);
     let mut stackerdb = StackerDB::new(
         &signer_test.running_nodes.conf.node.rpc_bind,
-        StacksPrivateKey::new(), // We are just reading so don't care what the key is
+        StacksPrivateKey::random(), // We are just reading so don't care what the key is
         false,
         next_reward_cycle,
         SignerSlotID(0), // We are just reading so again, don't care about index.
@@ -10636,7 +10636,7 @@ fn outgoing_signers_ignore_block_proposals() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -10701,7 +10701,7 @@ fn outgoing_signers_ignore_block_proposals() {
     let blocks_before = mined_blocks.load(Ordering::SeqCst);
     let mut stackerdb = StackerDB::new(
         &signer_test.running_nodes.conf.node.rpc_bind,
-        StacksPrivateKey::new(), // We are just reading so don't care what the key is
+        StacksPrivateKey::random(), // We are just reading so don't care what the key is
         false,
         old_reward_cycle,
         SignerSlotID(0), // We are just reading so again, don't care about index.
@@ -10808,8 +10808,10 @@ fn injected_signatures_are_ignored_across_boundaries() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 4;
     let new_num_signers = 5_usize;
-    let signer_private_keys: Vec<_> = (0..num_signers).map(|_| StacksPrivateKey::new()).collect();
-    let new_signer_private_key = StacksPrivateKey::new();
+    let signer_private_keys: Vec<_> = (0..num_signers)
+        .map(|_| StacksPrivateKey::random())
+        .collect();
+    let new_signer_private_key = StacksPrivateKey::random();
     let mut new_signer_private_keys = signer_private_keys.clone();
     new_signer_private_keys.push(new_signer_private_key);
 
@@ -10818,7 +10820,7 @@ fn injected_signatures_are_ignored_across_boundaries() {
         .map(|sk| Secp256k1PublicKey::from_private(sk).to_bytes_compressed())
         .collect();
     let new_signer_addresses: Vec<_> = new_signer_private_keys.iter().map(tests::to_addr).collect();
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -11211,7 +11213,7 @@ fn rejected_blocks_count_towards_miner_validity() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
@@ -11372,7 +11374,7 @@ fn fast_sortition() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
 
     let mut sender_nonce = 0;
@@ -11455,7 +11457,7 @@ fn multiple_miners_empty_sortition() {
         return;
     }
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_fee = 180;
 
@@ -11729,7 +11731,7 @@ fn single_miner_empty_sortition() {
         return;
     }
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let send_fee = 180;
 
@@ -12014,7 +12016,7 @@ fn allow_reorg_within_first_proposal_burn_block_timing_secs() {
 
     let num_signers = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
     let mut sender_nonce = 0;
     let send_amt = 100;


### PR DESCRIPTION
to run `cargo clippy --tests --all-features -- -Aclippy::all -W clippy::unnecessary_to_owned -W clippy::unwrap_or_default`