### PR TITLE
feat: set 3.2 start height in sample testnet configs

### DIFF
--- a/sample/conf/testnet-follower-conf.toml
+++ b/sample/conf/testnet-follower-conf.toml
@@ -82,3 +82,7 @@ start_height = 1900
 [[burnchain.epochs]]
 epoch_name = "3.1"
 start_height = 2000
+
+[[burnchain.epochs]]
+epoch_name = "3.2"
+start_height = 71525

--- a/sample/conf/testnet-miner-conf.toml
+++ b/sample/conf/testnet-miner-conf.toml
@@ -78,3 +78,7 @@ start_height = 1900
 [[burnchain.epochs]]
 epoch_name = "3.1"
 start_height = 2000
+
+[[burnchain.epochs]]
+epoch_name = "3.2"
+start_height = 71525


### PR DESCRIPTION
Block 71525 is chosen, which should hit 22 July 2025 ~14:00 UTC.