### PR TITLE
feat: skip sending pending payload if URL doesn't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - Logging improvements:
   - P2P logs now includes a reason for dropping a peer or neighbor
   - Improvements to how a PeerAddress is logged (human readable format vs hex)
+- Pending event dispatcher requests will no longer be sent to URLs that are no longer registered as event observers ([#5834](https://github.com/stacks-network/stacks-core/pull/5834))
 
 ### Fixed
 


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/5822

This PR updates the event dispatcher functionality to not send pending requests if the URL is no longer registered as an event observer.

The way pending requests are implemented is that each _individual_ event dispatcher instance checks for pending requests before it sends any new ones. If a node has multiple event observers, this code is ran for each one of them. The first dispatcher is the only one that will actually handle pending requests, if there are any.

Now, the code is updated so that each dispatcher gets pending requests, but then it compares that request to its own URL. If the URL doesn't match, the pending request is skipped.

I think this implementation leaves something to be desired, although I think the ideal change would involve a small refactor of this code. Currently, we're performing IO (O(n)) for each dispatcher for each request, even though we should only ever have pending requests on bootup, and then we should never check again. This would probably be best located in the `EventDispatcher` struct (of which we only have one) instead of `EventObserver`.