### PR TITLE
ci: fix wrong GH token in `workflow-cleanup` workflow

### DIFF
--- a/.github/workflows/workflow-cleanup.yml
+++ b/.github/workflows/workflow-cleanup.yml
@@ -41,7 +41,7 @@ jobs:
         id: cleanup
         uses: stacks-network/actions/cleanup/workflows@main
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           cache-ttl: ${{ inputs.cache-ttl || env.CACHE_TTL}}
           workflow-ttl: ${{ inputs.workflow-ttl || env.WORKFLOW_TTL}}
           failed-workflow-ttl: ${{ inputs.failed-workflow-ttl || env.FAILED_WORKFLOW_TTL }}

--- a/.github/workflows/workflow-cleanup.yml
+++ b/.github/workflows/workflow-cleanup.yml
@@ -21,6 +21,10 @@ on:
     ## Run every day at 00:00:00
     - cron: "0 0 * * *"
 
+permissions:
+  actions: write    # to delete workflow runs and caches
+  contents: read    # to access repo contents 
+
 ## env vars are transferred to composite action steps
 env:
   CACHE_TTL: 7 ## number of days to keep a cache

--- a/.github/workflows/workflow-cleanup.yml
+++ b/.github/workflows/workflow-cleanup.yml
@@ -12,11 +12,11 @@ on:
       workflow-ttl:
         description: "How many days to keep a successful workflow (default: 30)"
         required: false
-        default: "30"
+        default: "60"
       failed-workflow-ttl:
         description: "How many days to keep failed workflows (default: 15)"
         required: false
-        default: "15"
+        default: "60"
   schedule:
     ## Run every day at 00:00:00
     - cron: "0 0 * * *"


### PR DESCRIPTION
### Description

Fix workflow error due to wrong GH token.
For more details look at #6132 

### Applicable issues

- fixes #6132 

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
