### PR TITLE
Fix SIP-031 stateful tests burn height tracking and increase runs to 100

### DIFF
--- a/contrib/core-contract-tests/tests/sip-031/commands/MineBlocks.ts
+++ b/contrib/core-contract-tests/tests/sip-031/commands/MineBlocks.ts
@@ -11,6 +11,7 @@ export const MineBlocks = () =>
       trackCommandRun(model, "mine-blocks");
 
       simnet.mineEmptyBlocks(r.blocks);
+      model.blockHeight += BigInt(r.blocks);
 
       logCommand({
         sender: undefined,

--- a/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
+++ b/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
@@ -51,7 +51,7 @@ test("SIP-031 Stateful", () => {
         fc.modelRun(state, cmds);
       },
     ),
-    { numRuns: 10, verbose: 2 },
+    { numRuns: 100, verbose: 2 },
   );
 
   reportCommandRuns(model);


### PR DESCRIPTION
This PR fixes a bug in the SIP-031 stateful tests and increases the number of test iterations.

**The bug fix:**

When the test system mines new blocks, it wasn't updating the model counter that tracks how many blocks have been mined.

**The test improvement:**

The tests now run 100 times instead of 10 times. Running more stateful iterations can help find bugs that only show up occasionally or under specific conditions.