### PR TITLE
chore: Apply Clippy lint `comparison_chain`

### DIFF
--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
@@ -2310,30 +2311,34 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
             assert_eq!(matured_reward.parent_miner.coinbase, 1_000_000_000);
         }
 
-        if i < 11 {
-            // epoch2
-            assert_eq!(
-                matured_reward.parent_miner.tx_fees,
-                MinerPaymentTxFees::Epoch2 {
-                    anchored: 0,
-                    streamed: 0,
-                }
-            );
-        } else if i == 11 {
-            // transition
-            assert_eq!(
-                matured_reward.parent_miner.tx_fees,
-                MinerPaymentTxFees::Nakamoto { parent_fees: 0 }
-            );
-        } else {
-            // nakamoto
-            assert_eq!(
-                matured_reward.parent_miner.tx_fees,
-                MinerPaymentTxFees::Nakamoto {
-                    parent_fees: fee_counts[i - 12]
-                }
-            )
-        }
+        match i.cmp(&11) {
+            Ordering::Less => {
+                // epoch2
+                assert_eq!(
+                    matured_reward.parent_miner.tx_fees,
+                    MinerPaymentTxFees::Epoch2 {
+                        anchored: 0,
+                        streamed: 0,
+                    }
+                );
+            }
+            Ordering::Equal => {
+                // transition
+                assert_eq!(
+                    matured_reward.parent_miner.tx_fees,
+                    MinerPaymentTxFees::Nakamoto { parent_fees: 0 }
+                );
+            }
+            Ordering::Greater => {
+                // nakamoto
+                assert_eq!(
+                    matured_reward.parent_miner.tx_fees,
+                    MinerPaymentTxFees::Nakamoto {
+                        parent_fees: fee_counts[i - 12]
+                    }
+                )
+            }
+        };
 
         assert_eq!(matured_reward.latest_miners.len(), 1);
 
@@ -2344,30 +2349,35 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
         } else {
             assert_eq!(miner_reward.coinbase, 1_000_000_000);
         }
