### PR TITLE
Chore: logging niceties

### DIFF
--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -2468,13 +2468,24 @@ impl Default for NodeConfig {
 impl NodeConfig {
     /// Get a SocketAddr for this node's RPC endpoint which uses the loopback address
     pub fn get_rpc_loopback(&self) -> Option<SocketAddr> {
-        let rpc_port = SocketAddr::from_str(&self.rpc_bind)
-            .map_err(|e| {
+        let rpc_port = self.rpc_bind_addr()?.port();
+        Some(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), rpc_port))
+    }
+
+    pub fn rpc_bind_addr(&self) -> Option<SocketAddr> {
+        SocketAddr::from_str(&self.rpc_bind)
+            .inspect_err(|e| {
                 error!("Could not parse node.rpc_bind configuration setting as SocketAddr: {e}");
             })
-            .ok()?
-            .port();
-        Some(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), rpc_port))
+            .ok()
+    }
+
+    pub fn p2p_bind_addr(&self) -> Option<SocketAddr> {
+        SocketAddr::from_str(&self.p2p_bind)
+            .inspect_err(|e| {
+                error!("Could not parse node.rpc_bind configuration setting as SocketAddr: {e}");
+            })
+            .ok()
     }
 
     pub fn add_signers_stackerdbs(&mut self, is_mainnet: bool) {

--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -103,29 +103,17 @@ pub struct LocalPeer {
 
 impl fmt::Display for LocalPeer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "local.{:x}://(bind={:?})(pub={:?})",
-            self.network_id,
-            &self.addrbytes.to_socketaddr(self.port),
-            &self
-                .public_ip_address
-                .map(|(ref addrbytes, ref port)| addrbytes.to_socketaddr(*port))
-        )
+        write!(f, "local::{}", self.port)?;
+        match &self.public_ip_address {
+            None => Ok(()),
+            Some((addr, port)) => write!(f, "::pub={}", addr.to_socketaddr(*port)),
+        }
     }
 }
 
 impl fmt::Debug for LocalPeer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "local.{:x}://(bind={:?})(pub={:?})",
