### PR TITLE
Fix: better win detection on restart

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -169,6 +169,7 @@ jobs:
           - tests::nakamoto_integrations::v3_blockbyheight_api_endpoint
           - tests::nakamoto_integrations::mine_invalid_principal_from_consensus_buff
           - tests::nakamoto_integrations::test_tenure_extend_from_flashblocks
+          - tests::nakamoto_integrations::restarting_miner
           # TODO: enable these once v1 signer is supported by a new nakamoto epoch
           # - tests::signer::v1::dkg
           # - tests::signer::v1::sign_request_rejected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+### Fixed
+
+- Miners who restart their nodes immediately before a winning tenure now correctly detect that 
+  they won the tenure after their nodes restart ([#5750](https://github.com/stacks-network/stacks-core/issues/5750)).
+
 ## [3.1.0.0.4]
 
 ### Added

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -694,6 +694,9 @@ impl RelayerThread {
     /// this sortition matches the sortition tip and we have a parent to build atop.
     ///
     /// Otherwise, returns None, meaning no action will be taken.
+    // This method is covered by the e2e bitcoind tests, which do not show up
+    //  in mutant coverage.
+    #[cfg_attr(test, mutants::skip)]
     fn process_sortition(
         &mut self,
         consensus_hash: ConsensusHash,

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -705,8 +705,16 @@ impl RelayerThread {
             .expect("FATAL: unknown consensus hash");
 
         // always clear this even if this isn't the latest sortition
-        let cleared = self.last_commits.remove(&sn.winning_block_txid);
-        let won_sortition = sn.sortition && cleared;
+        let _cleared = self.last_commits.remove(&sn.winning_block_txid);
+        let was_winning_pkh = if let (Some(ref winning_pkh), Some(ref my_pkh)) =
+            (sn.miner_pk_hash, self.get_mining_key_pkh())
+        {
+            winning_pkh == my_pkh
+        } else {
+            false
+        };
+
+        let won_sortition = sn.sortition && was_winning_pkh;
         if won_sortition {
             increment_stx_blocks_mined_counter();
         }

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -1761,7 +1761,7 @@ fn restarting_miner() {
     naka_conf.miner.activated_vrf_key_path =
         Some(format!("{}/vrf_key", naka_conf.node.working_dir));
     naka_conf.miner.wait_on_interim_blocks = Duration::from_secs(5);
-    let sender_sk = Secp256k1PrivateKey::new();
+    let sender_sk = Secp256k1PrivateKey::from_seed(&[1, 2, 1, 2, 1, 2]);
     // setup sender + recipient for a test stx transfer
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 1000;
@@ -1770,7 +1770,7 @@ fn restarting_miner() {
         PrincipalData::from(sender_addr).to_string(),
         send_amt * 2 + send_fee,
     );
-    let sender_signer_sk = Secp256k1PrivateKey::new();
+    let sender_signer_sk = Secp256k1PrivateKey::from_seed(&[3, 2, 3, 2, 3, 2]);
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
     let mut signers = TestSigners::new(vec![sender_signer_sk]);
     naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);


### PR DESCRIPTION
### Description

This improves how miners detect whether or not they won a sortition. This mostly impacts miners on restarts, because previously they used in-memory state to detect a winning sortition (#5750)