### PR TITLE
Feat: persist stackerdb versioning for signers and miner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+### Added
+- Persisted tracking of StackerDB slot versions for mining. This improves miner p2p performance.
+
 ## [3.1.0.0.9]
 
 ### Added

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+### Added
+- Persisted tracking of StackerDB slot versions. This improves signer p2p performance.
+
 ## [3.1.0.0.9.0]
 
 ### Changed

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -49,6 +49,9 @@ pub enum ClientError {
     /// Failed to sign stacker-db chunk
     #[error("Failed to sign stacker-db chunk: {0}")]
     FailToSign(#[from] StackerDBError),
+    /// Failed on a DBError
+    #[error("SignerDB database error: {0}")]
+    SignerDBError(#[from] blockstack_lib::util_lib::db::Error),
     /// Stacker-db instance rejected the chunk
     #[error("Stacker-db rejected the chunk. Reason: {0}")]
     PutChunkRejected(String),

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -16,6 +16,7 @@
 //
 use blockstack_lib::net::api::poststackerdbchunk::StackerDBErrorCodes;
 use clarity::codec::read_next;
+use clarity::types::chainstate::StacksPublicKey;
 use hashbrown::HashMap;
 use libsigner::{MessageSlotID, SignerMessage, SignerSession, StackerDBSession};
 use libstackerdb::{StackerDBChunkAckData, StackerDBChunkData};
@@ -25,6 +26,7 @@ use stacks_common::{debug, info, warn};
 
 use crate::client::{retry_with_exponential_backoff, ClientError};
 use crate::config::{SignerConfig, SignerConfigMode};
+use crate::signerdb::SignerDb;
 
 /// The signer StackerDB slot ID, purposefully wrapped to prevent conflation with SignerID
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy, PartialOrd, Ord)]
@@ -50,13 +52,13 @@ pub struct StackerDB<M: MessageSlotID + std::cmp::Eq> {
     signers_message_stackerdb_sessions: HashMap<M, StackerDBSession>,
     /// The private key used in all stacks node communications
     stacks_private_key: StacksPrivateKey,
-    /// A map of a message ID to last chunk version for each session
-    slot_versions: HashMap<M, HashMap<SignerSlotID, u32>>,
     /// The running mode of the stackerdb (whether the signer is running in dry-run or
     ///  normal operation)
     mode: StackerDBMode,
     /// The reward cycle of the connecting signer
     reward_cycle: u64,
+    /// signerdb connection
+    signer_db: SignerDb,
 }
 
 impl<M: MessageSlotID + 'static> From<&SignerConfig> for StackerDB<M> {
@@ -69,12 +71,14 @@ impl<M: MessageSlotID + 'static> From<&SignerConfig> for StackerDB<M> {
                 signer_slot_id: *signer_slot_id,
             },
         };
+        let signer_db = SignerDb::new(&config.db_path).expect("Failed to connect to SignerDb");
 
         Self::new(
             &config.node_host,
             config.stacks_private_key,
             config.mainnet,
             config.reward_cycle,
+            signer_db,
             mode,
         )
     }
@@ -89,12 +93,14 @@ impl<M: MessageSlotID + 'static> StackerDB<M> {
         is_mainnet: bool,
         reward_cycle: u64,
         signer_slot_id: SignerSlotID,
+        signer_db: SignerDb,
     ) -> Self {
         Self::new(
             host,
             stacks_private_key,
             is_mainnet,
             reward_cycle,
+            signer_db,
             StackerDBMode::Normal { signer_slot_id },
         )
     }
@@ -105,6 +111,7 @@ impl<M: MessageSlotID + 'static> StackerDB<M> {
         stacks_private_key: StacksPrivateKey,
         is_mainnet: bool,
         reward_cycle: u64,
