### PR TITLE
feat: use .rustfmt.toml for formatting options

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [alias]
 stacks-node = "run --package stacks-node --"
+fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 clippy-stacks = "clippy -p libstackerdb -p stacks-signer -p pox-locking -p clarity -p libsigner -p stacks-common --no-deps --tests --all-features -- -D warnings"
 
 # Uncomment to improve performance slightly, at the cost of portability
@@ -11,4 +12,3 @@ clippy-stacks = "clippy -p libstackerdb -p stacks-signer -p pox-locking -p clari
 #[target.x86_64-unknown-linux-gnu]
 #linker = "/usr/bin/clang"
 #rustflags = ["-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Wl,--no-rosegment"]
-

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 [alias]
 stacks-node = "run --package stacks-node --"
-fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
 clippy-stacks = "clippy -p libstackerdb -p stacks-signer -p pox-locking -p clarity -p libsigner -p stacks-common --no-deps --tests --all-features -- -D warnings"
 
 # Uncomment to improve performance slightly, at the cost of portability

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Rustfmt
         id: rustfmt
         uses: stacks-network/actions/rustfmt@main
+        with:
+          alias: "+nightly fmt"
 
   ######################################################################################
   ## Check if the branch that this workflow is being run against is a release branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         id: rustfmt
         uses: stacks-network/actions/rustfmt@main
         with:
-          alias: "+nightly fmt"
+          alias: "fmt-stacks"
 
   ######################################################################################
   ## Check if the branch that this workflow is being run against is a release branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
       - name: Rustfmt
         id: rustfmt
         uses: stacks-network/actions/rustfmt@main
-        with:
-          alias: "fmt-stacks"
 
   ######################################################################################
   ## Check if the branch that this workflow is being run against is a release branch

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,11 @@
 {
-    "lldb.adapterType": "native",
-    "lldb.launch.sourceLanguages": ["rust"],
+    "lldb.launch.sourceLanguages": [
+        "rust"
+    ],
     "rust-analyzer.runnables.extraEnv": {
         "BITCOIND_TEST": "1"
-    }
+    },
+    "rust-analyzer.rustfmt.extraArgs": [
+        "+nightly"
+    ]
 }


### PR DESCRIPTION
We previously did this with the `cargo fmt-stacks` command because these config options were not supported in .rustfmt.toml, but they are now supported by the nightly build. Using this directly is better than the alias because we do not need to remember to run the alias.