### PR TITLE
fix clippy error and `cargo check` warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [alias]
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
-clippy-stacks = "clippy -p stx-genesis -p libstackerdb -p stacks-signer -p pox-locking -p clarity -p libsigner -p stacks-common --no-deps --tests --all-features -- -D warnings"
+clippy-stacks = "clippy -p stx-genesis -p libstackerdb -p stacks-signer -p pox-locking -p clarity -p libsigner -p stacks-common --no-deps --tests --all-features -- -D warnings -A clippy::uninlined-format-args"
 
 # Uncomment to improve performance slightly, at the cost of portability
 #   * Note that native binaries may not run on CPUs that are different from the build machine

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,8 @@
 {
-    "lldb.launch.sourceLanguages": [
-        "rust"
-    ],
-    "rust-analyzer.runnables.extraEnv": {
-        "BITCOIND_TEST": "1"
-    },
-    "rust-analyzer.rustfmt.extraArgs": [
-        "+nightly"
-    ],
-    "files.eol": "\n"
+  "lldb.launch.sourceLanguages": ["rust"],
+  "rust-analyzer.runnables.extraEnv": {
+    "BITCOIND_TEST": "1"
+  },
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+  "files.eol": "\n"
 }

--- a/stacks-common/build.rs
+++ b/stacks-common/build.rs
@@ -74,7 +74,7 @@ fn main() {
         "pub const GIT_COMMIT: Option<&'static str> = {git_commit:?};\n",
     ));
     if let Some(git_commit) = git_commit {
-        println!("cargo:rustc-env=GIT_COMMIT={}", git_commit);
+        println!("cargo:rustc-env=GIT_COMMIT={git_commit}");
     }
 
     let git_branch = current_git_branch();
@@ -82,15 +82,14 @@ fn main() {
         "pub const GIT_BRANCH: Option<&'static str> = {git_branch:?};\n",
     ));
     if let Some(git_branch) = git_branch {
-        println!("cargo:rustc-env=GIT_BRANCH={}", git_branch);
+        println!("cargo:rustc-env=GIT_BRANCH={git_branch}");
     }
 
     let is_clean = if is_working_tree_clean() { "" } else { "+" };
     rust_code.push_str(&format!(
-        "pub const GIT_TREE_CLEAN: Option<&'static str> = Some(\"{}\");\n",
-        is_clean
+        "pub const GIT_TREE_CLEAN: Option<&'static str> = Some(\"{is_clean}\");\n",
     ));
-    println!("cargo:rustc-env=GIT_TREE_CLEAN={}", is_clean);
+    println!("cargo:rustc-env=GIT_TREE_CLEAN={is_clean}");
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("versions.rs");

--- a/stacks-common/src/address/c32.rs
+++ b/stacks-common/src/address/c32.rs
@@ -369,7 +369,7 @@ pub fn c32_address_decode(c32_address_str: &str) -> Result<(u8, Vec<u8>), Error>
 
 pub fn c32_address(version: u8, data: &[u8]) -> Result<String, Error> {
     let c32_string = c32_check_encode(version, data)?;
-    Ok(format!("S{}", c32_string))
+    Ok(format!("S{c32_string}"))
 }
 
 #[cfg(test)]

--- a/stacks-common/src/address/mod.rs
+++ b/stacks-common/src/address/mod.rs
@@ -56,15 +56,14 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::InvalidCrockford32 => write!(f, "Invalid crockford 32 string"),
-            Error::InvalidVersion(ref v) => write!(f, "Invalid version {}", v),
+            Error::InvalidVersion(ref v) => write!(f, "Invalid version {v}"),
             Error::EmptyData => f.write_str("Empty data"),
-            Error::BadByte(b) => write!(f, "invalid base58 character 0x{:x}", b),
+            Error::BadByte(b) => write!(f, "invalid base58 character 0x{b:x}"),
             Error::BadChecksum(exp, actual) => write!(
                 f,
-                "base58ck checksum 0x{:x} does not match expected 0x{:x}",
-                actual, exp
+                "base58ck checksum 0x{actual:x} does not match expected 0x{exp:x}"
             ),
