### PR TITLE
Perf: improve next_ready_nakamoto_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Changed
 
 - Reduce the default `block_rejection_timeout_steps` configuration so that miners will retry faster when blocks fail to reach 70% approved or 30% rejected.
+- Added index for `next_ready_nakamoto_block()` which improves block processing performance.
 
 ## [3.1.0.0.8]
 

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -160,7 +160,12 @@ pub const NAKAMOTO_STAGING_DB_SCHEMA_3: &[&str] = &[
     r#"UPDATE db_version SET version = 3"#,
 ];
 
-pub const NAKAMOTO_STAGING_DB_SCHEMA_LATEST: u32 = 3;
+pub const NAKAMOTO_STAGING_DB_SCHEMA_4: &[&str] = &[
+    r#"CREATE INDEX nakamoto_staging_blocks_by_ready_and_height ON nakamoto_staging_blocks(burn_attachable, orphaned, processed, height);"#,
+    r#"UPDATE db_version SET version = 4"#,
+];
+
+pub const NAKAMOTO_STAGING_DB_SCHEMA_LATEST: u32 = 4;
 
 pub struct NakamotoStagingBlocksConn(rusqlite::Connection);
 
@@ -794,6 +799,15 @@ impl StacksChainState {
                     }
                     let version = Self::get_nakamoto_staging_blocks_db_version(conn)?;
                     assert_eq!(version, 3, "Nakamoto staging DB migration failure");
+                    debug!("Migrated Nakamoto staging blocks DB to schema 3");
+                }
+                3 => {
+                    debug!("Migrate Nakamoto staging blocks DB to schema 3");
+                    for cmd in NAKAMOTO_STAGING_DB_SCHEMA_4.iter() {
+                        conn.execute(cmd, NO_PARAMS)?;
+                    }
+                    let version = Self::get_nakamoto_staging_blocks_db_version(conn)?;
+                    assert_eq!(version, 4, "Nakamoto staging DB migration failure");
                     debug!("Migrated Nakamoto staging blocks DB to schema 3");
                 }
                 NAKAMOTO_STAGING_DB_SCHEMA_LATEST => {


### PR DESCRIPTION
This adds an index for the SQLite lookup that `next_ready_nakamoto_block()` requires. This improves block processing speeds  by replacing what was a scan with an indexed search.