### PR TITLE
Feat: Implement faster cost tracker for default cost functions

### DIFF
--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -715,6 +715,10 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
         })
     }
 
+    pub fn is_mainnet(&self) -> bool {
+        self.context.mainnet
+    }
+
     #[cfg(any(test, feature = "testing"))]
     pub fn stx_faucet(&mut self, recipient: &PrincipalData, amount: u128) {
         self.execute_in_env::<_, _, crate::vm::errors::Error>(

--- a/clarity/src/vm/costs/costs_1.rs
+++ b/clarity/src/vm/costs/costs_1.rs
@@ -1,0 +1,748 @@
+// Copyright (C) 2025 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This file implements the cost functions from costs.clar in Rust.
+use super::cost_functions::{linear, logn, nlogn, CostValues};
+use super::ExecutionCost;
+use crate::vm::errors::{InterpreterResult, RuntimeErrorType};
+
+pub struct Costs1;
+
+impl CostValues for Costs1 {
+    fn cost_analysis_type_annotate(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_type_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_type_lookup(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_visit(_n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_analysis_iterable_func(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_option_cons(_n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_analysis_option_check(_n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_analysis_bind_name(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_list_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_check_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(logn(n, 1000, 1000)?))
+    }
+
+    fn cost_analysis_check_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_check_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 1000, 1000)?))
+    }
+
+    fn cost_analysis_tuple_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_check_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_lookup_function(_n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_analysis_lookup_function_types(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_lookup_variable_const(_n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_analysis_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 1000, 1000)?))
+    }
+
+    fn cost_ast_parse(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 10000, 1000)))
+    }
+
+    fn cost_ast_cycle_detection(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_analysis_use_trait_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_get_function_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_fetch_contract_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_lookup_variable_size(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 0)))
+    }
+
+    fn cost_lookup_function(_n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_bind_name(_n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_inner_type_check_cost(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_user_function_application(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_if(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_asserts(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_filter(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_element_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_index_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_fold(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_list_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_type_parse_step(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 1000, 1000)?))
+    }
+
+    fn cost_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 1000, 1000)?))
+    }
+
+    fn cost_add(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_sub(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_mul(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_div(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_geq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_leq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_ge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_int_cast(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_mod(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_pow(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_sqrti(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_log2(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_xor(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_eq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_begin(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_hash160(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_sha256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_sha512(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_sha512t256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_keccak256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_secp256k1recover(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_secp256k1verify(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_print(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_some_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_ok_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_err_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_default_to(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_unwrap_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_unwrap_err_or_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_is_okay(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_is_none(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_is_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_is_some(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_unwrap(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_unwrap_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_try_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_match(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_append(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_concat(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_as_max_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_contract_call(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_contract_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_principal_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1000))
+    }
+
+    fn cost_at_block(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_load_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            // set to 3 because of the associated metadata loads
+            read_count: 3,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_create_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_nft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_ft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 1,
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_contract_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_owner(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_get_supply(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn poison_microblock(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1000,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_buff_to_int_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_uint_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_int_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_uint_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_is_standard(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_principal_destruct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_principal_construct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_string_to_int(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_string_to_uint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_int_to_ascii(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_int_to_utf8(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_burn_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_stx_account(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_slice(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_to_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_from_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_stx_transfer_memo(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_replace_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_as_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_left_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_right_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+}

--- a/clarity/src/vm/costs/costs_2.rs
+++ b/clarity/src/vm/costs/costs_2.rs
@@ -1,0 +1,748 @@
+// Copyright (C) 2025 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This file implements the cost functions from costs-2.clar in Rust.
+use super::cost_functions::{linear, logn, nlogn, CostValues};
+use super::ExecutionCost;
+use crate::vm::errors::{InterpreterResult, RuntimeErrorType};
+
+pub struct Costs2;
+
+impl CostValues for Costs2 {
+    fn cost_analysis_type_annotate(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 9)))
+    }
+
+    fn cost_analysis_type_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 113, 1)))
+    }
+
+    fn cost_analysis_type_lookup(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 6)))
+    }
+
+    fn cost_analysis_visit(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1))
+    }
+
+    fn cost_analysis_iterable_func(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 14)))
+    }
+
+    fn cost_analysis_option_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(6))
+    }
+
+    fn cost_analysis_option_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(3))
+    }
+
+    fn cost_analysis_bind_name(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 176)))
+    }
+
+    fn cost_analysis_list_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 4)))
+    }
+
+    fn cost_analysis_check_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(logn(n, 1, 2)?))
+    }
+
+    fn cost_analysis_check_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_check_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 3, 5)?))
+    }
+
+    fn cost_analysis_tuple_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 59)))
+    }
+
+    fn cost_analysis_check_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 12)))
+    }
+
+    fn cost_analysis_lookup_function(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(20))
+    }
+
+    fn cost_analysis_lookup_function_types(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 28)))
+    }
+
+    fn cost_analysis_lookup_variable_const(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(15))
+    }
+
+    fn cost_analysis_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 1, 34)?))
+    }
+
+    fn cost_ast_parse(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 172, 287441)))
+    }
+
+    fn cost_ast_cycle_detection(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 141, 72)))
+    }
+
+    fn cost_analysis_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 2, 100),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_analysis_use_trait_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 723),
+            write_length: linear(n, 1, 1),
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_get_function_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 81, 1303),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_fetch_contract_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 14)))
+    }
+
+    fn cost_lookup_variable_size(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 1)))
+    }
+
+    fn cost_lookup_function(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(16))
+    }
+
+    fn cost_bind_name(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(256))
+    }
+
+    fn cost_inner_type_check_cost(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 9)))
+    }
+
+    fn cost_user_function_application(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 26, 140)))
+    }
+
+    fn cost_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 146, 862)))
+    }
+
+    fn cost_if(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(200))
+    }
+
+    fn cost_asserts(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1210, 3314)))
+    }
+
+    fn cost_filter(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(460))
+    }
+
+    fn cost_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(486))
+    }
+
+    fn cost_element_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(619))
+    }
+
+    fn cost_index_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 243)))
+    }
+
+    fn cost_fold(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(483))
+    }
+
+    fn cost_list_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 198)))
+    }
+
+    fn cost_type_parse_step(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(5))
+    }
+
+    fn cost_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 4, 1780)?))
+    }
+
+    fn cost_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 4, 646)))
+    }
+
+    fn cost_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 11, 1101)?))
+    }
+
+    fn cost_add(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 157)))
+    }
+
+    fn cost_sub(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 157)))
+    }
+
+    fn cost_mul(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 157)))
+    }
+
+    fn cost_div(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 157)))
+    }
+
+    fn cost_geq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_leq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_ge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_int_cast(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_mod(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_pow(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_sqrti(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_log2(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_xor(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_eq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 7, 172)))
+    }
+
+    fn cost_begin(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(202))
+    }
+
+    fn cost_hash160(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 201)))
+    }
+
+    fn cost_sha256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 100)))
+    }
+
+    fn cost_sha512(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 176)))
+    }
+
+    fn cost_sha512t256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 188)))
+    }
+
+    fn cost_keccak256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 221)))
+    }
+
+    fn cost_secp256k1recover(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(14344))
+    }
+
+    fn cost_secp256k1verify(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(13540))
+    }
+
+    fn cost_print(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 1413)))
+    }
+
+    fn cost_some_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(230))
+    }
+
+    fn cost_ok_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(230))
+    }
+
+    fn cost_err_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(230))
+    }
+
+    fn cost_default_to(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_unwrap_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(339))
+    }
+
+    fn cost_unwrap_err_or_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(339))
+    }
+
+    fn cost_is_okay(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_is_none(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_is_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_is_some(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_unwrap(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_unwrap_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_try_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_match(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 149)))
+    }
+
+    fn cost_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 149)))
+    }
+
+    fn cost_append(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 71, 176)))
+    }
+
+    fn cost_concat(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 75, 244)))
+    }
+
+    fn cost_as_max_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(475))
+    }
+
+    fn cost_contract_call(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(153))
+    }
+
+    fn cost_contract_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(13400))
+    }
+
+    fn cost_principal_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(999))
+    }
+
+    fn cost_at_block(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 210,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_load_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 157),
+            write_length: 0,
+            write_count: 0,
+            // set to 3 because of the associated metadata loads
+            read_count: 3,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_create_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1631),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 7, 2152),
+            write_length: linear(n, 1, 1),
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_nft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1610),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_ft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1972,
+            write_length: 1,
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1539),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 4, 2204),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 543),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 5, 691),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_contract_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 13, 7982),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 6321,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1385,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1430,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1645,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 612,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 547,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_owner(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_get_supply(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 483,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 612,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn poison_microblock(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 29568,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_buff_to_int_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_uint_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_int_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_uint_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_is_standard(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_principal_destruct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_principal_construct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_string_to_int(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_string_to_uint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_int_to_ascii(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_int_to_utf8(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_burn_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_stx_account(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_slice(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_to_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_from_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_stx_transfer_memo(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_replace_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_as_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_left_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_right_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+}

--- a/clarity/src/vm/costs/costs_2_testnet.rs
+++ b/clarity/src/vm/costs/costs_2_testnet.rs
@@ -1,0 +1,748 @@
+// Copyright (C) 2025 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This file implements the cost functions from costs-2-testnet.clar in Rust.
+use super::cost_functions::{linear, logn, nlogn, CostValues};
+use super::ExecutionCost;
+use crate::vm::errors::{InterpreterResult, RuntimeErrorType};
+
+pub struct Costs2Testnet;
+
+impl CostValues for Costs2Testnet {
+    fn cost_analysis_type_annotate(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 9)))
+    }
+
+    fn cost_analysis_type_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 113, 1)))
+    }
+
+    fn cost_analysis_type_lookup(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 6)))
+    }
+
+    fn cost_analysis_visit(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1))
+    }
+
+    fn cost_analysis_iterable_func(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 14)))
+    }
+
+    fn cost_analysis_option_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(6))
+    }
+
+    fn cost_analysis_option_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(3))
+    }
+
+    fn cost_analysis_bind_name(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 176)))
+    }
+
+    fn cost_analysis_list_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 4)))
+    }
+
+    fn cost_analysis_check_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(logn(n, 1, 2)?))
+    }
+
+    fn cost_analysis_check_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1000, 1000)))
+    }
+
+    fn cost_analysis_check_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 3, 5)?))
+    }
+
+    fn cost_analysis_tuple_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 59)))
+    }
+
+    fn cost_analysis_check_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 12)))
+    }
+
+    fn cost_analysis_lookup_function(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(20))
+    }
+
+    fn cost_analysis_lookup_function_types(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 28)))
+    }
+
+    fn cost_analysis_lookup_variable_const(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(15))
+    }
+
+    fn cost_analysis_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 1, 34)?))
+    }
+
+    fn cost_ast_parse(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 172, 287441)))
+    }
+
+    fn cost_ast_cycle_detection(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 141, 72)))
+    }
+
+    fn cost_analysis_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 2, 100),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_analysis_use_trait_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 723),
+            write_length: linear(n, 1, 1),
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_get_function_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 81, 1303),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_fetch_contract_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1000, 1000),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 14)))
+    }
+
+    fn cost_lookup_variable_size(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 1)))
+    }
+
+    fn cost_lookup_function(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(16))
+    }
+
+    fn cost_bind_name(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(256))
+    }
+
+    fn cost_inner_type_check_cost(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 9)))
+    }
+
+    fn cost_user_function_application(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 26, 140)))
+    }
+
+    fn cost_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 146, 862)))
+    }
+
+    fn cost_if(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(200))
+    }
+
+    fn cost_asserts(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(158))
+    }
+
+    fn cost_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1210, 3314)))
+    }
+
+    fn cost_filter(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(460))
+    }
+
+    fn cost_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(486))
+    }
+
+    fn cost_element_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(619))
+    }
+
+    fn cost_index_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 243)))
+    }
+
+    fn cost_fold(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(483))
+    }
+
+    fn cost_list_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 198)))
+    }
+
+    fn cost_type_parse_step(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(5))
+    }
+
+    fn cost_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 4, 1780)?))
+    }
+
+    fn cost_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 4, 646)))
+    }
+
+    fn cost_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 11, 1101)?))
+    }
+
+    fn cost_add(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 12, 156)))
+    }
+
+    fn cost_sub(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 12, 156)))
+    }
+
+    fn cost_mul(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 157)))
+    }
+
+    fn cost_div(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 157)))
+    }
+
+    fn cost_geq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(166))
+    }
+
+    fn cost_leq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(166))
+    }
+
+    fn cost_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(166))
+    }
+
+    fn cost_ge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(166))
+    }
+
+    fn cost_int_cast(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(164))
+    }
+
+    fn cost_mod(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(168))
+    }
+
+    fn cost_pow(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(170))
+    }
+
+    fn cost_sqrti(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(167))
+    }
+
+    fn cost_log2(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(161))
+    }
+
+    fn cost_xor(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(167))
+    }
+
+    fn cost_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(162))
+    }
+
+    fn cost_eq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 7, 172)))
+    }
+
+    fn cost_begin(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(202))
+    }
+
+    fn cost_hash160(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 201)))
+    }
+
+    fn cost_sha256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 100)))
+    }
+
+    fn cost_sha512(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 176)))
+    }
+
+    fn cost_sha512t256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 188)))
+    }
+
+    fn cost_keccak256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 221)))
+    }
+
+    fn cost_secp256k1recover(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(14344))
+    }
+
+    fn cost_secp256k1verify(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(13540))
+    }
+
+    fn cost_print(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 1413)))
+    }
+
+    fn cost_some_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(230))
+    }
+
+    fn cost_ok_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(230))
+    }
+
+    fn cost_err_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(230))
+    }
+
+    fn cost_default_to(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(249))
+    }
+
+    fn cost_unwrap_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(299))
+    }
+
+    fn cost_unwrap_err_or_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(339))
+    }
+
+    fn cost_is_okay(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_is_none(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_is_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_is_some(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(287))
+    }
+
+    fn cost_unwrap(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(284))
+    }
+
+    fn cost_unwrap_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(264))
+    }
+
+    fn cost_try_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(256))
+    }
+
+    fn cost_match(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(286))
+    }
+
+    fn cost_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 149)))
+    }
+
+    fn cost_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 149)))
+    }
+
+    fn cost_append(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 71, 176)))
+    }
+
+    fn cost_concat(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 75, 244)))
+    }
+
+    fn cost_as_max_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(475))
+    }
+
+    fn cost_contract_call(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(153))
+    }
+
+    fn cost_contract_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(13400))
+    }
+
+    fn cost_principal_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(39))
+    }
+
+    fn cost_at_block(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 210,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_load_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 157),
+            write_length: 0,
+            write_count: 0,
+            // set to 3 because of the associated metadata loads
+            read_count: 3,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_create_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1631),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 7, 2152),
+            write_length: linear(n, 1, 1),
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_nft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1610),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_ft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1972,
+            write_length: 1,
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1539),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 4, 2204),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 543),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 5, 691),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_contract_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 13, 7982),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 6321,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1385,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1430,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1645,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 612,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 547,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_owner(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_get_supply(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 483,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 612,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn poison_microblock(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 29568,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_buff_to_int_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_uint_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_int_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_buff_to_uint_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_is_standard(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_principal_destruct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_principal_construct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_string_to_int(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_string_to_uint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_int_to_ascii(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_int_to_utf8(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_burn_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_stx_account(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_slice(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_to_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_from_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_stx_transfer_memo(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_replace_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_as_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_left_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+
+    fn cost_bitwise_right_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Err(RuntimeErrorType::NotImplemented.into())
+    }
+}

--- a/clarity/src/vm/costs/costs_3.rs
+++ b/clarity/src/vm/costs/costs_3.rs
@@ -1,0 +1,766 @@
+// Copyright (C) 2025 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This file implements the cost functions from costs-3.clar in Rust.
+use super::cost_functions::{linear, logn, nlogn, CostValues};
+use super::ExecutionCost;
+use crate::vm::errors::InterpreterResult;
+
+pub struct Costs3;
+
+impl CostValues for Costs3 {
+    fn cost_analysis_type_annotate(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 9)))
+    }
+
+    fn cost_analysis_type_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 113, 1)))
+    }
+
+    fn cost_analysis_type_lookup(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 4)))
+    }
+
+    fn cost_analysis_visit(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(1))
+    }
+
+    fn cost_analysis_iterable_func(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 14)))
+    }
+
+    fn cost_analysis_option_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(5))
+    }
+
+    fn cost_analysis_option_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(4))
+    }
+
+    fn cost_analysis_bind_name(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 59)))
+    }
+
+    fn cost_analysis_list_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 4)))
+    }
+
+    fn cost_analysis_check_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(logn(n, 1, 2)?))
+    }
+
+    fn cost_analysis_check_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 45, 49)?))
+    }
+
+    fn cost_analysis_check_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 3, 5)?))
+    }
+
+    fn cost_analysis_tuple_items_check(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 28)))
+    }
+
+    fn cost_analysis_check_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 10)))
+    }
+
+    fn cost_analysis_lookup_function(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(18))
+    }
+
+    fn cost_analysis_lookup_function_types(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 26)))
+    }
+
+    fn cost_analysis_lookup_variable_const(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(15))
+    }
+
+    fn cost_analysis_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 1, 12)?))
+    }
+
+    fn cost_ast_parse(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 27, 81)))
+    }
+
+    fn cost_ast_cycle_detection(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 141, 72)))
+    }
+
+    fn cost_analysis_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 2, 94),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_analysis_use_trait_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 698),
+            write_length: linear(n, 1, 1),
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_fetch_contract_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1516),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_analysis_get_function_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 78, 1307),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_lookup_variable_depth(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 1)))
+    }
+
+    fn cost_lookup_variable_size(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 1)))
+    }
+
+    fn cost_lookup_function(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(16))
+    }
+
+    fn cost_bind_name(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(216))
+    }
+
+    fn cost_inner_type_check_cost(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 2, 5)))
+    }
+
+    fn cost_user_function_application(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 26, 5)))
+    }
+
+    fn cost_let(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 117, 178)))
+    }
+
+    fn cost_if(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(168))
+    }
+
+    fn cost_asserts(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(128))
+    }
+
+    fn cost_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1198, 3067)))
+    }
+
+    fn cost_filter(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(407))
+    }
+
+    fn cost_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(429))
+    }
+
+    fn cost_element_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(498))
+    }
+
+    fn cost_index_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 211)))
+    }
+
+    fn cost_fold(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(460))
+    }
+
+    fn cost_list_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 14, 164)))
+    }
+
+    fn cost_type_parse_step(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(4))
+    }
+
+    fn cost_tuple_get(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 4, 1736)?))
+    }
+
+    fn cost_tuple_merge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 4, 408)))
+    }
+
+    fn cost_tuple_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 10, 1876)?))
+    }
+
+    fn cost_add(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 11, 125)))
+    }
+
+    fn cost_sub(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 11, 125)))
+    }
+
+    fn cost_mul(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 13, 125)))
+    }
+
+    fn cost_div(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 13, 125)))
+    }
+
+    fn cost_geq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 7, 128)))
+    }
+
+    fn cost_leq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 7, 128)))
+    }
+
+    fn cost_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 7, 128)))
+    }
+
+    fn cost_ge(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 7, 128)))
+    }
+
+    fn cost_int_cast(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(135))
+    }
+
+    fn cost_mod(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(141))
+    }
+
+    fn cost_pow(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(143))
+    }
+
+    fn cost_sqrti(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(142))
+    }
+
+    fn cost_log2(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(133))
+    }
+
+    fn cost_xor(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 15, 129)))
+    }
+
+    fn cost_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(138))
+    }
+
+    fn cost_eq(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 7, 151)))
+    }
+
+    fn cost_begin(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(151))
+    }
+
+    fn cost_hash160(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 188)))
+    }
+
+    fn cost_sha256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 100)))
+    }
+
+    fn cost_sha512(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 176)))
+    }
+
+    fn cost_sha512t256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 56)))
+    }
+
+    fn cost_keccak256(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 127)))
+    }
+
+    fn cost_secp256k1recover(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(8655))
+    }
+
+    fn cost_secp256k1verify(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(8349))
+    }
+
+    fn cost_print(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 15, 1458)))
+    }
+
+    fn cost_some_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(199))
+    }
+
+    fn cost_ok_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(199))
+    }
+
+    fn cost_err_cons(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(199))
+    }
+
+    fn cost_default_to(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(268))
+    }
+
+    fn cost_unwrap_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(274))
+    }
+
+    fn cost_unwrap_err_or_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(302))
+    }
+
+    fn cost_is_okay(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(258))
+    }
+
+    fn cost_is_none(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(214))
+    }
+
+    fn cost_is_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(245))
+    }
+
+    fn cost_is_some(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(195))
+    }
+
+    fn cost_unwrap(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(252))
+    }
+
+    fn cost_unwrap_err(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(248))
+    }
+
+    fn cost_try_ret(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(240))
+    }
+
+    fn cost_match(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(264))
+    }
+
+    fn cost_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 120)))
+    }
+
+    fn cost_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 3, 120)))
+    }
+
+    fn cost_append(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 73, 285)))
+    }
+
+    fn cost_concat(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 37, 220)))
+    }
+
+    fn cost_as_max_len(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(475))
+    }
+
+    fn cost_contract_call(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(134))
+    }
+
+    fn cost_contract_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(13400))
+    }
+
+    fn cost_principal_of(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(984))
+    }
+
+    fn cost_at_block(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1327,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_load_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 80),
+            write_length: 0,
+            write_count: 0,
+            // set to 3 because of the associated metadata loads
+            read_count: 3,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_create_map(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1564),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 7, 2025),
+            write_length: linear(n, 1, 1),
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_nft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1570),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_create_ft(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1831,
+            write_length: 1,
+            write_count: 2,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 1025),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_entry(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 4, 1899),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_fetch_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 1, 468),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: linear(n, 1, 1),
+        })
+    }
+
+    fn cost_set_var(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 5, 655),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 1,
+            read_length: 0,
+        })
+    }
+
+    fn cost_contract_storage(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 11, 7165),
+            write_length: linear(n, 1, 1),
+            write_count: 1,
+            read_count: 0,
+            read_length: 0,
+        })
+    }
+
+    fn cost_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 6321,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 4294,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 4640,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 1479,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 549,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_balance(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 479,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_mint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 575),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_transfer(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 572),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_owner(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 795),
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_get_supply(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 420,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_ft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 549,
+            write_length: 1,
+            write_count: 2,
+            read_count: 2,
+            read_length: 1,
+        })
+    }
+
+    fn cost_nft_burn(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: linear(n, 9, 572),
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn poison_microblock(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 17485,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_buff_to_int_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(141))
+    }
+
+    fn cost_buff_to_uint_le(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(141))
+    }
+
+    fn cost_buff_to_int_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(141))
+    }
+
+    fn cost_buff_to_uint_be(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(141))
+    }
+
+    fn cost_is_standard(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(127))
+    }
+
+    fn cost_principal_destruct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(314))
+    }
+
+    fn cost_principal_construct(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(398))
+    }
+
+    fn cost_string_to_int(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(168))
+    }
+
+    fn cost_string_to_uint(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(168))
+    }
+
+    fn cost_int_to_ascii(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(147))
+    }
+
+    fn cost_int_to_utf8(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(181))
+    }
+
+    fn cost_burn_block_info(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 96479,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_stx_account(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 4654,
+            write_length: 0,
+            write_count: 0,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_slice(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(448))
+    }
+
+    fn cost_to_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 233)))
+    }
+
+    fn cost_from_consensus_buff(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(nlogn(n, 3, 185)?))
+    }
+
+    fn cost_stx_transfer_memo(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost {
+            runtime: 4709,
+            write_length: 1,
+            write_count: 1,
+            read_count: 1,
+            read_length: 1,
+        })
+    }
+
+    fn cost_replace_at(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 1, 561)))
+    }
+
+    fn cost_as_contract(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(138))
+    }
+
+    fn cost_bitwise_and(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 15, 129)))
+    }
+
+    fn cost_bitwise_or(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(linear(n, 15, 129)))
+    }
+
+    fn cost_bitwise_not(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(147))
+    }
+
+    fn cost_bitwise_left_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(167))
+    }
+
+    fn cost_bitwise_right_shift(n: u64) -> InterpreterResult<ExecutionCost> {
+        Ok(ExecutionCost::runtime(167))
+    }
+}

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -16,11 +16,16 @@
 
 use std::{cmp, fmt};
 
