### PR TITLE
chore: update contributing.md adding details about a product oriented changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,16 @@ For an example of this process, see PRs
 
 ### Documentation Updates
 
-- Any major changes should be added to the [CHANGELOG](CHANGELOG.md).
+- Any major changes should be added to the [CHANGELOG](CHANGELOG.md)[*].
 - Mention any required documentation changes in the description of your pull request.
 - If adding or updating an RPC endpoint, ensure the change is documented in the
   OpenAPI spec: [`./docs/rpc/openapi.yaml`](./docs/rpc/openapi.yaml).
 - If your code adds or modifies any major features (struct, trait,
   test, module, function, etc.), each should be documented according
   to our [coding guidelines](#Coding-Guidelines).
+
+> [*] The Changelog focuses on product changes. A "major change" refers to updates that have a direct impact on the end user, such as introducing new features, modifying existing functionality, or optimizing runtime performance. 
+On the other hand, changes that do not need to be reflected in the Changelog include code refactoring, writing tests, or automating processes, as these do not directly affect the user experience.
 
 ## Git Commit Messages
 


### PR DESCRIPTION
### Description

This is a proposal to improve the contributing page about what change record can be included in the changelog or not.

### Applicable issues

- fixes #5939

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
