### PR TITLE
Test: Fix miner replay

### DIFF
--- a/stacks-node/src/nakamoto_node/miner.rs
+++ b/stacks-node/src/nakamoto_node/miner.rs
@@ -112,6 +112,15 @@ pub fn fault_injection_stall_miner() {
 }
 
 #[cfg(test)]
+/// Set the `TEST_MINE_STALL` flag to `Pending` and do not block.
+pub fn fault_injection_try_stall_miner() {
+    let mut stall_lock = TEST_MINE_STALL.0.lock().unwrap();
+    if stall_lock.as_ref().is_none() || stall_lock.as_ref() == Some(&TestMineStall::NotStalled) {
+        *stall_lock = Some(TestMineStall::Pending);
+    }
+}
+
+#[cfg(test)]
 /// Unstall the miner by setting the `TEST_MINE_STALL` flag to `NotStalled`.
 pub fn fault_injection_unstall_miner() {
     TEST_MINE_STALL.set(TestMineStall::NotStalled);

--- a/stacks-node/src/nakamoto_node/relayer.rs
+++ b/stacks-node/src/nakamoto_node/relayer.rs
@@ -899,12 +899,21 @@ impl RelayerThread {
                 .raise_initiative("process_sortition".to_string());
             return Ok(None);
         }
+
         // Reset the tenure extend time
         self.tenure_extend_time = None;
         let Some(mining_pk) = self.get_mining_key_pkh() else {
             debug!("No mining key, will not mine");
             return Ok(None);
         };
+
+        let epoch = SortitionDB::get_stacks_epoch(self.sortdb.conn(), sn.block_height)
+            .expect("FATAL: epoch not found for current snapshot")
+            .expect("FATAL: epoch not found for current snapshot");
+        if !epoch.epoch_id.uses_nakamoto_blocks() {
+            return Ok(None);
+        }
+
         let directive_opt = if sn.sortition {
             self.choose_directive_sortition_with_winner(sn, mining_pk, committed_index_hash)
         } else {

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -116,8 +116,9 @@ use stacks_signer::v0::SpawnedSigner;
 
 use super::bitcoin_regtest::BitcoinCoreController;
 use crate::nakamoto_node::miner::{
-    fault_injection_stall_miner, fault_injection_unstall_miner, TEST_BLOCK_ANNOUNCE_STALL,
-    TEST_BROADCAST_PROPOSAL_STALL, TEST_P2P_BROADCAST_SKIP, TEST_P2P_BROADCAST_STALL,
+    fault_injection_stall_miner, fault_injection_try_stall_miner, fault_injection_unstall_miner,
+    TEST_BLOCK_ANNOUNCE_STALL, TEST_BROADCAST_PROPOSAL_STALL, TEST_P2P_BROADCAST_SKIP,
+    TEST_P2P_BROADCAST_STALL,
 };
 use crate::nakamoto_node::relayer::TEST_MINER_THREAD_STALL;
 use crate::neon::Counters;
@@ -12598,7 +12599,7 @@ fn miner_constructs_replay_block() {
 
     // Pause mining to prevent any of the submitted txs getting mined.
     info!("Stalling mining...");
-    fault_injection_stall_miner();
+    fault_injection_try_stall_miner();
     let burn_height_before = get_chain_info(&naka_conf).burn_block_height;
     // Mine 1 bitcoin block to trigger a new block found transaction
     next_block_and(&mut btc_regtest_controller, 60, || {


### PR DESCRIPTION
This should fix the `miner_constructs_replay_block` test in CI. It does two things:

1. Updates the nakamoto relayer so that it doesn't try to spawn a nakamoto mining thread before nakamoto actually starts.
2. Adds a "no block" stalling directive to the tests, so that the stall directive doesn't depend on having a mining thread actually be running.