### PR TITLE
fix: remove unregistered signers in cleanup_stale_signers

### DIFF
--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -466,9 +466,15 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
                 // We are either the current or a future reward cycle, so we are not stale.
                 continue;
             }
-            if let ConfiguredSigner::RegisteredSigner(signer) = signer {
-                if !signer.has_unprocessed_blocks() {
-                    debug!("{signer}: Signer's tenure has completed.");
+            match signer {
+                ConfiguredSigner::RegisteredSigner(signer) => {
+                    if !signer.has_unprocessed_blocks() {
+                        debug!("{signer}: Signer's tenure has completed.");
+                        to_delete.push(*idx);
+                    }
+                }
+                ConfiguredSigner::NotRegistered { .. } => {
+                    debug!("{signer}: Unregistered signer's tenure has completed.");
                     to_delete.push(*idx);
                 }
             }


### PR DESCRIPTION
In `cleanup_stale_signers`, we remove registered signers if they don't have unprocessed blocks. We don't remove unregistered signers, which can lead to a memory leak over time. This PR removes unregistered signers in `cleanup_stale_signers`.