-            Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
+            Error::InvalidLength(ell) => write!(f, "length {ell} invalid for this base58 type"),
             Error::TooShort(_) => write!(f, "base58ck data not even long enough for a checksum"),
             Error::Other(ref s) => f.write_str(s),
         }

--- a/stacks-common/src/bitvec.rs
+++ b/stacks-common/src/bitvec.rs
@@ -246,7 +246,7 @@ impl<const MAX_SIZE: u16> BitVec<MAX_SIZE> {
             .data
             .into_iter()
             .fold(String::new(), |acc, byte| {
-                acc + &format!("{:08b}", byte).chars().rev().collect::<String>()
+                acc + &format!("{byte:08b}").chars().rev().collect::<String>()
             })
             .chars()
             .take(self.len() as usize)

--- a/stacks-common/src/codec/mod.rs
+++ b/stacks-common/src/codec/mod.rs
@@ -139,15 +139,13 @@ fn read_next_vec<T: StacksMessageCodec + Sized, R: Read>(
         if len > max_items {
             // too many items
             return Err(Error::DeserializeError(format!(
-                "Array has too many items ({} > {}",
-                len, max_items
+                "Array has too many items ({len} > {max_items})"
             )));
         }
     } else if len != num_items {
         // inexact item count
         return Err(Error::DeserializeError(format!(
-            "Array has incorrect number of items ({} != {})",
-            len, num_items
+            "Array has incorrect number of items ({len} != {num_items})"
         )));
     }
 

--- a/stacks-common/src/deps_common/bech32/mod.rs
+++ b/stacks-common/src/deps_common/bech32/mod.rs
@@ -679,11 +679,11 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::MissingSeparator => write!(f, "missing human-readable separator, \"{}\"", SEP),
+            Error::MissingSeparator => write!(f, "missing human-readable separator, \"{SEP}\""),
             Error::InvalidChecksum => write!(f, "invalid checksum"),
             Error::InvalidLength => write!(f, "invalid length"),
-            Error::InvalidChar(n) => write!(f, "invalid character (code={})", n),
-            Error::InvalidData(n) => write!(f, "invalid data point ({})", n),
+            Error::InvalidChar(n) => write!(f, "invalid character (code={n})"),
+            Error::InvalidData(n) => write!(f, "invalid data point ({n})"),
             Error::InvalidPadding => write!(f, "invalid padding"),
             Error::MixedCase => write!(f, "mixed-case strings not allowed"),
         }

