### PR TITLE
fix: --no-default-features compilation

### DIFF
--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -29,7 +29,7 @@ regex = "1.9.3"
 lazy_static = "1.4.0"
 integer-sqrt = "0.1.3"
 slog = { version = "2.5.2", features = [ "max_level_trace" ], optional = true }
-stacks_common = { path= "../stacks-common", package = "stacks-common", optional = true, default-features = false }
+stacks_common = { path= "../stacks-common", package = "stacks-common", default-features = false }
 rstest = { version = "0.17.0", optional = true }
 rstest_reuse = { version = "0.5.0", optional = true }
 wasmtime = { version = "15.0.0", optional = true }

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -56,11 +56,12 @@ mutants = "0.0.3"
 # criterion = "0.3"
 
 [features]
-default = ["rusqlite", "log", "clarity-wasm", "serde_stacker"]
+default = ["rusqlite", "log", "clarity-wasm", "serde_stacker", "vrf"]
 clarity-wasm = ["wasmtime"]
 developer-mode = ["stacks_common/developer-mode"]
 slog_json = ["stacks_common/slog_json"]
 rusqlite = ["stacks_common/rusqlite", "dep:rusqlite"]
+vrf = ["stacks_common/vrf"]
 devtools = []
 rollback_value_check = []
 disable-costs = []

--- a/clarity/src/libclarity.rs
+++ b/clarity/src/libclarity.rs
@@ -21,6 +21,7 @@
 #![cfg_attr(test, allow(unused_variables, unused_assignments))]
 
 #[allow(unused_imports)]
+#[cfg(feature = "log")]
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
 

--- a/clarity/src/vm/database/structures.rs
+++ b/clarity/src/vm/database/structures.rs
@@ -53,7 +53,7 @@ macro_rules! clarity_serializable {
             }
         }
         impl ClarityDeserializable<$Name> for $Name {
-            #[cfg(not(feature = "wasm"))]
+            #[cfg(feature = "default")]
             fn deserialize(json: &str) -> Result<Self> {
                 let mut deserializer = serde_json::Deserializer::from_str(&json);
                 // serde's default 128 depth limit can be exhausted
@@ -66,7 +66,7 @@ macro_rules! clarity_serializable {
                     InterpreterError::Expect("Failed to deserialize vm.Value".into()).into()
                 })
             }
-            #[cfg(feature = "wasm")]
+            #[cfg(not(feature = "default"))]
             fn deserialize(json: &str) -> Result<Self> {
                 serde_json::from_str(json).map_err(|_| {
                     InterpreterError::Expect("Failed to deserialize vm.Value".into()).into()

--- a/stacks-common/src/libcommon.rs
+++ b/stacks-common/src/libcommon.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::assertions_on_constants)]
 
 #[allow(unused_imports)]
+#[cfg(feature = "log")]
 #[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
 extern crate slog;
 

--- a/stacks-common/src/types/sqlite.rs
+++ b/stacks-common/src/types/sqlite.rs
@@ -23,6 +23,7 @@ use crate::types::chainstate::{
 };
 use crate::util::hash::{Hash160, Sha512Trunc256Sum};
 use crate::util::secp256k1::{MessageSignature, SchnorrSignature};
+#[cfg(feature = "vrf")]
 use crate::util::vrf::VRFProof;
 
 pub const NO_PARAMS: &[&dyn ToSql] = &[];
@@ -49,6 +50,7 @@ impl_byte_array_rusqlite_only!(Hash160);
 impl_byte_array_rusqlite_only!(BlockHeaderHash);
 impl_byte_array_rusqlite_only!(VRFSeed);
 impl_byte_array_rusqlite_only!(BurnchainHeaderHash);
+#[cfg(feature = "vrf")]
 impl_byte_array_rusqlite_only!(VRFProof);
 impl_byte_array_rusqlite_only!(TrieHash);
 impl_byte_array_rusqlite_only!(Sha512Trunc256Sum);


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

_To be merged on feat/clarity-wasm-develop_

### Description

Fixing a mistake I made in #5954.
Because the `clarity/canonical` cargo feature doesn't exist anymore, stacks_common must not be marked as optional anymore.

Also fix the compilation with --no-default-features, which I think wasn't working even before the merge.