+        signer_db: SignerDb,
         signer_mode: StackerDBMode,
     ) -> Self {
         let mut signers_message_stackerdb_sessions = HashMap::new();
@@ -117,9 +124,9 @@ impl<M: MessageSlotID + 'static> StackerDB<M> {
         Self {
             signers_message_stackerdb_sessions,
             stacks_private_key,
-            slot_versions: HashMap::new(),
             mode: signer_mode,
             reward_cycle,
+            signer_db,
         }
     }
 
@@ -160,27 +167,21 @@ impl<M: MessageSlotID + 'static> StackerDB<M> {
                 code: None,
             });
         };
+        let signer_pk = StacksPublicKey::from_private(&self.stacks_private_key);
         loop {
-            let mut slot_version = if let Some(versions) = self.slot_versions.get_mut(msg_id) {
-                if let Some(version) = versions.get(slot_id) {
-                    *version
-                } else {
-                    versions.insert(*slot_id, 0);
-                    1
-                }
-            } else {
-                let mut versions = HashMap::new();
-                versions.insert(*slot_id, 0);
-                self.slot_versions.insert(*msg_id, versions);
-                1
-            };
-
-            let mut chunk = StackerDBChunkData::new(slot_id.0, slot_version, message_bytes.clone());
-            chunk.sign(&self.stacks_private_key)?;
+            let slot_version = self
+                .signer_db
+                .get_latest_chunk_version(&signer_pk, slot_id.0)
+                .map_err(ClientError::SignerDBError)?
+                .map(|x| x.saturating_add(1))
+                .unwrap_or(0);
 
             let Some(session) = self.signers_message_stackerdb_sessions.get_mut(msg_id) else {
                 panic!("FATAL: would loop forever trying to send a message with ID {msg_id:?}, for which we don't have a session");
             };
+
+            let mut chunk = StackerDBChunkData::new(slot_id.0, slot_version, message_bytes.clone());
+            chunk.sign(&self.stacks_private_key)?;
 
             debug!(
                 "Sending a chunk to stackerdb slot ID {slot_id} with version {slot_version} and message ID {msg_id:?} to contract {:?}!\n{chunk:?}",
@@ -190,15 +191,11 @@ impl<M: MessageSlotID + 'static> StackerDB<M> {
             let send_request = || session.put_chunk(&chunk).map_err(backoff::Error::transient);
             let chunk_ack: StackerDBChunkAckData = retry_with_exponential_backoff(send_request)?;
 
-            if let Some(versions) = self.slot_versions.get_mut(msg_id) {
-                // NOTE: per the above, this is always executed
-                versions.insert(*slot_id, slot_version.saturating_add(1));
-            } else {
-                return Err(ClientError::NotConnected);
-            }
-
             if chunk_ack.accepted {
                 debug!("Chunk accepted by stackerdb: {chunk_ack:?}");
+                self.signer_db
+                    .set_latest_chunk_version(&signer_pk, slot_id.0, slot_version)
+                    .map_err(ClientError::SignerDBError)?;
                 return Ok(chunk_ack);
             } else {
                 warn!("Chunk rejected by stackerdb: {chunk_ack:?}");
@@ -208,15 +205,18 @@ impl<M: MessageSlotID + 'static> StackerDB<M> {
                     Some(StackerDBErrorCodes::DataAlreadyExists) => {
                         if let Some(slot_metadata) = chunk_ack.metadata {
                             warn!("Failed to send message to stackerdb due to wrong version number. Attempted {}. Expected {}. Retrying...", slot_version, slot_metadata.slot_version);
-                            slot_version = slot_metadata.slot_version;
+                            self.signer_db
+                                .set_latest_chunk_version(
+                                    &signer_pk,
+                                    slot_id.0,
+                                    slot_metadata.slot_version,
+                                )
+                                .map_err(ClientError::SignerDBError)?;
                         } else {
                             warn!("Failed to send message to stackerdb due to wrong version number. Attempted {}. Expected unknown version number. Incrementing and retrying...", slot_version);
-                        }
-                        if let Some(versions) = self.slot_versions.get_mut(msg_id) {
-                            // NOTE: per the above, this is always executed
-                            versions.insert(*slot_id, slot_version.saturating_add(1));
-                        } else {
-                            return Err(ClientError::NotConnected);
+                            self.signer_db
+                                .set_latest_chunk_version(&signer_pk, slot_id.0, slot_version)
+                                .map_err(ClientError::SignerDBError)?;
                         }
                     }
                     _ => {

--- a/stackslib/src/burnchains/bitcoin/blocks.rs
+++ b/stackslib/src/burnchains/bitcoin/blocks.rs
@@ -285,6 +285,9 @@ impl BitcoinBlockParser {
                     test_debug!("Data output does not use a standard OP_RETURN");
                     return None;
                 }
+                if data.len() <= MAGIC_BYTES_LENGTH {
+                    return None;
+                }
                 if !data.starts_with(self.magic_bytes.as_bytes()) {
                     test_debug!("Data output does not start with magic bytes");
                     return None;

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -16,6 +16,8 @@
 
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::types::{QualifiedContractIdentifier, StacksAddressExtensions};
@@ -1060,16 +1062,20 @@ impl<'a> TestRPC<'a> {
     }
 
     pub fn run(self, requests: Vec<StacksHttpRequest>) -> Vec<StacksHttpResponse> {
-        self.run_with_observer(requests, None)
+        self.run_with_observer(requests, None, |_, _| true)
     }
 
     /// Run zero or more HTTP requests on this setup RPC test harness.
     /// Return the list of responses.
-    pub fn run_with_observer(
+    pub fn run_with_observer<F>(
         self,
         requests: Vec<StacksHttpRequest>,
         event_observer: Option<&dyn MemPoolEventDispatcher>,
-    ) -> Vec<StacksHttpResponse> {
+        wait_for: F,
+    ) -> Vec<StacksHttpResponse>
+    where
+        F: Fn(&mut TestPeer, &mut TestPeer) -> bool,
+    {
         let mut peer_1 = self.peer_1;
         let mut peer_2 = self.peer_2;
         let peer_1_indexer = self.peer_1_indexer;
@@ -1079,7 +1085,14 @@ impl<'a> TestRPC<'a> {
         let unconfirmed_state = self.unconfirmed_state;
 
         let mut responses = vec![];
-        for request in requests.into_iter() {
+        for (ix, request) in requests.into_iter().enumerate() {
+            let start = Instant::now();
+            while !wait_for(&mut peer_1, &mut peer_2) {
+                if start.elapsed() > Duration::from_secs(120) {
+                    panic!("Timed out waiting for wait_for check to pass");
+                }
+                thread::sleep(Duration::from_secs(1));
+            }
             peer_1.refresh_burnchain_view();
             peer_2.refresh_burnchain_view();
 

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -46,7 +46,7 @@ use crate::net::api::*;
 use crate::net::connection::ConnectionOptions;
 use crate::net::httpcore::{RPCRequestHandler, StacksHttp, StacksHttpRequest};
 use crate::net::relay::Relayer;
-use crate::net::test::TestEventObserver;
+use crate::net::test::{TestEventObserver, TestPeer};
 use crate::net::ProtocolFamily;
 
 #[warn(unused)]
@@ -395,7 +395,11 @@ fn test_try_make_response() {
     let proposal_observer = Arc::clone(&observer.proposal_observer);
 
     info!("Run requests with observer");
-    let responses = rpc_test.run_with_observer(requests, Some(&observer));
+    let wait_for = |peer_1: &mut TestPeer, peer_2: &mut TestPeer| {
+        !peer_1.network.is_proposal_thread_running() && !peer_2.network.is_proposal_thread_running()
+    };
+
+    let responses = rpc_test.run_with_observer(requests, Some(&observer), wait_for);
 
     for response in responses.iter().take(3) {
         assert_eq!(response.preamble().status_code, 202);
@@ -567,8 +571,12 @@ fn replay_validation_test(
     let observer = ProposalTestObserver::new();
     let proposal_observer = Arc::clone(&observer.proposal_observer);
 
+    let wait_for = |peer_1: &mut TestPeer, peer_2: &mut TestPeer| {
+        !peer_1.network.is_proposal_thread_running() && !peer_2.network.is_proposal_thread_running()
+    };
+
     info!("Run request with observer for replay mismatch test");
-    let responses = rpc_test.run_with_observer(requests, Some(&observer));
+    let responses = rpc_test.run_with_observer(requests, Some(&observer), wait_for);
 
     // Expect 202 Accepted initially
     assert_eq!(responses[0].preamble().status_code, 202);

--- a/testnet/stacks-node/src/nakamoto_node.rs
+++ b/testnet/stacks-node/src/nakamoto_node.rs
@@ -43,6 +43,7 @@ use crate::run_loop::nakamoto::{Globals, RunLoop};
 use crate::run_loop::RegisteredKey;
 
 pub mod miner;
+pub mod miner_db;
 pub mod peer;
 pub mod relayer;
 pub mod signer_coordinator;

--- a/testnet/stacks-node/src/nakamoto_node.rs
+++ b/testnet/stacks-node/src/nakamoto_node.rs
@@ -49,6 +49,9 @@ pub mod relayer;
 pub mod signer_coordinator;
 pub mod stackerdb_listener;
 
+#[cfg(test)]
+mod tests;
+
 use self::peer::PeerThread;
 use self::relayer::{RelayerDirective, RelayerThread};
 

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -58,6 +58,7 @@ use stacks_common::types::{PrivateKey, StacksEpochId};
 use stacks_common::util::tests::TestFlag;
 use stacks_common::util::vrf::VRFProof;
 
+use super::miner_db::MinerDB;
 use super::relayer::{MinerStopHandle, RelayerThread};
 use super::{Config, Error as NakamotoNodeError, EventDispatcher, Keychain};
 use crate::nakamoto_node::signer_coordinator::SignerCoordinator;
@@ -227,6 +228,8 @@ pub struct BlockMinerThread {
     abort_flag: Arc<AtomicBool>,
     /// Should the nonce cache be reset before mining the next block?
     reset_nonce_cache: bool,
+    /// Storage for persisting non-confidential miner information
+    miner_db: MinerDB,
 }
 
 impl BlockMinerThread {
@@ -239,8 +242,8 @@ impl BlockMinerThread {
         parent_tenure_id: StacksBlockId,
         burn_tip_at_start: &ConsensusHash,
         reason: MinerReason,
-    ) -> BlockMinerThread {
-        BlockMinerThread {
+    ) -> Result<BlockMinerThread, NakamotoNodeError> {
+        Ok(BlockMinerThread {
             config: rt.config.clone(),
             globals: rt.globals.clone(),
             keychain: rt.keychain.clone(),
@@ -261,7 +264,8 @@ impl BlockMinerThread {
             tenure_cost: ExecutionCost::ZERO,
             tenure_budget: ExecutionCost::ZERO,
             reset_nonce_cache: true,
-        }
+            miner_db: MinerDB::open_with_config(&rt.config)?,
+        })
     }
 
     pub fn get_abort_flag(&self) -> Arc<AtomicBool> {
@@ -843,6 +847,7 @@ impl BlockMinerThread {
             stackerdbs,
             &self.globals.counters,
             &self.burn_election_block,
+            &self.miner_db,
         )
     }
 
@@ -1058,6 +1063,7 @@ impl BlockMinerThread {
             chain_state.mainnet,
             &mut miners_session,
             &self.burn_election_block.consensus_hash,
+            &self.miner_db,
         )
     }
 

--- a/testnet/stacks-node/src/nakamoto_node/miner_db.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner_db.rs
@@ -1,0 +1,141 @@
+// Copyright (C) 2025 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
+use stacks::config::Config;
+use stacks::types::chainstate::StacksPublicKey;
+use stacks::util_lib::db::{sqlite_open, tx_begin_immediate, Error as DBError};
+
+/// Structure for storing **non-confidential** miner information
+///  which can be reused between restarts
+pub struct MinerDB {
+    db: Connection,
+}
+
+static CREATE_STACKERDB_TRACKING: &str = "
+CREATE TABLE stackerdb_tracking(
+   public_key TEXT NOT NULL,
+   slot_id INTEGER NOT NULL,
+   slot_version INTEGER NOT NULL,
+   PRIMARY KEY (public_key, slot_id)
+) STRICT;
+";
+
+static CREATE_DB_CONFIG: &str = "
+CREATE TABLE db_config(
+   version INTEGER NOT NULL
+) STRICT;
+";
+
+static SCHEMA_0: &[&str] = &[
+    CREATE_STACKERDB_TRACKING,
+    CREATE_DB_CONFIG,
+    "INSERT INTO db_config VALUES (0);",
+];
+
+pub static CURRENT_SCHEMA: u32 = 0;
+pub static MINER_DB_NAME: &str = "miner.sqlite";
+
+impl MinerDB {
+    fn get_schema_version(conn: &Connection) -> Result<Option<u32>, DBError> {
+        let qry_db_exists =
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='db_config'";
+        let db_exists = conn
+            .query_row(&qry_db_exists, [], |_| Ok(true))
+            .optional()?
+            .is_some();
+        if !db_exists {
+            return Ok(None);
+        }
+        let version = conn.query_row("SELECT MAX(version) FROM db_config", [], |row| row.get(0))?;
+        Ok(Some(version))
+    }
+
+    fn apply_schema_changes(conn: &Connection, changes: &[&str]) -> Result<(), DBError> {
+        for query in changes.iter() {
+            conn.execute_batch(query)?
+        }
+        Ok(())
+    }
+
+    fn apply_schema(db: &mut Connection) -> Result<(), DBError> {
+        let tx = tx_begin_immediate(db)?;
+
+        loop {
+            match Self::get_schema_version(&tx)? {
+                None => Self::apply_schema_changes(&tx, SCHEMA_0)?,
+                Some(v) if v == CURRENT_SCHEMA => break,
+                Some(v) => {
+                    error!("Unexpected DB schema for minerdb: {v}. Latest supported schema is {CURRENT_SCHEMA}");
+                    return Err(DBError::Corruption);
+                }
+            }
+        }
+
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    pub fn miner_db_path(config: &Config) -> PathBuf {
+        let mut path = config.get_chainstate_path();
+        path.set_file_name(MINER_DB_NAME);
+        path
+    }
+
+    pub fn open<P: AsRef<Path>>(db_path: P) -> Result<Self, DBError> {
+        let open_flags = OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_READ_WRITE;
+        let mut db = sqlite_open(db_path, open_flags, false)?;
+        Self::apply_schema(&mut db)?;
+        Ok(Self { db })
+    }
+
+    pub fn open_with_config(config: &Config) -> Result<Self, DBError> {
+        let db_path = Self::miner_db_path(config);
+        Self::open(db_path)
+    }
+
+    /// Get the latest known version from the db for the given slot_id/pk pair
+    pub fn get_latest_chunk_version(
+        &self,
+        pk: &StacksPublicKey,
+        slot_id: u32,
+    ) -> Result<Option<u32>, DBError> {
+        self.db
+            .query_row(
+                "SELECT slot_version FROM stackerdb_tracking WHERE public_key = ? AND slot_id = ?",
+                params![pk.to_hex(), slot_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(DBError::from)
+    }
+
+    /// Set the latest known version for the given slot_id/pk pair
+    pub fn set_latest_chunk_version(
+        &self,
+        pk: &StacksPublicKey,
+        slot_id: u32,
+        slot_version: u32,
+    ) -> Result<(), DBError> {
+        self.db.execute(
+            "INSERT OR REPLACE INTO stackerdb_tracking (public_key, slot_id, slot_version) VALUES (?, ?, ?)",
+            params![pk.to_hex(), slot_id, slot_version],
+        )?;
+        Ok(())
+    }
+}

--- a/testnet/stacks-node/src/nakamoto_node/relayer.rs
+++ b/testnet/stacks-node/src/nakamoto_node/relayer.rs
@@ -1260,7 +1260,7 @@ impl RelayerThread {
             parent_tenure_id,
             burn_tip_at_start,
             reason,
-        );
+        )?;
         Ok(miner_thread_state)
     }
 
@@ -1625,7 +1625,9 @@ impl RelayerThread {
     /// Generate and submit the next block-commit, and record it locally
     fn issue_block_commit(&mut self) -> Result<(), NakamotoNodeError> {
         if self.fault_injection_skip_block_commit() {
-            warn!("Relayer: not submitting block-commit to bitcoin network due to test directive.");
+            debug!(
+                "Relayer: not submitting block-commit to bitcoin network due to test directive."
+            );
             return Ok(());
         }
         let (tip_block_ch, tip_block_bh) = SortitionDB::get_canonical_stacks_chain_tip_hash(

--- a/testnet/stacks-node/src/nakamoto_node/tests.rs
+++ b/testnet/stacks-node/src/nakamoto_node/tests.rs
@@ -1,0 +1,80 @@
+// Copyright (C) 2025 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use stacks::types::chainstate::{StacksPrivateKey, StacksPublicKey};
+
+use super::miner_db::MinerDB;
+
+#[test]
+fn miner_db_units() {
+    let miner_db = MinerDB::open(":memory:").unwrap();
+    let sk_0 = StacksPrivateKey::from_seed(&[0, 1, 2, 0]);
+    let pk_0 = StacksPublicKey::from_private(&sk_0);
+    let sk_1 = StacksPrivateKey::from_seed(&[1, 2, 0, 1]);
+    let pk_1 = StacksPublicKey::from_private(&sk_1);
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_0, 0).unwrap(), None);
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_0, 1).unwrap(), None);
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_1, 0).unwrap(), None);
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_1, 1).unwrap(), None);
+
+    miner_db.set_latest_chunk_version(&pk_0, 0, 10).unwrap();
+    miner_db.set_latest_chunk_version(&pk_0, 1, 20).unwrap();
+    miner_db.set_latest_chunk_version(&pk_1, 0, 30).unwrap();
+    miner_db.set_latest_chunk_version(&pk_1, 1, 40).unwrap();
+
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_0, 0).unwrap(),
+        Some(10)
+    );
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_0, 1).unwrap(),
+        Some(20)
+    );
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_1, 0).unwrap(),
+        Some(30)
+    );
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_1, 1).unwrap(),
+        Some(40)
+    );
+
+    miner_db.set_latest_chunk_version(&pk_0, 0, 110).unwrap();
+    miner_db.set_latest_chunk_version(&pk_0, 1, 120).unwrap();
+    miner_db.set_latest_chunk_version(&pk_1, 0, 130).unwrap();
+    miner_db.set_latest_chunk_version(&pk_1, 1, 140).unwrap();
+
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_0, 0).unwrap(),
+        Some(110)
+    );
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_0, 1).unwrap(),
+        Some(120)
+    );
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_1, 0).unwrap(),
+        Some(130)
+    );
+    assert_eq!(
+        miner_db.get_latest_chunk_version(&pk_1, 1).unwrap(),
+        Some(140)
+    );
+
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_0, 10).unwrap(), None);
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_0, 11).unwrap(), None);
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_1, 10).unwrap(), None);
+    assert_eq!(miner_db.get_latest_chunk_version(&pk_1, 11).unwrap(), None);
+}

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -223,6 +223,7 @@ use crate::burnchains::bitcoin_regtest_controller::{
 };
 use crate::burnchains::{make_bitcoin_indexer, Error as BurnchainControllerError};
 use crate::globals::{NeonGlobals as Globals, RelayerDirective};
