### PR TITLE
Resolves issues 5991 and 5989

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,6 +7,9 @@ name: Clippy Checks
 # Only run when:
 #   - PRs are (re)opened against develop branch
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     branches:
       - develop

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -164,8 +164,11 @@ jobs:
   ## Create the downstream PR for the release branch to master,develop
   create-pr:
     if: |
-      inputs.node_tag != '' ||
-      inputs.signer_tag != ''
+      !contains(github.ref, '-rc') &&
+      (
+        inputs.node_tag != '' ||
+        inputs.signer_tag != ''
+      )
     name: Create Downstream PR (${{ github.ref_name }})
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Resolves issues #5991  and #5989 

- adds the merge queue workflow trigger for clippy, so it may be a required status check on future pr's
- disables the release PR workflow when a release is an `-rc`

@obycode 