### PR TITLE
Master to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+## Added
+
+- Add `disable_retries` mode for events_observer disabling automatic retry on error
+
+## Changed
+
+- Implement faster cost tracker for default cost functions in Clarity
+- By default, miners will wait for a new tenure to start for a configurable amount of time after receiving a burn block before
+  submitting a block commit. This will reduce the amount of RBF transactions miners are expected to need.
+- Add weight threshold and percentages to `StackerDBListener` logs
+
 ## [3.1.0.0.6]
 
 ## Added
 
 - The `BlockProposal` StackerDB message serialization struct now includes a `server_version` string, which represents the version of the node that the miner is using. ([#5803](https://github.com/stacks-network/stacks-core/pull/5803))
 - Add `vrf_seed` to the `/v3/sortitions` rpc endpoint
-- Add `disable_retries` mode for events_observer disabling automatic retry on error
 
 ### Changed
 
-- Implement faster cost tracker for default cost functions in Clarity
 - Miner will stop waiting for signatures on a block if the Stacks tip advances (causing the block it had proposed to be invalid).
-- By default, miners will wait for a new tenure to start for a configurable amount of time after receiving a burn block before 
-  submitting a block commit. This will reduce the amount of RBF transactions miners are expected to need.
 - Logging improvements:
   - P2P logs now includes a reason for dropping a peer or neighbor
   - Improvements to how a PeerAddress is logged (human readable format vs hex)
-  - Add weight threshold and percentages to `StackerDBListener` logs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
+## [3.1.0.0.6]
 
 ## Added
 

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+## Changed
+
+- Add new reject codes to the signer response for better visibility into why a block was rejected.
+- When allowing a reorg within the `reorg_attempts_activity_timeout_ms`, the signer will now watch the responses from other signers and if >30% of them reject this reorg attempt, then the signer will mark the miner as invalid, reject further attempts to reorg and allow the previous miner to extend their tenure.
+
+### Fixed
+
+- The signer runloop no longer relies on pubkey reports from the SignerDB event system. This previously led to improper proposal rejections via #5858.
+
 ## [3.1.0.0.6.0]
 
 ## Added
@@ -17,12 +28,6 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - Increase default `block_proposal_timeout_ms` from 10 minutes to 4 hours. Until #5729 is implemented, there is no value in rejecting a late block from a miner, since a late block is better than no block at all.
 - Signers no longer view any block proposal by a miner in their DB as indicative of valid miner activity.
 - Various index improvements to the signer's database to improve performance.
-- Add new reject codes to the signer response for better visibility into why a block was rejected.
-- When allowing a reorg within the `reorg_attempts_activity_timeout_ms`, the signer will now watch the responses from other signers and if >30% of them reject this reorg attempt, then the signer will mark the miner as invalid, reject further attempts to reorg and allow the previous miner to extend their tenure.
-
-### Fixed
-
-- The signer runloop no longer relies on pubkey reports from the SignerDB event system. This previously led to improper proposal rejections via #5858. 
 
 ## [3.1.0.0.5.0]
 

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
+## [3.1.0.0.6.0]
 
 ## Added
 

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.1.0.0.5"
-stacks_signer_version = "3.1.0.0.5.0"
+stacks_node_version = "3.1.0.0.6"
+stacks_signer_version = "3.1.0.0.6.0"


### PR DESCRIPTION
This merges master into develop and separates the changelogs that were mixed in from 3.1.0.0.6.