### PR TITLE
fix: remove serde stacker for wasm target

### DIFF
--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -20,7 +20,6 @@ path = "./src/libclarity.rs"
 [dependencies]
 serde = "1"
 serde_derive = "1"
-serde_stacker = "0.1"
 regex = "1"
 lazy_static = "1.4.0"
 integer-sqrt = "0.1.3"
@@ -43,6 +42,9 @@ rstest_reuse = { version = "0.5.0" }
 # a nightly rustc regression (35dbef235 2021-03-02) prevents criterion from compiling
 #  but it isn't necessary for tests: only benchmarks. therefore, commenting out for now.
 # criterion = "0.3"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+serde_stacker = "0.1"
 
 [features]
 default = ["rusqlite"]

--- a/clarity/src/vm/database/structures.rs
+++ b/clarity/src/vm/database/structures.rs
@@ -53,6 +53,7 @@ macro_rules! clarity_serializable {
             }
         }
         impl ClarityDeserializable<$Name> for $Name {
+            #[cfg(not(target_family = "wasm"))]
             fn deserialize(json: &str) -> Result<Self> {
                 let mut deserializer = serde_json::Deserializer::from_str(&json);
                 // serde's default 128 depth limit can be exhausted
@@ -62,6 +63,12 @@ macro_rules! clarity_serializable {
                 //  this will instead spill to the heap
                 let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
                 Deserialize::deserialize(deserializer).map_err(|_| {
+                    InterpreterError::Expect("Failed to deserialize vm.Value".into()).into()
+                })
+            }
+            #[cfg(target_family = "wasm")]
+            fn deserialize(json: &str) -> Result<Self> {
+                serde_json::from_str(json).map_err(|_| {
                     InterpreterError::Expect("Failed to deserialize vm.Value".into()).into()
                 })
             }


### PR DESCRIPTION
`serde_stacker`  relies on `psm` that sometimes fails to compiue to `wasm32-unknown-unknown` with the error:

```
[watch] error: failed to build archive at `.../target/wasm32-unknown-unknown/release/deps/libpsm-b026689ff013e77e.rlib`: LLVM error: section too large
[watch] 
[watch] warning: psm@0.1.21: warning: .../ranlib: archive library: .../target/wasm32-unknown-unknown/release/build/psm-f6245e71013cd875/out/libpsm_s.a the table of contents is empty (no object file members in the library define global symbols)
[watch] error: could not compile `psm` (lib) due to 1 previous error
```

Clarinet, that was relying on a custom branch, had this change forever
https://github.com/stacks-network/stacks-core/blob/5295a70b28895d4786e6329acefea4a19a956ba2/clarity/src/vm/database/structures.rs#L55-L75


### Alternatives

I think it makes sense to include serde_stacker based on the target, but I can also make an optional dependency and include it in a feature flag, included in default (basically just like rusqlite).

Apparently, psm isn't [applicable to wasm](https://crates.io/crates/psm/0.1.26) anyway