### PR TITLE
Fix:remove duplicated `CostOverflowingMath` trait

### DIFF
--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::{cmp, fmt};
 
 pub use clarity_serialization::errors::CostErrors;
-pub use clarity_serialization::execution_cost::ExecutionCost;
+pub use clarity_serialization::execution_cost::{CostOverflowingMath, ExecutionCost};
 use costs_1::Costs1;
 use costs_2::Costs2;
 use costs_2_testnet::Costs2Testnet;
@@ -1241,28 +1241,6 @@ impl CostTracker for &mut LimitedCostTracker {
         input: &[u64],
     ) -> Result<bool> {
         LimitedCostTracker::short_circuit_contract_call(self, contract, function, input)
-    }
-}
-
-pub trait CostOverflowingMath<T> {
-    fn cost_overflow_mul(self, other: T) -> Result<T>;
-    fn cost_overflow_add(self, other: T) -> Result<T>;
-    fn cost_overflow_sub(self, other: T) -> Result<T>;
-    fn cost_overflow_div(self, other: T) -> Result<T>;
-}
-
-impl CostOverflowingMath<u64> for u64 {
-    fn cost_overflow_mul(self, other: u64) -> Result<u64> {
-        self.checked_mul(other).ok_or(CostErrors::CostOverflow)
-    }
-    fn cost_overflow_add(self, other: u64) -> Result<u64> {
-        self.checked_add(other).ok_or(CostErrors::CostOverflow)
-    }
-    fn cost_overflow_sub(self, other: u64) -> Result<u64> {
-        self.checked_sub(other).ok_or(CostErrors::CostOverflow)
-    }
-    fn cost_overflow_div(self, other: u64) -> Result<u64> {
-        self.checked_div(other).ok_or(CostErrors::CostOverflow)
     }
 }
 


### PR DESCRIPTION
### Description

During the line-by-line diff analysis of the clarity-serialization crate, @fdefelici found out that `CostOverflowingMath` was not removed from the original `clarity` crate and ended up being duplicated.

This PR addressed that.

Given that this duplicated symbol slipped through the first two reviews, I did another review do check that ALL symbols in clarity-serialization have no duplicate declaration in `clarity`. Nothing else was found!

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
