### PR TITLE
chore: Apply Clippy lint `match_like_matches_macro`

### DIFF
--- a/stackslib/src/burnchains/bitcoin/address.rs
+++ b/stackslib/src/burnchains/bitcoin/address.rs
@@ -396,27 +396,15 @@ impl SegwitBitcoinAddress {
     }
 
     pub fn is_p2wpkh(&self) -> bool {
-        if let SegwitBitcoinAddress::P2WPKH(..) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, SegwitBitcoinAddress::P2WPKH(..))
     }
 
     pub fn is_p2wsh(&self) -> bool {
-        if let SegwitBitcoinAddress::P2WSH(..) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, SegwitBitcoinAddress::P2WSH(..))
     }
 
     pub fn is_p2tr(&self) -> bool {
-        if let SegwitBitcoinAddress::P2TR(..) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, SegwitBitcoinAddress::P2TR(..))
     }
 }
 

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -150,10 +150,10 @@ impl BurnchainParameters {
     }
 
     pub fn is_testnet(network_id: u32) -> bool {
-        match network_id {
-            BITCOIN_NETWORK_ID_TESTNET | BITCOIN_NETWORK_ID_REGTEST => true,
-            _ => false,
-        }
+        matches!(
+            network_id,
+            BITCOIN_NETWORK_ID_TESTNET | BITCOIN_NETWORK_ID_REGTEST
+        )
     }
 }
 

--- a/stackslib/src/chainstate/burn/operations/delegate_stx.rs
+++ b/stackslib/src/chainstate/burn/operations/delegate_stx.rs
@@ -457,10 +457,7 @@ mod tests {
             &sender,
         )
         .unwrap_err();
-        assert!(match err {
-            op_error::ParseError => true,
-            _ => false,
-        });
+        assert!(matches!(err, op_error::ParseError));
 
         // Data is length 17. The 16th byte is set to 1, which signals that until_burn_height
         // is Some(u64), so the deserialize function expects another 8 bytes
@@ -496,10 +493,7 @@ mod tests {
             &sender,
         )
         .unwrap_err();
-        assert!(match err {
-            op_error::ParseError => true,
-            _ => false,
-        });
+        assert!(matches!(err, op_error::ParseError));
     }
 
     // This test sets the op code to the op code of the StackStx
@@ -540,10 +534,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(match err {
-            op_error::InvalidInput => true,
-            _ => false,
-        });
+        assert!(matches!(err, op_error::InvalidInput));
     }
 
     // This test constructs a tx with zero outputs, which causes
