### PR TITLE
ci: remove 'ready_for_review' pr trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
 
 defaults:
   run:


### PR DESCRIPTION
### Description

This change remove `ready_for_review` pull-request trigger, as demostrated to be redundant (see analysis in #6112).

### Applicable issues

- fixes #6112

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
