### PR TITLE
Perf: 2.0 syncing speedup

### DIFF
--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -294,15 +294,15 @@ impl DBConfig {
         });
         match epoch_id {
             StacksEpochId::Epoch10 => true,
-            StacksEpochId::Epoch20 => version_u32 >= 1 && version_u32 <= 8,
-            StacksEpochId::Epoch2_05 => version_u32 >= 2 && version_u32 <= 8,
-            StacksEpochId::Epoch21 => version_u32 >= 3 && version_u32 <= 8,
-            StacksEpochId::Epoch22 => version_u32 >= 3 && version_u32 <= 8,
-            StacksEpochId::Epoch23 => version_u32 >= 3 && version_u32 <= 8,
-            StacksEpochId::Epoch24 => version_u32 >= 3 && version_u32 <= 8,
-            StacksEpochId::Epoch25 => version_u32 >= 3 && version_u32 <= 8,
-            StacksEpochId::Epoch30 => version_u32 >= 3 && version_u32 <= 8,
-            StacksEpochId::Epoch31 => version_u32 >= 3 && version_u32 <= 8,
+            StacksEpochId::Epoch20 => version_u32 >= 1 && version_u32 <= 9,
+            StacksEpochId::Epoch2_05 => version_u32 >= 2 && version_u32 <= 9,
+            StacksEpochId::Epoch21 => version_u32 >= 3 && version_u32 <= 9,
+            StacksEpochId::Epoch22 => version_u32 >= 3 && version_u32 <= 9,
+            StacksEpochId::Epoch23 => version_u32 >= 3 && version_u32 <= 9,
+            StacksEpochId::Epoch24 => version_u32 >= 3 && version_u32 <= 9,
+            StacksEpochId::Epoch25 => version_u32 >= 3 && version_u32 <= 9,
+            StacksEpochId::Epoch30 => version_u32 >= 3 && version_u32 <= 9,
+            StacksEpochId::Epoch31 => version_u32 >= 3 && version_u32 <= 9,
         }
     }
 }
@@ -654,7 +654,7 @@ impl<'a> DerefMut for ChainstateTx<'a> {
     }
 }
 
-pub const CHAINSTATE_VERSION: &str = "8";
+pub const CHAINSTATE_VERSION: &str = "9";
 
 const CHAINSTATE_INITIAL_SCHEMA: &[&str] = &[
     "PRAGMA foreign_keys = ON;",
@@ -853,6 +853,15 @@ const CHAINSTATE_SCHEMA_3: &[&str] = &[
     "#,
 ];
 
+const CHAINSTATE_SCHEMA_4: &[&str] = &[
+    // schema change is JUST a new index, so just bump db_config.version
+    //   and add the index to `CHAINSTATE_INDEXES` (which gets re-execed
+    //   on every schema change)
+    r#"
+    UPDATE db_config SET version = "9";
+    "#,
+];
+
 const CHAINSTATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS index_block_hash_to_primary_key ON block_headers(index_block_hash,consensus_hash,block_hash);",
     "CREATE INDEX IF NOT EXISTS block_headers_hash_index ON block_headers(block_hash,block_height);",
@@ -877,6 +886,7 @@ const CHAINSTATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS index_block_header_by_affirmation_weight ON block_headers(affirmation_weight);",
     "CREATE INDEX IF NOT EXISTS index_block_header_by_height_and_affirmation_weight ON block_headers(block_height,affirmation_weight);",
     "CREATE INDEX IF NOT EXISTS index_headers_by_consensus_hash ON block_headers(consensus_hash);",
+    "CREATE INDEX IF NOT EXISTS processable_block ON staging_blocks(processed, orphaned, attachable);",
 ];
 
 pub use stacks_common::consts::MINER_REWARD_MATURITY;
@@ -1101,6 +1111,14 @@ impl StacksChainState {
                         "Migrating chainstate schema from version 7 to 8: add index for nakamoto block headers"
                     );
                     for cmd in NAKAMOTO_CHAINSTATE_SCHEMA_5.iter() {
+                        tx.execute_batch(cmd)?;
+                    }
+                }
+                "8" => {
+                    info!(
+                        "Migrating chainstate schema from version 8 to 9: add index for staging_blocks"
+                    );
+                    for cmd in CHAINSTATE_SCHEMA_4.iter() {
                         tx.execute_batch(cmd)?;
                     }
                 }

