### PR TITLE
chore: document missing config structs

### DIFF
--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -4168,6 +4168,8 @@ pub struct EventObserverConfigFile {
     pub endpoint: String,
     /// List of event types that this observer is configured to receive.
     ///
+    /// For a more detailed documentation check the event-dispatcher docs in the `/docs` folder.
+    ///
     /// Each string in the list specifies an event category or a specific event to subscribe to.
     /// For an observer to receive any notifications, this list must contain at least one valid key.
     /// Providing an invalid string that doesn't match any of the valid formats below will cause


### PR DESCRIPTION
### Description

Add documentation for all `FeeEstimationConfigFile`, `EventObserverConfigFile`, and `InitialBalanceFile` parameters

### Applicable issues

- fifth step of #5898

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
