### PR TITLE
feat: compute_cost should borrow immutable TrackerData

### DIFF
--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -799,6 +799,11 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
         self.context.cost_track.get_total()
     }
 
+    #[cfg(any(test, feature = "testing"))]
+    pub fn mut_cost_tracker(&mut self) -> &mut LimitedCostTracker {
+        &mut self.context.cost_track
+    }
+
     /// Destroys this environment, returning ownership of its database reference.
     ///  If the context wasn't top-level (i.e., it had uncommitted data), return None,
     ///   because the database is not guaranteed to be in a sane state.

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -38,7 +38,7 @@ use crate::vm::types::Value::UInt;
 use crate::vm::types::{
     FunctionType, PrincipalData, QualifiedContractIdentifier, TupleData, TypeSignature,
 };
-use crate::vm::{eval_all, ClarityName, SymbolicExpression, Value};
+use crate::vm::{CallStack, ClarityName, Environment, LocalContext, SymbolicExpression, Value};
 
 pub mod constants;
 pub mod cost_functions;
@@ -1054,7 +1054,7 @@ pub fn parse_cost(
 // TODO: add tests from mutation testing results #4832
 #[cfg_attr(test, mutants::skip)]
 fn compute_cost(
-    cost_tracker: &mut TrackerData,
+    cost_tracker: &TrackerData,
     cost_function_reference: ClarityCostFunctionReference,
     input_sizes: &[u64],
     eval_in_epoch: StacksEpochId,
@@ -1073,7 +1073,7 @@ fn compute_cost(
 
     let cost_contract = cost_tracker
         .cost_contracts
-        .get_mut(&cost_function_reference.contract_id)
+        .get(&cost_function_reference.contract_id)
         .ok_or(CostErrors::CostComputationFailed(format!(
             "CostFunction not found: {cost_function_reference}"
         )))?;
@@ -1088,14 +1088,23 @@ fn compute_cost(
         )));
     }
 
-    let function_invocation = [SymbolicExpression::list(program)];
+    let function_invocation = SymbolicExpression::list(program);
+    let eval_result = global_context.execute(|global_context| {
+        let context = LocalContext::new();
+        let mut call_stack = CallStack::new();
+        let publisher: PrincipalData = cost_contract.contract_identifier.issuer.clone().into();
+        let mut env = Environment::new(
+            global_context,
+            cost_contract,
+            &mut call_stack,
+            Some(publisher.clone()),
+            Some(publisher.clone()),
+            None,
+        );
 
-    let eval_result = eval_all(
-        &function_invocation,
-        cost_contract,
-        &mut global_context,
-        None,
-    );
+        let result = super::eval(&function_invocation, &mut env, &context)?;
+        Ok(Some(result))
+    });
 
     parse_cost(&cost_function_reference.to_string(), eval_result)
 }

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -331,7 +331,7 @@ pub struct TrackerData {
     /// if the cost tracker is non-free, this holds the StacksEpochId that should be used to evaluate
     ///  the Clarity cost functions. If the tracker *is* free, then those functions do not need to be
     ///  evaluated, so no epoch identifier is necessary.
-    epoch: StacksEpochId,
+    pub epoch: StacksEpochId,
     mainnet: bool,
     chain_id: u32,
 }
@@ -1053,7 +1053,7 @@ pub fn parse_cost(
 
 // TODO: add tests from mutation testing results #4832
 #[cfg_attr(test, mutants::skip)]
-fn compute_cost(
+pub fn compute_cost(
     cost_tracker: &TrackerData,
     cost_function_reference: ClarityCostFunctionReference,
     input_sizes: &[u64],

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -24,8 +24,9 @@ use clarity::vm::contexts::{
 use clarity::vm::contracts::Contract;
 use clarity::vm::costs::cost_functions::ClarityCostFunction;
 use clarity::vm::costs::{
-    parse_cost, ClarityCostFunctionEvaluator, ClarityCostFunctionReference, CostErrors,
-    DefaultVersion, ExecutionCost, LimitedCostTracker, COSTS_1_NAME, COSTS_2_NAME, COSTS_3_NAME,
+    compute_cost, parse_cost, ClarityCostFunctionEvaluator, ClarityCostFunctionReference,
+    CostErrors, DefaultVersion, ExecutionCost, LimitedCostTracker, COSTS_1_NAME, COSTS_2_NAME,
+    COSTS_3_NAME,
 };
 use clarity::vm::database::{ClarityDatabase, MemoryBackingStore};
 use clarity::vm::errors::{CheckErrors, Error, RuntimeErrorType};
@@ -885,19 +886,16 @@ fn eval_cost_fn(
     let mainnet = owned_env.is_mainnet();
     let boot_costs_id = boot_code_id(cost_contract_name, mainnet);
     let cost_fn_name = cost_fn.get_name_str();
-
-    let exec = format!("({cost_fn_name} u{argument})");
-
-    let exec_result = owned_env
-        .eval_read_only(&boot_costs_id, &exec)
-        .map(|(value, _, _)| Some(value));
-
+    let cost_tracker = owned_env.mut_cost_tracker();
+    let data = match cost_tracker {
+        LimitedCostTracker::Free => panic!(),
+        LimitedCostTracker::Limited(data) => data,
+    };
     let clarity_cost_fn_ref = ClarityCostFunctionReference {
         contract_id: boot_costs_id,
         function_name: cost_fn_name.to_string(),
     };
-
-    parse_cost(&clarity_cost_fn_ref.to_string(), exec_result)
+    compute_cost(data, clarity_cost_fn_ref, &[argument], data.epoch)
 }
 
 fn eval_replaced_cost_fn(
@@ -926,7 +924,13 @@ fn proptest_cost_fn(cost_fn: &ClarityCostFunction, cost_contract_name: &str) {
         inputs.push(2u64.pow(i) + 1);
     });
     for use_mainnet in [true, false] {
-        with_owned_env(StacksEpochId::latest(), use_mainnet, |mut owned_env| {
+        let epoch = match cost_contract_name {
+            COSTS_1_NAME => StacksEpochId::Epoch20,
+            COSTS_2_NAME => StacksEpochId::Epoch2_05,
+            COSTS_3_NAME => StacksEpochId::latest(),
+            _ => panic!(),
+        };
+        with_owned_env(epoch, use_mainnet, |mut owned_env| {
             for i in inputs.iter() {
                 eprintln!("Evaluating {cost_contract_name}.{cost_fn}({i})");
                 let clar_evaled = eval_cost_fn(&mut owned_env, cost_contract_name, cost_fn, *i);


### PR DESCRIPTION
### Description

+ Avoid using `eval_all` in `compute_cost`, to make it a pure function

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
