### PR TITLE
Add cargo check workflow

### DIFF
--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -60,17 +60,18 @@ jobs:
           # cargo check -p clarity --no-default-features
           cargo check -p stacks-common --no-default-features
       ## end cargo test
-      - name: Build stacks-inspect
-        id: build_stacks-inspect
-        run: |
-          cargo build --bin stacks-inspect
+      # - name: Build stacks-inspect
+      #   id: build_stacks-inspect
+      #   run: |
+      #     cargo build --bin stacks-inspect
 
       - name: Dump constants JSON
         id: consts-dump
         run: |
           cargo run --bin stacks-inspect -- dump-consts | tee out.json
 
-      - name: Set expected constants JSON
+      - name: Compare expected constants JSON
         id: expects-json
         run: |
-          diff out.json ./sample/expected_consts.json
+          # if there is a diff, return will be non-zero
+          diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
   ## for testing workflow. remove for PR
   workflow_dispatch:
-
+    
 jobs:
   check-consts:
     name: Check the constants from stacks-inspect
@@ -34,17 +34,15 @@ jobs:
         # if: ${{ false }}
         id: cargo_check_clarity
         run: |
-          cargo check -p clarity --no-default-features
+          RUSTFLAGS="" cargo check -p clarity --no-default-features
 
       - name: Cargo Check
         id: cargo_check
-        shell: bash
         run: |
           cargo check
 
       - name: Cargo Check (monitoring_prom)
         id: cargo_check_prom
-        shell: bash
         run: |
           cargo check --features monitoring_prom
 
@@ -57,19 +55,16 @@ jobs:
 
       - name: Cargo Check (stacks-common)
         id: cargo_check_stacks-common
-        shell: bash
         run: |
           cargo check -p stacks-common --no-default-features
 
       - name: Dump constants JSON
         id: consts-dump
-        shell: bash
         run: |
           cargo run --bin stacks-inspect -- dump-consts | tee out.json
 
       - name: Compare expected constants JSON
         id: expects-json
-        shell: bash
         run: |
           # if there is a diff, return will be non-zero
           diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -4,11 +4,17 @@ name: Core build tests
 #   - PRs are (re)opened against develop branch
 on:
   workflow_call:
+  ## for testing workflow. remove for PR
+  workflow_dispatch:
 
 jobs:
   check-consts:
     name: Check the constants from stacks-inspect
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout the latest code
         id: git_checkout
@@ -21,13 +27,50 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Build the binaries
-        id: build
+      ## run the cargo check steps
+      - name: Cargo Check
+        id: cargo_check
         run: |
-          cargo build
+          cargo check
+          # cargo check --features monitoring_prom
+          # cargo check -p clarity --no-default-features
+          # cargo check -p stacks-common --no-default-features
+
+      - name: Cargo Check (monitoring_prom)
+        id: cargo_check_prom
+        run: |
+          # cargo check
+          cargo check --features monitoring_prom
+          # cargo check -p clarity --no-default-features
+          # cargo check -p stacks-common --no-default-features
+
+      - name: Cargo Check (clarity)
+        id: cargo_check_clarity
+        run: |
+          # cargo check
+          # cargo check --features monitoring_prom
+          cargo check -p clarity --no-default-features
+          # cargo check -p stacks-common --no-default-features
+
+      - name: Cargo Check (stacks-common)
+        id: cargo_check_stacks-common
+        run: |
+          # cargo check
+          # cargo check --features monitoring_prom
+          # cargo check -p clarity --no-default-features
+          cargo check -p stacks-common --no-default-features
+      ## end cargo test
+      - name: Build stacks-inspect
+        id: build_stacks-inspect
+        run: |
+          cargo build --bin stacks-inspect
+
       - name: Dump constants JSON
         id: consts-dump
-        run: cargo run --bin stacks-inspect -- dump-consts | tee out.json
+        run: |
+          cargo run --bin stacks-inspect -- dump-consts | tee out.json
+
       - name: Set expected constants JSON
         id: expects-json
-        run: diff out.json ./sample/expected_consts.json
+        run: |
+          diff out.json ./sample/expected_consts.json

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       ## run the cargo check steps
+      - name: Cargo Version
+        id: cargo_version
+        run: |
+          cargo version
+
       - name: Cargo Check
         id: cargo_check
         run: |
