### PR TITLE
chore: A few workflow fixes

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -38,6 +38,18 @@ concurrency:
 run-name: ${{ inputs.node_tag || inputs.signer_tag }}
 
 jobs:
+  andon-cord:
+    if: |
+      inputs.node_tag != '' ||
+      inputs.signer_tag != ''
+    name: Build Binaries
+    runs-on: ubuntu-latest
+    environment: "Build Release"
+    steps:
+      - name: Check Approval
+        id: check
+        run: |
+          return true
   ## Build arch dependent binaries from source
   ##
   ## Runs when the following is true:
@@ -48,7 +60,8 @@ jobs:
       inputs.signer_tag != ''
     name: Build Binaries
     runs-on: ubuntu-latest
-    environment: "Build Release"
+    needs:
+      - andon-cord
     strategy:
       ## Run a maximum of 10 builds concurrently, using the matrix defined in inputs.arch
       max-parallel: 10
@@ -91,6 +104,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs:
+      - andon-cord
       - build-binaries
     permissions:
       contents: write
@@ -107,7 +121,6 @@ jobs:
           is_signer_release: ${{ inputs.is_signer_release }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
   ## Builds arch dependent Docker images from binaries
   ##
   ## Note: this step requires the binaries in the create-release step to be uploaded
@@ -120,6 +133,7 @@ jobs:
     name: Docker Image (Binary)
     runs-on: ubuntu-latest
     needs:
+      - andon-cord
       - build-binaries
       - create-release
     strategy:
@@ -152,6 +166,7 @@ jobs:
     name: Create Downstream PR (${{ github.ref_name }})
     runs-on: ubuntu-latest
     needs:
+      - andon-cord
       - build-binaries
       - create-release
       - docker-image

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -42,7 +42,7 @@ jobs:
     if: |
       inputs.node_tag != '' ||
       inputs.signer_tag != ''
-    name: Build Binaries
+    name: Andon Cord
     runs-on: ubuntu-latest
     environment: "Build Release"
     steps:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -38,6 +38,8 @@ concurrency:
 run-name: ${{ inputs.node_tag || inputs.signer_tag }}
 
 jobs:
+  ## This job's sole purpose is trigger a secondary approval outside of the matrix jobs below. 
+  ## If this job isn't approved to run, then the subsequent jobs will also not run - for this reason, we always exit 0
   andon-cord:
     if: |
       inputs.node_tag != '' ||
@@ -49,7 +51,7 @@ jobs:
       - name: Check Approval
         id: check
         run: |
-          return true
+          exit 0
   ## Build arch dependent binaries from source
   ##
   ## Runs when the following is true:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -39,7 +39,8 @@ run-name: ${{ inputs.node_tag || inputs.signer_tag }}
 
 jobs:
   ## This job's sole purpose is trigger a secondary approval outside of the matrix jobs below. 
-  ## If this job isn't approved to run, then the subsequent jobs will also not run - for this reason, we always exit 0
+  ##   - If this job isn't approved to run, then the subsequent jobs will also not run - for this reason, we always exit 0
+  ##   - `andon-cord` requires the repo environment "Build Release", which will trigger a secondary approval step before running this workflow.  
   andon-cord:
     if: |
       inputs.node_tag != '' ||

--- a/.github/workflows/image-build-source.yml
+++ b/.github/workflows/image-build-source.yml
@@ -21,6 +21,7 @@ jobs:
   image:
     name: Build Image
     runs-on: ubuntu-latest
+    environment: "Push to Docker"
     steps:
       ## Setup Docker for the builds
       - name: Docker setup

--- a/.github/workflows/image-build-source.yml
+++ b/.github/workflows/image-build-source.yml
@@ -21,6 +21,7 @@ jobs:
   image:
     name: Build Image
     runs-on: ubuntu-latest
+    ## Requires the repo environment "Push to Docker", which will trigger a secondary approval step before running this workflow.
     environment: "Push to Docker"
     steps:
       ## Setup Docker for the builds

--- a/contrib/tools/block-replay.sh
+++ b/contrib/tools/block-replay.sh
@@ -195,7 +195,7 @@ start_replay() {
             starting_block=0 # for the block counter, start at this block
             ## use these values if `--testing` arg is provided (only replay 1_000 blocks) Note:  2.5 epoch is at 153106
             ${TESTING} && total_blocks=153000
-            ${TESTING} && starting_block=15200
+            ${TESTING} && starting_block=152000
             ;;
     esac
     local block_diff=$((total_blocks - starting_block)) ## how many blocks are being replayed


### PR DESCRIPTION
Per @obycode the previous environment usage triggered several emails for approval due to the matrix. 
this PR adds a single job that checks for that approval before starting the matrix build jobs. 

additionally, this PR enables the image-build-source workflow, gated by an environment for ad-hoc image creation. 

lastly, there was an incorrect starting block in the block_replay.sh script used when testing a small number of blocks. rather than 1k blocks, testing mode was set to check 137,800 blocks. 