--- a/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
@@ -111,14 +111,14 @@ impl fmt::Debug for Script {
             if opcode == opcodes::All::OP_PUSHBYTES_0 {
                 f.write_str("OP_0")?;
             } else {
-                write!(f, "{:?}", opcode)?;
+                write!(f, "{opcode:?}")?;
             }
             // Write any pushdata
             if data_len > 0 {
                 f.write_str(" ")?;
                 if index + data_len <= self.0.len() {
                     for ch in &self.0[index..index + data_len] {
-                        write!(f, "{:02x}", ch)?;
+                        write!(f, "{ch:02x}")?;
                     }
                     index += data_len;
                 } else {
@@ -140,7 +140,7 @@ impl fmt::Display for Script {
 impl fmt::LowerHex for Script {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for &ch in self.0.iter() {
-            write!(f, "{:02x}", ch)?;
+            write!(f, "{ch:02x}")?;
         }
         Ok(())
     }
@@ -149,7 +149,7 @@ impl fmt::LowerHex for Script {
 impl fmt::UpperHex for Script {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for &ch in self.0.iter() {
-            write!(f, "{:02X}", ch)?;
+            write!(f, "{ch:02X}")?;
         }
         Ok(())
     }
@@ -677,7 +677,7 @@ impl serde::Serialize for Script {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("{:x}", self))
+        serializer.serialize_str(&format!("{self:x}"))
     }
 }
 

--- a/stacks-common/src/deps_common/bitcoin/network/serialize.rs
+++ b/stacks-common/src/deps_common/bitcoin/network/serialize.rs
@@ -77,14 +77,13 @@ impl fmt::Display for Error {
             Error::UnexpectedNetworkMagic {
                 expected: ref e,
                 actual: ref a,
-            } => write!(f, "unexpected network magic: expected {}, actual {}", e, a),
+            } => write!(f, "unexpected network magic: expected {e}, actual {a}"),
             Error::OversizedVectorAllocation {
                 requested: ref r,
                 max: ref m,
             } => write!(
                 f,
-                "allocation of oversized vector requested: requested {}, maximum {}",
-                r, m
+                "allocation of oversized vector requested: requested {r}, maximum {m}"
             ),
             Error::InvalidChecksum {
                 expected: ref e,
@@ -95,18 +94,18 @@ impl fmt::Display for Error {
                 hex_encode(e),
                 hex_encode(a)
             ),
-            Error::UnknownNetworkMagic(ref m) => write!(f, "unknown network magic: {}", m),
-            Error::ParseFailed(ref e) => write!(f, "parse failed: {}", e),
+            Error::UnknownNetworkMagic(ref m) => write!(f, "unknown network magic: {m}"),
+            Error::ParseFailed(ref e) => write!(f, "parse failed: {e}"),
             Error::UnsupportedWitnessVersion(ref wver) => {
-                write!(f, "unsupported witness version: {}", wver)
+                write!(f, "unsupported witness version: {wver}")
             }
             Error::UnsupportedSegwitFlag(ref swflag) => {
-                write!(f, "unsupported segwit version: {}", swflag)
+                write!(f, "unsupported segwit version: {swflag}")
             }
             Error::UnrecognizedNetworkCommand(ref nwcmd) => {
-                write!(f, "unrecognized network command: {}", nwcmd)
+                write!(f, "unrecognized network command: {nwcmd}")
             }
-            Error::UnexpectedHexDigit(ref d) => write!(f, "unexpected hex digit: {}", d),
+            Error::UnexpectedHexDigit(ref d) => write!(f, "unexpected hex digit: {d}"),
         }
     }
 }

--- a/stacks-common/src/deps_common/bitcoin/util/hash.rs
+++ b/stacks-common/src/deps_common/bitcoin/util/hash.rs
@@ -369,7 +369,7 @@ impl fmt::Debug for Sha256dHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let &Sha256dHash(data) = self;
         for ch in data.iter() {
-            write!(f, "{:02x}", ch)?;
+            write!(f, "{ch:02x}")?;
         }
         Ok(())
     }
@@ -380,7 +380,7 @@ impl fmt::Debug for Hash160 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let &Hash160(data) = self;
         for ch in data.iter() {
-            write!(f, "{:02x}", ch)?;
+            write!(f, "{ch:02x}")?;
         }
         Ok(())
     }
@@ -402,7 +402,7 @@ impl fmt::LowerHex for Sha256dHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let &Sha256dHash(data) = self;
         for ch in data.iter().rev() {
-            write!(f, "{:02x}", ch)?;
+            write!(f, "{ch:02x}")?;
         }
         Ok(())
     }
@@ -413,7 +413,7 @@ impl fmt::UpperHex for Sha256dHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let &Sha256dHash(data) = self;
         for ch in data.iter().rev() {
-            write!(f, "{:02X}", ch)?;
+            write!(f, "{ch:02X}")?;
         }
         Ok(())
     }

