### PR TITLE
Fix type in release arch matrix `s/x86_64/x86-64/`

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -91,7 +91,7 @@ jobs:
           - arch: macos # excludes macos-armv7
             cpu: armv7
           - arch: macos # excludes macos-x64
-            cpu: x86_64
+            cpu: x86-64
     steps:
       - name: Build Binary (${{ matrix.arch }}_${{ matrix.cpu }})
         uses: stacks-network/actions/stacks-core/release/create-source-binary@main


### PR DESCRIPTION
https://github.com/stacks-network/stacks-core/actions/runs/16945561662/job/48025872768#logs

the arch was incorrectly merged as x86_64, not x86-64: https://github.com/stacks-network/stacks-core/commit/2ed7b920e5da890c9e156523a77ab483728c0e15


