### PR TITLE
fix: build clarity vm for wasm

### DIFF
--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -34,7 +34,7 @@ rstest = { version = "0.17.0", optional = true }
 rstest_reuse = { version = "0.5.0", optional = true }
 wasmtime = { version = "15.0.0", optional = true }
 hashbrown = { workspace = true, features = ["serde"] }
-getrandom = { version = "0.2", features = ["js"], optional = true}
+getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [dependencies.serde_json]
 version = "1.0"

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -34,10 +34,9 @@ use self::trait_checker::TraitChecker;
 use self::type_checker::v2_05::TypeChecker as TypeChecker2_05;
 use self::type_checker::v2_1::TypeChecker as TypeChecker2_1;
 pub use self::types::{AnalysisPass, ContractAnalysis};
+#[cfg(feature = "rusqlite")]
 use crate::vm::ast::{build_ast_with_rules, ASTRules};
 use crate::vm::costs::LimitedCostTracker;
-#[cfg(feature = "rusqlite")]
-use crate::vm::database::MemoryBackingStore;
 use crate::vm::database::STORE_CONTRACT_SRC_INTERFACE;
 use crate::vm::representations::SymbolicExpression;
 use crate::vm::types::{QualifiedContractIdentifier, TypeSignature};
@@ -62,7 +61,7 @@ pub fn mem_type_check(
     .map_err(|_| CheckErrors::Expects("Failed to build AST".into()))?
     .expressions;
 
-    let mut marf = MemoryBackingStore::new();
+    let mut marf = crate::vm::database::MemoryBackingStore::new();
     let mut analysis_db = marf.as_analysis_db();
     let cost_tracker = LimitedCostTracker::new_free();
     match run_analysis(

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -31,7 +31,6 @@ use super::analysis::{self, ContractAnalysis};
 #[cfg(feature = "clarity-wasm")]
 use super::clarity_wasm::call_function;
 use super::EvalHook;
-use crate::vm::analysis::AnalysisDatabase;
 use crate::vm::ast::{ASTRules, ContractAST};
 use crate::vm::callables::{DefinedFunction, FunctionIdentifier};
 use crate::vm::contracts::Contract;
@@ -39,7 +38,7 @@ use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::{runtime_cost, CostErrors, CostTracker, ExecutionCost, LimitedCostTracker};
 use crate::vm::database::{
     ClarityDatabase, DataMapMetadata, DataVariableMetadata, FungibleTokenMetadata,
-    MemoryBackingStore, NonFungibleTokenMetadata,
+    NonFungibleTokenMetadata,
 };
 use crate::vm::errors::{
     CheckErrors, InterpreterError, InterpreterResult as Result, RuntimeErrorType,
@@ -660,7 +659,7 @@ impl<'a> OwnedEnvironment<'a> {
         sponsor: Option<PrincipalData>,
         ast_rules: ASTRules,
     ) -> Result<((), AssetMap, Vec<StacksTransactionEvent>)> {
-        let mut store = MemoryBackingStore::new();
+        let mut store = crate::vm::database::MemoryBackingStore::new();
         let mut analysis_db = store.as_analysis_db();
         analysis_db.begin();
 
@@ -696,7 +695,7 @@ impl<'a> OwnedEnvironment<'a> {
         contract_content: &str,
         sponsor: Option<PrincipalData>,
         ast_rules: ASTRules,
-        analysis_db: &mut AnalysisDatabase,
+        analysis_db: &mut analysis::AnalysisDatabase,
     ) -> Result<((), AssetMap, Vec<StacksTransactionEvent>)> {
         self.execute_in_env(
             contract_identifier.issuer.clone().into(),
@@ -760,7 +759,7 @@ impl<'a> OwnedEnvironment<'a> {
         contract_content: &str,
         sponsor: Option<PrincipalData>,
         ast_rules: ASTRules,
-        analysis_db: &mut AnalysisDatabase,
+        analysis_db: &mut analysis::AnalysisDatabase,
     ) -> Result<((), AssetMap, Vec<StacksTransactionEvent>)> {
         self.execute_in_env(
             contract_identifier.issuer.clone().into(),
@@ -1430,7 +1429,7 @@ impl<'a, 'b> Environment<'a, 'b> {
         contract_content: &str,
         ast_rules: ASTRules,
     ) -> Result<()> {
-        let mut store = MemoryBackingStore::new();
+        let mut store = crate::vm::database::MemoryBackingStore::new();
         let mut analysis_db = store.as_analysis_db();
         analysis_db.begin();
 
@@ -1468,7 +1467,7 @@ impl<'a, 'b> Environment<'a, 'b> {
         contract_identifier: QualifiedContractIdentifier,
         contract_content: &str,
         ast_rules: ASTRules,
-        analysis_db: &mut AnalysisDatabase,
+        analysis_db: &mut analysis::AnalysisDatabase,
     ) -> Result<()> {
         let clarity_version = self.contract_context.clarity_version;
 

--- a/clarity/src/vm/docs/contracts.rs
+++ b/clarity/src/vm/docs/contracts.rs
@@ -4,13 +4,10 @@ use hashbrown::{HashMap, HashSet};
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::StacksEpochId;
 
-#[cfg(feature = "rusqlite")]
-use crate::vm::analysis::mem_type_check;
-use crate::vm::analysis::ContractAnalysis;
+use crate::vm::analysis::{mem_type_check, ContractAnalysis};
 use crate::vm::ast::{build_ast_with_rules, ASTRules};
 use crate::vm::contexts::GlobalContext;
 use crate::vm::costs::LimitedCostTracker;
-#[cfg(feature = "rusqlite")]
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::docs::{get_input_type_string, get_output_type_string, get_signature};
 use crate::vm::types::{FunctionType, QualifiedContractIdentifier, Value};
@@ -63,7 +60,6 @@ pub fn make_func_ref(func_name: &str, func_type: &FunctionType, description: &st
     }
 }
 
-#[cfg(feature = "rusqlite")]
 #[allow(clippy::expect_used)]
 fn get_constant_value(var_name: &str, contract_content: &str) -> Value {
     let to_eval = format!("{}\n{}", contract_content, var_name);
@@ -72,7 +68,6 @@ fn get_constant_value(var_name: &str, contract_content: &str) -> Value {
         .expect("BUG: failed to return constant value")
 }
 
-#[cfg(feature = "rusqlite")]
 fn doc_execute(program: &str) -> Result<Option<Value>, vm::Error> {
     let contract_id = QualifiedContractIdentifier::transient();
     let mut contract_context = ContractContext::new(contract_id.clone(), ClarityVersion::Clarity2);
@@ -99,7 +94,6 @@ fn doc_execute(program: &str) -> Result<Option<Value>, vm::Error> {
     })
 }
 
-#[cfg(feature = "rusqlite")]
 #[allow(clippy::expect_used)]
 pub fn make_docs(
     content: &str,
@@ -185,7 +179,6 @@ pub fn make_docs(
 
 /// Produce a set of documents for multiple contracts, supplied as a list of `(contract_name, contract_content)` pairs,
 ///  and a map from `contract_name` to corresponding `ContractSupportDocs`
-#[cfg(feature = "rusqlite")]
 pub fn produce_docs_refs<A: AsRef<str>, B: AsRef<str>>(
     contracts: &[(A, B)],
     support_docs: &HashMap<&str, ContractSupportDocs>,

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -23,6 +23,7 @@ use crate::vm::types::{FixedFunction, FunctionType};
 use crate::vm::variables::NativeVariables;
 use crate::vm::ClarityVersion;
 
+#[cfg(feature = "rusqlite")]
 pub mod contracts;
 
 #[derive(Serialize)]


### PR DESCRIPTION
The clarity-vm couldn't be compiled to wasm32-unknown-unknown because of the `MemoryBackingStore` import in `clarity/src/vm/contexts.rs`

The other changes in this PR avoid a few unused imports in this configuration:

```bash
cargo check -p clarity --target wasm32-unknown-unknown --no-default-features --features clarity/wasm
```

A strategy to avoid having too many compilation flag is to have qualified imports when a specific function requires a specific function locally requires a specific import
```rust
let mut marf = crate::vm::database::MemoryBackingStore::new();
```