### PR TITLE
Fix/reduce downloader verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Changed
 
 - When a miner times out waiting for signatures, it will re-propose the same block instead of building a new block ([#5877](https://github.com/stacks-network/stacks-core/pull/5877))
+- Improve tenure downloader trace verbosity applying proper logging level depending on the tenure state ("debug" if unconfirmed, "info" otherwise) ([#5871](https://github.com/stacks-network/stacks-core/issues/5871))
 
 ## [3.1.0.0.7]
 

--- a/stackslib/src/net/download/nakamoto/tenure_downloader.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader.rs
@@ -149,6 +149,8 @@ pub struct NakamotoTenureDownloader {
     pub tenure_end_block: Option<NakamotoBlock>,
     /// Tenure blocks
     pub tenure_blocks: Option<Vec<NakamotoBlock>>,
+    /// Whether this tenure is unconfirmed
+    pub is_tenure_unconfirmed: bool,
 }
 
 impl NakamotoTenureDownloader {
@@ -161,6 +163,7 @@ impl NakamotoTenureDownloader {
         naddr: NeighborAddress,
         start_signer_keys: RewardSet,
         end_signer_keys: RewardSet,
+        is_tenure_unconfirmed: bool,
     ) -> Self {
         debug!(
             "Instantiate downloader to {}-{} for tenure {}: {}-{}",
@@ -187,6 +190,7 @@ impl NakamotoTenureDownloader {
             tenure_start_block: None,
             tenure_end_block: None,
             tenure_blocks: None,
+            is_tenure_unconfirmed,
         }
     }
 

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -520,6 +520,7 @@ impl NakamotoTenureDownloaderSet {
                 naddr.clone(),
                 start_reward_set.clone(),
                 end_reward_set.clone(),
+                false,
             );
 
             debug!("Request tenure {ch} from neighbor {naddr}");
@@ -671,14 +672,18 @@ impl NakamotoTenureDownloaderSet {
             );
             new_blocks.insert(downloader.tenure_id_consensus_hash.clone(), blocks);
             if downloader.is_done() {
-                info!(
-                    "Downloader for tenure {} is finished",
-                    &downloader.tenure_id_consensus_hash
-                );
-                debug!(
-                    "Downloader for tenure {} finished on {naddr}",
-                    &downloader.tenure_id_consensus_hash,
-                );
+                if downloader.is_tenure_unconfirmed {
+                    debug!(
+                        "Downloader for tenure {} finished on {naddr}",
+                        &downloader.tenure_id_consensus_hash,
+                    );
+                } else {
+                    info!(
+                        "Downloader for tenure {} is finished",
+                        &downloader.tenure_id_consensus_hash
+                    );
+                }
+
                 finished.push(naddr.clone());
                 finished_tenures.push(CompletedTenure::from(downloader));
                 continue;

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_unconfirmed.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_unconfirmed.rs
@@ -742,6 +742,7 @@ impl NakamotoUnconfirmedTenureDownloader {
             self.naddr.clone(),
             confirmed_signer_keys.clone(),
             unconfirmed_signer_keys.clone(),
+            true,
         );
 
         Ok(ntd)

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -292,6 +292,7 @@ fn test_nakamoto_tenure_downloader() {
         naddr,
         reward_set.clone(),
         reward_set,
+        false,
     );
 
     // must be first block


### PR DESCRIPTION
### Description

~This fix reduce tenure downloader trace verbosity by removing `info!` log statement.~

~basically with this change info log lines like the following example will no longer be written:~
```
INFO [1741330250.786256] [stackslib/src/net/download/nakamoto/tenure_downloader_set.rs:674] [ThreadId(5)] Downloader for tenure dd4aaf9c10bae038e324b74674db3d2710889b29 is finished
```

*EDIT*
contribution as been remade following the result of the discussion in the PR.
So, now this change regulate tenure downloader verbosity depending on the tenure state:
- if tenure is unconfirmed then `debug!` trace is applied, otherwise
- if tenure is confirmed then `info!` trace is used


### Applicable issues

- fixes #5871

### Additional info (benefits, drawbacks, caveats)

To evaluate if could be usefull to have the new  information (`is_tenure_unconfirmed`)  to be part of tenure downloader instantiation log:

https://github.com/stacks-network/stacks-core/blob/ace8fc3dde09c3f937e88df334c18f3ad6793b39/stackslib/src/net/download/nakamoto/tenure_downloader.rs#L167-L175



### Checklist

- [ ] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
