### PR TITLE
Do not count accept and reject from same signer

### DIFF
--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - Introduced `capitulate_miner_view_timeout_secs`: the duration (in seconds) for the signer to wait between updating the local state machine viewpoint and capitulating to other signers' miner views.
 - Added codepath to enable signers to evaluate block proposals and miner activity against global signer state for improved consistency and correctness. Currently feature gated behind the `SUPPORTED_SIGNER_PROTOCOL_VERSION`
 
+### Changed
+
+- Do not count both a block acceptance and a block rejection for the same signer/block. Also ignore repeated responses (mainly for logging purposes).
+
 ## [3.1.0.0.13.0]
 
 ### Changed


### PR DESCRIPTION
If a signer sends a duplicate block acceptance or rejection, ignore the repeats. If a signer has previously rejected a block, delete the rejection if it later accepts it. If a signer has previously accepted a block, ignore a rejection and warn about it (this shouldn't happen).