### PR TITLE
feat: improve wasm nested context error tracing

### DIFF
--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -200,7 +200,7 @@ pub trait TransactionConnection: ClarityConnection {
     where
         A: FnOnce(&AssetMap, &mut ClarityDatabase) -> Option<String>,
         F: FnOnce(&mut OwnedEnvironment) -> Result<(R, AssetMap, Vec<StacksTransactionEvent>), E>,
-        E: From<InterpreterError>;
+        E: From<InterpreterError> + std::error::Error;
 
     /// Do something with the analysis database and cost tracker
     ///  instance of this transaction connection. This is a low-level

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -63,11 +63,19 @@ enum StxErrorCodes {
     SENDER_IS_NOT_TX_SENDER = 4,
 }
 
+struct NestedContextTrace {
+    depth: u32,
+    action: &'static str,
+    expected_exit: &'static str,
+    phase: &'static str,
+    backtrace: Option<std::backtrace::Backtrace>,
+}
+
 /// The context used when making calls into the Wasm module.
 pub struct ClarityWasmContext<'a, 'b> {
     pub global_context: &'a mut GlobalContext<'b>,
     nested_context_count: u32,
-    nested_context_traces: Vec<String>,
+    nested_context_traces: Vec<NestedContextTrace>,
     contract_context: Option<&'a ContractContext>,
     contract_context_mut: Option<&'a mut ContractContext>,
     pub call_stack: &'a mut CallStack,
@@ -182,6 +190,46 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             .ok_or(Error::Wasm(WasmError::WasmGeneratorError(
                 "Could not pop at_block".to_string(),
             )))
+    }
+
+    fn should_capture_nested_context_backtrace() -> bool {
+        std::env::var("RUST_BACKTRACE").is_ok() || std::env::var("RUST_LIB_BACKTRACE").is_ok()
+    }
+
+    fn push_nested_context_trace(
+        &mut self,
+        action: &'static str,
+        expected_exit: &'static str,
+        phase: &'static str,
+    ) {
+        self.nested_context_traces.push(NestedContextTrace {
+            depth: self.nested_context_count,
+            action,
+            expected_exit,
+            phase,
+            backtrace: Self::should_capture_nested_context_backtrace()
+                .then(std::backtrace::Backtrace::force_capture),
+        });
+    }
+
+    fn nested_context_traces_report(&self) -> String {
+        let mut report = format!(
+            "open_nested_contexts={}\ntrace_backtraces_enabled={} (set RUST_BACKTRACE=1 to enable forced trace backtraces)",
+            self.nested_context_count,
+            Self::should_capture_nested_context_backtrace(),
+        );
+
+        for (idx, trace) in self.nested_context_traces.iter().enumerate() {
+            report.push_str(&format!(
+                "\n{idx}: depth={} action={} expected_exit={} phase={}",
+                trace.depth, trace.action, trace.expected_exit, trace.phase,
+            ));
+            if let Some(backtrace) = &trace.backtrace {
+                report.push_str(&format!("\nbacktrace:\n{backtrace}"));
+            }
+        }
+
+        report
     }
 
     /// Return an immutable reference to the contract_context
@@ -376,14 +424,14 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
         }
         if let Some(e) = e {
             panic!(
-                "Failed to rollback global context after wasm execution failure: {:?}\n{:?}",
+                "Failed to rollback global context after wasm execution failure: {:?}\n{}",
                 e,
-                self.nested_context_traces.join("\n")
+                self.nested_context_traces_report()
             );
         } else {
             panic!(
-                "Nested contexts have not exited:\n{:?}",
-                self.nested_context_traces.join("\n")
+                "Nested contexts have not exited:\n{}",
+                self.nested_context_traces_report()
             );
         }
     }
@@ -6862,12 +6910,12 @@ fn link_begin_public_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 let context = caller.data_mut();
                 context.global_context.begin();
-                context.nested_context_traces.push(format!(
-                    "{}: begin_public_call {}",
-                    context.nested_context_traces.len(),
-                    std::backtrace::Backtrace::capture(),
-                ));
                 context.nested_context_count += 1;
+                context.push_nested_context_trace(
+                    "begin_public_call",
+                    "commit_call or roll_back_call",
+                    "public function call setup",
+                );
                 Ok(())
             },
         )
