### PR TITLE
Do not evaluate globally accepted block proposals

### DIFF
--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -938,19 +938,25 @@ impl Signer {
         // TODO: should add a check to ignore an old burn block height if we know its outdated. Would require us to store the burn block height we last saw on the side.
         //  the signer needs to be able to determine whether or not the block they're about to sign would conflict with an already-signed Stacks block
         let signer_signature_hash = block_proposal.block.header.signer_signature_hash();
-        let prior_evaluation = self
-            .block_lookup_by_reward_cycle(&signer_signature_hash)
-            .and_then(|block_info| if should_reevaluate_block(&block_info) {
-                debug!("Received a proposal for this block before, but our rejection reason allows us to reconsider";
-                    "reject_reason" => ?block_info.reject_reason);
-                None
-            } else {
-                Some(block_info)
-            });
-
-        // we previously considered this proposal, handle the status here
-        if let Some(block_info) = prior_evaluation {
-            return self.handle_prior_proposal_eval(&block_info);
+        if let Some(block_info) = self.block_lookup_by_reward_cycle(&signer_signature_hash) {
+            if block_info.state == BlockState::GloballyAccepted {
+                info!("{self}: Received a block proposal for a block that is already globally accepted. Ignoring...";
+                    "signer_signature_hash" => %signer_signature_hash,
+                    "block_id" => %block_proposal.block.block_id(),
+                    "block_height" => block_proposal.block.header.chain_length,
+                    "burn_height" => block_proposal.burn_height,
+                    "consensus_hash" => %block_proposal.block.header.consensus_hash,
+                    "timestamp" => block_proposal.block.header.timestamp,
+                    "signed_group" => block_info.signed_group,
+                    "signed_self" => block_info.signed_self
+                );
+                return;
+            }
+            if !should_reevaluate_block(&block_info) {
+                return self.handle_prior_proposal_eval(&block_info);
+            }
+            debug!("Received a proposal for this block before, but our rejection reason allows us to reconsider";
+                "reject_reason" => ?block_info.reject_reason);
         }
 
         info!(


### PR DESCRIPTION
This was a cleanup suggested by @obycode when going through logs. 

We were seeing signers processing a NewBlock event for stacks block N. 
Then receiving a block proposal message delayed for stacks block N. 
Signer would then query the tip of the node and see that the tip had advanced to stacks block height N. This would cause signer to respond with a rejection with InvalidParentBlock even though stacks block N is canonical. 

Instead of even bothering to check the stacks tip on the node, since we already have processed the NewBlock event, just check if the block proposal is for a block that has been globally accepted. If so, return without issuing a response. Otherwise continue as normal. 