### PR TITLE
chore: bump versions to 3.1.0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
+## [3.1.0.0.7]
 
 ## Added
 

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
+## [3.1.0.0.7.0]
 
 ## Changed
 

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.1.0.0.6"
-stacks_signer_version = "3.1.0.0.6.0"
+stacks_node_version = "3.1.0.0.7"
+stacks_signer_version = "3.1.0.0.7.0"


### PR DESCRIPTION
See description. This is a protected branch so we can't just do this when we create the `release/3.1.0.0.7` branch.