### PR TITLE
fix: update versions.toml after merge

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.1.0.0.4"
-stacks_signer_version = "3.1.0.0.4.0"
+stacks_node_version = "3.1.0.0.5"
+stacks_signer_version = "3.1.0.0.5.0"


### PR DESCRIPTION
We merged #5399 , but that merge didn't happen to include the correct version at the time of the merge. This PR fixes that, so `develop` reflects the most recently published version.