### PR TITLE
Fix/6074

### DIFF
--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build the binaries
         id: build
         run: |
-          cargo build --release
+          cargo build
       - name: Dump constants JSON
         id: consts-dump
         run: cargo run --bin stacks-inspect -- dump-consts | tee out.json

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build the binaries
         id: build
         run: |
-          cargo build --bin stacks-inspect
+          cargo build --release
       - name: Dump constants JSON
         id: consts-dump
         run: cargo run --bin stacks-inspect -- dump-consts | tee out.json


### PR DESCRIPTION
Modifies the core build test workflow to build all binaries. 
When merged, this workflow should be a required step in order to catch any compile issues not using the test profile

https://github.com/stacks-network/stacks-core/issues/6072

closes #6074 