### PR TITLE
Fix flake: shadow recovery

### DIFF
--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -10042,9 +10042,7 @@ fn test_shadow_recovery() {
     info!("Beginning post-shadow tenures");
 
     // revive ATC-C by waiting for commits
-    for _i in 0..4 {
-        next_block_and_commits_only(btc_regtest_controller, 60, &naka_conf, &counters).unwrap();
-    }
+    next_block_and_commits_only(btc_regtest_controller, 60, &naka_conf, &counters).unwrap();
 
     // make another tenure
     next_block_and_mine_commit(btc_regtest_controller, 60, &naka_conf, &counters).unwrap();


### PR DESCRIPTION
The test flake in the `tests::nakamoto_integrations::test_shadow_recovery` test ([logs](https://productionresultssa14.blob.core.windows.net/actions-results/62a78cd4-12e4-4e87-a5b9-1ca97364f550/workflow-job-run-a595cb68-e3d9-5efb-4385-674fcb00d490/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-02-05T15%3A05%3A55Z&sig=wJ3xyXMZKxMGLQS8OkYNVH0HkPKaWT0Pj6iLy1FcCFc%3D&ske=2025-02-06T00%3A13%3A01Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-02-05T12%3A13%3A01Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-02-05T14%3A55%3A50Z&sv=2025-01-05)) seemed to be caused by:

1. `next_block_and_commits_only()` is invoked 4 times.
2. ATC-C only prevents a winner on the first invocation -- a miner can win after that.
3. Because `next_block_and_commits_only()` only checks for block commits at the current burn height, if a miner wins, wakes up, and mines a block, the submitted commits may not commit to that block.
4. Once the fork occurs, the subsequent `next_block_and_mine_commit()` times out. That invocation explicitly waits for the stacks block height to increase, but because there's a reorg, that doesn't happen.

This PR just reduces the number of `commits_only()` invocations to 1 (which is the only amount necessary for the next bitcoin block to have a winner).

Other options would be (1) to alter `next_block_and_commits_only()` to check if the stacks block height has advanced, and if so, make sure the commits point at it (to prevent forks), and (2) alter `next_block_and_mine_commit()` to accept reorgs. I think (2) is bad, because if reorgs are creating test flake, we should iron _that_ behavior out of the tests: the only tests that should be generating reorgs are the ones we expect. (1) may be viable, but I worry that `commits_only()` could be useful to tests that are explicitly trying to force reorgs to happen.