### PR TITLE
Renaming block-replay script to block-validation

### DIFF
--- a/contrib/stacks-inspect/src/lib.rs
+++ b/contrib/stacks-inspect/src/lib.rs
@@ -120,7 +120,7 @@ pub fn drain_common_opts(argv: &mut Vec<String>, start_at: usize) -> CommonOpts 
 ///
 /// Arguments:
 ///  - `argv`: Args in CLI format: `<command-name> [args...]`
-pub fn command_replay_block(argv: &[String], conf: Option<&Config>) {
+pub fn command_validate_block(argv: &[String], conf: Option<&Config>) {
     let print_help_and_exit = || -> ! {
         let n = &argv[0];
         eprintln!("Usage:");
@@ -202,7 +202,7 @@ pub fn command_replay_block(argv: &[String], conf: Option<&Config>) {
 ///
 /// Arguments:
 ///  - `argv`: Args in CLI format: `<command-name> [args...]`
-pub fn command_replay_block_nakamoto(argv: &[String], conf: Option<&Config>) {
+pub fn command_validate_block_nakamoto(argv: &[String], conf: Option<&Config>) {
     let print_help_and_exit = || -> ! {
         let n = &argv[0];
         eprintln!("Usage:");

--- a/contrib/stacks-inspect/src/main.rs
+++ b/contrib/stacks-inspect/src/main.rs
@@ -21,8 +21,8 @@ use clarity::types::StacksEpochId;
 use clarity::types::chainstate::StacksPrivateKey;
 use clarity_cli::DEFAULT_CLI_EPOCH;
 use stacks_inspect::{
-    command_contract_hash, command_validate_block, command_validate_block_nakamoto,
-    command_replay_mock_mining, command_try_mine, drain_common_opts,
+    command_contract_hash, command_replay_mock_mining, command_try_mine, command_validate_block,
+    command_validate_block_nakamoto, drain_common_opts,
 };
 use stackslib::chainstate::stacks::miner::BlockBuilderSettings;
 use stackslib::chainstate::stacks::{

--- a/contrib/stacks-inspect/src/main.rs
+++ b/contrib/stacks-inspect/src/main.rs
@@ -21,7 +21,7 @@ use clarity::types::StacksEpochId;
 use clarity::types::chainstate::StacksPrivateKey;
 use clarity_cli::DEFAULT_CLI_EPOCH;
 use stacks_inspect::{
-    command_contract_hash, command_replay_block, command_replay_block_nakamoto,
+    command_contract_hash, command_validate_block, command_validate_block_nakamoto,
     command_replay_mock_mining, command_try_mine, drain_common_opts,
 };
 use stackslib::chainstate::stacks::miner::BlockBuilderSettings;
@@ -1586,13 +1586,13 @@ check if the associated microblocks can be downloaded
         return;
     }
 
-    if argv[1] == "replay-block" {
-        command_replay_block(&argv[1..], common_opts.config.as_ref());
+    if argv[1] == "validate-block" {
+        command_validate_block(&argv[1..], common_opts.config.as_ref());
         process::exit(0);
     }
 
-    if argv[1] == "replay-naka-block" {
-        command_replay_block_nakamoto(&argv[1..], common_opts.config.as_ref());
+    if argv[1] == "validate-naka-block" {
+        command_validate_block_nakamoto(&argv[1..], common_opts.config.as_ref());
         process::exit(0);
     }
 

--- a/contrib/tools/block-validation.sh
+++ b/contrib/tools/block-validation.sh
@@ -2,33 +2,28 @@
 set -o pipefail
 
 
-## Using 10 cpu cores, a full replay will take between 12-14 hours (assuming there are no other cpu/io bound processes running at the same time)
+## Using 10 cpu cores, a full validation will take between 12-14 hours (assuming there are no other cpu/io bound processes running at the same time)
 ##
 ## ** Recommend to run this script in screen or tmux **
 ##
-## We'll need ~73GB per slice, plus an extra ~400GB for the chainstate archive and marf DB
-## as of 02/2025:
-##   for 10 slices, this is about 1.1TB 
-##     - 149GB for compressed chainstate
-##     - 232GB decompressed marf db
-##     - 73GB per slice dir (1 dir per cpu)
-##   for 15 slices, this is about 1.46TB
-##   for 20 slices, this is about 1.8TB
+## We'll need ~217GB per slice, plus an extra ~4500GB for the chainstate archive and marf DB
+## as of 09/2025:
+##   for 10 slices, this is about 2.5TB
 
-NETWORK="mainnet"                         ## network to replay
-REPO_DIR="$HOME/stacks-core"              ## where to build the source
-REMOTE_REPO="stacks-network/stacks-core"  ## remote git repo to build stacks-inspect from
-SCRATCH_DIR="$HOME/scratch"               ## root folder for the replay slices
-TIMESTAMP=$(date +%Y-%m-%d-%s)            ## use a simple date format year-month-day-epoch
-LOG_DIR="$HOME/replay_${TIMESTAMP}"       ## location of logfiles for the replay
-SLICE_DIR="${SCRATCH_DIR}/slice"          ## location of slice dirs
-TMUX_SESSION="replay"                     ## tmux session name to run the replay
-TERM_OUT=false                            ## terminal friendly output
-TESTING=false                             ## only run a replay on a few thousand blocks
-BRANCH="develop"                          ## default branch to build stacks-inspect from
-CORES=$(grep -c processor /proc/cpuinfo)  ## retrieve total number of CORES on the system
-RESERVED=8                                ## reserve this many CORES for other processes as default
-LOCAL_CHAINSTATE=                         ## path to local chainstate to use instead of snapshot download
+NETWORK="mainnet"                               ## network to validate
+REPO_DIR="$HOME/stacks-core"                    ## where to build the source
+REMOTE_REPO="stacks-network/stacks-core"        ## remote git repo to build stacks-inspect from
+SCRATCH_DIR="$HOME/scratch"                     ## root folder for the validation slices
+TIMESTAMP=$(date +%Y-%m-%d-%s)                  ## use a simple date format year-month-day-epoch
+LOG_DIR="$HOME/block-validation_${TIMESTAMP}"   ## location of logfiles for the validation
+SLICE_DIR="${SCRATCH_DIR}/slice"                ## location of slice dirs
+TMUX_SESSION="validation"                       ## tmux session name to run the validation
+TERM_OUT=false                                  ## terminal friendly output
+TESTING=false                                   ## only run a validation on a few thousand blocks
+BRANCH="develop"                                ## default branch to build stacks-inspect from
+CORES=$(grep -c processor /proc/cpuinfo)        ## retrieve total number of CORES on the system
+RESERVED=8                                      ## reserve this many CORES for other processes as default
+LOCAL_CHAINSTATE=                               ## path to local chainstate to use instead of snapshot download
 
 ## ansi color codes for terminal output
 COLRED=$'\033[31m'    ## Red
@@ -66,15 +61,15 @@ build_stacks_inspect() {
         }
     else
         echo "Cloning stacks-core ${BRANCH}"
-        (git clone "https://github.com/${REMOTE_REPO}" --branch "${BRANCH}" "${REPO_DIR}" && cd "${REPO_DIR}") || { 
+        (git clone "https://github.com/${REMOTE_REPO}" --branch "${BRANCH}" "${REPO_DIR}" && cd "${REPO_DIR}") || {
             echo "${COLRED}Error${COLRESET} cloning https://github.com/${REMOTE_REPO} into ${REPO_DIR}"
             exit 1
         }
     fi
     git pull
-    ## build stacks-inspect to: $HOME/stacks-inspect/target/release/stacks-inspect
+    ## build stacks-inspect to: ${REPO_DIR}/target/release/stacks-inspect
     echo "Building stacks-inspect binary"
-    cargo build --bin=stacks-inspect --release || {
+    cd contrib/stacks-inspect && cargo build --bin=stacks-inspect --release || {
         echo "${COLRED}Error${COLRESET} building stacks-inspect binary"
         exit 1
     }
@@ -82,7 +77,7 @@ build_stacks_inspect() {
 }
 
 ## create the slice dirs from an chainstate archive (symlinking marf.sqlite.blobs), 1 dir per CPU
-configure_replay_slices() {
+configure_validation_slices() {
     if [ -d "$HOME/scratch" ]; then
         echo "Deleting existing scratch dir: ${COLYELLOW}$HOME/scratch${COLRESET}"
         rm -rf "${HOME}/scratch" || {
@@ -134,9 +129,9 @@ configure_replay_slices() {
 }
 
 ## setup the tmux sessions and create the logdir for storing output
-setup_replay() {
+setup_validation() {
     ## if there is an existing folder, rm it
-    if [ -d "${LOG_DIR}" ];then 
+    if [ -d "${LOG_DIR}" ];then
         echo "Removing logdir ${LOG_DIR}"
         rm -rf "${LOG_DIR}"
     fi
@@ -145,7 +140,7 @@ setup_replay() {
         echo "Creating logdir ${LOG_DIR}"
         mkdir -p "${LOG_DIR}"
     fi
-    ## if tmux session "replay" exists, kill it and start anew 
+    ## if tmux session "${TMUX_SESSION}" exists, kill it and start anew
     if eval "tmux list-windows -t ${TMUX_SESSION} &> /dev/null"; then
         echo "Killing existing tmux session: ${TMUX_SESSION}"
         eval "tmux kill-session -t ${TMUX_SESSION}  &> /dev/null"
@@ -165,9 +160,9 @@ setup_replay() {
     return 0
 }
 
-## run the block replay
-start_replay() {  
-    local mode=$1 
+## run the block validation
+start_validation() {
+    local mode=$1
     local total_blocks=0
     local starting_block=0
     local inspect_command
@@ -177,11 +172,11 @@ start_replay() {
             ## nakamoto blocks
             echo "Mode: ${COLYELLOW}${mode}${COLRESET}"
             local log_append="_${mode}"
-            inspect_command="replay-naka-block"
+            inspect_command="validate-naka-block"
             ## get the total number of nakamoto blocks in db
             total_blocks=$(echo "select count(*) from nakamoto_block_headers" | sqlite3 "${SLICE_DIR}"0/chainstate/vm/index.sqlite)
             starting_block=0 # for the block counter, start at this block
-            ## use these values if `--testing` arg is provided (only replay 1_000 blocks)
+            ## use these values if `--testing` arg is provided (only validate 1_000 blocks)
             ${TESTING} && total_blocks=301883
             ${TESTING} && starting_block=300883
             ;;
@@ -189,18 +184,18 @@ start_replay() {
             ## pre-nakamoto blocks
             echo "Mode: ${COLYELLOW}pre-nakamoto${COLRESET}"
             local log_append=""
-            inspect_command="replay-block"
+            inspect_command="validate-block"
             ## get the total number of blocks (with orphans) in db
             total_blocks=$(echo "select count(*) from staging_blocks where orphaned = 0" | sqlite3 "${SLICE_DIR}"0/chainstate/vm/index.sqlite)
             starting_block=0 # for the block counter, start at this block
-            ## use these values if `--testing` arg is provided (only replay 1_000 blocks) Note:  2.5 epoch is at 153106
+            ## use these values if `--testing` arg is provided (only validate 1_000 blocks) Note:  2.5 epoch is at 153106
             ${TESTING} && total_blocks=153000
             ${TESTING} && starting_block=152000
             ;;
     esac
-    local block_diff=$((total_blocks - starting_block)) ## how many blocks are being replayed
-    local slices=$((CORES - RESERVED))                  ## how many replay slices to use
-    local slice_blocks=$((block_diff / slices))         ## how many blocks to replay per slice
+    local block_diff=$((total_blocks - starting_block)) ## how many blocks are being validated
+    local slices=$((CORES - RESERVED))                  ## how many validation slices to use
+    local slice_blocks=$((block_diff / slices))         ## how many blocks to validate per slice
     ${TESTING} && echo "${COLRED}Testing: ${TESTING}${COLRESET}"
     echo "Total blocks: ${COLYELLOW}${total_blocks}${COLRESET}"
     echo "Staring Block: ${COLYELLOW}$starting_block${COLRESET}"
@@ -215,9 +210,9 @@ start_replay() {
         if [[ "${end_block_count}" -gt "${total_blocks}"  ]] ||  [[ "${slice_counter}" -eq $((slices - 1))  ]]; then
             end_block_count="${total_blocks}"
         fi
-        if [ "${mode}" != "nakamoto" ]; then ## don't create the tmux windows if we're replaying nakamoto blocks (they should already exist). TODO: check if it does exist in case the function call order changes
+        if [ "${mode}" != "nakamoto" ]; then ## don't create the tmux windows if we're validating nakamoto blocks (they should already exist). TODO: check if it does exist in case the function call order changes
             if [ "${slice_counter}" -gt 0 ];then
-                tmux new-window -t replay -d -n "slice${slice_counter}" || {
+                tmux new-window -t "${TMUX_SESSION}" -d -n "slice${slice_counter}" || {
                     echo "${COLRED}Error${COLRESET} creating tmux window ${COLYELLOW}slice${slice_counter}${COLRESET}"
                     exit 1
                 }
@@ -226,12 +221,12 @@ start_replay() {
         local log_file="${LOG_DIR}/slice${slice_counter}${log_append}.log"
         local log=" | tee -a ${log_file}"
         local cmd="${REPO_DIR}/target/release/stacks-inspect --config ${REPO_DIR}/stackslib/conf/${NETWORK}-follower-conf.toml ${inspect_command}  ${SLICE_DIR}${slice_counter} index-range $start_block_count $end_block_count 2>/dev/null"
-        echo "  Creating tmux window: ${COLGREEN}replay:slice${slice_counter}${COLRESET} :: Blocks: ${COLYELLOW}${start_block_count}-${end_block_count}${COLRESET} || Logging to: ${log_file}"
+        echo "  Creating tmux window: ${COLGREEN}${TMUX_SESSION}:slice${slice_counter}${COLRESET} :: Blocks: ${COLYELLOW}${start_block_count}-${end_block_count}${COLRESET} || Logging to: ${log_file}"
         echo "Command: ${cmd}" > "${log_file}" ## log the command being run for the slice
-        echo "Replaying indexed blocks: ${start_block_count}-${end_block_count} (out of ${total_blocks})" >> "${log_file}"
-        ## send `cmd` to the tmux window where the replay will run
+        echo "Validating indexed blocks: ${start_block_count}-${end_block_count} (out of ${total_blocks})" >> "${log_file}"
+        ## send `cmd` to the tmux window where the validation will run
         tmux send-keys -t "${TMUX_SESSION}:slice${slice_counter}" "${cmd}${log}" Enter || {
-            echo "${COLRED}Error${COLRESET} sending replay command to tmux window ${COLYELLOW}slice${slice_counter}${COLRESET}"
+            echo "${COLRED}Error${COLRESET} sending stacks-inspect command to tmux window ${COLYELLOW}slice${slice_counter}${COLRESET}"
             exit 1
         }
         ## log the return code as the last line
@@ -258,12 +253,12 @@ check_progress() {
         sleep 1
     done
     echo "************************************************************************"
-    echo "Checking Block Replay status"
+    echo "Checking Block Validation status"
     echo -e ' '
     while true; do
         count=$(pgrep  -c "stacks-inspect")
         if [ "${count}" -gt 0 ]; then
-            ${TERM_OUT} && printf "Block replay processes are currently active [ %s%s%s%s ] ...  \b${sp:progress++%${#sp}:1}  \033[0K\r" "${COLYELLOW}" "${COLBOLD}" "${count}" "${COLRESET}"
+            ${TERM_OUT} && printf "Block validation processes are currently active [ %s%s%s%s ] ...  \b${sp:progress++%${#sp}:1}  \033[0K\r" "${COLYELLOW}" "${COLBOLD}" "${count}" "${COLRESET}"
         else
             ${TERM_OUT} && printf "\r\n"
             break
@@ -302,10 +297,10 @@ store_results() {
         return_code=$(tail -1 "${file}")
         case ${return_code} in
             0)
-                # block replay ran successfully
+                # block validation ran successfully
                 ;;
             1)
-                # block replay had some block failures
+                # block validation had some block failures
                 failed=1
                 ;;
             *)
@@ -355,10 +350,10 @@ store_results() {
         <div class="container">
 _EOF_
 
-    ## use the $failed var here in case there is a panic, then $failure_count may show zero, but the replay was not successful
+    ## use the $failed var here in case there is a panic, then $failure_count may show zero, but the validation was not successful
     if [ ${failed} == "1" ];then
         output=$(grep -r -h "Failed processing block" slice*.log)
-        IFS=$'\n' 
+        IFS=$'\n'
         for line in ${output}; do
             echo "        <div class=\"result fail\">${line}</div>" >> "${results_html}" || {
                 echo "${COLRED}Error${COLRESET} writing failure to: ${results_html}"
@@ -382,12 +377,12 @@ usage() {
     echo "    ${COLBOLD}${0}${COLRESET}"
     echo "        ${COLYELLOW}--testing${COLRESET}: only check a small number of blocks"
     echo "        ${COLYELLOW}-t|--terminal${COLRESET}: more terminal friendly output"
-    echo "        ${COLYELLOW}-n|--network${COLRESET}: run block replay against specific network (default: mainnet)"
+    echo "        ${COLYELLOW}-n|--network${COLRESET}: run block validation against specific network (default: mainnet)"
     echo "        ${COLYELLOW}-b|--branch${COLRESET}: branch of stacks-core to build stacks-inspect from (default: develop)"
     echo "        ${COLYELLOW}-c|--chainstate${COLRESET}: local chainstate copy to use instead of downloading a chainstaet snapshot"
     echo "        ${COLYELLOW}-l|--logdir${COLRESET}: use existing log directory"
     echo "        ${COLYELLOW}-r|--reserved${COLRESET}: how many cpu cores to reserve for system tasks"
-    echo 
+    echo
     echo "    ex: ${COLCYAN}${0} -t -u ${COLRESET}"
     echo
     exit 0
@@ -447,11 +442,11 @@ done
 while [ ${#} -gt 0 ]; do
     case ${1} in
         --testing)
-            # only replay 1_000 blocks
+            # only validate 1_000 blocks
             TESTING=true
             ;;
         -t|--terminal)
-            # update terminal with progress (it's just printf to show in real-time that the replays are running)
+            # update terminal with progress (it's just printf to show in real-time that the validations are running)
             TERM_OUT=true
             ;;
         -n|--network)
@@ -490,16 +485,16 @@ while [ ${#} -gt 0 ]; do
             LOG_DIR="${2}"
             shift
             ;;
-        -r|--RESERVED) 
+        -r|--RESERVED)
             # reserve this many cpus for the system (default is 10)
-            if [ "${2}" == "" ]; then 
+            if [ "${2}" == "" ]; then
                 echo "Missing required value for ${1}"
             fi
             if ! [[ "$2" =~ ^[0-9]+$ ]]; then
                 echo "ERROR: arg ($2) is not a number." >&2
                 exit 1
             fi
-            RESERVED=${2}    
+            RESERVED=${2}
             shift
             ;;
         -h|--help|--usage)
@@ -513,11 +508,11 @@ done
 
 ## clear display before starting
 tput reset
-echo "Replay Started: ${COLYELLOW}$(date)${COLRESET}"
-build_stacks_inspect        ## comment if using an existing chainstate/slice dir (ex: replay was performed already, and a second run is desired)
-configure_replay_slices     ## comment if using an existing chainstate/slice dir (ex: replay was performed already, and a second run is desired)
-setup_replay                ## configure logdir and tmux sessions
-start_replay                ## replay pre-nakamoto blocks (2.x)
-start_replay nakamoto       ## replay nakamoto blocks
-store_results               ## store aggregated results of replay
-echo "Replay finished: $(date)"
+echo "Validation Started: ${COLYELLOW}$(date)${COLRESET}"
+build_stacks_inspect        ## comment if using an existing chainstate/slice dir (ex: validation was performed already, and a second run is desired)
+configure_validation_slices ## comment if using an existing chainstate/slice dir (ex: validation was performed already, and a second run is desired)
+setup_validation            ## configure logdir and tmux sessions
+start_validation            ## validate pre-nakamoto blocks (2.x)
+start_validation nakamoto   ## validate nakamoto blocks
+store_results               ## store aggregated results of validation
+echo "Validation finished: $(date)"


### PR DESCRIPTION
closes https://github.com/stacks-network/stacks-core/issues/6535
Renaming block-replay script to block-validation

Renamed stacks-inspect functions
  - replay_block -> validate_block
  - replay_block_nakamoto -> validate_block_nakamoto


In testing mode, the script works as expected with the renamed args and variables. stacks-insepct running standalone:
```
$ /home/wileyj/stacks-core-wileyj/target/release/stacks-inspect --config /home/wileyj/stacks-core-wileyj/stackslib/conf/mainnet-follower-conf.toml validate-naka-block  /home/wileyj/scratch/slice0 index-range 300883 300884
Will check 1 blocks
Checked 0...
INFO [1759020683.082721] [contrib/stacks-inspect/src/lib.rs:921] [main] Process staging Nakamoto block, consensus_hash: e1199376248cf03bf4ff4e9fda9ce1f93aaf1e72, stacks_block_hash: 2376f9e52a0f149493d12713dce72315bb8f4a4e460b6ad12310c2544a37f1e4, stacks_block_id: 15471d806b8ae0ccbdf996b3de498874fc55597900eaaf08b3cc5c9052dc2e42, burn_block_hash: 00000000000000000001c7a7eed3c2e31045f9493a6184060a33b7a2f1c773ab
INFO [1759020683.201138] [stackslib/src/chainstate/stacks/db/transactions.rs:1127] [main] Contract-call successfully processed, txid: 175936b65b897209e10d5e2a288f1ed05bb112ef8f074b102b5dca9c76b52dfc, origin: SPJH144XQV4YAJJTD5FMWN97N46F6PVP6B4R1KPE, origin_nonce: 331, contract_name: SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.borrow-helper-v2-1-5, function_name: supply, function_args: [SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.zaeusdc-v2-0, SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.pool-0-reserve-v2-0, SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc, u99200000, SPJH144XQV4YAJJTD5FMWN97N46F6PVP6B4R1KPE, none, SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.incentives-v2-2], return_value: (ok true), cost: ExecutionCost { write_length: 3109, write_count: 12, read_length: 2367508, read_count: 438, runtime: 5064404 }
INFO [1759020683.235715] [stackslib/src/chainstate/stacks/db/transactions.rs:1127] [main] Contract-call successfully processed, txid: a1607dc0062f35ed8210aeb3049ad74e5d68f263978bb504be06cfb770fe9060, origin: SPN3AV2KQ8HYFHGKC34SGVSS9TNMJXG56GXRSR70, origin_nonce: 8736, contract_name: SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.stableswap-stx-ststx-v-1-2, function_name: swap-x-for-y, function_args: [SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token, SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.stx-ststx-lp-token-v-1-2, u1000000, u856651], return_value: (ok u892343), cost: ExecutionCost { write_length: 500, write_count: 7, read_length: 84424, read_count: 1178, runtime: 21068241 }
Finished. run_time_seconds = 0


$ /home/wileyj/stacks-core-wileyj/target/release/stacks-inspect --config /home/wileyj/stacks-core-wileyj/stackslib/conf/mainnet-follower-conf.toml validate-block  /home/wileyj/scratch/slice0 index-range 152000 152001
Will check 1 blocks
Checked 0...
INFO [1759020714.277165] [contrib/stacks-inspect/src/lib.rs:791] [main] Process block 6a72d4834537cbfaaa7a47fc318636712d156fb2/f9b6cdfb3d3e14da64ca8fa67d3a26490e54f71e37d73b43069b01d6575155c6 = d1b16d1b37ad04bd9089a653cb5a2cc4327d4963a984d0916a3003858db96145 in burn block 00000000000000000002ff0f8a651531c0c74f66195f9d97ae1eae383bce835d, parent microblock 0000000000000000000000000000000000000000000000000000000000000000
INFO [1759020714.329945] [stackslib/src/chainstate/stacks/db/transactions.rs:1127] [main] Contract-call successfully processed, txid: 25f8409fe41c70e6c28dc08b451481d00bdd6864e41aa468f32119aa2d7dc26c, origin: SP3AP6DRSQ6P4FETB5M33D082Q2ABGJW60MT6103Q, origin_nonce: 46317, contract_name: SP3NE50GEXFG9SZGTT51P40X2CKYSZ5CC4ZTZ7A2G.welshcorgicoin-token, function_name: transfer, function_args: [u99024010000, SP3AP6DRSQ6P4FETB5M33D082Q2ABGJW60MT6103Q, SP3RYGTCPHMMD2MSJ7VHX7AZWQHHXF4JZP7BQW0G0, none], return_value: (ok true), cost: ExecutionCost { write_length: 1, write_count: 2, read_length: 2268, read_count: 5, runtime: 5456 }
...
INFO [1759020715.322141] [contrib/stacks-inspect/src/lib.rs:859] [main] Block processed successfully! block = d1b16d1b37ad04bd9089a653cb5a2cc4327d4963a984d0916a3003858db96145
Finished. run_time_seconds = 1
```