### PR TITLE
Release workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
     needs:
       - rustfmt
       - check-release
+    secrets: inherit 
     uses: ./.github/workflows/github-release.yml
     with:
       node_tag: ${{ needs.check-release.outputs.node_tag }}

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build the binaries
         id: build
         run: |
-          cargo build
+          cargo build --bin stacks-inspect
       - name: Dump constants JSON
         id: consts-dump
         run: cargo run --bin stacks-inspect -- dump-consts | tee out.json

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -65,6 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - andon-cord
+    permissions:
+      id-token: write
+      attestations: write
     strategy:
       ## Run a maximum of 10 builds concurrently, using the matrix defined in inputs.arch
       max-parallel: 10

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -139,6 +139,7 @@ jobs:
       - andon-cord
       - build-binaries
       - create-release
+    environment: "Push to Docker"
     strategy:
       fail-fast: false
       ## Build a maximum of 2 images concurrently based on matrix.dist

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -38,9 +38,9 @@ concurrency:
 run-name: ${{ inputs.node_tag || inputs.signer_tag }}
 
 jobs:
-  ## This job's sole purpose is trigger a secondary approval outside of the matrix jobs below. 
+  ## This job's sole purpose is trigger a secondary approval outside of the matrix jobs below.
   ##   - If this job isn't approved to run, then the subsequent jobs will also not run - for this reason, we always exit 0
-  ##   - `andon-cord` requires the repo environment "Build Release", which will trigger a secondary approval step before running this workflow.  
+  ##   - `andon-cord` requires the repo environment "Build Release", which will trigger a secondary approval step before running this workflow.
   andon-cord:
     if: |
       inputs.node_tag != '' ||
@@ -135,11 +135,14 @@ jobs:
       inputs.signer_tag != ''
     name: Docker Image (Binary)
     runs-on: ubuntu-latest
+    environment: "Push to Docker"
+    permissions:
+      id-token: write
+      attestations: write
     needs:
       - andon-cord
       - build-binaries
       - create-release
-    environment: "Push to Docker"
     strategy:
       fail-fast: false
       ## Build a maximum of 2 images concurrently based on matrix.dist

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -164,7 +164,6 @@ jobs:
   ## Create the downstream PR for the release branch to master,develop
   create-pr:
     if: |
-      !contains(github.ref, '-rc') &&
       (
         inputs.node_tag != '' ||
         inputs.signer_tag != ''

--- a/.github/workflows/image-build-source.yml
+++ b/.github/workflows/image-build-source.yml
@@ -77,8 +77,7 @@ jobs:
         id: attest_primary
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
-          # subject-name: index.docker.io/${{ env.docker-org }}/${{ github.event.repository.name }}
-          subject-name:  |
+          subject-name: |
             index.docker.io/${{env.docker-org}}/${{ github.event.repository.name }}
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: true
@@ -87,8 +86,7 @@ jobs:
         id: attest_secondary
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
-          # subject-name: index.docker.io/${{ env.docker-org }}/${{ github.event.repository.name }}
-          subject-name:  |
+          subject-name: |
             index.docker.io/${{env.docker-org}}/stacks-blockchain
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/image-build-source.yml
+++ b/.github/workflows/image-build-source.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     ## Requires the repo environment "Push to Docker", which will trigger a secondary approval step before running this workflow.
     environment: "Push to Docker"
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       ## Setup Docker for the builds
       - name: Docker setup
@@ -68,3 +71,24 @@ jobs:
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
             TARGET_CPU=x86-64-v3
           push: ${{ env.DOCKER_PUSH }}
+
+      ## Generate docker image attestation(s)
+      - name: Generate artifact attestation (${{ github.event.repository.name }})
+        id: attest_primary
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          # subject-name: index.docker.io/${{ env.docker-org }}/${{ github.event.repository.name }}
+          subject-name:  |
+            index.docker.io/${{env.docker-org}}/${{ github.event.repository.name }}
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation (stacks-blockchain)
+        id: attest_secondary
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          # subject-name: index.docker.io/${{ env.docker-org }}/${{ github.event.repository.name }}
+          subject-name:  |
+            index.docker.io/${{env.docker-org}}/stacks-blockchain
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
works in conjuction with https://github.com/stacks-network/actions/pull/73

- Adds image attestation for docker images built from source
- only build `stacks-inspect` in the core-build-tests workflow to save compiling time
- Adds image attestation via https://github.com/stacks-network/actions/pull/73 for the github-release workflow (with required env checks). 

note: there are 2 approvals required for the release workflow in this PR:
1. initial approval to build the arch release binary archives
2. second approval to publish the docker images 




Example workflows using these changes and the composite changes:
stacks-core:
  https://github.com/wileyj/stacks-core/actions/runs/14383958535/job/40336789316
  https://hub.docker.com/repository/docker/wileyj/stacks-signer/tags?name=0.0.0.5.0
  https://hub.docker.com/repository/docker/wileyj/stacks-core/tags?name=0.0.0.0.5
  https://hub.docker.com/repository/docker/wileyj/stacks-blockchain/tags?name=0.0.0.0.5


signer:
  https://github.com/wileyj/stacks-core/actions/runs/14386084069
  https://hub.docker.com/repository/docker/wileyj/stacks-signer/tags?name=0.0.0.5.1


images may be attested i.e:
```
 $ gh attestation verify oci://wileyj/stacks-core:0.0.0.0.5 --repo wileyj/stacks-core --predicate-type https://slsa.dev/provenance/v1
  Loaded digest sha256:6f525b3fbbe049a88ee44797fea66930d9bc7d4a59b1ec3c671a4241386b3068 for oci://wileyj/stacks-core:0.0.0.0.5
  Loaded 2 attestations from GitHub API

  The following policy criteria will be enforced:
  - Predicate type must match:................ https://slsa.dev/provenance/v1
  - Source Repository Owner URI must match:... https://github.com/wileyj
  - Source Repository URI must match:......... https://github.com/wileyj/stacks-core
  - Subject Alternative Name must match regex: (?i)^https://github.com/wileyj/stacks-core/
  - OIDC Issuer must match:................... https://token.actions.githubusercontent.com

  ✓ Verification succeeded!

  The following 2 attestations matched the policy criteria

  - Attestation #1
    - Build repo:..... wileyj/stacks-core
    - Build workflow:. .github/workflows/ci.yml@refs/heads/release/0.0.0.0.5
    - Signer repo:.... wileyj/stacks-core
    - Signer workflow: .github/workflows/github-release.yml@refs/heads/release/0.0.0.0.5

  - Attestation #2
    - Build repo:..... wileyj/stacks-core
    - Build workflow:. .github/workflows/ci.yml@refs/heads/release/0.0.0.0.5
    - Signer repo:.... wileyj/stacks-core
    - Signer workflow: .github/workflows/github-release.yml@refs/heads/release/0.0.0.0.5

```