--- a/stackslib/src/chainstate/stacks/index/cache.rs
+++ b/stackslib/src/chainstate/stacks/index/cache.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::char::from_digit;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write};
@@ -135,6 +136,11 @@ impl<T: MarfTrieId> TrieCacheState<T> {
     /// Load up a block hash, given its ID
     pub fn load_block_hash(&self, block_id: u32) -> Option<T> {
         self.block_hash_cache.get(&block_id).cloned()
+    }
+
+    /// Return the HashMap Entry for a block_id
+    pub fn entry_block_hash(&mut self, block_id: u32) -> Entry<'_, u32, T> {
+        self.block_hash_cache.entry(block_id)
     }
 
     /// Cache a block hash, given its ID
@@ -307,6 +313,11 @@ impl<T: MarfTrieId> TrieCache<T> {
     /// Load a block's hash, given its block ID.
     pub fn load_block_hash(&mut self, block_id: u32) -> Option<T> {
         self.state_mut().load_block_hash(block_id)
+    }
+
+    /// Get entry for a block hash, given its ID
+    pub fn entry_block_hash<'a>(&'a mut self, block_id: u32) -> Entry<'a, u32, T> {
+        self.state_mut().entry_block_hash(block_id)
     }
 
     /// Store a block's ID and hash to teh cache.

--- a/stackslib/src/chainstate/stacks/index/cache.rs
+++ b/stackslib/src/chainstate/stacks/index/cache.rs
@@ -138,9 +138,23 @@ impl<T: MarfTrieId> TrieCacheState<T> {
         self.block_hash_cache.get(&block_id).cloned()
     }
 
-    /// Return the HashMap Entry for a block_id
-    pub fn entry_block_hash(&mut self, block_id: u32) -> Entry<'_, u32, T> {
-        self.block_hash_cache.entry(block_id)
+    /// Get cached entry for a block hash, given its ID, or, if not
+    ///  found, use `lookup` to get the corresponding block hash and
+    ///  store it in the cache
+    pub fn get_block_hash_caching<E, F: FnOnce(u32) -> Result<T, E>>(
+        &mut self,
+        id: u32,
+        lookup: F,
+    ) -> Result<&T, E> {
+        match self.block_hash_cache.entry(id) {
+            Entry::Occupied(occupied_entry) => Ok(occupied_entry.into_mut()),
+            Entry::Vacant(vacant_entry) => {
+                let block_hash = lookup(id)?;
+                let block_hash_ref = vacant_entry.insert(block_hash.clone());
+                self.block_id_cache.insert(block_hash, id);
+                Ok(block_hash_ref)
+            }
+        }
     }
 
     /// Cache a block hash, given its ID
@@ -315,9 +329,15 @@ impl<T: MarfTrieId> TrieCache<T> {
         self.state_mut().load_block_hash(block_id)
     }
 
-    /// Get entry for a block hash, given its ID
-    pub fn entry_block_hash<'a>(&'a mut self, block_id: u32) -> Entry<'a, u32, T> {
-        self.state_mut().entry_block_hash(block_id)
+    /// Get cached entry for a block hash, given its ID, or, if not
+    ///  found, use `lookup` to get the corresponding block hash and
+    ///  store it in the cache
+    pub fn get_block_hash_caching<E, F: FnOnce(u32) -> Result<T, E>>(
+        &mut self,
+        id: u32,
+        lookup: F,
+    ) -> Result<&T, E> {
+        self.state_mut().get_block_hash_caching(id, lookup)
     }
 
     /// Store a block's ID and hash to teh cache.

--- a/stackslib/src/chainstate/stacks/index/storage.rs
+++ b/stackslib/src/chainstate/stacks/index/storage.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::char::from_digit;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write};
@@ -108,12 +109,15 @@ impl<T: MarfTrieId> BlockMap for TrieStorageConnection<'_, T> {
         trie_sql::get_block_hash(&self.db, id)
     }
 
-    fn get_block_hash_caching(&mut self, id: u32) -> Result<&T, Error> {
-        if !self.is_block_hash_cached(id) {
-            let block_hash = self.get_block_hash(id)?;
-            self.cache.store_block_hash(id, block_hash);
+    fn get_block_hash_caching<'a>(&'a mut self, id: u32) -> Result<&'a T, Error> {
+        match self.cache.entry_block_hash(id) {
+            Entry::Occupied(occupied_entry) => Ok(occupied_entry.into_mut()),
+            Entry::Vacant(vacant_entry) => {
+                let block_hash = trie_sql::get_block_hash(&self.db, id)?;
+                let block_hash_ref = vacant_entry.insert(block_hash);
+                Ok(block_hash_ref)
+            }
         }
-        self.cache.ref_block_hash(id).ok_or(Error::NotFoundError)
     }
 
     fn is_block_hash_cached(&self, id: u32) -> bool {


### PR DESCRIPTION
### Description

This includes a handful of speedups that are primarily relevant while performing a genesis sync (these perf changes mostly impact the syncing speed of 2.x blocks, not nakamoto blocks).