### PR TITLE
fix: remove unwanted compilation flag

### DIFF
--- a/clarity/src/vm/database/clarity_store.rs
+++ b/clarity/src/vm/database/clarity_store.rs
@@ -21,7 +21,6 @@ use stacks_common::util::hash::{hex_bytes, to_hex, Sha512Trunc256Sum};
 
 use crate::vm::analysis::AnalysisDatabase;
 use crate::vm::contexts::GlobalContext;
-#[cfg(feature = "canonical")]
 use crate::vm::database::{
     ClarityDatabase, ClarityDeserializable, ClaritySerializable, NULL_BURN_STATE_DB, NULL_HEADER_DB,
 };

--- a/stacks-common/src/util/secp256k1/libsecp256k1.rs
+++ b/stacks-common/src/util/secp256k1/libsecp256k1.rs
@@ -23,7 +23,6 @@ use ::libsecp256k1::{
 };
 use rand::RngCore;
 use serde::de::{Deserialize, Error as de_Error};
-use serde::ser::Error as ser_Error;
 use serde::Serialize;
 
 use super::MessageSignature;


### PR DESCRIPTION
Following the removal of `allow(unused_imports)` on clarinet, we get many warnings when compiling the clarity-vm to wasm. This can be addressed later.

Also, an unused `sqlite` import was removed, but the compilation flag above it was left. Leading to an error