### PR TITLE
Feat/log tx fee for included and skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ## [Unreleased]
 
+### Added"
+- Add fee information to transaction log ending with "success" or "skipped", while building a new block  
+
 ### Changed
 
 - When a miner times out waiting for signatures, it will re-propose the same block instead of building a new block ([#5877](https://github.com/stacks-network/stacks-core/pull/5877))

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -418,7 +418,7 @@ pub enum TransactionEvent {
 impl TransactionResult {
     /// Logs a queryable message for the case where `txid` has succeeded.
     pub fn log_transaction_success(tx: &StacksTransaction) {
-        info!("Tx successfully processed.";
+        info!("Tx successfully processed";
             "event_name" => %"transaction_result",
             "tx_id" => %tx.txid(),
             "event_type" => %"success",

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -422,6 +422,7 @@ impl TransactionResult {
             "event_name" => %"transaction_result",
             "tx_id" => %tx.txid(),
             "event_type" => %"success",
+            "fee" => tx.get_tx_fee()
         );
     }
 
@@ -445,6 +446,7 @@ impl TransactionResult {
             "tx_id" => %tx.txid(),
             "event_type" => "skip",
             "reason" => %err,
+            "fee" => tx.get_tx_fee()
         );
     }
 


### PR DESCRIPTION
### Description

This change add `fee` information to the current transaction logging messages while producing a new block.
Specifically the new information is available for transaction ending with "success" or "skipped".

To minimize the impact of the change, the fee information has been retrieved by `StacksTransaction.get_tx_fee()` api, given that StacksTransaction is an argument already "known" by the logging methods.

Here an example of the logging output that show the `fee` data added to the tail of the message (no relevant information has been omitted with `...` for brevity):
```
INFO [...] [...] [...] Tx successfully processed., event_name: transaction_result, tx_id: ..., event_type: success, fee: 1

INFO [...] [...] [...] Tx successfully skipped, event_name: transaction_result, tx_id: ..., event_type: skip, reason: ..., fee: 1
```

### Applicable issues

- fixes #5601 

### Additional info (benefits, drawbacks, caveats)

I just add a couple of things I noticed while digging into the code.

First, a small thing, the transaction message related to success contains a dot a the end of the primary log message (e.g. "Tx successfully processed`.`" as also shown in the logging example above. So don't know if it is on purpose, or if we need a fix (in the current PR or dedicated issue? )

Second, I noticed that the costructor method for success result include a `fee` argument:
```rust
impl TransactionResult {
...
pub fn success(
        transaction: &StacksTransaction,
        fee: u64,
        receipt: StacksTransactionReceipt,
    ) -> TransactionResult { 
...
}
```
but, I don't understand the reason. if I'm not wrong, the transaction fee should never change once the StacksTransaction is created and could always be retrived calling `transaction.get_tx_fee()`. 

In case this is correct, then could be considered whether to adopt same signature also for the skipped transaction. 
Or eventually, could be opened a dedicated issue for removing the fee parameter (or even leave it as it is).

### Checklist

- [ ] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
