### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
 ]
 
@@ -1403,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.7",
+ "generic-array",
  "hmac 0.8.1",
 ]
 
@@ -1807,18 +1807,12 @@ dependencies = [
  "libc",
  "libstackerdb",
  "mutants",
- "prometheus",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "secp256k1",
  "serde",
- "serde_derive",
  "serde_json",
- "serde_stacker",
  "sha2 0.10.8",
  "slog",
- "slog-json",
- "slog-term",
  "stacks-common",
  "stackslib",
  "thiserror",
@@ -1843,8 +1837,6 @@ dependencies = [
  "clarity",
  "secp256k1",
  "serde",
- "serde_derive",
- "serde_stacker",
  "sha2 0.10.8",
  "stacks-common",
 ]
@@ -3147,7 +3139,6 @@ dependencies = [
  "mutants",
  "pico-args",
  "rand 0.8.5",
- "rand_core 0.6.4",
  "regex",
  "reqwest",
  "rusqlite",
@@ -3190,9 +3181,7 @@ dependencies = [
  "rusqlite",
  "secp256k1",
  "serde",
- "serde_derive",
  "serde_json",
- "serde_stacker",
  "slog",
  "slog-json",
  "slog-term",
@@ -3211,13 +3200,10 @@ name = "stackslib"
 version = "0.0.1"
 dependencies = [
  "assert-json-diff 1.1.0",
- "chrono",
  "clarity",
  "ed25519-dalek",
  "hashbrown 0.15.2",
- "integer-sqrt",
  "lazy_static",
- "libc",
  "libstackerdb",
  "mio 0.6.23",
  "mutants",
@@ -3238,13 +3224,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_stacker",
  "sha2 0.10.8",
- "sha3",
  "siphasher",
  "slog",
- "slog-json",
- "slog-term",
  "stacks-common",
  "stdext",
  "stx-genesis",

--- a/libsigner/Cargo.toml
+++ b/libsigner/Cargo.toml
@@ -21,13 +21,8 @@ hashbrown = { workspace = true }
 lazy_static = "1.4.0"
 libc = "0.2"
 libstackerdb = { path = "../libstackerdb" }
-prometheus = { version = "0.9", optional = true }
 serde = "1"
-serde_derive = "1"
-serde_stacker = "0.1"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
-slog-term = "2.6.0"
-slog-json = { version = "2.3.0", optional = true }
 stacks-common = { path = "../stacks-common" }
 stackslib = { path = "../stackslib"}
 thiserror = { workspace = true }
@@ -42,15 +37,8 @@ rand = { workspace = true }
 version = "1.0"
 features = ["arbitrary_precision", "unbounded_depth"]
 
-[dependencies.secp256k1]
-version = "0.24.3"
-features = ["serde", "recovery"]
-
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64"), not(any(target_os="windows"))))'.dependencies]
 sha2 = { version = "0.10", features = ["asm"] }
 
 [target.'cfg(any(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")), any(target_os = "windows")))'.dependencies]
 sha2 = { version = "0.10" }
-
-[features]
-monitoring_prom = ["prometheus"]

--- a/libstackerdb/Cargo.toml
+++ b/libstackerdb/Cargo.toml
@@ -17,8 +17,6 @@ path = "./src/libstackerdb.rs"
 
 [dependencies]
 serde = "1"
-serde_derive = "1"
-serde_stacker = "0.1"
 stacks-common = { path = "../stacks-common" }
 clarity = { path = "../clarity" }
 

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -31,8 +31,6 @@ prometheus = { version = "0.9", optional = true }
 rand_core = "0.6"
 reqwest = { version = "0.11.22", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = "1"
-serde_derive = "1"
-serde_stacker = "0.1"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
 slog-json = { version = "2.3.0", optional = true }
 slog-term = "2.6.0"
@@ -62,5 +60,5 @@ features = ["serde", "recovery"]
 
 [features]
 default = []
-monitoring_prom = ["libsigner/monitoring_prom", "prometheus", "tiny_http"]
+monitoring_prom = ["prometheus", "tiny_http"]
 testing = []

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -36,8 +36,6 @@ rand_core = { workspace = true }
 rand_chacha = { workspace = true }
 serde = "1"
 serde_derive = "1"
-serde_stacker = "0.1"
-sha3 = "0.10.1"
 ripemd = "0.1.1"
 regex = "1"
 mio = "0.6"
@@ -45,12 +43,7 @@ lazy_static = "1.4.0"
 url = "2.1.0"
 percent-encoding = "2.1.0"
 prometheus = { version = "0.9", optional = true }
-integer-sqrt = "0.1.3"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
-slog-term = "2.6.0"
-slog-json = { version = "2.3.0", optional = true }
-chrono = "0.4.19"
-libc = "0.2.82"
 clarity = { path = "../clarity" }
 stacks-common = { path = "../stacks-common" }
 pox-locking = { path = "../pox-locking" }
@@ -104,7 +97,7 @@ profile-sqlite = []
 disable-costs = []
 developer-mode = ["clarity/developer-mode"]
 monitoring_prom = ["prometheus"]
-slog_json = ["slog-json", "stacks-common/slog_json", "clarity/slog_json", "pox-locking/slog_json"]
+slog_json = ["stacks-common/slog_json", "clarity/slog_json", "pox-locking/slog_json"]
 testing = []
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64"), not(any(target_os="windows"))))'.dependencies]

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -25,7 +25,6 @@ regex = "1"
 libsigner = { path = "../../libsigner" }
 url = "2.1.0"
 rand = { workspace = true }
-rand_core = { workspace = true }
 hashbrown = { workspace = true }
 rusqlite = { workspace = true }
 async-h1 = { version = "2.3.2", optional = true }
@@ -62,7 +61,7 @@ name = "stacks-events"
 path = "src/stacks_events.rs"
 
 [features]
-monitoring_prom = ["stacks/monitoring_prom", "libsigner/monitoring_prom", "stacks-signer/monitoring_prom", "async-h1", "async-std", "http-types"]
+monitoring_prom = ["stacks/monitoring_prom", "stacks-signer/monitoring_prom", "async-h1", "async-std", "http-types"]
 slog_json = ["stacks/slog_json", "stacks-common/slog_json", "clarity/slog_json"]
 prod-genesis-chainstate = []
 default = []


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

I randomly found out that serde_stacker was only used in `clarity/` but listed in many other Cargo.toml. So I cleaned it, and end up removing a few other unused dependencies in other Cargo.toml in the workspace.
Also removed the unused `monitoring_prom` cargo feature in libsigner.
I think these extra dependencies were just copy-pasted during code splitting process into multiple crates.
They don't actually remove any dependency from the workspace in general, but it just clean up the Cargo files a little
