### PR TITLE
Mark current miner as invalid on capitulation

### DIFF
--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -427,7 +427,12 @@ impl Signer {
                             sortition_state,
                         ),
                         SignerMessage::StateMachineUpdate(update) => self
-                            .handle_state_machine_update(signer_public_key, update, received_time),
+                            .handle_state_machine_update(
+                                signer_public_key,
+                                update,
+                                received_time,
+                                sortition_state,
+                            ),
                         _ => {}
                     }
                 }
@@ -756,6 +761,7 @@ impl Signer {
         signer_public_key: &Secp256k1PublicKey,
         update: &StateMachineUpdate,
         received_time: &SystemTime,
+        sortition_state: &mut Option<SortitionsView>,
     ) {
         let address = StacksAddress::p2pkh(self.mainnet, signer_public_key);
         // Store the state machine update so we can reload it if we crash
@@ -778,6 +784,7 @@ impl Signer {
             self.stacks_address,
             version,
             self.reward_cycle,
+            sortition_state,
         );
     }
 

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -687,17 +687,16 @@ impl LocalStateMachine {
             match new_miner {
                 StateMachineUpdateMinerState::ActiveMiner {
                     current_miner_pkh, ..
-                } => match sortition_state {
-                    Some(sortition_state) => {
+                } => {
+                    if let Some(sortition_state) = sortition_state {
                         // if there is a mismatch between the new_miner ad the current sortition view, mark the current miner as invalid
                         if current_miner_pkh != sortition_state.cur_sortition.miner_pkh {
                             sortition_state.cur_sortition.miner_status =
                                 SortitionMinerStatus::InvalidatedBeforeFirstBlock
                         }
                     }
-                    None => (),
-                },
-                StateMachineUpdateMinerState::NoValidMiner => {}
+                }
+                StateMachineUpdateMinerState::NoValidMiner => (),
             }
         }
     }

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -34,7 +34,7 @@ use stacks_common::util::secp256k1::MessageSignature;
 use stacks_common::{debug, info, warn};
 
 use crate::chainstate::{
-    ProposalEvalConfig, SignerChainstateError, SortitionState, SortitionsView,
+    ProposalEvalConfig, SignerChainstateError, SortitionMinerStatus, SortitionState, SortitionsView,
 };
 use crate::client::{ClientError, CurrentAndLastSortition, StackerDB, StacksClient};
 use crate::signerdb::SignerDb;
@@ -579,6 +579,7 @@ impl LocalStateMachine {
         local_address: StacksAddress,
         local_supported_signer_protocol_version: u64,
         reward_cycle: u64,
+        sortition_state: &mut Option<SortitionsView>,
     ) {
         // Before we ever access eval...we should make sure to include our own local state machine update message in the evaluation
         let Ok(mut local_update) =
@@ -682,6 +683,22 @@ impl LocalStateMachine {
                 active_signer_protocol_version,
                 tx_replay_set,
             });
+
+            match new_miner {
+                StateMachineUpdateMinerState::ActiveMiner {
+                    current_miner_pkh, ..
+                } => match sortition_state {
+                    Some(sortition_state) => {
+                        // if there is a mismatch between the new_miner ad the current sortition view, mark the current miner as invalid
+                        if current_miner_pkh != sortition_state.cur_sortition.miner_pkh {
+                            sortition_state.cur_sortition.miner_status =
+                                SortitionMinerStatus::InvalidatedBeforeFirstBlock
+                        }
+                    }
+                    None => (),
+                },
+                StateMachineUpdateMinerState::NoValidMiner => {}
+            }
         }
     }
 


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This patch fixes a race condition where a signer decides to capitulate on a miner but does not update its current sortition view potentially rejecting perfectly valid blocks

### Applicable issues

- fixes #6146 

### Additional info (benefits, drawbacks, caveats)

* the relevant test here is reorging_signers_capitulate_to_nonreorging_signers_during_tenure_fork that used to be flaky

* I am doubtful about the InvalidatedBeforeFirstBlock, it does its jobs, but probably we need to check if the signer has already signed something from the previous (invalid) sortition view.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