@@ -59,5 +64,4 @@ jobs:
         id: expects-json
         run: |
           # if there is a diff, return will be non-zero
-          echo "asdf" >> out.json ## induce a diff
           diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -28,42 +28,48 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       ## run the cargo check steps with
-      - name: Cargo Version
-        id: cargo_version
+
+      ## this step fails on the unused imports
+      - name: Cargo Check (clarity)
+        # if: ${{ false }}
+        id: cargo_check_clarity
         run: |
-          cargo version
-          # cargo 1.86.0 (adf9b6ad1 2025-02-28)
+          cargo check -p clarity --no-default-features
 
       - name: Cargo Check
         id: cargo_check
+        shell: bash
         run: |
           cargo check
 
       - name: Cargo Check (monitoring_prom)
         id: cargo_check_prom
+        shell: bash
         run: |
           cargo check --features monitoring_prom
 
-      ## this step fails on the unused imports
-      - name: Cargo Check (clarity)
-        # if: ${{ false }}
-        shell: bash -e
-        id: cargo_check_clarity
-        run: |
-          cargo check -p clarity --no-default-features
+      # ## this step fails on the unused imports
+      # - name: Cargo Check (clarity)
+      #   # if: ${{ false }}
+      #   id: cargo_check_clarity
+      #   run: |
+      #     cargo check -p clarity --no-default-features
 
       - name: Cargo Check (stacks-common)
         id: cargo_check_stacks-common
+        shell: bash
         run: |
           cargo check -p stacks-common --no-default-features
 
       - name: Dump constants JSON
         id: consts-dump
+        shell: bash
         run: |
           cargo run --bin stacks-inspect -- dump-consts | tee out.json
 
       - name: Compare expected constants JSON
         id: expects-json
+        shell: bash
         run: |
           # if there is a diff, return will be non-zero
           diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -27,11 +27,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      ## run the cargo check steps
+      ## run the cargo check steps with
       - name: Cargo Version
         id: cargo_version
         run: |
           cargo version
+          # cargo 1.86.0 (adf9b6ad1 2025-02-28)
 
       - name: Cargo Check
         id: cargo_check
@@ -45,7 +46,8 @@ jobs:
 
       ## this step fails on the unused imports
       - name: Cargo Check (clarity)
-        if: ${{ false }}
+        # if: ${{ false }}
+        shell: bash -e {0}
         id: cargo_check_clarity
         run: |
           cargo check -p clarity --no-default-features

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -27,15 +27,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      ## run the cargo check steps with
 
-      ## this step fails on the unused imports
-      - name: Cargo Check (clarity)
-        # if: ${{ false }}
-        id: cargo_check_clarity
-        run: |
-          RUSTFLAGS="" cargo check -p clarity --no-default-features
-
+      ## run cargo check steps
       - name: Cargo Check
         id: cargo_check
         run: |
@@ -46,12 +39,11 @@ jobs:
         run: |
           cargo check --features monitoring_prom
 
-      # ## this step fails on the unused imports
-      # - name: Cargo Check (clarity)
-      #   # if: ${{ false }}
-      #   id: cargo_check_clarity
-      #   run: |
-      #     cargo check -p clarity --no-default-features
+      ## by default, RUSTFLAGS is set with `-D warnings`, which will fail this step. we run this with an empty RUSTFLAGS so the warnings won't cause a step failure
+      - name: Cargo Check (clarity)
+        id: cargo_check_clarity
+        run: |
+          RUSTFLAGS="" cargo check -p clarity --no-default-features
 
       - name: Cargo Check (stacks-common)
         id: cargo_check_stacks-common
@@ -63,8 +55,8 @@ jobs:
         run: |
           cargo run --bin stacks-inspect -- dump-consts | tee out.json
 
+      ## output any diff to the github job summary
       - name: Compare expected constants JSON
         id: expects-json
         run: |
-          # if there is a diff, return will be non-zero
           diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     
 jobs:
-  check-consts:
-    name: Check the constants from stacks-inspect
+  cargo-check:
+    name: Cargo Check
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,15 +27,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      ## run the cargo check steps with
 
-      ## this step fails on the unused imports
-      - name: Cargo Check (clarity)
-        # if: ${{ false }}
-        id: cargo_check_clarity
-        run: |
-          RUSTFLAGS="" cargo check -p clarity --no-default-features
-
+    ## run the cargo check steps
       - name: Cargo Check
         id: cargo_check
         run: |
