### PR TITLE
test: integrate pinny on stacks-node 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,11 +371,11 @@ A test should be marked `#[ignore]` if:
   2. Or, it runs for over a minute via a normal `cargo test` execution
    (the `cargo test` command will warn if this is not the case).
 
-- Integration tests need to be properly tagged using [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) crate. Tagging require two fundamental steps:
-  1. Define allowed tags in the package `Cargo.toml` file.
-  2. Use relevant tags for tests, picking from the allowd once
+- Integration tests need to be properly tagged using [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) crate. Tagging requires two fundamental steps:
+  1. Define allowed tags in the package `Cargo.toml` file (if needed).
+  2. Apply relevant tags to the tests, picking from the allowed onces.
   
-  Then will be possible to run test with filtering based on the tags using `cargo test` and `cargo nextest` runner.
+  Then will be possible to run tests with filtering based on the tags using `cargo test` and `cargo nextest` runner.
   
   For more information and examples on how tagging works, refer to the [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) readme.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,7 +375,7 @@ A test should be marked `#[ignore]` if:
   1. Define allowed tags in the package `Cargo.toml` file (if needed).
   2. Apply relevant tags to the tests, picking from the allowed set.
   
-  Then will be possible to run tests with filtering based on the tags using `cargo test` and `cargo nextest` runner.
+  Then it will be possible to run tests with filtering based on the tags using `cargo test` and `cargo nextest` runner.
   
   For more information and examples on how tagging works, refer to the [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) readme.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,16 +361,23 @@ A non-exhaustive list of examples of consensus-critical changes include:
 
 - Every consensus-critical change needs an integration test to verify that the feature activates only when the hard fork activates.
 
-PRs must include test coverage. However, if your PR includes large tests or tests which cannot run in parallel
+- PRs must include test coverage. However, if your PR includes large tests or tests which cannot run in parallel
 (which is the default operation of the `cargo test` command), these tests should be decorated with `#[ignore]`.
-
 A test should be marked `#[ignore]` if:
 
-1. It does not _always_ pass `cargo test` in a vanilla environment
+  1. It does not _always_ pass `cargo test` in a vanilla environment
    (i.e., it does not need to run with `--test-threads 1`).
 
-2. Or, it runs for over a minute via a normal `cargo test` execution
+  2. Or, it runs for over a minute via a normal `cargo test` execution
    (the `cargo test` command will warn if this is not the case).
+
+- Integration tests need to be properly tagged using [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) crate. Tagging require two fundamental steps:
+  1. Define allowed tags in the package `Cargo.toml` file.
+  2. Use relevant tags for tests, picking from the allowd once
+  
+  Then will be possible to run test with filtering based on the tags using `cargo test` and `cargo nextest` runner.
+  
+  For more information and examples on how tagging works, refer to the [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) readme.
 
 ## Formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,7 +373,7 @@ A test should be marked `#[ignore]` if:
 
 - Integration tests need to be properly tagged using [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) crate. Tagging requires two fundamental steps:
   1. Define allowed tags in the package `Cargo.toml` file (if needed).
-  2. Apply relevant tags to the tests, picking from the allowed onces.
+  2. Apply relevant tags to the tests, picking from the allowed set.
   
   Then will be possible to run tests with filtering based on the tags using `cargo test` and `cargo nextest` runner.
   

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,13 +371,20 @@ A test should be marked `#[ignore]` if:
   2. Or, it runs for over a minute via a normal `cargo test` execution
    (the `cargo test` command will warn if this is not the case).
 
-- Integration tests need to be properly tagged using [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) crate. Tagging requires two fundamental steps:
+- **Integration tests need to be properly tagged** using [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) crate. Tagging requires two fundamental steps:
   1. Define allowed tags in the package `Cargo.toml` file (if needed).
   2. Apply relevant tags to the tests, picking from the allowed set.
   
   Then it will be possible to run tests with filtering based on the tags using `cargo test` and `cargo nextest` runner.
+  > For more information and examples on how tagging works, refer to the [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) readme.
   
