### PR TITLE
feat: immutable TrackerData

### DIFF
--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -38,7 +38,7 @@ use crate::vm::types::Value::UInt;
 use crate::vm::types::{
     FunctionType, PrincipalData, QualifiedContractIdentifier, TupleData, TypeSignature,
 };
-use crate::vm::{eval_all, ClarityName, SymbolicExpression, Value};
+use crate::vm::{CallStack, ClarityName, Environment, LocalContext, SymbolicExpression, Value};
 
 pub mod constants;
 pub mod cost_functions;
@@ -406,7 +406,7 @@ impl PartialEq for LimitedCostTracker {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CostErrors {
     CostComputationFailed(String),
     CostOverflow,
@@ -1055,7 +1055,7 @@ pub fn parse_cost(
 // TODO: add tests from mutation testing results #4832
 #[cfg_attr(test, mutants::skip)]
 fn compute_cost(
-    cost_tracker: &mut TrackerData,
+    cost_tracker: &TrackerData,
     cost_function_reference: ClarityCostFunctionReference,
     input_sizes: &[u64],
     eval_in_epoch: StacksEpochId,
@@ -1074,7 +1074,7 @@ fn compute_cost(
 
     let cost_contract = cost_tracker
         .cost_contracts
-        .get_mut(&cost_function_reference.contract_id)
+        .get(&cost_function_reference.contract_id)
         .ok_or(CostErrors::CostComputationFailed(format!(
             "CostFunction not found: {cost_function_reference}"
         )))?;
@@ -1089,14 +1089,23 @@ fn compute_cost(
         )));
     }
 
-    let function_invocation = [SymbolicExpression::list(program)];
+    let function_invocation = SymbolicExpression::list(program);
+    let eval_result = global_context.execute(|global_context| {
+        let context = LocalContext::new();
+        let mut call_stack = CallStack::new();
+        let publisher: PrincipalData = cost_contract.contract_identifier.issuer.clone().into();
+        let mut env = Environment::new(
+            global_context,
+            cost_contract,
+            &mut call_stack,
+            Some(publisher.clone()),
+            Some(publisher.clone()),
+            None,
+        );
 
-    let eval_result = eval_all(
-        &function_invocation,
-        cost_contract,
-        &mut global_context,
-        None,
-    );
+        let result = super::eval(&function_invocation, &mut env, &context)?;
+        Ok(Some(result))
+    });
 
     parse_cost(&cost_function_reference.to_string(), eval_result)
 }

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -1027,6 +1027,7 @@ impl StacksChainState {
                 let cost_before = clarity_tx.cost_so_far();
                 let sponsor = tx.sponsor_address().map(|a| a.to_account_principal());
                 let epoch_id = clarity_tx.get_epoch();
+                let start_ts = std::time::Instant::now();
 
                 let contract_call_resp = clarity_tx.run_contract_call(
                     &origin_account.principal,
@@ -1061,7 +1062,8 @@ impl StacksChainState {
                               "function_name" => %contract_call.function_name,
                               "function_args" => %VecDisplay(&contract_call.function_args),
                               "return_value" => %return_value,
-                              "cost" => ?total_cost);
+                              "cost" => ?total_cost,
+                              "duration" => ?start_ts.elapsed());
                         (return_value, asset_map, events)
                     }
                     Err(e) => match handle_clarity_runtime_error(e) {


### PR DESCRIPTION
### Description

1. Avoid using eval_all for `compute_cost`, which makes `TrackerData` immutable
2. Cache `compute_cost` results

The 2nd change is based on that the relevant fields (epoch, mainnet, chain_id, cost_contracts, and cost_function_references) are immutable, and the length of cost function input is always 1.

This change will tremendously improve the performance, especially for contracts running fold/map loops, e.g. BitFlow stableswap. 

```bash
# without the optimization
INFO [1740128991.071985] [stackslib/src/chainstate/stacks/db/transactions.rs:1060] [main] Contract-call successfully processed, txid: 2cbc88aec948b5e436b36aa15c9e8c82a7aa8dc669c54664430000400cfee603, origin: SP1Z8F1C9AVVRMQCV3ZW7CBSKPHV89MG275AC5PA0, origin_nonce: 365, contract_name: SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.stableswap-core-v-1-2, function_name: add-liquidity, function_args: [SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.stableswap-pool-sbtc-pbtc-v-1-1, SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token, SP14NS8MVBRHXMM96BQY0727AJ59SWPV7RMHC0NCG.pontis-bridge-pBTC, u313601, u0, u300652], return_value: (ok u313180), cost: ExecutionCost { write_length: 57, write_count: 9, read_length: 163057, read_count: 85, runtime: 25882076 }, duration: 1.967533897s
INFO [1740128991.312623] [stackslib/src/chainstate/stacks/db/transactions.rs:1060] [main] Contract-call successfully processed, txid: c347efd44969c2a17b0dc007906078349135b2c979059ac08284550230b08ad1, origin: SP3WMZH4GCH820YP3XHD6GX5TKQ411MHSKPJ9H22R, origin_nonce: 22730, contract_name: SPGYCP878RYFVT03ZT8TWGPKNYTSQB1578VVXHGE.powerful-farmer, function_name: execute-both, function_args: [], return_value: (ok true), cost: ExecutionCost { write_length: 159, write_count: 75, read_length: 1168351, read_count: 945, runtime: 3063310 }, duration: 239.417538ms
```

```bash
# with the optimization
INFO [1740128660.323517] [stackslib/src/chainstate/stacks/db/transactions.rs:1060] [main] Contract-call successfully processed, txid: 2cbc88aec948b5e436b36aa15c9e8c82a7aa8dc669c54664430000400cfee603, origin: SP1Z8F1C9AVVRMQCV3ZW7CBSKPHV89MG275AC5PA0, origin_nonce: 365, contract_name: SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.stableswap-core-v-1-2, function_name: add-liquidity, function_args: [SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.stableswap-pool-sbtc-pbtc-v-1-1, SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token, SP14NS8MVBRHXMM96BQY0727AJ59SWPV7RMHC0NCG.pontis-bridge-pBTC, u313601, u0, u300652], return_value: (ok u313180), cost: ExecutionCost { write_length: 57, write_count: 9, read_length: 163057, read_count: 85, runtime: 25882076 }, duration: 411.462222ms
INFO [1740128730.306605] [stackslib/src/chainstate/stacks/db/transactions.rs:1060] [main] Contract-call successfully processed, txid: c347efd44969c2a17b0dc007906078349135b2c979059ac08284550230b08ad1, origin: SP3WMZH4GCH820YP3XHD6GX5TKQ411MHSKPJ9H22R, origin_nonce: 22730, contract_name: SPGYCP878RYFVT03ZT8TWGPKNYTSQB1578VVXHGE.powerful-farmer, function_name: execute-both, function_args: [], return_value: (ok true), cost: ExecutionCost { write_length: 159, write_count: 75, read_length: 1168351, read_count: 945, runtime: 3063310 }, duration: 151.164217ms
```

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
