### PR TITLE
fix: http endpoints should tolerate duplicate headers #5903

### DIFF
--- a/stackslib/src/net/api/tests/get_tenures_fork_info.rs
+++ b/stackslib/src/net/api/tests/get_tenures_fork_info.rs
@@ -37,6 +37,7 @@ fn make_preamble<T: Display, R: Display>(start: &T, stop: &R) -> HttpRequestPrea
         content_length: Some(0),
         keep_alive: false,
         headers: BTreeMap::new(),
+        set_cookie: Vec::new(),
     }
 }
 

--- a/stackslib/src/net/api/tests/getsigner.rs
+++ b/stackslib/src/net/api/tests/getsigner.rs
@@ -41,6 +41,7 @@ fn make_preamble(query: &str) -> HttpRequestPreamble {
         content_length: Some(0),
         keep_alive: false,
         headers: BTreeMap::new(),
+        set_cookie: Vec::new(),
     }
 }
 

--- a/stackslib/src/net/api/tests/getsortition.rs
+++ b/stackslib/src/net/api/tests/getsortition.rs
@@ -40,6 +40,7 @@ fn make_preamble(query: &str) -> HttpRequestPreamble {
         content_length: Some(0),
         keep_alive: false,
         headers: BTreeMap::new(),
+        set_cookie: Vec::new(),
     }
 }
 

--- a/stackslib/src/net/http/request.rs
+++ b/stackslib/src/net/http/request.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::Display;
 use std::io::{Read, Write};
 
 use percent_encoding::percent_decode_str;
@@ -54,6 +56,8 @@ pub struct HttpRequestPreamble {
     pub keep_alive: bool,
     /// Other headers that were not consumed in parsing
     pub headers: BTreeMap<String, String>,
+    /// `Set-Cookie` headers
+    pub set_cookie: Vec<String>,
 }
 
 impl HttpRequestPreamble {
@@ -74,6 +78,7 @@ impl HttpRequestPreamble {
             content_length: None,
             keep_alive,
             headers: BTreeMap::new(),
+            set_cookie: vec![],
         }
     }
 
@@ -105,6 +110,7 @@ impl HttpRequestPreamble {
             content_length: None,
             keep_alive: true,
             headers: BTreeMap::new(),
+            set_cookie: vec![],
         }
     }
 
