### PR TITLE
[miner] Miner attempts to tenure extend if it doesn't see the incoming miner produce a block

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -150,6 +150,7 @@ jobs:
           - tests::signer::v0::block_proposal_timeout
           - tests::signer::v0::rejected_blocks_count_towards_miner_validity
           - tests::signer::v0::allow_reorg_within_first_proposal_burn_block_timing_secs
+          - tests::signer::v0::prev_miner_extends_if_incoming_miner_fails_to_mine
           - tests::nakamoto_integrations::burn_ops_integration_test
           - tests::nakamoto_integrations::check_block_heights
           - tests::nakamoto_integrations::clarity_burn_state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 - Miner will include other transactions in blocks with tenure extend transactions (#5760)
 - Miner will not issue a tenure extend until at least half of the block budget has been spent (#5757)
+- Miner will issue a tenure extend if the incoming miner has failed to produce a block (#5729)
 
 ### Fixed
 

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -12727,3 +12727,487 @@ fn tenure_extend_cost_threshold() {
 
     signer_test.shutdown();
 }
+
+/// Test a scenario where:
+/// Two miners boot to Nakamoto.
+/// Miner 1 wins the first tenure.
+/// Miner 1 proposes a block N with a TenureChangeCause::BlockFound
+/// Signers accept and the stacks tip advances to N
+/// Miner 2 wins the second tenure B.
+/// Miner 2 proposes block N+1' AFTER signers' block proposal timeout.
+/// Signers reject block N+1' and mark miner 2 as malicious
+/// Miner 1 proposes block N+1 with a TenureChangeCause::Extended
+/// Signers accept and the stacks tip advances to N+1
+/// Miner 2 wins the third tenure C and proposes a block N+2 with a TenureChangeCause::BlockFound
+/// Signers accept block N+2.
+///
+/// Asserts:
+/// - Block N contains the TenureChangeCause::BlockFound
+/// - Block N+1 contains the TenureChangeCause::Extended
+/// - Block N+2 contains the TenureChangeCause::BlockFound
+/// - The stacks tip advances to N+2
+#[test]
+#[ignore]
+fn prev_miner_extends_if_incoming_miner_fails_to_mine() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+
+    let btc_miner_1_seed = vec![1, 1, 1, 1];
+    let btc_miner_2_seed = vec![2, 2, 2, 2];
+    let btc_miner_1_pk = Keychain::default(btc_miner_1_seed.clone()).get_pub_key();
+    let btc_miner_2_pk = Keychain::default(btc_miner_2_seed.clone()).get_pub_key();
+
+    let node_1_rpc = gen_random_port();
+    let node_1_p2p = gen_random_port();
+    let node_2_rpc = gen_random_port();
+    let node_2_p2p = gen_random_port();
+
+    debug!("Node 1 bound at (p2p={node_1_p2p}, rpc={node_1_rpc})");
+    debug!("Node 2 bound at (p2p={node_2_p2p}, rpc={node_2_rpc})");
+
+    let localhost = "127.0.0.1";
+    let node_1_rpc_bind = format!("{localhost}:{node_1_rpc}");
+    let node_2_rpc_bind = format!("{localhost}:{node_2_rpc}");
+    let mut node_2_listeners = Vec::new();
+
+    let max_nakamoto_tenures = 30;
+
+    let block_proposal_timeout = Duration::from_secs(30);
+    info!("------------------------- Test Setup -------------------------");
+    // partition the signer set so that ~half are listening and using node 1 for RPC and events,
+    //  and the rest are using node 2
+
+    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![],
+        |signer_config| {
+            let node_host = if signer_config.endpoint.port() % 2 == 0 {
+                &node_1_rpc_bind
+            } else {
+                &node_2_rpc_bind
+            };
+            signer_config.node_host = node_host.to_string();
+            signer_config.block_proposal_timeout = block_proposal_timeout;
+        },
+        |config| {
+            config.node.rpc_bind = format!("{localhost}:{node_1_rpc}");
+            config.node.p2p_bind = format!("{localhost}:{node_1_p2p}");
+            config.node.data_url = format!("http://{localhost}:{node_1_rpc}");
+            config.node.p2p_address = format!("{localhost}:{node_1_p2p}");
+            config.miner.wait_on_interim_blocks = Duration::from_secs(5);
+            config.node.pox_sync_sample_secs = 30;
+            config.burnchain.pox_reward_length = Some(max_nakamoto_tenures);
+
+            config.node.seed = btc_miner_1_seed.clone();
+            config.node.local_peer_seed = btc_miner_1_seed.clone();
+            config.burnchain.local_mining_public_key = Some(btc_miner_1_pk.to_hex());
+            config.miner.mining_key = Some(Secp256k1PrivateKey::from_seed(&[1]));
+
+            config.events_observers.retain(|listener| {
+                let Ok(addr) = std::net::SocketAddr::from_str(&listener.endpoint) else {
+                    warn!(
+                        "Cannot parse {} to a socket, assuming it isn't a signer-listener binding",
+                        listener.endpoint
+                    );
+                    return true;
+                };
+                if addr.port() % 2 == 0 || addr.port() == test_observer::EVENT_OBSERVER_PORT {
+                    return true;
+                }
+                node_2_listeners.push(listener.clone());
+                false
+            })
+        },
+        Some(vec![btc_miner_1_pk, btc_miner_2_pk]),
+        None,
+    );
+    let conf = signer_test.running_nodes.conf.clone();
+    let mut conf_node_2 = conf.clone();
+    conf_node_2.node.rpc_bind = format!("{localhost}:{node_2_rpc}");
+    conf_node_2.node.p2p_bind = format!("{localhost}:{node_2_p2p}");
+    conf_node_2.node.data_url = format!("http://{localhost}:{node_2_rpc}");
+    conf_node_2.node.p2p_address = format!("{localhost}:{node_2_p2p}");
+    conf_node_2.node.seed = btc_miner_2_seed.clone();
+    conf_node_2.burnchain.local_mining_public_key = Some(btc_miner_2_pk.to_hex());
+    conf_node_2.node.local_peer_seed = btc_miner_2_seed;
+    conf_node_2.miner.mining_key = Some(Secp256k1PrivateKey::from_seed(&[2]));
+    conf_node_2.node.miner = true;
+    conf_node_2.events_observers.clear();
+    conf_node_2.events_observers.extend(node_2_listeners);
+    assert!(!conf_node_2.events_observers.is_empty());
+
+    let node_1_sk = Secp256k1PrivateKey::from_seed(&conf.node.local_peer_seed);
+    let node_1_pk = StacksPublicKey::from_private(&node_1_sk);
+
+    conf_node_2.node.working_dir = format!("{}-1", conf_node_2.node.working_dir);
+
+    conf_node_2.node.set_bootstrap_nodes(
+        format!("{}@{}", &node_1_pk.to_hex(), conf.node.p2p_bind),
+        conf.burnchain.chain_id,
+        conf.burnchain.peer_version,
+    );
+
+    let mut run_loop_2 = boot_nakamoto::BootRunLoop::new(conf_node_2.clone()).unwrap();
+    let run_loop_stopper_2 = run_loop_2.get_termination_switch();
+    let rl2_coord_channels = run_loop_2.coordinator_channels();
+    let Counters {
+        naka_submitted_commits: rl2_commits,
+        naka_skip_commit_op: rl2_skip_commit_op,
+        naka_submitted_commit_last_stacks_tip: rl2_commit_last_stacks_tip,
+        ..
+    } = run_loop_2.counters();
+
+    let blocks_mined1 = signer_test.running_nodes.nakamoto_blocks_mined.clone();
+
+    info!("------------------------- Pause Miner 2's Block Commits -------------------------");
+
+    // Make sure Miner 2 cannot win a sortition at first.
+    rl2_skip_commit_op.set(true);
+
+    info!("------------------------- Boot to Epoch 3.0 -------------------------");
+
+    let run_loop_2_thread = thread::Builder::new()
+        .name("run_loop_2".into())
+        .spawn(move || run_loop_2.start(None, 0))
+        .unwrap();
+
+    signer_test.boot_to_epoch_3();
+
+    wait_for(120, || {
+        let Some(node_1_info) = get_chain_info_opt(&conf) else {
+            return Ok(false);
+        };
+        let Some(node_2_info) = get_chain_info_opt(&conf_node_2) else {
+            return Ok(false);
+        };
+        Ok(node_1_info.stacks_tip_height == node_2_info.stacks_tip_height)
+    })
+    .expect("Timed out waiting for boostrapped node to catch up to the miner");
+
+    let mining_pk_1 = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+    let mining_pk_2 = StacksPublicKey::from_private(&conf_node_2.miner.mining_key.unwrap());
+    let mining_pkh_1 = Hash160::from_node_public_key(&mining_pk_1);
+    let mining_pkh_2 = Hash160::from_node_public_key(&mining_pk_2);
+    debug!("The mining key for miner 1 is {mining_pkh_1}");
+    debug!("The mining key for miner 2 is {mining_pkh_2}");
+
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let burnchain = signer_test.running_nodes.conf.get_burnchain();
+    let sortdb = burnchain.open_sortition_db(true).unwrap();
+
+    let get_burn_height = || {
+        SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
+            .unwrap()
+            .block_height
+    };
+    let starting_peer_height = get_chain_info(&conf).stacks_tip_height;
+    let starting_burn_height = get_burn_height();
+    let mut btc_blocks_mined = 0;
+
+    info!("------------------------- Pause Miner 1's Block Commit -------------------------");
+    // Make sure miner 1 doesn't submit any further block commits for the next tenure BEFORE mining the bitcoin block
+    signer_test
+        .running_nodes
+        .nakamoto_test_skip_commit_op
+        .set(true);
+
+    info!("------------------------- Miner 1 Mines a Normal Tenure A -------------------------");
+    let blocks_processed_before_1 = blocks_mined1.load(Ordering::SeqCst);
+    let nmb_old_blocks = test_observer::get_blocks().len();
+    let stacks_height_before = signer_test
+        .stacks_client
+        .get_peer_info()
+        .expect("Failed to get peer info")
+        .stacks_tip_height;
+
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .build_next_block(1);
+    btc_blocks_mined += 1;
+
+    // assure we have a successful sortition that miner A won
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+    assert!(tip.sortition);
+    assert_eq!(tip.miner_pk_hash.unwrap(), mining_pkh_1);
+
+    // wait for the new block to be processed
+    wait_for(60, || {
+        let stacks_height = signer_test
+            .stacks_client
+            .get_peer_info()
+            .expect("Failed to get peer info")
+            .stacks_tip_height;
+        Ok(
+            blocks_mined1.load(Ordering::SeqCst) > blocks_processed_before_1
+                && stacks_height > stacks_height_before
+                && test_observer::get_blocks().len() > nmb_old_blocks,
+        )
+    })
+    .unwrap();
+
+    info!(
+        "------------------------- Verify Tenure Change Tx in Miner 1's Block N -------------------------"
+    );
+    verify_last_block_contains_tenure_change_tx(TenureChangeCause::BlockFound);
+
+    info!("------------------------- Submit Miner 2 Block Commit -------------------------");
+    let stacks_height_before = signer_test
+        .stacks_client
+        .get_peer_info()
+        .expect("Failed to get peer info")
+        .stacks_tip_height;
+
+    let rl2_commits_before = rl2_commits.load(Ordering::SeqCst);
+    // Unpause miner 2's block commits
+    rl2_skip_commit_op.set(false);
+
+    // Ensure the miner 2 submits a block commit before mining the bitcoin block
+    wait_for(30, || {
+        Ok(rl2_commits.load(Ordering::SeqCst) > rl2_commits_before)
+    })
+    .unwrap();
+
+    // Make miner 2 also fail to submit any FURTHER block commits
+    rl2_skip_commit_op.set(true);
+
+    let burn_height_before = get_burn_height();
+    // Pause the block proposal broadcast so that miner 2 will be unable to broadcast its
+    // tenure change proposal BEFORE the block_proposal_timeout and will be marked invalid.
+    TEST_BROADCAST_STALL.set(true);
+
+    info!("------------------------- Miner 2 Mines an Empty Tenure B -------------------------";
+        "burn_height_before" => burn_height_before,
+    );
+
+    next_block_and(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        60,
+        || Ok(get_burn_height() > burn_height_before),
+    )
+    .unwrap();
+    btc_blocks_mined += 1;
+
+    // assure we have a successful sortition that miner 2 won
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+    assert!(tip.sortition);
+    assert_eq!(tip.miner_pk_hash.unwrap(), mining_pkh_2);
+
+    // Make sure that miner 2 gets marked invalid by not proposing a block BEFORE block_proposal_timeout
+    std::thread::sleep(block_proposal_timeout.add(Duration::from_secs(1)));
+
+    let stacks_height_after = signer_test
+        .stacks_client
+        .get_peer_info()
+        .expect("Failed to get peer info")
+        .stacks_tip_height;
+
+    assert_eq!(stacks_height_before, stacks_height_after);
+
+    let nmb_old_blocks = test_observer::get_blocks().len();
+    // Unpause both miner's block proposals
+    TEST_BROADCAST_STALL.set(false);
+
+    info!("------------------------- Wait for Miner 2's Block N+1' ------------------------";
+        "stacks_height_before" => %stacks_height_before,
+        "nmb_old_blocks" => %nmb_old_blocks);
+
+    // wait for the new block to be processed
+    wait_for(30, || {
+        let stacks_height = signer_test
+            .stacks_client
+            .get_peer_info()
+            .expect("Failed to get peer info")
+            .stacks_tip_height;
+
+        Ok(stacks_height > stacks_height_before
+            && test_observer::get_blocks().len() > nmb_old_blocks)
+    })
+    .expect("Timed out waiting for block to be mined and processed");
+
+    info!("------------------------- Verify Miner 2's N+1' was Rejected and Miner 1's N+1 Accepted-------------------------");
+
+    let mut miner_1_block_n_1 = None;
+    let mut miner_2_block_n_1 = None;
+
+    wait_for(30, || {
+        let chunks = test_observer::get_stackerdb_chunks();
+        for chunk in chunks.into_iter().flat_map(|chunk| chunk.modified_slots) {
+            let Ok(message) = SignerMessage::consensus_deserialize(&mut chunk.data.as_slice())
+            else {
+                continue;
+            };
+            let SignerMessage::BlockProposal(proposal) = message else {
+                continue;
+            };
+            let miner_pk = proposal.block.header.recover_miner_pk().unwrap();
+            let block_stacks_height = proposal.block.header.chain_length;
+            if block_stacks_height != stacks_height_before + 1 {
+                continue;
+            }
+            if miner_pk == mining_pk_1 {
+                miner_1_block_n_1 = Some(proposal.block);
+            } else if miner_pk == mining_pk_2 {
+                miner_2_block_n_1 = Some(proposal.block);
+            }
+        }
+        Ok(miner_1_block_n_1.is_some() && miner_2_block_n_1.is_some())
+    })
+    .expect("Timed out waiting for N+1 and N+1' block proposals from miners 1 and 2");
+
+    let miner_1_block_n_1 = miner_1_block_n_1.expect("No block proposal from miner 1");
+    let miner_2_block_n_1 = miner_2_block_n_1.expect("No block proposal from miner 2");
+
+    // Miner 2's proposed block should get rejected by all the signers
+    let mut found_miner_2_rejections = HashSet::new();
+    let mut found_miner_1_accepts = HashSet::new();
+    wait_for(30, || {
+        let chunks = test_observer::get_stackerdb_chunks();
+        for chunk in chunks.into_iter().flat_map(|chunk| chunk.modified_slots) {
+            let Ok(message) = SignerMessage::consensus_deserialize(&mut chunk.data.as_slice())
+            else {
+                continue;
+            };
+            match message {
+                SignerMessage::BlockResponse(BlockResponse::Accepted(BlockAccepted {
+                    signer_signature_hash,
+                    signature,
+                    ..
+                })) => {
+                    if signer_signature_hash == miner_1_block_n_1.header.signer_signature_hash() {
+                        found_miner_1_accepts.insert(signature);
+                    }
+                }
+                SignerMessage::BlockResponse(BlockResponse::Rejected(BlockRejection {
+                    signer_signature_hash,
+                    signature,
+                    ..
+                })) => {
+                    if signer_signature_hash == miner_2_block_n_1.header.signer_signature_hash() {
+                        found_miner_2_rejections.insert(signature);
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(found_miner_2_rejections.len() >= num_signers * 3 / 10
+            && found_miner_1_accepts.len() >= num_signers * 7 / 10)
+    })
+    .expect("Timed out waiting for expeceted block responses");
+
+    let nakamoto_blocks = test_observer::get_mined_nakamoto_blocks();
+    let last_mined = nakamoto_blocks.last().unwrap();
+    assert_eq!(
+        last_mined.signer_signature_hash,
+        miner_1_block_n_1.header.signer_signature_hash()
+    );
+    let tip_block_header_hash = signer_test
+        .stacks_client
+        .get_peer_info()
+        .expect("Failed to get peer info")
+        .stacks_tip;
+    assert_eq!(tip_block_header_hash.to_string(), last_mined.block_hash);
+
+    info!(
+        "------------------------- Verify Tenure Change Extend Tx in Miner 1's Block N+1 -------------------------"
+    );
+    verify_last_block_contains_tenure_change_tx(TenureChangeCause::Extended);
+
+    let stacks_height_before = signer_test
+        .stacks_client
+        .get_peer_info()
+        .expect("Failed to get peer info")
+        .stacks_tip_height;
+
+    assert_eq!(
+        get_chain_info(&conf).stacks_tip_height,
+        stacks_height_before
+    );
+    info!("------------------------- Unpause Miner 2's Block Commits -------------------------");
+    let stacks_height_before = get_chain_info(&conf).stacks_tip_height;
+    let rl2_commits_before = rl2_commits.load(Ordering::SeqCst);
+    // Unpause miner 2's commits
+    rl2_skip_commit_op.set(false);
+
+    // Ensure that both miners' commits point at the stacks tip
+    wait_for(30, || {
+        let last_committed_2 = rl2_commit_last_stacks_tip.load(Ordering::SeqCst);
+        Ok(last_committed_2 >= stacks_height_before
+            && rl2_commits.load(Ordering::SeqCst) > rl2_commits_before)
+    })
+    .expect("Timed out waiting for block commit from Miner 2");
+
+    let nmb_old_blocks = test_observer::get_blocks().len();
+    let burn_height_before = get_burn_height();
+    let block_before = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
+        .unwrap()
+        .block_height;
+
+    info!("------------------------- Miner 2 Mines a Normal Tenure C -------------------------";
+    "nmb_old_blocks" => %nmb_old_blocks,
+    "burn_height_before" => burn_height_before);
+
+    next_block_and(
+        &mut signer_test.running_nodes.btc_regtest_controller,
+        60,
+        || {
+            Ok(get_burn_height() > burn_height_before
+                && SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
+                    .unwrap()
+                    .block_height
+                    > block_before)
+        },
+    )
+    .unwrap();
+    btc_blocks_mined += 1;
+
+    // assure we have a successful sortition that miner 2 won
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+    assert!(tip.sortition);
+    assert_eq!(tip.miner_pk_hash.unwrap(), mining_pkh_2);
+
+    info!("------------------------- Wait for Miner 2's Block N+2 -------------------------";
+        "stacks_height_before" => %stacks_height_before,
+        "nmb_old_blocks" => %nmb_old_blocks);
+
+    wait_for(30, || {
+        let stacks_height = signer_test
+            .stacks_client
+            .get_peer_info()
+            .expect("Failed to get peer info")
+            .stacks_tip_height;
+        Ok(stacks_height > stacks_height_before)
+    })
+    .expect("Timed out waiting for block N+2 to be mined and processed");
+
+    info!(
+        "------------------------- Verify Tenure Change Tx in Miner 2's Block N+2 -------------------------"
+    );
+    verify_last_block_contains_tenure_change_tx(TenureChangeCause::BlockFound);
+
+    info!(
+        "------------------------- Confirm Burn and Stacks Block Heights -------------------------"
+    );
+    assert_eq!(get_burn_height(), starting_burn_height + btc_blocks_mined);
+    assert_eq!(
+        signer_test
+            .stacks_client
+            .get_peer_info()
+            .expect("Failed to get peer info")
+            .stacks_tip_height,
+        starting_peer_height + 3
+    );
+
+    info!("------------------------- Shutdown -------------------------");
+    rl2_coord_channels
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    run_loop_stopper_2.store(false, Ordering::SeqCst);
+    run_loop_2_thread.join().unwrap();
+    signer_test.shutdown();
+}


### PR DESCRIPTION
Looking into improving use of tenure_extend_timeout

Need to distinguish a continue tenure due to bad sortition vs sortition followed by a wait. 

Closes: https://github.com/stacks-network/stacks-core/issues/5729