### PR TITLE
Update blockchain-team to blockchain-team-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 #
-# require both blockchain-team-codeowners and blockchain-team to review all PR's not specifically matched below
-* @stacks-network/blockchain-team-codeowners @stacks-network/blockchain-team
+# require both blockchain-team-codeowners and blockchain-team-reviewers to review all PR's not specifically matched below
+* @stacks-network/blockchain-team-codeowners @stacks-network/blockchain-team-reviewers
 
 
 # Signer code
@@ -11,6 +11,6 @@ libsigner/**/*.rs @stacks-network/blockchain-team-codeowners @stacks-network/blo
 stacks-signer/**/*.rs @stacks-network/blockchain-team-codeowners @stacks-network/blockchain-team-signer
 
 # CI workflows
-#  require both blockchain-team and blockchain-team-ci teams to review PR's modifying CI workflows
-/.github/workflows/ @stacks-network/blockchain-team @stacks-network/blockchain-team-ci
-/.github/actions/ @stacks-network/blockchain-team @stacks-network/blockchain-team-ci
+#  require both blockchain-team-ci and blockchain-team-reviewers teams to review PR's modifying CI workflows
+/.github/workflows/ @stacks-network/blockchain-team-ci @stacks-network/blockchain-team-reviewers
+/.github/actions/ @stacks-network/blockchain-team-ci @stacks-network/blockchain-team-reviewers


### PR DESCRIPTION
Builds off of #6081

To reduce number of people that may approve a PR and have it count towards a required review, a new smaller sub-team `blockchain-team-reviewers` will be a required approval step in addition to `blockchain-team-codeowners` for most codepaths (excpetion being stacks-signer, which uses a separate team)