-  For more information and examples on how tagging works, refer to the [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) readme.
+  Below the tag set currently defined with related purpose:
+
+  | Tag             | Description                                  |
+  |-----------------|----------------------------------------------|
+  | `slow`          | tests running over a minute                  |
+  | `bitcoind`      | tests requiring bitcoin daemon               |
+  | `flaky`         | tests that exhibit flaky behavior            |
 
 ## Formatting
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,8 +2204,8 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinny"
-version = "0.0.1"
-source = "git+https://github.com/BitcoinL2-Labs/pinny-rs.git?rev=bf3a985b877adbd062513ff93f880adc6fa6443d#bf3a985b877adbd062513ff93f880adc6fa6443d"
+version = "0.0.2"
+source = "git+https://github.com/BitcoinL2-Labs/pinny-rs.git?rev=54ba9d533a7b84525a5e65a3eae1a3ae76b9ea49#54ba9d533a7b84525a5e65a3eae1a3ae76b9ea49"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,6 +2195,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pinny"
+version = "0.0.1"
+source = "git+https://github.com/BitcoinL2-Labs/pinny-rs.git?rev=0a1bf618849ceb1b965bccccebb64e44cf4b3017#0a1bf618849ceb1b965bccccebb64e44cf4b3017"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.58",
+ "thiserror",
+ "toml 0.8.20",
+]
+
+[[package]]
 name = "piper"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,6 +2918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_stacker"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,7 +3200,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "time 0.2.27",
- "toml",
+ "toml 0.5.11",
  "winapi 0.3.9",
 ]
 
@@ -3200,6 +3222,7 @@ dependencies = [
  "mockito",
  "mutants",
  "pico-args",
+ "pinny",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -3251,7 +3274,7 @@ dependencies = [
  "stackslib",
  "thiserror",
  "tiny_http",
- "toml",
+ "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3295,7 +3318,7 @@ dependencies = [
  "stx-genesis",
  "tikv-jemallocator",
  "time 0.2.27",
- "toml",
+ "toml 0.5.11",
  "url",
  "winapi 0.3.9",
 ]
@@ -3676,6 +3699,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4200,6 +4257,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,14 +2197,14 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pinny"
 version = "0.0.1"
-source = "git+https://github.com/BitcoinL2-Labs/pinny-rs.git?rev=0a1bf618849ceb1b965bccccebb64e44cf4b3017#0a1bf618849ceb1b965bccccebb64e44cf4b3017"
+source = "git+https://github.com/BitcoinL2-Labs/pinny-rs.git?rev=bf3a985b877adbd062513ff93f880adc6fa6443d#bf3a985b877adbd062513ff93f880adc6fa6443d"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
  "syn 2.0.58",
  "thiserror",
- "toml 0.8.20",
+ "toml",
 ]
 
 [[package]]
@@ -2918,15 +2918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_stacker"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,7 +3191,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "time 0.2.27",
- "toml 0.5.11",
+ "toml",
  "winapi 0.3.9",
 ]
 
@@ -3274,7 +3265,7 @@ dependencies = [
  "stackslib",
  "thiserror",
  "tiny_http",
- "toml 0.5.11",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3318,7 +3309,7 @@ dependencies = [
  "stx-genesis",
  "tikv-jemallocator",
  "time 0.2.27",
- "toml 0.5.11",
+ "toml",
  "url",
  "winapi 0.3.9",
 ]
@@ -3699,40 +3690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -4257,15 +4214,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "winnow"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -51,7 +51,7 @@ http-types = "2.12"
 tempfile = "3.3"
 mockito = "1.5"
 serial_test = "3.2.0"
-pinny = { git = "https://github.com/BitcoinL2-Labs/pinny-rs.git", rev = "0a1bf618849ceb1b965bccccebb64e44cf4b3017" } #v0.0.1
+pinny = { git = "https://github.com/BitcoinL2-Labs/pinny-rs.git", rev = "bf3a985b877adbd062513ff93f880adc6fa6443d" } #v0.0.2
 
 [[bin]]
 name = "stacks-node"

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -51,6 +51,7 @@ http-types = "2.12"
 tempfile = "3.3"
 mockito = "1.5"
 serial_test = "3.2.0"
+pinny = { git = "https://github.com/BitcoinL2-Labs/pinny-rs.git", rev = "0a1bf618849ceb1b965bccccebb64e44cf4b3017" } #v0.0.1
 
 [[bin]]
 name = "stacks-node"
@@ -66,3 +67,6 @@ slog_json = ["stacks/slog_json", "stacks-common/slog_json", "clarity/slog_json"]
 prod-genesis-chainstate = []
 default = []
 testing = []
+
+[package.metadata.pinny] 
+allowed = ["fast", "slow", "signer", "bitcoind"]

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -51,7 +51,7 @@ http-types = "2.12"
 tempfile = "3.3"
 mockito = "1.5"
 serial_test = "3.2.0"
-pinny = { git = "https://github.com/BitcoinL2-Labs/pinny-rs.git", rev = "bf3a985b877adbd062513ff93f880adc6fa6443d" } #v0.0.2
+pinny = { git = "https://github.com/BitcoinL2-Labs/pinny-rs.git", rev = "54ba9d533a7b84525a5e65a3eae1a3ae76b9ea49" } #v0.0.2
 madhouse = { git = "https://github.com/stacks-network/madhouse-rs.git", rev = "fc651ddcbaf85e888b06d4a87aa788c4b7ba9309" }
 proptest = { git = "https://github.com/proptest-rs/proptest.git", rev = "c9bdf18c232665b2b740c667c81866b598d06dc7" }
 

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -71,4 +71,4 @@ default = []
 testing = []
 
 [package.metadata.pinny] 
-allowed = ["fast", "slow", "signer", "bitcoind"]
+allowed = ["bitcoind", "flaky", "slow"]

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -13,6 +13,7 @@ use clarity::vm::types::{
 };
 use clarity::vm::{ClarityVersion, Value};
 use lazy_static::lazy_static;
+use pinny::tag;
 use reqwest;
 use serde_json::json;
 use stacks::burnchains::Address;
@@ -41,7 +42,7 @@ use stacks::net::api::getistraitimplemented::GetIsTraitImplementedResponse;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId, VRFSeed};
 use stacks_common::util::hash::{hex_bytes, to_hex, Sha256Sum};
 