-        if i < 10 {
-            // epoch2
-            assert_eq!(
-                miner_reward.tx_fees,
-                MinerPaymentTxFees::Epoch2 {
-                    anchored: 0,
-                    streamed: 0,
-                }
-            );
-        } else if i == 10 {
-            // transition
-            assert_eq!(
-                miner_reward.tx_fees,
-                MinerPaymentTxFees::Nakamoto { parent_fees: 0 }
-            )
-        } else {
-            // nakamoto
-            assert_eq!(
-                miner_reward.tx_fees,
-                MinerPaymentTxFees::Nakamoto {
-                    parent_fees: fee_counts[i - 11]
-                }
-            )
-        }
+
+        match i.cmp(&10) {
+            Ordering::Less => {
+                // epoch2
+                assert_eq!(
+                    miner_reward.tx_fees,
+                    MinerPaymentTxFees::Epoch2 {
+                        anchored: 0,
+                        streamed: 0,
+                    }
+                )
+            }
+            Ordering::Equal => {
+                // transition
+                assert_eq!(
+                    miner_reward.tx_fees,
+                    MinerPaymentTxFees::Nakamoto { parent_fees: 0 }
+                )
+            }
+            Ordering::Greater => {
+                // nakamoto
+                assert_eq!(
+                    miner_reward.tx_fees,
+                    MinerPaymentTxFees::Nakamoto {
+                        parent_fees: fee_counts[i - 11]
+                    }
+                )
+            }
+        };
     }
 
     // replay the blocks and sortitions in random order, and verify that we still reach the chain

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -4875,6 +4875,7 @@ pub mod test {
             }
 
             if first_reward_cycle > 0 && second_reward_cycle == 0 {
+                #[allow(clippy::comparison_chain)]
                 if cur_reward_cycle == first_reward_cycle {
                     test_in_first_reward_cycle = true;
 
@@ -5002,6 +5003,7 @@ pub mod test {
                     assert_eq!(charlie_account.stx_balance.unlock_height() as u128, 0);
                 }
             } else if second_reward_cycle > 0 {
+                #[allow(clippy::comparison_chain)]
                 if cur_reward_cycle == second_reward_cycle {
                     test_in_second_reward_cycle = true;
 
@@ -5484,6 +5486,7 @@ pub mod test {
             }
 
             if reward_cycle > 0 {
+                #[allow(clippy::comparison_chain)]
                 if cur_reward_cycle == reward_cycle {
                     test_in_first_reward_cycle = true;
 
@@ -5510,7 +5513,7 @@ pub mod test {
                     for addr in stacker_addrs.iter() {
                         let (amount_ustx, pox_addr, lock_period, pox_reward_cycle) =
                             get_stacker_info(&mut peer, addr).unwrap();
-                        eprintln!("\naddr {}: {} uSTX stacked for {} cycle(s); addr is {:?}; first reward cycle is {}\n", addr, amount_ustx, lock_period, &pox_addr, reward_cycle);
+                        eprintln!("\naddr {addr}: {amount_ustx} uSTX stacked for {lock_period} cycle(s); addr is {pox_addr:?}; first reward cycle is {reward_cycle}\n");
 
                         assert_eq!(pox_reward_cycle, reward_cycle);
                         assert_eq!(lock_period, 1);

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -1217,19 +1217,13 @@ fn order_nonces(
     sponsor_actual: u64,
     sponsor_expected: u64,
 ) -> Ordering {
-    if origin_actual < origin_expected {
-        return Ordering::Less;
-    } else if origin_actual > origin_expected {
-        return Ordering::Greater;
+    if let o @ (Ordering::Greater | Ordering::Less) = origin_actual.cmp(&origin_expected) {
+        o
+    } else if let o @ (Ordering::Greater | Ordering::Less) = sponsor_actual.cmp(&sponsor_expected) {
+        o
+    } else {
+        Ordering::Equal
     }
-
-    if sponsor_actual < sponsor_expected {
-        return Ordering::Less;
-    } else if sponsor_actual > sponsor_expected {
-        return Ordering::Greater;
-    }
-
-    Ordering::Equal
 }
 
 impl MemPoolDB {

--- a/stackslib/src/net/inv/epoch2x.rs
+++ b/stackslib/src/net/inv/epoch2x.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::cmp;
+use std::cmp::{self, Ordering};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
@@ -445,23 +445,24 @@ impl PeerBlocksInv {
                 return Some((i, my_bit, pox_bit));
             }
         }
-        if (pox_id.len() as u64) - 1 == self.num_reward_cycles {
-            // all agreed
-            None
-        } else if (pox_id.len() as u64) - 1 < self.num_reward_cycles {
-            // pox inv is longer
-            Some((
-                (pox_id.len() as u64) - 1,
-                self.has_ith_anchor_block((pox_id.len() as u64) - 1),
-                false,
-            ))
-        } else {
-            // our inv is longer
-            Some((
-                self.num_reward_cycles,
-                false,
-                pox_id.has_ith_anchor_block(self.num_reward_cycles as usize),
-            ))
+        let reward_cycle = (pox_id.len() as u64) - 1;
+        match reward_cycle.cmp(&self.num_reward_cycles) {
+            Ordering::Less => {
+                // pox inv is longer
+                Some((reward_cycle, self.has_ith_anchor_block(reward_cycle), false))
+            }
+            Ordering::Equal => {
+                // all agreed
+                None
+            }
+            Ordering::Greater => {
+                // our inv is longer
+                Some((
+                    self.num_reward_cycles,
+                    false,
+                    pox_id.has_ith_anchor_block(self.num_reward_cycles as usize),
+                ))
+            }
         }
     }
 

--- a/stackslib/src/net/prune.rs
+++ b/stackslib/src/net/prune.rs
@@ -339,15 +339,7 @@ impl PeerNetwork {
 
         // sort in order by first-contact time (oldest first)
         for (_, stats_list) in ip_neighbor.iter_mut() {
-            stats_list.sort_by(|(_e1, _nk1, stats1), (_e2, _nk2, stats2)| {
-                if stats1.first_contact_time < stats2.first_contact_time {
-                    Ordering::Less
-                } else if stats1.first_contact_time > stats2.first_contact_time {
-                    Ordering::Greater
-                } else {
-                    Ordering::Equal
-                }
-            });
+            stats_list.sort_by_key(|(_e, _nk, stats)| stats.first_contact_time);
         }
 
         let mut to_remove = vec![];


### PR DESCRIPTION
### Description

Apply Clippy lint `comparison_chain`, which finds places where `if ... else if` statements can be replaced with `match a.cmp(b)`

There were a few locations where I didn't want to make this change, because I felt it would decrease readability by increasing the indent level for a large segment of code. I added `#[allow(clippy::comparison_chain)]` so Clippy will ignore them