### PR TITLE
fix: Disable flaky test `flash_blocks_on_epoch_3`

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -84,7 +84,7 @@ jobs:
           - tests::should_succeed_handling_malformed_and_valid_txs
           - tests::nakamoto_integrations::simple_neon_integration
           # Disable this flaky test. We don't need continue testing Epoch 2 -> 3 transition
-          - tests::nakamoto_integrations::flash_blocks_on_epoch_3_FLAKY
+          # - tests::nakamoto_integrations::flash_blocks_on_epoch_3_FLAKY
           - tests::nakamoto_integrations::mine_multiple_per_tenure_integration
           - tests::nakamoto_integrations::block_proposal_api_endpoint
           - tests::nakamoto_integrations::miner_writes_proposed_block_to_stackerdb

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -83,7 +83,8 @@ jobs:
           - tests::neon_integrations::start_stop_bitcoind
           - tests::should_succeed_handling_malformed_and_valid_txs
           - tests::nakamoto_integrations::simple_neon_integration
-          - tests::nakamoto_integrations::flash_blocks_on_epoch_3
+          # Disable this flaky test. We don't need continue testing Epoch 2 -> 3 transition
+          - tests::nakamoto_integrations::flash_blocks_on_epoch_3_FLAKY
           - tests::nakamoto_integrations::mine_multiple_per_tenure_integration
           - tests::nakamoto_integrations::block_proposal_api_endpoint
           - tests::nakamoto_integrations::miner_writes_proposed_block_to_stackerdb

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -1968,6 +1968,7 @@ fn restarting_miner() {
 
 #[test]
 #[ignore]
+#[allow(non_snake_case)]
 /// This test spins up a nakamoto-neon node.
 /// It starts in Epoch 2.0, mines with `neon_node` to Epoch 3.0,
 /// having flash blocks when epoch updates and expects everything to work normally,
@@ -1977,7 +1978,12 @@ fn restarting_miner() {
 ///  * 30 blocks are mined after 3.0 starts. This is enough to mine across 2 reward cycles
 ///  * A transaction submitted to the mempool in 3.0 will be mined in 3.0
 ///  * The final chain tip is a nakamoto block
-fn flash_blocks_on_epoch_3() {
+///
+/// NOTE: This test has been disabled because it's flaky, and we don't need to
+/// test the Epoch 3 transition since it's already happened
+///
+/// See issue [#5765](https://github.com/stacks-network/stacks-core/issues/5765) for details
+fn flash_blocks_on_epoch_3_FLAKY() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
     }


### PR DESCRIPTION
### Description

Disable flaky test `nakamoto_integrations::flash_blocks_on_epoch_3()`. This tests flash blocks at the Epoch 2 -> 3 transition, which is no longer needed since we've already made the transition on mainnet

### Applicable issues

- fixes #5765