@@ -6890,12 +6938,12 @@ fn link_begin_read_only_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Resu
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 let context = caller.data_mut();
                 context.global_context.begin_read_only();
-                context.nested_context_traces.push(format!(
-                    "{}: begin_read_only_call {}",
-                    context.nested_context_traces.len(),
-                    std::backtrace::Backtrace::capture(),
-                ));
                 context.nested_context_count += 1;
+                context.push_nested_context_trace(
+                    "begin_read_only_call",
+                    "roll_back_call",
+                    "read-only function call setup",
+                );
                 Ok(())
             },
         )
@@ -6919,11 +6967,11 @@ fn link_commit_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Er
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 let context = caller.data_mut();
                 context.global_context.commit()?;
-                context.nested_context_traces.push(format!(
-                    "{}: commit_call {}",
-                    context.nested_context_traces.len(),
-                    std::backtrace::Backtrace::capture(),
-                ));
+                context.push_nested_context_trace(
+                    "commit_call",
+                    "none",
+                    "public function call commit",
+                );
                 context.nested_context_count -= 1;
                 Ok(())
             },
@@ -6949,11 +6997,11 @@ fn link_roll_back_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(),
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 let context = caller.data_mut();
                 context.global_context.roll_back()?;
-                context.nested_context_traces.push(format!(
-                    "{}: roll_back_call {}",
-                    context.nested_context_traces.len(),
-                    std::backtrace::Backtrace::capture(),
-                ));
+                context.push_nested_context_trace(
+                    "roll_back_call",
+                    "none",
+                    "nested context rollback",
+                );
                 context.nested_context_count -= 1;
                 Ok(())
             },
@@ -7061,12 +7109,12 @@ fn link_enter_at_block_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(),
                     .map_err(|e| Error::from(e))?;
 
                 context.global_context.begin_read_only();
-                context.nested_context_traces.push(format!(
-                    "{}: enter_at_block {}",
-                    context.nested_context_traces.len(),
-                    std::backtrace::Backtrace::capture(),
-                ));
                 context.nested_context_count += 1;
+                context.push_nested_context_trace(
+                    "enter_at_block",
+                    "exit_at_block",
+                    "at-block entry",
+                );
 
                 let prev_bhh = context.global_context.database.set_block_hash(bhh, false)?;
 
@@ -7102,11 +7150,7 @@ fn link_exit_at_block_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
                 // expression. This is precautionary, since only read-only
                 // operations are allowed during an `at-block` expression.
                 context.global_context.roll_back()?;
