### PR TITLE
chore: Apply Clippy lints `derivable_impls`, `eq_op`, and `expect_fun_call`

### DIFF
--- a/stackslib/src/burnchains/bitcoin/indexer.rs
+++ b/stackslib/src/burnchains/bitcoin/indexer.rs
@@ -234,10 +234,7 @@ impl BitcoinIndexer {
             true,
             false,
         )
-        .expect(&format!(
-            "Failed to open {:?}",
-            working_dir_path.to_str().unwrap()
-        ));
+        .unwrap_or_else(|_| panic!("Failed to open {:?}", working_dir_path.to_str().unwrap()));
 
         BitcoinIndexer {
             config: BitcoinIndexerConfig::default_regtest(

--- a/stackslib/src/burnchains/bitcoin/indexer.rs
+++ b/stackslib/src/burnchains/bitcoin/indexer.rs
@@ -234,7 +234,7 @@ impl BitcoinIndexer {
             true,
             false,
         )
-        .unwrap_or_else(|_| panic!("Failed to open {:?}", working_dir_path.to_str().unwrap()));
+        .unwrap_or_else(|_| panic!("Failed to open {working_dir_path:?}"));
 
         BitcoinIndexer {
             config: BitcoinIndexerConfig::default_regtest(

--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -439,10 +439,7 @@ impl TestBurnchainBlock {
             // prove on the last-ever sortition's hash to produce the new seed
             let proof = miner
                 .make_proof(&leader_key.public_key, &last_snapshot.sortition_hash)
-                .expect(&format!(
-                    "FATAL: no private key for {}",
-                    leader_key.public_key.to_hex()
-                ));
+                .unwrap_or_else(|| panic!("FATAL: no private key for {:?}", leader_key.public_key));
 
             VRFSeed::from_proof(&proof)
         });
@@ -658,10 +655,12 @@ impl TestBurnchainBlock {
         let parent_hdr = indexer
             .read_burnchain_header(self.block_height.saturating_sub(1))
             .unwrap()
-            .expect(&format!(
-                "BUG: could not read block at height {}",
-                self.block_height.saturating_sub(1)
-            ));
+            .unwrap_or_else(|| {
+                panic!(
+                    "BUG: could not read block at height {}",
+                    self.block_height.saturating_sub(1)
+                )
+            });
 
         let now = BURNCHAIN_TEST_BLOCK_TIME;
         let block_hash = BurnchainHeaderHash::from_bitcoin_hash(

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -1344,7 +1344,7 @@ impl TestPeer<'_> {
                 );
             }
             Err(e) => {
-                panic!("Failure fetching recipient set: {:?}", e);
+                panic!("Failure fetching recipient set: {e:?}");
             }
         };
 
@@ -1368,16 +1368,11 @@ impl TestPeer<'_> {
         let proof = self
             .miner
             .make_proof(&miner_key.public_key, &tip.sortition_hash)
-            .expect(&format!(
-                "FATAL: no private key for {}",
-                miner_key.public_key.to_hex()
-            ));
+            .unwrap_or_else(|| panic!("FATAL: no private key for {:?}", miner_key.public_key));
         self.sortdb = Some(sortdb);
         debug!(
-            "VRF proof made from {} over {}: {}",
-            &miner_key.public_key.to_hex(),
-            &tip.sortition_hash,
-            &proof.to_hex()
+            "VRF proof made from {:?} over {}: {proof:?}",
+            miner_key.public_key, &tip.sortition_hash
         );
         proof
     }

--- a/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -334,10 +334,7 @@ pub fn check_stacking_state_invariants(
     .burn_header_height;
 
     let stacking_state_entry = get_stacking_state_pox(peer, tip, stacker, active_pox_contract)
-        .expect(&format!(
-            "Invariant violated: reward-cycle entry has stacker field set, but not present in stacker-state (pox_contract = {})",
-            active_pox_contract,
-        ))
+        .unwrap_or_else(|| panic!("Invariant violated: reward-cycle entry has stacker field set, but not present in stacker-state (pox_contract = {active_pox_contract})"))
         .expect_tuple().unwrap();
     let first_cycle = stacking_state_entry
         .get("first-reward-cycle")

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -10265,7 +10265,7 @@ fn test_scenario_five(use_nakamoto: bool) {
     for (idx, (stacker, stacker_lock_period)) in davids_stackers.iter().enumerate() {
         let (pox_address, first_reward_cycle, lock_period, _indices) =
             get_stacker_info_pox_4(&mut peer, &stacker.principal)
-                .expect(format!("Failed to find stacker {}", idx).as_str());
+                .unwrap_or_else(|| panic!("Failed to find stacker {idx}"));
         assert_eq!(first_reward_cycle, reward_cycle);
         assert_eq!(pox_address, david.pox_address);
         assert_eq!(lock_period, *stacker_lock_period);
@@ -10274,7 +10274,7 @@ fn test_scenario_five(use_nakamoto: bool) {
     for (idx, (stacker, stacker_lock_period)) in eves_stackers.iter().enumerate() {
         let (pox_address, first_reward_cycle, lock_period, _indices) =
             get_stacker_info_pox_4(&mut peer, &stacker.principal)
-                .expect(format!("Failed to find stacker {}", idx).as_str());
+                .unwrap_or_else(|| panic!("Failed to find stacker {idx}"));
         assert_eq!(first_reward_cycle, reward_cycle);
         assert_eq!(pox_address, eve.pox_address);
         assert_eq!(lock_period, *stacker_lock_period);

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -8353,9 +8353,9 @@ fn test_scenario_three(use_nakamoto: bool) {
     assert_eq!(amount_locked_actual, amount_locked_expected);
 
     // Check Bob signer key
-    let signer_key_expected = Value::buff_from(bob.public_key.to_bytes_compressed());
+    let signer_key_expected = Value::buff_from(bob.public_key.to_bytes_compressed()).unwrap();
     let signer_key_actual = bob_stack_tx_ok.data_map.get("signer-key").unwrap().clone();
-    assert_eq!(signer_key_actual, signer_key_actual);
+    assert_eq!(signer_key_actual, signer_key_expected);
 
     // 5. Check that David can't delegate-stack-stx Eve if delegation expires during lock period
     let eve_delegate_stx_to_david_err = receipts

--- a/stackslib/src/chainstate/stacks/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/tests/mod.rs
@@ -619,10 +619,7 @@ impl TestStacksNode {
                 &miner_key.public_key,
                 &burn_block.parent_snapshot.sortition_hash,
             )
-            .expect(&format!(
-                "FATAL: no private key for {}",
-                miner_key.public_key.to_hex()
-            ));
+            .unwrap_or_else(|| panic!("FATAL: no private key for {:?}", miner_key.public_key));
 
         let (builder, parent_block_snapshot_opt) = match parent_stacks_block {
             None => {

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -1664,38 +1664,23 @@ pub struct NodeConfig {
     pub stacker_dbs: Vec<QualifiedContractIdentifier>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum CostEstimatorName {
+    #[default]
     NaivePessimistic,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum FeeEstimatorName {
+    #[default]
     ScalarFeeRate,
     FuzzedWeightedMedianFeeRate,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum CostMetricName {
+    #[default]
     ProportionDotProduct,
-}
-
-impl Default for CostEstimatorName {
-    fn default() -> Self {
-        CostEstimatorName::NaivePessimistic
-    }
-}
-
-impl Default for FeeEstimatorName {
-    fn default() -> Self {
-        FeeEstimatorName::ScalarFeeRate
-    }
-}
-
-impl Default for CostMetricName {
-    fn default() -> Self {
-        CostMetricName::ProportionDotProduct
-    }
 }
 
 impl CostEstimatorName {

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -52,19 +52,10 @@ use crate::net::{
 use crate::util_lib::db::{DBConn, Error as db_error};
 
 // did we or did we not successfully send a message?
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct NeighborHealthPoint {
     pub success: bool,
     pub time: u64,
-}
-
-impl Default for NeighborHealthPoint {
-    fn default() -> NeighborHealthPoint {
-        NeighborHealthPoint {
-            success: false,
-            time: 0,
-        }
-    }
 }
 
 pub const NUM_HEALTH_POINTS: usize = 32;

--- a/stackslib/src/net/download/nakamoto/tenure.rs
+++ b/stackslib/src/net/download/nakamoto/tenure.rs
@@ -345,10 +345,12 @@ impl TenureStartEnd {
                 rc,
                 pox_constants
                     .block_height_to_reward_cycle(first_burn_height, wt_start.burn_height)
-                    .expect(&format!(
-                        "FATAL: tenure from before system start ({} <= {})",
-                        wt_start.burn_height, first_burn_height
-                    )),
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "FATAL: tenure from before system start ({} <= {first_burn_height})",
+                            wt_start.burn_height
+                        )
+                    }),
                 wt.processed,
             );
             tenure_start_end.fetch_end_block = true;

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -1014,10 +1014,9 @@ impl StacksHttp {
     pub fn set_response_handler(&mut self, request_verb: &str, request_path: &str) {
         let handler_index = self
             .find_response_handler(request_verb, request_path)
-            .expect(&format!(
-                "FATAL: could not find handler for '{}' '{}'",
-                request_verb, request_path
-            ));
+            .unwrap_or_else(|| {
+                panic!("FATAL: could not find handler for '{request_verb}' '{request_path}'")
+            });
         self.request_handler_index = Some(handler_index);
     }
 

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -4257,18 +4257,15 @@ pub mod test {
             let mut stacks_node = self.stacks_node.take().unwrap();
 
             let parent_block_opt = stacks_node.get_last_anchored_block(&self.miner);
-            let parent_sortition_opt = match parent_block_opt.as_ref() {
-                Some(parent_block) => {
-                    let ic = sortdb.index_conn();
-                    SortitionDB::get_block_snapshot_for_winning_stacks_block(
-                        &ic,
-                        &tip.sortition_id,
-                        &parent_block.block_hash(),
-                    )
-                    .unwrap()
-                }
-                None => None,
-            };
+            let parent_sortition_opt = parent_block_opt.as_ref().and_then(|parent_block| {
+                let ic = sortdb.index_conn();
+                SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                    &ic,
+                    &tip.sortition_id,
+                    &parent_block.block_hash(),
+                )
+                .unwrap()
+            });
 
             let parent_microblock_header_opt =
                 get_last_microblock_header(&stacks_node, &self.miner, parent_block_opt.as_ref());
@@ -4284,10 +4281,7 @@ pub mod test {
                     &last_key.public_key,
                     &burn_block.parent_snapshot.sortition_hash,
                 )
-                .expect(&format!(
-                    "FATAL: no private key for {}",
-                    last_key.public_key.to_hex()
-                ));
+                .unwrap_or_else(|| panic!("FATAL: no private key for {:?}", last_key.public_key));
 
             let (stacks_block, microblocks) = tenure_builder(
                 &mut self.miner,
@@ -4547,10 +4541,9 @@ pub mod test {
             self.config
                 .burnchain
                 .block_height_to_reward_cycle(block_height)
-                .expect(&format!(
-                    "Failed to get reward cycle for block height {}",
-                    block_height
-                ))
+                .unwrap_or_else(|| {
+                    panic!("Failed to get reward cycle for block height {block_height}")
+                })
         }
 
         /// Verify that the sortition DB migration into Nakamoto worked correctly.

--- a/stackslib/src/net/stackerdb/tests/config.rs
+++ b/stackslib/src/net/stackerdb/tests/config.rs
@@ -525,25 +525,24 @@ fn test_valid_and_invalid_stackerdb_configs() {
             )
             .unwrap()
             .into(),
-            ContractName::try_from(format!("test-{}", i)).unwrap(),
+            ContractName::try_from(format!("test-{i}")).unwrap(),
         );
         peer.with_db_state(|sortdb, chainstate, _, _| {
             match StackerDBConfig::from_smart_contract(chainstate, sortdb, &contract_id, 32, None) {
                 Ok(config) => {
                     let expected = result
                         .clone()
-                        .expect(&format!("FATAL: parsed a bad contract\n{}", code));
+                        .unwrap_or_else(|| panic!("FATAL: parsed a bad contract\n{code}"));
                     assert_eq!(config, expected);
                 }
                 Err(net_error::InvalidStackerDBContract(..)) => {
                     assert!(
                         result.is_none(),
-                        "FATAL: valid contract treated as invalid\n{}",
-                        code
+                        "FATAL: valid contract treated as invalid\n{code}"
                     );
                 }
                 Err(e) => {
-                    panic!("Unexpected error: {:?}", &e);
+                    panic!("Unexpected error: {e:?}");
                 }
             }
             Ok(())

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -1221,11 +1221,7 @@ fn test_tenure_start_end_from_inventory() {
                 // no tenure here
                 assert!(
                     tenure_start_end_opt.is_none(),
-                    "{}",
-                    format!(
-                        "tenure_start_end = {:?}, rc = {}, i = {}, wt = {:?}",
-                        &tenure_start_end_opt, rc, i, &wt
-                    )
+                    "tenure_start_end = {tenure_start_end_opt:?}, rc = {rc}, i = {i}, wt = {wt:?}"
                 );
             }
         }
@@ -1262,7 +1258,7 @@ fn test_tenure_start_end_from_inventory() {
             let tenure_start_end_opt = available.get(&wt.tenure_id_consensus_hash);
             if bits
                 .get(i as u16)
-                .expect(&format!("failed to get bit {}: {:?}", i, &wt))
+                .unwrap_or_else(|| panic!("failed to get bit {i}: {wt:?}"))
             {
                 // this sortition had a tenure
                 let mut j = (i + 1) as u16;
@@ -1288,13 +1284,11 @@ fn test_tenure_start_end_from_inventory() {
 
                 if tenure_start_index.is_some() && tenure_end_index.is_some() {
                     debug!(
-                        "rc = {}, i = {}, tenure_start_index = {:?}, tenure_end_index = {:?}",
-                        rc, i, &tenure_start_index, &tenure_end_index
+                        "rc = {rc}, i = {i}, tenure_start_index = {tenure_start_index:?}, tenure_end_index = {tenure_end_index:?}"
                     );
-                    let tenure_start_end = tenure_start_end_opt.expect(&format!(
-                        "failed to get tenure_start_end_opt: i = {}, wt = {:?}",
-                        i, &wt
-                    ));
+                    let tenure_start_end = tenure_start_end_opt.unwrap_or_else(|| {
+                        panic!("failed to get tenure_start_end_opt: i = {i}, wt = {wt:?}")
+                    });
                     assert_eq!(
                         all_tenures[tenure_start_index.unwrap() as usize].winning_block_id,
                         tenure_start_end.start_block_id
@@ -1310,11 +1304,7 @@ fn test_tenure_start_end_from_inventory() {
                 // no tenure here
                 assert!(
                     tenure_start_end_opt.is_none(),
-                    "{}",
-                    format!(
-                        "tenure_start_end = {:?}, rc = {}, i = {}, wt = {:?}",
-                        &tenure_start_end_opt, rc, i, &wt
-                    )
+                    "tenure_start_end = {tenure_start_end_opt:?}, rc = {rc}, i = {i}, wt = {wt:?}"
                 );
             }
         }


### PR DESCRIPTION
### Description

Apply the following Clippy lints:

- `derivable_impls`: Replace manually implemented `Default` traits
- `eq_op`: Find instances of `a == a` (indicates copy/paste error)
- `expect_fun_call`: Find and replace format strings in `expect()` calls