### PR TITLE
feat: add `empty_mempool_sleep_ms`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - When a miner times out waiting for signatures, it will re-propose the same block instead of building a new block ([#5877](https://github.com/stacks-network/stacks-core/pull/5877))
 - Improve tenure downloader trace verbosity applying proper logging level depending on the tenure state ("debug" if unconfirmed, "info" otherwise) ([#5871](https://github.com/stacks-network/stacks-core/issues/5871))
 - Remove warning log about missing UTXOs when a node is configured as `miner` with `mock_mining` mode enabled ([#5841](https://github.com/stacks-network/stacks-core/issues/5841)) 
-- Deprecated the `wait_on_interim_blocks` option in the miner config file. This option is no longer needed, as the miner will always wait for interim blocks to be processed before mining a new block. To wait extra time in between blocks, use the `min_time_between_blocks_ms` option instead.
+- Deprecated the `wait_on_interim_blocks` option in the miner config file. This option is no longer needed, as the miner will always wait for interim blocks to be processed before mining a new block. To wait extra time in between blocks, use the `min_time_between_blocks_ms` option instead. ([#5979](https://github.com/stacks-network/stacks-core/pull/5979))
+- Added `empty_mempool_sleep_ms` to the miner config file to control the time to wait in between mining attempts when the mempool is empty. If not set, the default sleep time is 2.5s. ([#5997](https://github.com/stacks-network/stacks-core/pull/5997))
 
 ## [3.1.0.0.7]
 

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -568,8 +568,13 @@ impl BlockMinerThread {
                     continue;
                 }
                 Err(NakamotoNodeError::MiningFailure(ChainstateError::NoTransactionsToMine)) => {
-                    debug!("Miner did not find any transactions to mine");
+                    debug!(
+                        "Miner did not find any transactions to mine, sleeping for {:?}",
+                        self.config.miner.empty_mempool_sleep_time
+                    );
                     self.reset_nonce_cache = false;
+
+                    thread::sleep(self.config.miner.empty_mempool_sleep_time);
                     break None;
                 }
                 Err(e) => {

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -574,7 +574,32 @@ impl BlockMinerThread {
                     );
                     self.reset_nonce_cache = false;
 
-                    thread::sleep(self.config.miner.empty_mempool_sleep_time);
+                    // Pause the miner to wait for transactions to arrive
+                    let now = Instant::now();
+                    while now.elapsed() < self.config.miner.empty_mempool_sleep_time {
+                        if self.abort_flag.load(Ordering::SeqCst) {
+                            info!("Miner interrupted while mining in order to shut down");
+                            self.globals
+                                .raise_initiative(format!("MiningFailure: aborted by node"));
+                            return Err(ChainstateError::MinerAborted.into());
+                        }
+
+                        // Check if the burnchain tip has changed
+                        let Ok(sort_db) = SortitionDB::open(
+                            &self.config.get_burn_db_file_path(),
+                            false,
+                            self.burnchain.pox_constants.clone(),
+                        ) else {
+                            error!("Failed to open sortition DB. Will try mining again.");
+                            continue;
+                        };
+                        if self.check_burn_tip_changed(&sort_db).is_err() {
+                            return Err(NakamotoNodeError::BurnchainTipChanged);
+                        }
+
+                        thread::sleep(Duration::from_millis(ABORT_TRY_AGAIN_MS));
+                    }
+
                     break None;
                 }
                 Err(e) => {
@@ -684,6 +709,13 @@ impl BlockMinerThread {
                 }
 
                 thread::sleep(Duration::from_millis(ABORT_TRY_AGAIN_MS));
+
+                if self.abort_flag.load(Ordering::SeqCst) {
+                    info!("Miner interrupted while mining in order to shut down");
+                    self.globals
+                        .raise_initiative(format!("MiningFailure: aborted by node"));
+                    return Err(ChainstateError::MinerAborted.into());
+                }
 
                 // Check if the burnchain tip has changed
                 let Ok(sort_db) = SortitionDB::open(

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -9819,7 +9819,11 @@ fn skip_mining_long_tx() {
 
             // Sleep for longer than the miner's attempt time, so that the miner will
             // mark this tx as long-running and skip it in the next attempt
-            sleep_ms(naka_conf.miner.nakamoto_attempt_time_ms + 1000);
+            sleep_ms(
+                naka_conf.miner.nakamoto_attempt_time_ms
+                    + naka_conf.miner.empty_mempool_sleep_time.as_millis() as u64
+                    + 1000,
+            );
 
             TEST_TX_STALL.set(false);
 

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -9360,10 +9360,7 @@ fn injected_signatures_are_ignored_across_boundaries() {
     }
 
     info!("---- Manually mine a single burn block to force the signers to update ----");
-    next_block_and_wait(
-        &mut signer_test.running_nodes.btc_regtest_controller,
-        &signer_test.running_nodes.counters.blocks_processed,
-    );
+    signer_test.mine_nakamoto_block(Duration::from_secs(60), true);
 
     signer_test.wait_for_registered_both_reward_cycles();
 


### PR DESCRIPTION
This defines a time that the miner should sleep after attempting to mine and finding an empty mempool.