--- a/stacks-common/src/types/chainstate.rs
+++ b/stacks-common/src/types/chainstate.rs
@@ -170,7 +170,7 @@ impl SortitionId {
         } else {
             let mut hasher = Sha512_256::new();
             hasher.update(bhh);
-            write!(hasher, "{}", pox).expect("Failed to deserialize PoX ID into the hasher");
+            write!(hasher, "{pox}").expect("Failed to deserialize PoX ID into the hasher");
             let h = Sha512Trunc256Sum::from_hasher(hasher);
             let s = SortitionId(h.0);
             test_debug!("SortitionId({}) = {} + {}", &s, bhh, pox);

--- a/stacks-common/src/types/net.rs
+++ b/stacks-common/src/types/net.rs
@@ -243,7 +243,7 @@ pub enum PeerHost {
 impl fmt::Display for PeerHost {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            PeerHost::DNS(ref s, ref p) => write!(f, "{}:{}", s, p),
+            PeerHost::DNS(ref s, ref p) => write!(f, "{s}:{p}"),
             PeerHost::IP(ref a, ref p) => write!(f, "{}", a.to_socketaddr(*p)),
         }
     }
@@ -252,8 +252,8 @@ impl fmt::Display for PeerHost {
 impl fmt::Debug for PeerHost {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            PeerHost::DNS(ref s, ref p) => write!(f, "PeerHost::DNS({},{})", s, p),
-            PeerHost::IP(ref a, ref p) => write!(f, "PeerHost::IP({:?},{})", a, p),
+            PeerHost::DNS(ref s, ref p) => write!(f, "PeerHost::DNS({s},{p})"),
+            PeerHost::IP(ref a, ref p) => write!(f, "PeerHost::IP({a:?},{p})"),
         }
     }
 }
