### PR TITLE
feat: hot-reload burn_fee_cap in nakamoto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 - The `BlockProposal` StackerDB message serialization struct now includes a `server_version` string, which represents the version of the node that the miner is using. ([#5803](https://github.com/stacks-network/stacks-core/pull/5803))
 - Add `vrf_seed` to the `/v3/sortitions` rpc endpoint
+- Added hot-reloading of `burnchain.burn_fee_cap` from a miner's config file ([#5857](https://github.com/stacks-network/stacks-core/pull/5857))
 
 ### Changed
 

--- a/testnet/stacks-node/src/globals.rs
+++ b/testnet/stacks-node/src/globals.rs
@@ -63,6 +63,8 @@ pub struct Globals<T> {
     pub leader_key_registration_state: Arc<Mutex<LeaderKeyRegistrationState>>,
     /// Last miner config loaded
     last_miner_config: Arc<Mutex<Option<MinerConfig>>>,
+    /// Last miner spend amount
+    last_miner_spend_amount: Arc<Mutex<Option<u64>>>,
     /// burnchain height at which we start mining
     start_mining_height: Arc<Mutex<u64>>,
     /// estimated winning probability at given bitcoin block heights
@@ -91,6 +93,7 @@ impl<T> Clone for Globals<T> {
             should_keep_running: self.should_keep_running.clone(),
             leader_key_registration_state: self.leader_key_registration_state.clone(),
             last_miner_config: self.last_miner_config.clone(),
+            last_miner_spend_amount: self.last_miner_spend_amount.clone(),
             start_mining_height: self.start_mining_height.clone(),
             estimated_winning_probs: self.estimated_winning_probs.clone(),
             previous_best_tips: self.previous_best_tips.clone(),
@@ -122,6 +125,7 @@ impl<T> Globals<T> {
             should_keep_running,
             leader_key_registration_state: Arc::new(Mutex::new(leader_key_registration_state)),
             last_miner_config: Arc::new(Mutex::new(None)),
+            last_miner_spend_amount: Arc::new(Mutex::new(None)),
             start_mining_height: Arc::new(Mutex::new(start_mining_height)),
             estimated_winning_probs: Arc::new(Mutex::new(HashMap::new())),
             previous_best_tips: Arc::new(Mutex::new(BTreeMap::new())),
@@ -346,6 +350,28 @@ impl<T> Globals<T> {
             Ok(ref mut last_miner_config) => **last_miner_config = Some(miner_config),
             Err(_e) => {
                 error!("FATAL; failed to lock last miner config");
+                panic!();
+            }
+        }
+    }
+
+    /// Get the last miner spend amount
+    pub fn get_last_miner_spend_amount(&self) -> Option<u64> {
+        match self.last_miner_spend_amount.lock() {
+            Ok(last_miner_spend_amount) => (*last_miner_spend_amount).clone(),
+            Err(_e) => {
+                error!("FATAL; failed to lock last miner spend amount");
+                panic!();
+            }
+        }
+    }
+
+    /// Set the last miner spend amount
+    pub fn set_last_miner_spend_amount(&self, spend_amount: u64) {
+        match self.last_miner_spend_amount.lock() {
+            Ok(ref mut last_miner_spend_amount) => **last_miner_spend_amount = Some(spend_amount),
+            Err(_e) => {
+                error!("FATAL; failed to lock last miner spend amount");
                 panic!();
             }
         }

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -40,7 +40,7 @@ use stacks::chainstate::nakamoto::{NakamotoBlockHeader, NakamotoChainState};
 use stacks::chainstate::stacks::address::PoxAddress;
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks::chainstate::stacks::miner::{
-    get_mining_spend_amount, signal_mining_blocked, signal_mining_ready,
+    set_mining_spend_amount, signal_mining_blocked, signal_mining_ready,
 };
 use stacks::chainstate::stacks::Error as ChainstateError;
 use stacks::core::mempool::MemPoolDB;
@@ -1030,8 +1030,29 @@ impl RelayerThread {
             return Err(NakamotoNodeError::SnapshotNotFoundForChainTip);
         };
 
+        let burnchain_config = self.config.get_burnchain_config();
+        let last_miner_spend_opt = self.globals.get_last_miner_spend_amount();
+        let force_remine = if let Some(last_miner_spend_amount) = last_miner_spend_opt {
+            last_miner_spend_amount != burnchain_config.burn_fee_cap
+        } else {
+            false
+        };
+        if force_remine {
+            info!(
+                "Miner config changed; updating spend amount {}",
+                burnchain_config.burn_fee_cap
+            );
+        }
+
+        self.globals
+            .set_last_miner_spend_amount(burnchain_config.burn_fee_cap);
+
+        set_mining_spend_amount(
+            self.globals.get_miner_status(),
+            burnchain_config.burn_fee_cap,
+        );
         // amount of burnchain tokens (e.g. sats) we'll spend across the PoX outputs
-        let burn_fee_cap = get_mining_spend_amount(self.globals.get_miner_status());
+        let burn_fee_cap = burnchain_config.burn_fee_cap;
 
         // let's commit, but target the current burnchain tip with our modulus so the commit is
         // only valid if it lands in the targeted burnchain block height

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -11153,7 +11153,6 @@ fn reload_miner_config() {
     let Counters {
         blocks_processed,
         naka_submitted_commits: commits_submitted,
-        naka_proposed_blocks: proposals_submitted,
         ..
     } = run_loop.counters();
 
@@ -11173,7 +11172,7 @@ fn reload_miner_config() {
 
     info!("------------------------- Reached Epoch 3.0 -------------------------");
 
-    blind_signer(&conf, &signers, proposals_submitted);
+    blind_signer(&conf, &signers, &counters);
 
     wait_for_first_naka_block_commit(60, &commits_submitted);
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs::File;
 use std::ops::RangeBounds;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -10764,7 +10765,7 @@ fn test_tenure_extend_from_flashblocks() {
 (define-data-var my-var uint u0)
 (define-data-var my-counter uint u0)
 
-(define-public (f) 
+(define-public (f)
    (begin
       (var-set my-var burn-block-height)
       (if (is-eq u0 (mod burn-block-height u2))
@@ -11156,6 +11157,149 @@ fn mine_invalid_principal_from_consensus_buff() {
     assert_eq!(dropped_txs.len(), 1);
     assert_eq!(dropped_txs[0].0, format!("0x{}", &contract_tx.txid()));
     assert_eq!(dropped_txs[0].1.as_str(), "Problematic");
+
+    coord_channel
+        .lock()
+        .expect("Mutex poisoned")
+        .stop_chains_coordinator();
+    run_loop_stopper.store(false, Ordering::SeqCst);
+
+    run_loop_thread.join().unwrap();
+}
+
+/// Test hot-reloading of miner config
+#[test]
+#[ignore]
+fn reload_miner_config() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (mut conf, _miner_account) = naka_neon_integration_conf(None);
+    let password = "12345".to_string();
+    let _http_origin = format!("http://{}", &conf.node.rpc_bind);
+    conf.connection_options.auth_token = Some(password.clone());
+    conf.miner.wait_on_interim_blocks = Duration::from_secs(1);
+    let stacker_sk = setup_stacker(&mut conf);
+    let signer_sk = Secp256k1PrivateKey::random();
+    let signer_addr = tests::to_addr(&signer_sk);
+    let sender_sk = Secp256k1PrivateKey::random();
+    // setup sender + recipient for some test stx transfers
+    // these are necessary for the interim blocks to get mined at all
+    let sender_addr = tests::to_addr(&sender_sk);
+    conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1000000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+
+    test_observer::spawn();
+    test_observer::register(&mut conf, &[EventKeyType::AnyEvent]);
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .expect("Failed starting bitcoind");
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    btc_regtest_controller.bootstrap_chain(201);
+
+    let conf_path =
+        std::env::temp_dir().join(format!("miner-config-test-{}.toml", rand::random::<u64>()));
+    conf.config_path = Some(conf_path.clone().to_str().unwrap().to_string());
+
+    // Make a minimum-viable config file
+    let update_config = |burn_fee_cap: u64, sats_vbyte: u64| {
+        use std::io::Write;
+
+        let new_config = format!(
+            r#"
+            [burnchain]
+            burn_fee_cap = {}
+            satoshis_per_byte = {}
+            "#,
+            burn_fee_cap, sats_vbyte,
+        );
+        // Write to a file
+        let mut file = File::create(&conf_path).unwrap();
+        file.write_all(new_config.as_bytes()).unwrap();
+    };
+
+    update_config(100000, 50);
+
+    let mut run_loop = boot_nakamoto::BootRunLoop::new(conf.clone()).unwrap();
+    let run_loop_stopper = run_loop.get_termination_switch();
+    let counters = run_loop.counters();
+    let Counters {
+        blocks_processed,
+        naka_submitted_commits: commits_submitted,
+        naka_proposed_blocks: proposals_submitted,
+        ..
+    } = run_loop.counters();
+
+    let coord_channel = run_loop.coordinator_channels();
+
+    let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
+    let mut signers = TestSigners::new(vec![signer_sk]);
+    wait_for_runloop(&blocks_processed);
+    boot_to_epoch_3(
+        &conf,
+        &blocks_processed,
+        &[stacker_sk],
+        &[signer_sk],
+        &mut Some(&mut signers),
+        &mut btc_regtest_controller,
+    );
+
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    blind_signer(&conf, &signers, proposals_submitted);
+
+    wait_for_first_naka_block_commit(60, &commits_submitted);
+
+    next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
+
+    let burn_blocks = test_observer::get_burn_blocks();
+    let burn_block = burn_blocks.last().unwrap();
+    info!("Burn block: {:?}", &burn_block);
+
+    let reward_amount = burn_block
+        .get("reward_recipients")
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .get(0)
+        .unwrap()
+        .get("amt")
+        .unwrap()
+        .as_u64()
+        .unwrap();
+
+    assert_eq!(reward_amount, 200000);
+
+    next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
+
+    info!("---- Updating config ----");
+    update_config(100010, 55);
+
+    // Due to timing of commits, just mine two blocks
+
+    next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
+    next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
+
+    let burn_blocks = test_observer::get_burn_blocks();
+    let burn_block = burn_blocks.last().unwrap();
+    info!("Burn block: {:?}", &burn_block);
+
+    let reward_amount = burn_block
+        .get("reward_recipients")
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .get(0)
+        .unwrap()
+        .get("amt")
+        .unwrap()
+        .as_u64()
+        .unwrap();
+
+    assert_eq!(reward_amount, 100010);
 
     coord_channel
         .lock()

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -11187,19 +11187,17 @@ fn reload_miner_config() {
         .unwrap()
         .as_array()
         .unwrap()
-        .get(0)
-        .unwrap()
-        .get("amt")
-        .unwrap()
-        .as_u64()
-        .unwrap();
+        .iter()
+        .map(|r| r.get("amt").unwrap().as_u64().unwrap())
+        .sum::<u64>();
 
     assert_eq!(reward_amount, 200000);
 
     next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
 
     info!("---- Updating config ----");
-    update_config(100010, 55);
+    let new_amount = 150000;
+    update_config(new_amount, 55);
 
     // Due to timing of commits, just mine two blocks
 
@@ -11215,14 +11213,11 @@ fn reload_miner_config() {
         .unwrap()
         .as_array()
         .unwrap()
-        .get(0)
-        .unwrap()
-        .get("amt")
-        .unwrap()
-        .as_u64()
-        .unwrap();
+        .iter()
+        .map(|r| r.get("amt").unwrap().as_u64().unwrap())
+        .sum::<u64>();
 
-    assert_eq!(reward_amount, 100010);
+    assert_eq!(reward_amount, new_amount);
 
     coord_channel
         .lock()


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/5583

This introduces behavior to hot-reload the `burnchain.burn_fee_cap` config field, which is what determines the amount of sats sent to reward recipients. We previously had this behavior, but it wasn't implemented in the Nakamoto miner.

(I would not that the `satoshis_per_byte` config field _is_ hot-reloaded, still)