### PR TITLE
Test: fix some test flake in partial_tenure_forking

### DIFF
--- a/testnet/stacks-node/src/globals.rs
+++ b/testnet/stacks-node/src/globals.rs
@@ -53,7 +53,7 @@ pub struct Globals<T> {
     unconfirmed_txs: Arc<Mutex<UnconfirmedTxMap>>,
     /// Writer endpoint to the relayer thread
     pub relay_send: SyncSender<T>,
-    /// Cointer state in the main thread
+    /// Counter state in the main thread
     pub counters: Counters,
     /// Connection to the PoX sync watchdog
     pub sync_comms: PoxSyncWatchdogComms,

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -1628,7 +1628,7 @@ impl RelayerThread {
         self.last_commits.insert(txid);
         self.globals
             .counters
-            .bump_naka_submitted_commits(last_committed.burn_tip.block_height);
+            .bump_naka_submitted_commits(last_committed.burn_tip.block_height, tip_height);
         self.last_committed = Some(last_committed);
 
         Ok(())

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -116,6 +116,7 @@ pub struct Counters {
     pub naka_mined_tenures: RunLoopCounter,
     pub naka_signer_pushed_blocks: RunLoopCounter,
     pub naka_miner_directives: RunLoopCounter,
+    pub naka_submitted_commit_last_stacks_tip: RunLoopCounter,
 
     #[cfg(test)]
     pub naka_skip_commit_op: TestFlag<bool>,
@@ -170,11 +171,19 @@ impl Counters {
         Counters::inc(&self.naka_submitted_vrfs);
     }
 
-    pub fn bump_naka_submitted_commits(&self, committed_height: u64) {
+    pub fn bump_naka_submitted_commits(
+        &self,
+        committed_burn_height: u64,
+        committed_stacks_height: u64,
+    ) {
         Counters::inc(&self.naka_submitted_commits);
         Counters::set(
             &self.naka_submitted_commit_last_burn_height,
-            committed_height,
+            committed_burn_height,
+        );
+        Counters::set(
+            &self.naka_submitted_commit_last_stacks_tip,
+            committed_stacks_height,
         );
     }
 

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -97,6 +97,7 @@ pub struct RunningNodes {
     pub nakamoto_blocks_signer_pushed: RunLoopCounter,
     pub nakamoto_miner_directives: Arc<AtomicU64>,
     pub nakamoto_test_skip_commit_op: TestFlag<bool>,
+    pub counters: Counters,
     pub coord_channel: Arc<Mutex<CoordinatorChannels>>,
     pub conf: NeonConfig,
 }
@@ -947,6 +948,7 @@ fn setup_stx_btc_node<G: FnMut(&mut NeonConfig)>(
         naka_signer_pushed_blocks,
         ..
     } = run_loop.counters();
+    let counters = run_loop.counters();
 
     let coord_channel = run_loop.coordinator_channels();
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
@@ -984,6 +986,7 @@ fn setup_stx_btc_node<G: FnMut(&mut NeonConfig)>(
         nakamoto_test_skip_commit_op,
         nakamoto_miner_directives: naka_miner_directives.0,
         coord_channel,
+        counters,
         conf: naka_conf,
     }
 }


### PR DESCRIPTION
This should fix (some, but perhaps not _all_) flakiness in `partial_tenure_forking`.

I think what happened in a particular run of this test is that miner 2 won the first testing tenure of the test. This, by itself, should be okay, but the problem is that the timing of the block commit pausing/unpausing and block processing are such that miner 2's first commit is actually a fork! This is because the CI runner builds the next bitcoin block before miner 2 has a chance to RBF their commit with one that points at miner 1's tenure. I solve this particular flakiness with a new Counters variable, but like my last PR that added a Counters variable, this is a kind of check we do in a lot of places. For now, trying to refactor all of the tests to be better about this is a pretty big undertaking, but its something worth keeping in mind (I'll open a refactoring issue for this).