-            self.network_id,
-            &self.addrbytes.to_socketaddr(self.port),
-            &self
-                .public_ip_address
-                .map(|(ref addrbytes, ref port)| addrbytes.to_socketaddr(*port))
-        )
+        write!(f, "{self}")
     }
 }
 

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -5260,7 +5260,7 @@ impl PeerNetwork {
             &stacks_epoch.block_limit,
             &stacks_epoch.epoch_id,
         ) {
-            info!("Transaction rejected from mempool, {}", &e.into_json(&txid));
+            debug!("Transaction rejected from mempool, {}", &e.into_json(&txid));
             return false;
         }
 

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -2459,7 +2459,7 @@ impl Relayer {
                 // forward if not stale
                 if chunk.rc_consensus_hash != *rc_consensus_hash {
                     debug!("Drop stale uploaded StackerDB chunk";
-                           "stackerdb_contract_id" => &format!("{}", &chunk.contract_id),
+                           "stackerdb_contract_id" => %chunk.contract_id,
                            "slot_id" => chunk.chunk_data.slot_id,
                            "slot_version" => chunk.chunk_data.slot_version,
                            "chunk.rc_consensus_hash" => %chunk.rc_consensus_hash,
@@ -2467,11 +2467,11 @@ impl Relayer {
                     continue;
                 }
 
-                debug!("Got uploaded StackerDB chunk"; "stackerdb_contract_id" => &format!("{}", &chunk.contract_id), "slot_id" => chunk.chunk_data.slot_id, "slot_version" => chunk.chunk_data.slot_version);
+                debug!("Got uploaded StackerDB chunk"; "stackerdb_contract_id" => %chunk.contract_id, "slot_id" => chunk.chunk_data.slot_id, "slot_version" => chunk.chunk_data.slot_version);
 
                 let msg = StacksMessageType::StackerDBPushChunk(chunk);
                 if let Err(e) = self.p2p.broadcast_message(vec![], msg) {
-                    warn!("Failed to broadcast Nakamoto blocks: {:?}", &e);
+                    warn!("Failed to broadcast Nakamoto blocks: {e:?}");
                 }
             }
             for (contract_id, new_chunks) in all_events.into_iter() {
@@ -2516,7 +2516,7 @@ impl Relayer {
                                 // to distinguish it from other message types.
                                 debug!(
                                     "Dropping stale StackerDB chunk";
-                                    "stackerdb_contract_id" => &format!("{}", &sync_result.contract_id),
+                                    "stackerdb_contract_id" => %sync_result.contract_id,
                                     "slot_id" => md.slot_id,
                                     "slot_version" => md.slot_version,
                                     "num_bytes" => chunk.data.len(),
@@ -2525,7 +2525,7 @@ impl Relayer {
                             } else {
                                 warn!(
                                     "Failed to store chunk for StackerDB";
-                                    "stackerdb_contract_id" => &format!("{}", &sync_result.contract_id),
+                                    "stackerdb_contract_id" => %sync_result.contract_id,
                                     "slot_id" => md.slot_id,
                                     "slot_version" => md.slot_version,
                                     "num_bytes" => chunk.data.len(),
@@ -2534,7 +2534,7 @@ impl Relayer {
                             }
                             continue;
                         } else {
-                            debug!("Stored chunk"; "stackerdb_contract_id" => &format!("{}", &sync_result.contract_id), "slot_id" => md.slot_id, "slot_version" => md.slot_version);
+                            debug!("Stored chunk"; "stackerdb_contract_id" => %sync_result.contract_id, "slot_id" => md.slot_id, "slot_version" => md.slot_version);
                         }
 
                         if let Some(event_list) = all_events.get_mut(&sync_result.contract_id) {
@@ -2548,13 +2548,13 @@ impl Relayer {
                             chunk_data: chunk,
                         });
                         if let Err(e) = self.p2p.broadcast_message(vec![], msg) {
-                            warn!("Failed to broadcast StackerDB chunk: {:?}", &e);
+                            warn!("Failed to broadcast StackerDB chunk: {e:?}");
                         }
                     }
                 }
                 tx.commit()?;
             } else {
-                info!("Got chunks for unconfigured StackerDB replica"; "stackerdb_contract_id" => &format!("{}", &sc));
+                debug!("Got chunks for unconfigured StackerDB replica"; "stackerdb_contract_id" => %sc);
             }
         }
 
@@ -2579,7 +2579,7 @@ impl Relayer {
         let sync_results = stackerdb_chunks
             .into_iter()
             .map(|chunk_data| {
-                debug!("Received pushed StackerDB chunk {:?}", &chunk_data);
+                debug!("Received pushed StackerDB chunk {chunk_data:?}");
                 let sync_result = StackerDBSyncResult::from_pushed_chunk(chunk_data);
                 sync_result
             })

--- a/stackslib/src/net/rpc.rs
+++ b/stackslib/src/net/rpc.rs
@@ -548,6 +548,11 @@ impl ConversationHttp {
                         |conv_http, req| conv_http.handle_request(req, node),
                     )?;
 
+                    let msg_opt_log = if let Some(ref msg) = msg_opt {
+                        msg.get_message_description()
+                    } else {
+                        "None".into()
+                    };
                     info!("Handled StacksHTTPRequest";
                           "verb" => %verb,
                           "path" => %request_path,
@@ -555,7 +560,7 @@ impl ConversationHttp {
                           "latency_ms" => latency,
                           "conn_id" => self.conn_id,
                           "peer_addr" => &self.peer_addr,
-                          "p2p_msg" => ?msg_opt);
+                          "p2p_msg" => msg_opt_log);
 
                     if let Some(msg) = msg_opt {
                         ret.push(msg);

--- a/testnet/stacks-node/src/run_loop/nakamoto.rs
+++ b/testnet/stacks-node/src/run_loop/nakamoto.rs
@@ -306,11 +306,13 @@ impl RunLoop {
         let coordinator_indexer =
             make_bitcoin_indexer(&self.config, Some(self.should_keep_running.clone()));
 
+        let rpc_port = moved_config
+            .node
+            .rpc_bind_addr()
+            .unwrap_or_else(|| panic!("Failed to parse socket: {}", &moved_config.node.rpc_bind))
+            .port();
         let coordinator_thread_handle = thread::Builder::new()
-            .name(format!(
-                "chains-coordinator-{}",
-                &moved_config.node.rpc_bind
-            ))
+            .name(format!("chains-coordinator:{rpc_port}"))
             .stack_size(BLOCK_PROCESSOR_STACK_SIZE)
             .spawn(move || {
                 debug!(


### PR DESCRIPTION
A selection of logging cleanup:

1. Narrower thread names: use the bind port rather than the whole bind addr.
2. Downgrade mempool reject to debug.
3. Use message_description in HTTP handler log line
4. Narrow local peer name
5. Downgrade unconfigured stackerdb chunk receipt

Example:

A log that looks like this:

```
INFO [1748461042.710308] [stackslib/src/net/rpc.rs:551] [p2p-(127.0.0.1:20444,127.0.0.1:20443)] Handled StacksHTTPRequest, verb: POST, path: /v3/blocks/upload/?broadcast=1, processing_time_ms: 0, latency_ms: 0, conn_id: 76, peer_addr: 127.0.0.1:37884, p2p_msg: Some(NakamotoBlocks(NakamotoBlocksData { blocks: [NakamotoBlock { header: NakamotoBlockHeader { versi
on: 0, chain_length: 1336266, burn_spent: 415199484456, consensus_hash: f018f278153e08e564b889c0847d830f0dd6da0e, parent_block_id: 2b85fddd908443d9a9ebacb94c32579a5fce201a1aa4d44096fc8703fe643d69, tx_merkle_root: c52124456937b8f79d07802e848d55e8da2586de319def7a90ce699f2a5c52fc, state_index_root: c5bc1092e079fec45051d24192ecb6c03d4caf568040d98500f3babe8f25c44d,
 timestamp: 1748461035, miner_signature: 01d4eb860aa631f11db08396b5c7bb7d50b88595615922c317acbd787c84b2fc4a37c291c250ecdd6456cf0bd9eb59a05ac212925e46c4c38e09d95d54e9e0bdc7, signer_signature: [00071cf6ca044d03e707a0ec53853cea786231c3a693f293766e415194be15855d402ccbfde0af69144c7854ddc3e68917f17ae7ac50d8583b9b76d2051bf3957a, 01a25baeb9d534e63b1203cfce1b5b24ff1fe2
998264d1d36e87dc8a9d8b8977ab3f6495f4f037639da93551b45566a82d66276525e4344d0a52a2bcdd17075ced, 00fa34818e6ec781515613511e8adb7c5fa0a243f17304a2e1e8874efc8ab114203c8ea686a334a5b818882350a81519b6c0fd609ba0db5f559b942953d7aa8da7, 003d8c865c937687965b51559f743144f9e2a44c6dd566e218efba136bf52372535038d87e21d0e1f7394a45439f910d378d2c4d27bda5c8a4a84e84dd390488ed, 00e2
0d52a0222b7feadc2a89bfcab308bcaa4173e6b99e19b43945f3002c0c39d90461c215c1e229b6bca2a5908ae8778b991186e70435adace4283fc70856ad82, 005fe6453e9515ea4b6cc5e624e0a4d40f6084c7be7148180581aecac7304030c264bfe28cfed6dca71ee7e38c5790e4978277f5dd58d8493ac4429c5da9522697, 00cbe66045c8213cff0975e59bb97f01ccbef45065cd10944d5c180072a6c4eac32a6640c6b4d39589993192539178e0315aec
2b4bd21ba040cb19593f90411c3e, 01f97282011fc47a814628bda9a946c12ff8174fb70fd7a9315aaa6b76482860242e26ee86438268394ef7c3e6abb31f1ab19136d40eed763e3598cdc572590c63, 00104f61f92f5a17b98c95d87d9cb1bccea2c34614027151ea2e05e83e60bd6b142bcb17b8ed4006bc544643b2697d65023131f0cbaefddb3231378dbae0a7e6a9, 00a1c8a4d3ef1209a904b9e89b4be384f3096ea03bdac87528e327ef074a2dd69843
af01bed69eee44bc34c7adfa04b6bd96e95cca09ca330d1a6057ba85d62232, 01240b885b9181490000396659a3a48fb15329394c5c5cb11d8a18451665df28e0710469ad3063d7b54eae381d7617b5af6fc0a56901e1505719eb6427e7337dbe, 00a05c06bbfbfb95c0c4c975bd09eeaa6087d74be1fd54b744ce1abc10948b6cc9031f17f57dce0d4dc15727abfa6f93c0066bc4d2e0672469adbaf068184af794, 0015b5b4cdf9d6444c0cd12c48379ac199
663ff48cd86790e33f8f5ac509d2cdc83e1a5b0be4a7988752f73fc8ef32f680e724833730d5323960be5f193950d7d2, 00703af6847d883979f46e05b77b22afacc40a8ba15fb3ca133663af969f9ed7112c707002d80cbd143d20988a1a61c867d2e64dfb2a78cb576412a298688a826d, 01054ca727f3983c0c9c266c7bed151fdd242e7e38e92a1b7b393bd2259135b88c73211e4d00af6537ab62d9b1b6c358a1253ac5194033979729a7c9e73c47d05c, 
01f6735cb34a70f51a822ac154f2ab20a23abc3510b68dc9d82cc0015f5600095f7f36942946b1491a0bc225d57e9a5fff6af6964ae338c76dae58e19780240241, 002dde9734cf346dc586a2c5bf8af34a96b3c9235b6549989cdca5723770af4a2d3d287afaf896c6b0094cfe399b281e46fe58ee32998e9758253c1ca165191edd, 001cd48a9adb2f450a7e809eb4775ca4344a036d4b3ee09d3dc653e5950135116c537390c2b58b1b59710c1fe45ab92b81
ca5f71ff1dd310b0a4de4d5d743203a9, 00da6a23633471f05bbbcef9c58fc4257d522c34d199ca9e704142dff0874c0c7137dd28ff1cd1580ad594b9b97c239fedb35c256c8ac0cc316675d1ea0739c086, 00eccf905f2a85908e1a7f780ba2586b37798478ab210a35c4258b56de0cf13cb26c95822e3946d354e9fbe819cba9b8ca016622e6ce6167b958595f95b19ca846, 01307bf7af3dac59003b2d8584302983e3b5da476efcbaa6c154349951e94935
d51b3b9591846290f5c9d54dad8a883a170b33a15a6a87da9bb95d9307bdc0fc88, 00fc098c9bf
```

Becomes a log that looks like this:

```
INFO [1748461116.201555] [stackslib/src/net/rpc.rs:556] [p2p:(20444,20443)] Handled StacksHTTPRequest, verb: POST, path: /v3/blocks/upload/?broadcast=1, processing_time_ms: 0, latency_ms: 0, conn_id: 3, peer_addr: 127.0.0.1:48982, p2p_msg: NakamotoBlocks([77fb172b057d7ea3510bc22627c52f4ae7debb4dfdaf9840844cd1844edee50b])
```