### PR TITLE
Perf: faster readonly MARF

### DIFF
--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -2071,15 +2071,15 @@ impl<'a> SortitionHandleConn<'a> {
         connection: &'a SortitionDBConn<'a>,
         chain_tip: &SortitionId,
     ) -> Result<SortitionHandleConn<'a>, db_error> {
-        Ok(SortitionHandleConn {
-            context: SortitionHandleContext {
+        Ok(SortitionHandleConn::new(
+            &connection.index,
+            SortitionHandleContext {
                 chain_tip: chain_tip.clone(),
                 first_block_height: connection.context.first_block_height,
                 pox_constants: connection.context.pox_constants.clone(),
                 dryrun: connection.context.dryrun,
             },
-            index: connection.index,
-        })
+        ))
     }
 
     fn get_tip_indexed(&self, key: &str) -> Result<Option<String>, db_error> {
@@ -3766,15 +3766,15 @@ impl SortitionDBTx<'_> {
 
 impl SortitionDBConn<'_> {
     pub fn as_handle<'b>(&'b self, chain_tip: &SortitionId) -> SortitionHandleConn<'b> {
-        SortitionHandleConn {
-            index: self.index,
-            context: SortitionHandleContext {
+        SortitionHandleConn::new(
+            &self.index,
+            SortitionHandleContext {
                 first_block_height: self.context.first_block_height.clone(),
                 chain_tip: chain_tip.clone(),
                 pox_constants: self.context.pox_constants.clone(),
                 dryrun: self.context.dryrun,
             },
-        }
+        )
     }
 
     /// Given a burnchain consensus hash,

--- a/stackslib/src/clarity_vm/database/marf.rs
+++ b/stackslib/src/clarity_vm/database/marf.rs
@@ -263,10 +263,7 @@ impl MarfedKV {
     }
 
     pub fn index_conn<C>(&self, context: C) -> IndexDBConn<'_, C, StacksBlockId> {
-        IndexDBConn {
-            index: &self.marf,
-            context,
-        }
+        IndexDBConn::new(&self.marf, context)
     }
 }
 

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -613,13 +613,13 @@ impl<'a, C, T: MarfTrieId> IndexDBConn<'a, C, T> {
         ancestor_block_hash: &T,
         tip_block_hash: &T,
     ) -> Result<Option<u64>, Error> {
-        get_ancestor_block_height(self.index, ancestor_block_hash, tip_block_hash)
+        get_ancestor_block_height(&self.index, ancestor_block_hash, tip_block_hash)
     }
 
     /// Get a value from the fork index
     pub fn get_indexed(&self, header_hash: &T, key: &str) -> Result<Option<String>, Error> {
-        let mut ro_index = self.index.reopen_readonly()?;
-        get_indexed(&mut ro_index, header_hash, key)
+        let mut connection = self.index.reopen_connection()?;
+        get_indexed(&mut connection, header_hash, key)
     }
 
     pub fn conn(&self) -> &DBConn {
@@ -727,7 +727,7 @@ pub fn get_ancestor_block_hash<T: MarfTrieId>(
     tip_block_hash: &T,
 ) -> Result<Option<T>, Error> {
     assert!(block_height <= u32::MAX as u64);
-    let mut read_only = index.reopen_readonly()?;
+    let mut read_only = index.reopen_connection()?;
     let bh = read_only.get_block_at_height(block_height as u32, tip_block_hash)?;
     Ok(bh)
 }
@@ -738,7 +738,7 @@ pub fn get_ancestor_block_height<T: MarfTrieId>(
     ancestor_block_hash: &T,
     tip_block_hash: &T,
 ) -> Result<Option<u64>, Error> {
-    let mut read_only = index.reopen_readonly()?;
+    let mut read_only = index.reopen_connection()?;
     let height_opt = read_only
         .get_block_height(ancestor_block_hash, tip_block_hash)?
         .map(|height| height as u64);


### PR DESCRIPTION
This performance improvement PR adds a new MARF connection implementation which "reopens" the transient data portions of the MARF connection (i.e., the tip pointer) so that indexed gets do not need to have a mutable pointer. This improves over the prior version which reopened the whole MARF struct: the reopened connection struct reuses the existing SQLite connection. Based on perf data, I think this should primarily impact performance in the p2p thread, where there were several hotpaths bottlenecked on `reopen_readonly()` invocations.