### PR TITLE
fix: not show empty `Stack Trace`

### DIFF
--- a/clarity/src/vm/errors.rs
+++ b/clarity/src/vm/errors.rs
@@ -139,9 +139,11 @@ impl fmt::Display for Error {
             Error::Runtime(ref err, ref stack) => {
                 write!(f, "{err}")?;
                 if let Some(ref stack_trace) = stack {
-                    writeln!(f, "\n Stack Trace: ")?;
-                    for item in stack_trace.iter() {
-                        writeln!(f, "{item}")?;
+                    if !stack_trace.is_empty() {
+                        writeln!(f, "\n Stack Trace: ")?;
+                        for item in stack_trace.iter() {
+                            writeln!(f, "{item}")?;
+                        }
                     }
                 }
                 Ok(())


### PR DESCRIPTION
# Update display VM error 

### Description
Right now vm will print "Stack Trace: " but then not have any stack trace -> update this not showing if empty `stack trace`

### Applicable issues

- fixes #6369 

