### PR TITLE
fix: clippy issue due to rust 1.89.0 update

### DIFF
--- a/clarity/src/vm/analysis/type_checker/contexts.rs
+++ b/clarity/src/vm/analysis/type_checker/contexts.rs
@@ -104,7 +104,7 @@ impl TypingContext<'_> {
         }
     }
 
-    pub fn extend(&self) -> CheckResult<TypingContext> {
+    pub fn extend(&self) -> CheckResult<TypingContext<'_>> {
         if self.depth >= MAX_CONTEXT_DEPTH {
             Err(CheckError::new(CheckErrors::MaxContextDepthReached))
         } else {

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1875,7 +1875,7 @@ impl<'a> LocalContext<'a> {
         self.depth
     }
 
-    pub fn function_context(&self) -> &LocalContext {
+    pub fn function_context(&self) -> &LocalContext<'_> {
         match self.function_context {
             Some(context) => context,
             None => self,

--- a/clarity/src/vm/database/clarity_store.rs
+++ b/clarity/src/vm/database/clarity_store.rs
@@ -187,11 +187,11 @@ impl NullBackingStore {
         NullBackingStore {}
     }
 
-    pub fn as_clarity_db(&mut self) -> ClarityDatabase {
+    pub fn as_clarity_db(&mut self) -> ClarityDatabase<'_> {
         ClarityDatabase::new(self, &NULL_HEADER_DB, &NULL_BURN_STATE_DB)
     }
 
-    pub fn as_analysis_db(&mut self) -> AnalysisDatabase {
+    pub fn as_analysis_db(&mut self) -> AnalysisDatabase<'_> {
         AnalysisDatabase::new(self)
     }
 }

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -302,11 +302,11 @@ impl MemoryBackingStore {
         memory_marf
     }
 
-    pub fn as_clarity_db(&mut self) -> ClarityDatabase {
+    pub fn as_clarity_db(&mut self) -> ClarityDatabase<'_> {
         ClarityDatabase::new(self, &NULL_HEADER_DB, &NULL_BURN_STATE_DB)
     }
 
-    pub fn as_analysis_db(&mut self) -> AnalysisDatabase {
+    pub fn as_analysis_db(&mut self) -> AnalysisDatabase<'_> {
         AnalysisDatabase::new(self)
     }
 }
@@ -405,7 +405,7 @@ impl ClarityBackingStore for MemoryBackingStore {
 }
 
 impl ToSql for ExecutionCost {
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         let val = serde_json::to_string(self)
             .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
         Ok(ToSqlOutput::from(val))

--- a/clarity/src/vm/tests/mod.rs
+++ b/clarity/src/vm/tests/mod.rs
@@ -171,7 +171,7 @@ pub fn tl_env_factory() -> TopLevelMemoryEnvironmentGenerator {
 
 pub struct MemoryEnvironmentGenerator(MemoryBackingStore);
 impl MemoryEnvironmentGenerator {
-    fn get_env(&mut self, epoch: StacksEpochId) -> OwnedEnvironment {
+    fn get_env(&mut self, epoch: StacksEpochId) -> OwnedEnvironment<'_, '_> {
         let mut db = self.0.as_clarity_db();
         db.begin();
         db.set_clarity_epoch_version(epoch).unwrap();
@@ -190,7 +190,7 @@ impl MemoryEnvironmentGenerator {
 
 pub struct TopLevelMemoryEnvironmentGenerator(MemoryBackingStore);
 impl TopLevelMemoryEnvironmentGenerator {
-    pub fn get_env(&mut self, epoch: StacksEpochId) -> OwnedEnvironment {
+    pub fn get_env(&mut self, epoch: StacksEpochId) -> OwnedEnvironment<'_, '_> {
         let mut db = self.0.as_clarity_db();
         db.begin();
         db.set_clarity_epoch_version(epoch).unwrap();

--- a/stacks-common/src/bitvec.rs
+++ b/stacks-common/src/bitvec.rs
@@ -171,7 +171,7 @@ impl<const MAX_SIZE: u16> BitVec<MAX_SIZE> {
         Ok(bitvec)
     }
 
-    pub fn iter(&self) -> BitVecIter<MAX_SIZE> {
+    pub fn iter(&self) -> BitVecIter<'_, MAX_SIZE> {
         let byte = self.data.first();
         BitVecIter {
             index: 0,

--- a/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/script.rs
@@ -385,7 +385,7 @@ impl Script {
     /// opcodes, datapushes and errors. At most one error will be returned and then the
     /// iterator will end. To instead iterate over the script as sequence of bytes, treat
     /// it as a slice using `script[..]` or convert it to a vector using `into_bytes()`.
-    pub fn iter(&self, enforce_minimal: bool) -> Instructions {
+    pub fn iter(&self, enforce_minimal: bool) -> Instructions<'_> {
         Instructions {
             data: &self.0[..],
             enforce_minimal,

--- a/stacks-common/src/types/sqlite.rs
+++ b/stacks-common/src/types/sqlite.rs
@@ -36,14 +36,14 @@ impl FromSql for Sha256dHash {
 }
 
 impl ToSql for Sha256dHash {
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         let hex_str = self.be_hex_string();
         Ok(hex_str.into())
     }
 }
 
-impl rusqlite::types::ToSql for StacksAddress {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
+impl ToSql for StacksAddress {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         let addr_str = self.to_string();
         Ok(addr_str.into())
     }

--- a/stacks-common/src/util/macros.rs
+++ b/stacks-common/src/util/macros.rs
@@ -749,7 +749,7 @@ macro_rules! impl_byte_array_rusqlite_only {
         }
 
         impl rusqlite::types::ToSql for $thing {
-            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
+            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
                 let hex_str = self.to_hex();
                 Ok(hex_str.into())
             }

--- a/stacks-common/src/util/vrf.rs
+++ b/stacks-common/src/util/vrf.rs
@@ -68,7 +68,7 @@ impl Eq for VRFPublicKey {}
 
 impl PartialOrd for VRFPublicKey {
     fn partial_cmp(&self, other: &VRFPublicKey) -> Option<Ordering> {
-        Some(self.as_bytes().to_vec().cmp(&other.as_bytes().to_vec()))
+        Some(self.cmp(other))
     }
 }
 

--- a/stacks-node/src/event_dispatcher.rs
+++ b/stacks-node/src/event_dispatcher.rs
@@ -615,7 +615,7 @@ impl EventObserver {
     fn make_new_block_txs_payload(
         receipt: &StacksTransactionReceipt,
         tx_index: u32,
-    ) -> TransactionEventPayload {
+    ) -> TransactionEventPayload<'_> {
         let tx = &receipt.transaction;
 
         let status = match (receipt.post_condition_aborted, &receipt.result) {

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -184,7 +184,7 @@ impl DerefMut for NakamotoStagingBlocksConn {
 }
 
 impl NakamotoStagingBlocksConn {
-    pub fn conn(&self) -> NakamotoStagingBlocksConnRef {
+    pub fn conn(&self) -> NakamotoStagingBlocksConnRef<'_> {
         NakamotoStagingBlocksConnRef(&self.0)
     }
 }
@@ -211,7 +211,7 @@ impl NakamotoStagingBlocksTx<'_> {
         self.0.commit()
     }
 
-    pub fn conn(&self) -> NakamotoStagingBlocksConnRef {
+    pub fn conn(&self) -> NakamotoStagingBlocksConnRef<'_> {
         NakamotoStagingBlocksConnRef(self.0.deref())
     }
 }
@@ -746,7 +746,7 @@ impl StacksChainState {
     }
 
     /// Get a ref to the nakamoto staging blocks connection
-    pub fn nakamoto_blocks_db(&self) -> NakamotoStagingBlocksConnRef {
+    pub fn nakamoto_blocks_db(&self) -> NakamotoStagingBlocksConnRef<'_> {
         NakamotoStagingBlocksConnRef(&self.nakamoto_staging_blocks_conn)
     }
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -1707,7 +1707,7 @@ impl<'a> ClarityBlockConnection<'a, '_> {
         })
     }
 
-    pub fn start_transaction_processing(&mut self) -> ClarityTransactionConnection {
+    pub fn start_transaction_processing(&mut self) -> ClarityTransactionConnection<'_, '_> {
         ClarityTransactionConnection::new(
             &mut self.datastore,
             self.header_db,

--- a/stackslib/src/util_lib/db.rs
+++ b/stackslib/src/util_lib/db.rs
@@ -334,7 +334,7 @@ macro_rules! impl_byte_array_from_column {
         }
 
         impl rusqlite::types::ToSql for $thing {
-            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
+            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
                 let hex_str = self.to_hex();
                 Ok(hex_str.into())
             }


### PR DESCRIPTION
### Description

This PR fixes the following Clippy lints, which are now treated as hard errors due to the `-D warnings` flag in Rust `1.89.0`:
- `clippy::mismatched-lifetime-syntaxes`
- `clippy::non-canonical-partial-ord-impl`

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
