### PR TITLE
ci: fix wrong GH token, #6133

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -29,7 +29,7 @@ jobs:
         id: lock_threads
         uses: stacks-network/actions/lock-threads@main
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: 7
           pr-inactive-days: 7
           discussion-inactive-days: 7


### PR DESCRIPTION
### Description

Fix workflow error due to wrong GH token. 
For more details look at #6133.

### Applicable issues

- fixes #6133 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
