### PR TITLE
Removed "fee" argument from `TransactionResult::success()` and `TransactionResult::success_with_soft_limit()`

### DIFF
--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -737,7 +737,7 @@ impl BlockBuilder for NakamotoBlockBuilder {
             }
 
             let cost_before = clarity_tx.cost_so_far();
-            let (fee, receipt) =
+            let (_fee, receipt) =
                 match StacksChainState::process_transaction(clarity_tx, tx, quiet, ast_rules) {
                     Ok(x) => x,
                     Err(e) => {
@@ -764,7 +764,7 @@ impl BlockBuilder for NakamotoBlockBuilder {
 
             // save
             self.txs.push(tx.clone());
-            TransactionResult::success_with_soft_limit(tx, fee, receipt, soft_limit_reached)
+            TransactionResult::success_with_soft_limit(tx, receipt, soft_limit_reached)
         };
 
         self.bytes_so_far += tx_len;

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -1053,7 +1053,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
 
         let quiet = !cfg!(test);
         match StacksChainState::process_transaction(clarity_tx, &tx, quiet, ast_rules) {
-            Ok((fee, receipt)) => Ok(TransactionResult::success(&tx, receipt)),
+            Ok((_fee, receipt)) => Ok(TransactionResult::success(&tx, receipt)),
             Err(e) => {
                 let (is_problematic, e) =
                     TransactionResult::is_problematic(&tx, e, clarity_tx.get_epoch());

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -463,13 +463,12 @@ impl TransactionResult {
     /// This method logs "transaction success" as a side effect.
     pub fn success(
         transaction: &StacksTransaction,
-        fee: u64,
         receipt: StacksTransactionReceipt,
     ) -> TransactionResult {
         Self::log_transaction_success(transaction);
         Self::Success(TransactionSuccess {
             tx: transaction.clone(),
-            fee,
+            fee: transaction.get_tx_fee(),
             receipt,
             soft_limit_reached: false,
         })
@@ -1054,7 +1053,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
 
         let quiet = !cfg!(test);
         match StacksChainState::process_transaction(clarity_tx, &tx, quiet, ast_rules) {
-            Ok((fee, receipt)) => Ok(TransactionResult::success(&tx, fee, receipt)),
+            Ok((fee, receipt)) => Ok(TransactionResult::success(&tx, receipt)),
             Err(e) => {
                 let (is_problematic, e) =
                     TransactionResult::is_problematic(&tx, e, clarity_tx.get_epoch());
@@ -2858,7 +2857,7 @@ impl BlockBuilder for StacksBlockBuilder {
             self.txs.push(tx.clone());
             self.total_anchored_fees += fee;
 
-            TransactionResult::success(tx, fee, receipt)
+            TransactionResult::success(tx, receipt)
         } else {
             // building up the microblocks
             if tx.anchor_mode != TransactionAnchorMode::OffChainOnly
@@ -2948,7 +2947,7 @@ impl BlockBuilder for StacksBlockBuilder {
             self.micro_txs.push(tx.clone());
             self.total_streamed_fees += fee;
 
-            TransactionResult::success(tx, fee, receipt)
+            TransactionResult::success(tx, receipt)
         };
 
         self.bytes_so_far += tx_len;

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -478,14 +478,13 @@ impl TransactionResult {
     /// This method logs "transaction success" as a side effect.
     pub fn success_with_soft_limit(
         transaction: &StacksTransaction,
-        fee: u64,
         receipt: StacksTransactionReceipt,
         soft_limit_reached: bool,
     ) -> TransactionResult {
         Self::log_transaction_success(transaction);
         Self::Success(TransactionSuccess {
             tx: transaction.clone(),
-            fee,
+            fee: transaction.get_tx_fee(),
             receipt,
             soft_limit_reached,
         })

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -4999,7 +4999,6 @@ fn paramaterized_mempool_walk_test(
                                 // Generate any success result
                                 TransactionResult::success(
                                     &available_tx.tx.tx,
-                                    available_tx.tx.metadata.tx_fee,
                                     StacksTransactionReceipt::from_stx_transfer(
                                         available_tx.tx.tx.clone(),
                                         vec![],

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -278,7 +278,6 @@ fn mempool_walk_over_fork() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -316,7 +315,6 @@ fn mempool_walk_over_fork() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -353,7 +351,6 @@ fn mempool_walk_over_fork() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -395,7 +392,6 @@ fn mempool_walk_over_fork() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -435,7 +431,6 @@ fn mempool_walk_over_fork() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -661,7 +656,6 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -698,7 +692,6 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -735,7 +728,6 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -844,7 +836,6 @@ fn test_iterate_candidates_skipped_transaction() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -959,7 +950,6 @@ fn test_iterate_candidates_processing_error_transaction() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -1074,7 +1064,6 @@ fn test_iterate_candidates_problematic_transaction() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -1226,7 +1215,6 @@ fn test_iterate_candidates_concurrent_write_lock() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -2725,7 +2713,6 @@ fn test_filter_txs_by_type() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],
@@ -2760,7 +2747,6 @@ fn test_filter_txs_by_type() {
                             // Generate any success result
                             TransactionResult::success(
                                 &available_tx.tx.tx,
-                                available_tx.tx.metadata.tx_fee,
                                 StacksTransactionReceipt::from_stx_transfer(
                                     available_tx.tx.tx.clone(),
                                     vec![],


### PR DESCRIPTION
### Description

This change makes a cleanup of `TransactionResult::success` and `TransactionResult::success_with_soft_limit`, removing the 'fee' argument, while it is possible to retrieve the same data using `StacksTransaction::get_tx_fee()` internally.

### Applicable issues

- fixes #5900 

### Additional info (benefits, drawbacks, caveats)

The refactoring has been kept localized to the direct client of  `TransactionResult::success` and `TransactionResult::success_with_soft_limit`. 

Maybe could be also cleaned the `TransactionSuccess`  struct  (instantiated by the two methods above) that as a copy of the `StacksTransaction` and related `fee`. (it could also be a non-problem considering that is now computed internally, and works like a shortcut over `tx.get_txt_fee()`, but potentially could be or become an unused field)

https://github.com/stacks-network/stacks-core/blob/3123ccb3ba6e1247fa04b37f85e17d357dd39b09/stackslib/src/chainstate/stacks/miner.rs#L303-L312


Furthermore, the refactor (around the fee topic) could be pushed a little further involving `StacksChainState::process_transaction`.
https://github.com/stacks-network/stacks-core/blob/3123ccb3ba6e1247fa04b37f85e17d357dd39b09/stackslib/src/chainstate/stacks/db/transactions.rs#L1468-L1474

Basically, this method receive a StacksTransaction and return a fee as part of the result (the `u64` in the tuple). This fee value is retrieved internally using `StacksTransaction::get_tx_fee()` (and not manipulated in any way if I got it right).

Then the fee result is used from the caller (the is the one that also pass the StacksTrasaction) to feed some `TansactionResult::success` and `TansactionResult::success_with_soft_limit` (and infact in the proposed change the fee result is marked as ignored variable), but also for doing other operation (like accumulating fee amount)

Probably, (just my speculation) the signature of `StacksChainState::process_transaction` has been designed this way to be `match keyword` friendly.

Anyhow if it's worth it, I'm opened to do further investigation on this (maybe in a separted PR?) or just leave as is if it is the correct design.

### Checklist

- [ ] Test coverage for new or modified code paths
- [X] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