@@ -187,10 +193,10 @@ impl HttpRequestPreamble {
                 return Some(format!("{}", &self.host));
             }
             "content-type" => {
-                return self.content_type.clone().map(|ct| format!("{}", &ct));
+                return self.content_type.as_ref().map(HttpContentType::to_string);
             }
             "content-length" => {
-                return self.content_length.clone().map(|cl| format!("{}", &cl));
+                return self.content_length.as_ref().map(u32::to_string);
             }
             _ => {
                 return self.headers.get(&hdr).cloned();
@@ -371,9 +377,10 @@ impl StacksMessageCodec for HttpRequestPreamble {
 
                 let mut headers: BTreeMap<String, String> = BTreeMap::new();
                 let mut seen_headers: HashSet<String> = HashSet::new();
+                let mut set_cookie = vec![];
 
-                for i in 0..req.headers.len() {
-                    let value = String::from_utf8(req.headers[i].value.to_vec()).map_err(|_e| {
+                for req_header in req.headers.iter() {
+                    let value = String::from_utf8(req_header.value.to_vec()).map_err(|_e| {
                         CodecError::DeserializeError(
                             "Invalid HTTP header value: not utf-8".to_string(),
                         )
@@ -389,7 +396,7 @@ impl StacksMessageCodec for HttpRequestPreamble {
                         ));
                     }
 
-                    let key = req.headers[i].name.to_string().to_lowercase();
+                    let key = req_header.name.to_lowercase();
 
                     if seen_headers.contains(&key) {
                         return Err(CodecError::DeserializeError(format!(
@@ -397,23 +404,25 @@ impl StacksMessageCodec for HttpRequestPreamble {
                             key
                         )));
                     }
-                    seen_headers.insert(key.clone());
 
                     if key == "host" {
                         peerhost = match value.parse::<PeerHost>() {
                             Ok(ph) => Some(ph),
                             Err(_) => None,
                         };
+                        seen_headers.insert(key);
                     } else if key == "content-type" {
                         // parse
                         let ctype = value.to_lowercase().parse::<HttpContentType>()?;
                         content_type = Some(ctype);
+                        seen_headers.insert(key);
                     } else if key == "content-length" {
                         // parse
                         content_length = match value.parse::<u32>() {
                             Ok(len) => Some(len),
                             Err(_) => None,
                         };
+                        seen_headers.insert(key);
                     } else if key == "connection" {
                         // parse
                         if value.to_lowercase() == "close" {
@@ -425,8 +434,19 @@ impl StacksMessageCodec for HttpRequestPreamble {
                                 "Inavlid HTTP request: invalid Connection: header".to_string(),
                             ));
                         }
+                        seen_headers.insert(key);
+                    } else if key == "set-cookie" {
+                        set_cookie.push(value);
                     } else {
-                        headers.insert(key, value);
+                        match headers.entry(key) {
+                            Entry::Vacant(vacant_entry) => {
+                                vacant_entry.insert(value);
+                            }
+                            Entry::Occupied(mut occupied_entry) => {
+                                occupied_entry.get_mut().push_str(", ");
+                                occupied_entry.get_mut().push_str(&value);
+                            }
+                        }
                     }
                 }
 
@@ -445,6 +465,7 @@ impl StacksMessageCodec for HttpRequestPreamble {
                     content_length,
                     keep_alive,
                     headers,
+                    set_cookie,
                 })
             }
         }

--- a/stackslib/src/net/http/tests.rs
+++ b/stackslib/src/net/http/tests.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use stacks_common::codec::StacksMessageCodec;
+use std::collections::BTreeMap;
+
+use stacks_common::codec::{Error as CodecError, StacksMessageCodec};
 use stacks_common::types::net::{PeerAddress, PeerHost};
 
 use crate::net::http::common::{HTTP_PREAMBLE_MAX_ENCODED_SIZE, HTTP_PREAMBLE_MAX_NUM_HEADERS};
@@ -75,6 +77,58 @@ fn test_parse_reserved_header() {
     for (key, value, expected_result) in tests {
         let result = HttpReservedHeader::try_from_str(key, value);
         assert_eq!(result, expected_result);
+    }
+}
+
+#[test]
+fn parse_http_request_duplicate_headers() {
+    let tests = vec![
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nCache-Control: no-cache\r\ncache-control: no-store\r\nConnection: close\r\n\r\n",
+         Ok(BTreeMap::from([("cache-control".to_string(), "no-cache, no-store".to_string())]))),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nCache-Control: no-store\r\ncache-control: no-cache\r\nConnection: close\r\n\r\n",
+         Ok(BTreeMap::from([("cache-control".into(), "no-store, no-cache".into())]))),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nHost: core2.blockstack.org\r\nConnection: close\r\n\r\n",
+         Err(CodecError::DeserializeError("Invalid HTTP request: duplicate header \"host\"".into()))),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nConnection: close\r\nConnection: keep-alive\r\n\r\n",
+         Err(CodecError::DeserializeError("Invalid HTTP request: duplicate header \"connection\"".into()))),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nContent-Type: application/json\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n",
+         Err(CodecError::DeserializeError("Invalid HTTP request: duplicate header \"content-type\"".into()))),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nContent-Length: 10\r\nContent-length: 5\r\nConnection: close\r\n\r\n",
+         Err(CodecError::DeserializeError("Invalid HTTP request: duplicate header \"content-length\"".into()))),
+    ];
+
+    for (data, expected) in tests.into_iter() {
+        let result = HttpRequestPreamble::consensus_deserialize(&mut data.as_bytes());
+        match result {
+            Ok(req) => {
+                let expected = expected.unwrap();
+                assert_eq!(req.headers, expected);
+            }
+            Err(e) => {
+                let expected = expected.unwrap_err();
+                assert_eq!(format!("{expected:?}"), format!("{e:?}"));
+            }
+        }
+    }
+}
+
+#[test]
+fn parse_http_request_set_cookie() {
+    let tests = vec![
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nConnection: close\r\n\r\n",
+         vec![]),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nset-Cookie: a1\r\nSet-Cookie: a2\r\nConnection: close\r\n\r\n",
+         vec!["a1".to_string(), "a2".to_string()]),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nset-Cookie: a2\r\nSet-Cookie: a1\r\nConnection: close\r\n\r\n",
+         vec!["a2".to_string(), "a1".to_string()]),
+        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nset-Cookie: a1\r\nConnection: close\r\n\r\n",
+         vec!["a1".to_string()]),
+    ];
+
+    for (data, expected) in tests.into_iter() {
+        let req = HttpRequestPreamble::consensus_deserialize(&mut data.as_bytes())
+            .expect("Should be able to parse the set-cookie requests");
+        assert_eq!(req.set_cookie, expected);
     }
 }
 


### PR DESCRIPTION
This PR lets the HTTP endpoints tolerate and handle duplicate HTTP headers.

Generally speaking, HTTP servers tolerate duplicate HTTP headers -- certain proxies like CF or nginx allow you to configure them to reject duplicate header requests, but its not the default behavior for most servers. The various HTTP spec documents suggest that servers should tolerate duplicate headers. From https://datatracker.ietf.org/doc/html/rfc9110#section-5.3 :

> A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace ([OWS](https://datatracker.ietf.org/doc/html/rfc9110#whitespace), defined in [Section 5.6.3](https://datatracker.ietf.org/doc/html/rfc9110#whitespace)). For consistency, use comma SP.

This PR implements the semantics described above: comma separate field lines for headers with the same field name. It also treats "Set-Cookie" specially (as described in that semantics document). The reserved headers "host", "content-type", "content-length" and "connection" do not accept duplicates.