### PR TITLE
Fix: flaky `net::tests::convergence` tests

### DIFF
--- a/stackslib/src/net/tests/convergence.rs
+++ b/stackslib/src/net/tests/convergence.rs
@@ -1053,6 +1053,45 @@ fn run_topology_test_ex<F>(
             (100.0 * (peer_counts as f64)) / ((peer_count * peer_count) as f64),
         );
 
+        // wait for stacker DBs to converge
+        for (i, peer) in peers.iter().enumerate() {
+            if i % 2 != 0 {
+                continue;
+            }
+            for (j, other_peer) in peers.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+
+                let all_neighbors =
+                    PeerDB::get_all_peers(other_peer.network.peerdb.conn()).unwrap();
+
+                if (all_neighbors.len() as u64) < ((peer_count - 1) as u64) {
+                    // this is a simulated-NAT'ed node -- it won't learn about other NAT'ed nodes'
+                    // DBs
+                    continue;
+                }
+
+                if j % 2 != 0 {
+                    continue; // this peer doesn't support Stacker DBs
+                }
+                let dbs = peer
+                    .network
+                    .peerdb
+                    .get_peer_stacker_dbs(&other_peer.config.to_neighbor())
+                    .unwrap();
+                if dbs.is_empty() {
+                    test_debug!(
+                        "waiting for peer {i} {} to learn about peer {j} {}'s stacker DBs",
+                        &peer.config.to_neighbor(),
+                        &other_peer.config.to_neighbor()
+                    );
+                    finished = false;
+                    break;
+                }
+            }
+        }
+
         if finished {
             break;
         }

--- a/stackslib/src/net/tests/convergence.rs
+++ b/stackslib/src/net/tests/convergence.rs
@@ -52,7 +52,7 @@ fn stacker_db_id(i: usize) -> QualifiedContractIdentifier {
 
 fn make_stacker_db_ids(i: usize) -> Vec<QualifiedContractIdentifier> {
     let mut dbs = vec![];
-    for j in 0..i {
+    for j in 0..i+1 {
         dbs.push(stacker_db_id(j));
     }
     dbs

--- a/stackslib/src/net/tests/convergence.rs
+++ b/stackslib/src/net/tests/convergence.rs
@@ -52,7 +52,7 @@ fn stacker_db_id(i: usize) -> QualifiedContractIdentifier {
 
 fn make_stacker_db_ids(i: usize) -> Vec<QualifiedContractIdentifier> {
     let mut dbs = vec![];
-    for j in 0..i+1 {
+    for j in 0..i + 1 {
         dbs.push(stacker_db_id(j));
     }
     dbs


### PR DESCRIPTION
### Description
~~If my read of these tests is correct, we are just looking for convergence, and these tests should not be testing the pruning of neighbors, so it is best to set these soft max values to be the same as the total number of peers to avoid any non-deterministic pruning. The pruning should be tested elsewhere.~~ See later comments and fixes.

### Applicable issues

- fixes #5761
- fixes #5758
- fixes #5780