### PR TITLE
chore: Apply Clippy lint `manual_inspect`

### DIFF
--- a/stackslib/src/burnchains/bitcoin/address.rs
+++ b/stackslib/src/burnchains/bitcoin/address.rs
@@ -302,9 +302,8 @@ impl SegwitBitcoinAddress {
 
     pub fn from_bech32(s: &str) -> Option<SegwitBitcoinAddress> {
         let (hrp, quintets, variant) = bech32::decode(s)
-            .map_err(|e| {
-                test_debug!("Failed to decode '{}': {:?}", s, &e);
-                e
+            .inspect_err(|_e| {
+                test_debug!("Failed to decode '{s}': {_e:?}");
             })
             .ok()?;
 
@@ -327,9 +326,8 @@ impl SegwitBitcoinAddress {
         prog.append(&mut quintets[1..].to_vec());
 
         let bytes = Vec::from_base32(&prog)
-            .map_err(|e| {
-                test_debug!("Failed to decode quintets: {:?}", &e);
-                e
+            .inspect_err(|_e| {
+                test_debug!("Failed to decode quintets: {_e:?}");
             })
             .ok()?;
 

--- a/stackslib/src/burnchains/bitcoin/bits.rs
+++ b/stackslib/src/burnchains/bitcoin/bits.rs
@@ -112,22 +112,15 @@ impl BitcoinTxInputStructured {
                 Instruction::PushBytes(payload) => payload,
                 _ => {
                     // not pushbytes, so this can't be a multisig script
-                    test_debug!(
-                        "Not a multisig script: Instruction {} is not a PushBytes",
-                        i
-                    );
+                    test_debug!("Not a multisig script: Instruction {i} is not a PushBytes");
                     return None;
                 }
             };
 
             let pubk = BitcoinPublicKey::from_slice(payload)
-                .map_err(|e| {
+                .inspect_err(|&e| {
                     // not a public key
-                    warn!(
-                        "Not a multisig script: pushbytes {} is not a public key ({:?})",
-                        i, e
-                    );
-                    e
+                    warn!("Not a multisig script: pushbytes {i} is not a public key ({e:?})");
                 })
                 .ok()?;
 
@@ -169,13 +162,9 @@ impl BitcoinTxInputStructured {
         for i in 0..pubkey_vecs.len() {
             let payload = &pubkey_vecs[i];
             let pubk = BitcoinPublicKey::from_slice(&payload[..])
-                .map_err(|e| {
+                .inspect_err(|&e| {
                     // not a public key
-                    warn!(
-                        "Not a multisig script: item {} is not a public key ({:?})",
-                        i, e
-                    );
-                    e
+                    warn!("Not a multisig script: item {i} is not a public key ({e:?})");
                 })
                 .ok()?;
 

--- a/stackslib/src/burnchains/bitcoin/indexer.rs
+++ b/stackslib/src/burnchains/bitcoin/indexer.rs
@@ -627,12 +627,8 @@ impl BitcoinIndexer {
         )?;
 
         // what's the last header we have from the canonical history?
-        let canonical_end_block = orig_spv_client.get_headers_height().map_err(|e| {
-            error!(
-                "Failed to get the last block from {}",
-                canonical_headers_path
-            );
-            e
+        let canonical_end_block = orig_spv_client.get_headers_height().inspect_err(|_e| {
+            error!("Failed to get the last block from {canonical_headers_path}");
         })?;
 
         // bootstrap reorg client
@@ -694,13 +690,12 @@ impl BitcoinIndexer {
 
             let reorg_headers = reorg_spv_client
                 .read_block_headers(start_block, start_block + REORG_BATCH_SIZE)
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     error!(
                         "Failed to read reorg Bitcoin headers from {} to {}",
                         start_block,
                         start_block + REORG_BATCH_SIZE
                     );
-                    e
                 })?;
 
             if reorg_headers.is_empty() {
@@ -724,13 +719,12 @@ impl BitcoinIndexer {
             // got reorg headers.  Find the equivalent headers in our canonical history
             let canonical_headers = orig_spv_client
                 .read_block_headers(start_block, start_block + REORG_BATCH_SIZE)
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     error!(
                         "Failed to read canonical headers from {} to {}",
                         start_block,
                         start_block + REORG_BATCH_SIZE
                     );
-                    e
                 })?;
 
             assert!(

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4896,16 +4896,12 @@ impl SortitionDB {
         let qry = "SELECT * FROM snapshots WHERE sortition_id = ?1";
         let args = [&sortition_id];
         query_row_panic(conn, qry, &args, || {
-            format!(
-                "FATAL: multiple block snapshots for the same block {}",
-                sortition_id
-            )
+            format!("FATAL: multiple block snapshots for the same block {sortition_id}")
         })
-        .map(|x| {
+        .inspect(|x| {
             if x.is_none() {
-                test_debug!("No snapshot with sortition ID {}", sortition_id);
+                test_debug!("No snapshot with sortition ID {sortition_id}");
             }
-            x
         })
     }
 

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1131,19 +1131,17 @@ impl LeaderBlockCommitOp {
             .is_after_pox_sunset_end(self.block_height, epoch.epoch_id)
         {
             // sunset has begun and we're not in epoch 2.1 or later, so apply sunset check
-            self.check_after_pox_sunset().map_err(|e| {
-                warn!("Invalid block-commit: bad PoX after sunset: {:?}", &e;
+            self.check_after_pox_sunset().inspect_err(|e| {
+                warn!("Invalid block-commit: bad PoX after sunset: {e:?}";
                           "apparent_sender" => %apparent_sender_repr);
-                e
             })?;
             vec![]
         } else {
             // either in epoch 2.1, or the PoX sunset hasn't completed yet
             self.check_pox(epoch.epoch_id, burnchain, tx, reward_set_info)
-                .map_err(|e| {
-                    warn!("Invalid block-commit: bad PoX: {:?}", &e;
+                .inspect_err(|e| {
+                    warn!("Invalid block-commit: bad PoX: {e:?}";
                           "apparent_sender" => %apparent_sender_repr);
-                    e
                 })?
         };
 

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -1710,29 +1710,26 @@ impl NakamotoChainState {
         block_id: &StacksBlockId,
     ) {
         loop {
-            let Ok(staging_block_tx) = stacks_chain_state.staging_db_tx_begin().map_err(|e| {
-                warn!("Failed to begin staging DB tx: {:?}", &e);
-                e
-            }) else {
+            let Ok(staging_block_tx) = stacks_chain_state
+                .staging_db_tx_begin()
+                .inspect_err(|e| warn!("Failed to begin staging DB tx: {e:?}"))
+            else {
                 sleep_ms(1000);
                 continue;
             };
 
-            let Ok(_) = staging_block_tx.set_block_processed(block_id).map_err(|e| {
-                warn!("Failed to mark {} as processed: {:?}", block_id, &e);
-                e
-            }) else {
+            let Ok(_) = staging_block_tx
+                .set_block_processed(block_id)
+                .inspect_err(|e| warn!("Failed to mark {block_id} as processed: {e:?}"))
+            else {
                 sleep_ms(1000);
                 continue;
             };
 
-            let Ok(_) = staging_block_tx.commit().map_err(|e| {
-                warn!(
-                    "Failed to commit staging block tx for {}: {:?}",
-                    block_id, &e
-                );
-                e
-            }) else {
+            let Ok(_) = staging_block_tx
+                .commit()
+                .inspect_err(|e| warn!("Failed to commit staging block tx for {block_id}: {e:?}"))
+            else {
                 sleep_ms(1000);
                 continue;
             };
@@ -1748,29 +1745,26 @@ impl NakamotoChainState {
         block_id: &StacksBlockId,
     ) {
         loop {
-            let Ok(staging_block_tx) = stacks_chain_state.staging_db_tx_begin().map_err(|e| {
-                warn!("Failed to begin staging DB tx: {:?}", &e);
-                e
-            }) else {
+            let Ok(staging_block_tx) = stacks_chain_state
+                .staging_db_tx_begin()
+                .inspect_err(|e| warn!("Failed to begin staging DB tx: {e:?}"))
+            else {
                 sleep_ms(1000);
                 continue;
             };
 
-            let Ok(_) = staging_block_tx.set_block_orphaned(block_id).map_err(|e| {
-                warn!("Failed to mark {} as orphaned: {:?}", &block_id, &e);
-                e
-            }) else {
+            let Ok(_) = staging_block_tx
+                .set_block_orphaned(block_id)
+                .inspect_err(|e| warn!("Failed to mark {block_id} as orphaned: {e:?}"))
+            else {
                 sleep_ms(1000);
                 continue;
             };
 
-            let Ok(_) = staging_block_tx.commit().map_err(|e| {
-                warn!(
-                    "Failed to commit staging block tx for {}: {:?}",
-                    &block_id, &e
-                );
-                e
-            }) else {
+            let Ok(_) = staging_block_tx
+                .commit()
+                .inspect_err(|e| warn!("Failed to commit staging block tx for {block_id}: {e:?}"))
+            else {
                 sleep_ms(1000);
                 continue;
             };
@@ -2352,12 +2346,11 @@ impl NakamotoChainState {
         let miner_pubkey_hash160 = leader_key
             .interpret_nakamoto_signing_key()
             .ok_or(ChainstateError::NoSuchBlockError)
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 warn!(
                     "Leader key did not contain a hash160 of the miner signing public key";
                     "leader_key" => ?leader_key,
                 );
-                e
             })?;
 
         // attaches to burn chain
@@ -2959,12 +2952,11 @@ impl NakamotoChainState {
                     warn!("No VRF proof for {}", &parent_sn.consensus_hash);
                     ChainstateError::NoSuchBlockError
                 })
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     warn!("Could not find parent VRF proof";
                       "tip_block_id" => %tip_block_id,
                       "parent consensus_hash" => %parent_sn.consensus_hash,
                       "block consensus_hash" => %consensus_hash);
-                    e
                 })?;
 
         Ok(parent_vrf_proof)
@@ -3029,12 +3021,11 @@ impl NakamotoChainState {
             }
             let proof = VRFProof::from_hex(&bytes)
                 .ok_or(DBError::Corruption)
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     warn!("Failed to load VRF proof: could not decode";
                           "vrf_proof" => %bytes,
                           "tenure_start_block_id" => %tenure_start_block_id,
                     );
-                    e
                 })?;
             Ok(Some(proof))
         } else {
@@ -3087,25 +3078,23 @@ impl NakamotoChainState {
         let sn =
             SortitionDB::get_block_snapshot_consensus(sortdb_conn, &block.header.consensus_hash)?
                 .ok_or(ChainstateError::NoSuchBlockError)
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     warn!("No block-commit for block";
                         "consensus_hash" => %block.header.consensus_hash,
                         "stacks_block_hash" => %block.header.block_hash(),
                         "stacks_block_id" => %block.header.block_id()
                     );
-                    e
                 })?;
 
         let block_commit =
             get_block_commit_by_txid(sortdb_conn, &sn.sortition_id, &sn.winning_block_txid)?
                 .ok_or(ChainstateError::NoSuchBlockError)
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     warn!("No block-commit for block";
                         "consensus_hash" => %block.header.consensus_hash,
                         "stacks_block_hash" => %block.header.block_hash(),
                         "stacks_block_id" => %block.header.block_id()
                     );
-                    e
                 })?;
 
         // N.B. passing block.block_id() here means that we'll look into the parent tenure

--- a/stackslib/src/chainstate/nakamoto/shadow.rs
+++ b/stackslib/src/chainstate/nakamoto/shadow.rs
@@ -347,14 +347,13 @@ impl NakamotoChainState {
         let vrf_proof =
             Self::get_block_vrf_proof(chainstate_conn, tip_block_id, &tenure_consensus_hash)?
                 .ok_or_else(|| {
-                    warn!("No VRF proof for {}", &tenure_consensus_hash);
+                    warn!("No VRF proof for {tenure_consensus_hash}");
                     ChainstateError::NoSuchBlockError
                 })
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     warn!("Could not find shadow tenure VRF proof";
                       "tip_block_id" => %tip_block_id,
                       "shadow consensus_hash" => %tenure_consensus_hash);
-                    e
                 })?;
 
         return Ok(Some(vrf_proof));

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -500,20 +500,19 @@ impl StacksChainState {
             .open(&path_tmp)
             .map_err(|e| {
                 if e.kind() == io::ErrorKind::NotFound {
-                    error!("File not found: {:?}", &path_tmp);
+                    error!("File not found: {path_tmp:?}");
                     Error::DBError(db_error::NotFoundError)
                 } else {
-                    error!("Failed to open {:?}: {:?}", &path_tmp, &e);
+                    error!("Failed to open {path_tmp:?}: {e:?}");
                     Error::DBError(db_error::IOError(e))
                 }
             })?;
 
-        writer(&mut fd).map_err(|e| {
+        writer(&mut fd).inspect_err(|_e| {
             if delete_on_error {
                 // abort
                 let _ = fs::remove_file(&path_tmp);
             }
-            e
         })?;
 
         fd.sync_all()
@@ -3983,7 +3982,7 @@ impl StacksChainState {
         }
 
         for (consensus_hash, anchored_block_hash) in to_delete.into_iter() {
-            info!("Orphan {}/{}: it does not connect to a previously-accepted block, because its consensus hash does not match an existing snapshot on the valid PoX fork.", &consensus_hash, &anchored_block_hash);
+            info!("Orphan {consensus_hash}/{anchored_block_hash}: it does not connect to a previously-accepted block, because its consensus hash does not match an existing snapshot on the valid PoX fork.");
             let _ = StacksChainState::set_block_processed(
                 blocks_tx,
                 None,
@@ -3992,12 +3991,8 @@ impl StacksChainState {
                 &anchored_block_hash,
                 false,
             )
-            .map_err(|e| {
-                warn!(
-                    "Failed to orphan {}/{}: {:?}",
-                    &consensus_hash, &anchored_block_hash, &e
-                );
-                e
+            .inspect_err(|e| {
+                warn!("Failed to orphan {consensus_hash}/{anchored_block_hash}: {e:?}")
             });
         }
 

--- a/stackslib/src/chainstate/stacks/index/marf.rs
+++ b/stackslib/src/chainstate/stacks/index/marf.rs
@@ -440,13 +440,12 @@ impl<'a, T: MarfTrieId> MarfTransaction<'a, T> {
 
         if new_extension {
             self.set_block_heights(chain_tip, next_chain_tip, block_height)
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     self.open_chain_tip.take();
-                    e
                 })?;
         }
 
-        debug!("Opened {} to {}", chain_tip, next_chain_tip);
+        debug!("Opened {chain_tip} to {next_chain_tip}");
         Ok(())
     }
 
@@ -932,9 +931,8 @@ impl<T: MarfTrieId> MARF<T> {
         let mut cursor = TrieCursor::new(path, storage.root_trieptr());
 
         // walk to insertion point
-        let mut node = Trie::read_root_nohash(storage).map_err(|e| {
-            test_debug!("Failed to read root of {:?}: {:?}", block_hash, &e);
-            e
+        let mut node = Trie::read_root_nohash(storage).inspect_err(|_e| {
+            test_debug!("Failed to read root of {block_hash:?}: {_e:?}");
         })?;
 
         for _ in 0..(cursor.path.len() + 1) {
@@ -956,7 +954,7 @@ impl<T: MarfTrieId> MARF<T> {
                                 ));
                             }
 
-                            trace!("Cursor reached leaf {:?}", &node);
+                            trace!("Cursor reached leaf {node:?}");
                             storage.bench_mut().marf_walk_from_finish();
                             return Ok((cursor, node));
                         }
@@ -1035,24 +1033,16 @@ impl<T: MarfTrieId> MARF<T> {
         block_hash: &T,
         path: &TrieHash,
     ) -> Result<Option<TrieLeaf>, Error> {
-        trace!("MARF::get_path({:?}) {:?}", block_hash, path);
+        trace!("MARF::get_path({block_hash:?}) {path:?}");
 
         // a NotFoundError _here_ means that a block didn't exist
-        storage.open_block(block_hash).map_err(|e| {
-            test_debug!("Failed to open block {:?}: {:?}", block_hash, &e);
-            e
+        storage.open_block(block_hash).inspect_err(|_e| {
+            test_debug!("Failed to open block {block_hash:?}: {_e:?}");
         })?;
 
         // a NotFoundError _here_ means that the key doesn't exist in this view
-        let (cursor, node) = MARF::walk(storage, block_hash, path).map_err(|e| {
-            trace!(
-                "Failed to look up key {:?} {:?}: {:?}",
-                &block_hash,
-                path,
-                &e
-            );
-            e
-        })?;
+        let (cursor, node) = MARF::walk(storage, block_hash, path)
+            .inspect_err(|e| trace!("Failed to look up key {block_hash:?} {path:?}: {e:?}"))?;
 
         // both of these get caught by get_by_key and turned into Ok(None)
         //   and a lot of downstream code seems to depend on that behavior, but
@@ -1177,13 +1167,9 @@ impl<T: MarfTrieId> MARF<T> {
         // restore
         storage
             .open_block_maybe_id(&cur_block_hash, cur_block_id)
-            .map_err(|e| {
-                warn!(
-                    "Failed to re-open {} {:?}: {:?}",
-                    &cur_block_hash, cur_block_id, &e
-                );
-                warn!("Result of failed path lookup '{}': {:?}", path, &result);
-                e
+            .inspect_err(|e| {
+                warn!("Failed to re-open {cur_block_hash} {cur_block_id:?}: {e:?}");
+                warn!("Result of failed path lookup '{path}': {result:?}");
             })?;
 
         result.map(|option_result| option_result.map(|leaf| leaf.data))
@@ -1208,13 +1194,9 @@ impl<T: MarfTrieId> MARF<T> {
         // restore
         storage
             .open_block_maybe_id(&cur_block_hash, cur_block_id)
-            .map_err(|e| {
-                warn!(
-                    "Failed to re-open {} {:?}: {:?}",
-                    &cur_block_hash, cur_block_id, &e
-                );
-                warn!("Result of failed key lookup '{}': {:?}", key, &result);
-                e
+            .inspect_err(|e| {
+                warn!("Failed to re-open {cur_block_hash} {cur_block_id:?}: {e:?}");
+                warn!("Result of failed key lookup '{key}': {result:?}");
             })?;
 
         result.map(|option_result| option_result.map(|leaf| leaf.data))
@@ -1237,13 +1219,9 @@ impl<T: MarfTrieId> MARF<T> {
         // restore
         storage
             .open_block_maybe_id(&cur_block_hash, cur_block_id)
-            .map_err(|e| {
-                warn!(
-                    "Failed to re-open {} {:?}: {:?}",
-                    &cur_block_hash, cur_block_id, &e
-                );
-                warn!("Result of failed hash lookup '{}': {:?}", path, &result);
-                e
+            .inspect_err(|e| {
+                warn!("Failed to re-open {cur_block_hash} {cur_block_id:?}: {e:?}");
+                warn!("Result of failed hash lookup '{path}': {result:?}");
             })?;
 
         result.map(|option_result| option_result.map(|leaf| leaf.data))

--- a/stackslib/src/chainstate/stacks/index/storage.rs
+++ b/stackslib/src/chainstate/stacks/index/storage.rs
@@ -892,10 +892,8 @@ impl<T: MarfTrieId> TrieRAM<T> {
         let root_disk_ptr = BLOCK_HEADER_HASH_ENCODED_SIZE as u64 + 4;
 
         let root_ptr = TriePtr::new(TrieNodeID::Node256 as u8, 0, root_disk_ptr as u32);
-        let (mut root_node, root_hash) = read_nodetype(f, &root_ptr).map_err(|e| {
-            error!("Failed to read root node info for {:?}: {:?}", bhh, &e);
-            e
-        })?;
+        let (mut root_node, root_hash) = read_nodetype(f, &root_ptr)
+            .inspect_err(|e| error!("Failed to read root node info for {bhh:?}: {e:?}"))?;
 
         let mut next_index = 1;
 
@@ -922,10 +920,8 @@ impl<T: MarfTrieId> TrieRAM<T> {
             let next_ptr = frontier
                 .pop_front()
                 .expect("BUG: no ptr in non-empty frontier");
-            let (mut next_node, next_hash) = read_nodetype(f, &next_ptr).map_err(|e| {
-                error!("Failed to read node at {:?}: {:?}", &next_ptr, &e);
-                e
-            })?;
+            let (mut next_node, next_hash) = read_nodetype(f, &next_ptr)
+                .inspect_err(|e| error!("Failed to read node at {next_ptr:?}: {e:?}"))?;
 
             if !next_node.is_leaf() {
                 // queue children in the same order we stored them

--- a/stackslib/src/chainstate/stacks/index/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/trie.rs
@@ -217,22 +217,19 @@ impl Trie {
             // ptr is a backptr -- find the block
             let back_block_hash = storage
                 .get_block_from_local_id(ptr.back_block())
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     test_debug!("Failed to get block from local ID {}", ptr.back_block());
-                    e
                 })?
                 .clone();
 
             storage
                 .open_block_known_id(&back_block_hash, ptr.back_block())
-                .map_err(|e| {
+                .inspect_err(|_e| {
                     test_debug!(
-                        "Failed to open block {} with id {}: {:?}",
+                        "Failed to open block {} with id {}: {_e:?}",
                         &back_block_hash,
                         ptr.back_block(),
-                        &e
                     );
-                    e
                 })?;
 
             let backptr = ptr.from_backptr();

--- a/stackslib/src/chainstate/stacks/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/tests/mod.rs
@@ -967,22 +967,11 @@ pub fn get_last_microblock_header(
     miner: &TestMiner,
     parent_block_opt: Option<&StacksBlock>,
 ) -> Option<StacksMicroblockHeader> {
-    let last_microblocks_opt =
-        parent_block_opt.and_then(|block| node.get_microblock_stream(miner, &block.block_hash()));
-
-    let last_microblock_header_opt = match last_microblocks_opt {
-        Some(last_microblocks) => {
-            if last_microblocks.is_empty() {
-                None
-            } else {
-                let l = last_microblocks.len() - 1;
-                Some(last_microblocks[l].header.clone())
-            }
-        }
-        None => None,
-    };
-
-    last_microblock_header_opt
+    parent_block_opt
+        .and_then(|block| node.get_microblock_stream(miner, &block.block_hash()))
+        .as_ref()
+        .and_then(|mblock_stream| mblock_stream.last())
+        .map(|mblock| mblock.header.clone())
 }
 
 pub fn get_all_mining_rewards(
@@ -990,17 +979,14 @@ pub fn get_all_mining_rewards(
     tip: &StacksHeaderInfo,
     block_height: u64,
 ) -> Vec<Vec<MinerPaymentSchedule>> {
-    let mut ret = vec![];
     let mut tx = chainstate.index_tx_begin();
 
-    for i in 0..block_height {
-        let block_rewards =
+    (0..block_height)
+        .map(|i| {
             StacksChainState::get_scheduled_block_rewards_in_fork_at_height(&mut tx, tip, i)
-                .unwrap();
-        ret.push(block_rewards);
-    }
-
-    ret
+                .unwrap()
+        })
+        .collect()
 }
 
 pub fn make_coinbase(miner: &mut TestMiner, burnchain_height: usize) -> StacksTransaction {

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -1579,9 +1579,8 @@ impl BurnchainConfigFile {
                 .unwrap_or(default_burnchain_config.fault_injection_burnchain_block_delay),
             max_unspent_utxos: self
                 .max_unspent_utxos
-                .map(|val| {
+                .inspect(|&val| {
                     assert!(val <= 1024, "Value for max_unspent_utxos should be <= 1024");
-                    val
                 })
                 .or(default_burnchain_config.max_unspent_utxos),
         };

--- a/stackslib/src/net/asn.rs
+++ b/stackslib/src/net/asn.rs
@@ -122,9 +122,8 @@ impl ASEntry4 {
             .ok_or(net_error::DeserializeError(
                 "Line does not match ANS4 regex".to_string(),
             ))
-            .map_err(|e| {
-                debug!("Failed to read line \"{}\"", &buf);
-                e
+            .inspect_err(|_e| {
+                debug!("Failed to read line \"{buf}\"");
             })?;
 
         let prefix_octets_str = caps
@@ -132,9 +131,8 @@ impl ASEntry4 {
             .ok_or(net_error::DeserializeError(
                 "Failed to read ANS4 prefix".to_string(),
             ))
-            .map_err(|e| {
-                debug!("Failed to get octets of \"{}\"", &buf);
-                e
+            .inspect_err(|_e| {
+                debug!("Failed to get octets of \"{buf}\"");
             })?
             .as_str();
 
@@ -143,9 +141,8 @@ impl ASEntry4 {
             .ok_or(net_error::DeserializeError(
                 "Failed to read ASN4 prefix mask".to_string(),
             ))
-            .map_err(|e| {
-                debug!("Failed to get mask of \"{}\"", &buf);
-                e
+            .inspect_err(|_e| {
+                debug!("Failed to get mask of \"{buf}\"");
             })?
             .as_str();
 
@@ -154,9 +151,8 @@ impl ASEntry4 {
             .ok_or(net_error::DeserializeError(
                 "Failed to read ASN ID".to_string(),
             ))
-            .map_err(|e| {
-                debug!("Failed to get ASN of \"{}\"", &buf);
-                e
+            .inspect_err(|_e| {
+                debug!("Failed to get ASN of \"{buf}\"");
             })?
             .as_str();
 

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -962,10 +962,9 @@ impl ConversationP2P {
             reply_message,
             request_preamble.seq,
         )?;
-        let reply_handle = self.relay_signed_message(reply).map_err(|e| {
-            debug!("Unable to reply a {}: {:?}", _msgtype, &e);
-            e
-        })?;
+        let reply_handle = self
+            .relay_signed_message(reply)
+            .inspect_err(|e| debug!("Unable to reply a {_msgtype}: {e:?}"))?;
 
         Ok(reply_handle)
     }
@@ -981,10 +980,9 @@ impl ConversationP2P {
         let _msgtype = forward_message.get_message_name().to_owned();
         let fwd =
             self.sign_relay_message(local_peer, burnchain_view, relay_hints, forward_message)?;
-        let fwd_handle = self.relay_signed_message(fwd).map_err(|e| {
-            debug!("Unable to forward a {}: {:?}", _msgtype, &e);
-            e
-        })?;
+        let fwd_handle = self
+            .relay_signed_message(fwd)
+            .inspect_err(|e| debug!("Unable to forward a {_msgtype}: {e:?}"))?;
 
         Ok(fwd_handle)
     }
@@ -1475,13 +1473,9 @@ impl ConversationP2P {
             neighbors: neighbor_addrs,
         });
         let reply = self.sign_reply(chain_view, &local_peer.private_key, payload, preamble.seq)?;
-        let reply_handle = self.relay_signed_message(reply).map_err(|e| {
-            debug!(
-                "Outbox to {:?} is full; cannot reply to GetNeighbors",
-                &self
-            );
-            e
-        })?;
+        let reply_handle = self
+            .relay_signed_message(reply)
+            .inspect_err(|_e| debug!("Outbox to {self:?} is full; cannot reply to GetNeighbors"))?;
 
         Ok(reply_handle)
     }
@@ -1747,12 +1741,8 @@ impl ConversationP2P {
             &network.stacks_tip.block_hash,
             reward_cycle,
         )?;
-        let nakamoto_inv = NakamotoInvData::try_from(&bitvec_bools).map_err(|e| {
-            warn!(
-                "Failed to create a NakamotoInv response to {:?}: {:?}",
-                get_nakamoto_inv, &e
-            );
-            e
+        let nakamoto_inv = NakamotoInvData::try_from(&bitvec_bools).inspect_err(|e| {
+            warn!("Failed to create a NakamotoInv response to {get_nakamoto_inv:?}: {e:?}")
         })?;
 
         debug!(

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -1186,12 +1186,11 @@ impl NakamotoDownloadStateMachine {
 
             let _ = downloader
                 .try_advance_from_chainstate(chainstate)
-                .map_err(|e| {
+                .inspect_err(|e| {
                     warn!(
-                        "Failed to advance downloader in state {} for {}: {:?}",
-                        &downloader.state, &downloader.naddr, &e
-                    );
-                    e
+                        "Failed to advance downloader in state {} for {}: {e:?}",
+                        &downloader.state, &downloader.naddr
+                    )
                 });
 
             debug!(
@@ -1257,13 +1256,11 @@ impl NakamotoDownloadStateMachine {
             {
                 if let Some(highest_complete_tenure_downloader) = downloader
                     .make_highest_complete_tenure_downloader()
-                    .map_err(|e| {
+                    .inspect_err(|e| {
                         warn!(
-                            "Failed to make highest complete tenure downloader for {:?}: {:?}",
-                            &downloader.unconfirmed_tenure_id(),
-                            &e
-                        );
-                        e
+                            "Failed to make highest complete tenure downloader for {:?}: {e:?}",
+                            &downloader.unconfirmed_tenure_id()
+                        )
                     })
                     .ok()
                 {

--- a/stackslib/src/net/download/nakamoto/tenure_downloader.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader.rs
@@ -781,9 +781,8 @@ impl NakamotoTenureDownloader {
                     &block_id,
                     get_epoch_time_ms().saturating_sub(start_request_time)
                 );
-                let block = response.decode_nakamoto_block().map_err(|e| {
-                    warn!("Failed to decode response for a Nakamoto block: {:?}", &e);
-                    e
+                let block = response.decode_nakamoto_block().inspect_err(|e| {
+                    warn!("Failed to decode response for a Nakamoto block: {e:?}")
                 })?;
                 self.try_accept_tenure_start_block(block)?;
                 Ok(None)
@@ -794,9 +793,8 @@ impl NakamotoTenureDownloader {
                     &block_id,
                     get_epoch_time_ms().saturating_sub(start_request_time)
                 );
-                let block = response.decode_nakamoto_block().map_err(|e| {
-                    warn!("Failed to decode response for a Nakamoto block: {:?}", &e);
-                    e
+                let block = response.decode_nakamoto_block().inspect_err(|e| {
+                    warn!("Failed to decode response for a Nakamoto block: {e:?}")
                 })?;
                 self.try_accept_tenure_end_block(&block)?;
                 Ok(None)
@@ -807,9 +805,8 @@ impl NakamotoTenureDownloader {
                     &end_block_id,
                     get_epoch_time_ms().saturating_sub(start_request_time)
                 );
-                let blocks = response.decode_nakamoto_tenure().map_err(|e| {
-                    warn!("Failed to decode response for a Nakamoto tenure: {:?}", &e);
-                    e
+                let blocks = response.decode_nakamoto_tenure().inspect_err(|e| {
+                    warn!("Failed to decode response for a Nakamoto tenure: {e:?}")
                 })?;
                 let blocks_opt = self.try_accept_tenure_blocks(blocks)?;
                 Ok(blocks_opt)

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -571,12 +571,11 @@ impl NakamotoTenureDownloaderSet {
 
             let _ = downloader
                 .try_advance_from_chainstate(chainstate)
-                .map_err(|e| {
+                .inspect_err(|e| {
                     warn!(
-                        "Failed to advance downloader in state {} for {}: {:?}",
-                        &downloader.state, &downloader.naddr, &e
+                        "Failed to advance downloader in state {} for {}: {e:?}",
+                        &downloader.state, &downloader.naddr
                     );
-                    e
                 });
 
             debug!(

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -1275,9 +1275,8 @@ impl StacksHttp {
             return Err(NetError::InvalidState);
         }
         if let Some(reply) = self.reply.as_mut() {
-            match reply.stream.consume_data(fd).map_err(|e| {
+            match reply.stream.consume_data(fd).inspect_err(|_e| {
                 self.reset();
-                e
             })? {
                 (Some((byte_vec, bytes_total)), sz) => {
                     // done receiving
@@ -1491,11 +1490,11 @@ impl ProtocolFamily for StacksHttp {
                 }
 
                 // message of unknown length.  Buffer up and maybe we can parse it.
-                let (message_bytes_opt, num_read) =
-                    self.consume_data(http_response_preamble, fd).map_err(|e| {
-                        self.reset();
-                        e
-                    })?;
+                let (message_bytes_opt, num_read) = self
+                    .consume_data(http_response_preamble, fd)
+                    .inspect_err(|_e| {
+                    self.reset();
+                })?;
 
                 match message_bytes_opt {
                     Some((message_bytes, total_bytes_consumed)) => {

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -982,24 +982,22 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
             );
             let Some(inv) = self.inventories.get_mut(&naddr) else {
                 debug!(
-                    "{:?}: Got a reply for an untracked inventory peer {}: {:?}",
+                    "{:?}: Got a reply for an untracked inventory peer {naddr}: {reply:?}",
                     network.get_local_peer(),
-                    &naddr,
-                    &reply
                 );
                 continue;
             };
 
-            let Ok(inv_learned) = inv.getnakamotoinv_try_finish(network, reply).map_err(|e| {
-                warn!(
-                    "{:?}: Failed to finish inventory sync to {}: {:?}",
-                    network.get_local_peer(),
-                    &naddr,
-                    &e
-                );
-                self.comms.add_broken(network, &naddr);
-                e
-            }) else {
+            let Ok(inv_learned) = inv
+                .getnakamotoinv_try_finish(network, reply)
+                .inspect_err(|e| {
+                    warn!(
+                        "{:?}: Failed to finish inventory sync to {naddr}: {e:?}",
+                        network.get_local_peer()
+                    );
+                    self.comms.add_broken(network, &naddr);
+                })
+            else {
                 continue;
             };
 
@@ -1051,14 +1049,15 @@ impl<NC: NeighborComms> NakamotoInvStateMachine<NC> {
                 &e
             );
         }
-        let Ok((_, learned)) = self.process_getnakamotoinv_finishes(network).map_err(|e| {
-            warn!(
-                "{:?}: Failed to finish Nakamoto tenure inventory sync: {:?}",
-                network.get_local_peer(),
-                &e
-            );
-            e
-        }) else {
+        let Ok((_, learned)) = self
+            .process_getnakamotoinv_finishes(network)
+            .inspect_err(|e| {
+                warn!(
+                    "{:?}: Failed to finish Nakamoto tenure inventory sync: {e:?}",
+                    network.get_local_peer(),
+                )
+            })
+        else {
             self.last_sort_tip = Some(network.burnchain_tip.clone());
             return false;
         };

--- a/stackslib/src/net/neighbors/comms.rs
+++ b/stackslib/src/net/neighbors/comms.rs
@@ -106,14 +106,12 @@ pub trait NeighborComms {
 
         let msg = network
             .sign_for_neighbor(&nk, StacksMessageType::Handshake(handshake_data))
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 info!(
-                    "{:?}: Failed to sign for peer {:?}",
+                    "{:?}: Failed to sign for peer {nk:?}",
                     network.get_local_peer(),
-                    &nk
                 );
                 self.add_dead(network, &nk);
-                e
             })?;
 
         network

--- a/stackslib/src/net/neighbors/db.rs
+++ b/stackslib/src/net/neighbors/db.rs
@@ -223,26 +223,22 @@ pub trait NeighborWalkDB {
         // favor neighbors with older last-contact times
         let next_neighbors_res = self
             .get_fresh_random_neighbors(network, (NUM_NEIGHBORS as u64) * 2)
-            .map_err(|e| {
+            .inspect_err(|e| {
                 debug!(
-                    "{:?}: Failed to load fresh initial walk neighbors: {:?}",
+                    "{:?}: Failed to load fresh initial walk neighbors: {e:?}",
                     network.get_local_peer(),
-                    &e
                 );
-                e
             });
 
         let db_neighbors = if let Ok(neighbors) = next_neighbors_res {
             neighbors
         } else {
             let any_neighbors = Self::pick_walk_neighbors(network, (NUM_NEIGHBORS as u64) * 2, 0)
-                .map_err(|e| {
+                .inspect_err(|e| {
                 info!(
-                    "{:?}: Failed to load any initial walk neighbors: {:?}",
+                    "{:?}: Failed to load any initial walk neighbors: {e:?}",
                     network.get_local_peer(),
-                    &e
                 );
-                e
             })?;
 
             any_neighbors

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -949,14 +949,12 @@ impl Relayer {
         if chainstate
             .nakamoto_blocks_db()
             .has_nakamoto_block_with_index_hash(&block.header.block_id())
-            .map_err(|e| {
+            .inspect_err(|e| {
                 warn!(
-                    "Failed to determine if we have Nakamoto block {}/{}: {:?}",
+                    "Failed to determine if we have Nakamoto block {}/{}: {e:?}",
                     &block.header.consensus_hash,
-                    &block.header.block_hash(),
-                    &e
+                    &block.header.block_hash()
                 );
-                e
             })?
         {
             if force_broadcast {
@@ -3135,21 +3133,22 @@ impl PeerNetwork {
                 Ok(m) => m,
                 Err(e) => {
                     warn!(
-                        "{:?}: Failed to sign for {:?}: {:?}",
-                        &self.local_peer, recipient, &e
+                        "{:?}: Failed to sign for {recipient:?}: {e:?}",
+                        &self.local_peer
                     );
                     continue;
                 }
             };
 
             // absorb errors
-            let _ = self.relay_signed_message(recipient, message).map_err(|e| {
-                warn!(
-                    "{:?}: Failed to announce {} entries to {:?}: {:?}",
-                    &self.local_peer, num_blocks, recipient, &e
-                );
-                e
-            });
+            let _ = self
+                .relay_signed_message(recipient, message)
+                .inspect_err(|e| {
+                    warn!(
+                        "{:?}: Failed to announce {num_blocks} entries to {recipient:?}: {e:?}",
+                        &self.local_peer
+                    );
+                });
         }
     }
 
@@ -3170,26 +3169,27 @@ impl PeerNetwork {
             Ok(m) => m,
             Err(e) => {
                 warn!(
-                    "{:?}: Failed to sign for {:?}: {:?}",
-                    &self.local_peer, recipient, &e
+                    "{:?}: Failed to sign for {recipient:?}: {e:?}",
+                    &self.local_peer
                 );
                 return;
             }
         };
 
         debug!(
-            "{:?}: Push block {}/{} to {:?}",
-            &self.local_peer, &ch, &blk_hash, recipient
+            "{:?}: Push block {ch}/{blk_hash} to {recipient:?}",
+            &self.local_peer
         );
 
         // absorb errors
-        let _ = self.relay_signed_message(recipient, message).map_err(|e| {
-            warn!(
-                "{:?}: Failed to push block {}/{} to {:?}: {:?}",
-                &self.local_peer, &ch, &blk_hash, recipient, &e
-            );
-            e
-        });
+        let _ = self
+            .relay_signed_message(recipient, message)
+            .inspect_err(|e| {
+                warn!(
+                    "{:?}: Failed to push block {ch}/{blk_hash} to {recipient:?}: {e:?}",
+                    &self.local_peer
+                )
+            });
     }
 
     /// Try to push a confirmed microblock stream to a peer.
@@ -3210,26 +3210,27 @@ impl PeerNetwork {
                 Ok(m) => m,
                 Err(e) => {
                     warn!(
-                        "{:?}: Failed to sign for {:?}: {:?}",
-                        &self.local_peer, recipient, &e
+                        "{:?}: Failed to sign for {recipient:?}: {e:?}",
+                        &self.local_peer
                     );
                     return;
                 }
             };
 
         debug!(
-            "{:?}: Push microblocks for {} to {:?}",
-            &self.local_peer, &idx_bhh, recipient
+            "{:?}: Push microblocks for {idx_bhh} to {recipient:?}",
+            &self.local_peer
         );
 
         // absorb errors
-        let _ = self.relay_signed_message(recipient, message).map_err(|e| {
-            warn!(
-                "{:?}: Failed to push microblocks for {} to {:?}: {:?}",
-                &self.local_peer, &idx_bhh, recipient, &e
-            );
-            e
-        });
+        let _ = self
+            .relay_signed_message(recipient, message)
+            .inspect_err(|e| {
+                warn!(
+                    "{:?}: Failed to push microblocks for {idx_bhh} to {recipient:?}: {e:?}",
+                    &self.local_peer
+                );
+            });
     }
 
     /// Announce blocks that we have to an outbound peer that doesn't have them.


### PR DESCRIPTION
### Description

Apply Clippy lint `manual_inspect`, which finds `map()`/`map_err()` calls that can be replaced by `inspect()`/`inspect_err()`