### PR TITLE
avoid "No UTXOs" warn log when in mock_mining mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 - When a miner times out waiting for signatures, it will re-propose the same block instead of building a new block ([#5877](https://github.com/stacks-network/stacks-core/pull/5877))
 - Improve tenure downloader trace verbosity applying proper logging level depending on the tenure state ("debug" if unconfirmed, "info" otherwise) ([#5871](https://github.com/stacks-network/stacks-core/issues/5871))
+- Remove warning log about missing UTXOs when a node is configured as `miner` with `mock_mining` mode enabled ([#5841](https://github.com/stacks-network/stacks-core/issues/5841)) 
 
 ## [3.1.0.0.7]
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -744,11 +744,6 @@ impl BitcoinRegtestController {
         utxos_to_exclude: Option<UTXOSet>,
         block_height: u64,
     ) -> Option<UTXOSet> {
-        // if mock mining, do not even bother requesting UTXOs
-        if self.config.get_node_config(false).mock_mining {
-            return None;
-        }
-
         let pubk = if self.config.miner.segwit && epoch_id >= StacksEpochId::Epoch21 {
             let mut p = *public_key;
             p.set_compressed(true);
@@ -1693,6 +1688,11 @@ impl BitcoinRegtestController {
             // in RBF, you have to consume the same UTXOs
             utxos
         } else {
+            // if mock mining, do not even bother requesting UTXOs
+            if self.config.node.mock_mining {
+                return Err(BurnchainControllerError::NoUTXOs);
+            }
+
             // Fetch some UTXOs
             let addr = self.get_miner_address(epoch_id, public_key);
             match self.get_utxos(


### PR DESCRIPTION
### Description

This patch prevents logging the warning "No UTXOs for address" when the node is configured as a miner in mock mining mode.

Here an example of the full message (unwanted):
```
stacks-node[348792]: WARN [1739887644.149435] [testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs:1707] [relayer-http://0.0.0.0:20543/] No UTXOs for 04423252e65b4219143e4b6d90608afa651511701ea6a8d08209e8db9d2c2a4aec966a0fa3d3775a54bd3e06cbbf87315b564fc9a3eea25136e5b2b71b8f9d9ee0 (1A7396ngNGn6cotfYx4VmHEWt13Cn2dyts) in epoch 3.1
```

Basically the check about `mock_mining` has been moved from `BitcoinRegtestController::get_utxos()` to its caller `BitcoinRegtestController::prepare_tx()`, while preserving the original behaviour, namely returning `Err(BurnchainControllerError::NoUTXOs` (to avoid regression to the calling code)

Please note that I changed the way on how to retrieve the mock mining flag from `self.config.get_node_config(false).mock_mining` to `self.config.node.mock_mining`.  Local tests execution seems fine. Anyhow let me know if "get_node_config" is relevant somehow in this context.

### Applicable issues

- fixes #5841 

### Additional info (benefits, drawbacks, caveats)

I investigated if it was possible to move away (upper in the call stack) the mock mining check even from `BitcoinRegtestController::prepare_tx()`, but it seems relevant to be there because of the "RBF" check (line 1692). 

https://github.com/stacks-network/stacks-core/blob/dffe26d968fc845b6e23f335c41977b7e4346ad3/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs#L1683-L1694

As an example the `tests::nakamoto_integrations::mock_mining` integration test seems relaying on this kind of the behaviour.

### Checklist

- [ ] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
