### PR TITLE
chore: add `cargo clippy-stackslib` to ci

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -42,3 +42,7 @@ jobs:
       - name: Clippy
         id: clippy
         run: cargo clippy-stacks
+
+      - name: Clippy Stackslib
+        id: clippy-stackslib
+        run: cargo clippy-stackslib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ For an example of this process, see PRs
   test, module, function, etc.), each should be documented according
   to our [coding guidelines](#Coding-Guidelines).
 
-> [*] The Changelog focuses on product changes. A "major change" refers to updates that have a direct impact on the end user, such as introducing new features, modifying existing functionality, or optimizing runtime performance. 
+> [*] The Changelog focuses on product changes. A "major change" refers to updates that have a direct impact on the end user, such as introducing new features, modifying existing functionality, or optimizing runtime performance.
 On the other hand, changes that do not need to be reflected in the Changelog include code refactoring, writing tests, or automating processes, as these do not directly affect the user experience.
 
 ## Git Commit Messages
@@ -374,10 +374,10 @@ A test should be marked `#[ignore]` if:
 - **Integration tests need to be properly tagged** using [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) crate. Tagging requires two fundamental steps:
   1. Define allowed tags in the package `Cargo.toml` file (if needed).
   2. Apply relevant tags to the tests, picking from the allowed set.
-  
+
   Then it will be possible to run tests with filtering based on the tags using `cargo test` and `cargo nextest` runner.
   > For more information and examples on how tagging works, refer to the [pinny-rs](https://github.com/BitcoinL2-Labs/pinny-rs/) readme.
-  
+
   Below the tag set currently defined with related purpose:
 
   | Tag             | Description                                  |
@@ -406,15 +406,25 @@ cargo fmt-stacks
 
 ## Clippy Warnings
 
-PRs will be checked against `clippy` and will _fail_ if any clippy warnings are generated.
-Unfortunately, not all existing clippy warnings have been addressed throughout stacks-core, so arguments must be passed via the command line. 
-Therefore, we handle `clippy` configurations using a Cargo alias: `cargo clippy-stacks`
+All PRs are checked with `clippy`, and the CI will **fail** if any warnings are raised.
+Because not all existing clippy warnings in `stacks-core` have been addressed, we use Cargo aliases to standardize how clippy is run across different parts of the codebase.
 
-You can check what warnings need to be addressed locally via: 
+Two commands are available:
+
+- `cargo clippy-stacks`
+  Runs clippy across the core packages of the repository (e.g. `stx-genesis`, `clarity`, `stacks-signer`, etc.).
+
+- `cargo clippy-stackslib`
+  Runs clippy specifically on the `stackslib` package, with a different configuration.
+
+To check warnings locally, run:
 
 ```bash
 cargo clippy-stacks
+cargo clippy-stackslib
 ```
+
+Make sure both commands pass before opening a pull request.
 
 ## Comments
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -1745,8 +1745,7 @@ impl<'a> ClarityBlockConnection<'a, '_> {
                 stx_balance: STXBalance::zero(),
             };
 
-            let costs_4_contract_tx =
-                StacksTransaction::new(tx_version.clone(), boot_code_auth, payload);
+            let costs_4_contract_tx = StacksTransaction::new(tx_version, boot_code_auth, payload);
 
             let costs_4_initialization_receipt = self.as_transaction(|tx_conn| {
                 // bump the epoch in the Clarity DB


### PR DESCRIPTION
### Description

While launching `cargo clippy-stackslib` locally I noticed that a warning popped up, and I realized that the command is not currently called by the CI, hence this PR!

This PR also updates the CONTRIBUTING.md with information about how to launch the command and fixes the warning.


### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
