### PR TITLE
bump version for 3.1.0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ### Added
 
+### Changed
+
+## [3.1.0.0.8]
+
+### Added
+
 - Add fee information to transaction log ending with "success" or "skipped", while building a new block
 - Add `max_execution_time_secs` to miner config for limiting duration of contract calls
 - When a miner's config file is updated (ie with a new fee rate), a new block commit is issued using

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+## [3.1.0.0.8.0]
+
 ### Changed
 
 - For some rejection reasons, a signer will reconsider a block proposal that it previously rejected ([#5880](https://github.com/stacks-network/stacks-core/pull/5880))

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.1.0.0.7"
-stacks_signer_version = "3.1.0.0.7.0"
+stacks_node_version = "3.1.0.0.8"
+stacks_signer_version = "3.1.0.0.8.0"


### PR DESCRIPTION
bumps version to 3.1.0.0.8 in:
- versions.toml
- CHANGELOG.md
- stacks-signer/CHANGELOG.md