### PR TITLE
fix: get last locally or globally accepted block in tenure

### DIFF
--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - Introduced `capitulate_miner_view_timeout_secs`: the duration (in seconds) for the signer to wait between updating the local state machine viewpoint and capitulating to other signers' miner views.
 - Added codepath to enable signers to evaluate block proposals and miner activity against global signer state for improved consistency and correctness. Currently feature gated behind the `SUPPORTED_SIGNER_PROTOCOL_VERSION`
 
+### Fixed
+
+- Fixed a bug where signers would incorrectly reject block proposals due to the parent block not being found as the last block in the current tenure
+
 ## [3.1.0.0.13.0]
 
 ### Changed


### PR DESCRIPTION
In `get_tenure_last_block_info`, we should return the last block that we know about in a tenure, whether that is a locally accepted block or a globally accepted block. Previously, this would only return a locally accepted block, which would cause signers to incorrectly reject blocks if they did not have a locally accepted block which was higher than the globally accepted block.