@@ -576,10 +567,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(match err {
-            op_error::InvalidInput => true,
-            _ => false,
-        });
+        assert!(matches!(err, op_error::InvalidInput));
     }
 
     // Parse a normal DelegateStx op in which the reward_addr is set to output index 2.

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1280,11 +1280,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(if let op_error::BlockCommitBadOutputs = err {
-            true
-        } else {
-            false
-        });
+        assert!(matches!(err, op_error::BlockCommitBadOutputs));
 
         // should succeed in epoch 2.1 -- can be PoX in 2.1
         let _op = LeaderBlockCommitOp::parse_from_tx(

--- a/stackslib/src/chainstate/stacks/auth.rs
+++ b/stackslib/src/chainstate/stacks/auth.rs
@@ -1256,17 +1256,11 @@ impl TransactionAuth {
     }
 
     pub fn is_standard(&self) -> bool {
-        match *self {
-            TransactionAuth::Standard(_) => true,
-            _ => false,
-        }
+        matches!(self, TransactionAuth::Standard(_))
     }
 
     pub fn is_sponsored(&self) -> bool {
-        match *self {
-            TransactionAuth::Sponsored(_, _) => true,
-            _ => false,
-        }
+        matches!(self, TransactionAuth::Sponsored(..))
     }
 
     /// When beginning to sign a sponsored transaction, the origin account will not commit to any

--- a/stackslib/src/chainstate/stacks/index/node.rs
+++ b/stackslib/src/chainstate/stacks/index/node.rs
@@ -1240,38 +1240,23 @@ macro_rules! with_node {
 
 impl TrieNodeType {
     pub fn is_leaf(&self) -> bool {
-        match self {
-            TrieNodeType::Leaf(_) => true,
-            _ => false,
-        }
+        matches!(self, TrieNodeType::Leaf(_))
     }
 
     pub fn is_node4(&self) -> bool {
-        match self {
-            TrieNodeType::Node4(_) => true,
-            _ => false,
-        }
+        matches!(self, TrieNodeType::Node4(_))
     }
 
     pub fn is_node16(&self) -> bool {
-        match self {
-            TrieNodeType::Node16(_) => true,
-            _ => false,
-        }
+        matches!(self, TrieNodeType::Node16(_))
     }
 
     pub fn is_node48(&self) -> bool {
-        match self {
-            TrieNodeType::Node48(_) => true,
-            _ => false,
-        }
+        matches!(self, TrieNodeType::Node48(_))
     }
 
     pub fn is_node256(&self) -> bool {
-        match self {
-            TrieNodeType::Node256(_) => true,
-            _ => false,
-        }
+        matches!(self, TrieNodeType::Node256(_))
     }
 
     pub fn id(&self) -> u8 {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -551,10 +551,7 @@ impl TransactionResult {
 
     /// Returns true iff this enum is backed by `TransactionSuccess`.
     pub fn is_ok(&self) -> bool {
-        match &self {
-            TransactionResult::Success(_) => true,
-            _ => false,
-        }
+        matches!(self, TransactionResult::Success(_))
     }
 
     /// Returns a TransactionSuccess result as a pair of 1) fee and 2) receipt.
@@ -568,10 +565,7 @@ impl TransactionResult {
 
     /// Returns true iff this enum is backed by `Error`.
     pub fn is_err(&self) -> bool {
-        match &self {
-            TransactionResult::ProcessingError(_) => true,
-            _ => false,
-        }
+        matches!(self, TransactionResult::ProcessingError(_))
     }
 
     /// Returns an Error result as an Error.

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -461,17 +461,11 @@ pub enum TransactionAuthField {
 
 impl TransactionAuthField {
     pub fn is_public_key(&self) -> bool {
-        match *self {
-            TransactionAuthField::PublicKey(_) => true,
-            _ => false,
-        }
+        matches!(self, TransactionAuthField::PublicKey(_))
     }
 
     pub fn is_signature(&self) -> bool {
-        match *self {
-            TransactionAuthField::Signature(_, _) => true,
-            _ => false,
-        }
+        matches!(self, TransactionAuthField::Signature(..))
     }
 
     pub fn as_public_key(&self) -> Option<StacksPublicKey> {

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -1277,20 +1277,14 @@ fn test_build_anchored_blocks_incrementing_nonces() {
     //  because the tx fee for each transaction increases with the nonce
     for (i, tx) in stacks_block.txs.iter().enumerate() {
         if i == 0 {
-            let okay = if let TransactionPayload::Coinbase(..) = tx.payload {
-                true
-            } else {
-                false
-            };
+            let okay = matches!(tx.payload, TransactionPayload::Coinbase(..));
             assert!(okay, "Coinbase should be first tx");
         } else {
             let expected_nonce = (i - 1) % 25;
             assert_eq!(
                 tx.get_origin_nonce(),
                 expected_nonce as u64,
-                "{}th transaction should have nonce = {}",
-                i,
-                expected_nonce
+                "{i}th transaction should have nonce = {expected_nonce}",
             );
         }
     }

--- a/stackslib/src/chainstate/stacks/transaction.rs
+++ b/stackslib/src/chainstate/stacks/transaction.rs
@@ -1030,10 +1030,7 @@ impl StacksTransaction {
 
     /// Is this a mainnet transaction?  false means 'testnet'
     pub fn is_mainnet(&self) -> bool {
-        match self.version {
-            TransactionVersion::Mainnet => true,
-            _ => false,
-        }
+        self.version == TransactionVersion::Mainnet
     }
 
     /// Is this a phantom transaction?
@@ -3993,10 +3990,10 @@ mod test {
             TransactionAuth::Standard(origin) => origin,
             TransactionAuth::Sponsored(_, sponsor) => sponsor,
         };
-        match spending_condition {
-            TransactionSpendingCondition::OrderIndependentMultisig(..) => true,
-            _ => false,
-        }
+        matches!(
+            spending_condition,
+            TransactionSpendingCondition::OrderIndependentMultisig(..)
+        )
     }
 
     fn check_oversign_origin_multisig(signed_tx: &StacksTransaction) {

--- a/stackslib/src/clarity_cli.rs
+++ b/stackslib/src/clarity_cli.rs
@@ -1001,11 +1001,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
         "initialize" => {
             let mut argv = args.to_vec();
 
-            let mainnet = if let Ok(Some(_)) = consume_arg(&mut argv, &["--testnet"], false) {
-                false
-            } else {
-                true
-            };
+            let mainnet = !matches!(consume_arg(&mut argv, &["--testnet"], false), Ok(Some(_)));
 
             let (db_name, allocations) = if argv.len() == 3 {
                 let filename = &argv[1];
@@ -1147,11 +1143,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                     panic_test!();
                 };
 
-            let costs = if let Ok(Some(_)) = consume_arg(&mut argv, &["--costs"], false) {
-                true
-            } else {
-                false
-            };
+            let costs = matches!(consume_arg(&mut argv, &["--costs"], false), Ok(Some(_)));
 
             // NOTE: ignored if we're using a DB
             let mut testnet_given = false;
@@ -1251,11 +1243,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
         }
         "repl" => {
             let mut argv = args.to_vec();
-            let mainnet = if let Ok(Some(_)) = consume_arg(&mut argv, &["--testnet"], false) {
-                false
-            } else {
-                true
-            };
+            let mainnet = !matches!(consume_arg(&mut argv, &["--testnet"], false), Ok(Some(_)));
             let mut marf = MemoryBackingStore::new();
             let mut vm_env = OwnedEnvironment::new_free(
                 mainnet,
@@ -1384,11 +1372,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
         "eval" => {
             let mut argv = args.to_vec();
 
-            let costs = if let Ok(Some(_)) = consume_arg(&mut argv, &["--costs"], false) {
-                true
-            } else {
-                false
-            };
+            let costs = matches!(consume_arg(&mut argv, &["--costs"], false), Ok(Some(_)));
 
             let evalInput = get_eval_input(invoked_by, &argv);
             let vm_filename = if argv.len() == 3 { &argv[2] } else { &argv[3] };
@@ -1447,16 +1431,8 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
         "eval_at_chaintip" => {
             let mut argv = args.to_vec();
 
-            let costs = if let Ok(Some(_)) = consume_arg(&mut argv, &["--costs"], false) {
-                true
-            } else {
-                false
-            };
-            let coverage_folder = if let Ok(covarg) = consume_arg(&mut argv, &["--c"], true) {
-                covarg
-            } else {
-                None
-            };
+            let costs = matches!(consume_arg(&mut argv, &["--costs"], false), Ok(Some(_)));
+            let coverage_folder = consume_arg(&mut argv, &["--c"], true).unwrap_or(None);
 
             let evalInput = get_eval_input(invoked_by, &argv);
             let vm_filename = if argv.len() == 3 { &argv[2] } else { &argv[3] };
@@ -1529,11 +1505,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
         "eval_at_block" => {
             let mut argv = args.to_vec();
 
-            let costs = if let Ok(Some(_)) = consume_arg(&mut argv, &["--costs"], false) {
-                true
-            } else {
-                false
-            };
+            let costs = matches!(consume_arg(&mut argv, &["--costs"], false), Ok(Some(_)));
 
             if argv.len() != 4 {
                 eprintln!(
@@ -1610,27 +1582,15 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
         }
         "launch" => {
             let mut argv = args.to_vec();
-            let coverage_folder = if let Ok(covarg) = consume_arg(&mut argv, &["--c"], true) {
-                covarg
-            } else {
-                None
-            };
-            let costs = if let Ok(Some(_)) = consume_arg(&mut argv, &["--costs"], false) {
-                true
-            } else {
-                false
-            };
-            let assets = if let Ok(Some(_)) = consume_arg(&mut argv, &["--assets"], false) {
-                true
-            } else {
-                false
-            };
-            let output_analysis =
-                if let Ok(Some(_)) = consume_arg(&mut argv, &["--output_analysis"], false) {
-                    true
-                } else {
-                    false
-                };
+            let coverage_folder = consume_arg(&mut argv, &["--c"], true).unwrap_or(None);
+
+            let costs = matches!(consume_arg(&mut argv, &["--costs"], false), Ok(Some(_)));
+            let assets = matches!(consume_arg(&mut argv, &["--assets"], false), Ok(Some(_)));
+            let output_analysis = matches!(
+                consume_arg(&mut argv, &["--output_analysis"], false),
+                Ok(Some(_))
+            );
+
             if argv.len() < 4 {
                 eprintln!(
                     "Usage: {} {} [--costs] [--assets] [--output_analysis] [contract-identifier] [contract-definition.clar] [vm-state.db]",
@@ -1765,22 +1725,10 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
         }
         "execute" => {
             let mut argv = args.to_vec();
-            let coverage_folder = if let Ok(covarg) = consume_arg(&mut argv, &["--c"], true) {
-                covarg
-            } else {
-                None
-            };
+            let coverage_folder = consume_arg(&mut argv, &["--c"], true).unwrap_or(None);
 
-            let costs = if let Ok(Some(_)) = consume_arg(&mut argv, &["--costs"], false) {
-                true
-            } else {
-                false
-            };
-            let assets = if let Ok(Some(_)) = consume_arg(&mut argv, &["--assets"], false) {
-                true
-            } else {
-                false
-            };
+            let costs = matches!(consume_arg(&mut argv, &["--costs"], false), Ok(Some(_)));
+            let assets = matches!(consume_arg(&mut argv, &["--assets"], false), Ok(Some(_)));
 
             if argv.len() < 5 {
                 eprintln!("Usage: {} {} [--costs] [--assets] [vm-state.db] [contract-identifier] [public-function-name] [sender-address] [args...]", invoked_by, argv[0]);

--- a/stackslib/src/net/atlas/download.rs
+++ b/stackslib/src/net/atlas/download.rs
@@ -442,16 +442,10 @@ impl AttachmentsBatchStateContext {
                         .iter()
                         .position(|page| page.index == page_index);
 
-                    let has_attachment = match index {
-                        Some(index) => match response.pages[index]
-                            .inventory
-                            .get(position_in_page as usize)
-                        {
-                            Some(result) if *result == 1 => true,
-                            _ => false,
-                        },
-                        None => false,
-                    };
+                    let has_attachment = index
+                        .and_then(|i| response.pages[i].inventory.get(position_in_page as usize))
+                        .map(|result| *result == 1)
+                        .unwrap_or(false);
 
                     if !has_attachment {
                         debug!(

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -1641,13 +1641,10 @@ pub mod test {
     fn check_deserialize<T: std::fmt::Debug>(r: Result<T, codec_error>) -> bool {
         match r {
             Ok(m) => {
-                test_debug!("deserialized {:?}", &m);
+                test_debug!("deserialized {m:?}");
                 false
             }
-            Err(e) => match e {
-                codec_error::DeserializeError(_) => true,
-                _ => false,
-            },
+            Err(e) => matches!(e, codec_error::DeserializeError(_)),
         }
     }
 

--- a/stackslib/src/net/http/common.rs
+++ b/stackslib/src/net/http/common.rs
@@ -46,11 +46,7 @@ pub enum HttpReservedHeader {
 
 impl HttpReservedHeader {
     pub fn is_reserved(header: &str) -> bool {
-        let hdr = header.to_string();
-        match hdr.as_str() {
-            "content-length" | "content-type" | "host" => true,
-            _ => false,
-        }
+        matches!(header, "content-length" | "content-type" | "host")
     }
 
     pub fn try_from_str(header: &str, value: &str) -> Option<HttpReservedHeader> {

--- a/stackslib/src/net/tests/inv/nakamoto.rs
+++ b/stackslib/src/net/tests/inv/nakamoto.rs
@@ -126,16 +126,12 @@ pub fn peer_get_nakamoto_invs<'a>(
             loop {
                 // read back the message
                 let msg: StacksMessage = read_next(&mut tcp_socket).unwrap();
-                let is_inv_reply = if let StacksMessageType::NakamotoInv(..) = &msg.payload {
-                    true
-                } else {
-                    false
-                };
-                if is_inv_reply {
+
+                if matches!(&msg.payload, StacksMessageType::NakamotoInv(..)) {
                     replies.push(msg.payload);
                     break;
                 } else {
-                    debug!("Got spurious meessage {:?}", &msg);
+                    debug!("Got spurious meessage {msg:?}");
                 }
             }
         }


### PR DESCRIPTION
### Description

> [!warning]
> These change were applied manually and not with `clippy --fix`.
> Please double-check to make sure I didn't accidentally reverse any `bool`s!

Apply Clippy lint `match_like_matches_macro`, which finds `if let` and `match` expressions which evaluate to `bool` and can be simplified with the `matches!()` macro

