### PR TITLE
Fix mock mining UTXO check to avoid unnecessary complaints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ lto = "fat"
 [profile.release-lite]
 inherits = "release"
 lto = "thin"
+
+[node]
+miner = true
+mock_mining = true

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -53,10 +53,6 @@ tempfile = "3.3"
 mockito = "1.5"
 serial_test = "3.2.0"
 
-[node]
-miner = true
-mock_mining = true
-
 [[bin]]
 name = "stacks-node"
 path = "src/main.rs"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -53,6 +53,10 @@ tempfile = "3.3"
 mockito = "1.5"
 serial_test = "3.2.0"
 
+[node]
+miner = true
+mock_mining = true
+
 [[bin]]
 name = "stacks-node"
 path = "src/main.rs"


### PR DESCRIPTION
closes #5841

This PR prevents the node from emitting misleading `No UTXOs` warnings when running in `mock_mining mode`.

Hi @diwakergupta ,I hoped this would work. Please let me know if there are any other suggestions or improvements.
