### PR TITLE
Chore/signer: Use send_block_response where possible

### DIFF
--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -721,7 +721,7 @@ impl Signer {
     #[cfg(not(any(test, feature = "testing")))]
     fn send_block_response(
         &mut self,
-        block: &Option<NakamotoBlock>,
+        block: Option<&NakamotoBlock>,
         block_response: BlockResponse,
     ) {
         self.impl_send_block_response(block, block_response)


### PR DESCRIPTION
While working on 2 phase commit I noticed this duplicate code all over. Figured I should pull out separately 