### PR TITLE
chore: remove sip folder and update GitHub URL reference

### DIFF
--- a/docs/rpc/entities/contracts/read-only-function-args.schema.json
+++ b/docs/rpc/entities/contracts/read-only-function-args.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ReadOnlyFunctionArgs",
-  "description": "Describes representation of a Type-0 Stacks 2.0 transaction. https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-005-blocks-and-transactions.md#type-0-transferring-an-asset",
+  "description": "Describes representation of a Type-0 Stacks 2.0 transaction. https://github.com/stacksgov/sips/blob/main/sips/sip-005/sip-005-blocks-and-transactions.md#type-0-transferring-an-asset",
   "type": "object",
   "required": ["sender", "arguments"],
   "properties": {

--- a/sip/README.md
+++ b/sip/README.md
@@ -1,5 +1,0 @@
-# Stacks Improvement Proposals (SIPs)
-
-This directory formerly contained all of the in-progress Stacks Improvement Proposals before the Stacks 2.0 mainnet launched.
-
-The SIPs are now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-000-stacks-improvement-proposal-process.md
+++ b/sip/sip-000-stacks-improvement-proposal-process.md
@@ -1,5 +1,0 @@
-# SIP-000 Stacks Improvement Proposal Process
-
-This document formerly contained SIP-000 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-001-burn-election.md
+++ b/sip/sip-001-burn-election.md
@@ -1,5 +1,0 @@
-# SIP-001 Burn Election
-
-This document formerly contained SIP-001 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-001/sip-001-burn-election.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-002-smart-contract-language.md
+++ b/sip/sip-002-smart-contract-language.md
@@ -1,5 +1,0 @@
-# SIP-002 Smart Contract Language
-
-This document formerly contained SIP-002 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-002/sip-002-smart-contract-language.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-003-peer-network.md
+++ b/sip/sip-003-peer-network.md
@@ -1,5 +1,0 @@
-# SIP-003 Peer Network
-
-This document formerly contained SIP-003 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-003/sip-003-peer-network.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-004-materialized-view.md
+++ b/sip/sip-004-materialized-view.md
@@ -1,5 +1,0 @@
-# SIP-004 Cryptographic Committment to Materialized Views
-
-This document formerly contained SIP-004 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-004/sip-004-materialized-view.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-005-blocks-and-transactions.md
+++ b/sip/sip-005-blocks-and-transactions.md
@@ -1,5 +1,0 @@
-# SIP-005 Blocks, Transactions, and Accounts
-
-This document formerly contained SIP-005 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-005/sip-005-blocks-and-transactions.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-006-runtime-cost-assessment.md
+++ b/sip/sip-006-runtime-cost-assessment.md
@@ -1,5 +1,0 @@
-# SIP-006 Clarity Execution Cost Assessment
-
-This document formerly contained SIP-006 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-006/sip-006-runtime-cost-assessment.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-007-stacking-consensus.md
+++ b/sip/sip-007-stacking-consensus.md
@@ -1,5 +1,0 @@
-# SIP-007 Stacking Consensus
-
-This document formerly contained SIP-007 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-007/sip-007-stacking-consensus.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).

--- a/sip/sip-008-analysis-cost-assessment.md
+++ b/sip/sip-008-analysis-cost-assessment.md
@@ -1,5 +1,0 @@
-# SIP-008 Clarity Parsing and Analysis Cost Assessment
-
-This document formerly contained SIP-008 before the Stacks 2.0 mainnet launched.
-
-This SIP is now located in the [stacksgov/sips repository](https://github.com/stacksgov/sips/blob/main/sips/sip-008/sip-008-analysis-cost-assessment.md) as part of the [Stacks Community Governance organization](https://github.com/stacksgov).


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Removed the sip/ folder since official SIP documentation is now at https://github.com/stacksgov/sips. Updated references from blockstack to stacksgov in schema definition.

### Applicable issues

- Remove the sip/ folder
- Update GitHub URL reference from blockstack to stacksgov in schema definition to point to the new location