+use costs_1::Costs1;
+use costs_2::Costs2;
+use costs_2_testnet::Costs2Testnet;
+use costs_3::Costs3;
 use hashbrown::HashMap;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use stacks_common::types::StacksEpochId;
 
+use super::errors::{CheckErrors, RuntimeErrorType};
 use crate::boot_util::boot_code_id;
 use crate::vm::contexts::{ContractContext, GlobalContext};
 use crate::vm::costs::cost_functions::ClarityCostFunction;
@@ -37,6 +42,14 @@ use crate::vm::{eval_all, ClarityName, SymbolicExpression, Value};
 
 pub mod constants;
 pub mod cost_functions;
+#[allow(unused_variables)]
+pub mod costs_1;
+#[allow(unused_variables)]
+pub mod costs_2;
+#[allow(unused_variables)]
+pub mod costs_2_testnet;
+#[allow(unused_variables)]
+pub mod costs_3;
 
 type Result<T> = std::result::Result<T, CostErrors>;
 
@@ -171,6 +184,80 @@ impl ::std::fmt::Display for ClarityCostFunctionReference {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Copy)]
+pub enum DefaultVersion {
+    Costs1,
+    Costs2,
+    Costs2Testnet,
+    Costs3,
+}
+
+impl DefaultVersion {
+    pub fn evaluate(
+        &self,
+        cost_function_ref: &ClarityCostFunctionReference,
+        f: &ClarityCostFunction,
+        input: &[u64],
+    ) -> Result<ExecutionCost> {
+        let n = input.first().ok_or_else(|| {
+            CostErrors::Expect("Default cost function supplied with 0 args".into())
+        })?;
+        let r = match self {
+            DefaultVersion::Costs1 => f.eval::<Costs1>(*n),
+            DefaultVersion::Costs2 => f.eval::<Costs2>(*n),
+            DefaultVersion::Costs2Testnet => f.eval::<Costs2Testnet>(*n),
+            DefaultVersion::Costs3 => f.eval::<Costs3>(*n),
+        };
+        r.map_err(|e| {
+            let e = match e {
+                crate::vm::errors::Error::Runtime(RuntimeErrorType::NotImplemented, _) => {
+                    CheckErrors::UndefinedFunction(cost_function_ref.function_name.clone()).into()
+                }
+                other => other,
+            };
+
+            CostErrors::CostComputationFailed(format!(
+                "Error evaluating result of cost function {}: {e}",
+                &cost_function_ref.function_name
+            ))
+        })
+    }
+}
+
+impl DefaultVersion {
+    pub fn try_from(
+        mainnet: bool,
+        value: &QualifiedContractIdentifier,
+    ) -> std::result::Result<Self, String> {
+        if !value.is_boot() {
+            return Err("Not a boot contract".into());
+        }
+        if value.name.as_str() == COSTS_1_NAME {
+            Ok(Self::Costs1)
+        } else if value.name.as_str() == COSTS_2_NAME {
+            if mainnet {
+                Ok(Self::Costs2)
+            } else {
+                Ok(Self::Costs2Testnet)
+            }
+        } else if value.name.as_str() == COSTS_3_NAME {
+            Ok(Self::Costs3)
+        } else {
+            Err(format!("Unknown default contract {}", &value.name))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub enum ClarityCostFunctionEvaluator {
+    Default(
+        ClarityCostFunctionReference,
+        ClarityCostFunction,
+        DefaultVersion,
+    ),
+    Clarity(ClarityCostFunctionReference),
+}
+
 impl ClarityCostFunctionReference {
     fn new(id: QualifiedContractIdentifier, name: String) -> ClarityCostFunctionReference {
         ClarityCostFunctionReference {
@@ -234,7 +321,7 @@ impl CostStateSummary {
 #[derive(Clone)]
 /// This struct holds all of the data required for non-free LimitedCostTracker instances
 pub struct TrackerData {
-    cost_function_references: HashMap<&'static ClarityCostFunction, ClarityCostFunctionReference>,
+    cost_function_references: HashMap<&'static ClarityCostFunction, ClarityCostFunctionEvaluator>,
     cost_contracts: HashMap<QualifiedContractIdentifier, ContractContext>,
     contract_call_circuits:
         HashMap<(QualifiedContractIdentifier, ClarityName), ClarityCostFunctionReference>,
@@ -272,7 +359,7 @@ impl LimitedCostTracker {
     }
     pub fn cost_function_references(
         &self,
-    ) -> HashMap<&'static ClarityCostFunction, ClarityCostFunctionReference> {
+    ) -> HashMap<&'static ClarityCostFunction, ClarityCostFunctionEvaluator> {
         match self {
             Self::Free => panic!("Cannot get cost function references on free tracker"),
             Self::Limited(TrackerData {
@@ -757,7 +844,7 @@ impl LimitedCostTracker {
         Self::Free
     }
 
-    fn default_cost_contract_for_epoch(epoch_id: StacksEpochId) -> Result<String> {
+    pub fn default_cost_contract_for_epoch(epoch_id: StacksEpochId) -> Result<String> {
         let result = match epoch_id {
             StacksEpochId::Epoch10 => {
                 return Err(CostErrors::Expect("Attempted to get default cost functions for Epoch 1.0 where Clarity does not exist".into()));
@@ -792,6 +879,12 @@ impl TrackerData {
             self.mainnet,
         );
 
+        let v = DefaultVersion::try_from(self.mainnet, &boot_costs_id).map_err(|e| {
+            CostErrors::Expect(format!(
+                "Failed to get version of default costs contract {e}"
+            ))
+        })?;
+
         let CostStateSummary {
             contract_call_circuits,
             mut cost_function_references,
@@ -811,6 +904,7 @@ impl TrackerData {
         let iter_len = iter.len();
         let mut cost_contracts = HashMap::with_capacity(iter_len);
         let mut m = HashMap::with_capacity(iter_len);
+
         for f in iter {
             let cost_function_ref = cost_function_references.remove(f).unwrap_or_else(|| {
                 ClarityCostFunctionReference::new(boot_costs_id.clone(), f.get_name())
@@ -832,7 +926,14 @@ impl TrackerData {
                 cost_contracts.insert(cost_function_ref.contract_id.clone(), contract_context);
             }
 
-            m.insert(f, cost_function_ref);
+            if cost_function_ref.contract_id == boot_costs_id {
+                m.insert(
+                    f,
+                    ClarityCostFunctionEvaluator::Default(cost_function_ref, *f, v),
+                );
+            } else {
+                m.insert(f, ClarityCostFunctionEvaluator::Clarity(cost_function_ref));
+            }
         }
 
         for (_, circuit_target) in self.contract_call_circuits.iter() {
@@ -906,7 +1007,7 @@ impl LimitedCostTracker {
     }
 }
 
-fn parse_cost(
+pub fn parse_cost(
     cost_function_name: &str,
     eval_result: InterpreterResult<Option<Value>>,
 ) -> Result<ExecutionCost> {
@@ -928,11 +1029,11 @@ fn parse_cost(
                     Some(UInt(read_length)),
                     Some(UInt(read_count)),
                 ) => Ok(ExecutionCost {
-                    write_length: (*write_length as u64),
-                    write_count: (*write_count as u64),
-                    runtime: (*runtime as u64),
-                    read_length: (*read_length as u64),
-                    read_count: (*read_count as u64),
+                    write_length: (*write_length).try_into().unwrap_or(u64::MAX),
+                    write_count: (*write_count).try_into().unwrap_or(u64::MAX),
+                    runtime: (*runtime).try_into().unwrap_or(u64::MAX),
+                    read_length: (*read_length).try_into().unwrap_or(u64::MAX),
+                    read_count: (*read_count).try_into().unwrap_or(u64::MAX),
                 }),
                 _ => Err(CostErrors::CostComputationFailed(
                     "Execution Cost tuple does not contain only UInts".to_string(),
@@ -946,8 +1047,7 @@ fn parse_cost(
             "Clarity cost function returned nothing".to_string(),
         )),
         Err(e) => Err(CostErrors::CostComputationFailed(format!(
-            "Error evaluating result of cost function {}: {}",
-            cost_function_name, e
+            "Error evaluating result of cost function {cost_function_name}: {e}"
         ))),
     }
 }
@@ -1051,15 +1151,22 @@ impl CostTracker for LimitedCostTracker {
                         "Used unimplemented cost function".into(),
                     ));
                 }
-                let cost_function_ref = data
-                    .cost_function_references
-                    .get(&cost_function)
-                    .ok_or(CostErrors::CostComputationFailed(format!(
+                let cost_function_ref = data.cost_function_references.get(&cost_function).ok_or(
+                    CostErrors::CostComputationFailed(format!(
                         "CostFunction not defined: {cost_function}"
-                    )))?
-                    .clone();
+                    )),
+                )?;
 
-                compute_cost(data, cost_function_ref, input, data.epoch)
+                match cost_function_ref {
+                    ClarityCostFunctionEvaluator::Default(
+                        cost_function_ref,
+                        clarity_cost_function,
+                        default_version,
+                    ) => default_version.evaluate(cost_function_ref, clarity_cost_function, input),
+                    ClarityCostFunctionEvaluator::Clarity(cost_function_ref) => {
+                        compute_cost(data, cost_function_ref.clone(), input, data.epoch)
+                    }
+                }
             }
         }
     }
@@ -1227,10 +1334,7 @@ impl ExecutionCost {
                 * 1_f64.min(self.write_length as f64 / 1_f64.max(block_limit.write_length as f64)),
         ]
         .iter()
-        .fold(0, |acc, dim| {
-            acc.checked_add(cmp::max(*dim as u64, 1))
-                .unwrap_or(u64::MAX)
-        })
+        .fold(0, |acc, dim| acc.saturating_add(cmp::max(*dim as u64, 1)))
     }
 
     pub fn max_value() -> ExecutionCost {

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2578,6 +2578,18 @@ impl NakamotoChainState {
             .map_err(ChainstateError::from)
     }
 
+    /// Return the ExecutionCost of `block`
+    pub fn get_block_cost(
+        chainstate_conn: &Connection,
+        block: &StacksBlockId,
+    ) -> Result<Option<ExecutionCost>, ChainstateError> {
+        let qry = "SELECT total_tenure_cost FROM nakamoto_block_headers WHERE index_block_hash = ?";
+        chainstate_conn
+            .query_row(qry, &[block], |row| row.get(0))
+            .optional()
+            .map_err(ChainstateError::from)
+    }
+
     /// Return the total transactions fees during the tenure up to and including
     ///  `block`
     pub fn get_total_tenure_tx_fees_at(

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -23,7 +23,10 @@ use clarity::vm::contexts::{
 };
 use clarity::vm::contracts::Contract;
 use clarity::vm::costs::cost_functions::ClarityCostFunction;
-use clarity::vm::costs::{ClarityCostFunctionReference, ExecutionCost, LimitedCostTracker};
+use clarity::vm::costs::{
+    parse_cost, ClarityCostFunctionEvaluator, ClarityCostFunctionReference, CostErrors,
+    DefaultVersion, ExecutionCost, LimitedCostTracker, COSTS_1_NAME, COSTS_2_NAME, COSTS_3_NAME,
+};
 use clarity::vm::database::{ClarityDatabase, MemoryBackingStore};
 use clarity::vm::errors::{CheckErrors, Error, RuntimeErrorType};
 use clarity::vm::events::StacksTransactionEvent;
@@ -873,6 +876,84 @@ fn setup_cost_tracked_test(
         .unwrap();
 }
 
+fn eval_cost_fn(
+    owned_env: &mut OwnedEnvironment,
+    cost_contract_name: &str,
+    cost_fn: &ClarityCostFunction,
+    argument: u64,
+) -> Result<ExecutionCost, CostErrors> {
+    let mainnet = owned_env.is_mainnet();
+    let boot_costs_id = boot_code_id(cost_contract_name, mainnet);
+    let cost_fn_name = cost_fn.get_name_str();
+
+    let exec = format!("({cost_fn_name} u{argument})");
+
+    let exec_result = owned_env
+        .eval_read_only(&boot_costs_id, &exec)
+        .map(|(value, _, _)| Some(value));
+
+    parse_cost(cost_fn_name, exec_result)
+}
+
+fn eval_replaced_cost_fn(
+    owned_env: &mut OwnedEnvironment,
+    cost_contract_name: &str,
+    cost_fn: &ClarityCostFunction,
+    argument: u64,
+) -> Result<ExecutionCost, CostErrors> {
+    let mainnet = owned_env.is_mainnet();
+    let boot_costs_id = boot_code_id(cost_contract_name, mainnet);
+    let clarity_cost_fn_default_version = DefaultVersion::try_from(mainnet, &boot_costs_id)
+        .expect("FAIL: should find default version for boot cost contracts");
+    let cost_fn_name = cost_fn.get_name_str();
+    let clarity_cost_fn_ref = ClarityCostFunctionReference {
+        contract_id: boot_costs_id,
+        function_name: cost_fn_name.to_string(),
+    };
+    clarity_cost_fn_default_version.evaluate(&clarity_cost_fn_ref, cost_fn, &[argument])
+}
+
+fn proptest_cost_fn(cost_fn: &ClarityCostFunction, cost_contract_name: &str) {
+    let mut inputs = vec![0, u64::MAX];
+    (1..64).for_each(|i| {
+        inputs.push(2u64.pow(i) - 1);
+        inputs.push(2u64.pow(i));
+        inputs.push(2u64.pow(i) + 1);
+    });
+    for use_mainnet in [true, false] {
+        with_owned_env(StacksEpochId::latest(), use_mainnet, |mut owned_env| {
+            for i in inputs.iter() {
+                eprintln!("Evaluating {cost_contract_name}.{cost_fn}({i})");
+                let clar_evaled = eval_cost_fn(&mut owned_env, cost_contract_name, cost_fn, *i);
+                let replace_evaled =
+                    eval_replaced_cost_fn(&mut owned_env, cost_contract_name, cost_fn, *i);
+                assert_eq!(clar_evaled, replace_evaled);
+            }
+        });
+    }
+}
+
+fn proptest_cost_contract(cost_contract_name: &str) {
+    for cost_fn in ClarityCostFunction::ALL.iter() {
+        proptest_cost_fn(cost_fn, cost_contract_name);
+    }
+}
+
+#[test]
+fn proptest_replacements_costs_1() {
+    proptest_cost_contract(COSTS_1_NAME);
+}
+
+#[test]
+fn proptest_replacements_costs_2() {
+    proptest_cost_contract(COSTS_2_NAME);
+}
+
+#[test]
+fn proptest_replacements_costs_3() {
+    proptest_cost_contract(COSTS_3_NAME);
+}
+
 fn test_program_cost(
     prog: &str,
     version: ClarityVersion,
@@ -1533,14 +1614,11 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
             "No contract call circuits should have been processed"
         );
         for (target, referenced_function) in tracker.cost_function_references().into_iter() {
-            assert_eq!(
-                &referenced_function.contract_id,
-                &boot_code_id("costs", use_mainnet),
-                "All cost functions should still point to the boot costs"
-            );
-            assert_eq!(
-                &referenced_function.function_name,
-                target.get_name_str(),
+            assert!(
+                matches!(
+                    referenced_function,
+                    ClarityCostFunctionEvaluator::Default(_, _, DefaultVersion::Costs1)
+                ),
                 "All cost functions should still point to the boot costs"
             );
         }
@@ -1649,17 +1727,19 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
 
         for (target, referenced_function) in tracker.cost_function_references().into_iter() {
             if target == &ClarityCostFunction::Le {
+                let ClarityCostFunctionEvaluator::Clarity(referenced_function) =
+                    referenced_function
+                else {
+                    panic!("Replaced function should be evaluated in Clarity");
+                };
                 assert_eq!(&referenced_function.contract_id, &cost_definer);
                 assert_eq!(&referenced_function.function_name, "cost-definition-le");
             } else {
-                assert_eq!(
-                    &referenced_function.contract_id,
-                    &boot_code_id("costs", use_mainnet),
-                    "Cost function should still point to the boot costs"
-                );
-                assert_eq!(
-                    &referenced_function.function_name,
-                    target.get_name_str(),
+                assert!(
+                    matches!(
+                        referenced_function,
+                        ClarityCostFunctionEvaluator::Default(_, _, DefaultVersion::Costs1)
+                    ),
                     "Cost function should still point to the boot costs"
                 );
             }

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -51,6 +51,7 @@ use stacks::chainstate::stacks::boot::{
 use stacks::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
 use stacks::chainstate::stacks::miner::{
     BlockBuilder, BlockLimitFunction, TransactionEvent, TransactionResult, TransactionSuccessEvent,
+    TEST_TX_STALL,
 };
 use stacks::chainstate::stacks::{
     SinglesigHashMode, SinglesigSpendingCondition, StacksTransaction, TenureChangeCause,
@@ -9842,8 +9843,6 @@ fn skip_mining_long_tx() {
     wait_for_first_naka_block_commit(60, &commits_submitted);
 
     // submit a long running TX and the transfer TX
-    let input_list: Vec<_> = (1..100u64).map(|x| x.to_string()).collect();
-    let input_list = input_list.join(" ");
 
     // Mine a few nakamoto tenures with some interim blocks in them
     for i in 0..5 {
@@ -9863,26 +9862,22 @@ fn skip_mining_long_tx() {
             .unwrap();
 
             TEST_P2P_BROADCAST_SKIP.set(true);
+            TEST_TX_STALL.set(true);
             let tx = make_contract_publish(
                 &sender_2_sk,
                 0,
                 9_000,
                 naka_conf.burnchain.chain_id,
                 "large_contract",
-                &format!(
-                    "(define-constant INP_LIST (list {input_list}))
-                        (define-private (mapping-fn (input int))
-                                (begin (sha256 (sha256 (sha256 (sha256 (sha256 (sha256 (sha256 (sha256 (sha256 input)))))))))
-                                       0))
-
-                        (define-private (mapping-fn-2 (input int))
-                                (begin (map mapping-fn INP_LIST) (map mapping-fn INP_LIST) (map mapping-fn INP_LIST) (map mapping-fn INP_LIST) 0))
-
-                        (begin
-                            (map mapping-fn-2 INP_LIST))"
-                ),
+                "(print \"hello world\")",
             );
             submit_tx(&http_origin, &tx);
+
+            // Sleep for longer than the miner's attempt time, so that the miner will
+            // mark this tx as long-running and skip it in the next attempt
+            sleep_ms(naka_conf.miner.nakamoto_attempt_time_ms + 1000);
+
+            TEST_TX_STALL.set(false);
 
             wait_for(90, || {
                 Ok(mined_naka_blocks.load(Ordering::SeqCst) > mined_before + 1)


### PR DESCRIPTION
This PR adds a "fast path" for cost function evaluations when the cost functions are the default/boot costs (which they currently always are in mainnet and testnet). Rather than evaluating the clarity contracts, it evaluates the same cost function but in rust directly.

As has been pointed out in #5848 and #5813, the current cost tracker can be pretty slow in a lot of cases -- this PR should speed things up substantially.

It is important that the rust evaluations be identical to the evaluations that they replace. To this end, this PR adds strict cost assertions to the block replay commands (meaning that during block replays, the final cost of each block is checked against the expectation, allowing us to check that the change is safe on the entire history of the chain so far) and also a set of property-like tests which assert that the results of evaluation are identical between the rust code and the clarity contracts for given inputs. The unit tests cover a fixed range of values, but they can be evaluated for any input.