### PR TITLE
feat: add parent_burn_block_hash to /new_burn_block payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Changed
 
 - Reduce the default `block_rejection_timeout_steps` configuration so that miners will retry faster when blocks fail to reach 70% approved or 30% rejected.
+- Added a new field, `parent_burn_block_hash`, to the payload that is included in the `/new_burn_block` event observer payload.
 
 ## [3.1.0.0.8]
 
@@ -25,7 +26,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 - When a miner times out waiting for signatures, it will re-propose the same block instead of building a new block ([#5877](https://github.com/stacks-network/stacks-core/pull/5877))
 - Improve tenure downloader trace verbosity applying proper logging level depending on the tenure state ("debug" if unconfirmed, "info" otherwise) ([#5871](https://github.com/stacks-network/stacks-core/issues/5871))
-- Remove warning log about missing UTXOs when a node is configured as `miner` with `mock_mining` mode enabled ([#5841](https://github.com/stacks-network/stacks-core/issues/5841)) 
+- Remove warning log about missing UTXOs when a node is configured as `miner` with `mock_mining` mode enabled ([#5841](https://github.com/stacks-network/stacks-core/issues/5841))
 - Deprecated the `wait_on_interim_blocks` option in the miner config file. This option is no longer needed, as the miner will always wait for interim blocks to be processed before mining a new block. To wait extra time in between blocks, use the `min_time_between_blocks_ms` option instead. ([#5979](https://github.com/stacks-network/stacks-core/pull/5979))
 - Added `empty_mempool_sleep_ms` to the miner config file to control the time to wait in between mining attempts when the mempool is empty. If not set, the default sleep time is 2.5s. ([#5997](https://github.com/stacks-network/stacks-core/pull/5997))
 

--- a/docs/event-dispatcher.md
+++ b/docs/event-dispatcher.md
@@ -27,13 +27,13 @@ These events are sent to the configured endpoint at two URLs:
 This payload includes data related to a newly processed block,
 and any events emitted from Stacks transactions during the block.
 
-If the transaction originally comes from the parent microblock stream 
+If the transaction originally comes from the parent microblock stream
 preceding this block, the microblock related fields will be filled in.
 
 If the `raw_tx` field for a particular transaction is "0x00", that indicates
-that it is a burnchain operation. A burnchain operation is a transaction that 
+that it is a burnchain operation. A burnchain operation is a transaction that
 is executed on the Stacks network, but was sent through the Bitcoin network.
-The Stacks network supports a few specific burnchain operations. You can read 
+The Stacks network supports a few specific burnchain operations. You can read
 more about them [here](https://github.com/stacksgov/sips/blob/main/sips/sip-007/sip-007-stacking-consensus.md#stx-operations-on-bitcoin).
 The section below has example json encodings for each of the burnchain operations.
 
@@ -152,8 +152,8 @@ Example:
 }
 ```
 
-#### Example json values for burnchain operations 
-- TransferStx 
+#### Example json values for burnchain operations
+- TransferStx
 ```json
 {
   "transfer_stx": {
@@ -233,6 +233,8 @@ Example:
 ```json
 {
   "burn_block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
+  "consensus_hash": "0x53c166a709a9abd64a92a57f928a8b26aad08992",
+  "parent_burn_block_hash": "0x6eaebcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
   "burn_block_height": 331,
   "reward_recipients": [
     {
@@ -258,8 +260,8 @@ Example:
 
 ### `POST /new_microblocks`
 
-This payload includes data related to one or more microblocks that are either emmitted by the 
-node itself, or received through the network. 
+This payload includes data related to one or more microblocks that are either emmitted by the
+node itself, or received through the network.
 
 Example:
 
@@ -311,9 +313,9 @@ Example:
 }
 ```
 
-* `burn_block_{}` are the stats related to the burn block that is associated with the stacks 
+* `burn_block_{}` are the stats related to the burn block that is associated with the stacks
   block that precedes this microblock stream.
-* Each transaction json object includes information about the microblock the transaction was packaged into. 
+* Each transaction json object includes information about the microblock the transaction was packaged into.
 
 ### `POST /new_mempool_tx`
 
@@ -384,23 +386,23 @@ Example:
   "tx_events": [
     {
       "Success": {
-        "txid": "3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6", 
-        "fee": 0, 
-        "execution_cost": { 
-          "write_length": 0, 
-          "write_count": 0, 
-          "read_length": 0, 
-          "read_count": 0, 
+        "txid": "3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6",
+        "fee": 0,
+        "execution_cost": {
+          "write_length": 0,
+          "write_count": 0,
+          "read_length": 0,
+          "read_count": 0,
           "runtime": 0
-        }, 
+        },
         "result": {
-          "ResponseData": 
+          "ResponseData":
           {
             "committed": true,
             "data": true
           }
         }
-    }}, 
+    }},
     {
       "ProcessingError": {
         "txid": "eef9f46b20fb637bd07ec92ad3ec175a5a4bdf3e8799259fc5b16a272090d4de",
@@ -432,23 +434,23 @@ Example:
   "tx_events": [
     {
       "Success": {
-        "txid": "3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6", 
-        "fee": 0, 
-        "execution_cost": { 
-          "write_length": 10, 
-          "write_count": 10, 
-          "read_length": 20, 
-          "read_count": 10, 
+        "txid": "3e04ada5426332bfef446ba0a06d124aace4ade5c11840f541bf88e2e919faf6",
+        "fee": 0,
+        "execution_cost": {
+          "write_length": 10,
+          "write_count": 10,
+          "read_length": 20,
+          "read_count": 10,
           "runtime": 1290
-        }, 
+        },
         "result": {
-          "ResponseData": 
+          "ResponseData":
           {
             "committed": true,
             "data": true
           }
         }
-    }}, 
+    }},
     {
       "Skipped": {
         "txid": "eef9f46b20fb637bd07ec92ad3ec175a5a4bdf3e8799259fc5b16a272090d4de",

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -195,6 +195,7 @@ pub trait BlockEventDispatcher {
         burns: u64,
         reward_recipients: Vec<PoxAddress>,
         consensus_hash: &ConsensusHash,
+        parent_burn_block_hash: &BurnchainHeaderHash,
     );
 }
 
@@ -964,6 +965,7 @@ pub fn dispatcher_announce_burn_ops<T: BlockEventDispatcher>(
         paid_rewards.burns,
         recipients,
         consensus_hash,
+        &burn_header.parent_block_hash,
     );
 }
 

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -446,6 +446,7 @@ impl BlockEventDispatcher for NullEventDispatcher {
         _burns: u64,
         _slot_holders: Vec<PoxAddress>,
         _consensus_hash: &ConsensusHash,
+        _parent_burn_block_hash: &BurnchainHeaderHash,
     ) {
     }
 }

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -205,6 +205,7 @@ impl BlockEventDispatcher for DummyEventDispatcher {
         _burns: u64,
         _slot_holders: Vec<PoxAddress>,
         _consensus_hash: &ConsensusHash,
+        _parent_burn_block_hash: &BurnchainHeaderHash,
     ) {
         error!("We should never try to announce to the dummy dispatcher");
         panic!();

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -2576,6 +2576,7 @@ pub mod test {
             _burns: u64,
             _reward_recipients: Vec<PoxAddress>,
             _consensus_hash: &ConsensusHash,
+            _parent_burn_block_hash: &BurnchainHeaderHash,
         ) {
             // pass
         }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -547,6 +547,7 @@ impl EventObserver {
         burns: u64,
         slot_holders: Vec<PoxAddress>,
         consensus_hash: &ConsensusHash,
+        parent_burn_block_hash: &BurnchainHeaderHash,
     ) -> serde_json::Value {
         let reward_recipients = rewards
             .into_iter()
@@ -570,6 +571,7 @@ impl EventObserver {
             "reward_slot_holders": serde_json::Value::Array(reward_slot_holders),
             "burn_amount": burns,
             "consensus_hash": format!("0x{consensus_hash}"),
+            "parent_burn_block_hash": format!("0x{parent_burn_block_hash}"),
         })
     }
 
@@ -1062,6 +1064,7 @@ impl BlockEventDispatcher for EventDispatcher {
         burns: u64,
         recipient_info: Vec<PoxAddress>,
         consensus_hash: &ConsensusHash,
+        parent_burn_block_hash: &BurnchainHeaderHash,
     ) {
         self.process_burn_block(
             burn_block,
@@ -1070,6 +1073,7 @@ impl BlockEventDispatcher for EventDispatcher {
             burns,
             recipient_info,
             consensus_hash,
+            parent_burn_block_hash,
         )
     }
 }
@@ -1114,6 +1118,7 @@ impl EventDispatcher {
         burns: u64,
         recipient_info: Vec<PoxAddress>,
         consensus_hash: &ConsensusHash,
+        parent_burn_block_hash: &BurnchainHeaderHash,
     ) {
         // lazily assemble payload only if we have observers
         let interested_observers = self.filter_observers(&self.burn_block_observers_lookup, true);
@@ -1128,6 +1133,7 @@ impl EventDispatcher {
             burns,
             recipient_info,
             consensus_hash,
+            parent_burn_block_hash,
         );
 
         for observer in interested_observers.iter() {

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -10625,10 +10625,26 @@ fn consensus_hash_event_dispatcher() {
     let expected_consensus_hash = format!("0x{}", tip.consensus_hash);
 
     let burn_blocks = test_observer::get_burn_blocks();
+    let parent_burn_block = burn_blocks.get(burn_blocks.len() - 2).unwrap();
     let burn_block = burn_blocks.last().unwrap();
     assert_eq!(
         burn_block.get("consensus_hash").unwrap().as_str().unwrap(),
         expected_consensus_hash
+    );
+
+    let parent_burn_block_hash = parent_burn_block
+        .get("burn_block_hash")
+        .unwrap()
+        .as_str()
+        .unwrap();
+
+    assert_eq!(
+        burn_block
+            .get("parent_burn_block_hash")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        parent_burn_block_hash
     );
 
     let stacks_blocks = test_observer::get_blocks();


### PR DESCRIPTION
This adds a new field, `parent_burn_block_hash`, to the event observer payload for `/new_burn_block`. This will be used in https://github.com/stacks-network/stacks-core/pull/6020 to efficiently find forked btc blocks.