### PR TITLE
fix: clippy error on windows 

### DIFF
--- a/stacks-common/src/deps_common/ctrlc/tests.rs
+++ b/stacks-common/src/deps_common/ctrlc/tests.rs
@@ -130,12 +130,16 @@ mod platform {
     }
 
     unsafe fn get_stdout() -> io::Result<HANDLE> {
+        use std::ffi::CString;
+
         use winapi::um::fileapi::{CreateFileA, OPEN_EXISTING};
         use winapi::um::handleapi::INVALID_HANDLE_VALUE;
         use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
 
+        let conout = CString::new("CONOUT$").expect("CString::new failed");
+
         let stdout = CreateFileA(
-            "CONOUT$\0".as_ptr() as *const CHAR,
+            conout.as_ptr() as *const CHAR,
             GENERIC_READ | GENERIC_WRITE,
             FILE_SHARE_WRITE,
             ptr::null_mut(),


### PR DESCRIPTION
### Description

This patch fix clippy error on windows. In details:

```
error: manually constructing a nul-terminated string
   --> stacks-common\src\deps_common\ctrlc\tests.rs:138:13
    |
138 |             "CONOUT$\0".as_ptr() as *const CHAR,
    |             ^^^^^^^^^^^ help: use a `c""` literal: `c"CONOUT$"`
```

this error prevents to run succesfully the command `cargo clippy-stacks` on the whole codebase on windows ide.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
