### PR TITLE
chore: adjust code owners for this branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,20 +1,3 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @stacks-network/blockchain-team-codeowners will be requested for
-# review when someone opens a pull request.
-* @stacks-network/blockchain-team-codeowners
-
-# Generic file extensions that shouldn't require much scrutiny. Anyone with write access to the repo may approve a PR
-*.md @stacks-network/blockchain-team
-*.yml @stacks-network/blockchain-team
-*.yaml @stacks-network/blockchain-team
-*.txt @stacks-network/blockchain-team
-*.toml @stacks-network/blockchain-team
-
-# Signer code
-libsigner/**/*.rs @stacks-network/blockchain-team-signer
-stacks-signer/**/*.rs @stacks-network/blockchain-team-signer
-
-# CI workflows
-/.github/workflows/ @stacks-network/blockchain-team-ci
-/.github/actions/ @stacks-network/blockchain-team-ci
+# For this branch (`feat/clarity-wasm-develop`) the code owners are simplified
+# to only require approvals from the Clarity Wasm team.
+* @stacks-network/clarity-wasm


### PR DESCRIPTION
This will allow the rules to be adjusted so that PRs to this branch only require approvals from the Clarity Wasm team.