@@ -46,17 +39,58 @@ jobs:
         run: |
           cargo check --features monitoring_prom
 
-      # ## this step fails on the unused imports
-      # - name: Cargo Check (clarity)
-      #   # if: ${{ false }}
-      #   id: cargo_check_clarity
-      #   run: |
-      #     cargo check -p clarity --no-default-features
+      - name: Cargo Check (clarity)
+        id: cargo_check_clarity
+        run: |
+          RUSTFLAGS="" cargo check -p clarity --no-default-features
 
       - name: Cargo Check (stacks-common)
         id: cargo_check_stacks-common
         run: |
           cargo check -p stacks-common --no-default-features
+  
+  check-consts:
+    name: Check the constants from stacks-inspect
+    runs-on: ubuntu-latest
+    needs:
+      - cargo-check
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout the latest code
+        id: git_checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Define Rust Toolchain
+        id: define_rust_toolchain
+        run: echo "RUST_TOOLCHAIN=$(cat ./rust-toolchain)" >> $GITHUB_ENV
+      - name: Setup Rust Toolchain
+        id: setup_rust_toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+    # ## run the cargo check steps
+    #   - name: Cargo Check
+    #     id: cargo_check
+    #     run: |
+    #       cargo check
+
+    #   - name: Cargo Check (monitoring_prom)
+    #     id: cargo_check_prom
+    #     run: |
+    #       cargo check --features monitoring_prom
+
+    #   - name: Cargo Check (clarity)
+    #     id: cargo_check_clarity
+    #     run: |
+    #       RUSTFLAGS="" cargo check -p clarity --no-default-features
+
+    #   - name: Cargo Check (stacks-common)
+    #     id: cargo_check_stacks-common
+    #     run: |
+    #       cargo check -p stacks-common --no-default-features
 
       - name: Dump constants JSON
         id: consts-dump
@@ -66,5 +100,4 @@ jobs:
       - name: Compare expected constants JSON
         id: expects-json
         run: |
-          # if there is a diff, return will be non-zero
           diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -39,11 +39,10 @@ jobs:
         run: |
           cargo check --features monitoring_prom
 
-      ## by default, RUSTFLAGS is set with `-D warnings`, which will fail this step. we run this with an empty RUSTFLAGS so the warnings won't cause a step failure
       - name: Cargo Check (clarity)
         id: cargo_check_clarity
         run: |
-          RUSTFLAGS="" cargo check -p clarity --no-default-features
+          cargo check -p clarity --no-default-features
 
       - name: Cargo Check (stacks-common)
         id: cargo_check_stacks-common

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -32,40 +32,23 @@ jobs:
         id: cargo_check
         run: |
           cargo check
-          # cargo check --features monitoring_prom
-          # cargo check -p clarity --no-default-features
-          # cargo check -p stacks-common --no-default-features
 
       - name: Cargo Check (monitoring_prom)
         id: cargo_check_prom
         run: |
-          # cargo check
           cargo check --features monitoring_prom
-          # cargo check -p clarity --no-default-features
-          # cargo check -p stacks-common --no-default-features
 
       ## this step fails on the unused imports
       - name: Cargo Check (clarity)
         if: ${{ false }}
         id: cargo_check_clarity
         run: |
-          # cargo check
-          # cargo check --features monitoring_prom
           cargo check -p clarity --no-default-features
-          # cargo check -p stacks-common --no-default-features
 
       - name: Cargo Check (stacks-common)
         id: cargo_check_stacks-common
         run: |
-          # cargo check
-          # cargo check --features monitoring_prom
-          # cargo check -p clarity --no-default-features
           cargo check -p stacks-common --no-default-features
-      ## end cargo test
-      # - name: Build stacks-inspect
-      #   id: build_stacks-inspect
-      #   run: |
-      #     cargo build --bin stacks-inspect
 
       - name: Dump constants JSON
         id: consts-dump
@@ -76,4 +59,5 @@ jobs:
         id: expects-json
         run: |
           # if there is a diff, return will be non-zero
+          echo "asdf" >> out.json ## induce a diff
           diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -44,7 +44,9 @@ jobs:
           # cargo check -p clarity --no-default-features
           # cargo check -p stacks-common --no-default-features
 
+      ## this step fails on the unused imports
       - name: Cargo Check (clarity)
