### PR TITLE
Refactor1: ReplayState as enum

### DIFF
--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -52,7 +52,7 @@ use crate::client::{ClientError, SignerSlotID, StackerDB, StacksClient};
 use crate::config::{SignerConfig, SignerConfigMode};
 use crate::runloop::SignerResult;
 use crate::signerdb::{BlockInfo, BlockState, SignerDb};
-use crate::v0::signer_state::{NewBurnBlock, TxReplayScopeOpt};
+use crate::v0::signer_state::{NewBurnBlock, ReplayScopeOpt};
 use crate::Signer as SignerTrait;
 
 /// A global variable that can be used to make signers repeat their proposal
@@ -126,7 +126,7 @@ pub struct Signer {
     /// Whether to validate blocks with replay transactions
     pub validate_with_replay_tx: bool,
     /// Scope of Tx Replay in terms of Burn block boundaries
-    pub tx_replay_scope: TxReplayScopeOpt,
+    pub tx_replay_scope: ReplayScopeOpt,
 }
 
 impl std::fmt::Display for SignerMode {

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -1067,7 +1067,6 @@ impl LocalStateMachine {
         // Check if fork occurred within current reward cycle. Reject tx replay otherwise.
         let reward_cycle_info = client.get_current_reward_cycle_info()?;
 
-        //let target_reward_cycle = reward_cycle_info.reward_cycle;
         let target_reward_cycle = reward_cycle_info.get_reward_cycle(fork_tip.burn_block_height);
         let is_fork_in_current_reward_cycle = fork_info.iter().all(|fork_info| {
             let block_height = fork_info.burn_block_height;

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -106,7 +106,10 @@ pub enum ReplayState {
     NotStartedOrCleared,
     /// A replay is currently in progress, with an associated transaction set and scope.
     InProgress(ReplayTransactionSet, ReplayScope),
+    /// A previous replay has been cleared.
+    //Cleared,
     /// An invalid state — a transaction set was provided without a valid scope.
+    /// Possibly caused by the scope being a local state in the `Signer` struct.
     Invalid,
 }
 
@@ -116,7 +119,7 @@ impl ReplayState {
     /// - Returns `NotStartedOrCleared` if the replay set is empty.
     /// - Returns `Invalid` if the replay set exists but the scope is missing.
     /// - Returns `InProgress` if both a non-empty replay set and a valid scope are provided.
-    fn from(replay_set: &ReplayTransactionSet, scope_opt: &ReplayScopeOpt) -> Self {
+    fn from_status(replay_set: &ReplayTransactionSet, scope_opt: &ReplayScopeOpt) -> Self {
         if replay_set.is_empty() {
             return Self::NotStartedOrCleared;
         }
@@ -599,7 +602,7 @@ impl LocalStateMachine {
                 return Err(ClientError::InvalidResponse(err_msg).into());
             }
 
-            let replay_state = ReplayState::from(&tx_replay_set, &tx_replay_scope);
+            let replay_state = ReplayState::from_status(&tx_replay_set, &tx_replay_scope);
             if let Some(new_replay_state) = self.handle_possible_bitcoin_fork(
                 db,
                 client,
@@ -616,7 +619,10 @@ impl LocalStateMachine {
                         tx_replay_set = new_txs_set;
                         *tx_replay_scope = Some(new_scope);
                     }
-                    ReplayState::Invalid => warn!("Tx Replay: Invalid is not possible here!"),
+                    ReplayState::Invalid => {
+                        warn!("Tx Replay: Invalid state due to scope being not set while in replay mode!");
+                        return Err(SignerChainstateError::LocalStateMachineNotReady);
+                    }
                 }
             }
         }
@@ -973,51 +979,31 @@ impl LocalStateMachine {
             return Ok(None);
         }
 
-        if matches!(replay_state, ReplayState::Invalid) {
-            warn!("Tx Replay: Invalid state due to scope being not set while in replay mode!");
-            return Err(SignerChainstateError::LocalStateMachineNotReady);
-        }
-
-        if let ReplayState::InProgress(_txs_set, scope) = replay_state {
-            info!("Tx Replay: detected bitcoin fork while in replay mode. Tryng to handle the fork";
-                "expected_burn_block.height" => expected_burn_block.burn_block_height,
-                "expected_burn_block.hash" => %expected_burn_block.consensus_hash,
-                "prior_state_machine.burn_block_height" => prior_state_machine.burn_block_height,
-                "prior_state_machine.burn_block" => %prior_state_machine.burn_block,
-            );
-
-            let is_deepest_fork =
-                expected_burn_block.burn_block_height < scope.fork_origin.burn_block_height;
-            if !is_deepest_fork {
-                //if it is within the scope or after - this is not a new fork, but the continue of a reorg
-                info!("Tx Replay: nothing todo. Reorg in progress!");
-                return Ok(None);
-            }
-
-            let replay_state;
-            if let Some(replay_set) = self.compute_forked_txs_set_in_same_cycle(
+        match replay_state {
+            ReplayState::Invalid => Ok(Some(ReplayState::Invalid)),
+            ReplayState::NotStartedOrCleared => self.handle_fork_for_new_replay(
                 db,
                 client,
                 expected_burn_block,
-                &scope.past_tip,
-            )? {
-                let scope = ReplayScope {
-                    fork_origin: expected_burn_block.clone(),
-                    past_tip: scope.past_tip.clone(),
-                };
-
-                info!("Tx Replay: replay set updated with {} tx(s)", replay_set.len();
-                    "tx_replay_set" => ?replay_set,
-                    "tx_replay_scope" => ?scope);
-                replay_state =
-                    ReplayState::InProgress(ReplayTransactionSet::new(replay_set), scope);
-            } else {
-                info!("Tx Replay: replay set will be cleared, because the fork involves the previous reward cycle.");
-                replay_state = ReplayState::NotStartedOrCleared;
-            }
-            return Ok(Some(replay_state));
+                prior_state_machine,
+            ),
+            ReplayState::InProgress(_, scope) => self.handle_fork_on_in_progress_replay(
+                db,
+                client,
+                expected_burn_block,
+                prior_state_machine,
+                scope,
+            ),
         }
+    }
 
+    fn handle_fork_for_new_replay(
+        &self,
+        db: &SignerDb,
+        client: &StacksClient,
+        expected_burn_block: &NewBurnBlock,
+        prior_state_machine: &SignerStateMachine,
+    ) -> Result<Option<ReplayState>, SignerChainstateError> {
         info!("Signer State: fork detected";
             "expected_burn_block.height" => expected_burn_block.burn_block_height,
             "expected_burn_block.hash" => %expected_burn_block.consensus_hash,
@@ -1069,6 +1055,52 @@ impl LocalStateMachine {
                 }
             }
         }
+    }
+
+    fn handle_fork_on_in_progress_replay(
+        &self,
+        db: &SignerDb,
+        client: &StacksClient,
+        expected_burn_block: &NewBurnBlock,
+        prior_state_machine: &SignerStateMachine,
+        scope: ReplayScope,
+    ) -> Result<Option<ReplayState>, SignerChainstateError> {
+        info!("Tx Replay: detected bitcoin fork while in replay mode. Tryng to handle the fork";
+            "expected_burn_block.height" => expected_burn_block.burn_block_height,
+            "expected_burn_block.hash" => %expected_burn_block.consensus_hash,
+            "prior_state_machine.burn_block_height" => prior_state_machine.burn_block_height,
+            "prior_state_machine.burn_block" => %prior_state_machine.burn_block,
+        );
+
+        let is_deepest_fork =
+            expected_burn_block.burn_block_height < scope.fork_origin.burn_block_height;
+        if !is_deepest_fork {
+            //if it is within the scope or after - this is not a new fork, but the continue of a reorg
+            info!("Tx Replay: nothing todo. Reorg in progress!");
+            return Ok(None);
+        }
+
+        let replay_state;
+        if let Some(replay_set) = self.compute_forked_txs_set_in_same_cycle(
+            db,
+            client,
+            expected_burn_block,
+            &scope.past_tip,
+        )? {
+            let scope = ReplayScope {
+                fork_origin: expected_burn_block.clone(),
+                past_tip: scope.past_tip.clone(),
+            };
+
+            info!("Tx Replay: replay set updated with {} tx(s)", replay_set.len();
+                    "tx_replay_set" => ?replay_set,
+                    "tx_replay_scope" => ?scope);
+            replay_state = ReplayState::InProgress(ReplayTransactionSet::new(replay_set), scope);
+        } else {
+            info!("Tx Replay: replay set will be cleared, because the fork involves the previous reward cycle.");
+            replay_state = ReplayState::NotStartedOrCleared;
+        }
+        return Ok(Some(replay_state));
     }
 
     /// Retrieves the set of transactions that were part of a Bitcoin fork within the same reward cycle.

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -95,6 +95,28 @@ fn fault_injection_stall_tx() {}
 /// Test flag to exclude replay txs from the next block
 pub static TEST_EXCLUDE_REPLAY_TXS: LazyLock<TestFlag<bool>> = LazyLock::new(TestFlag::default);
 
+#[cfg(any(test, feature = "testing"))]
+/// Test flag to mine specific txs belonging to the replay set
+pub static TEST_MINE_ALLOWED_REPLAY_TXS: LazyLock<TestFlag<Vec<String>>> =
+    LazyLock::new(TestFlag::default);
+
+#[cfg(any(test, feature = "testing"))]
+/// Given a tx id, check if it is should be skipped
+/// if not listed in `TEST_MINE_ALLOWED_REPLAY_TXS` flag.
+/// If flag is empty means no tx should be skipped
+fn should_skip_replay_tx(tx_id: Txid) -> bool {
+    let minable_txs = TEST_MINE_ALLOWED_REPLAY_TXS.get();
+    let allowed =
+        minable_txs.len() == 0 || minable_txs.iter().any(|tx_ids| *tx_ids == tx_id.to_hex());
+    if !allowed {
+        info!(
+            "Tx skipped due to test flag TEST_MINE_ALLOWED_REPLAY_TXS: {}",
+            tx_id.to_hex()
+        );
+    }
+    !allowed
+}
+
 /// Fully-assembled Stacks anchored, block as well as some extra metadata pertaining to how it was
 /// linked to the burnchain and what view(s) the miner had of the burnchain before and after
 /// completing the block.
@@ -3005,6 +3027,13 @@ fn select_and_apply_transactions_from_vec<B: BlockBuilder>(
     debug!("Replay block transaction selection begins (parent height = {tip_height})");
     for replay_tx in replay_transactions {
         fault_injection_stall_tx();
+        #[cfg(any(test, feature = "testing"))]
+        {
+            if should_skip_replay_tx(replay_tx.txid()) {
+                continue;
+            }
+        }
+
         let txid = replay_tx.txid();
         let tx_result = builder.try_mine_tx_with_len(
             epoch_tx,

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -458,6 +458,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     pub fn submit_contract_deploy(
         &self,
         sender_sk: &StacksPrivateKey,
+        tx_fee: u64,
         contract_code: &str,
         contract_name: &str,
     ) -> Result<(String, u64), String> {
@@ -468,7 +469,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         let contract_tx = make_contract_publish(
             &sender_sk,
             sender_nonce,
-            1000000,
+            tx_fee,
             self.running_nodes.conf.burnchain.chain_id,
             contract_name,
             contract_code,
@@ -485,6 +486,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     pub fn submit_contract_call(
         &self,
         sender_sk: &StacksPrivateKey,
+        tx_fee: u64,
         contract_name: &str,
         contract_func: &str,
         contract_args: &[Value],
@@ -495,7 +497,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         let contract_call_tx = make_contract_call(
             &sender_sk,
             sender_nonce,
-            1000,
+            tx_fee,
             self.running_nodes.conf.burnchain.chain_id,
             &sender_addr,
             contract_name,
@@ -529,7 +531,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
            (ok (var-set local-burn-block-ht burn-block-height)))
         ";
         let (txid, sender_nonce) =
-            self.submit_contract_deploy(sender_sk, burn_height_contract, "burn-height-local")?;
+            self.submit_contract_deploy(sender_sk, 1000, burn_height_contract, "burn-height-local")?;
 
         self.wait_for_nonce_increase(&to_addr(&sender_sk), sender_nonce)?;
         Ok(txid)
@@ -542,7 +544,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         sender_sk: &StacksPrivateKey,
     ) -> Result<String, String> {
         let (txid, sender_nonce) =
-            self.submit_contract_call(sender_sk, "burn-height-local", "run-update", &[])?;
+            self.submit_contract_call(sender_sk, 1000, "burn-height-local", "run-update", &[])?;
 
         self.wait_for_nonce_increase(&to_addr(&sender_sk), sender_nonce)?;
         Ok(txid)

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -530,8 +530,12 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
          (define-public (run-update)
            (ok (var-set local-burn-block-ht burn-block-height)))
         ";
-        let (txid, sender_nonce) =
-            self.submit_contract_deploy(sender_sk, 1000, burn_height_contract, "burn-height-local")?;
+        let (txid, sender_nonce) = self.submit_contract_deploy(
+            sender_sk,
+            1000,
+            burn_height_contract,
+            "burn-height-local",
+        )?;
 
         self.wait_for_nonce_increase(&to_addr(&sender_sk), sender_nonce)?;
         Ok(txid)

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -468,7 +468,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         let contract_tx = make_contract_publish(
             &sender_sk,
             sender_nonce,
-            1000,
+            1000000,
             self.running_nodes.conf.burnchain.chain_id,
             contract_name,
             contract_code,

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -3732,7 +3732,7 @@ fn tx_replay_disagreement() {
 
 #[test]
 #[ignore]
-/// Demostrate Tx Replay reject a proposal with partial replayed transactions,
+/// Demonstrates Tx Replay reject a proposal with partial replayed transactions,
 /// when not due to a Tenure Extend
 ///
 /// The test flow is:
@@ -4149,7 +4149,7 @@ fn tx_replay_rejected_when_forking_across_reward_cycle() {
 
 #[test]
 #[ignore]
-/// Demostrate Tx Replay state is kept by Signers after a fork
+/// Demonstrates Tx Replay state is kept by Signers after a fork
 /// occurred before the miner start replaying transactions
 ///
 /// The test flow is:
@@ -4487,7 +4487,7 @@ fn tx_replay_with_fork_after_empty_tenures_before_starting_replaying_txs() {
 
 #[test]
 #[ignore]
-/// Demostrate Tx Replay Set to be updated from a deepest fork
+/// Demonstrates Tx Replay Set to be updated from a deepest fork
 /// than the one that made Tx Replay to start
 ///
 /// The test flow is:
@@ -4660,7 +4660,7 @@ fn tx_replay_with_fork_causing_replay_set_to_be_updated() {
 
 #[test]
 #[ignore]
-/// Demostrate Tx Replay Set to be cleared from a deepest fork
+/// Demonstrates Tx Replay Set to be cleared from a deepest fork
 /// than the one that made Tx Replay to start, that led to
 /// previous reward cylce
 ///
@@ -4809,7 +4809,7 @@ fn tx_replay_with_fork_causing_replay_to_be_cleared_due_to_cycle() {
 
 #[test]
 #[ignore]
-/// Demostrate Tx Replay restart from scratch while it is in progress
+/// Demonstrates Tx Replay restart from scratch while it is in progress
 /// (partially replayed a subset of transaction) and a fork occurs.
 /// In this case, partial replay is allowed because of tenure extend,
 /// due to Tenure Budget exceeded.
@@ -5024,7 +5024,7 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending() {
 
 #[test]
 #[ignore]
-/// Demostrate Tx Replay restart from scratch while it is in progress
+/// Demonstrates Tx Replay restart from scratch while it is in progress
 /// (partially replayed a subset of transaction), other transactions
 /// are submitted, and then a fork occurs.
 /// In this case, partial replay is allowed because of tenure extend,

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -46,6 +46,7 @@ use stacks::chainstate::stacks::boot::MINERS_NAME;
 use stacks::chainstate::stacks::db::{StacksBlockHeaderTypes, StacksChainState, StacksHeaderInfo};
 use stacks::chainstate::stacks::miner::{
     TransactionEvent, TransactionSuccessEvent, TEST_EXCLUDE_REPLAY_TXS,
+    TEST_MINE_ALLOWED_REPLAY_TXS,
 };
 use stacks::chainstate::stacks::{
     StacksTransaction, TenureChangeCause, TenureChangePayload, TransactionPayload,
@@ -54,10 +55,10 @@ use stacks::codec::StacksMessageCodec;
 use stacks::config::{Config as NeonConfig, EventKeyType, EventObserverConfig};
 use stacks::core::mempool::MemPoolWalkStrategy;
 use stacks::core::test_util::{
-    insert_tx_in_mempool, make_contract_call, make_contract_publish,
+    insert_tx_in_mempool, make_big_read_count_contract, make_contract_call, make_contract_publish,
     make_stacks_transfer_serialized, to_addr,
 };
-use stacks::core::{StacksEpochId, CHAIN_ID_TESTNET};
+use stacks::core::{StacksEpochId, CHAIN_ID_TESTNET, HELIUM_BLOCK_LIMIT_20};
 use stacks::libstackerdb::StackerDBChunkData;
 use stacks::net::api::getsigner::GetSignerResponse;
 use stacks::net::api::postblock_proposal::{
@@ -3731,6 +3732,291 @@ fn tx_replay_disagreement() {
 
 #[test]
 #[ignore]
+/// Demostrate Tx Replay reject a proposal with partial replayed transactions,
+/// when not due to a Tenure Extend
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 3 tenures
+/// - Submit 2 STX transfers (Tx1, Tx2) in the last tenure
+/// - Trigger a Bitcoin fork
+/// - Verify that signers move into tx replay state [Tx1, Tx2]
+/// - Force Miner to do partial replay (only Tx1)
+/// - Signers should reject miner proposal
+/// - In the end, Tx Replay Set remains unchanged [Tx1, Tx2]
+fn tx_replay_rejected_for_invalid_proposal_due_to_partial_replay() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender1_sk = Secp256k1PrivateKey::random();
+    let sender1_addr = tests::to_addr(&sender1_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let num_txs = 2;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 3;
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+    signer_test.check_signer_states_normal();
+
+    // Make transfer txs (these will get forked)
+    let (sender1_tx1, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let (sender1_tx2, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(2, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork -------------------------");
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 2);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+    // note, we should still have normal signer states!
+    signer_test.check_signer_states_normal();
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1
+                && tx_replay_set[1].txid().to_hex() == sender1_tx2;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    // We should have forked 2 txs
+    let sender1_nonce_post_fork = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(0, sender1_nonce_post_fork);
+
+    info!("------------------------- Partial Tx Replay (only Tx1) -------------------------");
+    test_observer::clear();
+    TEST_MINE_ALLOWED_REPLAY_TXS.set(vec![sender1_tx1.clone()]);
+    TEST_MINE_STALL.set(false);
+
+    // First, a Tenure Change block mined
+    let tip = get_chain_info(&conf);
+    _ = wait_for_tenure_change_tx(30, TenureChangeCause::BlockFound, tip.stacks_tip_height + 1);
+
+    // Then, expect next block proposal to contain just Tx1
+    let block_prop = wait_for_block_proposal(30, tip.stacks_tip_height + 2, &stacks_miner_pk)
+        .expect("Time out waiting for block proposal");
+    assert_eq!(1, block_prop.txs.len());
+    assert_eq!(sender1_tx1, block_prop.txs[0].txid().to_hex());
+
+    // Signers should reject this proposal, because not justified (e.g. tenure extend)
+    wait_for_block_global_rejection_with_reject_reason(
+        30,
+        block_prop.header.signer_signature_hash(),
+        num_signers,
+        RejectReason::ValidationFailed(ValidateRejectCode::InvalidTransactionReplay),
+    )
+    .expect("Time out waiting for global block rejection due to invalid tx replay");
+
+    // Tx Replay Set remains untouched
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1
+                && tx_replay_set[1].txid().to_hex() == sender1_tx2;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(0, sender1_nonce);
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Demonstrates that transaction replay can be "solved" using mempool transactions,
+/// by coincidence, rather than using the Tx Replay Set as the source.
+/// This works because the transactions in the mempool happen to match those in the replay set.
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 3 tenures
+/// - Submit 2 STX Transfer txs (Tx1, Tx2) in the last tenure
+/// - Trigger a Bitcoin fork (3 blocks)
+/// - Verify that signers move into tx replay state [Tx1, Tx2]
+/// - Force miner to solve replay with mempool [Tx1, Tx2]
+fn tx_replay_solved_by_mempool_txs() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender1_sk = Secp256k1PrivateKey::random();
+    let sender1_addr = tests::to_addr(&sender1_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let num_txs = 2;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 3;
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+    signer_test.check_signer_states_normal();
+
+    // Make a transfer tx (this will get forked)
+    let (sender1_tx1, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let (sender1_tx2, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(2, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork -------------------------");
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 2);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+    // note, we should still have normal signer states!
+    signer_test.check_signer_states_normal();
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1
+                && tx_replay_set[1].txid().to_hex() == sender1_tx2;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    // We should have forked 2 txs
+    let sender1_nonce_post_fork = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(0, sender1_nonce_post_fork);
+
+    info!("------------------------- Mine Tx Replay Set -------------------------");
+    TEST_EXCLUDE_REPLAY_TXS.set(true); //Force solving Tx Replay with mempool txs
+    TEST_MINE_STALL.set(false);
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| Ok(state.get_tx_replay_set().is_none()))
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    let sender1_nonce_post_replay = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(2, sender1_nonce_post_replay);
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
 /// Trigger a Bitcoin fork across reward cycle
 /// and ensure that the signers detect the fork,
 /// but reject to move into a tx replay state
@@ -3754,12 +4040,14 @@ fn tx_replay_rejected_when_forking_across_reward_cycle() {
     let sender_addr = tests::to_addr(&sender_sk);
     let send_amt = 100;
     let send_fee = 180;
+    let num_txs = 1;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender_addr, (send_amt + send_fee) * 10)],
+        vec![(sender_addr, (send_amt + send_fee) * num_txs)],
         |_| {},
         |node_config| {
             node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
         },
         None,
         None,
@@ -3855,6 +4143,1124 @@ fn tx_replay_rejected_when_forking_across_reward_cycle() {
             .all(|state| state.get_tx_replay_set().is_none()))
     })
     .expect("Unable to confirm tx replay state");
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Demostrate Tx Replay state is kept by Signers after a fork
+/// occurred before the miner start replaying transactions
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 12 tenures (to handle multiple forks in Cycle #12)
+/// - Submit a STX transfer (Tx1) in the last tenure
+/// - Trigger a Bitcoin fork
+/// - Verify that signers move into tx replay state [Tx1]
+/// - Trigger a Bitcoin fork
+/// - Verify that signers stay into tx replay state [Tx1]
+/// - In the end, let the miner solve the Tx Replay Set
+fn tx_replay_with_fork_occured_before_starting_replaying_txs() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender1_sk = Secp256k1PrivateKey::random();
+    let sender1_addr = tests::to_addr(&sender1_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let num_txs = 1;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 12; //go to 2nd tenure of 12th cycle
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+
+    // Make 1 transfer tx (this will get forked)
+    let (sender1_tx1, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(1, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork #1 -------------------------");
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 2);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+    // note, we should still have normal signer states!
+    signer_test.check_signer_states_normal();
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    // Signers move in Tx Replay mode
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 1;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    // We should have forked 1 tx
+    let sender1_nonce_post_fork = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(0, sender1_nonce_post_fork);
+
+    info!("------------------------- Triggering Bitcoin Fork #2 -------------------------");
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    //Signers still are in the initial state of Tx Replay mode
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 1;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    info!("----------- Solve TX Replay ------------");
+    TEST_MINE_STALL.set(false);
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| Ok(state.get_tx_replay_set().is_none()))
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    let sender1_nonce_after_replay = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(1, sender1_nonce_after_replay);
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Demonstrates that the Tx Replay state is preserved by signers after a fork
+/// that occurs following an "empty" tenure,
+/// but before the miner begins replaying transactions.
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 10 tenures (to handle multiple forks in Cycle #12)
+/// - Submit a STX transfer (Tx1) in the last tenure
+/// - Trigger a Bitcoin fork
+/// - Verify that signers move into tx replay state [Tx1]
+/// - Force the miner to mine an "empty" tenure (only Block Found)
+/// - Trigger a Bitcoin fork
+/// - Verify that signers stay into tx replay state [Tx1]
+/// - In the end, let the miner solve the Tx Replay Set
+fn tx_replay_with_fork_after_empty_tenures_before_starting_replaying_txs() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender1_sk = Secp256k1PrivateKey::random();
+    let sender1_addr = tests::to_addr(&sender1_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let num_txs = 1;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 10; //go to Tenure #4 in Cycle #12
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+
+    info!("------------------------- Sending Transactions -------------------------");
+    // Make a transfer tx (this will get forked)
+    let (sender1_tx1, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(1, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork #1 -------------------------");
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 2);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+    // note, we should still have normal signer states!
+    signer_test.check_signer_states_normal();
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    // Signers moved in Tx Replay mode
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 1;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    // We should have forked tx1
+    let sender1_nonce_post_fork = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(0, sender1_nonce_post_fork);
+
+    info!("------------------- Produce Empty Tenuree -------------------------");
+    TEST_MINE_STALL.set(false);
+    let tip = get_chain_info(&conf);
+    _ = wait_for_tenure_change_tx(30, TenureChangeCause::BlockFound, tip.stacks_tip_height + 1);
+    TEST_MINE_STALL.set(true);
+
+    let commits_count = submitted_commits.load(Ordering::SeqCst);
+    next_block_and(btc_controller, 60, || {
+        Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+    })
+    .unwrap();
+
+    TEST_MINE_STALL.set(false);
+    let tip = get_chain_info(&conf);
+    _ = wait_for_tenure_change_tx(30, TenureChangeCause::BlockFound, tip.stacks_tip_height + 1);
+    TEST_MINE_STALL.set(true);
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 1;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    info!("------------------------- Triggering Bitcoin Fork #2 -------------------------");
+    test_observer::clear();
+
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    // Signers still are in Tx Replay mode (as the initial replay state)
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 1;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    info!("------------------------- Mine Tx Replay Set -------------------------");
+    TEST_MINE_STALL.set(false);
+    signer_test
+        .wait_for_signer_state_check(30, |state| Ok(state.get_tx_replay_set().is_none()))
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Demostrate Tx Replay Set to be updated from a deepest fork
+/// than the one that made Tx Replay to start
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 10 tenures (to handle multiple forks in Cycle #12)
+/// - Submit a STX transfer (Tx1) in the last tenure
+/// - Mine 3 new tenures
+/// - Submit a STX transfer (Tx2) in the last tenure
+/// - Trigger a Bitcoin fork (involving Tx2 only)
+/// - Verify that signers move into tx replay state [Tx2]
+/// - Trigger a Bitcoin fork (deepest to involve Tx1)
+/// - Verify that signers update tx replay state to [Tx1, Tx2]
+/// - In the end, let the miner solve the Tx Replay Set
+fn tx_replay_with_fork_causing_replay_set_to_be_updated() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender1_sk = Secp256k1PrivateKey::random();
+    let sender1_addr = tests::to_addr(&sender1_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let num_txs = 2;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 10;
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+        signer_test.check_signer_states_normal();
+    }
+
+    // Make 2 transfer txs, each in its own tenure so that can be forked in different forks
+    let tip_at_tx1 = get_chain_info(&conf);
+    assert_eq!(241, tip_at_tx1.burn_block_height);
+    let (sender1_tx1, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+
+    let tip_at_tx2 = get_chain_info(&conf);
+    assert_eq!(244, tip_at_tx2.burn_block_height);
+    let (sender1_tx2, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(2, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork #1 -------------------------");
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip_at_tx2.burn_block_height - 2);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+    // note, we should still have normal signer states!
+    signer_test.check_signer_states_normal();
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+    assert_eq!(247, get_chain_info(&conf).burn_block_height);
+
+    // Signers move in Tx Replay mode
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 1;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx2;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    // We should have forked one tx (Tx2)
+    let sender1_nonce_post_fork = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(1, sender1_nonce_post_fork);
+
+    info!("------------------------- Triggering Bitcoin Fork #2 -------------------------");
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip_at_tx1.burn_block_height);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(7);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+    assert_eq!(250, get_chain_info(&conf).burn_block_height);
+
+    //Signers should update the Tx Replay Set
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1
+                && tx_replay_set[1].txid().to_hex() == sender1_tx2;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    info!("----------- Solve TX Replay ------------");
+    TEST_MINE_STALL.set(false);
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| Ok(state.get_tx_replay_set().is_none()))
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    let sender1_nonce_after_replay = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(2, sender1_nonce_after_replay);
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Demostrate Tx Replay Set to be cleared from a deepest fork
+/// than the one that made Tx Replay to start, that led to
+/// previous reward cylce
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 8 tenures (to arrive at Cycle #11 boundary)
+/// - Mine 3 more tenures (to enter Cycle #12)
+/// - Submit a STX transfer (Tx1) in the last tenure
+/// - Trigger a Bitcoin fork (in Cycle #12)
+/// - Verify that signers move into tx replay state [Tx1]
+/// - Trigger a Bitcoin fork (deepest to involve Cycle #11)
+/// - Verify that signers clear the tx replay state
+fn tx_replay_with_fork_causing_replay_to_be_cleared_due_to_cycle() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender1_sk = Secp256k1PrivateKey::random();
+    let sender1_addr = tests::to_addr(&sender1_sk);
+    let send_amt = 100;
+    let send_fee = 180;
+    let num_txs = 2;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 8;
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+        signer_test.check_signer_states_normal();
+    }
+
+    let tip_at_rc11 = get_chain_info(&conf);
+    assert_eq!(239, tip_at_rc11.burn_block_height);
+    assert_eq!(11, signer_test.get_current_reward_cycle());
+
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+
+    let tip_at_rc12 = get_chain_info(&conf);
+    assert_eq!(242, tip_at_rc12.burn_block_height);
+    assert_eq!(12, signer_test.get_current_reward_cycle());
+
+    // Make 2 transfer txs, each in its own tenure so that can be forked in different forks
+    let (sender1_tx1, sender1_nonce) = signer_test
+        .submit_transfer_tx(&sender1_sk, send_fee, send_amt)
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, sender1_nonce)
+        .expect("Expect sender1 nonce increased");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(1, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork #1 -------------------------");
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip_at_rc12.burn_block_height - 2);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+    // note, we should still have normal signer states!
+    signer_test.check_signer_states_normal();
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    // Signers move in Tx Replay mode
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 1;
+            let txid_ok = tx_replay_set[0].txid().to_hex() == sender1_tx1;
+            Ok(len_ok && txid_ok)
+        })
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    // We should have forked one tx (Tx2)
+    let sender1_nonce_post_fork = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(0, sender1_nonce_post_fork);
+
+    info!("------------------------- Triggering Bitcoin Fork #2 -------------------------");
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip_at_rc11.burn_block_height);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(7);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    //Signers should clear the Tx Replay Set
+    signer_test
+        .wait_for_signer_state_check(30, |state| Ok(state.get_tx_replay_set().is_none()))
+        .expect("Timed out waiting for tx replay set to be updated");
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Demostrate Tx Replay restart from scratch while it is in progress
+/// (partially replayed a subset of transaction) and a fork occurs.
+/// In this case, partial replay is allowed because of tenure extend,
+/// due to Tenure Budget exceeded.
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 10 tenures (to handle multiple fork in Cycle 12)
+/// - Deploy 1 Big Contract and mine 2 tenures (to escape fork)
+/// - Submit 2 Contract Call txs (Tx1, Tx2) in the last tenure,
+///   requiring Tenure Extend due to Tenure Budget exceeded
+/// - Trigger a Bitcoin fork
+/// - Verify that signers move into tx replay state [Tx1, Tx2]
+/// - Force Miner to do a partial replay (only Tx1),
+///   blocking Tenure extension
+/// - Trigger a Bitcoin fork
+/// - In the end, Tx Replay Set is solved from scratch [Tx1, Tx2]
+fn tx_replay_with_fork_middle_replay_while_tenure_extending() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_addr = tests::to_addr(&sender_sk);
+    let send_amt = 1000;
+    let send_fee = 1000000;
+    let num_txs = 3;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender_addr, (send_amt + send_fee) * num_txs)],
+        |c| {
+            c.validate_with_replay_tx = true;
+            c.tenure_idle_timeout = Duration::from_secs(10);
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 10;
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+    signer_test.check_signer_states_normal();
+
+    info!("---- Deploying big contract ----");
+    // First, just deploy the contract in its own tenure
+    let contract_code = make_big_read_count_contract(HELIUM_BLOCK_LIMIT_20, 50);
+    let (_deploy_txid, deploy_nonce) = signer_test
+        .submit_contract_deploy(&sender_sk, contract_code.as_str(), "big-contract")
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender_addr, deploy_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+
+    // Then, sumbmit 2 Contract Calls that require Tenure Extension to be addressed.
+    info!("---- Submit big tx1 to be mined ----");
+    let (txid1, txid1_nonce) = signer_test
+        .submit_contract_call(&sender_sk, "big-contract", "big-tx", &vec![])
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender_addr, txid1_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    info!("---- Submit big tx2 to be mined ----");
+    let (txid2, txid2_nonce) = signer_test
+        .submit_contract_call(&sender_sk, "big-contract", "big-tx", &vec![])
+        .unwrap();
+
+    // Tenure Extend happen because of tenure budget exceeded
+    let tip = get_chain_info(conf);
+    _ = wait_for_tenure_change_tx(30, TenureChangeCause::Extended, tip.stacks_tip_height + 1);
+
+    signer_test
+        .wait_for_nonce_increase(&sender_addr, txid2_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    let sender1_nonce = get_account(&http_origin, &sender_addr).nonce;
+    assert_eq!(3, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork -------------------------");
+    let tip = get_chain_info(conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 1);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
+            let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
+            Ok(len_ok && txid1_ok && txid2_ok)
+        })
+        .expect("Timed out waiting for tx replay set");
+
+    let post_fork_nonce = get_account(&http_origin, &sender_addr).nonce;
+    assert_eq!(1, post_fork_nonce); //due to contract deploy tx
+
+    info!("---- Force Partial Tx Replay ----");
+    // Only Tx1 is replayed, preventing Tenure Extension stalling the miner
+    TEST_MINE_STALL.set(false);
+    let tip = get_chain_info(&conf);
+    _ = wait_for_tenure_change_tx(30, TenureChangeCause::BlockFound, tip.stacks_tip_height + 1);
+    _ = wait_for_block_proposal(30, tip.stacks_tip_height + 2, &stacks_miner_pk);
+    TEST_MINE_STALL.set(true);
+
+    // Signers still waiting for the Tx Replay set to be completed
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
+            let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
+            Ok(len_ok && txid1_ok && txid2_ok)
+        })
+        .expect("Timed out waiting for tx replay set");
+
+    info!("------------------------- Triggering Bitcoin Fork #2 -------------------------");
+    //Fork in the middle of Tx Replay
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 1);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
+            let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
+            Ok(len_ok && txid1_ok && txid2_ok)
+        })
+        .expect("Timed out waiting for tx replay set");
+
+    let post_fork_nonce = get_account(&http_origin, &sender_addr).nonce;
+    assert_eq!(1, post_fork_nonce); //due to contract deploy tx
+
+    info!("---- Waiting for replay set to be cleared ----");
+    TEST_MINE_STALL.set(false);
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let tx_replay_set = state.get_tx_replay_set();
+            Ok(tx_replay_set.is_none())
+        })
+        .expect("Timed out waiting for tx replay set to be cleared");
+
+    let post_replay_nonce = get_account(&http_origin, &sender_addr).nonce;
+    assert_eq!(3, post_replay_nonce); //1 contract deploy tx + 2 contract call txs
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Demostrate Tx Replay restart from scratch while it is in progress
+/// (partially replayed a subset of transaction), other transactions
+/// are submitted, and then a fork occurs.
+/// In this case, partial replay is allowed because of tenure extend,
+/// due to Tenure Budget exceeded.
+///
+/// The test flow is:
+///
+/// - Boot to Epoch 3
+/// - Mine 10 tenures (to handle multiple fork in Cycle 12)
+/// - Deploy 1 Big Contract and mine 2 tenures (to escape fork)
+/// - Submit 2 Contract Call txs (Tx1, Tx2) in the last tenure,
+///   requiring Tenure Extend due to Tenure Budget exceeded
+/// - Trigger a Bitcoin fork
+/// - Verify that signers move into tx replay state [Tx1, Tx2]
+/// - Force Miner to do a partial replay (only Tx1),
+///   blocking Tenure extension
+/// - Submit a STX Transfer tx (Tx3) in the last tenure
+/// - Trigger a Bitcoin fork
+/// - In the end:
+///   - first, Tx Replay Set is solved from scratch [Tx1, Tx2]
+///   - then, Tx3 is mined normally
+fn tx_replay_with_fork_middle_replay_while_tenure_extending_and_new_tx_submitted() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender1_sk = Secp256k1PrivateKey::random();
+    let sender1_addr = tests::to_addr(&sender1_sk);
+    let send1_amt = 1000;
+    let send1_fee = 1000000;
+    let send1_txs = 3;
+    let sender2_sk = Secp256k1PrivateKey::random();
+    let sender2_addr = tests::to_addr(&sender2_sk);
+    let send2_amt = 100;
+    let send2_fee = 180;
+    let send2_txs = 1;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![
+            (sender1_addr, (send1_amt + send1_fee) * send1_txs),
+            (sender2_addr, (send2_amt + send2_fee) * send2_txs),
+        ],
+        |c| {
+            c.validate_with_replay_tx = true;
+            c.tenure_idle_timeout = Duration::from_secs(10);
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+            node_config.miner.replay_transactions = true;
+        },
+        None,
+        None,
+    );
+    let conf = &signer_test.running_nodes.conf;
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+    let counters = &signer_test.running_nodes.counters;
+    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+    let pre_fork_tenures = 10;
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+    signer_test.check_signer_states_normal();
+
+    info!("---- Deploying big contract ----");
+    // First, just deploy the contract in its own tenure
+    let contract_code = make_big_read_count_contract(HELIUM_BLOCK_LIMIT_20, 50);
+    let (_deploy_txid, deploy_nonce) = signer_test
+        .submit_contract_deploy(&sender1_sk, contract_code.as_str(), "big-contract")
+        .unwrap();
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, deploy_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+
+    // Then, sumbmit 2 Contract Calls that require Tenure Extension to be addressed.
+    info!("---- Waiting for first big tx to be mined ----");
+    let (txid1, txid1_nonce) = signer_test
+        .submit_contract_call(&sender1_sk, "big-contract", "big-tx", &vec![])
+        .unwrap();
+
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, txid1_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    info!("---- Waiting for second big tx to be mined ----");
+    let (txid2, txid2_nonce) = signer_test
+        .submit_contract_call(&sender1_sk, "big-contract", "big-tx", &vec![])
+        .unwrap();
+
+    // Tenure Extend happen because of tenure budget exceeded
+    let tip = get_chain_info(conf);
+    _ = wait_for_tenure_change_tx(30, TenureChangeCause::Extended, tip.stacks_tip_height + 1);
+
+    signer_test
+        .wait_for_nonce_increase(&sender1_addr, txid2_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    let sender1_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(3, sender1_nonce);
+
+    info!("------------------------- Triggering Bitcoin Fork -------------------------");
+    let tip = get_chain_info(conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 1);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
+            let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
+            Ok(len_ok && txid1_ok && txid2_ok)
+        })
+        .expect("Timed out waiting for tx replay set");
+
+    let post_fork_nonce = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(1, post_fork_nonce); //due to contract deploy tx
+
+    info!("---- Force Partial Tx Replay ----");
+    // Only Tx1 is replayed, preventing Tenure Extension stalling the miner
+    TEST_MINE_STALL.set(false);
+    let tip = get_chain_info(&conf);
+    _ = wait_for_tenure_change_tx(30, TenureChangeCause::BlockFound, tip.stacks_tip_height + 1);
+    _ = wait_for_block_proposal(30, tip.stacks_tip_height + 2, &stacks_miner_pk);
+    TEST_MINE_STALL.set(true);
+
+    // Signers still waiting for the Tx Replay set to be completed
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
+            let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
+            Ok(len_ok && txid1_ok && txid2_ok)
+        })
+        .expect("Timed out waiting for tx replay set");
+
+    info!("---- New Transaction is Submitted ----");
+    // Tx3 reach the mempool, meanwhile mining is stalled
+    let (_sender2_tx3, sender2_nonce) = signer_test
+        .submit_transfer_tx(&sender2_sk, send2_fee, send2_amt)
+        .unwrap();
+
+    info!("------------------------- Triggering Bitcoin Fork #2 -------------------------");
+    //Fork in the middle of Tx Replay
+    let tip = get_chain_info(&conf);
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 1);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+
+    info!("Wait for block off of shallow fork");
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = counters.naka_submitted_commits.clone();
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
+            let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
+            Ok(len_ok && txid1_ok && txid2_ok)
+        })
+        .expect("Timed out waiting for tx replay set");
+
+    let sender1_nonce_post_fork = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(1, sender1_nonce_post_fork); //due to contract deploy tx
+
+    let sender2_nonce_post_fork = get_account(&http_origin, &sender2_addr).nonce;
+    assert_eq!(0, sender2_nonce_post_fork);
+
+    info!("---- Waiting for replay set to be cleared ----");
+    TEST_MINE_STALL.set(false);
+
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let tx_replay_set = state.get_tx_replay_set();
+            Ok(tx_replay_set.is_none())
+        })
+        .expect("Timed out waiting for tx replay set to be cleared");
+
+    let sender1_nonce_post_replay = get_account(&http_origin, &sender1_addr).nonce;
+    assert_eq!(3, sender1_nonce_post_replay); //1 contract deploy tx + 2 contract call txs
+
+    //waiting for Tx3 to be processed normally
+    signer_test
+        .wait_for_nonce_increase(&sender2_addr, sender2_nonce)
+        .expect("Timed out waiting for nonce to increase");
+    let sender2_nonce_post_replay = get_account(&http_origin, &sender2_addr).nonce;
+    assert_eq!(1, sender2_nonce_post_replay);
 
     signer_test.shutdown();
 }

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -3117,7 +3117,10 @@ fn tx_replay_forking_test() {
     let call_fee = 1000;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender_addr, (send_amt + send_fee) * 10 + deploy_fee + call_fee)],
+        vec![(
+            sender_addr,
+            (send_amt + send_fee) * 10 + deploy_fee + call_fee,
+        )],
         |c| {
             c.validate_with_replay_tx = true;
         },
@@ -4874,7 +4877,12 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending() {
     // First, just deploy the contract in its own tenure
     let contract_code = make_big_read_count_contract(HELIUM_BLOCK_LIMIT_20, 50);
     let (_deploy_txid, deploy_nonce) = signer_test
-        .submit_contract_deploy(&sender_sk, deploy_fee, contract_code.as_str(), "big-contract")
+        .submit_contract_deploy(
+            &sender_sk,
+            deploy_fee,
+            contract_code.as_str(),
+            "big-contract",
+        )
         .unwrap();
     signer_test
         .wait_for_nonce_increase(&sender_addr, deploy_nonce)
@@ -5067,7 +5075,10 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending_and_new_tx_submitted
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![
-            (sender1_addr, send1_deploy_fee + send1_call_fee * send1_call_num),
+            (
+                sender1_addr,
+                send1_deploy_fee + send1_call_fee * send1_call_num,
+            ),
             (sender2_addr, (send2_amt + send2_fee) * send2_txs),
         ],
         |c| {
@@ -5100,7 +5111,12 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending_and_new_tx_submitted
     // First, just deploy the contract in its own tenure
     let contract_code = make_big_read_count_contract(HELIUM_BLOCK_LIMIT_20, 50);
     let (_deploy_txid, deploy_nonce) = signer_test
-        .submit_contract_deploy(&sender1_sk, send1_deploy_fee, contract_code.as_str(), "big-contract")
+        .submit_contract_deploy(
+            &sender1_sk,
+            send1_deploy_fee,
+            contract_code.as_str(),
+            "big-contract",
+        )
         .unwrap();
     signer_test
         .wait_for_nonce_increase(&sender1_addr, deploy_nonce)
@@ -5112,7 +5128,13 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending_and_new_tx_submitted
     // Then, sumbmit 2 Contract Calls that require Tenure Extension to be addressed.
     info!("---- Waiting for first big tx to be mined ----");
     let (txid1, txid1_nonce) = signer_test
-        .submit_contract_call(&sender1_sk, send1_call_fee,"big-contract", "big-tx", &vec![])
+        .submit_contract_call(
+            &sender1_sk,
+            send1_call_fee,
+            "big-contract",
+            "big-tx",
+            &vec![],
+        )
         .unwrap();
 
     signer_test
@@ -5121,7 +5143,13 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending_and_new_tx_submitted
 
     info!("---- Waiting for second big tx to be mined ----");
     let (txid2, txid2_nonce) = signer_test
-        .submit_contract_call(&sender1_sk, send1_call_fee, "big-contract", "big-tx", &vec![])
+        .submit_contract_call(
+            &sender1_sk,
+            send1_call_fee,
+            "big-contract",
+            "big-tx",
+            &vec![],
+        )
         .unwrap();
 
     // Tenure Extend happen because of tenure budget exceeded
@@ -17182,7 +17210,13 @@ fn bitcoin_reorg_extended_tenure() {
 
     miners
         .signer_test
-        .submit_contract_call(&miners.sender_sk, 1000,"burn-height-local", "run-update", &[])
+        .submit_contract_call(
+            &miners.sender_sk,
+            1000,
+            "burn-height-local",
+            "run-update",
+            &[],
+        )
         .unwrap();
 
     let rc = miners.signer_test.get_current_reward_cycle();


### PR DESCRIPTION
Refactor to ReplayState as enum:

```
pub enum ReplayState {
    /// No replay has started yet, or the previous replay was cleared.
    NotStartedOrCleared,
    /// A replay is currently in progress, with an associated transaction set and scope.
    InProgress(ReplayTransactionSet, ReplayScope),
    /// A previous replay has been cleared.
    //Cleared,
    /// An invalid state — a transaction set was provided without a valid scope.
    /// Possibly caused by the scope being a local state in the `Signer` struct.
    Invalid,
}
```