### PR TITLE
Expand input coverage in the `clarity` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "integer-sqrt",
  "lazy_static",
  "mutants",
+ "proptest",
  "regex",
  "rstest",
  "rstest_reuse",

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -37,6 +37,7 @@ features = ["arbitrary_precision", "unbounded_depth"]
 [dev-dependencies]
 assert-json-diff = "1.0.0"
 mutants = "0.0.3"
+proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 rstest = { version = "0.17.0" }
 rstest_reuse = { version = "0.5.0" }
 # a nightly rustc regression (35dbef235 2021-03-02) prevents criterion from compiling

--- a/clarity/src/vm/tests/mod.rs
+++ b/clarity/src/vm/tests/mod.rs
@@ -32,6 +32,7 @@ mod contracts;
 mod datamaps;
 mod defines;
 mod principals;
+mod representations;
 mod sequences;
 #[cfg(test)]
 mod simple_apply_eval;

--- a/clarity/src/vm/tests/representations.rs
+++ b/clarity/src/vm/tests/representations.rs
@@ -1,0 +1,62 @@
+#[cfg(test)]
+use proptest::{prelude::*, string::string_regex};
+
+#[cfg(test)]
+use crate::vm::{
+    representations::{CLARITY_NAME_REGEX_STRING, MAX_STRING_LEN},
+    ClarityName,
+};
+
+#[cfg(test)]
+/// Generates a proptest strategy for valid Clarity names.
+///
+/// This function creates a branched strategy based on the `CLARITY_NAME_REGEX_STRING` pattern.
+///
+/// The strategy covers three categories of valid names:
+/// - Letter-based names starting with a letter followed by alphanumeric or symbol characters
+/// - Single arithmetic operators (`-`, `+`, `=`, `/`, `*`)
+/// - Comparison operators (`<`, `>`, `<=`, `>=`)
+fn any_valid_clarity_name() -> impl Strategy<Value = String> {
+    // Ensure the regex branches match the actual validator.
+    let expected_regex = "^[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*])*$|^[-+=/*]$|^[<>]=?$";
+    assert_eq!(
+        CLARITY_NAME_REGEX_STRING.as_str(),
+        expected_regex,
+        "CLARITY_NAME_REGEX_STRING has changed"
+    );
+
+    let letter_names = string_regex(&format!(
+        "[a-zA-Z][a-zA-Z0-9_!?+<>=/*-]{{0,{}}}",
+        (MAX_STRING_LEN as usize).saturating_sub(1)
+    ))
+    .unwrap();
+
+    let single_ops = prop_oneof![
+        Just("-".to_string()),
+        Just("+".to_string()),
+        Just("=".to_string()),
+        Just("/".to_string()),
+        Just("*".to_string()),
+    ];
+
+    let comparison_ops = prop_oneof![
+        Just("<".to_string()),
+        Just(">".to_string()),
+        Just("<=".to_string()),
+        Just(">=".to_string()),
+    ];
+
+    prop_oneof![letter_names, single_ops, comparison_ops]
+}
+
+#[test]
+fn prop_clarity_name_valid_patterns() {
+    proptest!(|(name in any_valid_clarity_name())| {
+        prop_assume!(!name.is_empty());
+        prop_assume!(name.len() <= MAX_STRING_LEN as usize);
+
+        let clarity_name = ClarityName::try_from(name.clone())
+            .unwrap_or_else(|_| panic!("Should parse valid clarity name: {}", name));
+        prop_assert_eq!(clarity_name.as_str(), name);
+    });
+}

--- a/clarity/src/vm/tests/representations.rs
+++ b/clarity/src/vm/tests/representations.rs
@@ -3,6 +3,7 @@ use proptest::{prelude::*, string::string_regex};
 
 #[cfg(test)]
 use crate::vm::{
+    errors::RuntimeErrorType,
     representations::{CLARITY_NAME_REGEX_STRING, MAX_STRING_LEN},
     ClarityName,
 };
