### PR TITLE
test: remove unsused mutable from test utils to improve usabilty

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -2280,7 +2280,7 @@ impl BurnchainController for BitcoinRegtestController {
     }
 
     #[cfg(test)]
-    fn bootstrap_chain(&mut self, num_blocks: u64) {
+    fn bootstrap_chain(&self, num_blocks: u64) {
         let Some(ref local_mining_pubkey) = &self.config.burnchain.local_mining_public_key else {
             warn!("No local mining pubkey while bootstrapping bitcoin regtest, will not generate bitcoin blocks");
             return;

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -2121,7 +2121,7 @@ impl BitcoinRegtestController {
     /// Produce `num_blocks` regtest bitcoin blocks, sending the bitcoin coinbase rewards
     ///  to the bitcoin single sig addresses corresponding to `pks` in a round robin fashion.
     #[cfg(test)]
-    pub fn bootstrap_chain_to_pks(&mut self, num_blocks: usize, pks: &[Secp256k1PublicKey]) {
+    pub fn bootstrap_chain_to_pks(&self, num_blocks: usize, pks: &[Secp256k1PublicKey]) {
         info!("Creating wallet if it does not exist");
         if let Err(e) = self.create_wallet_if_dne() {
             error!("Error when creating wallet: {e:?}");

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -309,7 +309,7 @@ impl BurnchainController for MocknetController {
     }
 
     #[cfg(test)]
-    fn bootstrap_chain(&mut self, _num_blocks: u64) {}
+    fn bootstrap_chain(&self, _num_blocks: u64) {}
 
     fn connect_dbs(&mut self) -> Result<(), BurnchainControllerError> {
         Ok(())

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -56,7 +56,7 @@ pub trait BurnchainController {
     fn get_stacks_epochs(&self) -> EpochList;
 
     #[cfg(test)]
-    fn bootstrap_chain(&mut self, blocks_count: u64);
+    fn bootstrap_chain(&self, blocks_count: u64);
 }
 
 #[derive(Debug, Clone)]

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -750,7 +750,7 @@ pub fn next_block_and_mine_commit(
 /// Mine a bitcoin block, and wait until a block-commit has been issued, **or** a timeout occurs
 /// (timeout_secs)
 pub fn next_block_and_commits_only(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     timeout_secs: u64,
     node_conf: &Config,
     node_counters: &Counters,
@@ -1234,7 +1234,7 @@ pub fn setup_epoch_3_reward_set(
     blocks_processed: &Arc<AtomicU64>,
     stacker_sks: &[StacksPrivateKey],
     signer_sks: &[StacksPrivateKey],
-    btc_regtest_controller: &mut BitcoinRegtestController,
+    btc_regtest_controller: &BitcoinRegtestController,
     num_stacking_cycles: Option<u64>,
 ) {
     assert_eq!(stacker_sks.len(), signer_sks.len());
@@ -1326,7 +1326,7 @@ pub fn boot_to_epoch_3_reward_set_calculation_boundary(
     blocks_processed: &Arc<AtomicU64>,
     stacker_sks: &[StacksPrivateKey],
     signer_sks: &[StacksPrivateKey],
-    btc_regtest_controller: &mut BitcoinRegtestController,
+    btc_regtest_controller: &BitcoinRegtestController,
     num_stacking_cycles: Option<u64>,
 ) {
     setup_epoch_3_reward_set(
@@ -1371,7 +1371,7 @@ pub fn boot_to_epoch_3_reward_set_calculation_boundary(
 pub fn boot_to_epoch_25(
     naka_conf: &Config,
     blocks_processed: &Arc<AtomicU64>,
-    btc_regtest_controller: &mut BitcoinRegtestController,
+    btc_regtest_controller: &BitcoinRegtestController,
 ) {
     let epochs = naka_conf.burnchain.epochs.clone().unwrap();
     let epoch_25 = &epochs[StacksEpochId::Epoch25];
@@ -1414,7 +1414,7 @@ pub fn boot_to_epoch_3_reward_set(
     blocks_processed: &Arc<AtomicU64>,
     stacker_sks: &[StacksPrivateKey],
     signer_sks: &[StacksPrivateKey],
-    btc_regtest_controller: &mut BitcoinRegtestController,
+    btc_regtest_controller: &BitcoinRegtestController,
     num_stacking_cycles: Option<u64>,
 ) {
     boot_to_epoch_3_reward_set_calculation_boundary(

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -9153,7 +9153,7 @@ fn utxo_check_on_startup_panic() {
     btcd_controller
         .start_bitcoind()
         .expect("Failed starting bitcoind");
-    let mut btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
+    let btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
     // Do not fully bootstrap the chain, so that the UTXOs are not yet available
     btc_regtest_controller.bootstrap_chain(99);
 
@@ -9229,7 +9229,7 @@ fn utxo_check_on_startup_recover() {
     btcd_controller
         .start_bitcoind()
         .expect("Failed starting bitcoind");
-    let mut btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
+    let btc_regtest_controller = BitcoinRegtestController::new(naka_conf.clone(), None);
     // Do not fully bootstrap the chain, so that the UTXOs are not yet available
     btc_regtest_controller.bootstrap_chain(99);
     // btc_regtest_controller.bootstrap_chain(108);
@@ -9902,11 +9902,11 @@ fn test_shadow_recovery() {
         return;
     }
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(1, vec![]);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(1, vec![]);
     signer_test.boot_to_epoch_3();
 
     let naka_conf = signer_test.running_nodes.conf.clone();
-    let btc_regtest_controller = &mut signer_test.running_nodes.btc_regtest_controller;
+    let btc_regtest_controller = &signer_test.running_nodes.btc_regtest_controller;
     let counters = signer_test.running_nodes.counters.clone();
 
     // make another tenure
@@ -10698,7 +10698,7 @@ fn test_tenure_extend_from_flashblocks() {
     let deployer_sk = account_keys.pop().unwrap();
     let deployer_addr = tests::to_addr(&deployer_sk);
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         1,
         initial_balances,
         |_| {},
@@ -10711,7 +10711,7 @@ fn test_tenure_extend_from_flashblocks() {
     let naka_conf = signer_test.running_nodes.conf.clone();
 
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
-    let btc_regtest_controller = &mut signer_test.running_nodes.btc_regtest_controller;
+    let btc_regtest_controller = &signer_test.running_nodes.btc_regtest_controller;
     let coord_channel = signer_test.running_nodes.coord_channel.clone();
     let counters = signer_test.running_nodes.counters.clone();
 

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -659,7 +659,7 @@ pub fn naka_neon_integration_conf(seed: Option<&[u8]>) -> (Config, StacksAddress
 }
 
 pub fn next_block_and<F>(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     timeout_secs: u64,
     mut check: F,
 ) -> Result<(), String>
@@ -670,12 +670,12 @@ where
 }
 
 pub fn next_block_and_controller<F>(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     timeout_secs: u64,
     mut check: F,
 ) -> Result<(), String>
 where
-    F: FnMut(&mut BitcoinRegtestController) -> Result<bool, String>,
+    F: FnMut(&BitcoinRegtestController) -> Result<bool, String>,
 {
     eprintln!("Issuing bitcoin block");
     btc_controller.build_next_block(1);
@@ -708,7 +708,7 @@ where
 /// Mine a bitcoin block, and wait until:
 ///  (1) a new block has been processed by the coordinator
 pub fn next_block_and_process_new_stacks_block(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     timeout_secs: u64,
     coord_channels: &Arc<Mutex<CoordinatorChannels>>,
 ) -> Result<(), String> {
@@ -733,7 +733,7 @@ pub fn next_block_and_process_new_stacks_block(
 ///  (2) 2 block commits have been issued ** or ** more than 10 seconds have
 ///      passed since (1) occurred
 pub fn next_block_and_mine_commit(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     timeout_secs: u64,
     node_conf: &Config,
     node_counters: &Counters,
@@ -770,7 +770,7 @@ pub fn next_block_and_commits_only(
 ///      passed since (1) occurred
 /// This waits for this check to pass on *all* supplied channels
 pub fn next_block_and_wait_for_commits(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     timeout_secs: u64,
     node_confs: &[&Config],
     node_counters: &[&Counters],

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -7337,7 +7337,7 @@ fn test_chainwork_first_intervals() {
         .start_bitcoind()
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
 
     btc_regtest_controller.bootstrap_chain(2016 * 2 - 1);
 
@@ -7364,7 +7364,7 @@ fn test_chainwork_partial_interval() {
         .start_bitcoind()
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
 
     btc_regtest_controller.bootstrap_chain(2016 - 1);
 
@@ -8345,7 +8345,7 @@ fn push_boot_receipts() {
         .start_bitcoind()
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
 
     btc_regtest_controller.bootstrap_chain(201);
 
@@ -9661,7 +9661,7 @@ fn listunspent_max_utxos() {
         .start_bitcoind()
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
 
     btc_regtest_controller.bootstrap_chain(201);
 
@@ -9707,7 +9707,7 @@ fn start_stop_bitcoind() {
         .start_bitcoind()
         .expect("Failed starting bitcoind");
 
-    let mut btc_regtest_controller = BitcoinRegtestController::new(conf, None);
+    let btc_regtest_controller = BitcoinRegtestController::new(conf, None);
 
     btc_regtest_controller.bootstrap_chain(201);
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -666,7 +666,7 @@ const PANIC_TIMEOUT_SECS: u64 = 600;
 
 /// Returns `false` on a timeout, true otherwise.
 pub fn next_block_and_wait(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     blocks_processed: &Arc<AtomicU64>,
 ) -> bool {
     next_block_and_wait_with_timeout(btc_controller, blocks_processed, PANIC_TIMEOUT_SECS)
@@ -674,7 +674,7 @@ pub fn next_block_and_wait(
 
 /// Returns `false` on a timeout, true otherwise.
 pub fn next_block_and_wait_with_timeout(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     blocks_processed: &Arc<AtomicU64>,
     timeout: u64,
 ) -> bool {
@@ -702,7 +702,7 @@ pub fn next_block_and_wait_with_timeout(
 
 /// Returns `false` on a timeout, true otherwise.
 pub fn next_block_and_iterate(
-    btc_controller: &mut BitcoinRegtestController,
+    btc_controller: &BitcoinRegtestController,
     blocks_processed: &Arc<AtomicU64>,
     iteration_delay_ms: u64,
 ) -> bool {
@@ -734,7 +734,7 @@ pub fn next_block_and_iterate(
 ///
 /// Returns `false` if `next_block_and_wait` times out.
 pub fn run_until_burnchain_height(
-    btc_regtest_controller: &mut BitcoinRegtestController,
+    btc_regtest_controller: &BitcoinRegtestController,
     blocks_processed: &Arc<AtomicU64>,
     target_height: u64,
     conf: &Config,

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -233,7 +233,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         }
     }
 
-    pub fn wait_for_registered(&mut self) {
+    pub fn wait_for_registered(&self) {
         let mut finished_signers = HashSet::new();
         wait_for(120, || {
             self.send_status_request(&finished_signers);
@@ -253,7 +253,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     }
 
     /// Send a status request to the signers to ensure they are registered for both reward cycles.
-    pub fn wait_for_registered_both_reward_cycles(&mut self) {
+    pub fn wait_for_registered_both_reward_cycles(&self) {
         let mut finished_signers = HashSet::new();
         wait_for(120, || {
             self.send_status_request(&finished_signers);
@@ -279,7 +279,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         .expect("Timed out while waiting for the signers to be registered for both reward cycles");
     }
 
-    pub fn wait_for_cycle(&mut self, timeout_secs: u64, reward_cycle: u64) {
+    pub fn wait_for_cycle(&self, timeout_secs: u64, reward_cycle: u64) {
         let mut finished_signers = HashSet::new();
         wait_for(timeout_secs, || {
             self.send_status_request(&finished_signers);
@@ -299,9 +299,9 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         }).unwrap();
     }
 
-    pub fn mine_bitcoin_block(&mut self) {
+    pub fn mine_bitcoin_block(&self) {
         let info = self.get_peer_info();
-        next_block_and(&mut self.running_nodes.btc_regtest_controller, 60, || {
+        next_block_and(&self.running_nodes.btc_regtest_controller, 60, || {
             Ok(get_chain_info(&self.running_nodes.conf).burn_block_height > info.burn_block_height)
         })
         .unwrap();
@@ -314,7 +314,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     ///    1. Having a valid sortition
     ///    2. The active miner is the winner of that sortition
     ///    3. The active miner is building off of the prior tenure
-    pub fn check_signer_states_normal(&mut self) {
+    pub fn check_signer_states_normal(&self) {
         let (state_machines, info_cur) = self.get_burn_updated_states();
 
         let sortition_latest =
@@ -375,7 +375,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     ///  latest burn block:
     ///    1. Having an invalid miner
     ///    2. The active miner is the winner of the prior sortition
-    pub fn check_signer_states_revert_to_prior(&mut self) {
+    pub fn check_signer_states_revert_to_prior(&self) {
         let (state_machines, info_cur) = self.get_burn_updated_states();
 
         let sortition_latest =
@@ -431,7 +431,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
 
     /// Submit a stacks transfer just to trigger block production
     pub fn submit_transfer_tx(
-        &mut self,
+        &self,
         sender_sk: &StacksPrivateKey,
         send_fee: u64,
         send_amt: u64,
@@ -454,7 +454,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     /// Submit a burn block dependent contract for publishing
     ///  and wait until it is included in a block
     pub fn submit_burn_block_contract_and_wait(
-        &mut self,
+        &self,
         sender_sk: &StacksPrivateKey,
     ) -> Result<String, String> {
         let http_origin = format!("http://{}", &self.running_nodes.conf.node.rpc_bind);
@@ -485,7 +485,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     /// Submit a burn block dependent contract-call
     ///  and wait until it is included in a block
     pub fn submit_burn_block_call_and_wait(
-        &mut self,
+        &self,
         sender_sk: &StacksPrivateKey,
     ) -> Result<String, String> {
         let http_origin = format!("http://{}", &self.running_nodes.conf.node.rpc_bind);
@@ -582,7 +582,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     ///    1. Not having a sortition!
     ///    2. The active miner is the winner of the last sortition
     ///    3. The active miner is building off of the prior tenure
-    pub fn check_signer_states_normal_missed_sortition(&mut self) {
+    pub fn check_signer_states_normal_missed_sortition(&self) {
         let (state_machines, info_cur) = self.get_burn_updated_states();
         let non_sortition_latest =
             get_sortition_info_ch(&self.running_nodes.conf, &info_cur.pox_consensus);
@@ -653,7 +653,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     ///    2. The active miner is the winner of that sortition
     ///    3. The active miner is building off of the prior tenure
     pub fn check_signer_states_reorg(
-        &mut self,
+        &self,
         accepting_reorg: &[StacksPublicKey],
         rejecting_reorg: &[StacksPublicKey],
     ) {
@@ -841,7 +841,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     }
 
     fn mine_block_wait_on_processing(
-        &mut self,
+        &self,
         node_confs: &[&NeonConfig],
         node_counters: &[&Counters],
         timeout: Duration,
@@ -849,7 +849,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         let blocks_len = test_observer::get_blocks().len();
         let mined_block_time = Instant::now();
         next_block_and_wait_for_commits(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             timeout.as_secs(),
             node_confs,
             node_counters,
@@ -872,7 +872,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     /// Chain information is captured before `f` is called, and then again after `f`
     /// to ensure that the block was mined.
     /// Note: this function does _not_ mine a BTC block.
-    fn wait_for_nakamoto_block(&mut self, timeout_secs: u64, f: impl FnOnce() -> ()) {
+    fn wait_for_nakamoto_block(&self, timeout_secs: u64, f: impl FnOnce() -> ()) {
         let blocks_before = self.running_nodes.counters.naka_mined_blocks.get();
         let info_before = self.get_peer_info();
 
@@ -891,7 +891,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     /// Wait for a confirmed block and return a list of individual
     /// signer signatures
     fn wait_for_confirmed_block_v0(
-        &mut self,
+        &self,
         block_signer_sighash: &Sha512Trunc256Sum,
         timeout: Duration,
     ) -> Vec<MessageSignature> {
@@ -911,7 +911,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     /// Wait for a confirmed block and return a list of individual
     /// signer signatures
     fn wait_for_confirmed_block_with_hash(
-        &mut self,
+        &self,
         block_signer_sighash: &Sha512Trunc256Sum,
         timeout: Duration,
     ) -> serde_json::Map<String, serde_json::Value> {
@@ -938,7 +938,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         panic!("Timed out while waiting for confirmation of block with signer sighash = {block_signer_sighash}")
     }
 
-    fn wait_for_validate_ok_response(&mut self, timeout: Duration) -> BlockValidateOk {
+    fn wait_for_validate_ok_response(&self, timeout: Duration) -> BlockValidateOk {
         // Wait for the block to show up in the test observer
         let t_start = Instant::now();
         loop {
@@ -958,7 +958,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     }
 
     fn wait_for_validate_reject_response(
-        &mut self,
+        &self,
         timeout: Duration,
         signer_signature_hash: Sha512Trunc256Sum,
     ) -> BlockValidateReject {
@@ -983,14 +983,14 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     }
 
     // Must be called AFTER booting the chainstate
-    fn run_until_epoch_3_boundary(&mut self) {
+    fn run_until_epoch_3_boundary(&self) {
         let epochs = self.running_nodes.conf.burnchain.epochs.clone().unwrap();
         let epoch_3 = &epochs[StacksEpochId::Epoch30];
 
         let epoch_30_boundary = epoch_3.start_height - 1;
         // advance to epoch 3.0 and trigger a sign round (cannot vote on blocks in pre epoch 3.0)
         run_until_burnchain_height(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             &self.running_nodes.counters.blocks_processed,
             epoch_30_boundary,
             &self.running_nodes.conf,

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -513,7 +513,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     /// Get the local state machines and most recent peer info from the stacks-node,
     ///  waiting until all of the signers have updated their state machines to
     ///  reflect the most recent burn block.
-    pub fn get_burn_updated_states(&mut self) -> (Vec<LocalStateMachine>, PeerInfo) {
+    pub fn get_burn_updated_states(&self) -> (Vec<LocalStateMachine>, PeerInfo) {
         let info_cur = self.get_peer_info();
         let current_rc = self.get_current_reward_cycle();
         let mut states = Vec::with_capacity(0);
@@ -731,7 +731,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
 
     /// Get status check results (if returned) from each signer (blocks on the receipt)
     /// Returns Some() or None() for each signer, in order of `self.spawned_signers`
-    pub fn get_all_states(&mut self) -> Vec<StateInfo> {
+    pub fn get_all_states(&self) -> Vec<StateInfo> {
         let mut finished_signers = HashSet::new();
         let mut output_states = Vec::new();
         let mut sent_request = false;
@@ -795,7 +795,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
 
     /// Get status check results (if returned) from each signer without blocking
     /// Returns Some() or None() for each signer, in order of `self.spawned_signers`
-    pub fn get_states(&mut self, exclude: &HashSet<usize>) -> Vec<Option<StateInfo>> {
+    pub fn get_states(&self, exclude: &HashSet<usize>) -> Vec<Option<StateInfo>> {
         let mut output = Vec::new();
         for (ix, signer) in self.spawned_signers.iter().enumerate() {
             if exclude.contains(&ix) {
@@ -817,12 +817,12 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
 
     /// Mine a BTC block and wait for a new Stacks block to be mined
     /// Note: do not use nakamoto blocks mined heuristic if running a test with multiple miners
-    fn mine_nakamoto_block(&mut self, timeout: Duration, use_nakamoto_blocks_mined: bool) {
+    fn mine_nakamoto_block(&self, timeout: Duration, use_nakamoto_blocks_mined: bool) {
         let mined_block_time = Instant::now();
         let mined_before = self.running_nodes.counters.naka_mined_blocks.get();
         let info_before = self.get_peer_info();
         next_block_and_mine_commit(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             timeout.as_secs(),
             &self.running_nodes.conf,
             &self.running_nodes.counters,

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -2824,7 +2824,7 @@ fn bitcoind_forking_test() {
         .unwrap()
         .unwrap();
 
-    let get_unconfirmed_commit_data = |btc_controller: &mut BitcoinRegtestController| {
+    let get_unconfirmed_commit_data = |btc_controller: &BitcoinRegtestController| {
         let unconfirmed_utxo = btc_controller
             .get_all_utxos(&miner_pk)
             .into_iter()

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -121,15 +121,15 @@ pub fn test_mine_stall_set(value: bool) {
 impl SignerTest<SpawnedSigner> {
     /// Run the test until the first epoch 2.5 reward cycle.
     /// Will activate pox-4 and register signers for the first full Epoch 2.5 reward cycle.
-    fn boot_to_epoch_25_reward_cycle(&mut self) {
+    fn boot_to_epoch_25_reward_cycle(&self) {
         boot_to_epoch_25(
             &self.running_nodes.conf,
             &self.running_nodes.counters.blocks_processed,
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
         );
 
         next_block_and_wait(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             &self.running_nodes.counters.blocks_processed,
         );
 
@@ -194,11 +194,11 @@ impl SignerTest<SpawnedSigner> {
             submit_tx(&http_origin, &stacking_tx);
         }
         next_block_and_wait(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             &self.running_nodes.counters.blocks_processed,
         );
         next_block_and_wait(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             &self.running_nodes.counters.blocks_processed,
         );
 
@@ -216,7 +216,7 @@ impl SignerTest<SpawnedSigner> {
         let target_height = next_reward_cycle_boundary - 1;
         info!("Advancing to burn block height {target_height}...",);
         run_until_burnchain_height(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             &self.running_nodes.counters.blocks_processed,
             target_height,
             &self.running_nodes.conf,
@@ -248,7 +248,7 @@ impl SignerTest<SpawnedSigner> {
         debug!("Waiting for signers to initialize.");
         info!("Advancing to the first full Epoch 2.5 reward cycle boundary...");
         next_block_and_wait(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             &self.running_nodes.counters.blocks_processed,
         );
         self.wait_for_registered();
@@ -262,13 +262,13 @@ impl SignerTest<SpawnedSigner> {
     }
 
     /// Run the test until the epoch 3 boundary
-    pub fn boot_to_epoch_3(&mut self) {
+    pub fn boot_to_epoch_3(&self) {
         boot_to_epoch_3_reward_set(
             &self.running_nodes.conf,
             &self.running_nodes.counters.blocks_processed,
             &self.signer_stacks_private_keys,
             &self.signer_stacks_private_keys,
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             Some(self.num_stacking_cycles),
         );
         info!("Waiting for signer set calculation.");
@@ -291,7 +291,7 @@ impl SignerTest<SpawnedSigner> {
         // Manually consume one more block to ensure signers refresh their state
         info!("Waiting for signers to initialize.");
         next_block_and_wait(
-            &mut self.running_nodes.btc_regtest_controller,
+            &self.running_nodes.btc_regtest_controller,
             &self.running_nodes.counters.blocks_processed,
         );
         self.wait_for_registered();
@@ -318,7 +318,7 @@ impl SignerTest<SpawnedSigner> {
 
     // Only call after already past the epoch 3.0 boundary
     fn mine_and_verify_confirmed_naka_block(
-        &mut self,
+        &self,
         timeout: Duration,
         num_signers: usize,
         use_nakamoto_blocks_mined: bool,
@@ -399,7 +399,7 @@ impl SignerTest<SpawnedSigner> {
 
     // Only call after already past the epoch 3.0 boundary
     fn run_until_burnchain_height_nakamoto(
-        &mut self,
+        &self,
         timeout: Duration,
         burnchain_height: u64,
         num_signers: usize,
@@ -420,7 +420,7 @@ impl SignerTest<SpawnedSigner> {
     }
 
     /// Propose a block to the signers
-    fn propose_block(&mut self, block: NakamotoBlock, timeout: Duration) {
+    fn propose_block(&self, block: NakamotoBlock, timeout: Duration) {
         let miners_contract_id = boot_code_id(MINERS_NAME, false);
         let mut session =
             StackerDBSession::new(&self.running_nodes.conf.node.rpc_bind, miners_contract_id);
@@ -1541,7 +1541,7 @@ fn block_proposal_rejection() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
     signer_test.boot_to_epoch_3();
     let short_timeout = Duration::from_secs(30);
 
@@ -1659,7 +1659,7 @@ fn miner_gather_signatures() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
     let timeout = Duration::from_secs(30);
 
     signer_test.boot_to_epoch_3();
@@ -1717,7 +1717,7 @@ fn mine_2_nakamoto_reward_cycles() {
     info!("------------------------- Test Setup -------------------------");
     let nmb_reward_cycles = 2;
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
     let timeout = Duration::from_secs(200);
     signer_test.boot_to_epoch_3();
     let curr_reward_cycle = signer_test.get_current_reward_cycle();
@@ -1777,7 +1777,7 @@ fn revalidate_unknown_parent() {
     let node_1_rpc_bind = format!("{localhost}:{node_1_rpc}");
 
     // All signers are listening to node 1
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(
             sender_addr,
@@ -2066,7 +2066,7 @@ fn regr_use_block_header_pk() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let signer_listeners: Mutex<Vec<String>> = Mutex::default();
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![],
         |_| {},
@@ -2319,7 +2319,7 @@ fn reloads_signer_set_in() {
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, send_amt + send_fee)]);
 
     setup_epoch_3_reward_set(
@@ -2327,7 +2327,7 @@ fn reloads_signer_set_in() {
         &signer_test.running_nodes.counters.blocks_processed,
         &signer_test.signer_stacks_private_keys,
         &signer_test.signer_stacks_private_keys,
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         Some(signer_test.num_stacking_cycles),
     );
 
@@ -2347,7 +2347,7 @@ fn reloads_signer_set_in() {
     let before_epoch_3_reward_set_calculation =
         epoch_3_reward_cycle_boundary.saturating_sub(prepare_phase_len);
     run_until_burnchain_height(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         &signer_test.running_nodes.counters.blocks_processed,
         before_epoch_3_reward_set_calculation,
         naka_conf,
@@ -2384,7 +2384,7 @@ fn reloads_signer_set_in() {
     // Manually consume one more block to ensure signers refresh their state
     info!("Waiting for signers to initialize.");
     next_block_and_wait(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         &signer_test.running_nodes.counters.blocks_processed,
     );
     signer_test.wait_for_registered();
@@ -2401,7 +2401,7 @@ fn reloads_signer_set_in() {
     info!("Waiting 1 burnchain block for miner VRF key confirmation");
     // Wait one block to confirm the VRF register, wait until a block commit is submitted
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = commits_submitted.load(Ordering::SeqCst);
@@ -2441,7 +2441,7 @@ fn forked_tenure_testing(
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -2511,7 +2511,7 @@ fn forked_tenure_testing(
     let blocks_before = mined_blocks.load(Ordering::SeqCst);
 
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = commits_submitted.load(Ordering::SeqCst);
@@ -2544,7 +2544,7 @@ fn forked_tenure_testing(
 
     info!("Starting Tenure B.");
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = commits_submitted.load(Ordering::SeqCst);
@@ -2631,7 +2631,7 @@ fn forked_tenure_testing(
     skip_commit_op.set(false);
 
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = commits_submitted.load(Ordering::SeqCst);
@@ -2797,7 +2797,7 @@ fn bitcoind_forking_test() {
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |_| {},
@@ -2896,7 +2896,7 @@ fn bitcoind_forking_test() {
         );
         let commits_count = submitted_commits.load(Ordering::SeqCst);
         next_block_and_controller(
-            &mut signer_test.running_nodes.btc_regtest_controller,
+            &signer_test.running_nodes.btc_regtest_controller,
             60,
             |btc_controller| {
                 let commits_submitted = submitted_commits
@@ -2982,7 +2982,7 @@ fn bitcoind_forking_test() {
         );
         let commits_count = commits_submitted.load(Ordering::SeqCst);
         next_block_and_controller(
-            &mut signer_test.running_nodes.btc_regtest_controller,
+            &signer_test.running_nodes.btc_regtest_controller,
             60,
             |btc_controller| {
                 let commits_submitted = commits_submitted
@@ -3440,7 +3440,7 @@ fn end_of_tenure() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, send_amt + send_fee)]);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
     let long_timeout = Duration::from_secs(200);
@@ -3579,7 +3579,7 @@ fn retry_on_rejection() {
     let send_fee = 180;
     let short_timeout = Duration::from_secs(30);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, (send_amt + send_fee) * 3)]);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
     signer_test.boot_to_epoch_3();
@@ -3699,7 +3699,7 @@ fn signers_broadcast_signed_blocks() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, send_amt + send_fee)]);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
@@ -3781,7 +3781,7 @@ fn tenure_extend_after_idle_signers() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let idle_timeout = Duration::from_secs(30);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![],
         |config| {
@@ -3834,7 +3834,7 @@ fn tenure_extend_with_other_transactions() {
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let idle_timeout = Duration::from_secs(30);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * 2)],
         |config| {
@@ -3942,7 +3942,7 @@ fn tenure_extend_after_idle_miner() {
     let _recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let idle_timeout = Duration::from_secs(30);
     let miner_idle_timeout = idle_timeout + Duration::from_secs(10);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -3967,7 +3967,7 @@ fn tenure_extend_after_idle_miner() {
     let tip_height_before = get_chain_info(&signer_test.running_nodes.conf).stacks_tip_height;
     TEST_IGNORE_SIGNERS.set(true);
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         30,
         || {
             let tip_height = get_chain_info(&signer_test.running_nodes.conf).stacks_tip_height;
@@ -4016,7 +4016,7 @@ fn tenure_extend_succeeds_after_rejected_attempt() {
     let _recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let idle_timeout = Duration::from_secs(30);
     let miner_idle_timeout = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -4091,7 +4091,7 @@ fn stx_transfers_dont_effect_idle_timeout() {
     let num_txs = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let idle_timeout = Duration::from_secs(60);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * num_txs)],
         |config| {
@@ -4224,7 +4224,7 @@ fn idle_tenure_extend_active_mining() {
         deploy_fee + tx_fee * num_txs * tenure_count * num_naka_blocks * 100 + 100 * tenure_count;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let idle_timeout = Duration::from_secs(30);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, amount), (deployer_addr, amount)],
         |config| {
@@ -4487,7 +4487,7 @@ fn empty_tenure_delayed() {
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let block_proposal_timeout = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -4518,7 +4518,7 @@ fn empty_tenure_delayed() {
     let commits_before = submitted_commits.load(Ordering::SeqCst);
     // Mine a regular tenure, but wait for commits to be submitted
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = submitted_commits.load(Ordering::SeqCst);
@@ -4537,7 +4537,7 @@ fn empty_tenure_delayed() {
     // Start new Tenure B
     // In the next block, the miner should win the tenure
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = submitted_commits.load(Ordering::SeqCst);
@@ -4656,7 +4656,7 @@ fn empty_sortition_before_approval() {
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let block_proposal_timeout = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -4683,7 +4683,7 @@ fn empty_sortition_before_approval() {
         .clone();
 
     next_block_and_process_new_stacks_block(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         &signer_test.running_nodes.coord_channel,
     )
@@ -4703,7 +4703,7 @@ fn empty_sortition_before_approval() {
     let proposed_before = proposed_blocks.load(Ordering::SeqCst);
     // Mine a regular tenure and wait for a block proposal
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || Ok(proposed_blocks.load(Ordering::SeqCst) > proposed_before),
     )
@@ -4714,7 +4714,7 @@ fn empty_sortition_before_approval() {
 
     // Trigger an empty tenure
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let burn_height = get_chain_info(&signer_test.running_nodes.conf).burn_block_height;
@@ -4768,7 +4768,7 @@ fn empty_sortition_before_approval() {
     .expect("Failed to advance chain tip with STX transfer");
 
     next_block_and_process_new_stacks_block(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         &signer_test.running_nodes.coord_channel,
     )
@@ -4803,7 +4803,7 @@ fn empty_sortition_before_proposal() {
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let block_proposal_timeout = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -4825,7 +4825,7 @@ fn empty_sortition_before_proposal() {
     signer_test.boot_to_epoch_3();
 
     next_block_and_process_new_stacks_block(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         &signer_test.running_nodes.coord_channel,
     )
@@ -4924,7 +4924,7 @@ fn empty_sortition_before_proposal() {
     info!("------------------------- Test Miner Tenure C  -------------------------");
 
     next_block_and_process_new_stacks_block(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         &signer_test.running_nodes.coord_channel,
     )
@@ -4956,7 +4956,7 @@ fn mock_sign_epoch_25() {
     let send_amt = 100;
     let send_fee = 180;
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |_| {},
@@ -5511,7 +5511,7 @@ fn min_gap_between_blocks() {
     let interim_blocks = 5;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let time_between_blocks_ms = 10_000;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * interim_blocks)],
         |_config| {},
@@ -5632,7 +5632,7 @@ fn duplicate_signers() {
         "Recovered pubkeys don't match"
     );
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![],
         |_| {},
@@ -5855,7 +5855,7 @@ fn partial_tenure_fork() {
     let node_1_rpc_bind = format!("{localhost}:{node_1_rpc}");
 
     // All signers are listening to node 1
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(
             sender_addr,
@@ -6188,7 +6188,7 @@ fn locally_accepted_blocks_overriden_by_global_rejection() {
     let nmb_txs = 3;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let short_timeout_secs = 20;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * nmb_txs)],
     );
@@ -6328,7 +6328,7 @@ fn locally_rejected_blocks_overriden_by_global_acceptance() {
     let nmb_txs = 3;
 
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * nmb_txs)],
     );
@@ -6476,7 +6476,7 @@ fn reorg_locally_accepted_blocks_across_tenures_succeeds() {
     let send_fee = 180;
     let nmb_txs = 2;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * nmb_txs)],
         |config| {
@@ -6580,7 +6580,7 @@ fn reorg_locally_accepted_blocks_across_tenures_succeeds() {
         .clone();
     let commits_before = commits_submitted.load(Ordering::SeqCst);
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = commits_submitted.load(Ordering::SeqCst);
@@ -6648,7 +6648,7 @@ fn reorg_locally_accepted_blocks_across_tenures_fails() {
     let send_fee = 180;
     let nmb_txs = 2;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * nmb_txs)],
         |config| {
@@ -6797,7 +6797,7 @@ fn miner_recovers_when_broadcast_block_delay_across_tenures_occurs() {
     let send_fee = 180;
     let nmb_txs = 3;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * nmb_txs)],
         |_config| {},
@@ -6900,7 +6900,7 @@ fn miner_recovers_when_broadcast_block_delay_across_tenures_occurs() {
         .clone();
     let commits_before = commits_submitted.load(Ordering::SeqCst);
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = commits_submitted.load(Ordering::SeqCst);
@@ -7240,7 +7240,7 @@ fn continue_after_tenure_extend() {
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let send_amt = 100;
     let send_fee = 180;
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, (send_amt + send_fee) * 5)]);
     let timeout = Duration::from_secs(200);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
@@ -7323,7 +7323,7 @@ fn signing_in_0th_tenure_of_reward_cycle() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
     let signer_public_keys = signer_test.signer_test_pks();
     let long_timeout = Duration::from_secs(200);
     signer_test.boot_to_epoch_3();
@@ -7553,7 +7553,7 @@ fn block_commit_delay() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![],
         |config| {
@@ -7579,7 +7579,7 @@ fn block_commit_delay() {
     let commits_before = commits_submitted.load(Ordering::SeqCst);
 
     next_block_and_process_new_stacks_block(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         &signer_test.running_nodes.coord_channel,
     )
@@ -7601,7 +7601,7 @@ fn block_commit_delay() {
 
     // Mine a burn block and wait for it to be processed.
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let burn_height = get_chain_info(&signer_test.running_nodes.conf).burn_block_height;
@@ -7659,7 +7659,7 @@ fn block_validation_response_timeout() {
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -7829,7 +7829,7 @@ fn block_validation_check_rejection_timeout_heuristic() {
     let send_amt = 100;
     let send_fee = 180;
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -7865,7 +7865,7 @@ fn block_validation_check_rejection_timeout_heuristic() {
 
     // note we just use mined nakamoto_blocks as the second block is not going to be confirmed
 
-    let mut test_rejections = |signer_split_index: usize, expected_timeout: u64| {
+    let test_rejections = |signer_split_index: usize, expected_timeout: u64| {
         test_observer::clear();
         let blocks_before = test_observer::get_mined_nakamoto_blocks().len();
         let (ignore_signers, reject_signers) = all_signers.split_at(signer_split_index);
@@ -7877,7 +7877,7 @@ fn block_validation_check_rejection_timeout_heuristic() {
 
         let height_before = signer_test.get_peer_info().stacks_tip_height;
         next_block_and(
-            &mut signer_test.running_nodes.btc_regtest_controller,
+            &signer_test.running_nodes.btc_regtest_controller,
             30,
             || Ok(test_observer::get_mined_nakamoto_blocks().len() > blocks_before),
         )
@@ -7954,7 +7954,7 @@ fn block_validation_pending_table() {
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let short_timeout = Duration::from_secs(20);
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |_| {},
@@ -8115,7 +8115,7 @@ fn new_tenure_while_validating_previous_scenario() {
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |_| {},
@@ -8657,7 +8657,7 @@ fn block_proposal_max_age_rejections() {
 
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![],
         |config| {
@@ -8793,7 +8793,7 @@ fn global_acceptance_depends_on_block_announcement() {
     let nmb_txs = 4;
 
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * nmb_txs)],
         |config| {
@@ -9198,7 +9198,7 @@ fn incoming_signers_ignore_block_proposals() {
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, send_amt + send_fee)]);
     let timeout = Duration::from_secs(200);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
@@ -9376,7 +9376,7 @@ fn outgoing_signers_ignore_block_proposals() {
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, send_amt + send_fee)]);
     let timeout = Duration::from_secs(200);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
@@ -9600,7 +9600,7 @@ fn injected_signatures_are_ignored_across_boundaries() {
     let new_spawned_signer = SpawnedSigner::new(signer_config.clone());
 
     // Boot with some initial signer set
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         initial_balances,
         |_| {},
@@ -9952,7 +9952,7 @@ fn reorg_attempts_count_towards_miner_validity() {
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let block_proposal_timeout = Duration::from_secs(30);
     let reorg_attempts_activity_timeout = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -10003,7 +10003,7 @@ fn reorg_attempts_count_towards_miner_validity() {
     let commits_before = commits_submitted.load(Ordering::SeqCst);
 
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || Ok(commits_submitted.load(Ordering::SeqCst) > commits_before),
     )
@@ -10104,7 +10104,7 @@ fn reorg_attempts_activity_timeout_exceeded() {
     let block_proposal_timeout = Duration::from_secs(30);
     let reorg_attempts_activity_timeout = Duration::from_secs(20);
     let tenure_extend_wait_timeout = Duration::from_secs(1000);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, send_amt + send_fee)],
         |config| {
@@ -10157,7 +10157,7 @@ fn reorg_attempts_activity_timeout_exceeded() {
     let commits_before = commits_submitted.load(Ordering::SeqCst);
     let chain_before = get_chain_info(&signer_test.running_nodes.conf);
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let chain_info = get_chain_info(&signer_test.running_nodes.conf);
@@ -10249,7 +10249,7 @@ fn fast_sortition() {
     let send_fee = 400;
     let num_transfers = 3;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
         num_signers,
         vec![(sender_addr, num_transfers * (send_amt + send_fee))],
     );
@@ -10282,7 +10282,7 @@ fn fast_sortition() {
         .btc_regtest_controller
         .build_next_block(1);
     next_block_and_process_new_stacks_block(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         &signer_test.running_nodes.coord_channel,
     )
@@ -10464,7 +10464,7 @@ fn single_miner_empty_sortition() {
     // partition the signer set so that ~half are listening and using node 1 for RPC and events,
     //  and the rest are using node 2
 
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, send_fee * 2 * 60 + 1000)]);
     let conf = signer_test.running_nodes.conf.clone();
 
@@ -10575,7 +10575,7 @@ fn block_proposal_timeout() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let block_proposal_timeout = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![],
         |config| {
@@ -10602,7 +10602,7 @@ fn block_proposal_timeout() {
         .load(Ordering::SeqCst);
 
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let commits_count = signer_test
@@ -10990,7 +10990,7 @@ fn tenure_extend_cost_threshold() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let idle_timeout = Duration::from_secs(10);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(deployer_addr, deploy_fee + tx_fee * num_txs)],
         |config| {
@@ -11281,7 +11281,7 @@ fn tenure_extend_after_idle_signers_with_buffer() {
     let num_signers = 5;
     let idle_timeout = Duration::from_secs(1);
     let buffer = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![],
         |config| {
@@ -12523,7 +12523,7 @@ fn repeated_rejection() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * 3)],
         |_| {},
@@ -12635,7 +12635,7 @@ fn retry_proposal() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * 3)],
         |_| {},
@@ -12764,7 +12764,7 @@ fn signer_can_accept_rejected_block() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * 3)],
         |_| {},
@@ -13165,7 +13165,7 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
         .collect::<Vec<_>>();
 
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         initial_balances,
         |_| {},
@@ -13453,7 +13453,7 @@ fn larger_mempool() {
         .collect::<Vec<_>>();
 
     let num_signers = 5;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         initial_balances,
         |_| {},
@@ -13868,7 +13868,7 @@ fn verify_mempool_caches() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let mut signer_test: SignerTest<SpawnedSigner> =
+    let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new(num_signers, vec![(sender_addr, (send_amt + send_fee) * 3)]);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
     let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
@@ -14026,7 +14026,7 @@ fn burn_block_height_behavior() {
     let tx_fee = 10000;
     let deploy_fee = 200000;
     let block_proposal_timeout = Duration::from_secs(20);
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![
             (sender_addr, send_amt + send_fee),
@@ -14079,7 +14079,7 @@ fn burn_block_height_behavior() {
     // Mine a regular tenure
     let info_before = signer_test.get_peer_info();
     next_block_and(
-        &mut signer_test.running_nodes.btc_regtest_controller,
+        &signer_test.running_nodes.btc_regtest_controller,
         60,
         || {
             let chain_info = get_chain_info(&signer_test.running_nodes.conf);
@@ -14499,7 +14499,7 @@ fn rollover_signer_protocol_version() {
     }
     let num_signers = 5;
 
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
     signer_test.boot_to_epoch_3();
 
     let conf = signer_test.running_nodes.conf.clone();

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -3062,7 +3062,7 @@ fn tx_replay_forking_test() {
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
-    let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * 10)],
         |_| {},
@@ -3177,7 +3177,7 @@ fn tx_replay_forking_test() {
         );
         let commits_count = submitted_commits.load(Ordering::SeqCst);
         next_block_and_controller(
-            &mut signer_test.running_nodes.btc_regtest_controller,
+            &signer_test.running_nodes.btc_regtest_controller,
             60,
             |_btc_controller| {
                 let commits_submitted = submitted_commits.load(Ordering::SeqCst);
@@ -3341,7 +3341,7 @@ fn tx_replay_forking_test() {
         );
         let commits_count = submitted_commits.load(Ordering::SeqCst);
         next_block_and_controller(
-            &mut signer_test.running_nodes.btc_regtest_controller,
+            &signer_test.running_nodes.btc_regtest_controller,
             60,
             |_btc_controller| {
                 let commits_submitted = submitted_commits.load(Ordering::SeqCst);


### PR DESCRIPTION
### Description

This pr address a usability friction concerning integration test utils, described in #6104 

Currently in draft, the goal is to show the main idea and collect early feedback.
If the direction looks good, I’ll proceed pushing the refactor further.

NOTE: This change will not address the verbosity of pre-existing integration tests

### Applicable issues

- fixes #6104 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
