### PR TITLE
Fix/5864

### DIFF
--- a/.github/workflows/image-build-source.yml
+++ b/.github/workflows/image-build-source.yml
@@ -21,13 +21,6 @@ jobs:
   image:
     name: Build Image
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      ## Build a maximum of 2 images concurrently based on matrix.dist
-      max-parallel: 2
-      matrix:
-        dist:
-          - debian
     steps:
       ## Setup Docker for the builds
       - name: Docker setup
@@ -63,7 +56,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
-          file: ./.github/actions/dockerfiles/Dockerfile.${{matrix.dist}}-source
+          file: ./Dockerfile
           platforms: ${{ env.docker_platforms }}
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-bookworm AS build
+FROM rust:bookworm AS build
 
 ARG STACKS_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
@@ -10,6 +10,7 @@ COPY . .
 
 RUN mkdir /out
 
+RUN rustup toolchain install
 RUN cargo build --features monitoring_prom,slog_json --release
 
 RUN cp target/release/stacks-node /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 
 RUN mkdir /out
 
-RUN rustup toolchain install
+RUN rustup toolchain install stable
 RUN cargo build --features monitoring_prom,slog_json --release
 
 RUN cp target/release/stacks-node /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:bookworm AS build
+FROM rust:1.84-bookworm AS build
 
 ARG STACKS_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'


### PR DESCRIPTION
Fixes the docker image from source workflow that was failing. 
2 changes:
- use the repo root Dockerfile rather than the specific one in ./github/actions/dockerfiles
- install stable toolchain (per https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html)