### PR TITLE
fix: do not break UTXO chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## Unreleased
+
+### Changed
+
+- When a previous block commit is unable to be RBFed, the miner will now just wait for it to be confirmed instead of submitting a new block commit which breaks the miner's UTXO chain.
+
 ## [3.1.0.0.11]
 
 - Hotfix for p2p stack misbehavior in mempool syncing conditions


### PR DESCRIPTION
Bad timing between the Stacks node's processing and the Bitcoin network including a block commit can cause a miner to submit a block commit which breaks the UTXO chain, severly hurting its chances of winning blocks. It is better to just miss this commit than to break the UTXO chain.