+        if: ${{ false }}
         id: cargo_check_clarity
         run: |
           # cargo check

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -4,8 +4,6 @@ name: Core build tests
 #   - PRs are (re)opened against develop branch
 on:
   workflow_call:
-  ## for testing workflow. remove for PR
-  workflow_dispatch:
     
 jobs:
   check-consts:

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     
 jobs:
-  cargo-check:
-    name: Cargo Check
+  check-consts:
+    name: Check the constants from stacks-inspect
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,8 +27,15 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
+      ## run the cargo check steps with
 
-    ## run the cargo check steps
+      ## this step fails on the unused imports
+      - name: Cargo Check (clarity)
+        # if: ${{ false }}
+        id: cargo_check_clarity
+        run: |
+          RUSTFLAGS="" cargo check -p clarity --no-default-features
+
       - name: Cargo Check
         id: cargo_check
         run: |
@@ -39,58 +46,17 @@ jobs:
         run: |
           cargo check --features monitoring_prom
 
-      - name: Cargo Check (clarity)
-        id: cargo_check_clarity
-        run: |
-          RUSTFLAGS="" cargo check -p clarity --no-default-features
+      # ## this step fails on the unused imports
+      # - name: Cargo Check (clarity)
+      #   # if: ${{ false }}
+      #   id: cargo_check_clarity
+      #   run: |
+      #     cargo check -p clarity --no-default-features
 
       - name: Cargo Check (stacks-common)
         id: cargo_check_stacks-common
         run: |
           cargo check -p stacks-common --no-default-features
-  
-  check-consts:
-    name: Check the constants from stacks-inspect
-    runs-on: ubuntu-latest
-    needs:
-      - cargo-check
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout the latest code
-        id: git_checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Define Rust Toolchain
-        id: define_rust_toolchain
-        run: echo "RUST_TOOLCHAIN=$(cat ./rust-toolchain)" >> $GITHUB_ENV
-      - name: Setup Rust Toolchain
-        id: setup_rust_toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-    # ## run the cargo check steps
-    #   - name: Cargo Check
-    #     id: cargo_check
-    #     run: |
-    #       cargo check
-
-    #   - name: Cargo Check (monitoring_prom)
-    #     id: cargo_check_prom
-    #     run: |
-    #       cargo check --features monitoring_prom
-
-    #   - name: Cargo Check (clarity)
-    #     id: cargo_check_clarity
-    #     run: |
-    #       RUSTFLAGS="" cargo check -p clarity --no-default-features
-
-    #   - name: Cargo Check (stacks-common)
-    #     id: cargo_check_stacks-common
-    #     run: |
-    #       cargo check -p stacks-common --no-default-features
 
       - name: Dump constants JSON
         id: consts-dump
@@ -100,4 +66,5 @@ jobs:
       - name: Compare expected constants JSON
         id: expects-json
         run: |
+          # if there is a diff, return will be non-zero
           diff out.json ./sample/expected_consts.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/core-build-tests.yml
+++ b/.github/workflows/core-build-tests.yml
@@ -47,7 +47,7 @@ jobs:
       ## this step fails on the unused imports
       - name: Cargo Check (clarity)
         # if: ${{ false }}
-        shell: bash -e {0}
+        shell: bash -e
         id: cargo_check_clarity
         run: |
           cargo check -p clarity --no-default-features


### PR DESCRIPTION
closes #5928

This change adds the cargo check steps defined in 5928, and modifies the final steps:
- cargo run vs cargo build;cargo run to reduce some unneeded steps (time taken is marginally better, but barely noticeable)
- output the diff (if it exists) to the github summary so it's easy to see. 

There is one caveat here that needed to be addressed - the step running `cargo check -p clarity --no-default-features` will fail due to the default RUSTFLAGS being set to `-D warnings`. to get around this and continue on warnings in this workflow, i'm setting RUSTFLAGS to an empty value when running this check. 

the warning will be annotated, but the only other options are to fix the warnings or disable this step. 
ex of a successful run:
https://github.com/wileyj/stacks-core/actions/runs/14917420199

ex of using the default RUSTFLAGS (which will fail the job):
https://github.com/wileyj/stacks-core/actions/runs/14914948870

ex of a diff existing (note summary output - in this case, it's a simple `echo asdf` to the out.json file):
https://github.com/wileyj/stacks-core/actions/runs/14916965904
