### PR TITLE
fix: do not send events to observers for stale stackerdb messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Fixed
 
 - Fixed tenure downloader logic on reward cycle boundaries (#6234).
+- Do not send events to event observers for stale StackerDB chunks.
 
 ## [3.1.0.0.13]
 


### PR DESCRIPTION
This reverts [a change](https://github.com/stacks-network/stacks-core/pull/6229/commits/377c7aab5e614d8e3dd94bf220ce99f7e5ff6c61) that was included in release 3.1.0.0.13. We've determined that this change causes too many old messages to be sent to signers, slowing block production and causing some to be forever stuck behind. In addition to reverting that change, the other location that was already sending stale chunks is also changed to only send non-stale chunks to the observers.