-use super::{ADDR_4, SK_1, SK_2, SK_3};
+use super::{new_test_conf, ADDR_4, SK_1, SK_2, SK_3};
 use crate::helium::RunLoop;
 
 const OTHER_CONTRACT: &str = "
@@ -162,10 +163,11 @@ lazy_static! {
     static ref HTTP_BINDING: Mutex<Option<String>> = Mutex::new(None);
 }
 
+#[tag(slow)]
 #[test]
 #[ignore]
 fn integration_test_get_info() {
-    let mut conf = super::new_test_conf();
+    let mut conf = new_test_conf();
     let spender_addr = to_addr(&StacksPrivateKey::from_hex(SK_3).unwrap()).into();
     let principal_sk = StacksPrivateKey::from_hex(SK_2).unwrap();
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
@@ -1086,9 +1088,10 @@ const FAUCET_CONTRACT: &str = "
       (print (as-contract (stx-transfer? u1 .faucet recipient)))))
 ";
 
+#[tag(slow)]
 #[test]
 fn contract_stx_transfer() {
-    let mut conf = super::new_test_conf();
+    let mut conf = new_test_conf();
 
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();
@@ -1452,7 +1455,7 @@ fn contract_stx_transfer() {
 
 #[test]
 fn mine_transactions_out_of_order() {
-    let mut conf = super::new_test_conf();
+    let mut conf = new_test_conf();
 
     let sk = StacksPrivateKey::from_hex(SK_3).unwrap();
     let addr = to_addr(&sk);
@@ -1624,7 +1627,7 @@ fn mine_transactions_out_of_order() {
 ///   in the block it was processed for. Tests issue #1540
 #[test]
 fn mine_contract_twice() {
-    let mut conf = super::new_test_conf();
+    let mut conf = new_test_conf();
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
 
     conf.burnchain.commit_anchor_block_within = 1000;
@@ -1710,7 +1713,7 @@ fn mine_contract_twice() {
 
 #[test]
 fn bad_contract_tx_rollback() {
-    let mut conf = super::new_test_conf();
+    let mut conf = new_test_conf();
 
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
@@ -1994,7 +1997,7 @@ fn make_keys(seed: &str, count: u64) -> Vec<StacksPrivateKey> {
 
 #[test]
 fn block_limit_runtime_test() {
-    let mut conf = super::new_test_conf();
+    let mut conf = new_test_conf();
 
     conf.burnchain.epochs = Some(EpochList::new(&[
         StacksEpoch {
@@ -2179,7 +2182,7 @@ fn block_limit_runtime_test() {
 
 #[test]
 fn mempool_errors() {
-    let mut conf = super::new_test_conf();
+    let mut conf = new_test_conf();
 
     conf.burnchain.commit_anchor_block_within = 5000;
 

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -29,6 +29,7 @@ use libsigner::v0::messages::{
 use libsigner::{
     BlockProposal, BlockProposalData, SignerSession, StackerDBSession, VERSION_STRING,
 };
+use pinny::tag;
 use rand::{thread_rng, Rng};
 use rusqlite::Connection;
 use stacks::address::AddressHashMode;
@@ -1434,6 +1435,7 @@ pub fn wait_for_state_machine_update(
     })
 }
 
+#[tag(fast, signer, bitcoind)]
 #[test]
 #[ignore]
 /// Test that a signer can respond to an invalid block proposal

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -1488,7 +1488,7 @@ pub fn wait_for_state_machine_update(
     })
 }
 
-#[tag(fast, signer, bitcoind)]
+#[tag(bitcoind)]
 #[test]
 #[ignore]
 /// Test that a signer can respond to an invalid block proposal
@@ -10122,6 +10122,7 @@ fn multiple_miners_empty_sortition() {
     miners.shutdown();
 }
 
+#[tag(bitcoind, flaky, slow)]
 #[test]
 #[ignore]
 /// This test spins up a single nakamoto node configured to mine.


### PR DESCRIPTION
### Description

Integrate [pinny](https://github.com/BitcoinL2-Labs/pinny-rs.git) crate on `stacks-node` package.

Added a demo configuration about tag labels and tagged tests.

Here an example of test filtering  and execution using `cargo test`:

- run "slow" tests
  ```bash
  cargo test -p stacks-node :slow:
  ...
  running 2 tests
  
  test tests::signer::v0::block_proposal_rejection::t::slow::signer::bitcoind::t ... ignored
  test tests::integrations::contract_stx_transfer::t::slow::t ... ok
  
  test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 251 filtered out; finished in 26.05s
  ```
- run "fast" tests
  ```bash
  cargo test -p stacks-node :fast:
  
  running 1 tests
  
  test tests::signer::v0::block_proposal_rejection::t::fast::signer::bitcoind::t ... ok
  
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 252 filtered out; finished in 0.14s
  ```

### Applicable issues

- fixes #6033

### Additional info (benefits, drawbacks, caveats)

#### Drawback
In specific cases, because of test function mangling is not possible to use `super::<symbol>` within a test function. Full description of this drawbacks can be found here: https://github.com/BitcoinL2-Labs/pinny-rs/blob/master/README.md.
(easy fixable as proposed in the current change, importing the symbol properly outside the test function)

#### Tag Naming
~~One thing to notice is the tag "signer". By the fact it is not unique due to the module path where "signer" is a real module name,   we have 2 options:~~
- ~~filtering test using anti-clash mechanism using expression (like t::*:signer). Note: not possible with `cargo test`, but possible with nextest~~
- ~~Make the tag "unique" (e.g. "_signer", "tsigner").~~

_**EDIT1**: Maybe not a an issue because if filter by "signer" probably one wants to execute all the tests related to signers anyway._

_**EDIT2**: here follow a tag proposal, after some reasoning_
#### Tags Proposal
List of tags (non-exhaustive) that we could use, with related meaning and potential benefits:

| Tag             | Description                                  | Benefits                      |
|-----------------|----------------------------------------------|--------------------------------|
| `fast`(1)       | tests running withing a minute               | easy filtering tests opposed to `slow`. With nextest we could write `'!(test(name =~ "slow"))'` expression |
| `slow`          | tests running over a minute                  | avoid the use of `#[ignore]` as described in contributing page |
| `bitcoind`      | tests requiring bitcoin daemon               | avoid the use of `#[ignore]` and the code check for `BITCOIND_TEST` env variable within the test |
| `flaky`         | tests that are consistently flaky            | highlighting flaky tests and make them filter friendly |
| `sequential`(2) | tests requiring sequential execution         | avoid the use of `#[ignore]` as described in contributing page |
| `parallel`(1)   | tests supporting parallel execution          | easy filtering tests opposed to `sequential`. With nextest we could write `'!(test(name =~ "sequential"))'` expression | 
| `miner` (3)     | tests targeting miner as primary scenario    | easy filtering tests that validate miner behavior | 
| `signer` (3)    | tests targeting signer as primary scenario   | easy filtering tests that validate signer behavior | 

> **(1)**: `fast` and `parallel` are not really required if we opt to use `not` expression using `nextest`
> So, avoiding them will be good to have less tags (or at least avoiding the ones that could be redundant somehow).
> On the other side, having them allow "easy" filtering (working also with `cargo test`).

> **(2)**: Instead of marking the test with tag `sequential` and handle them with dedicated filter, we could also evaluate the usage of the [serial](https://crates.io/crates/serial_test) crate that enforce test sequential execution at runtime.
> I have used it for some tests in `pinny-rs`([here](https://github.com/BitcoinL2-Labs/pinny-rs/blob/54ba9d533a7b84525a5e65a3eae1a3ae76b9ea49/src/tests/config_test.rs)).
> Obviously tagging them will allow us to extract all tests with that label (using `--list` option on `cargo test` or `nextest`), but we need to explicitly handle runtime execution with proper configuration on the runner.

> **(3)**: Eventually avoidable splitting tests with proper module path (e.g. as signer tests are managed today).

Once this tag proposal becomes consistent, we can update the [contributing](https://github.com/stacks-network/stacks-core/blob/develop/CONTRIBUTING.md#testing) page accordingly.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
