### PR TITLE
test: fix flakiness from `boot_to_epoch_3`

### DIFF
--- a/stacks-node/src/tests/signer/v0.rs
+++ b/stacks-node/src/tests/signer/v0.rs
@@ -143,20 +143,36 @@ impl<Z: SpawnedSignerTrait> SignerTest<Z> {
             &self.running_nodes.btc_regtest_controller,
             Some(self.num_stacking_cycles),
         );
+
         info!("Waiting for signer set calculation.");
         // Make sure the signer set is calculated before continuing or signers may not
         // recognize that they are registered signers in the subsequent burn block event
         let reward_cycle = self.get_current_reward_cycle() + 1;
+        let mut last_probe = Instant::now();
         wait_for(120, || {
-            let Ok(Some(reward_set)) = self.stacks_client.get_reward_set_signers(reward_cycle)
-            else {
-                return Ok(false);
-            };
-
-            debug!("Signer set: {reward_set:?}");
-            Ok(true)
+            match self.stacks_client.get_reward_set_signers(reward_cycle).unwrap_or_default() {
+                Some(reward_set) => {
+                    debug!("Signer set: {reward_set:?}");
+                    Ok(true)
+                }
+                None => {
+                    // If we've been waiting ~30s since the last probe, maybe the last block failed
+                    // so we should try to mine another block
+                    if last_probe.elapsed() >= Duration::from_secs(30) {
+                        warn!(
+                            "Timed out waiting for reward set calculation. Mining another block to try again."
+                        );
+                        self.running_nodes
+                            .btc_regtest_controller
+                            .build_next_block(1);
+                        last_probe = Instant::now();
+                    }
+                    Ok(false)
+                }
+            }
         })
         .expect("Timed out waiting for reward set calculation");
+
         info!("Signer set calculated");
 
         // Manually consume one more block to ensure signers refresh their state


### PR DESCRIPTION
If we did not successfully mine a block after the signer set has been calculated, then we will stall below. If retrieving the reward set times out, then try mining another block so we can recover.

This should fix flakiness in all epoch 3 signer tests.