@@ -58,5 +59,98 @@ fn prop_clarity_name_valid_patterns() {
         let clarity_name = ClarityName::try_from(name.clone())
             .unwrap_or_else(|_| panic!("Should parse valid clarity name: {}", name));
         prop_assert_eq!(clarity_name.as_str(), name);
+    });
+}
+
+#[cfg(test)]
+/// Generates a proptest strategy for invalid Clarity names.
+///
+/// This function creates a strategy that generates strings that should be rejected
+/// by `ClarityName::try_from()` validation by systematically violating each valid branch.
+///
+/// The strategy generates names that violate the three valid branches:
+/// - Branch 1 violations: Invalid starting characters or invalid characters in letter-based names
+/// - Branch 2 violations: Multi-character strings starting with single operators
+/// - Branch 3 violations: Invalid extensions to comparison operators
+/// - General violations: Empty strings and length violations
+///
+/// Valid branches being violated:
+/// 1. `^[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*])*$` - Letter-based names
+/// 2. `^[-+=/*]$` - Single arithmetic operators
+/// 3. `^[<>]=?$` - Comparison operators
+fn any_invalid_clarity_name() -> impl Strategy<Value = String> {
+    // Ensure the regex branches match the actual validator.
+    let expected_regex = "^[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*])*$|^[-+=/*]$|^[<>]=?$";
+    assert_eq!(
+        CLARITY_NAME_REGEX_STRING.as_str(),
+        expected_regex,
+        "CLARITY_NAME_REGEX_STRING has changed"
+    );
+
+    let empty_string = Just("".to_string());
+
+    // Names starting with numbers (violates first branch requirement of starting with letter).
+    let starts_with_number = string_regex(&format!(
+        "[0-9][a-zA-Z0-9_!?+<>=/*-]{{0,{}}}",
+        (MAX_STRING_LEN as usize).saturating_sub(1)
+    ))
+    .unwrap();
+
+    // Names starting with invalid symbols (violates all branches - not letters, not valid single
+    // operators, not comparison operators).
+    let starts_with_invalid_symbol = string_regex(&format!(
+        "[@ #$%&.,;:|\\\"'\\[\\](){{}}][a-zA-Z0-9_!?+<>=/*-]{{0,{}}}",
+        (MAX_STRING_LEN as usize).saturating_sub(1)
+    ))
+    .unwrap();
+
+    // Names starting with letters but containing invalid characters (violates first branch
+    // character set restrictions).
+    let invalid_chars_in_letter_names = string_regex(&format!(
+        "[a-zA-Z][a-zA-Z0-9_!?+<>=/*-]*[@ #$%&.,;:|\\\"'\\[\\](){{}}][a-zA-Z0-9_!?+<>=/*-]*"
+    ))
+    .unwrap();
+
+    // Multi-character strings starting with single operators (violates second branch which only
+    // allows single characters).
+    // Covers: --, ++, ==, //, **, -a, +1, =x, etc.
+    let invalid_operator_extensions = string_regex(&format!(
+        "[-+=/*][a-zA-Z0-9_!?+<>=/*-]{{1,{}}}",
+        (MAX_STRING_LEN as usize).saturating_sub(1)
+    ))
+    .unwrap();
+
+    // Invalid comparison operator extensions (violates third branch pattern).
+    // Covers: <<, >>, <a, >1, <=x, >=z, <==, >==, etc.
+    let invalid_comparison_ops = string_regex(&format!(
+        "[<>]=?[a-zA-Z0-9_!?+<>=/*-]{{1,{}}}",
+        (MAX_STRING_LEN as usize).saturating_sub(1)
+    ))
+    .unwrap();
+
+    // Names that are too long (exceeds MAX_STRING_LEN).
+    let too_long = (MAX_STRING_LEN as usize + 1..=MAX_STRING_LEN as usize + 10)
+        .prop_map(|len| "a".repeat(len));
+
+    prop_oneof![
+        empty_string,
+        starts_with_number,
+        starts_with_invalid_symbol,
+        invalid_chars_in_letter_names,
+        invalid_operator_extensions,
+        invalid_comparison_ops,
+        too_long,
+    ]
+}
+
+#[test]
+fn prop_clarity_name_invalid_patterns() {
+    proptest!(|(name in any_invalid_clarity_name())| {
+        let result = ClarityName::try_from(name.clone());
+        prop_assert!(result.is_err(), "Expected invalid name '{}' to be rejected", name);
+        prop_assert!(matches!(
+            result.unwrap_err(),
+            RuntimeErrorType::BadNameValue(_, _)
+        ), "Expected BadNameValue error for invalid name '{}'", name);
     });
 }

--- a/clarity/src/vm/tests/representations.rs
+++ b/clarity/src/vm/tests/representations.rs
@@ -307,3 +307,19 @@ fn prop_contract_name_invalid_patterns() {
         ), "Expected BadNameValue error for invalid contract name '{}'", name);
     });
 }
+
+#[test]
+fn prop_contract_name_roundtrip() {
+    proptest!(|(s in any_valid_contract_name())| {
+        let name = ContractName::try_from(s.clone()).unwrap();
+        prop_assert_eq!(name.as_str(), s);
+
+        let mut buf = Vec::with_capacity((name.len() + 1) as usize);
+        name.consensus_serialize(&mut buf).unwrap();
+        prop_assert_eq!(buf.first().copied(), Some(name.len()));
+        prop_assert_eq!(&buf[1..], name.as_bytes());
+
+        let back = ContractName::consensus_deserialize(&mut buf.as_slice()).unwrap();
+        prop_assert_eq!(back, name);
+    });
+}


### PR DESCRIPTION
This PR broadens the range of tested inputs (as per https://github.com/stacks-network/stacks-core/issues/6355) to include boundaries and edge cases. It validates that serialization, deserialization, and regex checks behave consistently.

[Originally opened](https://github.com/Jiloc/stacks-core/pull/3) by @moodmosaic targeting the `clarity-serialization` crate, currently targeting the `clarity` crate as per @Jiloc's comment https://github.com/Jiloc/stacks-core/pull/3#pullrequestreview-3165059967.