-                context.nested_context_traces.push(format!(
-                    "{}: exit_at_block {}",
-                    context.nested_context_traces.len(),
-                    std::backtrace::Backtrace::capture(),
-                ));
+                context.push_nested_context_trace("exit_at_block", "none", "at-block exit");
                 context.nested_context_count -= 1;
 
                 context

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -66,6 +66,8 @@ enum StxErrorCodes {
 /// The context used when making calls into the Wasm module.
 pub struct ClarityWasmContext<'a, 'b> {
     pub global_context: &'a mut GlobalContext<'b>,
+    nested_context_count: u32,
+    nested_context_traces: Vec<String>,
     contract_context: Option<&'a ContractContext>,
     contract_context_mut: Option<&'a mut ContractContext>,
     pub call_stack: &'a mut CallStack,
@@ -97,6 +99,8 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
     ) -> Self {
         ClarityWasmContext {
             global_context,
+            nested_context_count: 0,
+            nested_context_traces: vec![],
             contract_context: None,
             contract_context_mut: Some(contract_context),
             call_stack,
@@ -121,6 +125,8 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
     ) -> Self {
         ClarityWasmContext {
             global_context,
+            nested_context_count: 0,
+            nested_context_traces: vec![],
             contract_context: Some(contract_context),
             contract_context_mut: None,
             call_stack,
@@ -362,6 +368,25 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
         self.push_to_event_batch(event);
         Ok(())
     }
+
+    /// Ensure all nested contexts have exited.
+    pub fn ensure_nested_contexts_exited(&self, e: Option<&wasmtime::Error>) -> Result<(), Error> {
+        if self.nested_context_count == 0 {
+            return Ok(());
+        }
+        if let Some(e) = e {
+            panic!(
+                "Failed to rollback global context after wasm execution failure: {:?}\n{:?}",
+                e,
+                self.nested_context_traces.join("\n")
+            );
+        } else {
+            panic!(
+                "Nested contexts have not exited:\n{:?}",
+                self.nested_context_traces.join("\n")
+            );
+        }
+    }
 }
 
 /// Push a placeholder value for Wasm type `ty` onto the data stack.
@@ -434,8 +459,13 @@ pub fn initialize_contract(
     top_level
         .call(&mut store, &[], results.as_mut_slice())
         .map_err(|e| {
+            store
+                .data()
+                .ensure_nested_contexts_exited(Some(&e))
+                .unwrap();
             error_mapping::resolve_error(e, instance, &mut store, &epoch, &clarity_version)
         })?;
+    store.data().ensure_nested_contexts_exited(None).unwrap();
 
     // Save the compiled Wasm module into the contract context
     store.data_mut().contract_context_mut()?.set_wasm_module(
@@ -590,8 +620,13 @@ pub fn call_function<'a>(
         .collect();
     func.call(&mut store, &wasm_args, &mut results)
         .map_err(|e| {
+            store
+                .data()
+                .ensure_nested_contexts_exited(Some(&e))
+                .unwrap();
             error_mapping::resolve_error(e, instance, &mut store, &epoch, &clarity_version)
         })?;
+    store.data().ensure_nested_contexts_exited(None).unwrap();
 
     // If the function returns a value, translate it into a Clarity `Value`
     wasm_to_clarity_value(&return_type, 0, &results, memory, &mut &mut store, epoch)
@@ -6661,6 +6696,9 @@ fn link_contract_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
 
                 // Write the result to the return buffer
                 let return_ty = if trait_id_length == 0 {
+                    if function.get_return_type().is_none() {
+                        warn!("Return type is none: {:?}", function);
+                    }
                     // This is a direct call
                     function
                         .get_return_type()
@@ -6822,7 +6860,14 @@ fn link_begin_public_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<
             "clarity",
             "begin_public_call",
             |mut caller: Caller<'_, ClarityWasmContext>| {
-                caller.data_mut().global_context.begin();
+                let context = caller.data_mut();
+                context.global_context.begin();
+                context.nested_context_traces.push(format!(
+                    "{}: begin_public_call {}",
+                    context.nested_context_traces.len(),
+                    std::backtrace::Backtrace::capture(),
+                ));
+                context.nested_context_count += 1;
                 Ok(())
             },
         )
@@ -6843,7 +6888,14 @@ fn link_begin_read_only_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Resu
             "clarity",
             "begin_read_only_call",
             |mut caller: Caller<'_, ClarityWasmContext>| {
-                caller.data_mut().global_context.begin_read_only();
+                let context = caller.data_mut();
+                context.global_context.begin_read_only();
+                context.nested_context_traces.push(format!(
+                    "{}: begin_read_only_call {}",
+                    context.nested_context_traces.len(),
+                    std::backtrace::Backtrace::capture(),
+                ));
+                context.nested_context_count += 1;
                 Ok(())
             },
         )
@@ -6865,7 +6917,14 @@ fn link_commit_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Er
             "clarity",
             "commit_call",
             |mut caller: Caller<'_, ClarityWasmContext>| {
-                caller.data_mut().global_context.commit()?;
+                let context = caller.data_mut();
+                context.global_context.commit()?;
+                context.nested_context_traces.push(format!(
+                    "{}: commit_call {}",
+                    context.nested_context_traces.len(),
+                    std::backtrace::Backtrace::capture(),
+                ));
+                context.nested_context_count -= 1;
                 Ok(())
             },
         )
@@ -6888,7 +6947,14 @@ fn link_roll_back_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(),
             "clarity",
             "roll_back_call",
             |mut caller: Caller<'_, ClarityWasmContext>| {
-                caller.data_mut().global_context.roll_back()?;
+                let context = caller.data_mut();
+                context.global_context.roll_back()?;
+                context.nested_context_traces.push(format!(
+                    "{}: roll_back_call {}",
+                    context.nested_context_traces.len(),
+                    std::backtrace::Backtrace::capture(),
+                ));
+                context.nested_context_count -= 1;
                 Ok(())
             },
         )
@@ -6988,21 +7054,23 @@ fn link_enter_at_block_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(),
                     }
                 };
 
