### PR TITLE
Remove Copy from Secp256k1PrivateKey, Secp256k1PublicKey, StacksAddress, VerifyVoteArgs, and VoteInfo

### DIFF
--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -949,7 +949,7 @@ impl TrackerData {
             if cost_function_ref.contract_id == boot_costs_id {
                 m.insert(
                     f,
-                    ClarityCostFunctionEvaluator::Default(cost_function_ref, *f, v),
+                    ClarityCostFunctionEvaluator::Default(cost_function_ref, f.clone(), v),
                 );
             } else {
                 m.insert(f, ClarityCostFunctionEvaluator::Clarity(cost_function_ref));

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -280,7 +280,7 @@ pub fn apply(
         env.call_stack.insert(&identifier, track_recursion);
         let mut resp = match function {
             CallableType::NativeFunction(_, function, cost_function) => {
-                runtime_cost(*cost_function, env, evaluated_args.len())
+                runtime_cost(cost_function.clone(), env, evaluated_args.len())
                     .map_err(Error::from)
                     .and_then(|_| function.apply(evaluated_args, env))
             }
@@ -290,7 +290,7 @@ pub fn apply(
                 } else {
                     evaluated_args.len() as u64
                 };
-                runtime_cost(*cost_function, env, cost_input)
+                runtime_cost(cost_function.clone(), env, cost_input)
                     .map_err(Error::from)
                     .and_then(|_| function.apply(evaluated_args, env))
             }

--- a/libsigner/src/signer_set.rs
+++ b/libsigner/src/signer_set.rs
@@ -67,12 +67,12 @@ impl SignerEntries {
                 })?;
 
             let stacks_address = StacksAddress::p2pkh(is_mainnet, &signer_public_key);
-            signer_addr_to_id.insert(stacks_address, signer_id);
-            signer_id_to_pk.insert(signer_id, signer_public_key);
-            signer_pk_to_id.insert(signer_public_key, signer_id);
+            signer_addr_to_id.insert(stacks_address.clone(), signer_id);
+            signer_id_to_pk.insert(signer_id, signer_public_key.clone());
+            signer_pk_to_id.insert(signer_public_key.clone(), signer_id);
             signer_pks.push(signer_public_key);
-            signer_id_to_addr.insert(signer_id, stacks_address);
-            signer_addr_to_weight.insert(stacks_address, entry.weight);
+            signer_id_to_addr.insert(signer_id, stacks_address.clone());
+            signer_addr_to_weight.insert(stacks_address.clone(), entry.weight);
             signer_addresses.push(stacks_address);
         }
 

--- a/libsigner/src/tests/signer_state.rs
+++ b/libsigner/src/tests/signer_state.rs
@@ -53,7 +53,7 @@ fn generate_global_state_evaluator(num_addresses: u32) -> GlobalStateEvaluator {
 
     let mut address_updates = HashMap::new();
     for address in address_weights.keys() {
-        address_updates.insert(*address, update.clone());
+        address_updates.insert(address.clone(), update.clone());
     }
     GlobalStateEvaluator::new(address_updates, address_weights)
 }
@@ -72,7 +72,7 @@ fn determine_latest_supported_signer_protocol_versions() {
     let mut global_eval = generate_global_state_evaluator(5);
 
     let addresses: Vec<_> = global_eval.address_weights.keys().cloned().collect();
-    let local_address = addresses[0];
+    let local_address = addresses[0].clone();
 
     let local_update = global_eval
         .address_updates
@@ -152,7 +152,7 @@ fn determine_global_burn_views() {
     let mut global_eval = generate_global_state_evaluator(5);
 
     let addresses: Vec<_> = global_eval.address_weights.keys().cloned().collect();
-    let local_address = addresses[0];
+    let local_address = addresses[0].clone();
     let local_update = global_eval
         .address_updates
         .get(&local_address)
@@ -211,7 +211,7 @@ fn determine_global_states() {
     let mut global_eval = generate_global_state_evaluator(5);
 
     let addresses: Vec<_> = global_eval.address_weights.keys().cloned().collect();
-    let local_address = addresses[0];
+    let local_address = addresses[0].clone();
     let local_update = global_eval
         .address_updates
         .get(&local_address)
@@ -240,7 +240,7 @@ fn determine_global_states() {
         tx_replay_set: ReplayTransactionSet::none(),
     };
 
-    global_eval.insert_update(local_address, local_update);
+    global_eval.insert_update(local_address.clone(), local_update);
     assert_eq!(global_eval.determine_global_state().unwrap(), state_machine);
     let new_miner = StateMachineUpdateMinerState::ActiveMiner {
         current_miner_pkh: Hash160([0x00; 20]),
@@ -289,7 +289,7 @@ fn determine_global_states_with_tx_replay_set() {
     let mut global_eval = generate_global_state_evaluator(5);
 
     let addresses: Vec<_> = global_eval.address_weights.keys().cloned().collect();
-    let local_address = addresses[0];
+    let local_address = addresses[0].clone();
     let local_update = global_eval
         .address_updates
         .get(&local_address)
@@ -337,7 +337,7 @@ fn determine_global_states_with_tx_replay_set() {
 
     // Let's update 3 signers to some new tx_replay_set but one that has no txs in it
     for address in addresses.iter().skip(1).take(3) {
-        global_eval.insert_update(*address, no_tx_replay_set_update.clone());
+        global_eval.insert_update(address.clone(), no_tx_replay_set_update.clone());
     }
 
     // we have disagreement about the burn block height
@@ -346,7 +346,7 @@ fn determine_global_states_with_tx_replay_set() {
         "We should have disagreement about the burn view"
     );
 
-    global_eval.insert_update(local_address, no_tx_replay_set_update.clone());
+    global_eval.insert_update(local_address.clone(), no_tx_replay_set_update.clone());
 
     let new_burn_view_state_machine = SignerStateMachine {
         burn_block,
@@ -357,7 +357,7 @@ fn determine_global_states_with_tx_replay_set() {
     };
 
     // Let's tip the scales over to the correct burn view
-    global_eval.insert_update(local_address, no_tx_replay_set_update);
+    global_eval.insert_update(local_address.clone(), no_tx_replay_set_update);
     assert_eq!(
         global_eval.determine_global_state().unwrap(),
         new_burn_view_state_machine
@@ -372,7 +372,7 @@ fn determine_global_states_with_tx_replay_set() {
         post_condition_mode: TransactionPostConditionMode::Allow,
         post_conditions: vec![],
         payload: TransactionPayload::TokenTransfer(
-            local_address.into(),
+            local_address.clone().into(),
             123,
             TokenTransferMemo([0u8; 34]),
         ),

--- a/stacks-common/src/types/chainstate.rs
+++ b/stacks-common/src/types/chainstate.rs
@@ -286,7 +286,7 @@ impl fmt::Display for PoxId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct StacksAddress {
     version: u8,
     bytes: Hash160,

--- a/stacks-common/src/util/macros.rs
+++ b/stacks-common/src/util/macros.rs
@@ -50,7 +50,7 @@ macro_rules! define_named_enum {
         }
     ) => {
         $(#[$enum_meta])*
-        #[derive(::serde::Serialize, ::serde::Deserialize, Debug, Hash, PartialEq, Eq, Copy, Clone)]
+        #[derive(::serde::Serialize, ::serde::Deserialize, Debug, Hash, PartialEq, Eq, Clone)]
         pub enum $Name {
             $(
                 $(#[$variant_meta])*

--- a/stacks-common/src/util/secp256k1/native.rs
+++ b/stacks-common/src/util/secp256k1/native.rs
@@ -34,7 +34,7 @@ use crate::util::hash::{hex_bytes, to_hex, Sha256Sum};
 // per-thread Secp256k1 context
 thread_local!(static _secp256k1: Secp256k1<secp256k1::All> = Secp256k1::new());
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Hash)]
 pub struct Secp256k1PublicKey {
     // serde is broken for secp256k1, so do it ourselves
     #[serde(
@@ -45,7 +45,7 @@ pub struct Secp256k1PublicKey {
     compressed: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Secp256k1PrivateKey {
     // serde is broken for secp256k1, so do it ourselves
     #[serde(
@@ -468,7 +468,7 @@ mod tests {
             .unwrap()
             .compress_public());
 
-        assert_eq!(Secp256k1PrivateKey::from_hex(&h_uncomp), Ok(t1));
+        assert_eq!(Secp256k1PrivateKey::from_hex(&h_uncomp), Ok(t1.clone()));
 
         t1.set_compress_public(true);
 

--- a/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -629,11 +629,11 @@ impl BitcoinRegtestController {
         let filter_addresses = vec![addr2str(&address)];
 
         let pubk = if self.config.miner.segwit {
-            let mut p = *public_key;
+            let mut p = public_key.clone();
             p.set_compressed(true);
             p
         } else {
-            *public_key
+            public_key.clone()
         };
 
         test_debug!("Import public key '{}'", &pubk.to_hex());
@@ -736,11 +736,11 @@ impl BitcoinRegtestController {
         block_height: u64,
     ) -> Option<UTXOSet> {
         let pubk = if self.config.miner.segwit && epoch_id >= StacksEpochId::Epoch21 {
-            let mut p = *public_key;
+            let mut p = public_key.clone();
             p.set_compressed(true);
             p
         } else {
-            *public_key
+            public_key.clone()
         };
 
         // Configure UTXO filter

--- a/stacks-node/src/keychain.rs
+++ b/stacks-node/src/keychain.rs
@@ -354,7 +354,7 @@ mod tests {
                 }
             };
             sk.set_compress_public(true);
-            self.microblocks_secret_keys.push(sk);
+            self.microblocks_secret_keys.push(sk.clone());
 
             debug!("Microblock keypair rotated";
                    "burn_block_height" => %burn_block_height,
@@ -451,7 +451,7 @@ mod tests {
         }
 
         pub fn generate_op_signer(&self) -> BurnchainOpSigner {
-            BurnchainOpSigner::new(self.secret_keys[0])
+            BurnchainOpSigner::new(self.secret_keys[0].clone())
         }
     }
 
@@ -536,7 +536,7 @@ mod tests {
                 TransactionVersion::Testnet,
                 k1.get_transaction_auth().unwrap(),
                 TransactionPayload::TokenTransfer(
-                    recv_addr.into(),
+                    recv_addr.clone().into(),
                     123,
                     TokenTransferMemo([0u8; 34]),
                 ),

--- a/stacks-node/src/nakamoto_node.rs
+++ b/stacks-node/src/nakamoto_node.rs
@@ -186,7 +186,7 @@ impl StacksNode {
         let burnchain = runloop.get_burnchain();
         let atlas_config = config.atlas.clone();
         let mut keychain = Keychain::default(config.node.seed.clone());
-        if let Some(mining_key) = config.miner.mining_key {
+        if let Some(mining_key) = config.miner.mining_key.clone() {
             keychain.set_nakamoto_sk(mining_key);
         }
 

--- a/stacks-node/src/nakamoto_node/miner.rs
+++ b/stacks-node/src/nakamoto_node/miner.rs
@@ -466,7 +466,7 @@ impl BlockMinerThread {
         let mut last_block_rejected = false;
 
         let reward_set = self.load_signer_set()?;
-        let Some(miner_privkey) = self.config.miner.mining_key else {
+        let Some(miner_privkey) = self.config.miner.mining_key.clone() else {
             return Err(NakamotoNodeError::MinerConfigurationFailed(
                 "No mining key configured, cannot mine",
             ));

--- a/stacks-node/src/operations.rs
+++ b/stacks-node/src/operations.rs
@@ -116,7 +116,7 @@ impl BurnchainOpSigner {
     /// This is useful in testing scenarios where you need a fresh, undisposed copy
     /// of a signer without recreating the private key.
     pub fn undisposed(&self) -> Self {
-        Self::new(self.secret_key)
+        Self::new(self.secret_key.clone())
     }
 }
 

--- a/stacks-node/src/tests/epoch_205.rs
+++ b/stacks-node/src/tests/epoch_205.rs
@@ -689,7 +689,7 @@ fn test_cost_limit_switch_version205() {
     // Create three characters, `creator`, `alice` and `bob`.
     let creator_sk = StacksPrivateKey::random();
     let creator_addr = to_addr(&creator_sk);
-    let creator_pd: PrincipalData = creator_addr.into();
+    let creator_pd: PrincipalData = creator_addr.clone().into();
 
     let alice_sk = StacksPrivateKey::random();
     let alice_addr = to_addr(&alice_sk);

--- a/stacks-node/src/tests/epoch_21.rs
+++ b/stacks-node/src/tests/epoch_21.rs
@@ -543,7 +543,7 @@ fn transition_fixes_bitcoin_rigidity() {
 
     let spender_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let spender_stx_addr: StacksAddress = to_addr(&spender_sk);
-    let spender_addr: PrincipalData = spender_stx_addr.into();
+    let spender_addr: PrincipalData = spender_stx_addr.clone().into();
     let _spender_btc_addr = BitcoinAddress::from_bytes_legacy(
         BitcoinNetworkType::Regtest,
         LegacyBitcoinAddressType::PublicKeyHash,
@@ -553,7 +553,7 @@ fn transition_fixes_bitcoin_rigidity() {
 
     let spender_2_sk = StacksPrivateKey::from_hex(SK_2).unwrap();
     let spender_2_stx_addr: StacksAddress = to_addr(&spender_2_sk);
-    let spender_2_addr: PrincipalData = spender_2_stx_addr.into();
+    let spender_2_addr: PrincipalData = spender_2_stx_addr.clone().into();
 
     let epoch_2_05 = 210;
     let epoch_2_1 = 215;
@@ -654,7 +654,7 @@ fn transition_fixes_bitcoin_rigidity() {
 
     // okay, let's send a pre-stx op for a transfer-stx op that will get mined before the 2.1 epoch
     let pre_stx_op = PreStxOp {
-        output: spender_stx_addr,
+        output: spender_stx_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -685,8 +685,8 @@ fn transition_fixes_bitcoin_rigidity() {
     let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
     let transfer_stx_op = TransferStxOp {
-        sender: spender_stx_addr,
-        recipient: recipient_addr,
+        sender: spender_stx_addr.clone(),
+        recipient: recipient_addr.clone(),
         transfered_ustx: 100_000,
         memo: vec![],
         // to be filled in
@@ -696,7 +696,7 @@ fn transition_fixes_bitcoin_rigidity() {
         burn_header_hash: BurnchainHeaderHash([0u8; 32]),
     };
 
-    let mut spender_signer = BurnchainOpSigner::new(spender_sk);
+    let mut spender_signer = BurnchainOpSigner::new(spender_sk.clone());
 
     assert!(
         btc_regtest_controller
@@ -808,7 +808,7 @@ fn transition_fixes_bitcoin_rigidity() {
 
     // okay, let's send a pre-stx op.
     let pre_stx_op = PreStxOp {
-        output: spender_stx_addr,
+        output: spender_stx_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -835,8 +835,8 @@ fn transition_fixes_bitcoin_rigidity() {
     let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
     let transfer_stx_op = TransferStxOp {
-        sender: spender_stx_addr,
-        recipient: recipient_addr,
+        sender: spender_stx_addr.clone(),
+        recipient: recipient_addr.clone(),
         transfered_ustx: 100_000,
         memo: vec![],
         // to be filled in
@@ -879,7 +879,7 @@ fn transition_fixes_bitcoin_rigidity() {
 
     // okay, let's send a pre-stx op.
     let pre_stx_op = PreStxOp {
-        output: spender_2_stx_addr,
+        output: spender_2_stx_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -908,8 +908,8 @@ fn transition_fixes_bitcoin_rigidity() {
 
     // let's fire off our transfer op.
     let transfer_stx_op = TransferStxOp {
-        sender: spender_2_stx_addr,
-        recipient: recipient_addr,
+        sender: spender_2_stx_addr.clone(),
+        recipient: recipient_addr.clone(),
         transfered_ustx: 100_000,
         memo: vec![],
         // to be filled in
@@ -919,7 +919,7 @@ fn transition_fixes_bitcoin_rigidity() {
         burn_header_hash: BurnchainHeaderHash([0u8; 32]),
     };
 
-    let mut spender_signer = BurnchainOpSigner::new(spender_2_sk);
+    let mut spender_signer = BurnchainOpSigner::new(spender_2_sk.clone());
 
     btc_regtest_controller
         .submit_manual(
@@ -974,8 +974,8 @@ fn transition_fixes_bitcoin_rigidity() {
     };
 
     let transfer_stx_op = TransferStxOp {
-        sender: spender_stx_addr,
-        recipient: recipient_addr,
+        sender: spender_stx_addr.clone(),
+        recipient: recipient_addr.clone(),
         transfered_ustx: 123,
         memo: vec![],
         // to be filled in
@@ -1082,7 +1082,7 @@ fn transition_adds_get_pox_addr_recipients() {
     .iter()
     .enumerate()
     {
-        let spender_sk = spender_sks[i];
+        let spender_sk = spender_sks[i].clone();
         let pox_addr_tuple = execute(
             &format!(
                 "{{ hashbytes: 0x{pox_pubkey_hash}, version: 0x{:02x} }}",

--- a/stacks-node/src/tests/epoch_23.rs
+++ b/stacks-node/src/tests/epoch_23.rs
@@ -53,7 +53,7 @@ fn trait_invocation_behavior() {
     let spender_addr: PrincipalData = to_addr(&spender_sk).into();
 
     let impl_contract_id =
-        QualifiedContractIdentifier::new(contract_addr.into(), "impl-simple".into());
+        QualifiedContractIdentifier::new(contract_addr.clone().into(), "impl-simple".into());
 
     let mut spender_nonce = 0;
     let fee_amount = 10_000;

--- a/stacks-node/src/tests/integrations.rs
+++ b/stacks-node/src/tests/integrations.rs
@@ -923,7 +923,7 @@ fn integration_test_get_info() {
                 let path = format!("{http_origin}/v2/fees/transaction");
 
                 let tx_payload =
-                    TransactionPayload::TokenTransfer(contract_addr.into(), 10_000_000, TokenTransferMemo([0; 34]));
+                    TransactionPayload::TokenTransfer(contract_addr.clone().into(), 10_000_000, TokenTransferMemo([0; 34]));
 
                 let payload_data = tx_payload.serialize_to_vec();
                 let payload_hex = format!("0x{}", to_hex(&payload_data));
@@ -968,7 +968,7 @@ fn integration_test_get_info() {
                 assert_eq!(estimated_fees.count(), 3, "Fees should be length 3 array");
 
                 let tx_payload = TransactionPayload::from(TransactionContractCall {
-                    address: contract_addr,
+                    address: contract_addr.clone(),
                     contract_name: "get-info".into(),
                     function_name: "update-info".into(),
                     function_args: vec![],
@@ -1738,7 +1738,7 @@ fn bad_contract_tx_rollback() {
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
             let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();
-            let addr_2 = to_addr(&sk_2);
+            let addr_2: StacksAddress = to_addr(&sk_2);
 
             let contract_identifier = QualifiedContractIdentifier::parse(&format!(
                 "{}.faucet",
@@ -1779,7 +1779,7 @@ fn bad_contract_tx_rollback() {
                     1,
                     10,
                     CHAIN_ID_TESTNET,
-                    &addr_2.into(),
+                    &addr_2.clone().into(),
                     1000,
                 );
                 let (consensus_hash, block_hash) = (

--- a/stacks-node/src/tests/mempool.rs
+++ b/stacks-node/src/tests/mempool.rs
@@ -467,7 +467,7 @@ fn mempool_setup_chainstate() {
                 assert!(matches!(e, MemPoolRejection::NotEnoughFunds(111000, 99500)));
 
                 // sender == recipient
-                let contract_princ = PrincipalData::from(contract_addr);
+                let contract_princ = PrincipalData::from(contract_addr.clone());
                 let tx_bytes = make_stacks_transfer_serialized(
                     &contract_sk,
                     5,
@@ -525,7 +525,7 @@ fn mempool_setup_chainstate() {
                 assert!(matches!(e, MemPoolRejection::BadAddressVersionByte));
 
                 // tx version must be testnet
-                let contract_princ = PrincipalData::from(contract_addr);
+                let contract_princ = PrincipalData::from(contract_addr.clone());
                 let payload = TransactionPayload::TokenTransfer(
                     contract_princ,
                     1000,
@@ -910,7 +910,7 @@ fn mempool_setup_chainstate() {
                 assert!(matches!(e, MemPoolRejection::Other(_)));
 
                 let contract_id = QualifiedContractIdentifier::new(
-                    StandardPrincipalData::from(contract_addr),
+                    StandardPrincipalData::from(contract_addr.clone()),
                     ContractName::from("implement-trait-contract"),
                 );
                 let contract_principal = PrincipalData::Contract(contract_id);
@@ -938,7 +938,7 @@ fn mempool_setup_chainstate() {
                     .unwrap();
 
                 let contract_id = QualifiedContractIdentifier::new(
-                    StandardPrincipalData::from(contract_addr),
+                    StandardPrincipalData::from(contract_addr.clone()),
                     ContractName::from("bad-trait-contract"),
                 );
                 let contract_principal = PrincipalData::Contract(contract_id);

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -1566,13 +1566,16 @@ fn simple_neon_integration() {
     let send_amt = 1000;
     let send_fee = 100;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt * 2 + send_fee,
     );
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -1597,7 +1600,7 @@ fn simple_neon_integration() {
     boot_to_epoch_3(
         &naka_conf,
         &node_counters.blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -1789,13 +1792,16 @@ fn restarting_miner() {
     let send_amt = 1000;
     let send_fee = 100;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt * 2 + send_fee,
     );
     let sender_signer_sk = Secp256k1PrivateKey::from_seed(&[3, 2, 3, 2, 3, 2]);
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     test_observer::spawn();
@@ -1831,7 +1837,7 @@ fn restarting_miner() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -2010,13 +2016,16 @@ fn flash_blocks_on_epoch_3_FLAKY() {
     let send_amt = 1000;
     let send_fee = 100;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt * 2 + send_fee,
     );
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -2046,7 +2055,7 @@ fn flash_blocks_on_epoch_3_FLAKY() {
     boot_to_pre_epoch_3_boundary(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -2257,10 +2266,13 @@ fn mine_multiple_per_tenure_integration() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -2290,11 +2302,11 @@ fn mine_multiple_per_tenure_integration() {
         .spawn(move || run_loop.start(None, 0))
         .unwrap();
     wait_for_runloop(&blocks_processed);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -2441,10 +2453,13 @@ fn multiple_miners() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -2534,11 +2549,11 @@ fn multiple_miners() {
         .unwrap();
     wait_for_runloop(&blocks_processed);
 
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -2698,9 +2713,12 @@ fn correct_burn_outs() {
     let stacker_accounts = accounts[0..3].to_vec();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
 
-    let signers = TestSigners::new(vec![sender_signer_sk]);
+    let signers = TestSigners::new(vec![sender_signer_sk.clone()]);
 
     test_observer::spawn();
     test_observer::register_any(&mut naka_conf);
@@ -3037,12 +3055,12 @@ fn block_proposal_api_endpoint() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -3375,16 +3393,19 @@ fn miner_writes_proposed_block_to_stackerdb() {
     let send_amt = 1000;
     let send_fee = 100;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
 
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
 
     test_observer::spawn();
     test_observer::register(
@@ -3415,7 +3436,7 @@ fn miner_writes_proposed_block_to_stackerdb() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -3488,9 +3509,9 @@ fn vote_for_aggregate_key_burn_op() {
     let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
 
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
 
-    naka_conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     test_observer::spawn();
@@ -3522,8 +3543,8 @@ fn vote_for_aggregate_key_burn_op() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -3549,7 +3570,7 @@ fn vote_for_aggregate_key_burn_op() {
     let mut miner_signer = Keychain::default(naka_conf.node.seed.clone()).generate_op_signer();
     info!("Submitting pre-stx op");
     let pre_stx_op = PreStxOp {
-        output: signer_addr,
+        output: signer_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -3703,7 +3724,7 @@ fn follower_bootup_simple() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
     // setup sender + recipient for some test stx transfers
@@ -3712,10 +3733,13 @@ fn follower_bootup_simple() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -3747,7 +3771,7 @@ fn follower_bootup_simple() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -4022,7 +4046,7 @@ fn follower_bootup_across_multiple_cycles() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
     // setup sender + recipient for some test stx transfers
@@ -4031,10 +4055,13 @@ fn follower_bootup_across_multiple_cycles() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     test_observer::spawn();
@@ -4065,7 +4092,7 @@ fn follower_bootup_across_multiple_cycles() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -4245,7 +4272,7 @@ fn follower_bootup_custom_chain_id() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
     // setup sender + recipient for some test stx transfers
@@ -4254,10 +4281,13 @@ fn follower_bootup_custom_chain_id() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -4289,7 +4319,7 @@ fn follower_bootup_custom_chain_id() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -4591,14 +4621,23 @@ fn burn_ops_integration_test() {
     let sender_addr = tests::to_addr(&sender_sk);
     let mut sender_nonce = 0;
 
-    let mut signers = TestSigners::new(vec![signer_sk_1]);
+    let mut signers = TestSigners::new(vec![signer_sk_1.clone()]);
 
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     // Add the initial balances to the other accounts
-    naka_conf.add_initial_balance(PrincipalData::from(stacker_addr_1).to_string(), 1000000);
-    naka_conf.add_initial_balance(PrincipalData::from(stacker_addr_2).to_string(), 1000000);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 100_000_000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(stacker_addr_1.clone()).to_string(),
+        1000000,
+    );
+    naka_conf.add_initial_balance(
+        PrincipalData::from(stacker_addr_2.clone()).to_string(),
+        1000000,
+    );
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        100_000_000,
+    );
 
     test_observer::spawn();
     test_observer::register_any(&mut naka_conf);
@@ -4631,8 +4670,8 @@ fn burn_ops_integration_test() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk_1],
+        &[stacker_sk.clone()],
+        &[signer_sk_1.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -4651,7 +4690,7 @@ fn burn_ops_integration_test() {
 
     info!("Submitting first pre-stx op");
     let pre_stx_op = PreStxOp {
-        output: signer_addr_1,
+        output: signer_addr_1.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -4675,7 +4714,7 @@ fn burn_ops_integration_test() {
     let mut miner_signer_2 = Keychain::default(naka_conf.node.seed.clone()).generate_op_signer();
     info!("Submitting second pre-stx op");
     let pre_stx_op_2 = PreStxOp {
-        output: signer_addr_2,
+        output: signer_addr_2.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -4696,7 +4735,7 @@ fn burn_ops_integration_test() {
     let mut miner_signer_3 = Keychain::default(naka_conf.node.seed.clone()).generate_op_signer();
     info!("Submitting third pre-stx op");
     let pre_stx_op_3 = PreStxOp {
-        output: stacker_addr_1,
+        output: stacker_addr_1.clone(),
         txid: Txid([0u8; 32]),
         vtxindex: 0,
         block_height: 0,
@@ -4716,7 +4755,7 @@ fn burn_ops_integration_test() {
     info!("Submitting fourth pre-stx op");
     let mut miner_signer_4 = Keychain::default(naka_conf.node.seed.clone()).generate_op_signer();
     let pre_stx_op_4 = PreStxOp {
-        output: stacker_addr_2,
+        output: stacker_addr_2.clone(),
         txid: Txid([0u8; 32]),
         vtxindex: 0,
         block_height: 0,
@@ -4753,7 +4792,8 @@ fn burn_ops_integration_test() {
     let lock_period: u8 = 6;
     let topic = Pox4SignatureTopic::StackStx;
     let auth_id: u32 = 1;
-    let pox_addr = PoxAddress::Standard(signer_addr_1, Some(AddressHashMode::SerializeP2PKH));
+    let pox_addr =
+        PoxAddress::Standard(signer_addr_1.clone(), Some(AddressHashMode::SerializeP2PKH));
 
     info!(
         "Submitting set-signer-key-authorization";
@@ -4838,13 +4878,13 @@ fn burn_ops_integration_test() {
             .total_available(),
     );
 
-    info!("Signer 1 addr: {}", signer_addr_1.to_b58());
-    info!("Signer 2 addr: {}", signer_addr_2.to_b58());
+    info!("Signer 1 addr: {}", signer_addr_1.clone().to_b58());
+    info!("Signer 2 addr: {}", signer_addr_2.clone().to_b58());
 
     info!("Submitting transfer STX op");
     let transfer_stx_op = TransferStxOp {
-        sender: stacker_addr_1,
-        recipient: stacker_addr_2,
+        sender: stacker_addr_1.clone(),
+        recipient: stacker_addr_2.clone(),
         transfered_ustx: 10000,
         memo: vec![],
         txid: Txid([0u8; 32]),
@@ -4865,8 +4905,8 @@ fn burn_ops_integration_test() {
 
     info!("Submitting delegate STX op");
     let del_stx_op = DelegateStxOp {
-        sender: stacker_addr_2,
-        delegate_to: stacker_addr_1,
+        sender: stacker_addr_2.clone(),
+        delegate_to: stacker_addr_1.clone(),
         reward_addr: None,
         delegated_ustx: 100_000,
         // to be filled in
@@ -4892,7 +4932,7 @@ fn burn_ops_integration_test() {
     let min_stx = pox_info.next_cycle.min_threshold_ustx;
 
     let stack_stx_op_with_some_signer_key = StackStxOp {
-        sender: signer_addr_1,
+        sender: signer_addr_1.clone(),
         reward_addr: pox_addr,
         stacked_ustx: min_stx.into(),
         num_cycles: lock_period,
@@ -4918,7 +4958,7 @@ fn burn_ops_integration_test() {
     );
 
     let stack_stx_op_with_no_signer_key = StackStxOp {
-        sender: signer_addr_2,
+        sender: signer_addr_2.clone(),
         reward_addr: PoxAddress::Standard(signer_addr_2, None),
         stacked_ustx: 100000,
         num_cycles: 6,
@@ -4961,7 +5001,7 @@ fn burn_ops_integration_test() {
                 sender_nonce,
                 200,
                 naka_conf.burnchain.chain_id,
-                &stacker_addr_1.into(),
+                &stacker_addr_1.clone().into(),
                 10000,
             );
             sender_nonce += 1;
@@ -5166,14 +5206,17 @@ fn forked_tenure_is_ignored() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
 
@@ -5183,7 +5226,7 @@ fn forked_tenure_is_ignored() {
         &[EventKeyType::AnyEvent, EventKeyType::MinedBlocks],
     );
 
-    let miner_sk = naka_conf.miner.mining_key.unwrap();
+    let miner_sk = naka_conf.miner.mining_key.clone().unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     let mut btcd_controller = BitcoinCoreController::new(naka_conf.clone());
@@ -5211,7 +5254,7 @@ fn forked_tenure_is_ignored() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -5530,10 +5573,13 @@ fn check_block_heights() {
     let send_fee = 180;
     let deploy_fee = 3000;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         3 * deploy_fee + (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     naka_conf.miner.tenure_cost_limit_per_block_percentage = None;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
@@ -5582,7 +5628,7 @@ fn check_block_heights() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -5946,7 +5992,10 @@ fn nakamoto_attempt_time() {
 
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_addr = tests::to_addr(&sender_sk);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1_000_000_000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        1_000_000_000,
+    );
 
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
@@ -6003,7 +6052,7 @@ fn nakamoto_attempt_time() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -6271,10 +6320,13 @@ fn clarity_burn_state() {
     let tx_fee = 1000;
     let deploy_fee = 3000;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         deploy_fee + tx_fee * tenure_count + tx_fee * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     naka_conf.miner.tenure_cost_limit_per_block_percentage = None;
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -6307,7 +6359,7 @@ fn clarity_burn_state() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -6537,12 +6589,15 @@ fn signer_chainstate() {
     let send_amt = 1000;
     let send_fee = 200;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * 20,
     );
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -6573,7 +6628,7 @@ fn signer_chainstate() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -6618,7 +6673,7 @@ fn signer_chainstate() {
     blind_signer(&naka_conf, &signers, &counters);
 
     let signer_client = stacks_signer::client::StacksClient::new(
-        StacksPrivateKey::from_seed(&[0, 1, 2, 3]),
+        &StacksPrivateKey::from_seed(&[0, 1, 2, 3]),
         naka_conf.node.rpc_bind.clone(),
         naka_conf
             .connection_options
@@ -7068,12 +7123,15 @@ fn continue_tenure_extend() {
     let send_amt = 1000;
     let send_fee = 200;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * 20,
     );
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
     let mut transfer_nonce = 0;
@@ -7104,7 +7162,7 @@ fn continue_tenure_extend() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -7515,10 +7573,13 @@ fn check_block_times() {
     let send_fee = 180;
     let deploy_fee = 3000;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         3 * deploy_fee + (send_amt + send_fee) * 12,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -7570,7 +7631,7 @@ fn check_block_times() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -7903,10 +7964,13 @@ fn check_block_info() {
     let send_fee = 180;
     let deploy_fee = 3000;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         3 * deploy_fee + (send_amt + send_fee) * 2,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
     let contract3_name = "test-contract-3";
@@ -8026,7 +8090,7 @@ fn check_block_info() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -8534,10 +8598,13 @@ fn check_block_info_rewards() {
     let send_fee = 180;
     let deploy_fee = 3000;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         3 * deploy_fee + (send_amt + send_fee) * 2,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -8611,7 +8678,7 @@ fn check_block_info_rewards() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -8854,7 +8921,7 @@ fn mock_mining() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     let tenure_count = 3;
     let inter_blocks_per_tenure = 3;
     // setup sender + recipient for some test stx transfers
@@ -8876,10 +8943,13 @@ fn mock_mining() {
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
 
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
 
@@ -8912,7 +8982,7 @@ fn mock_mining() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -9238,10 +9308,10 @@ fn v3_signer_api_endpoint() {
     let send_amt = 100;
     let send_fee = 180;
     conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
 
     // only subscribe to the block proposal events
@@ -9265,13 +9335,13 @@ fn v3_signer_api_endpoint() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -9402,10 +9472,10 @@ fn v3_blockbyheight_api_endpoint() {
     let send_amt = 100;
     let send_fee = 180;
     conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
     // only subscribe to the block proposal events
     test_observer::spawn();
@@ -9429,13 +9499,13 @@ fn v3_blockbyheight_api_endpoint() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -9520,10 +9590,10 @@ fn nakamoto_lockup_events() {
     let send_amt = 100;
     let send_fee = 180;
     conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * 100,
     );
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
 
     // only subscribe to the block proposal events
@@ -9546,13 +9616,13 @@ fn nakamoto_lockup_events() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -9687,14 +9757,20 @@ fn skip_mining_long_tx() {
     let send_amt = 1000;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_1_addr).to_string(),
+        PrincipalData::from(sender_1_addr.clone()).to_string(),
         send_amt * 15 + send_fee * 15,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_2_addr).to_string(), 10000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_2_addr.clone()).to_string(),
+        10000,
+    );
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
@@ -9726,7 +9802,7 @@ fn skip_mining_long_tx() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -10043,7 +10119,7 @@ fn sip029_coinbase_change() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
     // setup sender + recipient for some test stx transfers
@@ -10052,10 +10128,13 @@ fn sip029_coinbase_change() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     test_observer::spawn();
@@ -10087,7 +10166,7 @@ fn sip029_coinbase_change() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -10244,8 +10323,8 @@ fn clarity_cost_spend_down() {
         .collect();
     let sender_signer_addrs: Vec<_> = sender_signer_sks.iter().map(tests::to_addr).collect();
     let sender_addrs: Vec<_> = sender_sks.iter().map(tests::to_addr).collect();
-    let deployer_sk = sender_sks[0];
-    let deployer_addr = sender_addrs[0];
+    let deployer_sk = sender_sks[0].clone();
+    let deployer_addr = sender_addrs[0].clone();
     let mut sender_nonces: HashMap<String, u64> = HashMap::new();
 
     let get_and_increment_nonce =
@@ -10266,7 +10345,7 @@ fn clarity_cost_spend_down() {
     let amount =
         (large_deploy_fee + small_deploy_fee) + tx_fee * nmb_txs_per_signer + 100 * tenure_count;
     for sender_addr in sender_addrs {
-        naka_conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), amount);
+        naka_conf.add_initial_balance(PrincipalData::from(sender_addr.clone()).to_string(), amount);
     }
     for sender_signer_addr in sender_signer_addrs {
         naka_conf.add_initial_balance(
@@ -10534,10 +10613,10 @@ fn consensus_hash_event_dispatcher() {
     let send_amt = 100;
     let send_fee = 180;
     conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
     // only subscribe to the block proposal events
     test_observer::spawn();
@@ -10562,13 +10641,13 @@ fn consensus_hash_event_dispatcher() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -10975,8 +11054,11 @@ fn mine_invalid_principal_from_consensus_buff() {
     // setup sender + recipient for some test stx transfers
     // these are necessary for the interim blocks to get mined at all
     let sender_addr = tests::to_addr(&sender_sk);
-    conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1000000);
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        1000000,
+    );
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
     test_observer::spawn();
     test_observer::register(&mut conf, &[EventKeyType::AnyEvent]);
@@ -11001,13 +11083,13 @@ fn mine_invalid_principal_from_consensus_buff() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -11091,8 +11173,11 @@ fn reload_miner_config() {
     let sender_addr = tests::to_addr(&sender_sk);
     let old_burn_fee_cap: u64 = 100000;
     conf.burnchain.burn_fee_cap = old_burn_fee_cap;
-    conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1000000);
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        1000000,
+    );
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
     test_observer::spawn();
     test_observer::register(&mut conf, &[EventKeyType::AnyEvent]);
@@ -11137,13 +11222,13 @@ fn reload_miner_config() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -11234,8 +11319,11 @@ fn rbf_on_config_change() {
     let sender_addr = tests::to_addr(&sender_sk);
     let old_burn_fee_cap: u64 = 100000;
     conf.burnchain.burn_fee_cap = old_burn_fee_cap;
-    conf.add_initial_balance(PrincipalData::from(sender_addr).to_string(), 1000000);
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(
+        PrincipalData::from(sender_addr.clone()).to_string(),
+        1000000,
+    );
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
     test_observer::spawn();
     test_observer::register(&mut conf, &[EventKeyType::AnyEvent]);
@@ -11280,13 +11368,13 @@ fn rbf_on_config_change() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -11365,8 +11453,11 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
 
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
 
@@ -11397,7 +11488,10 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
     //   (1305150 + 180) * 25 + 1305150 = 33_938_400 uSTX.
     let initial_balance = 33_938_400;
     for addr in initial_sender_addrs.iter() {
-        naka_conf.add_initial_balance(PrincipalData::from(*addr).to_string(), initial_balance);
+        naka_conf.add_initial_balance(
+            PrincipalData::from(addr.clone()).to_string(),
+            initial_balance,
+        );
     }
     // This will hold tuples for all of our senders, with the sender pk and
     // the nonce
@@ -11438,7 +11532,7 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -11703,8 +11797,11 @@ fn larger_mempool() {
 
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
 
@@ -11732,7 +11829,10 @@ fn larger_mempool() {
     // (13011180 + 180) * 26 = 338_295_360 uSTX.
     let initial_balance = 338_295_360;
     for addr in initial_sender_addrs.iter() {
-        naka_conf.add_initial_balance(PrincipalData::from(*addr).to_string(), initial_balance);
+        naka_conf.add_initial_balance(
+            PrincipalData::from(addr.clone()).to_string(),
+            initial_balance,
+        );
     }
     // This will hold tuples for all of our senders, with the sender pk and
     // the nonce
@@ -11775,7 +11875,7 @@ fn larger_mempool() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -12014,10 +12114,10 @@ fn v3_transaction_api_endpoint() {
     let send_amt = 100;
     let send_fee = 180;
     conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
     // only subscribe to the block proposal events
     test_observer::spawn();
@@ -12042,13 +12142,13 @@ fn v3_transaction_api_endpoint() {
     let coord_channel = run_loop.coordinator_channels();
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -12168,20 +12268,23 @@ fn handle_considered_txs_foreign_key_failure() {
     let bad_sender_sk = Secp256k1PrivateKey::from_seed(&[30]);
     let bad_sender_addr = tests::to_addr(&bad_sender_sk);
     naka_conf.add_initial_balance(
-        PrincipalData::from(bad_sender_addr).to_string(),
+        PrincipalData::from(bad_sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
     let good_sender_sk = Secp256k1PrivateKey::from_seed(&[31]);
     let good_sender_addr = tests::to_addr(&good_sender_sk);
     naka_conf.add_initial_balance(
-        PrincipalData::from(good_sender_addr).to_string(),
+        PrincipalData::from(good_sender_addr.clone()).to_string(),
         (send_amt + send_fee) * 2,
     );
 
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let stacker_sk = setup_stacker(&mut naka_conf);
     let http_origin = format!("http://{}", &naka_conf.node.rpc_bind);
@@ -12212,7 +12315,7 @@ fn handle_considered_txs_foreign_key_failure() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -12322,10 +12425,10 @@ fn empty_mempool_sleep_ms() {
     let send_amt = 100;
     let send_fee = 180;
     conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         send_amt + send_fee,
     );
-    conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
     // Set the empty mempool sleep time to something long enough that we can
     // see the effect in the test.
@@ -12352,13 +12455,13 @@ fn empty_mempool_sleep_ms() {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
     wait_for_runloop(&blocks_processed);
     boot_to_epoch_3(
         &conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -12450,9 +12553,9 @@ fn miner_constructs_replay_block() {
     let signer_sk = Secp256k1PrivateKey::random();
     let signer_addr = tests::to_addr(&signer_sk);
     let stacker_sk = setup_stacker(&mut naka_conf);
-    naka_conf.add_initial_balance(PrincipalData::from(signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(PrincipalData::from(signer_addr.clone()).to_string(), 100000);
 
-    let mut signers = TestSigners::new(vec![signer_sk]);
+    let mut signers = TestSigners::new(vec![signer_sk.clone()]);
 
     test_observer::spawn();
     test_observer::register(
@@ -12483,8 +12586,8 @@ fn miner_constructs_replay_block() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
-        &[signer_sk],
+        &[stacker_sk.clone()],
+        &[signer_sk.clone()],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
     );
@@ -12704,7 +12807,7 @@ fn test_sip_031_activation() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     let tenure_count = 5;
     let inter_blocks_per_tenure = 9;
     // setup sender + recipient for some test stx transfers
@@ -12713,10 +12816,13 @@ fn test_sip_031_activation() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     test_observer::spawn();
@@ -12748,7 +12854,7 @@ fn test_sip_031_activation() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -13008,7 +13114,7 @@ fn test_sip_031_last_phase() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     // let's assume funds for 200 tenures
     let tenure_count = 200;
     let inter_blocks_per_tenure = 9;
@@ -13018,10 +13124,13 @@ fn test_sip_031_last_phase() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     let epoch32_start_height =
@@ -13075,7 +13184,7 @@ fn test_sip_031_last_phase() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -13168,6 +13277,7 @@ fn test_sip_031_last_phase() {
 
     let mut sender_nonce = 0;
     // 50 more tenures (each one with 3 stacks blocks)
+    let principal = PrincipalData::from(sender_signer_addr);
     for _ in 0..50 {
         let commits_before = commits_submitted.load(Ordering::SeqCst);
         next_block_and_process_new_stacks_blocks(
@@ -13181,7 +13291,7 @@ fn test_sip_031_last_phase() {
                     sender_nonce,
                     send_fee,
                     naka_conf.burnchain.chain_id,
-                    &PrincipalData::from(sender_signer_addr),
+                    &principal,
                     send_amt,
                 );
                 submit_tx(&http_origin, &transfer_tx);
@@ -13328,7 +13438,7 @@ fn test_sip_031_last_phase_out_of_epoch() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     // let's assume funds for 200 tenures
     let tenure_count = 200;
     let inter_blocks_per_tenure = 9;
@@ -13338,10 +13448,13 @@ fn test_sip_031_last_phase_out_of_epoch() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     let epoch32_start_height =
@@ -13395,7 +13508,7 @@ fn test_sip_031_last_phase_out_of_epoch() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -13538,7 +13651,7 @@ fn test_sip_031_last_phase_coinbase_matches_activation() {
     let sender_sk = Secp256k1PrivateKey::random();
     let sender_signer_sk = Secp256k1PrivateKey::random();
     let sender_signer_addr = tests::to_addr(&sender_signer_sk);
-    let mut signers = TestSigners::new(vec![sender_signer_sk]);
+    let mut signers = TestSigners::new(vec![sender_signer_sk.clone()]);
     // let's assume funds for 200 tenures
     let tenure_count = 200;
     let inter_blocks_per_tenure = 9;
@@ -13548,10 +13661,13 @@ fn test_sip_031_last_phase_coinbase_matches_activation() {
     let send_amt = 100;
     let send_fee = 180;
     naka_conf.add_initial_balance(
-        PrincipalData::from(sender_addr).to_string(),
+        PrincipalData::from(sender_addr.clone()).to_string(),
         (send_amt + send_fee) * tenure_count * inter_blocks_per_tenure,
     );
-    naka_conf.add_initial_balance(PrincipalData::from(sender_signer_addr).to_string(), 100000);
+    naka_conf.add_initial_balance(
+        PrincipalData::from(sender_signer_addr.clone()).to_string(),
+        100000,
+    );
     let stacker_sk = setup_stacker(&mut naka_conf);
 
     let epoch32_start_height =
@@ -13591,7 +13707,7 @@ fn test_sip_031_last_phase_coinbase_matches_activation() {
     boot_to_epoch_3(
         &naka_conf,
         &blocks_processed,
-        &[stacker_sk],
+        &[stacker_sk.clone()],
         &[sender_signer_sk],
         &mut Some(&mut signers),
         &mut btc_regtest_controller,
@@ -13757,7 +13873,7 @@ fn test_sip_031_last_phase_coinbase_matches_activation() {
                 sender_nonce,
                 send_fee,
                 naka_conf.burnchain.chain_id,
-                &PrincipalData::from(sender_signer_addr),
+                &PrincipalData::from(sender_signer_addr.clone()),
                 send_amt,
             );
             submit_tx(&http_origin, &transfer_tx);

--- a/stacks-node/src/tests/neon_integrations.rs
+++ b/stacks-node/src/tests/neon_integrations.rs
@@ -1566,7 +1566,7 @@ fn deep_contract() {
 
     let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
-    let spender_princ: PrincipalData = spender_addr.into();
+    let spender_princ: PrincipalData = spender_addr.clone().into();
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
 
@@ -1676,7 +1676,7 @@ fn liquid_ustx_integration() {
 
     let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
-    let spender_princ: PrincipalData = spender_addr.into();
+    let spender_princ: PrincipalData = spender_addr.clone().into();
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
 
@@ -1916,7 +1916,7 @@ fn stx_transfer_btc_integration_test() {
 
     let spender_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let spender_stx_addr: StacksAddress = to_addr(&spender_sk);
-    let spender_addr: PrincipalData = spender_stx_addr.into();
+    let spender_addr: PrincipalData = spender_stx_addr.clone().into();
     let _spender_btc_addr = BitcoinAddress::from_bytes_legacy(
         BitcoinNetworkType::Regtest,
         LegacyBitcoinAddressType::PublicKeyHash,
@@ -1926,7 +1926,7 @@ fn stx_transfer_btc_integration_test() {
 
     let spender_2_sk = StacksPrivateKey::from_hex(SK_2).unwrap();
     let spender_2_stx_addr: StacksAddress = to_addr(&spender_2_sk);
-    let spender_2_addr: PrincipalData = spender_2_stx_addr.into();
+    let spender_2_addr: PrincipalData = spender_2_stx_addr.clone().into();
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
 
@@ -1981,7 +1981,7 @@ fn stx_transfer_btc_integration_test() {
 
     // okay, let's send a pre-stx op.
     let pre_stx_op = PreStxOp {
-        output: spender_stx_addr,
+        output: spender_stx_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -2008,7 +2008,7 @@ fn stx_transfer_btc_integration_test() {
     let recipient_addr = to_addr(&recipient_sk);
     let transfer_stx_op = TransferStxOp {
         sender: spender_stx_addr,
-        recipient: recipient_addr,
+        recipient: recipient_addr.clone(),
         transfered_ustx: 100_000,
         memo: vec![],
         // to be filled in
@@ -2048,7 +2048,7 @@ fn stx_transfer_btc_integration_test() {
 
     // okay, let's send a pre-stx op.
     let pre_stx_op = PreStxOp {
-        output: spender_2_stx_addr,
+        output: spender_2_stx_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -2078,7 +2078,7 @@ fn stx_transfer_btc_integration_test() {
     // let's fire off our transfer op.
     let transfer_stx_op = TransferStxOp {
         sender: spender_2_stx_addr,
-        recipient: recipient_addr,
+        recipient: recipient_addr.clone(),
         transfered_ustx: 100_000,
         memo: vec![],
         // to be filled in
@@ -2142,7 +2142,7 @@ fn stx_delegate_btc_integration_test() {
 
     let spender_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let spender_stx_addr: StacksAddress = to_addr(&spender_sk);
-    let spender_addr: PrincipalData = spender_stx_addr.into();
+    let spender_addr: PrincipalData = spender_stx_addr.clone().into();
 
     let recipient_sk = StacksPrivateKey::random();
     let recipient_addr = to_addr(&recipient_sk);
@@ -2159,7 +2159,7 @@ fn stx_delegate_btc_integration_test() {
         amount: 100300,
     });
     conf.initial_balances.push(InitialBalance {
-        address: recipient_addr.into(),
+        address: recipient_addr.clone().into(),
         amount: 300,
     });
 
@@ -2248,7 +2248,7 @@ fn stx_delegate_btc_integration_test() {
 
     // okay, let's send a pre-stx op.
     let pre_stx_op = PreStxOp {
-        output: spender_stx_addr,
+        output: spender_stx_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -2273,8 +2273,8 @@ fn stx_delegate_btc_integration_test() {
 
     // let's fire off our delegate op.
     let del_stx_op = DelegateStxOp {
-        sender: spender_stx_addr,
-        delegate_to: recipient_addr,
+        sender: spender_stx_addr.clone(),
+        delegate_to: recipient_addr.clone(),
         reward_addr: None,
         delegated_ustx: 100_000,
         // to be filled in
@@ -2392,7 +2392,7 @@ fn stack_stx_burn_op_test() {
 
     let spender_sk_1 = StacksPrivateKey::from_hex(SK_1).unwrap();
     let spender_stx_addr_1: StacksAddress = to_addr(&spender_sk_1);
-    let spender_addr_1: PrincipalData = spender_stx_addr_1.into();
+    let spender_addr_1: PrincipalData = spender_stx_addr_1.clone().into();
 
     let spender_sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
     let spender_stx_addr_2: StacksAddress = to_addr(&spender_sk_2);
@@ -2529,7 +2529,10 @@ fn stack_stx_burn_op_test() {
     let signer_sk_2 = spender_sk_2;
     let signer_pk_1 = StacksPublicKey::from_private(&signer_sk_1);
 
-    let pox_addr = PoxAddress::Standard(spender_stx_addr_1, Some(AddressHashMode::SerializeP2PKH));
+    let pox_addr = PoxAddress::Standard(
+        spender_stx_addr_1.clone(),
+        Some(AddressHashMode::SerializeP2PKH),
+    );
 
     let mut block_height = channel.get_sortitions_processed();
 
@@ -2538,7 +2541,7 @@ fn stack_stx_burn_op_test() {
     // Submitting 2 pre-stx operations
     let mut miner_signer_1 = Keychain::default(conf.node.seed.clone()).generate_op_signer();
     let pre_stx_op_1 = PreStxOp {
-        output: spender_stx_addr_1,
+        output: spender_stx_addr_1.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -2558,7 +2561,7 @@ fn stack_stx_burn_op_test() {
 
     let mut miner_signer_2 = Keychain::default(conf.node.seed.clone()).generate_op_signer();
     let pre_stx_op_2 = PreStxOp {
-        output: spender_stx_addr_2,
+        output: spender_stx_addr_2.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -2790,7 +2793,7 @@ fn vote_for_aggregate_key_burn_op_test() {
 
     let spender_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let spender_stx_addr: StacksAddress = to_addr(&spender_sk);
-    let spender_addr: PrincipalData = spender_stx_addr.into();
+    let spender_addr: PrincipalData = spender_stx_addr.clone().into();
 
     let pox_pubkey = Secp256k1PublicKey::from_hex(
         "02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede",
@@ -2922,10 +2925,13 @@ fn vote_for_aggregate_key_burn_op_test() {
 
     // setup stack-stx tx
 
-    let signer_sk = spender_sk;
+    let signer_sk = spender_sk.clone();
     let signer_pk = StacksPublicKey::from_private(&signer_sk);
 
-    let pox_addr = PoxAddress::Standard(spender_stx_addr, Some(AddressHashMode::SerializeP2PKH));
+    let pox_addr = PoxAddress::Standard(
+        spender_stx_addr.clone(),
+        Some(AddressHashMode::SerializeP2PKH),
+    );
 
     let mut block_height = btc_regtest_controller.get_headers_height();
 
@@ -2969,7 +2975,7 @@ fn vote_for_aggregate_key_burn_op_test() {
 
     let mut miner_signer = Keychain::default(conf.node.seed.clone()).generate_op_signer();
     let pre_stx_op = PreStxOp {
-        output: spender_stx_addr,
+        output: spender_stx_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -3021,7 +3027,7 @@ fn vote_for_aggregate_key_burn_op_test() {
         BlockstackOperationType::VoteForAggregateKey(VoteForAggregateKeyOp {
             signer_key,
             signer_index,
-            sender: spender_stx_addr,
+            sender: spender_stx_addr.clone(),
             round: 0,
             reward_cycle,
             aggregate_key,
@@ -4115,7 +4121,7 @@ fn cost_voting_integration() {
 
     let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
-    let spender_princ: PrincipalData = spender_addr.into();
+    let spender_princ: PrincipalData = spender_addr.clone().into();
 
     let (mut conf, miner_account) = neon_integration_test_conf();
 
@@ -4446,11 +4452,11 @@ fn mining_events_integration_test() {
     let (mut conf, _) = neon_integration_test_conf();
 
     conf.initial_balances.push(InitialBalance {
-        address: addr.into(),
+        address: addr.clone().into(),
         amount: 10000000,
     });
     conf.initial_balances.push(InitialBalance {
-        address: addr_2.into(),
+        address: addr_2.clone().into(),
         amount: 10000000,
     });
 
@@ -4726,15 +4732,15 @@ fn setup_block_limit_test(strategy: MemPoolWalkStrategy) -> (Vec<serde_json::Val
     conf.miner.mempool_walk_strategy = strategy;
 
     conf.initial_balances.push(InitialBalance {
-        address: addr.into(),
+        address: addr.clone().into(),
         amount: 10_000_000,
     });
     conf.initial_balances.push(InitialBalance {
-        address: second_spender_addr.into(),
+        address: second_spender_addr.clone().into(),
         amount: 10_000_000,
     });
     conf.initial_balances.push(InitialBalance {
-        address: third_spender_addr.into(),
+        address: third_spender_addr.clone().into(),
         amount: 10_000_000,
     });
 
@@ -4778,7 +4784,7 @@ fn setup_block_limit_test(strategy: MemPoolWalkStrategy) -> (Vec<serde_json::Val
         0,
         180,
         conf.burnchain.chain_id,
-        &PrincipalData::from(addr),
+        &PrincipalData::from(addr.clone()),
         100,
     );
 
@@ -5035,7 +5041,7 @@ fn block_large_tx_integration_test() {
     test_observer::register_any(&mut conf);
 
     conf.initial_balances.push(InitialBalance {
-        address: spender_addr.into(),
+        address: spender_addr.clone().into(),
         amount: 10000000,
     });
 
@@ -5704,6 +5710,7 @@ fn atlas_integration_test() {
     let (bootstrap_node_tx, bootstrap_node_rx) = mpsc::channel();
     let (follower_node_tx, follower_node_rx) = mpsc::channel();
 
+    let moved_user_1 = user_1.clone();
     let bootstrap_node_thread = thread::spawn(move || {
         let burnchain_config = Burnchain::regtest(&conf_bootstrap_node.get_burn_db_path());
 
@@ -5759,7 +5766,7 @@ fn atlas_integration_test() {
         let salted_namespace = format!("{namespace}{salt}");
         let hashed_namespace = Hash160::from_data(salted_namespace.as_bytes());
         let tx_1 = make_contract_call(
-            &user_1,
+            &moved_user_1,
             0,
             260,
             conf_bootstrap_node.burnchain.chain_id,
@@ -5819,7 +5826,7 @@ fn atlas_integration_test() {
         //                                  (lifetime uint)
         //                                  (namespace-import principal))
         let tx_2 = make_contract_call(
-            &user_1,
+            &moved_user_1,
             1,
             1000,
             conf_bootstrap_node.burnchain.chain_id,
@@ -5882,7 +5889,7 @@ fn atlas_integration_test() {
         let zonefile_hex = "facade00";
         let hashed_zonefile = Hash160::from_data(&hex_bytes(zonefile_hex).unwrap());
         let tx_3 = make_contract_call(
-            &user_1,
+            &moved_user_1,
             2,
             500,
             conf_bootstrap_node.burnchain.chain_id,
@@ -5892,7 +5899,7 @@ fn atlas_integration_test() {
             &[
                 Value::buff_from(namespace.as_bytes().to_vec()).unwrap(),
                 Value::buff_from("johndoe".as_bytes().to_vec()).unwrap(),
-                Value::Principal(to_addr(&user_1).into()),
+                Value::Principal(to_addr(&moved_user_1).into()),
                 Value::buff_from(hashed_zonefile.as_bytes().to_vec()).unwrap(),
             ],
         );
@@ -7187,7 +7194,7 @@ fn fuzzed_median_fee_rate_estimation_test(window_size: u64, expected_final_value
     conf.estimation.fee_rate_window_size = window_size;
 
     conf.initial_balances.push(InitialBalance {
-        address: spender_addr.into(),
+        address: spender_addr.clone().into(),
         amount: 10000000000,
     });
     test_observer::spawn();
@@ -7258,7 +7265,7 @@ fn fuzzed_median_fee_rate_estimation_test(window_size: u64, expected_final_value
             let path = format!("{http_origin}/v2/fees/transaction");
 
             let tx_payload = TransactionPayload::ContractCall(TransactionContractCall {
-                address: spender_addr,
+                address: spender_addr.clone(),
                 contract_name: ContractName::from("increment-contract"),
                 function_name: ClarityName::from("increment-many"),
                 function_args: vec![],
@@ -7354,7 +7361,7 @@ fn use_latest_tip_integration_test() {
 
     let spender_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let spender_stacks_addr = to_addr(&spender_sk);
-    let spender_addr: PrincipalData = spender_stacks_addr.into();
+    let spender_addr: PrincipalData = spender_stacks_addr.clone().into();
 
     let (mut conf, _) = neon_integration_test_conf();
 
@@ -7533,7 +7540,7 @@ fn use_latest_tip_integration_test() {
     // This should fail because the anchored tip would be unaware of this contract.
     let err_opt = get_contract_src(
         &http_origin,
-        spender_stacks_addr,
+        spender_stacks_addr.clone(),
         "caller".to_string(),
         false,
     );
@@ -7555,7 +7562,7 @@ fn use_latest_tip_integration_test() {
     // This should succeeed.
     assert!(get_contract_src(
         &http_origin,
-        spender_stacks_addr,
+        spender_stacks_addr.clone(),
         "caller".to_string(),
         true,
     )
@@ -9157,7 +9164,7 @@ fn min_txs() {
 
     let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
-    let spender_princ: PrincipalData = spender_addr.into();
+    let spender_princ: PrincipalData = spender_addr.clone().into();
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
 
@@ -9260,7 +9267,7 @@ fn filter_txs_by_type() {
 
     let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
-    let spender_princ: PrincipalData = spender_addr.into();
+    let spender_princ: PrincipalData = spender_addr.clone().into();
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
 
@@ -9373,7 +9380,7 @@ fn filter_txs_by_origin() {
 
     let spender_sk = StacksPrivateKey::random();
     let spender_addr = to_addr(&spender_sk);
-    let spender_princ: PrincipalData = spender_addr.into();
+    let spender_princ: PrincipalData = spender_addr.clone().into();
 
     let (mut conf, _miner_account) = neon_integration_test_conf();
 

--- a/stacks-node/src/tests/signer/mod.rs
+++ b/stacks-node/src/tests/signer/mod.rs
@@ -243,7 +243,8 @@ impl<Z: SpawnedSignerTrait> SignerTest<Z> {
 
         // Add initial balances to the config
         for (address, amount) in initial_balances.iter() {
-            naka_conf.add_initial_balance(PrincipalData::from(*address).to_string(), *amount);
+            naka_conf
+                .add_initial_balance(PrincipalData::from(address.clone()).to_string(), *amount);
         }
 
         // So the combination is... one, two, three, four, five? That's the stupidest combination I've ever heard in my life!

--- a/stacks-node/src/tests/signer/multiversion.rs
+++ b/stacks-node/src/tests/signer/multiversion.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use std::sync::mpsc::TryRecvError;
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use libsigner::v0::messages::{SignerMessage, StateMachineUpdate};
 use libsigner::v0::signer_state::{MinerState, ReplayTransactionSet, SignerStateMachine};
@@ -285,7 +285,10 @@ fn with_new_miners<S: SpawnedSignerTrait>(supported_signer_protocol_version: u64
 
     let localhost = "127.0.0.1";
     let num_transfer_txs = 20;
-    let initial_balances = vec![(sender_addr, (send_amt + send_fee) * num_transfer_txs)];
+    let initial_balances = vec![(
+        sender_addr.clone(),
+        (send_amt + send_fee) * num_transfer_txs,
+    )];
     let miner_1_sk = Secp256k1PrivateKey::from_seed(&[1]);
 
     let num_signers = 5;
@@ -311,7 +314,7 @@ fn with_new_miners<S: SpawnedSignerTrait>(supported_signer_protocol_version: u64
             config.burnchain.local_mining_public_key = Some(btc_miner_1_pk.to_hex());
             config.miner.mining_key = Some(miner_1_sk.clone());
         },
-        Some(vec![btc_miner_1_pk]),
+        Some(vec![btc_miner_1_pk.clone()]),
         None,
     );
 

--- a/stacks-node/src/tests/signer/v0.rs
+++ b/stacks-node/src/tests/signer/v0.rs
@@ -495,6 +495,7 @@ impl SignerTest<SpawnedSigner> {
             .conf
             .miner
             .mining_key
+            .clone()
             .expect("No mining key");
         assert_eq!(signed_by, Secp256k1PublicKey::from_private(&miner_sk),
                    "signer tests should only propose blocks that have been signed by the signer test miner. Otherwise, signers won't even consider them via this channel.");
@@ -668,7 +669,7 @@ impl MultipleMinerTest {
                 });
                 node_1_config_modifier(config);
             },
-            Some(vec![btc_miner_1_pk, btc_miner_2_pk]),
+            Some(vec![btc_miner_1_pk.clone(), btc_miner_2_pk.clone()]),
             None,
         );
         let conf = signer_test.running_nodes.conf.clone();
@@ -757,8 +758,9 @@ impl MultipleMinerTest {
                 .conf
                 .miner
                 .mining_key
+                .clone()
                 .unwrap(),
-            self.conf_node_2.miner.mining_key.unwrap(),
+            self.conf_node_2.miner.mining_key.clone().unwrap(),
         )
     }
 
@@ -1829,7 +1831,13 @@ fn miner_gather_signatures() {
     info!("------------------------- Test Setup -------------------------");
     let num_signers = 5;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     let miner_pkh = Hash160::from_node_public_key(&miner_pk);
 
@@ -1973,7 +1981,7 @@ fn revalidate_unknown_parent() {
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(
-            sender_addr,
+            sender_addr.clone(),
             (send_amt + send_fee) * max_nakamoto_tenures * inter_blocks_per_tenure,
         )],
         |signer_config| {
@@ -2011,7 +2019,7 @@ fn revalidate_unknown_parent() {
                 panic!("Expected epochs to be set");
             }
         },
-        Some(vec![btc_miner_1_pk, btc_miner_2_pk]),
+        Some(vec![btc_miner_1_pk.clone(), btc_miner_2_pk.clone()]),
         None,
     );
 
@@ -2039,8 +2047,8 @@ fn revalidate_unknown_parent() {
         conf.burnchain.peer_version,
     );
 
-    let mining_pk_1 = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
-    let mining_pk_2 = StacksPublicKey::from_private(&conf_node_2.miner.mining_key.unwrap());
+    let mining_pk_1 = StacksPublicKey::from_private(&conf.miner.mining_key.clone().unwrap());
+    let mining_pk_2 = StacksPublicKey::from_private(&conf_node_2.miner.mining_key.clone().unwrap());
     let mining_pkh_1 = Hash160::from_node_public_key(&mining_pk_1);
     let mining_pkh_2 = Hash160::from_node_public_key(&mining_pk_2);
     debug!("The mining key for miner 1 is {mining_pkh_1}");
@@ -2642,7 +2650,7 @@ fn forked_tenure_testing(
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender_addr, send_amt + send_fee)],
+        vec![(sender_addr.clone(), send_amt + send_fee)],
         |config| {
             // make the duration long enough that the reorg attempt will definitely be accepted
             config.first_proposal_burn_block_timing = odd_proposal_limit
@@ -2677,7 +2685,7 @@ fn forked_tenure_testing(
     info!("------------------------- Reached Epoch 3.0 -------------------------");
 
     let naka_conf = signer_test.running_nodes.conf.clone();
-    let miner_sk = naka_conf.miner.mining_key.unwrap();
+    let miner_sk = naka_conf.miner.mining_key.clone().unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     let burnchain = naka_conf.get_burnchain();
     let sortdb = burnchain.open_sortition_db(true).unwrap();
@@ -3268,7 +3276,7 @@ fn tx_replay_forking_test() {
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(
-            sender_addr,
+            sender_addr.clone(),
             (send_amt + send_fee) * 10 + deploy_fee + call_fee,
         )],
         |c| {
@@ -3283,7 +3291,7 @@ fn tx_replay_forking_test() {
     );
     let conf = &signer_test.running_nodes.conf;
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
-    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.clone().unwrap());
 
     let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
 
@@ -3534,7 +3542,7 @@ fn tx_replay_reject_invalid_proposals_during_replay() {
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![
-            (sender_addr, send_amt + send_fee),
+            (sender_addr.clone(), send_amt + send_fee),
             (sender_addr2, send_amt + send_fee),
         ],
         |c| {
@@ -3551,7 +3559,7 @@ fn tx_replay_reject_invalid_proposals_during_replay() {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
     let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
 
-    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.clone().unwrap());
 
     signer_test.boot_to_epoch_3();
     info!("------------------------- Reached Epoch 3.0 -------------------------");
@@ -3745,7 +3753,7 @@ fn tx_replay_btc_on_stx_invalidation() {
     let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new_with_config_modifications_and_snapshot(
             num_signers,
-            vec![(sender_addr, (send_amt + send_fee) * 10)],
+            vec![(sender_addr.clone(), (send_amt + send_fee) * 10)],
             |c| {
                 c.validate_with_replay_tx = true;
             },
@@ -3791,7 +3799,7 @@ fn tx_replay_btc_on_stx_invalidation() {
 
     info!("Submitting first pre-stx op");
     let pre_stx_op = PreStxOp {
-        output: sender_addr,
+        output: sender_addr.clone(),
         // to be filled in
         txid: Txid([0u8; 32]),
         vtxindex: 0,
@@ -3820,7 +3828,7 @@ fn tx_replay_btc_on_stx_invalidation() {
     let recipient_balance = send_amt + send_fee;
     let transfer_stx_op = TransferStxOp {
         sender: sender_addr,
-        recipient: recipient_addr,
+        recipient: recipient_addr.clone(),
         transfered_ustx: recipient_balance.into(),
         memo: vec![],
         txid: Txid([0u8; 32]),
@@ -4121,7 +4129,7 @@ fn tx_replay_solved_by_mempool_txs() {
     let num_txs = 2;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        vec![(sender1_addr.clone(), (send_amt + send_fee) * num_txs)],
         |c| {
             c.validate_with_replay_tx = true;
         },
@@ -4249,7 +4257,7 @@ fn tx_replay_rejected_when_forking_across_reward_cycle() {
     let num_txs = 1;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender_addr, (send_amt + send_fee) * num_txs)],
+        vec![(sender_addr.clone(), (send_amt + send_fee) * num_txs)],
         |_| {},
         |node_config| {
             node_config.miner.block_commit_delay = Duration::from_secs(1);
@@ -4381,7 +4389,7 @@ fn tx_replay_with_fork_occured_before_starting_replaying_txs() {
     let num_txs = 1;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        vec![(sender1_addr.clone(), (send_amt + send_fee) * num_txs)],
         |c| {
             c.validate_with_replay_tx = true;
         },
@@ -4538,7 +4546,7 @@ fn tx_replay_with_fork_after_empty_tenures_before_starting_replaying_txs() {
     let num_txs = 1;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        vec![(sender1_addr.clone(), (send_amt + send_fee) * num_txs)],
         |c| {
             c.validate_with_replay_tx = true;
         },
@@ -4721,7 +4729,7 @@ fn tx_replay_with_fork_causing_replay_set_to_be_updated() {
     let num_txs = 2;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        vec![(sender1_addr.clone(), (send_amt + send_fee) * num_txs)],
         |c| {
             c.validate_with_replay_tx = true;
         },
@@ -4893,7 +4901,7 @@ fn tx_replay_with_fork_causing_replay_to_be_cleared_due_to_cycle() {
     let num_txs = 2;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender1_addr, (send_amt + send_fee) * num_txs)],
+        vec![(sender1_addr.clone(), (send_amt + send_fee) * num_txs)],
         |c| {
             c.validate_with_replay_tx = true;
         },
@@ -5046,7 +5054,7 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending() {
     let call_num = 2;
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender_addr, deploy_fee + call_fee * call_num)],
+        vec![(sender_addr.clone(), deploy_fee + call_fee * call_num)],
         |c| {
             c.validate_with_replay_tx = true;
             c.tenure_idle_timeout = Duration::from_secs(10);
@@ -5062,7 +5070,7 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending() {
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
     let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
     let counters = &signer_test.running_nodes.counters;
-    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.clone().unwrap());
 
     signer_test.boot_to_epoch_3();
     info!("------------------------- Reached Epoch 3.0 -------------------------");
@@ -5277,10 +5285,10 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending_and_new_tx_submitted
         num_signers,
         vec![
             (
-                sender1_addr,
+                sender1_addr.clone(),
                 send1_deploy_fee + send1_call_fee * send1_call_num,
             ),
-            (sender2_addr, (send2_amt + send2_fee) * send2_txs),
+            (sender2_addr.clone(), (send2_amt + send2_fee) * send2_txs),
         ],
         |c| {
             c.validate_with_replay_tx = true;
@@ -5297,7 +5305,7 @@ fn tx_replay_with_fork_middle_replay_while_tenure_extending_and_new_tx_submitted
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
     let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
     let counters = &signer_test.running_nodes.counters;
-    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+    let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.clone().unwrap());
 
     signer_test.boot_to_epoch_3();
     info!("------------------------- Reached Epoch 3.0 -------------------------");
@@ -5705,7 +5713,7 @@ fn miner_forking() {
 
     info!("------------------------- RL1 Wins Sortition -------------------------");
     info!("Pausing stacks block proposal to force an empty tenure commit from RL2");
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![mining_pk_1, mining_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![mining_pk_1.clone(), mining_pk_2.clone()]);
 
     info!("Pausing commits from RL1");
     skip_commit_op_rl1.set(true);
@@ -5801,7 +5809,7 @@ fn miner_forking() {
 
     info!("------------------------- RL1 RBFs its Own Commit -------------------------");
     info!("Pausing stacks block proposal to test RBF capability");
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![mining_pk_1, mining_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![mining_pk_1.clone(), mining_pk_2.clone()]);
     miners.submit_commit_miner_1(&sortdb);
 
     info!("Mine RL1 Tenure");
@@ -6304,7 +6312,13 @@ fn tenure_extend_with_other_transactions() {
         None,
         None,
     );
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
@@ -6401,7 +6415,7 @@ fn snapshot_test() {
     let signer_test: SignerTest<SpawnedSigner> =
         SignerTest::new_with_config_modifications_and_snapshot(
             num_signers,
-            vec![(sender_addr, (send_amt + send_fee) * 1000)],
+            vec![(sender_addr.clone(), (send_amt + send_fee) * 1000)],
             |config| {
                 config.tenure_idle_timeout = idle_timeout;
             },
@@ -6549,7 +6563,13 @@ fn tenure_extend_succeeds_after_rejected_attempt() {
         None,
     );
     let _http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     signer_test.boot_to_epoch_3();
@@ -6745,7 +6765,7 @@ fn idle_tenure_extend_active_mining() {
     let idle_timeout = Duration::from_secs(30);
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(sender_addr, amount), (deployer_addr, amount)],
+        vec![(sender_addr, amount), (deployer_addr.clone(), amount)],
         |config| {
             config.tenure_idle_timeout = idle_timeout;
         },
@@ -7028,7 +7048,13 @@ fn empty_tenure_delayed() {
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
     let short_timeout = Duration::from_secs(20);
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     signer_test.boot_to_epoch_3();
 
@@ -7727,7 +7753,7 @@ fn signer_set_rollover() {
 
     let mut initial_balances = new_signer_addresses
         .iter()
-        .map(|addr| (*addr, POX_4_DEFAULT_STACKER_BALANCE))
+        .map(|addr| (addr.clone(), POX_4_DEFAULT_STACKER_BALANCE))
         .collect::<Vec<_>>();
 
     initial_balances.push((sender_addr, (send_amt + send_fee) * 4));
@@ -8146,7 +8172,7 @@ fn duplicate_signers() {
         .collect::<Vec<_>>();
 
     // First two signers have same private key
-    signer_stacks_private_keys[1] = signer_stacks_private_keys[0];
+    signer_stacks_private_keys[1] = signer_stacks_private_keys[0].clone();
     let unique_signers = num_signers - 1;
     let duplicate_pubkey = Secp256k1PublicKey::from_private(&signer_stacks_private_keys[0]);
     let duplicate_pubkey_from_copy =
@@ -8242,7 +8268,7 @@ fn signer_multinode_rollover() {
     let new_signer_addrs: Vec<_> = new_signer_sks.iter().map(tests::to_addr).collect();
     let additional_initial_balances: Vec<_> = new_signer_addrs
         .iter()
-        .map(|addr| (*addr, POX_4_DEFAULT_STACKER_BALANCE))
+        .map(|addr| (addr.clone(), POX_4_DEFAULT_STACKER_BALANCE))
         .collect();
     let new_signers_port_start = 3000 + num_signers;
 
@@ -8658,7 +8684,7 @@ fn partial_tenure_fork() {
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(
-            sender_addr,
+            sender_addr.clone(),
             (send_amt + send_fee) * max_nakamoto_tenures * inter_blocks_per_tenure,
         )],
         |signer_config| {
@@ -8694,7 +8720,7 @@ fn partial_tenure_fork() {
                 panic!("Expected epochs to be set");
             }
         },
-        Some(vec![btc_miner_1_pk, btc_miner_2_pk]),
+        Some(vec![btc_miner_1_pk.clone(), btc_miner_2_pk.clone()]),
         None,
     );
 
@@ -8722,8 +8748,8 @@ fn partial_tenure_fork() {
         conf.burnchain.peer_version,
     );
 
-    let mining_pk_1 = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
-    let mining_pk_2 = StacksPublicKey::from_private(&conf_node_2.miner.mining_key.unwrap());
+    let mining_pk_1 = StacksPublicKey::from_private(&conf.miner.mining_key.clone().unwrap());
+    let mining_pk_2 = StacksPublicKey::from_private(&conf_node_2.miner.mining_key.clone().unwrap());
     let mining_pkh_1 = Hash160::from_node_public_key(&mining_pk_1);
     let mining_pkh_2 = Hash160::from_node_public_key(&mining_pk_2);
     debug!("The mining key for miner 1 is {mining_pkh_1}");
@@ -8996,7 +9022,13 @@ fn locally_accepted_blocks_overriden_by_global_rejection() {
     let all_signers = signer_test.signer_test_pks();
 
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     signer_test.boot_to_epoch_3();
 
@@ -9139,7 +9171,13 @@ fn locally_rejected_blocks_overriden_by_global_acceptance() {
         .map(StacksPublicKey::from_private)
         .collect();
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
@@ -9292,7 +9330,13 @@ fn reorg_locally_accepted_blocks_across_tenures_succeeds() {
     let all_signers = signer_test.signer_test_pks();
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     signer_test.boot_to_epoch_3();
@@ -9501,7 +9545,13 @@ fn reorg_locally_accepted_blocks_across_tenures_fails() {
     let all_signers = signer_test.signer_test_pks();
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     signer_test.boot_to_epoch_3();
@@ -9652,7 +9702,13 @@ fn miner_recovers_when_broadcast_block_delay_across_tenures_occurs() {
         None,
     );
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     signer_test.boot_to_epoch_3();
@@ -10138,7 +10194,13 @@ fn continue_after_tenure_extend() {
     let timeout = Duration::from_secs(200);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     let burnchain = signer_test.running_nodes.conf.get_burnchain();
@@ -10750,7 +10812,13 @@ fn block_validation_check_rejection_timeout_heuristic() {
         None,
         None,
     );
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     let all_signers = signer_test.signer_test_pks();
 
@@ -11020,7 +11088,13 @@ fn new_tenure_while_validating_previous_scenario() {
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
     signer_test.boot_to_epoch_3();
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     info!("----- Starting test -----";
@@ -11728,7 +11802,13 @@ fn global_acceptance_depends_on_block_announcement() {
     );
 
     let all_signers = signer_test.signer_test_pks();
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     let miner_pkh = Hash160::from_node_public_key(&miner_pk);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
@@ -12505,7 +12585,7 @@ fn injected_signatures_are_ignored_across_boundaries() {
         .collect();
     let new_signer_private_key = StacksPrivateKey::random();
     let mut new_signer_private_keys = signer_private_keys.clone();
-    new_signer_private_keys.push(new_signer_private_key);
+    new_signer_private_keys.push(new_signer_private_key.clone());
 
     let new_signer_public_keys: Vec<_> = new_signer_private_keys
         .iter()
@@ -12520,7 +12600,7 @@ fn injected_signatures_are_ignored_across_boundaries() {
 
     let mut initial_balances = new_signer_addresses
         .iter()
-        .map(|addr| (*addr, POX_4_DEFAULT_STACKER_BALANCE))
+        .map(|addr| (addr.clone(), POX_4_DEFAULT_STACKER_BALANCE))
         .collect::<Vec<_>>();
 
     initial_balances.push((sender_addr, (send_amt + send_fee) * 4));
@@ -12532,7 +12612,7 @@ fn injected_signatures_are_ignored_across_boundaries() {
 
     // Setup the new signers that will take over
     let new_signer_config = build_signer_config_tomls(
-        &[new_signer_private_key],
+        &[new_signer_private_key.clone()],
         &rpc_bind,
         Some(Duration::from_millis(128)), // Timeout defaults to 5 seconds. Let's override it to 128 milliseconds.
         &Network::Testnet,
@@ -12916,7 +12996,13 @@ fn reorg_attempts_count_towards_miner_validity() {
 
     signer_test.boot_to_epoch_3();
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     info!("------------------------- Test Mine Block N -------------------------");
@@ -13095,7 +13181,13 @@ fn reorg_attempts_activity_timeout_exceeded() {
     );
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     signer_test.boot_to_epoch_3();
 
@@ -13122,7 +13214,7 @@ fn reorg_attempts_activity_timeout_exceeded() {
             .expect("Failed to propose block N");
     let chain_after = get_chain_info(&signer_test.running_nodes.conf);
     assert_eq!(chain_after, chain_start);
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk.clone()]);
 
     info!("------------------------- Start Tenure B  -------------------------");
     test_observer::clear();
@@ -13155,7 +13247,7 @@ fn reorg_attempts_activity_timeout_exceeded() {
         wait_for_block_proposal(30, chain_start.stacks_tip_height + 1, &miner_pk)
             .expect("Failed to get block proposal N'");
     // Make sure that no subsequent proposal arrives before the block_proposal_timeout is exceeded
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk.clone()]);
     info!("------------------------- Wait for block N' to arrive late  -------------------------");
     // Allow block N validation to finish.
     TEST_VALIDATE_STALL.set(false);
@@ -13236,7 +13328,7 @@ fn fast_sortition() {
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
         num_signers,
-        vec![(sender_addr, num_transfers * (send_amt + send_fee))],
+        vec![(sender_addr.clone(), num_transfers * (send_amt + send_fee))],
     );
 
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
@@ -13571,14 +13663,20 @@ fn block_proposal_timeout() {
         None,
     );
 
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
     let miner_pkh = Hash160::from_node_public_key(&miner_pk);
 
     signer_test.boot_to_epoch_3();
 
     // Pause the miner's block proposals
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk.clone()]);
 
     info!("------------------------- Start Tenure A -------------------------");
     let commits_before = signer_test
@@ -13724,7 +13822,7 @@ fn allow_reorg_within_first_proposal_burn_block_timing_secs() {
     miners.submit_commit_miner_2(&sortdb);
 
     info!("------------------------- Pause Miner 2's Block Proposals -------------------------");
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2.clone()]);
 
     info!("------------------------- Mine Tenure -------------------------");
     miners
@@ -13739,7 +13837,7 @@ fn allow_reorg_within_first_proposal_burn_block_timing_secs() {
 
     info!("------------------------- Miner 2 Mines Block N+1 -------------------------");
     test_observer::clear();
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1.clone()]);
     let miner_2_block_n_1 = wait_for_block_pushed_by_miner_key(30, block_n_height + 1, &miner_pk_2)
         .expect("Failed to get block N+1");
 
@@ -14041,7 +14139,7 @@ fn tenure_extend_cost_threshold() {
     let idle_timeout = Duration::from_secs(10);
     let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
-        vec![(deployer_addr, deploy_fee + tx_fee * num_txs)],
+        vec![(deployer_addr.clone(), deploy_fee + tx_fee * num_txs)],
         |config| {
             config.tenure_idle_timeout = idle_timeout;
         },
@@ -14258,7 +14356,7 @@ fn interrupt_miner_on_new_stacks_tip() {
 
     info!("------------------------- Block N is Announced -------------------------");
 
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1, miner_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1.clone(), miner_pk_2.clone()]);
     TEST_P2P_BROADCAST_STALL.set(false);
 
     // Wait for RL2's tip to advance to the last block
@@ -14485,7 +14583,7 @@ fn prev_miner_extends_if_incoming_miner_fails_to_mine_success() {
 
     // Pause the block proposal broadcast so that miner 2 will be unable to broadcast its
     // tenure change proposal BEFORE the block_proposal_timeout and will be marked invalid.
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2.clone()]);
 
     info!("------------------------- Miner 2 Mines an Empty Tenure B -------------------------");
     test_observer::clear();
@@ -14665,7 +14763,7 @@ fn prev_miner_extends_if_incoming_miner_fails_to_mine_failure() {
 
     // Pause the block proposal broadcast so that miner 2 will be unable to broadcast its
     // tenure change proposal BEFORE miner 1 attempts to extend.
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2.clone()]);
 
     info!("------------------------- Miner 2 Wins Tenure B -------------------------";
         "burn_height_before" => burn_height_before,
@@ -15026,7 +15124,7 @@ fn non_blocking_minority_configured_to_favour_incoming_miner() {
     let burn_height_before = get_burn_height();
     // Pause the block proposal broadcast so that miner 2 AND miner 1 are unable to propose
     // a block BEFORE block_proposal_timeout
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2, miner_pk_1]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2.clone(), miner_pk_1.clone()]);
 
     info!("------------------------- Miner 2 Wins Tenure B -------------------------";
         "burn_height_before" => burn_height_before,
@@ -15047,7 +15145,7 @@ fn non_blocking_minority_configured_to_favour_incoming_miner() {
     std::thread::sleep(tenure_extend_wait_timeout.add(Duration::from_secs(1)));
 
     // Allow miner 2 to attempt to start their tenure.
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1.clone()]);
 
     info!("------------------------- Wait for Miner 2's Block N+1' to be Proposed ------------------------";
         "stacks_height_before" => %stacks_height_before);
@@ -15254,7 +15352,7 @@ fn non_blocking_minority_configured_to_favour_prev_miner() {
     miners.submit_commit_miner_2(&sortdb);
     // Pause the block proposal broadcast so that miner 2 will be unable to broadcast its
     // tenure change proposal BEFORE miner 1 attempts to extend.
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_2.clone()]);
 
     let stacks_height_before = miners.get_peer_stacks_tip_height();
     info!("------------------------- Miner 2 Wins Tenure B -------------------------";
@@ -15421,7 +15519,7 @@ fn mark_miner_as_invalid_if_reorg_is_rejected_v1() {
     );
     let all_signers = miners.signer_test.signer_test_pks();
     // Pin all the signers to version 1;
-    let pinned_signers = all_signers.iter().map(|key| (*key, 1)).collect();
+    let pinned_signers = all_signers.iter().map(|key| (key.clone(), 1)).collect();
     TEST_PIN_SUPPORTED_SIGNER_PROTOCOL_VERSION.set(pinned_signers);
     let mut approving_signers = vec![];
     let mut rejecting_signers = vec![];
@@ -15528,7 +15626,7 @@ fn mark_miner_as_invalid_if_reorg_is_rejected_v1() {
     let block_n_1_prime = wait_for_block_proposal(30, block_n_height + 1, &miner_pk_1)
         .expect("Failed to get block proposal N+1'");
     // Stall the miner from proposing again until we're ready
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1.clone()]);
     miners
         .signer_test
         .check_signer_states_reorg(&approving_signers, &rejecting_signers);
@@ -15617,7 +15715,7 @@ fn repeated_rejection() {
     // make signer[0] reject all proposals and to repeat the rejection
     let rejecting_signer =
         StacksPublicKey::from_private(&signer_test.signer_stacks_private_keys[0]);
-    TEST_REJECT_ALL_BLOCK_PROPOSAL.set(vec![rejecting_signer]);
+    TEST_REJECT_ALL_BLOCK_PROPOSAL.set(vec![rejecting_signer.clone()]);
     TEST_REPEAT_PROPOSAL_RESPONSE.set(vec![rejecting_signer]);
 
     // make signer[1] ignore all proposals
@@ -15857,7 +15955,13 @@ fn signer_can_accept_rejected_block() {
         None,
     );
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     signer_test.boot_to_epoch_3();
@@ -16840,7 +16944,7 @@ fn signers_send_state_message_updates() {
     // Pause the block proposal broadcast so that miner 2 will be unable to broadcast its
     // tenure change proposal BEFORE the block_proposal_timeout and will be marked invalid.
     // Also pause miner 1's blocks so we don't go extending that tenure either
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1, miner_pk_2]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1.clone(), miner_pk_2.clone()]);
 
     info!("------------------------- Miner 2 Mines an Empty Tenure B -------------------------");
     miners
@@ -16924,10 +17028,18 @@ fn verify_mempool_caches() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let signer_test: SignerTest<SpawnedSigner> =
-        SignerTest::new(num_signers, vec![(sender_addr, (send_amt + send_fee) * 3)]);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
+        num_signers,
+        vec![(sender_addr.clone(), (send_amt + send_fee) * 3)],
+    );
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
-    let miner_sk = signer_test.running_nodes.conf.miner.mining_key.unwrap();
+    let miner_sk = signer_test
+        .running_nodes
+        .conf
+        .miner
+        .mining_key
+        .clone()
+        .unwrap();
     let miner_pk = StacksPublicKey::from_private(&miner_sk);
 
     signer_test.boot_to_epoch_3();
@@ -17086,7 +17198,7 @@ fn burn_block_height_behavior() {
         num_signers,
         vec![
             (sender_addr, send_amt + send_fee),
-            (deployer_addr, deploy_fee + tx_fee * 3),
+            (deployer_addr.clone(), deploy_fee + tx_fee * 3),
         ],
         |config| {
             // make the duration long enough that the miner will be marked as malicious
@@ -17328,7 +17440,7 @@ fn reorging_signers_capitulate_to_nonreorging_signers_during_tenure_fork() {
         .signer_addresses_versions()
         .iter()
         .enumerate()
-        .filter_map(|(i, key)| if i % 2 == 0 { None } else { Some(*key) })
+        .filter_map(|(i, key)| if i % 2 == 0 { None } else { Some(key.clone()) })
         .collect();
     info!("------------------------- Pause Miner 2's Block Commits -------------------------");
 
@@ -17368,7 +17480,7 @@ fn reorging_signers_capitulate_to_nonreorging_signers_during_tenure_fork() {
 
     info!("------------------------- Pause Block Proposals -------------------------");
     // For the next tenure, submit the commit op but do not allow any stacks blocks to be broadcasted
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1.clone()]);
     TEST_BLOCK_ANNOUNCE_STALL.set(true);
 
     miners.submit_commit_miner_1(&sortdb);
@@ -17443,7 +17555,7 @@ fn reorging_signers_capitulate_to_nonreorging_signers_during_tenure_fork() {
     let info = get_chain_info(&conf_1);
     info!("--------------- Miner 2 Wins Tenure C With Old Block Commit ----------------");
     info!("Prevent Miner 1 from extending at first");
-    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1]);
+    TEST_BROADCAST_PROPOSAL_STALL.set(vec![miner_pk_1.clone()]);
 
     test_observer::clear();
     miners
@@ -17553,7 +17665,7 @@ fn rollover_signer_protocol_version() {
         .collect();
     let pinned_signers_versions: HashMap<StacksPublicKey, u64> = pinned_signers
         .iter()
-        .map(|signer| (*signer, downgraded_version))
+        .map(|signer| (signer.clone(), downgraded_version))
         .collect();
     TEST_PIN_SUPPORTED_SIGNER_PROTOCOL_VERSION.set(pinned_signers_versions);
 
@@ -17582,7 +17694,7 @@ fn rollover_signer_protocol_version() {
         .collect();
     let pinned_signers_versions: HashMap<StacksPublicKey, u64> = pinned_signers
         .iter()
-        .map(|signer| (*signer, downgraded_version))
+        .map(|signer| (signer.clone(), downgraded_version))
         .collect();
     TEST_PIN_SUPPORTED_SIGNER_PROTOCOL_VERSION.set(pinned_signers_versions);
 

--- a/stacks-signer/src/chainstate/tests/v1.rs
+++ b/stacks-signer/src/chainstate/tests/v1.rs
@@ -103,7 +103,7 @@ fn setup_test_environment(
     };
 
     let stacks_client = StacksClient::new(
-        StacksPrivateKey::random(),
+        &StacksPrivateKey::random(),
         SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 10000).to_string(),
         "FOO".into(),
         false,

--- a/stacks-signer/src/chainstate/tests/v2.rs
+++ b/stacks-signer/src/chainstate/tests/v2.rs
@@ -97,7 +97,7 @@ fn setup_test_environment(
     };
 
     let stacks_client = StacksClient::new(
-        StacksPrivateKey::random(),
+        &StacksPrivateKey::random(),
         SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 10000).to_string(),
         "FOO".into(),
         false,
@@ -435,7 +435,7 @@ fn check_sortition_timeout() {
     std::thread::sleep(Duration::from_secs(3));
     let address = StacksAddress::p2pkh(false, &StacksPublicKey::new());
     let mut address_weights = HashMap::new();
-    address_weights.insert(address, 10);
+    address_weights.insert(address.clone(), 10);
     let eval = GlobalStateEvaluator::new(HashMap::new(), address_weights);
     // We have not yet timed out
     assert!(!SortitionState::is_timed_out(

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -152,7 +152,7 @@ pub struct GenerateVoteArgs {
     pub vote_info: VoteInfo,
 }
 
-#[derive(Parser, Debug, Clone, Copy)]
+#[derive(Parser, Debug, Clone)]
 /// Arguments for the VerifyVote command
 pub struct VerifyVoteArgs {
     /// The Stacks public key to verify against
@@ -166,7 +166,7 @@ pub struct VerifyVoteArgs {
     pub vote_info: VoteInfo,
 }
 
-#[derive(Parser, Debug, Clone, Copy)]
+#[derive(Parser, Debug, Clone)]
 /// Information about a SIP vote
 pub struct VoteInfo {
     /// The SIP number to vote on

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -387,20 +387,20 @@ pub(crate) mod tests {
 
         for signer_id in 0..num_signers {
             let private_key = if signer_id == 0 {
-                config.stacks_private_key
+                config.stacks_private_key.clone()
             } else {
                 StacksPrivateKey::random()
             };
             let public_key = StacksPublicKey::from_private(&private_key);
 
-            signer_id_to_pk.insert(signer_id, public_key);
-            signer_pk_to_id.insert(public_key, signer_id);
+            signer_id_to_pk.insert(signer_id, public_key.clone());
+            signer_pk_to_id.insert(public_key.clone(), signer_id);
             let address = StacksAddress::p2pkh(false, &public_key);
-            signer_addr_to_id.insert(address, signer_id);
+            signer_addr_to_id.insert(address.clone(), signer_id);
             signer_pks.push(public_key);
             signer_slot_ids.push(SignerSlotID(signer_id));
-            signer_id_to_addr.insert(signer_id, address);
-            signer_addr_to_weight.insert(address, weight_per_signer + remaining_weight);
+            signer_id_to_addr.insert(signer_id, address.clone());
+            signer_addr_to_weight.insert(address.clone(), weight_per_signer + remaining_weight);
             signer_addresses.push(address);
             remaining_weight = 0; // The first signer gets the extra weight if there is any. All other signers only get the weight_per_signer
         }
@@ -420,7 +420,7 @@ pub(crate) mod tests {
                 signer_addresses,
             },
             signer_slot_ids,
-            stacks_private_key: config.stacks_private_key,
+            stacks_private_key: config.stacks_private_key.clone(),
             node_host: config.node_host.to_string(),
             mainnet: config.network.is_mainnet(),
             db_path: config.db_path.clone(),

--- a/stacks-signer/src/client/stackerdb.rs
+++ b/stacks-signer/src/client/stackerdb.rs
@@ -75,7 +75,7 @@ impl<M: MessageSlotID + 'static> From<&SignerConfig> for StackerDB<M> {
 
         Self::new(
             &config.node_host,
-            config.stacks_private_key,
+            config.stacks_private_key.clone(),
             config.mainnet,
             config.reward_cycle,
             signer_db,

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -86,7 +86,7 @@ pub struct CurrentAndLastSortition {
 impl From<&GlobalConfig> for StacksClient {
     fn from(config: &GlobalConfig) -> Self {
         Self {
-            stacks_address: config.stacks_address,
+            stacks_address: config.stacks_address.clone(),
             http_origin: format!("http://{}", config.node_host),
             tx_version: config.network.to_transaction_version(),
             chain_id: config.to_chain_id(),
@@ -100,13 +100,13 @@ impl From<&GlobalConfig> for StacksClient {
 impl StacksClient {
     /// Create a new signer StacksClient with the provided private key, stacks node host endpoint, version, and auth password
     pub fn new(
-        stacks_private_key: StacksPrivateKey,
+        stacks_private_key: &StacksPrivateKey,
         node_host: String,
         auth_password: String,
         mainnet: bool,
         chain_id: u32,
     ) -> Self {
-        let pubkey = StacksPublicKey::from_private(&stacks_private_key);
+        let pubkey = StacksPublicKey::from_private(stacks_private_key);
         let tx_version = if mainnet {
             TransactionVersion::Mainnet
         } else {
@@ -126,7 +126,7 @@ impl StacksClient {
 
     /// Create a new signer StacksClient and attempt to connect to the stacks node to determine the version
     pub fn try_from_host(
-        stacks_private_key: StacksPrivateKey,
+        stacks_private_key: &StacksPrivateKey,
         node_host: String,
         auth_password: String,
     ) -> Result<Self, ClientError> {
@@ -137,7 +137,7 @@ impl StacksClient {
             true,
             CHAIN_ID_MAINNET,
         );
-        let pubkey = StacksPublicKey::from_private(&stacks_private_key);
+        let pubkey = StacksPublicKey::from_private(stacks_private_key);
         let info = stacks_client.get_peer_info()?;
         if info.network_id == CHAIN_ID_MAINNET {
             stacks_client.mainnet = true;

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -111,7 +111,7 @@ fn handle_generate_stacking_signature(
 ) -> MessageSignature {
     let config = GlobalConfig::try_from(&args.config).unwrap();
 
-    let private_key = config.stacks_private_key;
+    let private_key = config.stacks_private_key.clone();
     let public_key = StacksPublicKey::from_private(&private_key);
     let pk_hex = to_hex(&public_key.to_bytes_compressed());
 
@@ -396,7 +396,7 @@ pub mod tests {
         let public_key = StacksPublicKey::from_private(&private_key);
         let args = GenerateVoteArgs {
             config: config_file.into(),
-            vote_info,
+            vote_info: vote_info.clone(),
         };
         let message_signature = handle_generate_vote(args, false);
         assert!(
@@ -421,9 +421,9 @@ pub mod tests {
         };
 
         let args = VerifyVoteArgs {
-            public_key,
+            public_key: public_key.clone(),
             signature: vote_info.sign(&private_key).unwrap(),
-            vote_info,
+            vote_info: vote_info.clone(),
         };
         let valid = handle_verify_vote(args, false);
         assert!(valid, "Vote should be valid");
@@ -431,13 +431,13 @@ pub mod tests {
         let args = VerifyVoteArgs {
             public_key: invalid_public_key,
             signature: vote_info.sign(&private_key).unwrap(), // Invalid corresponding public key
-            vote_info,
+            vote_info: vote_info.clone(),
         };
         let valid = handle_verify_vote(args, false);
         assert!(!valid, "Vote should be invalid");
 
         let args = VerifyVoteArgs {
-            public_key,
+            public_key: public_key.clone(),
             signature: vote_info.sign(&private_key).unwrap(),
             vote_info: VoteInfo {
                 vote: Vote::Yes, // Invalid vote

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -316,7 +316,7 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
             signer_entries,
             signer_slot_ids: signer_slot_ids.into_values().collect(),
             first_proposal_burn_block_timing: self.config.first_proposal_burn_block_timing,
-            stacks_private_key: self.config.stacks_private_key,
+            stacks_private_key: self.config.stacks_private_key.clone(),
             node_host: self.config.node_host.to_string(),
             mainnet: self.config.network.is_mainnet(),
             db_path: self.config.db_path.clone(),

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -1785,7 +1785,7 @@ impl SignerDb {
 
         // Add our own vote if we received this consensus hash
         if let Some(local_received_time) = self.get_burn_block_receive_time_ch(ch)? {
-            entries.push((*local_address, local_received_time));
+            entries.push((local_address.clone(), local_received_time));
         }
 
         // Query other signer received times from the DB
@@ -2251,7 +2251,7 @@ pub mod tests {
             .unwrap());
         assert_eq!(
             db.get_block_rejection_signer_addrs(&block_id).unwrap(),
-            vec![(address1, RejectReasonPrefix::DuplicateBlockFound)]
+            vec![(address1.clone(), RejectReasonPrefix::DuplicateBlockFound)]
         );
 
         assert!(db
@@ -2288,7 +2288,7 @@ pub mod tests {
             .unwrap());
         assert_eq!(
             db.get_block_rejection_signer_addrs(&block_id).unwrap(),
-            vec![(address, RejectReasonPrefix::InvalidParentBlock)]
+            vec![(address.clone(), RejectReasonPrefix::InvalidParentBlock)]
         );
 
         assert!(db
@@ -2296,7 +2296,7 @@ pub mod tests {
             .unwrap());
         assert_eq!(
             db.get_block_rejection_signer_addrs(&block_id).unwrap(),
-            vec![(address, RejectReasonPrefix::InvalidMiner)]
+            vec![(address.clone(), RejectReasonPrefix::InvalidMiner)]
         );
 
         assert!(!db
@@ -2324,7 +2324,7 @@ pub mod tests {
             .unwrap());
         assert_eq!(
             db.get_block_rejection_signer_addrs(&block_id).unwrap(),
-            vec![(address, RejectReasonPrefix::InvalidParentBlock)]
+            vec![(address.clone(), RejectReasonPrefix::InvalidParentBlock)]
         );
 
         assert!(db.add_block_signature(&block_id, &address, &sig1).unwrap());
@@ -3282,10 +3282,10 @@ pub mod tests {
         .unwrap();
 
         let mut address_weights = HashMap::new();
-        address_weights.insert(local_address, 10);
-        address_weights.insert(address_1, 10);
-        address_weights.insert(address_2, 10);
-        address_weights.insert(address_3, 10);
+        address_weights.insert(local_address.clone(), 10);
+        address_weights.insert(address_1.clone(), 10);
+        address_weights.insert(address_2.clone(), 10);
+        address_weights.insert(address_3.clone(), 10);
         let eval = GlobalStateEvaluator::new(HashMap::new(), address_weights);
 
         assert!(db

--- a/stacks-signer/src/tests/signer_state.rs
+++ b/stacks-signer/src/tests/signer_state.rs
@@ -54,7 +54,7 @@ fn check_capitulate_miner_view() {
     } = MockServerClient::new();
 
     let mut address_weights = HashMap::new();
-    address_weights.insert(*client.get_signer_address(), 10);
+    address_weights.insert(client.get_signer_address().clone(), 10);
     for _ in 1..10 {
         let stacks_address = StacksAddress::p2pkh(false, &StacksPublicKey::new());
         address_weights.insert(stacks_address, 10);
@@ -93,13 +93,13 @@ fn check_capitulate_miner_view() {
 
     let mut address_updates = HashMap::new();
     for address in address_weights.keys() {
-        address_updates.insert(*address, old_update.clone());
+        address_updates.insert(address.clone(), old_update.clone());
     }
     let mut global_eval = GlobalStateEvaluator::new(address_updates, address_weights);
 
     let addresses: Vec<_> = global_eval.address_weights.keys().cloned().collect();
     // Let's say we are the very first signer in the list
-    let local_address = addresses[0];
+    let local_address = addresses[0].clone();
     let local_update = global_eval
         .address_updates
         .get(&local_address)
@@ -373,8 +373,8 @@ fn check_miner_inactivity_timeout() {
     };
 
     let mut address_weights = HashMap::new();
-    let address = *stacks_client.get_signer_address();
-    address_weights.insert(address, 10_u32);
+    let address = stacks_client.get_signer_address();
+    address_weights.insert(address.clone(), 10_u32);
 
     let eval = GlobalStateEvaluator::new(HashMap::new(), address_weights);
     // This local state machine should not change as an uninitialized local state cannot be modified

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -721,7 +721,7 @@ impl Signer {
             .try_into_update_message_with_version(local_version)
         {
             self.global_state_evaluator
-                .insert_update(self.stacks_address, update);
+                .insert_update(self.stacks_address.clone(), update);
         };
         let Some(latest_version) = self
             .global_state_evaluator

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -730,7 +730,10 @@ impl LocalStateMachine {
 
         let old_protocol_version = local_update.active_signer_protocol_version;
         // First check if we should update our active protocol version
-        eval.insert_update(*stacks_client.get_signer_address(), local_update.clone());
+        eval.insert_update(
+            stacks_client.get_signer_address().clone(),
+            local_update.clone(),
+        );
         let active_signer_protocol_version = eval
             .determine_latest_supported_signer_protocol_version()
             .unwrap_or(old_protocol_version);
@@ -863,7 +866,10 @@ impl LocalStateMachine {
         tenure_last_block_proposal_timeout: Duration,
     ) -> Option<StateMachineUpdateMinerState> {
         // First always make sure we consider our own viewpoint
-        eval.insert_update(*stacks_client.get_signer_address(), local_update.clone());
+        eval.insert_update(
+            stacks_client.get_signer_address().clone(),
+            local_update.clone(),
+        );
 
         // Determine the current burn block from the local update
         let (current_burn_block, current_burn_block_height) =

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -449,7 +449,7 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
     let (mut test_signers, test_stackers) = TestStacker::common_signing_set();
     let mut peer = boot_nakamoto(
         function_name!(),
-        vec![(addr.into(), 100_000_000)],
+        vec![(addr.clone().into(), 100_000_000)],
         &mut test_signers,
         &test_stackers,
         None,
@@ -823,7 +823,7 @@ fn block_descendant() {
     let mut boot_plan = NakamotoBootPlan::new(function_name!())
         .with_test_stackers(test_stackers)
         .with_test_signers(test_signers)
-        .with_private_key(private_key);
+        .with_private_key(private_key.clone());
     boot_plan.pox_constants = pox_constants;
 
     let mut peer = boot_plan.boot_into_nakamoto_peer(vec![], None);
@@ -918,7 +918,7 @@ fn block_info_tests(use_primary_testnet: bool) {
         NakamotoBootPlan::new(&format!("{}.{use_primary_testnet}", function_name!()))
             .with_test_stackers(test_stackers)
             .with_test_signers(test_signers)
-            .with_private_key(private_key)
+            .with_private_key(private_key.clone())
             .with_network_id(chain_id);
     boot_plan.pox_constants = pox_constants;
 
@@ -1341,7 +1341,7 @@ fn pox_treatment() {
     let mut boot_plan = NakamotoBootPlan::new(function_name!())
         .with_test_stackers(test_stackers.clone())
         .with_test_signers(test_signers)
-        .with_private_key(private_key);
+        .with_private_key(private_key.clone());
     boot_plan.pox_constants = pox_constants;
 
     let mut peer = boot_plan.boot_into_nakamoto_peer(vec![], None);
@@ -1594,7 +1594,7 @@ fn transactions_indexing() {
     let mut boot_plan = NakamotoBootPlan::new(function_name!())
         .with_test_stackers(test_stackers.clone())
         .with_test_signers(test_signers.clone())
-        .with_private_key(private_key)
+        .with_private_key(private_key.clone())
         .with_txindex(true);
     boot_plan.pox_constants = pox_constants;
 
@@ -1659,7 +1659,7 @@ fn transactions_not_indexing() {
     let mut boot_plan = NakamotoBootPlan::new(function_name!())
         .with_test_stackers(test_stackers.clone())
         .with_test_signers(test_signers.clone())
-        .with_private_key(private_key)
+        .with_private_key(private_key.clone())
         .with_txindex(false);
     boot_plan.pox_constants = pox_constants;
 
@@ -1708,7 +1708,7 @@ fn test_nakamoto_chainstate_getters() {
     let (mut test_signers, test_stackers) = TestStacker::common_signing_set();
     let mut peer = boot_nakamoto(
         function_name!(),
-        vec![(addr.into(), 100_000_000)],
+        vec![(addr.clone().into(), 100_000_000)],
         &mut test_signers,
         &test_stackers,
         None,
@@ -2196,7 +2196,7 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
     let (mut test_signers, test_stackers) = TestStacker::common_signing_set();
     let mut peer = boot_nakamoto(
         function_name!(),
-        vec![(addr.into(), 100_000_000)],
+        vec![(addr.clone().into(), 100_000_000)],
         &mut test_signers,
         &test_stackers,
         None,
@@ -2541,7 +2541,7 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
     let (mut test_signers, test_stackers) = TestStacker::common_signing_set();
     let mut peer = boot_nakamoto(
         function_name!(),
-        vec![(addr.into(), 100_000_000)],
+        vec![(addr.clone().into(), 100_000_000)],
         &mut test_signers,
         &test_stackers,
         None,
@@ -2894,7 +2894,7 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
     ]);
     let mut peer = boot_nakamoto(
         function_name!(),
-        vec![(addr.into(), 100_000_000)],
+        vec![(addr.clone().into(), 100_000_000)],
         &mut test_signers,
         &test_stackers,
         None,
@@ -3212,7 +3212,7 @@ fn process_next_nakamoto_block_deadlock() {
     let mut boot_plan = NakamotoBootPlan::new(function_name!())
         .with_test_stackers(test_stackers)
         .with_test_signers(test_signers)
-        .with_private_key(private_key);
+        .with_private_key(private_key.clone());
     boot_plan.pox_constants = pox_constants;
 
     info!("Creating peer");
@@ -3301,7 +3301,7 @@ fn test_stacks_on_burnchain_ops() {
     let observer = TestEventObserver::new();
     let mut peer = boot_nakamoto(
         function_name!(),
-        vec![(addr.into(), 100_000_000)],
+        vec![(addr.clone().into(), 100_000_000)],
         &mut test_signers,
         &test_stackers,
         Some(&observer),

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -624,7 +624,11 @@ pub fn test_load_store_update_nakamoto_blocks() {
     let mut stx_transfer_tx = StacksTransaction::new(
         TransactionVersion::Testnet,
         TransactionAuth::from_p2pkh(&private_key).unwrap(),
-        TransactionPayload::TokenTransfer(recipient_addr.into(), 123, TokenTransferMemo([0u8; 34])),
+        TransactionPayload::TokenTransfer(
+            recipient_addr.clone().into(),
+            123,
+            TokenTransferMemo([0u8; 34]),
+        ),
     );
     stx_transfer_tx.chain_id = 0x80000000;
     stx_transfer_tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
@@ -632,7 +636,11 @@ pub fn test_load_store_update_nakamoto_blocks() {
     let mut stx_transfer_tx_3 = StacksTransaction::new(
         TransactionVersion::Testnet,
         TransactionAuth::from_p2pkh(&private_key).unwrap(),
-        TransactionPayload::TokenTransfer(recipient_addr.into(), 124, TokenTransferMemo([0u8; 34])),
+        TransactionPayload::TokenTransfer(
+            recipient_addr.clone().into(),
+            124,
+            TokenTransferMemo([0u8; 34]),
+        ),
     );
     stx_transfer_tx_3.chain_id = 0x80000000;
     stx_transfer_tx_3.anchor_mode = TransactionAnchorMode::OnChainOnly;

--- a/stackslib/src/chainstate/stacks/address.rs
+++ b/stackslib/src/chainstate/stacks/address.rs
@@ -116,8 +116,8 @@ impl PoxAddress {
     /// Used only in tests, and even then, only in ones that expect a legacy Bitcoin address.
     #[cfg(any(test, feature = "testing"))]
     pub fn hash160(&self) -> Hash160 {
-        match *self {
-            PoxAddress::Standard(addr, _) => addr.bytes().clone(),
+        match self {
+            PoxAddress::Standard(addr, _) => *addr.bytes(),
             _ => panic!("Called hash160 on a non-standard PoX address"),
         }
     }
@@ -125,7 +125,7 @@ impl PoxAddress {
     /// Get the data portion of this address.  This does not include the address or witness
     /// version.
     pub fn bytes(&self) -> Vec<u8> {
-        match *self {
+        match self {
             PoxAddress::Standard(addr, _) => addr.bytes().0.to_vec(),
             PoxAddress::Addr20(_, _, bytes) => bytes.to_vec(),
             PoxAddress::Addr32(_, _, bytes) => bytes.to_vec(),
@@ -409,7 +409,7 @@ impl PoxAddress {
 
     /// Convert this PoxAddress into a Bitcoin tx output
     pub fn to_bitcoin_tx_out(&self, value: u64) -> TxOut {
-        match *self {
+        match self {
             PoxAddress::Standard(addr, _) => {
                 // legacy Bitcoin address
                 let btc_version = to_b58_version_byte(addr.version()).expect(

--- a/stackslib/src/chainstate/stacks/auth.rs
+++ b/stackslib/src/chainstate/stacks/auth.rs
@@ -2396,33 +2396,34 @@ mod test {
         tx_auth_check_all_epochs(auth_p2wpkh, None);
         tx_auth_check_all_epochs(auth_sponsored_p2wpkh, None);
 
-        let auth_p2sh = TransactionAuth::from_p2sh(&[privk_1, privk_2], 2).unwrap();
+        let privks = [privk_1.clone(), privk_2.clone()];
+        let auth_p2sh = TransactionAuth::from_p2sh(&privks, 2).unwrap();
         let auth_sponsored_p2sh = auth_p2sh.clone().into_sponsored(
-            TransactionAuth::from_p2sh(&[privk_1, privk_2], 2).unwrap()
+            TransactionAuth::from_p2sh(&privks, 2).unwrap()
         ).unwrap();
 
         tx_auth_check_all_epochs(auth_p2sh, None);
         tx_auth_check_all_epochs(auth_sponsored_p2sh, None);
 
-        let auth_p2wsh = TransactionAuth::from_p2wsh(&[privk_1, privk_2], 2).unwrap();
+        let auth_p2wsh = TransactionAuth::from_p2wsh(&privks, 2).unwrap();
         let auth_sponsored_p2wsh = auth_p2wsh.clone().into_sponsored(
-            TransactionAuth::from_p2wsh(&[privk_1, privk_2], 2).unwrap()
+            TransactionAuth::from_p2wsh(&privks, 2).unwrap()
         ).unwrap();
 
         tx_auth_check_all_epochs(auth_p2wsh, None);
         tx_auth_check_all_epochs(auth_sponsored_p2wsh, None);
 
-        let auth_order_independent_p2sh = TransactionAuth::from_order_independent_p2sh(&[privk_1, privk_2], 2).unwrap();
+        let auth_order_independent_p2sh = TransactionAuth::from_order_independent_p2sh(&privks, 2).unwrap();
         let auth_sponsored_order_independent_p2sh = auth_order_independent_p2sh.clone().into_sponsored(
-            TransactionAuth::from_order_independent_p2sh(&[privk_1, privk_2], 2).unwrap()
+            TransactionAuth::from_order_independent_p2sh(&privks, 2).unwrap()
         ).unwrap();
 
         tx_auth_check_all_epochs(auth_order_independent_p2sh, Some(StacksEpochId::Epoch30));
         tx_auth_check_all_epochs(auth_sponsored_order_independent_p2sh, Some(StacksEpochId::Epoch30));
 
-        let auth_order_independent_p2wsh = TransactionAuth::from_order_independent_p2wsh(&[privk_1, privk_2], 2).unwrap();
+        let auth_order_independent_p2wsh = TransactionAuth::from_order_independent_p2wsh(&privks, 2).unwrap();
         let auth_sponsored_order_independent_p2wsh = auth_order_independent_p2wsh.clone().into_sponsored(
-            TransactionAuth::from_order_independent_p2wsh(&[privk_1, privk_2], 2).unwrap()
+            TransactionAuth::from_order_independent_p2wsh(&privks, 2).unwrap()
         ).unwrap();
 
         tx_auth_check_all_epochs(auth_order_independent_p2wsh, Some(StacksEpochId::Epoch30));

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -1825,7 +1825,7 @@ mod test {
             TransactionVersion::Mainnet,
             order_independent_origin_auth_p2sh,
             TransactionPayload::TokenTransfer(
-                stx_address.into(),
+                stx_address.clone().into(),
                 123,
                 TokenTransferMemo([1u8; 34]),
             ),
@@ -1835,7 +1835,7 @@ mod test {
             TransactionVersion::Mainnet,
             order_independent_origin_auth_p2wsh,
             TransactionPayload::TokenTransfer(
-                stx_address.into(),
+                stx_address.clone().into(),
                 123,
                 TokenTransferMemo([1u8; 34]),
             ),
@@ -1845,7 +1845,7 @@ mod test {
             TransactionVersion::Mainnet,
             order_independent_sponsored_auth_p2sh,
             TransactionPayload::TokenTransfer(
-                stx_address.into(),
+                stx_address.clone().into(),
                 123,
                 TokenTransferMemo([1u8; 34]),
             ),
@@ -1928,7 +1928,7 @@ mod test {
             TransactionVersion::Testnet,
             origin_auth.clone(),
             TransactionPayload::TokenTransfer(
-                stx_address.into(),
+                stx_address.clone().into(),
                 123,
                 TokenTransferMemo([1u8; 34]),
             ),
@@ -1937,7 +1937,7 @@ mod test {
             TransactionVersion::Mainnet,
             origin_auth.clone(),
             TransactionPayload::TokenTransfer(
-                stx_address.into(),
+                stx_address.clone().into(),
                 123,
                 TokenTransferMemo([1u8; 34]),
             ),
@@ -1946,7 +1946,7 @@ mod test {
             TransactionVersion::Testnet,
             origin_auth.clone(),
             TransactionPayload::TokenTransfer(
-                stx_address.into(),
+                stx_address.clone().into(),
                 123,
                 TokenTransferMemo([1u8; 34]),
             ),

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -2915,15 +2915,15 @@ pub mod test {
         let alice = StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap();
         let bob = StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap();
         peer_config.initial_lockups = vec![
-            ChainstateAccountLockup::new(alice, 1000, 1),
-            ChainstateAccountLockup::new(bob, 1000, 1),
-            ChainstateAccountLockup::new(alice, 1000, 2),
-            ChainstateAccountLockup::new(bob, 1000, 3),
-            ChainstateAccountLockup::new(alice, 1000, 4),
-            ChainstateAccountLockup::new(bob, 1000, 4),
-            ChainstateAccountLockup::new(bob, 1000, 5),
-            ChainstateAccountLockup::new(alice, 1000, 6),
-            ChainstateAccountLockup::new(alice, 1000, 7),
+            ChainstateAccountLockup::new(alice.clone(), 1000, 1),
+            ChainstateAccountLockup::new(bob.clone(), 1000, 1),
+            ChainstateAccountLockup::new(alice.clone(), 1000, 2),
+            ChainstateAccountLockup::new(bob.clone(), 1000, 3),
+            ChainstateAccountLockup::new(alice.clone(), 1000, 4),
+            ChainstateAccountLockup::new(bob.clone(), 1000, 4),
+            ChainstateAccountLockup::new(bob.clone(), 1000, 5),
+            ChainstateAccountLockup::new(alice.clone(), 1000, 6),
+            ChainstateAccountLockup::new(alice.clone(), 1000, 7),
         ];
         let mut peer = TestPeer::new(peer_config);
 
@@ -2931,8 +2931,8 @@ pub mod test {
         let mut missed_initial_blocks = 0;
 
         for tenure_id in 0..num_blocks {
-            let alice_balance = get_balance(&mut peer, &alice.to_account_principal());
-            let bob_balance = get_balance(&mut peer, &bob.to_account_principal());
+            let alice_balance = get_balance(&mut peer, &alice.clone().to_account_principal());
+            let bob_balance = get_balance(&mut peer, &bob.clone().to_account_principal());
             match tenure_id {
                 0 => {
                     assert_eq!(alice_balance, 0);

--- a/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -1455,7 +1455,7 @@ fn delegate_stack_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, *bob_address.bytes());
     let mut alice_nonce = 0;
     let mut bob_nonce = 0;
 
@@ -2947,10 +2947,7 @@ fn test_delegate_extend_transition_pox_2() {
         "delegate-stack-extend",
         vec![
             PrincipalData::from(alice_address.clone()).into(),
-            make_pox_addr(
-                AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes().clone(),
-            ),
+            make_pox_addr(AddressHashMode::SerializeP2PKH, *charlie_address.bytes()),
             Value::UInt(6),
         ],
     );
@@ -3056,10 +3053,7 @@ fn test_delegate_extend_transition_pox_2() {
         "delegate-stack-extend",
         vec![
             PrincipalData::from(bob_address.clone()).into(),
-            make_pox_addr(
-                AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes().clone(),
-            ),
+            make_pox_addr(AddressHashMode::SerializeP2PKH, *charlie_address.bytes()),
             Value::UInt(1),
         ],
     );
@@ -3138,10 +3132,7 @@ fn test_delegate_extend_transition_pox_2() {
         "delegate-stack-extend",
         vec![
             PrincipalData::from(bob_address.clone()).into(),
-            make_pox_addr(
-                AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes().clone(),
-            ),
+            make_pox_addr(AddressHashMode::SerializeP2PKH, *charlie_address.bytes()),
             Value::UInt(1),
         ],
     );
@@ -4493,7 +4484,7 @@ fn stack_aggregation_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, *bob_address.bytes());
     let charlie = keys.pop().unwrap();
     let charlie_address = key_to_stacks_addr(&charlie);
     let charlie_pox_addr = make_pox_addr(
@@ -4503,7 +4494,7 @@ fn stack_aggregation_increase() {
     let dan = keys.pop().unwrap();
     let dan_address = key_to_stacks_addr(&dan);
     let dan_principal = PrincipalData::from(dan_address.clone());
-    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, dan_address.bytes().clone());
+    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, *dan_address.bytes());
     let alice_nonce = 0;
     let mut bob_nonce = 0;
     let mut charlie_nonce = 0;

--- a/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
@@ -1012,7 +1012,7 @@ fn delegate_stack_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, *bob_address.bytes());
     let mut alice_nonce = 0;
     let mut bob_nonce = 0;
 
@@ -2756,10 +2756,7 @@ fn delegate_extend_pox_3() {
         "delegate-stack-extend",
         vec![
             PrincipalData::from(bob_address.clone()).into(),
-            make_pox_addr(
-                AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes().clone(),
-            ),
+            make_pox_addr(AddressHashMode::SerializeP2PKH, *charlie_address.bytes()),
             Value::UInt(1),
         ],
     );
@@ -2849,10 +2846,7 @@ fn delegate_extend_pox_3() {
         "delegate-stack-extend",
         vec![
             PrincipalData::from(bob_address.clone()).into(),
-            make_pox_addr(
-                AddressHashMode::SerializeP2PKH,
-                charlie_address.bytes().clone(),
-            ),
+            make_pox_addr(AddressHashMode::SerializeP2PKH, *charlie_address.bytes()),
             Value::UInt(3),
         ],
     );
@@ -3837,7 +3831,7 @@ fn stack_aggregation_increase() {
     let bob = keys.pop().unwrap();
     let bob_address = key_to_stacks_addr(&bob);
     let bob_principal = PrincipalData::from(bob_address.clone());
-    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, bob_address.bytes().clone());
+    let bob_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, *bob_address.bytes());
     let charlie = keys.pop().unwrap();
     let charlie_address = key_to_stacks_addr(&charlie);
     let charlie_pox_addr = make_pox_addr(
@@ -3847,7 +3841,7 @@ fn stack_aggregation_increase() {
     let dan = keys.pop().unwrap();
     let dan_address = key_to_stacks_addr(&dan);
     let dan_principal = PrincipalData::from(dan_address.clone());
-    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, dan_address.bytes().clone());
+    let dan_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, *dan_address.bytes());
     let alice_nonce = 0;
     let mut bob_nonce = 0;
     let mut charlie_nonce = 0;

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -1385,10 +1385,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val = make_pox_addr(
-        AddressHashMode::SerializeP2PKH,
-        steph_address.bytes().clone(),
-    );
+    let steph_pox_addr_val = make_pox_addr(AddressHashMode::SerializeP2PKH, *steph_address.bytes());
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -1776,10 +1773,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val = make_pox_addr(
-        AddressHashMode::SerializeP2PKH,
-        steph_address.bytes().clone(),
-    );
+    let steph_pox_addr_val = make_pox_addr(AddressHashMode::SerializeP2PKH, *steph_address.bytes());
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -2422,10 +2416,7 @@ fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val = make_pox_addr(
-        AddressHashMode::SerializeP2PKH,
-        steph_address.bytes().clone(),
-    );
+    let steph_pox_addr_val = make_pox_addr(AddressHashMode::SerializeP2PKH, *steph_address.bytes());
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -2545,10 +2536,7 @@ fn pox_4_check_cycle_id_range_in_print_events_in_prepare_phase() {
     let steph_key = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph_key);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr_val = make_pox_addr(
-        AddressHashMode::SerializeP2PKH,
-        steph_address.bytes().clone(),
-    );
+    let steph_pox_addr_val = make_pox_addr(AddressHashMode::SerializeP2PKH, *steph_address.bytes());
     let steph_pox_addr = pox_addr_from(&steph_key);
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph_key);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -2779,10 +2767,7 @@ fn pox_4_revoke_delegate_stx_events() {
     let steph = keys.pop().unwrap();
     let steph_address = key_to_stacks_addr(&steph);
     let steph_principal = PrincipalData::from(steph_address.clone());
-    let steph_pox_addr = make_pox_addr(
-        AddressHashMode::SerializeP2PKH,
-        steph_address.bytes().clone(),
-    );
+    let steph_pox_addr = make_pox_addr(AddressHashMode::SerializeP2PKH, *steph_address.bytes());
 
     let steph_signing_key = Secp256k1PublicKey::from_private(&steph);
     let steph_key_val = Value::buff_from(steph_signing_key.to_bytes_compressed()).unwrap();
@@ -4201,7 +4186,7 @@ impl StackerSignerInfo {
         let public_key = StacksPublicKey::from_private(&private_key);
         let address = key_to_stacks_addr(&private_key);
         let pox_address =
-            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, address.bytes().clone());
+            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, *address.bytes());
         let principal = PrincipalData::from(address.clone());
         let nonce = 0;
         Self {
@@ -6326,7 +6311,7 @@ fn stack_increase(use_nakamoto: bool) {
     let signing_sk = StacksPrivateKey::from_seed(&[1]);
     let signing_pk = StacksPublicKey::from_private(&signing_sk);
     let signing_bytes = signing_pk.to_bytes_compressed();
-    let alice_balance = get_balance(&mut peer, &alice_address.into());
+    let alice_balance = get_balance(&mut peer, &alice_address.clone().into());
 
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
     let pox_addr = PoxAddress::from_legacy(
@@ -6395,7 +6380,7 @@ fn stack_increase(use_nakamoto: bool) {
     // Next tx arr includes a stack_increase pox_4 helper found in mod.rs
     let txs = vec![stack_increase];
     let latest_block = tenure_with_txs(&mut peer, &txs, &mut coinbase_nonce, &mut test_signers);
-    let stacker_transactions = get_last_block_sender_transactions(&observer, alice_address);
+    let stacker_transactions = get_last_block_sender_transactions(&observer, alice_address.clone());
 
     let actual_result = stacker_transactions.first().cloned().unwrap().result;
 
@@ -7143,7 +7128,7 @@ fn test_scenario_one(use_nakamoto: bool) {
 
     // Also vote for aggregate key with default test signer if in Nakamoto:
     if let Some(test_signers) = test_signers.clone() {
-        let tester_key = test_signers.signer_keys[0];
+        let tester_key = test_signers.signer_keys[0].clone();
         let tester_addr = key_to_stacks_addr(&tester_key);
         let tester_index = get_signer_index(
             &mut peer,
@@ -8626,7 +8611,7 @@ fn test_scenario_four(use_nakamoto: bool) {
 
     // Also vote for aggregate key with default test signer if in Nakamoto:
     if let Some(test_signers) = test_signers.clone() {
-        let tester_key = test_signers.signer_keys[0];
+        let tester_key = test_signers.signer_keys[0].clone();
         let tester_addr = key_to_stacks_addr(&tester_key);
         let tester_index = get_signer_index(
             &mut peer,

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -897,7 +897,7 @@ impl StacksChainState {
             } else {
                 // no poison microblock reported
                 (
-                    participant.address,
+                    participant.address.clone(),
                     participant.recipient.clone(),
                     coinbase_reward,
                     false,

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -4292,8 +4292,8 @@ impl StacksChainState {
                         } = transfer_stx_op.clone();
                         let result = clarity_tx.connection().as_transaction(|tx| {
                             tx.run_stx_transfer(
-                                &sender.into(),
-                                &recipient.into(),
+                                &sender.clone().into(),
+                                &recipient.clone().into(),
                                 transfered_ustx,
                                 &BuffData { data: memo },
                             )
@@ -6858,7 +6858,7 @@ impl StacksChainState {
 
                 let contract_identifier =
                     QualifiedContractIdentifier::new(address.clone().into(), contract_name.clone());
-                let epoch = clarity_connection.get_epoch().clone();
+                let epoch = clarity_connection.get_epoch();
                 clarity_connection.with_analysis_db_readonly(|db| {
                     let function_type = db
                         .get_public_function_type(&contract_identifier, function_name, &epoch)
@@ -11005,7 +11005,7 @@ pub mod test {
 
         let mut last_block_id = StacksBlockId([0x00; 32]);
         for tenure_id in 0..num_blocks {
-            let del_addr = del_addrs[tenure_id];
+            let del_addr = &del_addrs[tenure_id];
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -11233,11 +11233,11 @@ pub mod test {
         );
 
         for i in 0..(num_blocks - 1) {
-            let del_addr = del_addrs[i];
+            let del_addr = &del_addrs[i];
             let result = eval_at_tip(
                 &mut peer,
                 "pox-2",
-                &format!("(get-delegation-info '{})", &del_addr),
+                &format!("(get-delegation-info '{del_addr})"),
             );
 
             let data = result
@@ -11328,7 +11328,7 @@ pub mod test {
 
         let mut last_block_id = StacksBlockId([0x00; 32]);
         for tenure_id in 0..num_blocks {
-            let del_addr = del_addrs[tenure_id];
+            let del_addr = &del_addrs[tenure_id];
             let tip =
                 SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
                     .unwrap();
@@ -11939,14 +11939,13 @@ pub mod test {
             if i == 5 {
                 continue;
             }
-            let del_addr = del_addrs[i];
+            let del_addr = &del_addrs[i];
             let result = eval_at_tip(
                 &mut peer,
                 "pox-2",
                 &format!(
                     "
-                (get-delegation-info '{})",
-                    &del_addr
+                (get-delegation-info '{del_addr})"
                 ),
             );
 

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -1268,9 +1268,9 @@ impl StacksChainState {
 
         let boot_code_address = boot_code_addr(mainnet);
 
-        let boot_code_auth = boot_code_tx_auth(boot_code_address);
+        let boot_code_auth = boot_code_tx_auth(boot_code_address.clone());
 
-        let mut boot_code_account = boot_code_acc(boot_code_address, 0);
+        let mut boot_code_account = boot_code_acc(boot_code_address.clone(), 0);
 
         let mut initial_liquid_ustx = 0u128;
         let mut receipts = vec![];

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -5101,7 +5101,7 @@ pub mod test {
 
         let asset_id_1 = AssetIdentifier {
             contract_identifier: QualifiedContractIdentifier::new(
-                StandardPrincipalData::from(asset_info_1.contract_address),
+                StandardPrincipalData::from(asset_info_1.contract_address.clone()),
                 asset_info_1.contract_name.clone(),
             ),
             asset_name: asset_info_1.asset_name.clone(),
@@ -5109,7 +5109,7 @@ pub mod test {
 
         let asset_id_2 = AssetIdentifier {
             contract_identifier: QualifiedContractIdentifier::new(
-                StandardPrincipalData::from(asset_info_2.contract_address),
+                StandardPrincipalData::from(asset_info_2.contract_address.clone()),
                 asset_info_2.contract_name.clone(),
             ),
             asset_name: asset_info_2.asset_name.clone(),
@@ -5117,7 +5117,7 @@ pub mod test {
 
         let _asset_id_3 = AssetIdentifier {
             contract_identifier: QualifiedContractIdentifier::new(
-                StandardPrincipalData::from(asset_info_3.contract_address),
+                StandardPrincipalData::from(asset_info_3.contract_address.clone()),
                 asset_info_3.contract_name.clone(),
             ),
             asset_name: asset_info_3.asset_name.clone(),
@@ -6933,7 +6933,7 @@ pub mod test {
 
         let asset_id = AssetIdentifier {
             contract_identifier: QualifiedContractIdentifier::new(
-                StandardPrincipalData::from(asset_info.contract_address),
+                StandardPrincipalData::from(asset_info.contract_address.clone()),
                 asset_info.contract_name.clone(),
             ),
             asset_name: asset_info.asset_name.clone(),
@@ -8345,7 +8345,7 @@ pub mod test {
             // there must be a poison record for this microblock, from the reporter, for the microblock
             // sequence.
             let report_opt = StacksChainState::get_poison_microblock_report(&mut conn, 1).unwrap();
-            assert_eq!(report_opt.unwrap(), (reporter_addr, 123));
+            assert_eq!(report_opt.unwrap(), (reporter_addr.clone(), 123));
 
             // result must encode poison information
             let result_data = receipt.result.expect_tuple().unwrap();
@@ -8585,7 +8585,7 @@ pub mod test {
             // there must be a poison record for this microblock, from the reporter, for the microblock
             // sequence.
             let report_opt = StacksChainState::get_poison_microblock_report(&mut conn, 1).unwrap();
-            assert_eq!(report_opt.unwrap(), (reporter_addr_1, 123));
+            assert_eq!(report_opt.unwrap(), (reporter_addr_1.clone(), 123));
 
             // process the second one!
             let (fee, receipt) = StacksChainState::process_transaction(
@@ -8601,7 +8601,7 @@ pub mod test {
             // sequence.  Moreover, since the fork was earlier in the stream, the second reporter gets
             // it.
             let report_opt = StacksChainState::get_poison_microblock_report(&mut conn, 1).unwrap();
-            assert_eq!(report_opt.unwrap(), (reporter_addr_2, 122));
+            assert_eq!(report_opt.unwrap(), (reporter_addr_2.clone(), 122));
 
             // result must encode poison information
             let result_data = receipt.result.expect_tuple().unwrap();
@@ -9815,7 +9815,7 @@ pub mod test {
             panic!("Did not get epoch is not activated error");
         }
 
-        let acct = StacksChainState::get_account(&mut conn, &addr.into());
+        let acct = StacksChainState::get_account(&mut conn, &addr.clone().into());
         assert_eq!(acct.nonce, 3);
 
         let err = validate_transactions_static_epoch_and_process_transaction(
@@ -9832,7 +9832,7 @@ pub mod test {
         } else {
             panic!("Did not get unchecked interpreter error");
         }
-        let acct = StacksChainState::get_account(&mut conn, &addr.into());
+        let acct = StacksChainState::get_account(&mut conn, &addr.clone().into());
         assert_eq!(acct.nonce, 3);
 
         conn.commit_block();
@@ -9926,7 +9926,7 @@ pub mod test {
         } else {
             panic!("Did not get epoch is not activated error");
         }
-        let acct = StacksChainState::get_account(&mut conn, &addr.into());
+        let acct = StacksChainState::get_account(&mut conn, &addr.clone().into());
         assert_eq!(acct.nonce, 3);
 
         let err = validate_transactions_static_epoch_and_process_transaction(
@@ -9943,7 +9943,7 @@ pub mod test {
         } else {
             panic!("Did not get unchecked interpreter error");
         }
-        let acct = StacksChainState::get_account(&mut conn, &addr.into());
+        let acct = StacksChainState::get_account(&mut conn, &addr.clone().into());
         assert_eq!(acct.nonce, 3);
 
         conn.commit_block();
@@ -10002,7 +10002,7 @@ pub mod test {
         assert_eq!(fee, 1);
 
         // nonce keeps advancing despite error
-        let acct = StacksChainState::get_account(&mut conn, &addr.into());
+        let acct = StacksChainState::get_account(&mut conn, &addr.clone().into());
         assert_eq!(acct.nonce, 4);
 
         // no state change materialized
@@ -10026,7 +10026,7 @@ pub mod test {
         assert_eq!(fee, 1);
 
         // nonce keeps advancing despite error
-        let acct = StacksChainState::get_account(&mut conn, &addr.into());
+        let acct = StacksChainState::get_account(&mut conn, &addr.clone().into());
         assert_eq!(acct.nonce, 5);
 
         // no state change materialized
@@ -10088,7 +10088,7 @@ pub mod test {
         assert_eq!(fee, 1);
 
         // nonce keeps advancing
-        let acct = StacksChainState::get_account(&mut conn, &addr.into());
+        let acct = StacksChainState::get_account(&mut conn, &addr.clone().into());
         assert_eq!(acct.nonce, 4);
 
         // state change materialized

--- a/stackslib/src/chainstate/stacks/db/unconfirmed.rs
+++ b/stackslib/src/chainstate/stacks/db/unconfirmed.rs
@@ -844,7 +844,7 @@ mod test {
                 .with_read_only_unconfirmed_clarity_tx(&iconn, |clarity_tx| {
                     clarity_tx.with_clarity_db_readonly(|clarity_db| {
                         clarity_db
-                            .get_account_stx_balance(&recv_addr.into())
+                            .get_account_stx_balance(&recv_addr.clone().into())
                             .unwrap()
                     })
                 })
@@ -1082,7 +1082,7 @@ mod test {
                         |clarity_tx| {
                             clarity_tx.with_clarity_db_readonly(|clarity_db| {
                                 clarity_db
-                                    .get_account_stx_balance(&recv_addr.into())
+                                    .get_account_stx_balance(&recv_addr.clone().into())
                                     .unwrap()
                             })
                         },
@@ -1108,7 +1108,7 @@ mod test {
                         |clarity_tx| {
                             clarity_tx.with_clarity_db_readonly(|clarity_db| {
                                 clarity_db
-                                    .get_account_stx_balance(&recv_addr.into())
+                                    .get_account_stx_balance(&recv_addr.clone().into())
                                     .unwrap()
                             })
                         },

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -1374,7 +1374,7 @@ pub mod test {
         let proof = VRFProof::from_bytes(&proof_bytes[..]).unwrap();
         let mut tx_payloads = vec![
             TransactionPayload::TokenTransfer(
-                stx_address.into(),
+                stx_address.clone().into(),
                 123,
                 TokenTransferMemo([0u8; 34]),
             ),

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -4768,7 +4768,7 @@ fn paramaterized_mempool_walk_test(
 
             let origin_address = tx.origin_address();
             let origin_nonce = tx.get_origin_nonce();
-            let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+            let sponsor_address = tx.sponsor_address().unwrap_or(origin_address.clone());
             let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
 
             tx.set_tx_fee(100);
@@ -4998,7 +4998,7 @@ fn mempool_walk_test_next_nonce_with_highest_fee_rate_strategy() {
         let mut mempool_tx = mempool.tx_begin().unwrap();
 
         let origin_address = tx.origin_address();
-        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address.clone());
         tx.set_tx_fee(fee_rate as u64);
         let txid = tx.txid();
         let tx_bytes = tx.serialize_to_vec();

--- a/stackslib/src/chainstate/stacks/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/tests/mod.rs
@@ -1113,7 +1113,7 @@ pub fn make_token_transfer(
     let mut tx_stx_transfer = StacksTransaction::new(
         TransactionVersion::Testnet,
         miner.as_transaction_auth().unwrap(),
-        TransactionPayload::TokenTransfer((*recipient).clone().into(), amount, (*memo).clone()),
+        TransactionPayload::TokenTransfer((*recipient).clone().into(), amount, *memo),
     );
 
     tx_stx_transfer.chain_id = miner.chain_id;

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -2062,7 +2062,7 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
-    use clarity::types::chainstate::{BurnchainHeaderHash, SortitionId};
+    use clarity::types::chainstate::{BurnchainHeaderHash, SortitionId, StacksAddress};
     use clarity::vm::analysis::errors::CheckErrors;
     use clarity::vm::database::{ClarityBackingStore, STXBalance, SqliteConnection};
     use clarity::vm::test_util::{TEST_BURN_STATE_DB, TEST_HEADER_DB};
@@ -2802,7 +2802,7 @@ mod tests {
 
         let marf = MarfedKV::temporary();
         let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
-        let sender = StandardPrincipalData::transient().into();
+        let sender: StacksAddress = StandardPrincipalData::transient().into();
 
         let spending_cond = TransactionSpendingCondition::Singlesig(SinglesigSpendingCondition {
             signer: Hash160([0x11u8; 20]),
@@ -2849,7 +2849,7 @@ mod tests {
             TransactionVersion::Mainnet,
             TransactionAuth::Standard(spending_cond),
             TransactionPayload::ContractCall(TransactionContractCall {
-                address: sender,
+                address: sender.clone(),
                 contract_name: "hello-world".into(),
                 function_name: "foo".into(),
                 function_args: vec![],

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -475,10 +475,10 @@ impl MemPoolTxMetadata {
     pub fn get_unknown_nonces(&self) -> Vec<StacksAddress> {
         let mut needs_nonces = vec![];
         if self.last_known_origin_nonce.is_none() {
-            needs_nonces.push(self.origin_address);
+            needs_nonces.push(self.origin_address.clone());
         }
         if self.last_known_sponsor_nonce.is_none() {
-            needs_nonces.push(self.sponsor_address);
+            needs_nonces.push(self.sponsor_address.clone());
         }
         needs_nonces
     }

--- a/stackslib/src/core/nonce_cache.rs
+++ b/stackslib/src/core/nonce_cache.rs
@@ -138,7 +138,7 @@ impl NonceCache {
         let mut backoff = Duration::from_millis(rand::thread_rng().gen_range(50..200));
 
         loop {
-            let result = self.try_flush_with_evicted(conn, evicted);
+            let result = self.try_flush_with_evicted(conn, evicted.clone());
 
             match result {
                 Ok(_) => return, // Success: exit the loop

--- a/stackslib/src/core/test_util.rs
+++ b/stackslib/src/core/test_util.rs
@@ -387,7 +387,7 @@ pub fn make_contract_call(
     let function_name = ClarityName::from(function_name);
 
     let payload = TransactionContractCall {
-        address: *contract_addr,
+        address: contract_addr.clone(),
         contract_name,
         function_name,
         function_args: function_args.to_vec(),
@@ -414,7 +414,7 @@ pub fn make_contract_call_mblock_only(
     let function_name = ClarityName::from(function_name);
 
     let payload = TransactionContractCall {
-        address: *contract_addr,
+        address: contract_addr.clone(),
         contract_name,
         function_name,
         function_args: function_args.to_vec(),

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -584,7 +584,7 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
 
         let origin_address = tx.origin_address();
         let origin_nonce = tx.get_origin_nonce();
-        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address.clone());
         let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
 
         tx.set_tx_fee(100);
@@ -775,7 +775,7 @@ fn test_iterate_candidates_skipped_transaction() {
 
         let origin_address = tx.origin_address();
         let origin_nonce = tx.get_origin_nonce();
-        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address.clone());
         let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
 
         tx.set_tx_fee(100);
@@ -887,7 +887,7 @@ fn test_iterate_candidates_processing_error_transaction() {
 
         let origin_address = tx.origin_address();
         let origin_nonce = tx.get_origin_nonce();
-        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address.clone());
         let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
 
         tx.set_tx_fee(100);
@@ -1001,7 +1001,7 @@ fn test_iterate_candidates_problematic_transaction() {
 
         let origin_address = tx.origin_address();
         let origin_nonce = tx.get_origin_nonce();
-        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address.clone());
         let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
 
         tx.set_tx_fee(100);
@@ -1117,7 +1117,7 @@ fn test_iterate_candidates_concurrent_write_lock() {
 
         let origin_address = tx.origin_address();
         let origin_nonce = tx.get_origin_nonce();
-        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address.clone());
         let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
 
         if let Some(nonce) = expected_addr_nonces.get_mut(&origin_address) {
@@ -1623,7 +1623,7 @@ fn mempool_db_test_rbf() {
     let stx_address = StacksAddress::new(1, Hash160([0xff; 20])).unwrap();
     let payload = TransactionPayload::TokenTransfer(
         PrincipalData::from(QualifiedContractIdentifier {
-            issuer: stx_address.into(),
+            issuer: stx_address.clone().into(),
             name: "hello-contract-name".into(),
         }),
         123,

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -857,7 +857,7 @@ fn replay_validation_test_transaction_mineable_mismatch_series_2() {
             36,
             300,
             CHAIN_ID_TESTNET,
-            &recipient_addr.into(),
+            &recipient_addr.clone().into(),
             1000000,
         );
 

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -1513,10 +1513,7 @@ impl<P: ProtocolFamily + Clone> NetworkConnection<P> {
 
     /// Get a copy of the public key
     pub fn get_public_key(&self) -> Option<Secp256k1PublicKey> {
-        match self.inbox.public_key {
-            Some(pubk) => Some(pubk.clone()),
-            None => None,
-        }
+        self.inbox.public_key.clone()
     }
 
     /// Get a copy of the public key

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -952,7 +952,7 @@ impl NakamotoDownloadStateMachine {
             if available_count == 0 {
                 continue;
             }
-            highest_available.push((*ch).clone());
+            highest_available.push(**ch);
             if highest_available.len() == 2 {
                 break;
             }

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -3034,7 +3034,7 @@ pub mod test {
                             stx_balance: STXBalance::zero(),
                         };
 
-                        let boot_code_auth = boot_code_tx_auth(boot_code_addr);
+                        let boot_code_auth = boot_code_tx_auth(boot_code_addr.clone());
 
                         debug!(
                             "Instantiate test-specific boot code contract '{}.{}' ({} bytes)...",

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -3250,7 +3250,7 @@ impl PeerNetwork {
                             None => {
                                 network.advertize_to_peer(
                                     recipient,
-                                    &[((*ch).clone(), (*bhh).clone())],
+                                    &[(*ch, *bhh)],
                                     StacksMessageType::BlocksAvailable,
                                 );
                             }
@@ -3292,7 +3292,7 @@ impl PeerNetwork {
                             None => {
                                 network.advertize_to_peer(
                                     recipient,
-                                    &[((*ch).clone(), (*bhh).clone())],
+                                    &[(*ch, *bhh)],
                                     StacksMessageType::MicroblocksAvailable,
                                 );
                             }
@@ -3317,7 +3317,7 @@ impl PeerNetwork {
     {
         let mut wanted: Vec<(ConsensusHash, BurnchainHeaderHash)> = vec![];
         for (burn_header_hash, (_, consensus_hash)) in available.iter() {
-            wanted.push(((*consensus_hash).clone(), (*burn_header_hash).clone()));
+            wanted.push((*consensus_hash, (*burn_header_hash)));
         }
 
         self.advertize_to_peer(recipient, &wanted, msg_builder);

--- a/stackslib/src/net/stackerdb/tests/db.rs
+++ b/stackslib/src/net/stackerdb/tests/db.rs
@@ -563,12 +563,24 @@ fn test_reconfigure_stackerdb() {
     let new_pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let reconfigured_pks = vec![
         // first five slots are unchanged
-        pks[0], pks[1], pks[2], pks[3], pks[4],
+        pks[0].clone(),
+        pks[1].clone(),
+        pks[2].clone(),
+        pks[3].clone(),
+        pks[4].clone(),
         // next five slots are different, so their contents will be dropped and versions and write
         // timestamps reset
-        new_pks[0], new_pks[1], new_pks[2], new_pks[3], new_pks[4],
+        new_pks[0].clone(),
+        new_pks[1].clone(),
+        new_pks[2].clone(),
+        new_pks[3].clone(),
+        new_pks[4].clone(),
         // next five slots are now, so they'll be uninitialized
-        new_pks[5], new_pks[6], new_pks[7], new_pks[8], new_pks[9],
+        new_pks[5].clone(),
+        new_pks[6].clone(),
+        new_pks[7].clone(),
+        new_pks[8].clone(),
+        new_pks[9].clone(),
     ];
     let reconfigured_addrs: Vec<_> = reconfigured_pks
         .iter()
@@ -644,11 +656,18 @@ fn test_reconfigure_stackerdb() {
     let new_pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let reconfigured_pks = vec![
         // first five slots are unchanged
-        pks[0], pks[1], pks[2], pks[3], pks[4],
+        pks[0].clone(),
+        pks[1].clone(),
+        pks[2].clone(),
+        pks[3].clone(),
+        pks[4].clone(),
         // next five slots are different, so their contents will be dropped and versions and write
         // timestamps reset
-        new_pks[0], new_pks[1], new_pks[2], new_pks[3],
-        new_pks[4],
+        new_pks[0].clone(),
+        new_pks[1].clone(),
+        new_pks[2].clone(),
+        new_pks[3].clone(),
+        new_pks[4].clone(),
         // slots 10-15 will disappear
     ];
     let reconfigured_addrs: Vec<_> = reconfigured_pks

--- a/stackslib/src/net/tests/mempool/mod.rs
+++ b/stackslib/src/net/tests/mempool/mod.rs
@@ -901,7 +901,7 @@ pub fn test_mempool_storage_nakamoto() {
     let (mut test_signers, test_stackers) = TestStacker::common_signing_set();
     let mut peer = boot_nakamoto(
         function_name!(),
-        vec![(addr.into(), 100_000_000)],
+        vec![(addr.clone().into(), 100_000_000)],
         &mut test_signers,
         &test_stackers,
         None,


### PR DESCRIPTION
Partially replaces https://github.com/stacks-network/stacks-core/pull/5764 

As part of the old PR, it was determined that clone should be removed from StacksAddress, StacksPrivateKey, and StacksPublicKey (removed from VerifyVoteArgs and VoteInfo by necessity)

Not sure if we want to remove the blanket Copy implementation from impl_array_newtype which would remove it from all the various arrays wrappers such as `ConsensusHash`? @kantai let me know if you have an opinion on this (would do in a sep pr if so)?
