### PR TITLE
fix: flaky reload_miner_config test

### DIFF
--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -11113,6 +11113,8 @@ fn reload_miner_config() {
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);
+    let old_burn_fee_cap: u64 = 200000;
+    conf.burnchain.burn_fee_cap = 200000;
     conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1000000);
     conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
 
@@ -11193,7 +11195,7 @@ fn reload_miner_config() {
         .map(|r| r.get("amt").unwrap().as_u64().unwrap())
         .sum::<u64>();
 
-    assert_eq!(reward_amount, 200000);
+    assert_eq!(reward_amount, old_burn_fee_cap);
 
     next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -11113,8 +11113,8 @@ fn reload_miner_config() {
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);
-    let old_burn_fee_cap: u64 = 200000;
-    conf.burnchain.burn_fee_cap = 200000;
+    let old_burn_fee_cap: u64 = 100000;
+    conf.burnchain.burn_fee_cap = old_burn_fee_cap;
     conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1000000);
     conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
 
@@ -11149,8 +11149,6 @@ fn reload_miner_config() {
         file.write_all(new_config.as_bytes()).unwrap();
     };
 
-    update_config(100000, 50);
-
     let mut run_loop = boot_nakamoto::BootRunLoop::new(conf.clone()).unwrap();
     let run_loop_stopper = run_loop.get_termination_switch();
     let counters = run_loop.counters();
@@ -11181,6 +11179,8 @@ fn reload_miner_config() {
     wait_for_first_naka_block_commit(60, &commits_submitted);
 
     next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
+    next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
+    next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
 
     let burn_blocks = test_observer::get_burn_blocks();
     let burn_block = burn_blocks.last().unwrap();
@@ -11195,7 +11195,9 @@ fn reload_miner_config() {
         .map(|r| r.get("amt").unwrap().as_u64().unwrap())
         .sum::<u64>();
 
-    assert_eq!(reward_amount, old_burn_fee_cap);
+    let burn_amount = burn_block.get("burn_amount").unwrap().as_u64().unwrap();
+
+    assert_eq!(reward_amount + burn_amount, old_burn_fee_cap);
 
     next_block_and_mine_commit(&mut btc_regtest_controller, 60, &conf, &counters).unwrap();
 
@@ -11221,7 +11223,9 @@ fn reload_miner_config() {
         .map(|r| r.get("amt").unwrap().as_u64().unwrap())
         .sum::<u64>();
 
-    assert_eq!(reward_amount, new_amount);
+    let burn_amount = burn_block.get("burn_amount").unwrap().as_u64().unwrap();
+
+    assert_eq!(reward_amount + burn_amount, new_amount);
 
     coord_channel
         .lock()


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/5887

Fixes test flakiness by using an explicit burn_fee_cap in the original config.