### PR TITLE
Chore: match the error strings in cost errors

### DIFF
--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -217,8 +217,7 @@ impl DefaultVersion {
             };
 
             CostErrors::CostComputationFailed(format!(
-                "Error evaluating result of cost function {}: {e}",
-                &cost_function_ref.function_name
+                "Error evaluating result of cost function {cost_function_ref}: {e}",
             ))
         })
     }

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -892,7 +892,12 @@ fn eval_cost_fn(
         .eval_read_only(&boot_costs_id, &exec)
         .map(|(value, _, _)| Some(value));
 
-    parse_cost(cost_fn_name, exec_result)
+    let clarity_cost_fn_ref = ClarityCostFunctionReference {
+        contract_id: boot_costs_id,
+        function_name: cost_fn_name.to_string(),
+    };
+
+    parse_cost(&clarity_cost_fn_ref.to_string(), exec_result)
 }
 
 fn eval_replaced_cost_fn(


### PR DESCRIPTION
This just matches the error strings in some cost errors. This doesn't have any impact on the execution, but its more hygienic to get the error strings to exactly match.