### PR TITLE
Fixes unused imports from cargo check

### DIFF
--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -41,9 +41,9 @@ use crate::vm::costs::LimitedCostTracker;
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::database::STORE_CONTRACT_SRC_INTERFACE;
 use crate::vm::representations::SymbolicExpression;
+use crate::vm::types::QualifiedContractIdentifier;
 #[cfg(feature = "rusqlite")]
 use crate::vm::types::TypeSignature;
-use crate::vm::types::QualifiedContractIdentifier;
 use crate::vm::ClarityVersion;
 
 /// Used by CLI tools like the docs generator. Not used in production

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -34,13 +34,16 @@ use self::trait_checker::TraitChecker;
 use self::type_checker::v2_05::TypeChecker as TypeChecker2_05;
 use self::type_checker::v2_1::TypeChecker as TypeChecker2_1;
 pub use self::types::{AnalysisPass, ContractAnalysis};
+#[cfg(feature = "rusqlite")]
 use crate::vm::ast::{build_ast_with_rules, ASTRules};
 use crate::vm::costs::LimitedCostTracker;
 #[cfg(feature = "rusqlite")]
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::database::STORE_CONTRACT_SRC_INTERFACE;
 use crate::vm::representations::SymbolicExpression;
-use crate::vm::types::{QualifiedContractIdentifier, TypeSignature};
+#[cfg(feature = "rusqlite")]
+use crate::vm::types::TypeSignature;
+use crate::vm::types::QualifiedContractIdentifier;
 use crate::vm::ClarityVersion;
 
 /// Used by CLI tools like the docs generator. Not used in production

--- a/clarity/src/vm/docs/contracts.rs
+++ b/clarity/src/vm/docs/contracts.rs
@@ -4,8 +4,7 @@ use hashbrown::{HashMap, HashSet};
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::StacksEpochId;
 
-use crate::vm::analysis::mem_type_check;
-use crate::vm::analysis::ContractAnalysis;
+use crate::vm::analysis::{mem_type_check, ContractAnalysis};
 use crate::vm::ast::{build_ast_with_rules, ASTRules};
 use crate::vm::contexts::GlobalContext;
 use crate::vm::costs::LimitedCostTracker;

--- a/clarity/src/vm/docs/contracts.rs
+++ b/clarity/src/vm/docs/contracts.rs
@@ -4,13 +4,11 @@ use hashbrown::{HashMap, HashSet};
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::StacksEpochId;
 
-#[cfg(feature = "rusqlite")]
 use crate::vm::analysis::mem_type_check;
 use crate::vm::analysis::ContractAnalysis;
 use crate::vm::ast::{build_ast_with_rules, ASTRules};
 use crate::vm::contexts::GlobalContext;
 use crate::vm::costs::LimitedCostTracker;
-#[cfg(feature = "rusqlite")]
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::docs::{get_input_type_string, get_output_type_string, get_signature};
 use crate::vm::types::{FunctionType, QualifiedContractIdentifier, Value};
@@ -63,7 +61,6 @@ fn make_func_ref(func_name: &str, func_type: &FunctionType, description: &str) -
     }
 }
 
-#[cfg(feature = "rusqlite")]
 #[allow(clippy::expect_used)]
 fn get_constant_value(var_name: &str, contract_content: &str) -> Value {
     let to_eval = format!("{}\n{}", contract_content, var_name);
@@ -72,7 +69,6 @@ fn get_constant_value(var_name: &str, contract_content: &str) -> Value {
         .expect("BUG: failed to return constant value")
 }
 
-#[cfg(feature = "rusqlite")]
 fn doc_execute(program: &str) -> Result<Option<Value>, vm::Error> {
     let contract_id = QualifiedContractIdentifier::transient();
     let mut contract_context = ContractContext::new(contract_id.clone(), ClarityVersion::Clarity2);
@@ -99,7 +95,6 @@ fn doc_execute(program: &str) -> Result<Option<Value>, vm::Error> {
     })
 }
 
-#[cfg(feature = "rusqlite")]
 #[allow(clippy::expect_used)]
 pub fn make_docs(
     content: &str,
@@ -185,7 +180,6 @@ pub fn make_docs(
 
 /// Produce a set of documents for multiple contracts, supplied as a list of `(contract_name, contract_content)` pairs,
 ///  and a map from `contract_name` to corresponding `ContractSupportDocs`
-#[cfg(feature = "rusqlite")]
 pub fn produce_docs_refs<A: AsRef<str>, B: AsRef<str>>(
     contracts: &[(A, B)],
     support_docs: &HashMap<&str, ContractSupportDocs>,

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -23,6 +23,7 @@ use crate::vm::types::{FixedFunction, FunctionType};
 use crate::vm::variables::NativeVariables;
 use crate::vm::ClarityVersion;
 
+#[cfg(feature = "rusqlite")]
 pub mod contracts;
 
 #[derive(Serialize)]


### PR DESCRIPTION
re-opening with the "dirty" patch commits removed, and the (apparently) correct patch from https://github.com/stacks-network/stacks-core/pull/6102#issuecomment-2872747038 ( thanks @kantai ).

with this patch, cargo check is running as expected:
```
RUSTFLAGS="-D warnings" cargo check
RUSTFLAGS="-D warnings" cargo check --features monitoring_prom
RUSTFLAGS="-D warnings" cargo check -p clarity --no-default-features
RUSTFLAGS="-D warnings" cargo check -p stacks-common --no-default-features
```