### PR TITLE
Bumping versions for 3.1.0.0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
+## [3.1.0.0.9]
 
 ### Added
 

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
+## [3.1.0.0.9.0]
 
 ### Changed
 

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
 stacks_node_version = "3.1.0.0.9"
-stacks_signer_version = "3.1.0.0.9.1"
+stacks_signer_version = "3.1.0.0.9.0"

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.1.0.0.8"
-stacks_signer_version = "3.1.0.0.8.1"
+stacks_node_version = "3.1.0.0.9"
+stacks_signer_version = "3.1.0.0.9.1"


### PR DESCRIPTION
Bumps versions in the changelogs and `versions.toml` for the 3.1.0.0.9 release branch. 