### PR TITLE
skip over matrix for macos x86_64 binary builds (deprecated arch)

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -90,6 +90,8 @@ jobs:
             cpu: armv7
           - arch: macos # excludes macos-armv7
             cpu: armv7
+          - arch: macos # excludes macos-x64
+            cpu: x86_64
     steps:
       - name: Build Binary (${{ matrix.arch }}_${{ matrix.cpu }})
         uses: stacks-network/actions/stacks-core/release/create-source-binary@main


### PR DESCRIPTION
For the release workflow, this change excludes binaries being built for macos-x86_64

associated build script removal: https://github.com/stacks-network/actions/pull/84

https://github.com/wileyj/stacks-core/actions/runs/16528194936