-                caller
-                    .data_mut()
+                let context = caller.data_mut();
+                context
                     .global_context
                     .add_memory(cost_constants::AT_BLOCK_MEMORY)
                     .map_err(|e| Error::from(e))?;
 
-                caller.data_mut().global_context.begin_read_only();
+                context.global_context.begin_read_only();
+                context.nested_context_traces.push(format!(
+                    "{}: enter_at_block {}",
+                    context.nested_context_traces.len(),
+                    std::backtrace::Backtrace::capture(),
+                ));
+                context.nested_context_count += 1;
 
-                let prev_bhh = caller
-                    .data_mut()
-                    .global_context
-                    .database
-                    .set_block_hash(bhh, false)?;
+                let prev_bhh = context.global_context.database.set_block_hash(bhh, false)?;
 
-                caller.data_mut().push_at_block(prev_bhh);
+                context.push_at_block(prev_bhh);
 
                 Ok(())
             },
@@ -7027,19 +7095,21 @@ fn link_exit_at_block_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 // Pop back to the current block
                 let bhh = caller.data_mut().pop_at_block()?;
-                caller
-                    .data_mut()
-                    .global_context
-                    .database
-                    .set_block_hash(bhh, true)?;
+                let context = caller.data_mut();
+                context.global_context.database.set_block_hash(bhh, true)?;
 
                 // Roll back any changes that occurred during the `at-block`
                 // expression. This is precautionary, since only read-only
                 // operations are allowed during an `at-block` expression.
-                caller.data_mut().global_context.roll_back()?;
+                context.global_context.roll_back()?;
+                context.nested_context_traces.push(format!(
+                    "{}: exit_at_block {}",
+                    context.nested_context_traces.len(),
+                    std::backtrace::Backtrace::capture(),
+                ));
+                context.nested_context_count -= 1;
 
-                caller
-                    .data_mut()
+                context
                     .global_context
                     .cost_track
                     .drop_memory(cost_constants::AT_BLOCK_MEMORY)?;

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1560,8 +1560,8 @@ impl<'a, 'b> Environment<'a, 'b> {
             result
         })();
 
-        match result {
-            Ok(contract) => {
+        let result = match result {
+            Ok(contract) => (|| {
                 let data_size = contract.contract_context.data_size;
                 self.global_context
                     .database
@@ -1569,14 +1569,17 @@ impl<'a, 'b> Environment<'a, 'b> {
                 self.global_context
                     .database
                     .set_contract_data_size(&contract_identifier, data_size)?;
-
-                self.global_context.commit()?;
                 Ok(())
-            }
-            Err(e) => {
-                self.global_context.roll_back()?;
-                Err(e)
-            }
+            })(),
+            Err(e) => Err(e),
+        };
+
+        if let Err(e) = result {
+            self.global_context.roll_back()?;
+            return Err(e);
+        } else {
+            self.global_context.commit()?;
+            return Ok(());
         }
     }
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -2055,7 +2055,7 @@ impl TransactionConnection for ClarityTransactionConnection<'_, '_> {
     where
         A: FnOnce(&AssetMap, &mut ClarityDatabase) -> Option<String>,
         F: FnOnce(&mut OwnedEnvironment) -> Result<(R, AssetMap, Vec<StacksTransactionEvent>), E>,
-        E: From<InterpreterError>,
+        E: From<InterpreterError> + std::error::Error,
     {
         using!(self.log, "log", |log| {
             using!(self.cost_track, "cost tracker", |cost_track| {
@@ -2077,8 +2077,15 @@ impl TransactionConnection for ClarityTransactionConnection<'_, '_> {
                     self.epoch,
                 );
                 let result = to_do(&mut vm_env);
-                let (mut db, cost_track) = vm_env
-                    .destruct()
+                let destruct_result = vm_env.destruct();
+                if destruct_result.is_none() {
+                    if let Err(e) = result.as_ref() {
+                        error!("Failed to recover database reference after executing transaction, execution failed with error: {:?}", e);
+                    } else {
+                        error!("Failed to recover database reference after executing transaction");
+                    }
+                }
+                let (mut db, cost_track) = destruct_result
                     .expect("Failed to recover database reference after executing transaction");
                 // DO NOT reset memory usage yet -- that should happen only when the TX commits.
 


### PR DESCRIPTION
### Description

This PR records nested context transitions in the Wasm context and panics if any nested contexts are not committed or rolled back.

@csgui