### PR TITLE
Adding workflow to create release PR's ref stacks-network/actions/pul…

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -142,3 +142,21 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           dist: ${{ matrix.dist }}
+
+  ## Create the downstream PR for the release branch to master,develop
+  create-pr:
+    if: |
+      inputs.node_tag != '' ||
+      inputs.signer_tag != ''
+    name: Create Downstream PR (${{ github.ref_name }})
+    runs-on: ubuntu-latest
+    needs:
+      - build-binaries
+      - create-release
+      - docker-image
+    steps:
+      - name: Open Downstream PR
+        id: create-pr
+        uses: stacks-network/actions/stacks-core/release/downstream-pr@main
+        with:
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
dependent on https://github.com/stacks-network/actions/pull/66

as part of the release workflow, this will call the composite action in the above PR to create the 2 PR's to finish the relase process:
- release/branch -> master
- release/branch -> develop

it will not create the PR's if they exist, or if there are no changed files. 