### PR TITLE
chore: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,3 @@
 - [ ] Changelog is updated
 - [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
 - [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
-- [ ] New integration test(s) added to `bitcoin-tests.yml`


### PR DESCRIPTION
Remove "New integration test(s) added to `bitcoin-tests.yml`" since tests no longer need to be manually added to that file.