### PR TITLE
chore: upgrade curve25519-dalek to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -479,7 +479,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -488,7 +488,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -572,7 +572,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -745,7 +745,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -755,7 +755,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
 ]
 
@@ -770,20 +770,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core 0.5.1",
- "serde",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
@@ -794,6 +780,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.0",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -836,20 +823,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -906,7 +884,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -1191,15 +1169,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -3043,7 +3012,7 @@ name = "stacks-common"
 version = "0.0.1"
 dependencies = [
  "chrono",
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "ed25519-dalek",
  "hashbrown 0.15.2",
  "lazy_static",
@@ -3152,7 +3121,6 @@ dependencies = [
  "assert-json-diff 1.1.0",
  "chrono",
  "clarity",
- "curve25519-dalek 2.0.0",
  "ed25519-dalek",
  "hashbrown 0.15.2",
  "integer-sqrt",
@@ -3708,7 +3676,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
 ]
 

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -54,7 +54,7 @@ features = ["serde", "recovery"]
 workspace = true
 
 [dependencies.curve25519-dalek]
-version = "=2.0.0"
+version = "4.1.3"
 features = ["serde"]
 
 [dependencies.time]

--- a/stacks-common/src/util/vrf.rs
+++ b/stacks-common/src/util/vrf.rs
@@ -282,8 +282,8 @@ impl VRFProof {
                 // |----------------------------|----------|---------------------------|
                 //      Gamma point               c scalar   s scalar
                 let gamma_opt = CompressedEdwardsY::from_slice(&bytes[0..32])
-                    .unwrap()
-                    .decompress();
+                    .ok()
+                    .and_then(|y| y.decompress());
                 if gamma_opt.is_none() {
                     test_debug!("Invalid Gamma");
                     return None;
@@ -299,8 +299,8 @@ impl VRFProof {
 
                 c_buf[..16].copy_from_slice(&bytes[32..(16 + 32)]);
                 s_buf[..32].copy_from_slice(&bytes[48..(32 + 48)]);
-                let c = ed25519_Scalar::from_canonical_bytes(c_buf).expect("Invalid C scalar");
-                let s = ed25519_Scalar::from_canonical_bytes(s_buf).expect("Invalid S scalar");
+                let c = ed25519_Scalar::from_canonical_bytes(c_buf).ok()?;
+                let s = ed25519_Scalar::from_canonical_bytes(s_buf).ok()?;
 
                 Some(VRFProof { Gamma: gamma, c, s })
             }
@@ -388,7 +388,7 @@ impl VRF {
             }
 
             let y = CompressedEdwardsY::from_slice(&hasher.finalize()[0..32]);
-            if let Some(h) = y.unwrap().decompress() {
+            if let Some(h) = y.ok().and_then(|y| y.decompress()) {
                 break h;
             }
 

--- a/stacks-common/src/util/vrf.rs
+++ b/stacks-common/src/util/vrf.rs
@@ -299,10 +299,14 @@ impl VRFProof {
 
                 c_buf[..16].copy_from_slice(&bytes[32..(16 + 32)]);
                 s_buf[..32].copy_from_slice(&bytes[48..(32 + 48)]);
-                let c = ed25519_Scalar::from_canonical_bytes(c_buf).ok()?;
-                let s = ed25519_Scalar::from_canonical_bytes(s_buf).ok()?;
+                let c: Option<ed25519_Scalar> = ed25519_Scalar::from_canonical_bytes(c_buf).into();
+                let s: Option<ed25519_Scalar> = ed25519_Scalar::from_canonical_bytes(s_buf).into();
 
-                Some(VRFProof { Gamma: gamma, c, s })
+                Some(VRFProof {
+                    Gamma: gamma,
+                    c: c?,
+                    s: s?,
+                })
             }
             _ => None,
         }

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -83,10 +83,6 @@ features = ["serde", "recovery"]
 [dependencies.ed25519-dalek]
 workspace = true
 
-[dependencies.curve25519-dalek]
-version = "=2.0.0"
-features = ["serde"]
-
 [dependencies.time]
 version = "0.2.23"
 features = ["std"]

--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -241,7 +241,7 @@ impl TestMiner {
         );
         match self.vrf_key_map.get(vrf_pubkey) {
             Some(prover_key) => {
-                let proof = VRF::prove(prover_key, last_sortition_hash.as_bytes());
+                let proof = VRF::prove(prover_key, last_sortition_hash.as_bytes())?;
                 let valid = match VRF::verify(vrf_pubkey, &proof, last_sortition_hash.as_bytes()) {
                     Ok(v) => v,
                     Err(e) => false,

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -646,7 +646,7 @@ fn make_genesis_block_with_recipients(
 
     let parent_stacks_header = StacksHeaderInfo::regtest_genesis();
 
-    let proof = VRF::prove(vrf_key, sortition_tip.sortition_hash.as_bytes());
+    let proof = VRF::prove(vrf_key, sortition_tip.sortition_hash.as_bytes()).unwrap();
 
     let mut builder = StacksBlockBuilder::make_regtest_block_builder(
         burnchain,
@@ -909,7 +909,7 @@ fn make_stacks_block_with_input(
 
     eprintln!("Build off of {:?}", &parent_stacks_header);
 
-    let proof = VRF::prove(vrf_key, sortition_tip.sortition_hash.as_bytes());
+    let proof = VRF::prove(vrf_key, sortition_tip.sortition_hash.as_bytes()).unwrap();
 
     let total_burn = parents_sortition.total_burn;
 

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -1628,7 +1628,7 @@ fn test_nakamoto_block_static_verification() {
     let vrf_privkey = VRFPrivateKey::new();
     let vrf_pubkey = VRFPublicKey::from_private(&vrf_privkey);
     let sortition_hash = SortitionHash([0x01; 32]);
-    let vrf_proof = VRF::prove(&vrf_privkey, sortition_hash.as_bytes());
+    let vrf_proof = VRF::prove(&vrf_privkey, sortition_hash.as_bytes()).unwrap();
 
     let burn_recipient = StacksAddress::burn_address(false).to_account_principal();
     let alt_recipient = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&private_key_2))

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -1127,6 +1127,17 @@ impl BlockMinerThread {
             )
         };
 
+        let Some(vrf_proof) = vrf_proof else {
+            error!(
+                "Unable to generate VRF proof, will be unable to mine";
+                "burn_block_sortition_hash" => %self.burn_election_block.sortition_hash,
+                "burn_block_block_height" => %self.burn_block.block_height,
+                "burn_block_hash" => %self.burn_block.burn_header_hash,
+                "vrf_pubkey" => &self.registered_key.vrf_public_key.to_hex()
+            );
+            return None;
+        };
+
         debug!(
             "Generated VRF Proof: {} over {} ({},{}) with key {}",
             vrf_proof.to_hex(),

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1730,6 +1730,17 @@ impl BlockMinerThread {
             )
         };
 
+        let Some(vrf_proof) = vrf_proof else {
+            error!(
+                "Unable to generate VRF proof, will be unable to mine";
+                "burn_block_sortition_hash" => %self.burn_block.sortition_hash,
+                "burn_block_block_height" => %self.burn_block.block_height,
+                "burn_block_hash" => %self.burn_block.burn_header_hash,
+                "vrf_pubkey" => &self.registered_key.vrf_public_key.to_hex()
+            );
+            return None;
+        };
+
         debug!(
             "Generated VRF Proof: {} over {} ({},{}) with key {}",
             vrf_proof.to_hex(),

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -659,10 +659,13 @@ impl Node {
             .expect("FATAL: failed to query canonical burn chain tip");
 
         // Generates a proof out of the sortition hash provided in the params.
-        let vrf_proof = self.keychain.generate_proof(
+        let Some(vrf_proof) = self.keychain.generate_proof(
             registered_key.target_block_height,
             tip.sortition_hash.as_bytes(),
-        );
+        ) else {
+            warn!("Failed to generate VRF proof, will be unable to initiate new tenure");
+            return None;
+        };
 
         // Generates a new secret key for signing the trail of microblocks
         // of the upcoming tenure.
@@ -731,10 +734,13 @@ impl Node {
         if self.active_registered_key.is_some() {
             let registered_key = self.active_registered_key.clone().unwrap();
 
-            let vrf_proof = self.keychain.generate_proof(
+            let Some(vrf_proof) = self.keychain.generate_proof(
                 registered_key.target_block_height,
                 burnchain_tip.block_snapshot.sortition_hash.as_bytes(),
-            );
+            ) else {
+                warn!("Failed to generate VRF proof, will be unable to mine commits");
+                return;
+            };
 
             let op = self.generate_block_commit_op(
                 anchored_block_from_ongoing_tenure.header.block_hash(),


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

- Upgrade `curve25519-dalek` to v4 in stacks-common
- Remove it from stackslib (wasn't used)
- `curve25519-dalek` v4 was already pulled as a subdependency of `ed25519-dalek`, so in the Cargo.lock you'll only see removed dependendencies, but no addtions.


The v4 comes with a few breaking changes list here:
https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek#breaking-changes-in-400
The impact for this PR are:
- `Scalar::reduce()` was removed https://github.com/dalek-cryptography/curve25519-dalek/pull/519 
-  `Scalar::from_canonical_bytes()` now return CtOptions
- `Scalar::from_bits()` was removed https://github.com/dalek-cryptography/curve25519-dalek/issues/547
  - I'm actually not sure of my fixes there

### Applicable issues

/

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