+use crate::nakamoto_node::miner_db::MinerDB;
 use crate::nakamoto_node::signer_coordinator::SignerCoordinator;
 use crate::run_loop::neon::RunLoop;
 use crate::run_loop::RegisteredKey;
@@ -2366,6 +2367,7 @@ impl BlockMinerThread {
         let miner_contract_id = boot_code_id(MINERS_NAME, self.config.is_mainnet());
         let mut miners_stackerdb =
             StackerDBSession::new(&self.config.node.rpc_bind, miner_contract_id);
+        let miner_db = MinerDB::open_with_config(&self.config).map_err(|e| e.to_string())?;
 
         SignerCoordinator::send_miners_message(
             &mining_key,
@@ -2377,6 +2379,7 @@ impl BlockMinerThread {
             self.config.is_mainnet(),
             &mut miners_stackerdb,
             &election_sortition,
+            &miner_db,
         )
         .map_err(|e| {
             warn!("Failed to write mock proposal to stackerdb.");
@@ -2405,6 +2408,7 @@ impl BlockMinerThread {
             self.config.is_mainnet(),
             &mut miners_stackerdb,
             &election_sortition,
+            &miner_db,
         )
         .map_err(|e| {
             warn!("Failed to write mock block to stackerdb.");

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -54,7 +54,7 @@ use stacks_signer::client::{ClientError, SignerSlotID, StackerDB, StacksClient};
 use stacks_signer::config::{build_signer_config_tomls, GlobalConfig as SignerConfig, Network};
 use stacks_signer::runloop::{SignerResult, State, StateInfo};
 use stacks_signer::signerdb::SignerDb;
-use stacks_signer::v0::signer_state::{LocalStateMachine, MinerState};
+use stacks_signer::v0::signer_state::LocalStateMachine;
 use stacks_signer::{Signer, SpawnedSigner};
 
 use super::nakamoto_integrations::{

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -52,6 +52,7 @@ use stacks_common::util::hash::Sha512Trunc256Sum;
 use stacks_signer::client::{ClientError, SignerSlotID, StackerDB, StacksClient};
 use stacks_signer::config::{build_signer_config_tomls, GlobalConfig as SignerConfig, Network};
 use stacks_signer::runloop::{SignerResult, State, StateInfo};
+use stacks_signer::signerdb::SignerDb;
 use stacks_signer::v0::signer_state::{LocalStateMachine, MinerState};
 use stacks_signer::{Signer, SpawnedSigner};
 
@@ -1151,6 +1152,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
             false,
             self.get_current_reward_cycle(),
             SignerSlotID(0), // We are just reading so again, don't care about index.
+            SignerDb::new(":memory:").unwrap(),
         );
         let latest_msgs = StackerDB::get_messages(
             stackerdb
@@ -1200,6 +1202,17 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
             .expect("Failed to get peer info")
     }
 
+    pub fn readonly_stackerdb_client(&self, reward_cycle: u64) -> StackerDB<MessageSlotID> {
+        StackerDB::new_normal(
+            &self.running_nodes.conf.node.rpc_bind,
+            StacksPrivateKey::random(), // We are just reading so don't care what the key is
+            self.running_nodes.conf.is_mainnet(),
+            reward_cycle,
+            SignerSlotID(0), // We are just reading so again, don't care about index.
+            SignerDb::new(":memory:").unwrap(), // also don't care about the signer db for version tracking
+        )
+    }
+
     pub fn verify_no_block_response_found(
         &self,
         stackerdb: &mut StackerDB<MessageSlotID>,
@@ -1240,6 +1253,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
             self.get_signer_slot_id(reward_cycle, &to_addr(private_key))
                 .expect("Failed to get signer slot id")
                 .expect("Signer does not have a slot id"),
+            SignerDb::new(":memory:").unwrap(),
         );
 
         let signature = private_key


### PR DESCRIPTION
This adds persisted tracking of the latest version that a signer or miner has used, improving stackerdb push performance.

This change adds a new table to the signerdb, and a new sqlite db for persisting non-confidential tracking information for the miner.