### PR TITLE
ci: reduce test flakiness (CI is so slow)

### DIFF
--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -12925,7 +12925,7 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
         last_block.tx_events.len()
     );
     if strategy == MemPoolWalkStrategy::NextNonceWithHighestFeeRate {
-        assert!(last_block.tx_events.len() > 5000);
+        assert!(last_block.tx_events.len() > 2000);
     }
 
     // Wait for the first block to be accepted.


### PR DESCRIPTION
I noticed that sometimes the miner's 5 seconds runs out before it has time to include 5000 transactions in the block, triggering a failure.