### PR TITLE
feat: enable pretty print logging for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,7 +3107,6 @@ dependencies = [
  "ed25519-dalek",
  "hashbrown 0.15.2",
  "lazy_static",
- "libc",
  "libsecp256k1",
  "nix",
  "rand 0.8.5",

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -29,12 +29,12 @@ slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 slog-term = "2.6.0"
 slog-json = { version = "2.3.0", optional = true }
 chrono = "0.4.19"
-libc = "0.2.82"
 hashbrown = { workspace = true }
 rusqlite = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
+libc = "0.2.82"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -34,7 +34,6 @@ rusqlite = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
-libc = "0.2.82"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }


### PR DESCRIPTION
### Description

Currenlty, pretty printing is disabled for platform different from unix (where the lint warning, mentioned in the issue, is coming from)
This patch implement a general purpose `isatty` to allow log pretty printing on supported terminals (when configuring env variable `STACKS_LOG_PP=1`)

Added a "manual test" to visually verify pretty printing log configuration.

### Applicable issues

- fixes #5936

### Additional info (benefits, drawbacks, caveats)

`isatty` check has been improved:
- removing os specific apis (libc and winapi) using `std::io::IsTerminal` (rust v1.70+)
- pairing isatty behavior with `get_decorator` function (previously isatty was bound to the production configuration)

As a conseguence `libc` dependency is no more needed and therefore removed from Cargo.toml (stacks-common)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