@@ -289,7 +289,7 @@ impl FromStr for PeerHost {
             )),
             Err(_) => {
                 // maybe missing :port
-                let hostport = format!("{}:80", header);
+                let hostport = format!("{header}:80");
                 match hostport.parse::<SocketAddr>() {
                     Ok(socketaddr) => Ok(PeerHost::IP(
                         PeerAddress::from_socketaddr(&socketaddr),

--- a/stacks-common/src/util/chunked_encoding.rs
+++ b/stacks-common/src/util/chunked_encoding.rs
@@ -361,7 +361,7 @@ impl<'a, 'state, W: Write> HttpChunkedTransferWriter<'a, 'state, W> {
             bytes.len()
         };
 
-        fd.write_all(format!("{:x}\r\n", to_send).as_bytes())?;
+        fd.write_all(format!("{to_send:x}\r\n").as_bytes())?;
         fd.write_all(&bytes[0..to_send])?;
         fd.write_all("\r\n".as_bytes())?;
         Ok(to_send)

--- a/stacks-common/src/util/hash.rs
+++ b/stacks-common/src/util/hash.rs
@@ -498,10 +498,7 @@ where
 
         if hash_index % 2 == 0 {
             if hash_index + 1 >= self.nodes[row_index].len() {
-                panic!(
-                    "Corrupt Merkle tree -- colunn {} is the last item in row {}",
-                    hash_index, row_index
-                );
+                panic!("Corrupt Merkle tree -- colunn {hash_index} is the last item in row {row_index}");
             }
 
             // left sibling
@@ -637,7 +634,7 @@ pub fn bin_bytes(s: &str) -> Result<Vec<u8>, HexError> {
 pub fn to_hex(s: &[u8]) -> String {
     let mut r = String::with_capacity(s.len() * 2);
     for b in s.iter() {
-        write!(r, "{:02x}", b).unwrap();
+        write!(r, "{b:02x}").unwrap();
     }
     r
 }
@@ -646,7 +643,7 @@ pub fn to_hex(s: &[u8]) -> String {
 pub fn to_bin(s: &[u8]) -> String {
     let mut r = String::with_capacity(s.len() * 8);
     for b in s.iter() {
-        write!(r, "{:08b}", b).unwrap();
+        write!(r, "{b:08b}").unwrap();
     }
     r
 }

--- a/stacks-common/src/util/log.rs
+++ b/stacks-common/src/util/log.rs
@@ -64,7 +64,7 @@ fn print_msg_header(mut rd: &mut dyn RecordDecorator, record: &Record) -> io::Re
     write!(rd, " ")?;
     match thread::current().name() {
         None => write!(rd, "[{:?}]", thread::current().id())?,
-        Some(name) => write!(rd, "[{}]", name)?,
+        Some(name) => write!(rd, "[{name}]")?,
     }
 
     rd.start_whitespace()?;

--- a/stacks-common/src/util/lru_cache.rs
+++ b/stacks-common/src/util/lru_cache.rs
@@ -89,7 +89,7 @@ impl<K: Display, V: Display> Display for LruCache<K, V> {
                 writeln!(f, "  <invalid>")?;
                 break;
             };
-            writeln!(f, "  {}", node)?;
+            writeln!(f, "  {node}")?;
             curr = node.next;
         }
         Ok(())

--- a/stacks-common/src/util/mod.rs
+++ b/stacks-common/src/util/mod.rs
@@ -94,8 +94,8 @@ pub enum HexError {
 impl fmt::Display for HexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            HexError::BadLength(n) => write!(f, "bad length {} for hex string", n),
-            HexError::BadCharacter(c) => write!(f, "bad character {} for hex string", c),
+            HexError::BadLength(n) => write!(f, "bad length {n} for hex string"),
+            HexError::BadCharacter(c) => write!(f, "bad character {c} for hex string"),
         }
     }
 }

--- a/stacks-common/src/util/serde_serializers.rs
+++ b/stacks-common/src/util/serde_serializers.rs
@@ -137,7 +137,7 @@ pub mod prefix_string_0x {
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(val: &str, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_str(&format!("0x{}", val))
+        s.serialize_str(&format!("0x{val}"))
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error> {

--- a/stx-genesis/build.rs
+++ b/stx-genesis/build.rs
@@ -133,7 +133,7 @@ fn sha256_digest<R: Read>(mut reader: R) -> String {
 fn encode_hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
     for &b in bytes {
-        write!(&mut s, "{:02x}", b).unwrap();
+        write!(&mut s, "{b:02x}").unwrap();
     }
     s
 }

--- a/testnet/stacks-node/src/tests/signer/commands/block_verify.rs
+++ b/testnet/stacks-node/src/tests/signer/commands/block_verify.rs
@@ -17,6 +17,7 @@ pub struct ChainVerifyMinerNakaBlockCount {
 #[derive(Debug)]
 enum HeightStrategy {
     AfterBootToEpoch3,
+    #[allow(dead_code)]
     AfterSpecificHeight(u64),
 }
 
@@ -48,6 +49,7 @@ impl ChainVerifyMinerNakaBlockCount {
         )
     }
 
+    #[allow(dead_code)]
     pub fn after_specific_height(
         ctx: Arc<SignerTestContext>,
         miner_index: usize,

--- a/testnet/stacks-node/src/tests/signer/commands/block_wait.rs
+++ b/testnet/stacks-node/src/tests/signer/commands/block_wait.rs
@@ -222,6 +222,7 @@ impl ChainExpectNakaBlockProposal {
         }
     }
 
+    #[allow(dead_code)]
     pub fn with_ok(ctx: Arc<SignerTestContext>, miner_index: usize) -> Self {
         Self {
             ctx,

--- a/testnet/stacks-node/src/tests/signer/commands/context.rs
+++ b/testnet/stacks-node/src/tests/signer/commands/context.rs
@@ -61,6 +61,7 @@ impl SignerTestContext {
     }
 
     // Getter for num_transfer_txs
+    #[allow(dead_code)]
     pub fn get_num_transfer_txs(&self) -> u64 {
         self.num_transfer_txs
     }

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -49,7 +49,6 @@ use stacks::chainstate::stacks::boot::MINERS_NAME;
 use stacks::chainstate::stacks::db::{StacksBlockHeaderTypes, StacksChainState, StacksHeaderInfo};
 use stacks::chainstate::stacks::miner::{
     TransactionEvent, TransactionSuccessEvent, TEST_EXCLUDE_REPLAY_TXS,
-    TEST_MINE_ALLOWED_REPLAY_TXS,
 };
 use stacks::chainstate::stacks::{
     StacksTransaction, TenureChangeCause, TenureChangePayload, TransactionPayload,


### PR DESCRIPTION
I recently started seeing Clippy errors due to non-inlined variables in our `build.rs` script. I also fixed the `cargo check` warnings for a few new parts of our test code that are unused.