### PR TITLE
feat: add monitoring for signer agreement state change reason

### DIFF
--- a/stacks-signer/src/monitoring/mod.rs
+++ b/stacks-signer/src/monitoring/mod.rs
@@ -14,38 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use stacks_common::define_named_enum;
+
 #[cfg(feature = "monitoring_prom")]
 mod prometheus;
 
 #[cfg(feature = "monitoring_prom")]
 mod server;
 
+define_named_enum!(
 /// Represent different state change reason on signer agreement protocol
-pub enum SignerAgreementStateChangeReason {
+SignerAgreementStateChangeReason {
     /// A new burn block has arrived
-    BurnBlockArrival,
+    BurnBlockArrival("burn_block_arrival"),
     /// A new stacks block has arrived
-    StacksBlockArrival,
+    StacksBlockArrival("stacks_block_arrival"),
     /// A miner is inactive when it should be starting its tenure
-    InactiveMiner,
+    InactiveMiner("inactive_miner"),
     /// Signer agreement protocol version has been upgraded
-    ProtocalUpgrade,
-}
-
-impl std::fmt::Display for SignerAgreementStateChangeReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                SignerAgreementStateChangeReason::BurnBlockArrival => "burn_block_arrival",
-                SignerAgreementStateChangeReason::StacksBlockArrival => "stacks_block_arrival",
-                SignerAgreementStateChangeReason::InactiveMiner => "inactive_miner",
-                SignerAgreementStateChangeReason::ProtocalUpgrade => "protocol_upgrade",
-            }
-        )
-    }
-}
+    ProtocalUpgrade("protocol_upgrade"),
+});
 
 /// Actions for updating metrics
 #[cfg(feature = "monitoring_prom")]
@@ -140,7 +128,7 @@ pub mod actions {
     pub fn increment_signer_agreement_state_change_reason(
         reason: SignerAgreementStateChangeReason,
     ) {
-        let label_value = reason.to_string();
+        let label_value = reason.get_name();
         SIGNER_AGREEMENT_STATE_CHANGE_REASONS
             .with_label_values(&[&label_value])
             .inc();

--- a/stacks-signer/src/monitoring/mod.rs
+++ b/stacks-signer/src/monitoring/mod.rs
@@ -32,7 +32,7 @@ SignerAgreementStateChangeReason {
     /// A miner is inactive when it should be starting its tenure
     InactiveMiner("inactive_miner"),
     /// Signer agreement protocol version has been upgraded
-    ProtocalUpgrade("protocol_upgrade"),
+    ProtocolUpgrade("protocol_upgrade"),
 });
 
 /// Actions for updating metrics

--- a/stacks-signer/src/monitoring/prometheus.rs
+++ b/stacks-signer/src/monitoring/prometheus.rs
@@ -79,6 +79,12 @@ lazy_static! {
         vec![0.005, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0]
     ), &[]).unwrap();
 
+    pub static ref SIGNER_AGREEMENT_STATE_CHANGE_REASONS: IntCounterVec = register_int_counter_vec!(
+        "stacks_signer_agreement_state_change_reasons",
+        "The number of state machine changes in signer agreement protocol. `reason` can be one of: 'burn_block_arrival', 'stacks_block_arrival', 'inactive_miner', 'protocol_upgrade'",
+        &["reason"]
+    ).unwrap();
+
     pub static ref SIGNER_LOCAL_STATE_MACHINE: Mutex<Option<LocalStateMachine>> = Mutex::new(None);
 }
 


### PR DESCRIPTION
### Description

This is a first PR to start implementing prometheus monitoring on signer agreement protocol.

In details, this PR implement the following metric:
`Counting state changes, eventually by type (block arrivals, inactive miners, protocol upgrades)` 

The metric is implemented a prometheus `IntCounterVec` with labels depending on the state change type (aka "reason")

I put the monitoring hooks right where the stage change happen, and discriminating the reason label by enum.

I have also considered as a reason the "Protocol Upgrades", but didn't add the related monitoring hook in the code, because we haven't the related state change logic already in place.

### Applicable issues

- fixes #5918

### Additional info (benefits, drawbacks, caveats)

Just to share a thought that come up to my mind, while I introduced an enum for monitoring purpose (`SignerAgreementStateChangeReason`): I'm wondering if it could be a useful information for the state machine (and eventually the StackerDB), to store the reason that make the state change happen.

If it is, then we would need just one monitoring hook at the end of `process_event(..)` where `send_signer_update_message(..)` is invoked.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
