### PR TITLE
Make TestPeer use TestChainstate internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## Unreleased
+## [3.2.0.0.2]
 
 ### Added
 

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
 
-## Unreleased
+## [3.2.0.0.2.0]
 
 ### Added
 

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -60,6 +60,7 @@ use crate::chainstate::stacks::{
     TokenTransferMemo, TransactionAnchorMode, TransactionAuth, TransactionPayload,
     TransactionSmartContract, TransactionVersion,
 };
+use crate::chainstate::tests::TestChainstateConfig;
 use crate::clarity::vm::types::StacksAddressExtensions;
 use crate::core::StacksEpochExtension;
 use crate::net::relay::{BlockAcceptResponse, Relayer};
@@ -176,8 +177,9 @@ pub fn boot_nakamoto<'a>(
     peer_config
         .stacker_dbs
         .push(boot_code_id(MINERS_NAME, false));
-    peer_config.epochs = Some(StacksEpoch::unit_test_3_0_only(37));
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
+    peer_config.chain_config.epochs = Some(StacksEpoch::unit_test_3_0_only(37));
+    peer_config.chain_config.initial_balances =
+        vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
 
     // Create some balances for test Stackers
     let mut stacker_balances = test_stackers
@@ -201,15 +203,40 @@ pub fn boot_nakamoto<'a>(
         })
         .collect();
 
-    peer_config.initial_balances.append(&mut stacker_balances);
-    peer_config.initial_balances.append(&mut signer_balances);
-    peer_config.initial_balances.append(&mut initial_balances);
-    peer_config.burnchain.pox_constants.v2_unlock_height = 21;
-    peer_config.burnchain.pox_constants.pox_3_activation_height = 26;
-    peer_config.burnchain.pox_constants.v3_unlock_height = 27;
-    peer_config.burnchain.pox_constants.pox_4_activation_height = 31;
-    peer_config.test_stackers = Some(test_stackers.to_vec());
-    peer_config.test_signers = Some(test_signers.clone());
+    peer_config
+        .chain_config
+        .initial_balances
+        .append(&mut stacker_balances);
+    peer_config
+        .chain_config
+        .initial_balances
+        .append(&mut signer_balances);
+    peer_config
+        .chain_config
+        .initial_balances
+        .append(&mut initial_balances);
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .v2_unlock_height = 21;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_3_activation_height = 26;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .v3_unlock_height = 27;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_4_activation_height = 31;
+    peer_config.chain_config.test_stackers = Some(test_stackers.to_vec());
+    peer_config.chain_config.test_signers = Some(test_signers.clone());
     let mut peer = TestPeer::new_with_observer(peer_config, observer);
 
     advance_to_nakamoto(&mut peer, test_signers, test_stackers);
@@ -220,13 +247,18 @@ pub fn boot_nakamoto<'a>(
 /// Make a replay peer, used for replaying the blockchain
 pub fn make_replay_peer<'a>(peer: &mut TestPeer<'a>) -> TestPeer<'a> {
     let mut replay_config = peer.config.clone();
-    replay_config.test_name = format!("{}.replay", &peer.config.test_name);
+    replay_config.chain_config.test_name =
+        format!("{}.replay", &peer.config.chain_config.test_name);
     replay_config.server_port = 0;
     replay_config.http_port = 0;
-    replay_config.test_stackers = peer.config.test_stackers.clone();
+    replay_config.chain_config.test_stackers = peer.config.chain_config.test_stackers.clone();
 
-    let test_stackers = replay_config.test_stackers.clone().unwrap_or_default();
-    let mut test_signers = replay_config.test_signers.clone().unwrap();
+    let test_stackers = replay_config
+        .chain_config
+        .test_stackers
+        .clone()
+        .unwrap_or_default();
+    let mut test_signers = replay_config.chain_config.test_signers.clone().unwrap();
     let mut replay_peer = TestPeer::new(replay_config);
     let observer = TestEventObserver::new();
     advance_to_nakamoto(
@@ -237,12 +269,12 @@ pub fn make_replay_peer<'a>(peer: &mut TestPeer<'a>) -> TestPeer<'a> {
 
     // sanity check
     let replay_tip = {
-        let sort_db = replay_peer.sortdb.as_ref().unwrap();
+        let sort_db = replay_peer.sortdb_ref();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         tip
     };
     let tip = {
-        let sort_db = peer.sortdb.as_ref().unwrap();
+        let sort_db = peer.sortdb_ref();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let sort_ic = sort_db.index_conn();
         let ancestor_tip = SortitionDB::get_ancestor_snapshot(
@@ -330,7 +362,12 @@ fn replay_reward_cycle(
     stacks_blocks: &[NakamotoBlock],
 ) {
     eprintln!("\n\n=============================================\nBegin replay\n==============================================\n");
-    let reward_cycle_length = peer.config.burnchain.pox_constants.reward_cycle_length as usize;
+    let reward_cycle_length = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .reward_cycle_length as usize;
     let reward_cycle_indices: Vec<usize> = (0..stacks_blocks.len())
         .step_by(reward_cycle_length)
         .collect();
@@ -339,8 +376,8 @@ fn replay_reward_cycle(
         let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
     }
 
-    let sortdb = peer.sortdb.take().unwrap();
-    let mut node = peer.stacks_node.take().unwrap();
+    let sortdb = peer.chain.sortdb.take().unwrap();
+    let mut node = peer.chain.stacks_node.take().unwrap();
 
     let sort_tip = SortitionDB::get_canonical_sortition_tip(sortdb.conn()).unwrap();
     let mut sort_handle = sortdb.index_handle(&sort_tip);
@@ -353,7 +390,7 @@ fn replay_reward_cycle(
         info!("Process Nakamoto block {} ({:?}", &block_id, &block.header);
 
         let accepted = Relayer::process_new_nakamoto_block(
-            &peer.config.burnchain,
+            &peer.config.chain_config.burnchain,
             &sortdb,
             &mut sort_handle,
             &mut node.chainstate,
@@ -367,7 +404,7 @@ fn replay_reward_cycle(
         ));
         if accepted.is_accepted() {
             test_debug!("Accepted Nakamoto block {block_id}");
-            peer.coord.handle_new_nakamoto_stacks_block().unwrap();
+            peer.chain.coord.handle_new_nakamoto_stacks_block().unwrap();
         } else {
             test_debug!("Did NOT accept Nakamoto block {block_id}");
             blocks_to_process.push(block);
@@ -375,8 +412,8 @@ fn replay_reward_cycle(
         }
     }
 
-    peer.sortdb = Some(sortdb);
-    peer.stacks_node = Some(node);
+    peer.chain.sortdb = Some(sortdb);
+    peer.chain.stacks_node = Some(node);
 
     peer.check_nakamoto_migration();
 }
@@ -400,8 +437,8 @@ fn test_simple_nakamoto_coordinator_bootup() {
 
     tenure_change.tenure_consensus_hash = consensus_hash.clone();
     tenure_change.burn_view_consensus_hash = consensus_hash.clone();
-    let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change);
-    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let tenure_change_tx = peer.chain.miner.make_nakamoto_tenure_change(tenure_change);
+    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
     let blocks_and_sizes = peer.make_nakamoto_tenure(
         tenure_change_tx,
@@ -414,8 +451,8 @@ fn test_simple_nakamoto_coordinator_bootup() {
         .map(|(block, _, _)| block)
         .collect();
 
-    let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-    let sort_db = peer.sortdb.as_mut().unwrap();
+    let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
     let tip = NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
         .unwrap()
         .unwrap();
@@ -463,8 +500,8 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
     tenure_change.tenure_consensus_hash = consensus_hash.clone();
     tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
-    let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change);
-    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let tenure_change_tx = peer.chain.miner.make_nakamoto_tenure_change(tenure_change);
+    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
     // do a stx transfer in each block to a given recipient
     let recipient_addr =
@@ -502,8 +539,8 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
         .collect();
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -527,8 +564,8 @@ fn test_simple_nakamoto_coordinator_1_tenure_10_blocks() {
     replay_reward_cycle(&mut replay_peer, &[burn_ops], &blocks);
 
     let tip = {
-        let chainstate = &mut replay_peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = replay_peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut replay_peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = replay_peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -563,8 +600,8 @@ impl TestPeer<'_> {
         G: FnMut(&mut NakamotoBlock) -> bool,
     {
         let nakamoto_tip = {
-            let chainstate = &mut self.stacks_node.as_mut().unwrap().chainstate;
-            let sort_db = self.sortdb.as_mut().unwrap();
+            let chainstate = &mut self.chain.stacks_node.as_mut().unwrap().chainstate;
+            let sort_db = self.chain.sortdb.as_mut().unwrap();
             NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
                 .unwrap()
                 .unwrap()
@@ -593,7 +630,7 @@ impl TestPeer<'_> {
         G: FnMut(&mut NakamotoBlock) -> bool,
     {
         let sender_addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(sender_key));
-        let mut test_signers = self.config.test_signers.clone().unwrap();
+        let mut test_signers = self.config.chain_config.test_signers.clone().unwrap();
         let recipient_addr =
             StacksAddress::from_string("ST2YM3J4KQK09V670TD6ZZ1XYNYCNGCWCVTASN5VM").unwrap();
 
@@ -643,7 +680,7 @@ impl TestPeer<'_> {
         let (burn_height, _, consensus_hash) = self.next_burnchain_block(burn_ops);
         let pox_constants = self.sortdb().pox_constants.clone();
         let first_burn_height = self.sortdb().first_block_height;
-        let mut test_signers = self.config.test_signers.clone().unwrap();
+        let mut test_signers = self.config.chain_config.test_signers.clone().unwrap();
 
         info!(
             "Burnchain block produced: {burn_height}, in_prepare_phase?: {}, first_reward_block?: {}",
@@ -656,12 +693,12 @@ impl TestPeer<'_> {
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
         let nakamoto_tip =
-            if let Some(nakamoto_parent_tenure) = self.nakamoto_parent_tenure_opt.as_ref() {
+            if let Some(nakamoto_parent_tenure) = self.chain.nakamoto_parent_tenure_opt.as_ref() {
                 nakamoto_parent_tenure.last().as_ref().unwrap().block_id()
             } else {
                 let tip = {
-                    let chainstate = &mut self.stacks_node.as_mut().unwrap().chainstate;
-                    let sort_db = self.sortdb.as_mut().unwrap();
+                    let chainstate = &mut self.chain.stacks_node.as_mut().unwrap().chainstate;
+                    let sort_db = self.chain.sortdb.as_mut().unwrap();
                     NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
                         .unwrap()
                         .unwrap()
@@ -669,16 +706,19 @@ impl TestPeer<'_> {
                 tip.index_block_hash()
             };
 
-        let miner_addr = self.miner.origin_address().unwrap();
+        let miner_addr = self.chain.miner.origin_address().unwrap();
         let miner_acct = self.get_account(&nakamoto_tip, &miner_addr.to_account_principal());
 
         let tenure_change_tx = self
+            .chain
             .miner
             .make_nakamoto_tenure_change_with_nonce(tenure_change, miner_acct.nonce);
 
-        let coinbase_tx =
-            self.miner
-                .make_nakamoto_coinbase_with_nonce(None, vrf_proof, miner_acct.nonce + 1);
+        let coinbase_tx = self.chain.miner.make_nakamoto_coinbase_with_nonce(
+            None,
+            vrf_proof,
+            miner_acct.nonce + 1,
+        );
 
         self.make_nakamoto_tenure_and(
             tenure_change_tx,
@@ -746,12 +786,12 @@ impl TestPeer<'_> {
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
         let nakamoto_tip =
-            if let Some(nakamoto_parent_tenure) = self.nakamoto_parent_tenure_opt.as_ref() {
+            if let Some(nakamoto_parent_tenure) = self.chain.nakamoto_parent_tenure_opt.as_ref() {
                 nakamoto_parent_tenure.last().as_ref().unwrap().block_id()
             } else {
                 let tip = {
-                    let chainstate = &mut self.stacks_node.as_mut().unwrap().chainstate;
-                    let sort_db = self.sortdb.as_mut().unwrap();
+                    let chainstate = &mut self.chain.stacks_node.as_mut().unwrap().chainstate;
+                    let sort_db = self.chain.sortdb.as_mut().unwrap();
                     NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
                         .unwrap()
                         .unwrap()
@@ -759,16 +799,19 @@ impl TestPeer<'_> {
                 tip.index_block_hash()
             };
 
-        let miner_addr = self.miner.origin_address().unwrap();
+        let miner_addr = self.chain.miner.origin_address().unwrap();
         let miner_acct = self.get_account(&nakamoto_tip, &miner_addr.to_account_principal());
 
         let tenure_change_tx = self
+            .chain
             .miner
             .make_nakamoto_tenure_change_with_nonce(tenure_change, miner_acct.nonce);
 
-        let coinbase_tx =
-            self.miner
-                .make_nakamoto_coinbase_with_nonce(None, vrf_proof, miner_acct.nonce + 1);
+        let coinbase_tx = self.chain.miner.make_nakamoto_coinbase_with_nonce(
+            None,
+            vrf_proof,
+            miner_acct.nonce + 1,
+        );
 
         let block = self.mine_single_block_tenure_at_tip(
             &nakamoto_tip,
@@ -813,7 +856,7 @@ fn block_descendant() {
         })
         .collect::<Vec<_>>();
     let test_signers = TestSigners::new(vec![signing_key]);
-    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    let mut pox_constants = TestChainstateConfig::default().burnchain.pox_constants;
     pox_constants.reward_cycle_length = 10;
     pox_constants.v2_unlock_height = 21;
     pox_constants.pox_3_activation_height = 26;
@@ -902,7 +945,7 @@ fn block_info_tests(use_primary_testnet: bool) {
         })
         .collect::<Vec<_>>();
     let test_signers = TestSigners::new(vec![signing_key]);
-    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    let mut pox_constants = TestChainstateConfig::default().burnchain.pox_constants;
     pox_constants.reward_cycle_length = 10;
     pox_constants.v2_unlock_height = 21;
     pox_constants.pox_3_activation_height = 26;
@@ -1337,7 +1380,7 @@ fn pox_treatment() {
         })
         .collect::<Vec<_>>();
     let test_signers = TestSigners::new(vec![signing_key]);
-    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    let mut pox_constants = TestChainstateConfig::default().burnchain.pox_constants;
     pox_constants.reward_cycle_length = 10;
     pox_constants.v2_unlock_height = 21;
     pox_constants.pox_3_activation_height = 26;
@@ -1550,8 +1593,8 @@ fn pox_treatment() {
     blocks.push(block);
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -1590,7 +1633,7 @@ fn transactions_indexing() {
         })
         .collect::<Vec<_>>();
     let test_signers = TestSigners::new(vec![signing_key]);
-    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    let mut pox_constants = TestChainstateConfig::default().burnchain.pox_constants;
     pox_constants.reward_cycle_length = 10;
     pox_constants.v2_unlock_height = 21;
     pox_constants.pox_3_activation_height = 26;
@@ -1614,7 +1657,7 @@ fn transactions_indexing() {
 
     let tracked_block_id = tracked_block.block_id();
 
-    let chainstate = &peer.stacks_node.unwrap().chainstate;
+    let chainstate = &peer.chain.stacks_node.unwrap().chainstate;
 
     // compare transactions to what has been tracked
     for tx in tracked_block.txs {
@@ -1655,7 +1698,7 @@ fn transactions_not_indexing() {
         })
         .collect::<Vec<_>>();
     let test_signers = TestSigners::new(vec![signing_key]);
-    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    let mut pox_constants = TestChainstateConfig::default().burnchain.pox_constants;
     pox_constants.reward_cycle_length = 10;
     pox_constants.v2_unlock_height = 21;
     pox_constants.pox_3_activation_height = 26;
@@ -1679,7 +1722,7 @@ fn transactions_not_indexing() {
 
     let untracked_block_id = untracked_block.block_id();
 
-    let chainstate = &peer.stacks_node.unwrap().chainstate;
+    let chainstate = &peer.chain.stacks_node.unwrap().chainstate;
 
     // ensure untracked transactions are not recorded
     for tx in untracked_block.txs {
@@ -1721,13 +1764,13 @@ fn test_nakamoto_chainstate_getters() {
     );
 
     let sort_tip = {
-        let sort_db = peer.sortdb.as_ref().unwrap();
+        let sort_db = peer.chain.sortdb.as_ref().unwrap();
         SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
     };
     {
         // scope this to drop the chainstate ref and db tx
-        let chainstate = &peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let sort_handle = sort_db.index_handle(&sort_tip.sortition_id);
 
         // no tenures yet
@@ -1753,8 +1796,8 @@ fn test_nakamoto_chainstate_getters() {
 
     tenure_change.tenure_consensus_hash = consensus_hash.clone();
     tenure_change.burn_view_consensus_hash = consensus_hash.clone();
-    let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change);
-    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let tenure_change_tx = peer.chain.miner.make_nakamoto_tenure_change(tenure_change);
+    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
     // do a stx transfer in each block to a given recipient
     let recipient_addr =
@@ -1792,8 +1835,8 @@ fn test_nakamoto_chainstate_getters() {
         .collect();
 
     let tip = {
-        let chainstate = &peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -1811,14 +1854,10 @@ fn test_nakamoto_chainstate_getters() {
         &blocks.last().unwrap().header
     );
 
-    let sort_tip = {
-        let sort_db = peer.sortdb.as_ref().unwrap();
-        SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
-    };
+    let sort_tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb_ref().conn()).unwrap();
     {
         // scope this to drop the chainstate ref and db tx
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_ref().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
 
         for coinbase_height in 0..=((tip
             .anchored_header
@@ -1856,8 +1895,8 @@ fn test_nakamoto_chainstate_getters() {
     debug!("\n======================================\nBegin tests\n===========================================\n");
     {
         // scope this to drop the chainstate ref and db tx
-        let chainstate = &peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let mut sort_tx = sort_db.tx_handle_begin(&sort_tip.sortition_id).unwrap();
 
         // we now have a tenure, and it confirms the last epoch2 block
@@ -1999,8 +2038,14 @@ fn test_nakamoto_chainstate_getters() {
     next_tenure_change.tenure_consensus_hash = next_consensus_hash.clone();
     next_tenure_change.burn_view_consensus_hash = next_consensus_hash.clone();
 
-    let next_tenure_change_tx = peer.miner.make_nakamoto_tenure_change(next_tenure_change);
-    let next_coinbase_tx = peer.miner.make_nakamoto_coinbase(None, next_vrf_proof);
+    let next_tenure_change_tx = peer
+        .chain
+        .miner
+        .make_nakamoto_tenure_change(next_tenure_change);
+    let next_coinbase_tx = peer
+        .chain
+        .miner
+        .make_nakamoto_coinbase(None, next_vrf_proof);
 
     // make the second tenure's blocks
     let blocks_and_sizes = peer.make_nakamoto_tenure(
@@ -2035,13 +2080,13 @@ fn test_nakamoto_chainstate_getters() {
         .collect();
 
     let sort_tip = {
-        let sort_db = peer.sortdb.as_ref().unwrap();
+        let sort_db = peer.sortdb_ref();
         SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
     };
     {
         // scope this to drop the chainstate ref and db tx
-        let chainstate = &peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
 
         let mut sort_tx = sort_db.tx_handle_begin(&sort_tip.sortition_id).unwrap();
 
@@ -2215,7 +2260,7 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
     let mut consensus_hashes = vec![];
     let mut fee_counts = vec![];
     let mut total_blocks = 0;
-    let stx_miner_key = peer.miner.nakamoto_miner_key();
+    let stx_miner_key = peer.chain.miner.nakamoto_miner_key();
     let stx_miner_addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -2235,9 +2280,10 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
         let tenure_change_tx = peer
+            .chain
             .miner
             .make_nakamoto_tenure_change(tenure_change.clone());
-        let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+        let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
         debug!("Next burnchain block: {}", &consensus_hash);
 
@@ -2296,11 +2342,12 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
 
         // if we're starting a new reward cycle, then save the current one
         let tip = {
-            let sort_db = peer.sortdb.as_mut().unwrap();
+            let sort_db = peer.chain.sortdb.as_mut().unwrap();
             SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
         };
         if peer
             .config
+            .chain_config
             .burnchain
             .is_naka_signing_cycle_start(tip.block_height)
         {
@@ -2324,8 +2371,8 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
     // in nakamoto, tx fees are rewarded by the next tenure, so the
     // scheduled rewards come 1 tenure after the coinbase reward matures
     let miner = p2pkh_from(&stx_miner_key);
-    let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-    let sort_db = peer.sortdb.as_mut().unwrap();
+    let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
 
     // this is sortition height 12, and this miner has earned all 12 of the coinbases
     // plus the initial per-block mining bonus of 2600 STX, but minus the last three rewards (since
@@ -2389,8 +2436,8 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
     }
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -2411,8 +2458,8 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
     // verify that matured miner records were in place
     let mut matured_rewards = vec![];
     {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let (mut chainstate_tx, _) = chainstate.chainstate_tx_begin().unwrap();
         for i in 0..24 {
             let matured_reward_opt = NakamotoChainState::get_matured_miner_reward_schedules(
@@ -2502,8 +2549,8 @@ pub fn simple_nakamoto_coordinator_10_tenures_10_sortitions<'a>() -> TestPeer<'a
     }
 
     let tip = {
-        let chainstate = &mut replay_peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = replay_peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut replay_peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = replay_peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -2565,9 +2612,10 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
     tenure_change.tenure_consensus_hash = consensus_hash.clone();
     tenure_change.burn_view_consensus_hash = consensus_hash.clone();
     let tenure_change_tx = peer
+        .chain
         .miner
         .make_nakamoto_tenure_change(tenure_change.clone());
-    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
     rc_burn_ops.push(burn_ops);
 
@@ -2609,8 +2657,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
     all_blocks.append(&mut blocks.clone());
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -2630,8 +2678,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
 
     // highest tenure is our tenure-change
     let (highest_tenure, sort_tip) = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let tenure = NakamotoChainState::get_ongoing_tenure(
             &mut chainstate.index_conn(),
@@ -2668,7 +2716,10 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
         blocks.last().cloned().unwrap().header.block_id(),
         blocks.len() as u32,
     );
-    let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change_extend);
+    let tenure_change_tx = peer
+        .chain
+        .miner
+        .make_nakamoto_tenure_change(tenure_change_extend);
 
     let blocks_and_sizes = peer.make_nakamoto_tenure_extension(
         tenure_change_tx,
@@ -2703,8 +2754,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
     all_blocks.append(&mut blocks.clone());
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -2725,8 +2776,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
 
     // highest tenure is our tenure-extend
     let (highest_tenure, sort_tip) = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let tenure = NakamotoChainState::get_ongoing_tenure(
             &mut chainstate.index_conn(),
@@ -2759,8 +2810,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
     tenure_change.tenure_consensus_hash = consensus_hash.clone();
     tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
-    let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change);
-    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let tenure_change_tx = peer.chain.miner.make_nakamoto_tenure_change(tenure_change);
+    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
     rc_burn_ops.push(burn_ops);
 
@@ -2802,8 +2853,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
     all_blocks.append(&mut blocks.clone());
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -2823,8 +2874,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
 
     // highest tenure is our new tenure-change
     let (highest_tenure, sort_tip) = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
         let tenure = NakamotoChainState::get_ongoing_tenure(
             &mut chainstate.index_conn(),
@@ -2854,8 +2905,8 @@ pub fn simple_nakamoto_coordinator_2_tenures_3_sortitions<'a>() -> TestPeer<'a> 
     replay_reward_cycle(&mut replay_peer, &rc_burn_ops, &all_blocks);
 
     let tip = {
-        let chainstate = &mut replay_peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = replay_peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut replay_peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = replay_peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -2912,7 +2963,7 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
     let mut rc_burn_ops = vec![];
     let mut consensus_hashes = vec![];
     let mut fee_counts = vec![];
-    let stx_miner_key = peer.miner.nakamoto_miner_key();
+    let stx_miner_key = peer.chain.miner.nakamoto_miner_key();
 
     for i in 0..10 {
         let (burn_ops, mut tenure_change, miner_key) =
@@ -2924,9 +2975,10 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
         let tenure_change_tx = peer
+            .chain
             .miner
             .make_nakamoto_tenure_change(tenure_change.clone());
-        let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+        let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
         debug!("Next burnchain block: {}", &consensus_hash);
 
@@ -3002,8 +3054,8 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
 
         // check that our tenure-extends have been getting applied
         let (highest_tenure, sort_tip) = {
-            let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-            let sort_db = peer.sortdb.as_mut().unwrap();
+            let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+            let sort_db = peer.chain.sortdb.as_mut().unwrap();
             let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
             let tenure = NakamotoChainState::get_ongoing_tenure(
                 &mut chainstate.index_conn(),
@@ -3037,11 +3089,12 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
 
         // if we're starting a new reward cycle, then save the current one
         let tip = {
-            let sort_db = peer.sortdb.as_mut().unwrap();
+            let sort_db = peer.chain.sortdb.as_mut().unwrap();
             SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
         };
         if peer
             .config
+            .chain_config
             .burnchain
             .is_naka_signing_cycle_start(tip.block_height)
         {
@@ -3062,8 +3115,8 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
     // in nakamoto, tx fees are rewarded by the next tenure, so the
     // scheduled rewards come 1 tenure after the coinbase reward matures
     let miner = p2pkh_from(&stx_miner_key);
-    let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-    let sort_db = peer.sortdb.as_mut().unwrap();
+    let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
 
     // this is sortition height 12, and this miner has earned all 12 of the coinbases
     // plus the initial per-block mining bonus of 2600 STX, but minus the last three rewards (since
@@ -3111,13 +3164,9 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
         }
 
         eprintln!(
-            "Checking block #{} ({},{}): {} =?= {} + {}",
-            i,
-            &ch,
+            "Checking block #{i} ({ch},{}): {} =?= {expected_total_coinbase} + {expected_total_tx_fees}",
             &sn.block_height,
-            stx_balance.amount_unlocked(),
-            expected_total_coinbase,
-            expected_total_tx_fees
+            stx_balance.amount_unlocked()
         );
         assert_eq!(
             stx_balance.amount_unlocked(),
@@ -3126,8 +3175,8 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
     }
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -3153,8 +3202,8 @@ pub fn simple_nakamoto_coordinator_10_extended_tenures_10_sortitions() -> TestPe
     }
 
     let tip = {
-        let chainstate = &mut replay_peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = replay_peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut replay_peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = replay_peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -3208,7 +3257,7 @@ fn process_next_nakamoto_block_deadlock() {
         })
         .collect::<Vec<_>>();
     let test_signers = TestSigners::new(vec![signing_key]);
-    let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+    let mut pox_constants = TestChainstateConfig::default().burnchain.pox_constants;
     pox_constants.reward_cycle_length = 10;
     pox_constants.v2_unlock_height = 21;
     pox_constants.pox_3_activation_height = 26;
@@ -3226,6 +3275,7 @@ fn process_next_nakamoto_block_deadlock() {
     let mut peer = boot_plan.boot_into_nakamoto_peer(vec![], None);
     let mut sortition_db = peer.sortdb().reopen().unwrap();
     let (chainstate, _) = &mut peer
+        .chain
         .stacks_node
         .as_mut()
         .unwrap()
@@ -3314,13 +3364,14 @@ fn test_stacks_on_burnchain_ops() {
     );
 
     let mut all_blocks: Vec<NakamotoBlock> = vec![];
-    let stx_miner_key = peer.miner.nakamoto_miner_key();
+    let stx_miner_key = peer.chain.miner.nakamoto_miner_key();
 
     let mut extra_burn_ops = vec![];
     let mut bitpatterns = HashMap::new(); // map consensus hash to txid bit pattern
 
     let cur_reward_cycle = peer
         .config
+        .chain_config
         .burnchain
         .block_height_to_reward_cycle(peer.get_burn_block_height())
         .unwrap();
@@ -3417,9 +3468,10 @@ fn test_stacks_on_burnchain_ops() {
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
         let tenure_change_tx = peer
+            .chain
             .miner
             .make_nakamoto_tenure_change(tenure_change.clone());
-        let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+        let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
         debug!("Next burnchain block: {}", &consensus_hash);
 
@@ -3517,8 +3569,8 @@ fn test_stacks_on_burnchain_ops() {
 
         // check that our tenure-extends have been getting applied
         let (highest_tenure, sort_tip) = {
-            let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-            let sort_db = peer.sortdb.as_mut().unwrap();
+            let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+            let sort_db = peer.chain.sortdb.as_mut().unwrap();
             let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
             let tenure = NakamotoChainState::get_ongoing_tenure(
                 &mut chainstate.index_conn(),
@@ -3608,8 +3660,8 @@ fn test_stacks_on_burnchain_ops() {
     }
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -1991,7 +1991,7 @@ fn test_make_miners_stackerdb_config() {
         None,
     );
 
-    let naka_miner_hash160 = peer.miner.nakamoto_miner_hash160();
+    let naka_miner_hash160 = peer.chain.miner.nakamoto_miner_hash160();
     let miner_keys: Vec<_> = (0..10).map(|_| StacksPrivateKey::random()).collect();
     let miner_hash160s: Vec<_> = miner_keys
         .iter()
@@ -2009,8 +2009,8 @@ fn test_make_miners_stackerdb_config() {
     debug!("miners = {:#?}", &miner_hash160s);
 
     // extract chainstate, sortdb, and stackerdbs -- we don't need the peer anymore
-    let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-    let sort_db = peer.sortdb.as_mut().unwrap();
+    let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
     let mut last_snapshot = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
     let stackerdbs = peer.network.stackerdbs;
     let miners_contract_id = boot_code_id(MINERS_NAME, false);
@@ -3261,9 +3261,7 @@ pub mod nakamoto_block_signatures {
 
         match header.verify_signer_signatures(&reward_set) {
             Ok(_) => panic!("Expected duplicate signature to fail"),
-            Err(ChainstateError::InvalidStacksBlock(msg)) => {
-                assert!(msg.contains("Signatures are out of order"));
-            }
+            Err(ChainstateError::InvalidStacksBlock(_)) => {}
             _ => panic!("Expected InvalidStacksBlock error"),
         }
     }

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -34,15 +34,12 @@ use crate::chainstate::burn::operations::{
 use crate::chainstate::burn::*;
 use crate::chainstate::coordinator::tests::NullEventDispatcher;
 use crate::chainstate::coordinator::{ChainsCoordinator, OnChainRewardSetProvider};
-use crate::chainstate::nakamoto::coordinator::{
-    get_nakamoto_next_recipients, load_nakamoto_reward_set,
-};
+use crate::chainstate::nakamoto::coordinator::load_nakamoto_reward_set;
 use crate::chainstate::nakamoto::miner::NakamotoBlockBuilder;
 use crate::chainstate::nakamoto::staging_blocks::{
     NakamotoBlockObtainMethod, NakamotoStagingBlocksConnRef,
 };
 use crate::chainstate::nakamoto::test_signers::TestSigners;
-use crate::chainstate::nakamoto::tests::get_account;
 use crate::chainstate::nakamoto::{
     NakamotoBlock, NakamotoBlockHeader, NakamotoChainState, StacksDBIndexed,
 };
@@ -1152,218 +1149,23 @@ impl TestPeer<'_> {
         TenureChangePayload,
         LeaderKeyRegisterOp,
     ) {
-        let mut sortdb = self.sortdb.take().unwrap();
-        let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
-
-        let mut burn_block = TestBurnchainBlock::new(&tip, 0);
-        let mut stacks_node = self.stacks_node.take().unwrap();
-
-        let (last_tenure_id, parent_block_opt, parent_tenure_opt) =
-            if let Some(nakamoto_parent_tenure) = self.nakamoto_parent_tenure_opt.as_ref() {
-                (
-                    nakamoto_parent_tenure.first().as_ref().unwrap().block_id(),
-                    None,
-                    Some(nakamoto_parent_tenure.clone()),
-                )
-            } else {
-                get_nakamoto_parent(&self.miner, &stacks_node, &sortdb)
-            };
-
-        // find the VRF leader key register tx to use.
-        // it's the one pointed to by the parent tenure
-        let parent_consensus_hash_and_tenure_start_id_opt =
-            if let Some(parent_tenure) = parent_tenure_opt.as_ref() {
-                let tenure_start_block = parent_tenure.first().unwrap();
-                Some((
-                    tenure_start_block.header.consensus_hash.clone(),
-                    tenure_start_block.block_id(),
-                ))
-            } else if let Some(parent_block) = parent_block_opt.as_ref() {
-                let parent_header_info =
-                    StacksChainState::get_stacks_block_header_info_by_index_block_hash(
-                        stacks_node.chainstate.db(),
-                        &last_tenure_id,
-                    )
-                    .unwrap()
-                    .unwrap();
-                Some((
-                    parent_header_info.consensus_hash.clone(),
-                    parent_header_info.index_block_hash(),
-                ))
-            } else {
-                None
-            };
-
-        let last_key = if let Some((ch, parent_tenure_start_block_id)) =
-            parent_consensus_hash_and_tenure_start_id_opt.clone()
-        {
-            // it's possible that the parent was a shadow block.
-            // if so, find the highest non-shadow ancestor's block-commit, so we can
-            let mut cursor = ch;
-            let (tenure_sn, tenure_block_commit) = loop {
-                let tenure_sn = SortitionDB::get_block_snapshot_consensus(sortdb.conn(), &cursor)
-                    .unwrap()
-                    .unwrap();
-
-                let Some(tenure_block_commit) = get_block_commit_by_txid(
-                    sortdb.conn(),
-                    &tenure_sn.sortition_id,
-                    &tenure_sn.winning_block_txid,
-                )
-                .unwrap() else {
-                    // parent must be a shadow block
-                    let header = NakamotoChainState::get_block_header_nakamoto(
-                        stacks_node.chainstate.db(),
-                        &parent_tenure_start_block_id,
-                    )
-                    .unwrap()
-                    .unwrap()
-                    .anchored_header
-                    .as_stacks_nakamoto()
-                    .cloned()
-                    .unwrap();
-
-                    if !header.is_shadow_block() {
-                        panic!("Parent tenure start block ID {} has no block-commit and is not a shadow block", &parent_tenure_start_block_id);
-                    }
-
-                    cursor = stacks_node
-                        .chainstate
-                        .index_conn()
-                        .get_parent_tenure_consensus_hash(&parent_tenure_start_block_id, &cursor)
-                        .unwrap()
-                        .unwrap();
-
-                    continue;
-                };
-                break (tenure_sn, tenure_block_commit);
-            };
-
-            let tenure_leader_key = SortitionDB::get_leader_key_at(
-                &sortdb.index_conn(),
-                tenure_block_commit.key_block_ptr.into(),
-                tenure_block_commit.key_vtxindex.into(),
-                &tenure_sn.sortition_id,
-            )
-            .unwrap()
-            .unwrap();
-            tenure_leader_key
-        } else {
-            panic!("No leader key");
-        };
-
-        let network_id = self.config.network_id;
-        let chainstate_path = self.chainstate_path.clone();
-        let burn_block_height = burn_block.block_height;
-
-        let (mut block_commit_op, tenure_change_payload) = stacks_node.begin_nakamoto_tenure(
-            &sortdb,
-            &mut self.miner,
-            &mut burn_block,
-            &last_key,
-            parent_block_opt.as_ref(),
-            parent_tenure_opt.as_ref().map(|blocks| blocks.as_slice()),
-            1000,
-            tenure_change_cause,
-        );
-
-        // patch up block-commit -- these blocks all mine off of genesis
-        if last_tenure_id == StacksBlockId(BOOT_BLOCK_HASH.0) {
-            block_commit_op.parent_block_ptr = 0;
-            block_commit_op.parent_vtxindex = 0;
-        }
-
-        let mut burn_ops = vec![];
-        if self.miner.last_VRF_public_key().is_none() {
-            let leader_key_op = stacks_node.add_key_register(&mut burn_block, &mut self.miner);
-            burn_ops.push(BlockstackOperationType::LeaderKeyRegister(leader_key_op));
-        }
-
-        // patch in reward set info
-        match get_nakamoto_next_recipients(
-            &tip,
-            &mut sortdb,
-            &mut stacks_node.chainstate,
-            &tenure_change_payload.previous_tenure_end,
-            &self.config.burnchain,
-        ) {
-            Ok(recipients) => {
-                block_commit_op.commit_outs = match recipients {
-                    Some(info) => {
-                        let mut recipients = info
-                            .recipients
-                            .into_iter()
-                            .map(|x| x.0)
-                            .collect::<Vec<PoxAddress>>();
-                        if recipients.len() == 1 {
-                            recipients.push(PoxAddress::standard_burn_address(false));
-                        }
-                        recipients
-                    }
-                    None => {
-                        if self
-                            .config
-                            .burnchain
-                            .is_in_prepare_phase(burn_block.block_height)
-                        {
-                            vec![PoxAddress::standard_burn_address(false)]
-                        } else {
-                            vec![
-                                PoxAddress::standard_burn_address(false),
-                                PoxAddress::standard_burn_address(false),
-                            ]
-                        }
-                    }
-                };
-                test_debug!(
-                    "Block commit at height {} has {} recipients: {:?}",
-                    block_commit_op.block_height,
-                    block_commit_op.commit_outs.len(),
-                    &block_commit_op.commit_outs
-                );
-            }
-            Err(e) => {
-                panic!("Failure fetching recipient set: {e:?}");
-            }
-        };
-
-        burn_ops.push(BlockstackOperationType::LeaderBlockCommit(block_commit_op));
-
-        // prepare to mine
-        let miner_addr = self.miner.origin_address().unwrap();
-        let miner_account = get_account(&mut stacks_node.chainstate, &sortdb, &miner_addr);
-        self.miner.set_nonce(miner_account.nonce);
-
-        self.stacks_node = Some(stacks_node);
-        self.sortdb = Some(sortdb);
-        (burn_ops, tenure_change_payload, last_key)
+        self.chain.begin_nakamoto_tenure(tenure_change_cause)
     }
 
     /// Make the VRF proof for this tenure.
     /// Call after processing the block-commit
     pub fn make_nakamoto_vrf_proof(&mut self, miner_key: LeaderKeyRegisterOp) -> VRFProof {
-        let sortdb = self.sortdb.take().unwrap();
-        let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
-        let proof = self
-            .miner
-            .make_proof(&miner_key.public_key, &tip.sortition_hash)
-            .unwrap_or_else(|| panic!("FATAL: no private key for {:?}", miner_key.public_key));
-        self.sortdb = Some(sortdb);
-        debug!(
-            "VRF proof made from {:?} over {}: {proof:?}",
-            miner_key.public_key, &tip.sortition_hash
-        );
-        proof
+        self.chain.make_nakamoto_vrf_proof(miner_key)
     }
 
     pub fn try_process_block(&mut self, block: &NakamotoBlock) -> Result<bool, ChainstateError> {
-        let mut sort_handle = self.sortdb.as_ref().unwrap().index_handle_at_tip();
+        let mut sort_handle = self.chain.sortdb.as_ref().unwrap().index_handle_at_tip();
         let stacks_tip = sort_handle.get_nakamoto_tip_block_id().unwrap().unwrap();
         let accepted = Relayer::process_new_nakamoto_block(
-            &self.config.burnchain,
-            self.sortdb.as_ref().unwrap(),
+            &self.config.chain_config.burnchain,
+            self.chain.sortdb.as_ref().unwrap(),
             &mut sort_handle,
-            &mut self.stacks_node.as_mut().unwrap().chainstate,
+            &mut self.chain.stacks_node.as_mut().unwrap().chainstate,
             &stacks_tip,
             block,
             None,
@@ -1375,11 +1177,11 @@ impl TestPeer<'_> {
         let sort_tip = SortitionDB::get_canonical_sortition_tip(self.sortdb().conn()).unwrap();
         let Some(block_receipt) =
             NakamotoChainState::process_next_nakamoto_block::<NullEventDispatcher>(
-                &mut self.stacks_node.as_mut().unwrap().chainstate,
-                self.sortdb.as_mut().unwrap(),
+                &mut self.chain.stacks_node.as_mut().unwrap().chainstate,
+                self.chain.sortdb.as_mut().unwrap(),
                 &sort_tip,
                 None,
-                self.config.txindex,
+                self.config.chain_config.txindex,
             )?
         else {
             return Ok(false);
@@ -1454,7 +1256,7 @@ impl TestPeer<'_> {
             let blocks = TestStacksNode::make_nakamoto_tenure_blocks(
                 &mut stacks_node.chainstate,
                 sortdb,
-                &mut peer.miner,
+                &mut peer.chain.miner,
                 signers,
                 &tenure_change
                     .try_as_tenure_change()
@@ -1463,12 +1265,12 @@ impl TestPeer<'_> {
                     .clone(),
                 Some(tenure_change),
                 Some(coinbase),
-                &mut peer.coord,
+                &mut peer.chain.coord,
                 miner_setup,
                 block_builder,
                 after_block,
-                peer.mine_malleablized_blocks,
-                peer.nakamoto_parent_tenure_opt.is_none(),
+                peer.chain.mine_malleablized_blocks,
+                peer.chain.nakamoto_parent_tenure_opt.is_none(),
                 None,
             )?;
 
@@ -1486,7 +1288,9 @@ impl TestPeer<'_> {
                 .flat_map(|(_, _, _, malleablized)| malleablized)
                 .collect();
 
-            peer.malleablized_blocks.append(&mut malleablized_blocks);
+            peer.chain
+                .malleablized_blocks
+                .append(&mut malleablized_blocks);
 
             let block_data = blocks
                 .into_iter()
@@ -1516,8 +1320,8 @@ impl TestPeer<'_> {
             &[(NakamotoBlock, u64, ExecutionCost)],
         ) -> Vec<StacksTransaction>,
     {
-        let mut stacks_node = self.stacks_node.take().unwrap();
-        let mut sortdb = self.sortdb.take().unwrap();
+        let mut stacks_node = self.chain.stacks_node.take().unwrap();
+        let mut sortdb = self.chain.sortdb.take().unwrap();
 
         let tenure_extend_payload =
             if let TransactionPayload::TenureChange(ref tc) = &tenure_extend_tx.payload {
@@ -1543,7 +1347,7 @@ impl TestPeer<'_> {
         let blocks = TestStacksNode::make_nakamoto_tenure_blocks(
             &mut stacks_node.chainstate,
             &mut sortdb,
-            &mut self.miner,
+            &mut self.chain.miner,
             signers,
             &tenure_extend_tx
                 .try_as_tenure_change()
@@ -1552,12 +1356,12 @@ impl TestPeer<'_> {
                 .clone(),
             Some(tenure_extend_tx),
             None,
-            &mut self.coord,
+            &mut self.chain.coord,
             |_| {},
             block_builder,
             |_| true,
-            self.mine_malleablized_blocks,
-            self.nakamoto_parent_tenure_opt.is_none(),
+            self.chain.mine_malleablized_blocks,
+            self.chain.nakamoto_parent_tenure_opt.is_none(),
             None,
         )
         .unwrap();
@@ -1576,15 +1380,17 @@ impl TestPeer<'_> {
             .flat_map(|(_, _, _, malleablized)| malleablized)
             .collect();
 
-        self.malleablized_blocks.append(&mut malleablized_blocks);
+        self.chain
+            .malleablized_blocks
+            .append(&mut malleablized_blocks);
 
         let block_data = blocks
             .into_iter()
             .map(|(blk, sz, cost, _)| (blk, sz, cost))
             .collect();
 
-        self.stacks_node = Some(stacks_node);
-        self.sortdb = Some(sortdb);
+        self.chain.stacks_node = Some(stacks_node);
+        self.chain.sortdb = Some(sortdb);
 
         block_data
     }
@@ -1593,8 +1399,8 @@ impl TestPeer<'_> {
     pub fn process_nakamoto_tenure(&mut self, blocks: Vec<NakamotoBlock>) {
         debug!("Peer will process {} Nakamoto blocks", blocks.len());
 
-        let mut sortdb = self.sortdb.take().unwrap();
-        let mut node = self.stacks_node.take().unwrap();
+        let mut sortdb = self.chain.sortdb.take().unwrap();
+        let mut node = self.chain.stacks_node.take().unwrap();
 
         let tip = SortitionDB::get_canonical_sortition_tip(sortdb.conn()).unwrap();
 
@@ -1616,7 +1422,7 @@ impl TestPeer<'_> {
             .unwrap();
             if accepted.is_accepted() {
                 test_debug!("Accepted Nakamoto block {}", &block_id);
-                self.coord.handle_new_nakamoto_stacks_block().unwrap();
+                self.chain.coord.handle_new_nakamoto_stacks_block().unwrap();
 
                 debug!("Begin check Nakamoto block {}", &block.block_id());
                 TestPeer::check_processed_nakamoto_block(&mut sortdb, &mut node.chainstate, block);
@@ -1626,8 +1432,8 @@ impl TestPeer<'_> {
             }
         }
 
-        self.sortdb = Some(sortdb);
-        self.stacks_node = Some(node);
+        self.chain.sortdb = Some(sortdb);
+        self.chain.stacks_node = Some(node);
     }
 
     /// Get the tenure-start block of the parent tenure of `tenure_id_consensus_hash`
@@ -1764,7 +1570,7 @@ impl TestPeer<'_> {
         let Ok(Some(parent_block_header)) =
             NakamotoChainState::get_block_header(chainstate.db(), &block.header.parent_block_id)
         else {
-            panic!("No parent block for {:?}", &block);
+            panic!("No parent block for {block:?}");
         };
 
         // get_coinbase_height
@@ -2479,8 +2285,8 @@ impl TestPeer<'_> {
             &naka_tip_id
         );
 
-        let mut stacks_node = self.stacks_node.take().unwrap();
-        let sortdb = self.sortdb.take().unwrap();
+        let mut stacks_node = self.chain.stacks_node.take().unwrap();
+        let sortdb = self.chain.sortdb.take().unwrap();
 
         let shadow_block = NakamotoBlockBuilder::make_shadow_tenure(
             &mut stacks_node.chainstate,
@@ -2494,12 +2300,13 @@ impl TestPeer<'_> {
         // Get the reward set
         let sort_tip_sn = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         let reward_set = load_nakamoto_reward_set(
-            self.miner
+            self.chain
+                .miner
                 .burnchain
                 .block_height_to_reward_cycle(sort_tip_sn.block_height)
                 .expect("FATAL: no reward cycle for sortition"),
             &sort_tip_sn.sortition_id,
-            &self.miner.burnchain,
+            &self.chain.miner.burnchain,
             &mut stacks_node.chainstate,
             &shadow_block.header.parent_block_id,
             &sortdb,
@@ -2561,11 +2368,11 @@ impl TestPeer<'_> {
 
         drop(rollback_tx);
 
-        self.stacks_node = Some(stacks_node);
-        self.sortdb = Some(sortdb);
+        self.chain.stacks_node = Some(stacks_node);
+        self.chain.sortdb = Some(sortdb);
 
         // process it
-        self.coord.handle_new_nakamoto_stacks_block().unwrap();
+        self.chain.coord.handle_new_nakamoto_stacks_block().unwrap();
 
         // verify that it processed
         self.refresh_burnchain_view();

--- a/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -60,7 +60,7 @@ pub fn get_reward_set_entries_at(
     tip: &StacksBlockId,
     at_burn_ht: u64,
 ) -> Vec<RawRewardSetEntry> {
-    let burnchain = peer.config.burnchain.clone();
+    let burnchain = peer.config.chain_config.burnchain.clone();
     with_sortdb(peer, |ref mut c, sortdb| {
         get_reward_set_entries_at_block(c, &burnchain, sortdb, tip, at_burn_ht).unwrap()
     })
@@ -73,7 +73,7 @@ pub fn get_reward_set_entries_index_order_at(
     tip: &StacksBlockId,
     at_burn_ht: u64,
 ) -> Vec<RawRewardSetEntry> {
-    let burnchain = peer.config.burnchain.clone();
+    let burnchain = peer.config.chain_config.burnchain.clone();
     with_sortdb(peer, |ref mut c, sortdb| {
         c.get_reward_addresses(&burnchain, sortdb, at_burn_ht, tip)
             .unwrap()
@@ -149,9 +149,15 @@ pub fn check_all_stacker_link_invariants(
         // For cycles where PoX-3 is active, check if Epoch24 has activated first.
         let active_pox_contract = peer
             .config
+            .chain_config
             .burnchain
             .pox_constants
-            .active_pox_contract(peer.config.burnchain.reward_cycle_to_block_height(cycle));
+            .active_pox_contract(
+                peer.config
+                    .chain_config
+                    .burnchain
+                    .reward_cycle_to_block_height(cycle),
+            );
         if active_pox_contract == POX_3_NAME && epoch < StacksEpochId::Epoch24 {
             info!(
                 "Skipping check on a PoX-3 reward cycle because Epoch24 has not started yet";
@@ -337,6 +343,7 @@ pub fn check_stacking_state_invariants(
 
     let stacking_state_unlock_ht = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height((first_cycle + lock_period) as u64);
 
@@ -430,11 +437,13 @@ pub fn check_stacker_link_invariants(peer: &mut TestPeer, tip: &StacksBlockId, c
     .burn_header_height;
     let tip_cycle = peer
         .config
+        .chain_config
         .burnchain
         .block_height_to_reward_cycle(current_burn_height.into())
         .unwrap();
     let cycle_start = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(cycle_number);
 
@@ -446,11 +455,17 @@ pub fn check_stacker_link_invariants(peer: &mut TestPeer, tip: &StacksBlockId, c
         .unwrap()
         .unwrap();
 
-    let active_pox_contract = peer.config.burnchain.pox_constants.active_pox_contract(
-        peer.config
-            .burnchain
-            .reward_cycle_to_block_height(cycle_number),
-    );
+    let active_pox_contract = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .active_pox_contract(
+            peer.config
+                .chain_config
+                .burnchain
+                .reward_cycle_to_block_height(cycle_number),
+        );
 
     if cycle_start_epoch.epoch_id == StacksEpochId::Epoch22
         || cycle_start_epoch.epoch_id == StacksEpochId::Epoch23
@@ -467,8 +482,8 @@ pub fn check_stacker_link_invariants(peer: &mut TestPeer, tip: &StacksBlockId, c
             "Skipping validation of reward set that started in Epoch24, but its cycle starts before pox-3 activation";
             "cycle" => cycle_number,
             "cycle_start" => cycle_start,
-            "pox_3_activation" => peer.config.burnchain.pox_constants.pox_3_activation_height,
-            "pox_4_activation" => peer.config.burnchain.pox_constants.pox_4_activation_height,
+            "pox_3_activation" => peer.config.chain_config.burnchain.pox_constants.pox_3_activation_height,
+            "pox_4_activation" => peer.config.chain_config.burnchain.pox_constants.pox_4_activation_height,
             "epoch_2_4_start" => cycle_start_epoch.start_height,
         );
         return;
@@ -510,7 +525,12 @@ pub fn check_stacker_link_invariants(peer: &mut TestPeer, tip: &StacksBlockId, c
 
             if tip_epoch.epoch_id >= StacksEpochId::Epoch24
                 && current_burn_height
-                    <= peer.config.burnchain.pox_constants.pox_3_activation_height
+                    <= peer
+                        .config
+                        .chain_config
+                        .burnchain
+                        .pox_constants
+                        .pox_3_activation_height
             {
                 // if the tip is epoch-2.4, and pox-3 isn't the active pox contract yet,
                 //  the invariant checks will not make sense for the same reasons as above
@@ -519,7 +539,12 @@ pub fn check_stacker_link_invariants(peer: &mut TestPeer, tip: &StacksBlockId, c
 
             if tip_epoch.epoch_id >= StacksEpochId::Epoch25
                 && current_burn_height
-                    <= peer.config.burnchain.pox_constants.pox_4_activation_height
+                    <= peer
+                        .config
+                        .chain_config
+                        .burnchain
+                        .pox_constants
+                        .pox_4_activation_height
             {
                 // if the tip is epoch-2.5, and pox-5 isn't the active pox contract yet,
                 //  the invariant checks will not make sense for the same reasons as above
@@ -550,11 +575,17 @@ pub fn check_stacker_link_invariants(peer: &mut TestPeer, tip: &StacksBlockId, c
 
 /// Get the `cycle_number`'s total stacked amount at the given chaintip
 pub fn get_reward_cycle_total(peer: &mut TestPeer, tip: &StacksBlockId, cycle_number: u64) -> u128 {
-    let active_pox_contract = peer.config.burnchain.pox_constants.active_pox_contract(
-        peer.config
-            .burnchain
-            .reward_cycle_to_block_height(cycle_number),
-    );
+    let active_pox_contract = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .active_pox_contract(
+            peer.config
+                .chain_config
+                .burnchain
+                .reward_cycle_to_block_height(cycle_number),
+        );
 
     with_clarity_db_ro(peer, tip, |db| {
         let total_stacked_key = TupleData::from_data(vec![(
@@ -776,7 +807,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
     };
 
     // our "tenure counter" is now at 0
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
 
     // first tenure is empty
@@ -794,7 +825,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
     assert_eq!(alice_account.stx_balance.unlock_height(), 0);
 
     // next tenure include Alice's lockup
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let alice_lockup = make_pox_lockup(
         &alice,
         0,
@@ -854,7 +885,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
     //  should be accepted (checked via the tx receipt). Also, importantly,
     //  the cost tracker should assign costs to Charlie's transaction.
     //  This is also checked by the transaction receipt.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // our "tenure counter" is now at 9
     assert_eq!(tip.block_height, 9 + EMPTY_SORTITIONS as u64);
@@ -880,7 +911,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10, and 11
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_pox_2_lockup(
         &bob,
@@ -904,7 +935,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
     assert_eq!(alice_balance, 0);
 
     // Now, Bob tries to lock in PoX v1 too, but it shouldn't work!
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_pox_lockup(
         &bob,
@@ -921,7 +952,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
     let block_id = peer.tenure_with_txs(&[bob_lockup], &mut coinbase_nonce);
 
     // our "tenure counter" is now at 12
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 12 + EMPTY_SORTITIONS as u64);
     // One more empty tenure to reach the unlock height
     let block_id = peer.tenure_with_txs(&[], &mut coinbase_nonce);
@@ -932,7 +963,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
 
     // At this point, the auto unlock height for v1 accounts should be reached.
     //  let Alice stack in PoX v2
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // our "tenure counter" is now at 13
     assert_eq!(tip.block_height, 13 + EMPTY_SORTITIONS as u64);
@@ -963,7 +994,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
         assert_eq!(alice_balance, 512 * POX_THRESHOLD_STEPS_USTX);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // our "tenure counter" is now at 31
     assert_eq!(tip.block_height, 31 + EMPTY_SORTITIONS as u64);
@@ -1174,7 +1205,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10, and 11
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let alice_lockup = make_pox_2_lockup(
         &alice,
@@ -1245,7 +1276,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
     .unwrap();
     assert_eq!(bob_bal.amount_locked(), POX_THRESHOLD_STEPS_USTX);
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -1470,7 +1501,7 @@ fn delegate_stack_increase() {
     }
 
     // in the next tenure, PoX 2 should now exist.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit delegation tx
     let success_alice_delegation = alice_nonce;
@@ -1528,7 +1559,7 @@ fn delegate_stack_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(EXPECTED_FIRST_V2_CYCLE + 3) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -1822,7 +1853,7 @@ fn stack_increase() {
     }
 
     // in the next tenure, PoX 2 should now exist.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit an increase: this should fail, because Alice is not yet locked
     let fail_no_lock_tx = alice_nonce;
@@ -1876,7 +1907,7 @@ fn stack_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(EXPECTED_FIRST_V2_CYCLE + 3) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -2031,7 +2062,7 @@ fn test_lock_period_invariant_extend_transition() {
         .unwrap()
         + 1;
 
-    eprintln!("First v2 cycle = {}", first_v2_cycle);
+    eprintln!("First v2 cycle = {first_v2_cycle}");
     assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
 
     let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
@@ -2059,7 +2090,7 @@ fn test_lock_period_invariant_extend_transition() {
     let ALICE_LOCKUP = 1024 * POX_THRESHOLD_STEPS_USTX;
 
     // our "tenure counter" is now at 0
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
 
     // first tenure is empty
@@ -2074,7 +2105,7 @@ fn test_lock_period_invariant_extend_transition() {
     assert_eq!(alice_account.stx_balance.unlock_height(), 0);
 
     // next tenure include Alice's lockup
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let alice_lockup = make_pox_lockup(
         &alice,
         0,
@@ -2138,7 +2169,7 @@ fn test_lock_period_invariant_extend_transition() {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // Alice _will_ auto-unlock: she can stack-extend in PoX v2
     let alice_lockup = make_pox_2_extend(
@@ -2311,7 +2342,7 @@ fn test_pox_extend_transition_pox_2() {
     };
 
     // our "tenure counter" is now at 0
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
 
     // first tenure is empty
@@ -2326,7 +2357,7 @@ fn test_pox_extend_transition_pox_2() {
     assert_eq!(alice_account.stx_balance.unlock_height(), 0);
 
     // next tenure include Alice's lockup
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let alice_lockup = make_pox_lockup(
         &alice,
         0,
@@ -2392,7 +2423,7 @@ fn test_pox_extend_transition_pox_2() {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_pox_2_lockup(
         &bob,
@@ -2451,7 +2482,7 @@ fn test_pox_extend_transition_pox_2() {
         alice_rewards_to_v2_start_checks(tip_index_block, &mut peer);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     // our "tenure counter" is now at 15
     assert_eq!(tip.block_height, 15 + EMPTY_SORTITIONS as u64);
 
@@ -2468,7 +2499,7 @@ fn test_pox_extend_transition_pox_2() {
     }
 
     // our "tenure counter" is now at 32
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 32 + EMPTY_SORTITIONS as u64);
 
     // Alice would have unlocked under v1 rules, so try to stack again via PoX 1 and expect a runtime error
@@ -2736,7 +2767,7 @@ fn test_delegate_extend_transition_pox_2() {
     };
 
     // our "tenure counter" is now at 0
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
 
     // first tenure is empty
@@ -2751,7 +2782,7 @@ fn test_delegate_extend_transition_pox_2() {
     assert_eq!(alice_account.stx_balance.unlock_height(), 0);
 
     // next tenure include Alice's lockup
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let delegate_tx = make_pox_contract_call(
         &alice,
         0,
@@ -2883,7 +2914,7 @@ fn test_delegate_extend_transition_pox_2() {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_delegate_tx = make_pox_2_contract_call(
         &bob,
@@ -3090,7 +3121,7 @@ fn test_delegate_extend_transition_pox_2() {
         alice_rewards_to_v2_start_checks(tip_index_block, &mut peer);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     // our "tenure counter" is now at 15
     assert_eq!(tip.block_height, 15 + EMPTY_SORTITIONS as u64);
 
@@ -3156,7 +3187,7 @@ fn test_delegate_extend_transition_pox_2() {
     }
 
     // our "tenure counter" is now at 32
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 32 + EMPTY_SORTITIONS as u64);
 
     // Alice would have unlocked under v1 rules, so try to stack again via PoX 1 and expect a runtime error
@@ -3185,7 +3216,7 @@ fn test_delegate_extend_transition_pox_2() {
         for r in b.receipts.into_iter() {
             if let TransactionOrigin::Stacks(ref t) = r.transaction {
                 let addr = t.auth.origin().address_testnet();
-                eprintln!("TX addr: {}", addr);
+                eprintln!("TX addr: {addr}");
                 if addr == alice_address {
                     alice_txs.insert(t.auth.get_origin_nonce(), r);
                 } else if addr == bob_address {
@@ -3375,7 +3406,7 @@ fn test_pox_2_getters() {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let cur_reward_cycle = burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -3645,8 +3676,9 @@ fn test_get_pox_addrs() {
         let microblock_privkey = StacksPrivateKey::random();
         let microblock_pubkeyhash =
             Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let cur_reward_cycle = burnchain
             .block_height_to_reward_cycle(tip.block_height)
@@ -3923,8 +3955,9 @@ fn test_stack_with_segwit() {
         let microblock_privkey = StacksPrivateKey::random();
         let microblock_pubkeyhash =
             Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let cur_reward_cycle = burnchain
             .block_height_to_reward_cycle(tip.block_height)
@@ -4257,7 +4290,7 @@ fn test_pox_2_delegate_stx_addr_validation() {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let cur_reward_cycle = burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -4463,7 +4496,7 @@ fn stack_aggregation_increase() {
     }
 
     // in the next tenure, PoX 2 should now exist.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit delegation tx for alice
     let alice_delegation_1 = make_pox_2_contract_call(
@@ -4529,7 +4562,7 @@ fn stack_aggregation_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(EXPECTED_FIRST_V2_CYCLE + 3) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -4552,7 +4585,7 @@ fn stack_aggregation_increase() {
         assert_eq!(partial_stacked, 512 * POX_THRESHOLD_STEPS_USTX);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let cur_reward_cycle = burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -4603,7 +4636,7 @@ fn stack_aggregation_increase() {
     bob_nonce += 1;
 
     latest_block = peer.tenure_with_txs(&txs_to_submit, &mut coinbase_nonce);
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let cur_reward_cycle = burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -4900,7 +4933,7 @@ fn stack_in_both_pox1_and_pox2() {
     }
 
     // in the next tenure, PoX 2 should now exist.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // our "tenure counter" is now at 10
     assert_eq!(tip.block_height, 10 + EMPTY_SORTITIONS as u64);

--- a/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
@@ -184,7 +184,7 @@ fn simple_pox_lockup_transition_pox_2() {
     let mut coinbase_nonce = 0;
 
     // our "tenure counter" is now at 0
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
 
     // first tenure is empty
@@ -202,7 +202,7 @@ fn simple_pox_lockup_transition_pox_2() {
     assert_eq!(alice_account.stx_balance.unlock_height(), 0);
 
     // next tenure include Alice's lockup
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let alice_lockup = make_pox_lockup(
         &alice,
         0,
@@ -249,7 +249,9 @@ fn simple_pox_lockup_transition_pox_2() {
     assert_eq!(alice_balance, 0);
 
     // produce blocks until immediately before the 2.1 epoch switch
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch21].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch21].start_height
+    {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
 
         // alice is still locked, balance should be 0
@@ -261,7 +263,7 @@ fn simple_pox_lockup_transition_pox_2() {
     //  should be accepted (checked via the tx receipt). Also, importantly,
     //  the cost tracker should assign costs to Charlie's transaction.
     //  This is also checked by the transaction receipt.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let test = make_pox_2_contract_call(
         &charlie,
@@ -284,7 +286,7 @@ fn simple_pox_lockup_transition_pox_2() {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10, and 11
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_pox_2_lockup(
         &bob,
@@ -301,7 +303,7 @@ fn simple_pox_lockup_transition_pox_2() {
     let block_id = peer.tenure_with_txs(&[bob_lockup], &mut coinbase_nonce);
 
     assert_eq!(
-        get_tip(peer.sortdb.as_ref()).block_height as u32,
+        get_tip(peer.chain.sortdb.as_ref()).block_height as u32,
         pox_constants.v1_unlock_height + 1,
         "Test should have reached 1 + PoX-v1 unlock height"
     );
@@ -311,7 +313,7 @@ fn simple_pox_lockup_transition_pox_2() {
     assert_eq!(alice_balance, 1024 * POX_THRESHOLD_STEPS_USTX);
 
     // Now, Bob tries to lock in PoX v1 too, but it shouldn't work!
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_pox_lockup(
         &bob,
@@ -327,7 +329,7 @@ fn simple_pox_lockup_transition_pox_2() {
 
     // At this point, the auto unlock height for v1 accounts has been reached.
     //  let Alice stack in PoX v2
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let alice_lockup = make_pox_2_lockup(
         &alice,
@@ -347,7 +349,9 @@ fn simple_pox_lockup_transition_pox_2() {
     assert_eq!(alice_balance, 512 * POX_THRESHOLD_STEPS_USTX);
 
     // now, let's roll the chain forward until just before Epoch-2.2
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch22].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch22].start_height
+    {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // at this point, alice's balance should always include this half lockup
         let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -364,7 +368,8 @@ fn simple_pox_lockup_transition_pox_2() {
     assert_eq!(alice_balance, 1024 * POX_THRESHOLD_STEPS_USTX);
 
     // now, roll the chain forward to Epoch-2.4
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // at this point, alice's balance should always be unlocked
@@ -372,7 +377,7 @@ fn simple_pox_lockup_transition_pox_2() {
         assert_eq!(alice_balance, 1024 * POX_THRESHOLD_STEPS_USTX);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref()).block_height;
+    let tip = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let bob_lockup = make_pox_3_lockup(
         &bob,
         2,
@@ -583,7 +588,8 @@ fn pox_auto_unlock(alice_first: bool) {
     let mut coinbase_nonce = 0;
 
     // produce blocks until epoch 2.1
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch21].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch21].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
@@ -592,7 +598,7 @@ fn pox_auto_unlock(alice_first: bool) {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10, and 11
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let alice_lockup = make_pox_2_lockup(
         &alice,
@@ -653,7 +659,7 @@ fn pox_auto_unlock(alice_first: bool) {
     );
     assert_eq!(bob_bal.amount_locked(), POX_THRESHOLD_STEPS_USTX);
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -734,7 +740,8 @@ fn pox_auto_unlock(alice_first: bool) {
     // now, lets check behavior in Epochs 2.2-2.4, with pox-3 auto unlock tests
 
     // produce blocks until epoch 2.2
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch22].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch22].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
         let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -747,13 +754,14 @@ fn pox_auto_unlock(alice_first: bool) {
     assert_eq!(alice_balance, 1024 * POX_THRESHOLD_STEPS_USTX);
 
     // produce blocks until epoch 2.4
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // repeat the lockups as before, so we can test the pox-3 auto unlock behavior
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let alice_lockup = make_pox_3_lockup(
         &alice,
@@ -815,7 +823,7 @@ fn pox_auto_unlock(alice_first: bool) {
     );
     assert_eq!(bob_bal.amount_locked(), POX_THRESHOLD_STEPS_USTX);
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -1022,13 +1030,14 @@ fn delegate_stack_increase() {
     let mut coinbase_nonce = 0;
 
     // produce blocks until epoch 2.1
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch21].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch21].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // in the next tenure, PoX 2 should now exist.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit delegation tx
     let alice_delegation_1 = make_pox_2_contract_call(
@@ -1089,7 +1098,7 @@ fn delegate_stack_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(EXPECTED_FIRST_V2_CYCLE + 1) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -1208,7 +1217,9 @@ fn delegate_stack_increase() {
     //  on pox-3
 
     // roll the chain forward until just before Epoch-2.2
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch22].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch22].start_height
+    {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // at this point, alice's balance should always include this half lockup
         assert_eq!(
@@ -1251,12 +1262,13 @@ fn delegate_stack_increase() {
     );
 
     // Roll to Epoch-2.4 and re-do the above tests
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit delegation tx
     let alice_delegation_1 = make_pox_3_contract_call(
@@ -1315,7 +1327,7 @@ fn delegate_stack_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(first_v3_cycle + 3) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -1639,13 +1651,14 @@ fn stack_increase() {
     let increase_amt = total_balance - first_lockup_amt;
 
     // produce blocks until epoch 2.1
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch21].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch21].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // in the next tenure, PoX 2 should now exist.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit an increase: this should fail, because Alice is not yet locked
     let fail_no_lock_tx = alice_nonce;
@@ -1691,7 +1704,7 @@ fn stack_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(EXPECTED_FIRST_V2_CYCLE + 1) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -1773,7 +1786,9 @@ fn stack_increase() {
     //  on pox-3
 
     // roll the chain forward until just before Epoch-2.2
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch22].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch22].start_height
+    {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // at this point, alice's balance should always include this half lockup
         assert_eq!(
@@ -1802,13 +1817,14 @@ fn stack_increase() {
     );
 
     // Roll to Epoch-2.4 and re-do the above stack-increase tests
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // in the next tenure, PoX 3 should now exist.
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit an increase: this should fail, because Alice is not yet locked
     let pox_3_fail_no_lock_tx = alice_nonce;
@@ -1858,7 +1874,7 @@ fn stack_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(first_v3_cycle + 3) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -2165,7 +2181,7 @@ fn pox_extend_transition() {
     assert_eq!(alice_account.stx_balance.unlock_height(), 0);
 
     // next tenure include Alice's lockup
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let alice_lockup = make_pox_lockup(
         &alice,
         0,
@@ -2212,12 +2228,14 @@ fn pox_extend_transition() {
     let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
     assert_eq!(alice_balance, 0);
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // produce blocks until epoch 2.1
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch21].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch21].start_height
+    {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
         alice_rewards_to_v2_start_checks(latest_block.clone(), &mut peer);
     }
@@ -2226,7 +2244,7 @@ fn pox_extend_transition() {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_pox_2_lockup(
         &bob,
@@ -2271,7 +2289,7 @@ fn pox_extend_transition() {
 
     // produce blocks until the v2 reward cycles start
     let height_target = burnchain.reward_cycle_to_block_height(first_v2_cycle) - 1;
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // alice is still locked, balance should be 0
         let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -2286,7 +2304,9 @@ fn pox_extend_transition() {
     // Roll to Epoch-2.4 and re-do the above tests
 
     // roll the chain forward until just before Epoch-2.2
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch22].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch22].start_height
+    {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // at this point, alice's balance should be locked, and so should bob's
         let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -2313,12 +2333,13 @@ fn pox_extend_transition() {
     assert_eq!(bob_account.amount_unlocked(), INITIAL_BALANCE);
 
     // Roll to Epoch-2.4 and re-do the above stack-extend tests
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let alice_lockup = make_pox_3_lockup(
         &alice,
         2,
@@ -2362,11 +2383,11 @@ fn pox_extend_transition() {
     assert_eq!(alice_balance, 0);
 
     // advance to the first v3 reward cycle
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let bob_lockup = make_pox_3_lockup(
         &bob,
         2,
@@ -2448,7 +2469,7 @@ fn pox_extend_transition() {
         for r in b.receipts.into_iter() {
             if let TransactionOrigin::Stacks(ref t) = r.transaction {
                 let addr = t.auth.origin().address_testnet();
-                eprintln!("TX addr: {}", addr);
+                eprintln!("TX addr: {addr}");
                 if addr == alice_address {
                     alice_txs.insert(t.auth.get_origin_nonce(), r);
                 } else if addr == bob_address {
@@ -2580,21 +2601,22 @@ fn delegate_extend_pox_3() {
     let LOCKUP_AMT = 1024 * POX_THRESHOLD_STEPS_USTX;
 
     // our "tenure counter" is now at 0
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
 
     // first tenure is empty
     let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
 
     // Roll to Epoch-2.4 and perform the delegate-stack-extend tests
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // in the next tenure, PoX 3 should now exist.
     //  charlie will lock bob and alice through the delegation interface
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let mut alice_nonce = 0;
     let mut bob_nonce = 0;
@@ -2818,13 +2840,13 @@ fn delegate_extend_pox_3() {
     }
 
     let height_target = burnchain.reward_cycle_to_block_height(first_v3_cycle) + 1;
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
         assert_eq!(alice_balance, 0);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // Extend bob's lockup via `delegate-stack-extend` for 1 more cycle
     //  so that we can check the first-reward-cycle is correctly updated
@@ -3046,12 +3068,13 @@ fn pox_3_getters() {
 
     let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     // Roll to Epoch-2.4 and perform the delegate-stack-extend tests
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let LOCKUP_AMT = 1024 * POX_THRESHOLD_STEPS_USTX;
 
     // alice locks in v2
@@ -3291,7 +3314,7 @@ fn pox_3_getters() {
 }
 
 fn get_burn_pox_addr_info(peer: &mut TestPeer) -> (Vec<PoxAddress>, u128) {
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tip_index_block = tip.get_canonical_stacks_block_id();
     let burn_height = tip.block_height - 1;
     let addrs_and_payout = with_sortdb(peer, |ref mut chainstate, ref mut sortdb| {
@@ -3377,7 +3400,7 @@ fn get_pox_addrs() {
     let mut coinbase_nonce = 0;
 
     let assert_latest_was_burn = |peer: &mut TestPeer| {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let tip_index_block = tip.get_canonical_stacks_block_id();
         let burn_height = tip.block_height - 1;
 
@@ -3393,11 +3416,16 @@ fn get_pox_addrs() {
         assert!(commit.burn_fee > 0);
 
         let (addrs, payout) = get_burn_pox_addr_info(peer);
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let tip_index_block = tip.get_canonical_stacks_block_id();
         let burn_height = tip.block_height - 1;
         info!("Checking burn outputs at burn_height = {}", burn_height);
-        if peer.config.burnchain.is_in_prepare_phase(burn_height) {
+        if peer
+            .config
+            .chain_config
+            .burnchain
+            .is_in_prepare_phase(burn_height)
+        {
             assert_eq!(addrs.len(), 1);
             assert_eq!(payout, 1000);
             assert!(addrs[0].is_burn());
@@ -3410,7 +3438,7 @@ fn get_pox_addrs() {
     };
 
     let assert_latest_was_pox = |peer: &mut TestPeer| {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let tip_index_block = tip.get_canonical_stacks_block_id();
         let burn_height = tip.block_height - 1;
 
@@ -3438,18 +3466,20 @@ fn get_pox_addrs() {
     };
 
     // produce blocks until epoch 2.2
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // if we reach epoch 2.1, perform the check
-        if get_tip(peer.sortdb.as_ref()).block_height > epochs[StacksEpochId::Epoch21].start_height
+        if get_tip(peer.chain.sortdb.as_ref()).block_height
+            > epochs[StacksEpochId::Epoch21].start_height
         {
             assert_latest_was_burn(&mut peer);
         }
     }
 
     let mut txs = vec![];
-    let tip_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let tip_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let stackers: Vec<_> = keys
         .iter()
         .zip([
@@ -3477,7 +3507,7 @@ fn get_pox_addrs() {
 
     let target_height = burnchain.reward_cycle_to_block_height(first_v3_cycle);
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < target_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < target_height {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         assert_latest_was_burn(&mut peer);
     }
@@ -3588,7 +3618,7 @@ fn stack_with_segwit() {
     let mut coinbase_nonce = 0;
 
     let assert_latest_was_burn = |peer: &mut TestPeer| {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let tip_index_block = tip.get_canonical_stacks_block_id();
         let burn_height = tip.block_height - 1;
 
@@ -3604,11 +3634,16 @@ fn stack_with_segwit() {
         assert!(commit.burn_fee > 0);
 
         let (addrs, payout) = get_burn_pox_addr_info(peer);
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let tip_index_block = tip.get_canonical_stacks_block_id();
         let burn_height = tip.block_height - 1;
         info!("Checking burn outputs at burn_height = {}", burn_height);
-        if peer.config.burnchain.is_in_prepare_phase(burn_height) {
+        if peer
+            .config
+            .chain_config
+            .burnchain
+            .is_in_prepare_phase(burn_height)
+        {
             assert_eq!(addrs.len(), 1);
             assert_eq!(payout, 1000);
             assert!(addrs[0].is_burn());
@@ -3621,7 +3656,7 @@ fn stack_with_segwit() {
     };
 
     let assert_latest_was_pox = |peer: &mut TestPeer| {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let tip_index_block = tip.get_canonical_stacks_block_id();
         let burn_height = tip.block_height - 1;
 
@@ -3649,18 +3684,20 @@ fn stack_with_segwit() {
     };
 
     // produce blocks until epoch 2.2
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // if we reach epoch 2.1, perform the check
-        if get_tip(peer.sortdb.as_ref()).block_height > epochs[StacksEpochId::Epoch21].start_height
+        if get_tip(peer.chain.sortdb.as_ref()).block_height
+            > epochs[StacksEpochId::Epoch21].start_height
         {
             assert_latest_was_burn(&mut peer);
         }
     }
 
     let mut txs = vec![];
-    let tip_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let tip_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let stackers: Vec<_> = keys
         .iter()
         .zip([
@@ -3687,7 +3724,7 @@ fn stack_with_segwit() {
 
     let target_height = burnchain.reward_cycle_to_block_height(first_v3_cycle);
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < target_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < target_height {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         assert_latest_was_burn(&mut peer);
     }
@@ -3830,12 +3867,13 @@ fn stack_aggregation_increase() {
     let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
 
     // Roll to Epoch-2.4 and perform the delegate-stack-extend tests
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     // submit delegation tx for alice
     let alice_delegation_1 = make_pox_3_contract_call(
@@ -3898,7 +3936,7 @@ fn stack_aggregation_increase() {
     //  this is one block after the reward cycle starts
     let height_target = burnchain.reward_cycle_to_block_height(first_v3_cycle + 3) + 1;
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -3926,7 +3964,7 @@ fn stack_aggregation_increase() {
         assert_eq!(partial_stacked, 512 * POX_THRESHOLD_STEPS_USTX);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let cur_reward_cycle = burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -3977,7 +4015,7 @@ fn stack_aggregation_increase() {
     bob_nonce += 1;
 
     latest_block = peer.tenure_with_txs(&txs_to_submit, &mut coinbase_nonce);
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let cur_reward_cycle = burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -4245,12 +4283,13 @@ fn pox_3_delegate_stx_addr_validation() {
     let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
 
     // Roll to Epoch-2.4 and perform the delegate-stack-extend tests
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch24].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch24].start_height
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let cur_reward_cycle = burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -46,6 +46,7 @@ use crate::chainstate::stacks::boot::signers_tests::get_signer_index;
 use crate::chainstate::stacks::boot::{PoxVersions, MINERS_NAME};
 use crate::chainstate::stacks::events::{StacksTransactionReceipt, TransactionOrigin};
 use crate::chainstate::stacks::*;
+use crate::chainstate::tests::TestChainstateConfig;
 use crate::core::*;
 use crate::net::test::{TestEventObserver, TestEventObserverBlock, TestPeer, TestPeerConfig};
 use crate::net::tests::NakamotoBootPlan;
@@ -79,9 +80,10 @@ fn make_simple_pox_4_lock(
     let addr = key_to_stacks_addr(key);
     let pox_addr = PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes().clone());
     let signer_pk = StacksPublicKey::from_private(key);
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let next_reward_cycle = peer
         .config
+        .chain_config
         .burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -369,7 +371,7 @@ fn pox_extend_transition() {
     assert_eq!(alice_account.stx_balance.unlock_height(), 0);
 
     // next tenure include Alice's lockup
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let alice_lockup = make_pox_lockup(
         &alice,
         0,
@@ -416,12 +418,14 @@ fn pox_extend_transition() {
     let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
     assert_eq!(alice_balance, 0);
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // produce blocks until epoch 2.1
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch21].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch21].start_height
+    {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
         alice_rewards_to_v2_start_checks(latest_block.clone(), &mut peer);
     }
@@ -430,7 +434,7 @@ fn pox_extend_transition() {
     // Lets have Bob lock up for v2
     // this will lock for cycles 8, 9, 10
     //  the first v2 cycle will be 8
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_pox_2_lockup(
         &bob,
@@ -475,7 +479,7 @@ fn pox_extend_transition() {
 
     // produce blocks until the v2 reward cycles start
     let height_target = burnchain.reward_cycle_to_block_height(first_v2_cycle) - 1;
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // alice is still locked, balance should be 0
         let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -488,7 +492,9 @@ fn pox_extend_transition() {
     v2_rewards_checks(latest_block, &mut peer);
 
     // roll the chain forward until just before Epoch-2.2
-    while get_tip(peer.sortdb.as_ref()).block_height < epochs[StacksEpochId::Epoch22].start_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        < epochs[StacksEpochId::Epoch22].start_height
+    {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // at this point, alice's balance should be locked, and so should bob's
         let alice_balance = get_balance(&mut peer, &key_to_stacks_addr(&alice).into());
@@ -515,13 +521,13 @@ fn pox_extend_transition() {
     assert_eq!(bob_account.amount_unlocked(), INITIAL_BALANCE);
 
     // Roll to pox4 activation and re-do the above stack-extend tests
-    while get_tip(peer.sortdb.as_ref()).block_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
         < u64::from(burnchain.pox_constants.pox_4_activation_height)
     {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let alice_signer_private = Secp256k1PrivateKey::random();
     let alice_signer_key = Secp256k1PublicKey::from_private(&alice_signer_private);
@@ -569,7 +575,7 @@ fn pox_extend_transition() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     // check that the "raw" reward set will contain entries for alice at the cycle start
@@ -598,7 +604,7 @@ fn pox_extend_transition() {
     assert_eq!(alice_balance, 0);
 
     // advance to the first v3 reward cycle
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -621,7 +627,7 @@ fn pox_extend_transition() {
         2,
     );
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let bob_lockup = make_pox_4_lockup(
         &bob,
         2,
@@ -818,7 +824,7 @@ fn pox_extend_transition() {
 }
 
 fn get_burn_pox_addr_info(peer: &mut TestPeer) -> (Vec<PoxAddress>, u128) {
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tip_index_block = tip.get_canonical_stacks_block_id();
     let burn_height = tip.block_height - 1;
     let addrs_and_payout = with_sortdb(peer, |ref mut chainstate, ref mut sortdb| {
@@ -900,10 +906,11 @@ fn pox_lock_unlock() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
         // if we reach epoch 2.1, perform the check
-        if get_tip(peer.sortdb.as_ref()).block_height > epochs[StacksEpochId::Epoch21].start_height
+        if get_tip(peer.chain.sortdb.as_ref()).block_height
+            > epochs[StacksEpochId::Epoch21].start_height
         {
             assert_latest_was_burn(&mut peer);
         }
@@ -911,11 +918,11 @@ fn pox_lock_unlock() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     let mut txs = vec![];
-    let tip_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let tip_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let reward_cycle = burnchain.block_height_to_reward_cycle(tip_height).unwrap() as u128;
     let stackers: Vec<_> = keys
         .iter()
@@ -960,13 +967,13 @@ fn pox_lock_unlock() {
 
     // Advance to start of rewards cycle stackers are participating in
     let target_height = burnchain.pox_constants.pox_4_activation_height + 5;
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     // now we should be in the reward phase, produce the reward blocks
@@ -976,7 +983,7 @@ fn pox_lock_unlock() {
 
     // Check that STX are locked for 2 reward cycles
     for _ in 0..lock_period {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let cycle = burnchain
             .block_height_to_reward_cycle(tip.block_height)
             .unwrap();
@@ -1081,10 +1088,11 @@ fn pox_3_defunct() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // if we reach epoch 2.1, perform the check
-        if get_tip(peer.sortdb.as_ref()).block_height > epochs[StacksEpochId::Epoch21].start_height
+        if get_tip(peer.chain.sortdb.as_ref()).block_height
+            > epochs[StacksEpochId::Epoch21].start_height
         {
             assert_latest_was_burn(&mut peer);
         }
@@ -1092,11 +1100,11 @@ fn pox_3_defunct() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     let mut txs = vec![];
-    let tip_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let tip_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let stackers: Vec<_> = keys
         .iter()
         .zip([
@@ -1153,13 +1161,13 @@ fn pox_3_defunct() {
 
     // Advance to start of rewards cycle stackers are participating in
     let target_height = burnchain.pox_constants.pox_4_activation_height + 5;
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     // now we should be in the reward phase, produce the reward blocks
@@ -1168,7 +1176,7 @@ fn pox_3_defunct() {
 
     // Check next 3 reward cycles
     for _ in 0..=lock_period {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let cycle = burnchain
             .block_height_to_reward_cycle(tip.block_height)
             .unwrap();
@@ -1211,10 +1219,11 @@ fn pox_3_unlocks() {
     // Advance to a few blocks before pox 3 unlock
     let target_height = burnchain.pox_constants.v3_unlock_height - 14;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
         // if we reach epoch 2.1, perform the check
-        if get_tip(peer.sortdb.as_ref()).block_height > epochs[StacksEpochId::Epoch21].start_height
+        if get_tip(peer.chain.sortdb.as_ref()).block_height
+            > epochs[StacksEpochId::Epoch21].start_height
         {
             assert_latest_was_burn(&mut peer);
         }
@@ -1222,11 +1231,11 @@ fn pox_3_unlocks() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     let mut txs = vec![];
-    let tip_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let tip_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let stackers: Vec<_> = keys
         .iter()
         .zip([
@@ -1264,7 +1273,7 @@ fn pox_3_unlocks() {
 
     // Check that STX are locked for 2 reward cycles
     for _ in 0..2 {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let cycle = burnchain
             .block_height_to_reward_cycle(tip.block_height)
             .unwrap();
@@ -1308,18 +1317,18 @@ fn pox_3_unlocks() {
 
     // Advance to v3 unlock
     let target_height = burnchain.pox_constants.v3_unlock_height;
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     // Check that STX are not locked for 3 reward cycles after pox4 starts
     for _ in 0..3 {
-        let tip = get_tip(peer.sortdb.as_ref());
+        let tip = get_tip(peer.chain.sortdb.as_ref());
         let cycle = burnchain
             .block_height_to_reward_cycle(tip.block_height)
             .unwrap();
@@ -1396,7 +1405,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
 
@@ -1405,11 +1414,11 @@ fn pox_4_check_cycle_id_range_in_print_events_pool() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     let lock_period = 1;
-    let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let block_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap());
 
     // stack-stx
@@ -1483,7 +1492,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool() {
     steph_nonce += 1;
 
     // alice delegates STX to bob
-    let target_height = get_tip(peer.sortdb.as_ref()).block_height
+    let target_height = get_tip(peer.chain.sortdb.as_ref()).block_height
         + (3 * pox_constants.reward_cycle_length as u64) // 3 cycles (next cycle + 2)
         + 1; // additional few blocks shouldn't matter to unlock-cycle
     let alice_delegate = make_pox_4_delegate_stx(
@@ -1497,7 +1506,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool() {
     let alice_delegate_nonce = alice_nonce;
     alice_nonce += 1;
 
-    let curr_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let curr_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let bob_delegate_stack_nonce = bob_nonce;
     let bob_delegate_stack = make_pox_4_delegate_stack_stx(
         &bob,
@@ -1544,7 +1553,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool() {
         &mut coinbase_nonce,
     ));
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tipId = StacksBlockId::new(&tip.consensus_hash, &tip.canonical_stacks_tip_hash);
     assert_eq!(tipId, latest_block.unwrap());
 
@@ -1784,11 +1793,11 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
     // produce blocks until the we're in the prepare phase (first block of prepare-phase was mined, i.e. pox-set for next cycle determined)
-    while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height) {
+    while !burnchain.is_in_prepare_phase(get_tip(peer.chain.sortdb.as_ref()).block_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
 
@@ -1797,11 +1806,11 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height,
+        get_tip(peer.chain.sortdb.as_ref()).block_height,
     );
 
     let lock_period = 1;
-    let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let block_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap());
 
     // stack-stx
@@ -1875,7 +1884,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
     steph_nonce += 1;
 
     // alice delegates STX to bob
-    let target_height = get_tip(peer.sortdb.as_ref()).block_height
+    let target_height = get_tip(peer.chain.sortdb.as_ref()).block_height
         + (3 * pox_constants.reward_cycle_length as u64) // 3 cycles (next cycle + 2)
         + 1; // additional few blocks shouldn't matter to unlock-cycle
     let alice_delegate = make_pox_4_delegate_stx(
@@ -1889,7 +1898,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
     let alice_delegate_nonce = alice_nonce;
     alice_nonce += 1;
 
-    let curr_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let curr_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let bob_delegate_stack_nonce = bob_nonce;
     let bob_delegate_stack = make_pox_4_delegate_stack_stx(
         &bob,
@@ -1936,7 +1945,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase() {
         &mut coinbase_nonce,
     ));
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tipId = StacksBlockId::new(&tip.consensus_hash, &tip.canonical_stacks_tip_hash);
     assert_eq!(tipId, latest_block.clone().unwrap());
 
@@ -2215,11 +2224,11 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase_skip_cycle()
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
     // produce blocks until the we're in the prepare phase (first block of prepare-phase was mined, i.e. pox-set for next cycle determined)
-    while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height) {
+    while !burnchain.is_in_prepare_phase(get_tip(peer.chain.sortdb.as_ref()).block_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
 
@@ -2228,15 +2237,15 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase_skip_cycle()
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     let lock_period = 2;
-    let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let block_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap());
 
     // alice delegates STX to bob
-    let target_height = get_tip(peer.sortdb.as_ref()).block_height
+    let target_height = get_tip(peer.chain.sortdb.as_ref()).block_height
         + (3 * pox_constants.reward_cycle_length as u64) // 3 cycles (next cycle + 2)
         + 1; // additional few blocks shouldn't matter to unlock-cycle
     let alice_delegate = make_pox_4_delegate_stx(
@@ -2250,7 +2259,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase_skip_cycle()
     let alice_delegate_nonce = alice_nonce;
     alice_nonce += 1;
 
-    let curr_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let curr_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let bob_delegate_stack_nonce = bob_nonce;
     let bob_delegate_stack = make_pox_4_delegate_stack_stx(
         &bob,
@@ -2291,7 +2300,7 @@ fn pox_4_check_cycle_id_range_in_print_events_pool_in_prepare_phase_skip_cycle()
         &mut coinbase_nonce,
     ));
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tipId = StacksBlockId::new(&tip.consensus_hash, &tip.canonical_stacks_tip_hash);
     assert_eq!(tipId, latest_block.unwrap());
 
@@ -2440,11 +2449,11 @@ fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
     // produce blocks until the we're 1 before the prepare phase (first block of prepare-phase not yet mined, whatever txs we create now won't be included in the reward set)
-    while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height + 1) {
+    while !burnchain.is_in_prepare_phase(get_tip(peer.chain.sortdb.as_ref()).block_height + 1) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
 
@@ -2452,7 +2461,7 @@ fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap()) * 120 / 100; // * 1.2
@@ -2477,7 +2486,7 @@ fn pox_4_check_cycle_id_range_in_print_events_before_prepare_phase() {
         &steph_pox_addr,
         steph_lock_period,
         &steph_signing_key,
-        get_tip(peer.sortdb.as_ref()).block_height,
+        get_tip(peer.chain.sortdb.as_ref()).block_height,
         Some(signature),
         u128::MAX,
         1,
@@ -2560,11 +2569,11 @@ fn pox_4_check_cycle_id_range_in_print_events_in_prepare_phase() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
     // produce blocks until the we're in the prepare phase (first block of prepare-phase was mined, i.e. pox-set for next cycle determined)
-    while !burnchain.is_in_prepare_phase(get_tip(peer.sortdb.as_ref()).block_height) {
+    while !burnchain.is_in_prepare_phase(get_tip(peer.chain.sortdb.as_ref()).block_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
 
@@ -2572,7 +2581,7 @@ fn pox_4_check_cycle_id_range_in_print_events_in_prepare_phase() {
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
 
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap()) * 120 / 100; // * 1.2
@@ -2597,7 +2606,7 @@ fn pox_4_check_cycle_id_range_in_print_events_in_prepare_phase() {
         &steph_pox_addr,
         steph_lock_period,
         &steph_signing_key,
-        get_tip(peer.sortdb.as_ref()).block_height,
+        get_tip(peer.chain.sortdb.as_ref()).block_height,
         Some(signature),
         u128::MAX,
         1,
@@ -2681,7 +2690,7 @@ fn pox_4_delegate_stack_increase_events() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
 
@@ -2697,7 +2706,7 @@ fn pox_4_delegate_stack_increase_events() {
         alice_principal.clone(),
         amount / 2,
         bob_pox_addr.clone(),
-        get_tip(peer.sortdb.as_ref()).block_height as u128,
+        get_tip(peer.chain.sortdb.as_ref()).block_height as u128,
         2,
     );
 
@@ -2791,15 +2800,15 @@ fn pox_4_revoke_delegate_stx_events() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = Some(peer.tenure_with_txs(&[], &mut coinbase_nonce));
     }
 
     info!(
         "Block height: {}",
-        get_tip(peer.sortdb.as_ref()).block_height
+        get_tip(peer.chain.sortdb.as_ref()).block_height
     );
-    let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let block_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let current_cycle = get_current_reward_cycle(&peer, &burnchain);
     let next_cycle = current_cycle + 1;
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block.unwrap());
@@ -2845,7 +2854,7 @@ fn pox_4_revoke_delegate_stx_events() {
 
     // check delegate with expiry
 
-    let target_height = get_tip(peer.sortdb.as_ref()).block_height + 10;
+    let target_height = get_tip(peer.chain.sortdb.as_ref()).block_height + 10;
     let alice_delegate_2 = make_pox_4_delegate_stx(
         &alice,
         alice_nonce,
@@ -2860,7 +2869,7 @@ fn pox_4_revoke_delegate_stx_events() {
     peer.tenure_with_txs(&[alice_delegate_2], &mut coinbase_nonce);
 
     // produce blocks until delegation expired
-    while get_tip(peer.sortdb.as_ref()).block_height <= target_height {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height <= target_height {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -3015,7 +3024,7 @@ fn verify_signer_key_signatures() {
     // Advance into pox4
     let target_height = burnchain.pox_constants.pox_4_activation_height;
     // produce blocks until the first reward phase that everyone should be in
-    while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -4297,31 +4306,74 @@ fn stack_agg_increase() {
     )
     .unwrap();
 
-    peer_config.aggregate_public_key = Some(aggregate_public_key);
+    peer_config.chain_config.aggregate_public_key = Some(aggregate_public_key);
     peer_config
         .stacker_dbs
         .push(boot_code_id(MINERS_NAME, false));
-    peer_config.epochs = Some(StacksEpoch::unit_test_3_0_only(1000)); // Let us not activate nakamoto to make life easier
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
-    peer_config.initial_balances.append(&mut initial_balances);
-    peer_config.burnchain.pox_constants.v2_unlock_height = 81;
-    peer_config.burnchain.pox_constants.pox_3_activation_height = 101;
-    peer_config.burnchain.pox_constants.v3_unlock_height = 102;
-    peer_config.burnchain.pox_constants.pox_4_activation_height = 105;
-    peer_config.test_signers = Some(test_signers);
-    peer_config.burnchain.pox_constants.reward_cycle_length = 20;
-    peer_config.burnchain.pox_constants.prepare_length = 5;
-    let epochs = peer_config.epochs.clone().unwrap();
+    peer_config.chain_config.epochs = Some(StacksEpoch::unit_test_3_0_only(1000)); // Let us not activate nakamoto to make life easier
+    peer_config.chain_config.initial_balances =
+        vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
+    peer_config
+        .chain_config
+        .initial_balances
+        .append(&mut initial_balances);
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .v2_unlock_height = 81;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_3_activation_height = 101;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .v3_unlock_height = 102;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_4_activation_height = 105;
+    peer_config.chain_config.test_signers = Some(test_signers);
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .reward_cycle_length = 20;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .prepare_length = 5;
+    let epochs = peer_config.chain_config.epochs.clone().unwrap();
     let epoch_3 = &epochs[StacksEpochId::Epoch30];
 
     let mut peer = TestPeer::new_with_observer(peer_config, Some(&observer));
     let mut peer_nonce = 0;
     // Set constants
-    let reward_cycle_len = peer.config.burnchain.pox_constants.reward_cycle_length;
-    let prepare_phase_len = peer.config.burnchain.pox_constants.prepare_length;
+    let reward_cycle_len = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .reward_cycle_length;
+    let prepare_phase_len = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .prepare_length;
 
     // Advance into pox4
-    let mut target_height = peer.config.burnchain.pox_constants.pox_4_activation_height;
+    let mut target_height = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_4_activation_height;
     let mut latest_block = None;
     // Produce blocks until the first reward phase that everyone should be in
     while peer.get_burn_block_height() < u64::from(target_height) {
@@ -4329,7 +4381,7 @@ fn stack_agg_increase() {
     }
     let latest_block = latest_block.expect("Failed to get tip");
     // Current reward cycle: 5 (starts at burn block 101)
-    let reward_cycle = get_current_reward_cycle(&peer, &peer.config.burnchain);
+    let reward_cycle = get_current_reward_cycle(&peer, &peer.config.chain_config.burnchain);
     let next_reward_cycle = reward_cycle.wrapping_add(1);
     // Current burn block height: 105
     let burn_block_height = peer.get_burn_block_height();
@@ -5089,7 +5141,7 @@ fn stack_increase_different_signer_keys(use_nakamoto: bool) {
 }
 
 pub fn assert_latest_was_burn(peer: &mut TestPeer) {
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tip_index_block = tip.get_canonical_stacks_block_id();
     let burn_height = tip.block_height - 1;
 
@@ -5105,11 +5157,16 @@ pub fn assert_latest_was_burn(peer: &mut TestPeer) {
     assert!(commit.burn_fee > 0);
 
     let (addrs, payout) = get_burn_pox_addr_info(peer);
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tip_index_block = tip.get_canonical_stacks_block_id();
     let burn_height = tip.block_height - 1;
     info!("Checking burn outputs at burn_height = {burn_height}");
-    if peer.config.burnchain.is_in_prepare_phase(burn_height) {
+    if peer
+        .config
+        .chain_config
+        .burnchain
+        .is_in_prepare_phase(burn_height)
+    {
         assert_eq!(addrs.len(), 1);
         assert_eq!(payout, 1000);
         assert!(addrs[0].is_burn());
@@ -5122,7 +5179,7 @@ pub fn assert_latest_was_burn(peer: &mut TestPeer) {
 }
 
 fn assert_latest_was_pox(peer: &mut TestPeer) -> Vec<PoxAddress> {
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
     let tip_index_block = tip.get_canonical_stacks_block_id();
     let burn_height = tip.block_height - 1;
 
@@ -6648,31 +6705,72 @@ pub fn pox_4_scenario_test_setup<'a>(
     )
     .unwrap();
 
-    peer_config.aggregate_public_key = Some(aggregate_public_key);
+    peer_config.chain_config.aggregate_public_key = Some(aggregate_public_key);
     peer_config
         .stacker_dbs
         .push(boot_code_id(MINERS_NAME, false));
-    peer_config.epochs = Some(StacksEpoch::unit_test_3_0_only(1000));
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
+    peer_config.chain_config.epochs = Some(StacksEpoch::unit_test_3_0_only(1000));
+    peer_config.chain_config.initial_balances =
+        vec![(addr.to_account_principal(), 1_000_000_000_000_000_000)];
     peer_config
+        .chain_config
         .initial_balances
         .extend_from_slice(&initial_balances);
-    peer_config.burnchain.pox_constants.v2_unlock_height = 81;
-    peer_config.burnchain.pox_constants.pox_3_activation_height = 101;
-    peer_config.burnchain.pox_constants.v3_unlock_height = 102;
-    peer_config.burnchain.pox_constants.pox_4_activation_height = 105;
-    peer_config.test_signers = Some(test_signers);
-    peer_config.burnchain.pox_constants.reward_cycle_length = 20;
-    peer_config.burnchain.pox_constants.prepare_length = 5;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .v2_unlock_height = 81;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_3_activation_height = 101;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .v3_unlock_height = 102;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_4_activation_height = 105;
+    peer_config.chain_config.test_signers = Some(test_signers);
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .reward_cycle_length = 20;
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .prepare_length = 5;
 
     let mut peer = TestPeer::new_with_observer(peer_config.clone(), Some(observer));
 
     let mut peer_nonce = 0;
 
-    let reward_cycle_len = peer.config.burnchain.pox_constants.reward_cycle_length;
-    let prepare_phase_len = peer.config.burnchain.pox_constants.prepare_length;
+    let reward_cycle_len = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .reward_cycle_length;
+    let prepare_phase_len = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .prepare_length;
 
-    let target_height = peer.config.burnchain.pox_constants.pox_4_activation_height;
+    let target_height = peer
+        .config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .pox_4_activation_height;
     let mut latest_block = None;
 
     while peer.get_burn_block_height() < u64::from(target_height) {
@@ -6681,10 +6779,10 @@ pub fn pox_4_scenario_test_setup<'a>(
     }
     let latest_block = latest_block.expect("Failed to get tip");
 
-    let reward_cycle = get_current_reward_cycle(&peer, &peer.config.burnchain);
+    let reward_cycle = get_current_reward_cycle(&peer, &peer.config.chain_config.burnchain);
     let next_reward_cycle = reward_cycle.wrapping_add(1);
     let burn_block_height = peer.get_burn_block_height();
-    let current_block_height = peer.config.current_block;
+    let current_block_height = peer.config.chain_config.current_block;
     let min_ustx = get_stacking_minimum(&mut peer, &latest_block);
 
     (
@@ -6745,8 +6843,8 @@ pub fn pox_4_scenario_test_setup_nakamoto<'a>(
         max_amount: None,
     }];
     let mut peer_config = TestPeerConfig::default();
-    peer_config.aggregate_public_key = Some(aggregate_public_key);
-    let mut pox_constants = peer_config.clone().burnchain.pox_constants;
+    peer_config.chain_config.aggregate_public_key = Some(aggregate_public_key);
+    let mut pox_constants = peer_config.chain_config.burnchain.pox_constants.clone();
     pox_constants.reward_cycle_length = 10;
     pox_constants.v2_unlock_height = 21;
     pox_constants.pox_3_activation_height = 26;
@@ -6762,12 +6860,12 @@ pub fn pox_4_scenario_test_setup_nakamoto<'a>(
     boot_plan.initial_balances = initial_balances;
     boot_plan.pox_constants = pox_constants.clone();
     burnchain.pox_constants = pox_constants;
-    peer_config.burnchain = burnchain.clone();
-    peer_config.test_signers = Some(test_signers.clone());
+    peer_config.chain_config.burnchain = burnchain.clone();
+    peer_config.chain_config.test_signers = Some(test_signers.clone());
 
     info!("---- Booting into Nakamoto Peer ----");
     let mut peer = boot_plan.boot_into_nakamoto_peer(vec![], Some(observer));
-    let sort_db = peer.sortdb.as_ref().unwrap();
+    let sort_db = peer.chain.sortdb.as_ref().unwrap();
     let latest_block = sort_db
         .index_handle_at_tip()
         .get_nakamoto_tip_block_id()
@@ -6775,7 +6873,7 @@ pub fn pox_4_scenario_test_setup_nakamoto<'a>(
         .unwrap();
     let coinbase_nonce = 0;
 
-    let burn_block_height = get_tip(peer.sortdb.as_ref()).block_height;
+    let burn_block_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
     let reward_cycle = burnchain
         .block_height_to_reward_cycle(burn_block_height)
         .unwrap() as u128;
@@ -6954,9 +7052,16 @@ fn test_scenario_one(use_nakamoto: bool) {
     // Commit tx & advance to the reward set calculation height (2nd block of the prepare phase)
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer.config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer.config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     let (latest_block, tx_block, receipts) = advance_to_block_height(
         &mut peer,
@@ -7043,6 +7148,7 @@ fn test_scenario_one(use_nakamoto: bool) {
     // 4.3 Check unlock height
     let unlock_height_expected = Value::UInt(
         peer.config
+            .chain_config
             .burnchain
             .reward_cycle_to_block_height(next_reward_cycle as u64 + lock_period as u64)
             .wrapping_sub(1) as u128,
@@ -7092,6 +7198,7 @@ fn test_scenario_one(use_nakamoto: bool) {
     // 6.3 Check unlock height (end of cycle 7 - block 140)
     let unlock_height_expected = Value::UInt(
         peer.config
+            .chain_config
             .burnchain
             .reward_cycle_to_block_height((next_reward_cycle + lock_period) as u64)
             .wrapping_sub(1) as u128,
@@ -7112,7 +7219,11 @@ fn test_scenario_one(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         alice_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -7122,7 +7233,11 @@ fn test_scenario_one(use_nakamoto: bool) {
         &bob.private_key,
         bob.nonce,
         bob_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -7139,7 +7254,7 @@ fn test_scenario_one(use_nakamoto: bool) {
             &tester_key,
             1, // only tx is a stack-stx
             tester_index,
-            peer_config.aggregate_public_key.unwrap(),
+            peer_config.chain_config.aggregate_public_key.unwrap(),
             1,
             next_reward_cycle,
         );
@@ -7150,6 +7265,7 @@ fn test_scenario_one(use_nakamoto: bool) {
     // Commit vote txs & advance to the first burn block of reward cycle 8 (block 161)
     let mut target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(target_reward_cycle as u64);
     info!(
@@ -7387,9 +7503,16 @@ fn test_deser_abort() {
     // Commit tx & advance to the reward set calculation height (2nd block of the prepare phase)
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer.config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer.config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     let (latest_block, tx_block, receipts) = advance_to_block_height(
         &mut peer,
@@ -7476,6 +7599,7 @@ fn test_deser_abort() {
     // 4.3 Check unlock height
     let unlock_height_expected = Value::UInt(
         peer.config
+            .chain_config
             .burnchain
             .reward_cycle_to_block_height(next_reward_cycle as u64 + lock_period as u64)
             .wrapping_sub(1) as u128,
@@ -7525,6 +7649,7 @@ fn test_deser_abort() {
     // 6.3 Check unlock height (end of cycle 7 - block 140)
     let unlock_height_expected = Value::UInt(
         peer.config
+            .chain_config
             .burnchain
             .reward_cycle_to_block_height((next_reward_cycle + lock_period) as u64)
             .wrapping_sub(1) as u128,
@@ -7712,9 +7837,16 @@ fn test_scenario_two(use_nakamoto: bool) {
     // Commit tx & advance to the reward set calculation height (2nd block of the prepare phase for reward cycle 6)
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer_config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     let (latest_block, tx_block, receipts) = advance_to_block_height(
         &mut peer,
@@ -7824,7 +7956,11 @@ fn test_scenario_two(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         alice_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -7834,7 +7970,11 @@ fn test_scenario_two(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         alice_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -7844,7 +7984,11 @@ fn test_scenario_two(use_nakamoto: bool) {
         &bob.private_key,
         bob.nonce,
         bob_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         3,
         next_reward_cycle,
     );
@@ -7854,7 +7998,7 @@ fn test_scenario_two(use_nakamoto: bool) {
         &bob.private_key,
         bob.nonce,
         bob_index,
-        peer_config.aggregate_public_key.unwrap(),
+        peer_config.chain_config.aggregate_public_key.unwrap(),
         1,
         next_reward_cycle,
     );
@@ -7870,6 +8014,7 @@ fn test_scenario_two(use_nakamoto: bool) {
     // Commit vote txs & advance to the first burn block of reward cycle 8 (block 161)
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(target_reward_cycle as u64);
     let (latest_block, tx_block, receipts) = advance_to_block_height(
@@ -8097,6 +8242,7 @@ fn test_scenario_three(use_nakamoto: bool) {
         david.principal.clone(),
         Some(
             peer.config
+                .chain_config
                 .burnchain
                 .reward_cycle_to_block_height(next_reward_cycle as u64)
                 .into(),
@@ -8213,9 +8359,16 @@ fn test_scenario_three(use_nakamoto: bool) {
     // Commit txs in next block & advance to reward set calculation of the next reward cycle
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer_config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     let (latest_block, tx_block, receipts) = advance_to_block_height(
         &mut peer,
@@ -8527,9 +8680,16 @@ fn test_scenario_four(use_nakamoto: bool) {
     // Commit tx & advance to the reward set calculation height (2nd block of the prepare phase for reward cycle 6)
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer_config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     let (latest_block, tx_block, _receipts) = advance_to_block_height(
         &mut peer,
@@ -8561,7 +8721,11 @@ fn test_scenario_four(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         bob_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -8571,7 +8735,11 @@ fn test_scenario_four(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         alice_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -8581,7 +8749,11 @@ fn test_scenario_four(use_nakamoto: bool) {
         &bob.private_key,
         bob.nonce,
         bob_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -8598,7 +8770,11 @@ fn test_scenario_four(use_nakamoto: bool) {
             &tester_key,
             1, // only tx is a stack-stx
             tester_index,
-            peer_config.aggregate_public_key.clone().unwrap(),
+            peer_config
+                .chain_config
+                .aggregate_public_key
+                .clone()
+                .unwrap(),
             1,
             next_reward_cycle,
         );
@@ -8608,9 +8784,16 @@ fn test_scenario_four(use_nakamoto: bool) {
     // Commit vote txs & move to the prepare phase of reward cycle 7 (block 155)
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64 + 1)
-        .saturating_sub(peer_config.burnchain.pox_constants.prepare_length as u64);
+        .saturating_sub(
+            peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        );
     let (latest_block, tx_block, receipts) = advance_to_block_height(
         &mut peer,
         &observer,
@@ -8654,7 +8837,11 @@ fn test_scenario_four(use_nakamoto: bool) {
         .expect("No approved key found");
     assert_eq!(
         approved_key,
-        peer_config.aggregate_public_key.clone().unwrap()
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap()
     );
 
     // Alice stack-extend err tx
@@ -8689,7 +8876,7 @@ fn test_scenario_four(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         alice_index,
-        peer_config.aggregate_public_key.unwrap(),
+        peer_config.chain_config.aggregate_public_key.unwrap(),
         1,
         7,
     );
@@ -9089,7 +9276,7 @@ pub fn prepare_pox4_test<'a>(
                 max_amount: None,
             })
             .collect::<Vec<_>>();
-        let mut pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+        let mut pox_constants = TestChainstateConfig::default().burnchain.pox_constants;
         pox_constants.reward_cycle_length = 10;
         pox_constants.v2_unlock_height = 21;
         pox_constants.pox_3_activation_height = 26;
@@ -9113,7 +9300,7 @@ pub fn prepare_pox4_test<'a>(
 
         info!("---- Booting into Nakamoto Peer ----");
         let peer = boot_plan.boot_into_nakamoto_peer(vec![], observer);
-        let sort_db = peer.sortdb.as_ref().unwrap();
+        let sort_db = peer.chain.sortdb.as_ref().unwrap();
         let latest_block = sort_db
             .index_handle_at_tip()
             .get_nakamoto_tip_block_id()
@@ -9121,7 +9308,7 @@ pub fn prepare_pox4_test<'a>(
             .unwrap();
         let coinbase_nonce = 0;
 
-        let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+        let block_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
 
         info!("Block height: {}", block_height);
 
@@ -9139,16 +9326,16 @@ pub fn prepare_pox4_test<'a>(
         let target_height = burnchain.pox_constants.pox_4_activation_height;
         let mut coinbase_nonce = 0;
         let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
-        while get_tip(peer.sortdb.as_ref()).block_height < u64::from(target_height) {
+        while get_tip(peer.chain.sortdb.as_ref()).block_height < u64::from(target_height) {
             latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
             // if we reach epoch 2.1, perform the check
-            if get_tip(peer.sortdb.as_ref()).block_height
+            if get_tip(peer.chain.sortdb.as_ref()).block_height
                 > epochs[StacksEpochId::Epoch21].start_height
             {
                 assert_latest_was_burn(&mut peer);
             }
         }
-        let block_height = get_tip(peer.sortdb.as_ref()).block_height;
+        let block_height = get_tip(peer.chain.sortdb.as_ref()).block_height;
         (
             burnchain,
             peer,
@@ -9178,9 +9365,10 @@ pub fn tenure_with_txs_fallible(
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
         let tenure_change_tx = peer
+            .chain
             .miner
             .make_nakamoto_tenure_change(tenure_change.clone());
-        let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+        let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
         let blocks_and_sizes = peer.make_nakamoto_tenure_and(
             tenure_change_tx,
@@ -9202,8 +9390,8 @@ pub fn tenure_with_txs_fallible(
             .map(|(block, _, _)| block)
             .collect();
 
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let latest_block = sort_db
             .index_handle_at_tip()
             .get_nakamoto_tip_block_id()
@@ -9230,8 +9418,8 @@ pub fn tenure_with_txs(
         tenure_change.tenure_consensus_hash = consensus_hash.clone();
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
-        let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change);
-        let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+        let tenure_change_tx = peer.chain.miner.make_nakamoto_tenure_change(tenure_change);
+        let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
         let blocks_and_sizes = peer.make_nakamoto_tenure(
             tenure_change_tx,
@@ -9251,8 +9439,8 @@ pub fn tenure_with_txs(
             .map(|(block, _, _)| block)
             .collect();
 
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         let latest_block = sort_db
             .index_handle_at_tip()
             .get_nakamoto_tip_block_id()
@@ -9328,13 +9516,14 @@ fn missed_slots_no_unlock() {
         + 1;
 
     // produce blocks until epoch 2.5
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch25].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch25].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
     // perform lockups so we can test that pox-4 does not exhibit unlock-on-miss behavior
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let alice_lockup =
         make_simple_pox_4_lock(&alice, &mut peer, 1024 * POX_THRESHOLD_STEPS_USTX, 6);
@@ -9377,7 +9566,7 @@ fn missed_slots_no_unlock() {
     );
     assert_eq!(bob_bal.amount_locked(), POX_THRESHOLD_STEPS_USTX);
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -9578,12 +9767,13 @@ fn no_lockups_2_5() {
         + 1;
 
     // produce blocks until epoch 2.5
-    while get_tip(peer.sortdb.as_ref()).block_height <= epochs[StacksEpochId::Epoch25].start_height
+    while get_tip(peer.chain.sortdb.as_ref()).block_height
+        <= epochs[StacksEpochId::Epoch25].start_height
     {
         peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
-    let tip = get_tip(peer.sortdb.as_ref());
+    let tip = get_tip(peer.chain.sortdb.as_ref());
 
     let bob_lockup = make_simple_pox_4_lock(&bob, &mut peer, 1 * POX_THRESHOLD_STEPS_USTX, 6);
 
@@ -9618,7 +9808,7 @@ fn no_lockups_2_5() {
     );
     assert_eq!(bob_bal.amount_locked(), POX_THRESHOLD_STEPS_USTX);
 
-    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+    while get_tip(peer.chain.sortdb.as_ref()).block_height < height_target {
         latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
     }
 
@@ -9722,36 +9912,43 @@ fn test_scenario_five(use_nakamoto: bool) {
 
     let carl_end_burn_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle.wrapping_add(carl_lock_period) as u64)
         as u128;
     let frank_end_burn_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle.wrapping_add(frank_lock_period) as u64)
         as u128;
     let grace_end_burn_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle.wrapping_add(grace_lock_period) as u64)
         as u128;
     let heidi_end_burn_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle.wrapping_add(heidi_lock_period) as u64)
         as u128;
     let ivan_end_burn_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle.wrapping_add(ivan_lock_period) as u64)
         as u128;
     let jude_end_burn_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle.wrapping_add(jude_lock_period) as u64)
         as u128;
     let mallory_end_burn_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle.wrapping_add(mallory_lock_period) as u64)
         as u128;
@@ -9964,15 +10161,22 @@ fn test_scenario_five(use_nakamoto: bool) {
     // Advance to reward set calculation of the next reward cycle
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer_config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     info!(
         "Scenario five: submitting stacking txs.";
         "target_height" => target_height,
         "next_reward_cycle" => next_reward_cycle,
-        "prepare_length" => peer_config.burnchain.pox_constants.prepare_length,
+        "prepare_length" => peer_config.chain_config.burnchain.pox_constants.prepare_length,
     );
     let (latest_block, tx_block, _receipts) = advance_to_block_height(
         &mut peer,
@@ -10031,7 +10235,11 @@ fn test_scenario_five(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         alice_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -10039,7 +10247,11 @@ fn test_scenario_five(use_nakamoto: bool) {
         &bob.private_key,
         bob.nonce,
         bob_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -10047,7 +10259,11 @@ fn test_scenario_five(use_nakamoto: bool) {
         &carl.private_key,
         carl.nonce,
         carl_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -10058,6 +10274,7 @@ fn test_scenario_five(use_nakamoto: bool) {
     // Mine vote txs & advance to the reward set calculation of the next reward cycle
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64);
     info!(
@@ -10088,7 +10305,10 @@ fn test_scenario_five(use_nakamoto: bool) {
     }
     let approved_key = get_approved_aggregate_key(&mut peer, &latest_block, next_reward_cycle)
         .expect("No approved key found");
-    assert_eq!(approved_key, peer_config.aggregate_public_key.unwrap());
+    assert_eq!(
+        approved_key,
+        peer_config.chain_config.aggregate_public_key.unwrap()
+    );
 
     // Stack for following reward cycle again and then advance to epoch 3.0 activation boundary
     let reward_cycle = peer.get_reward_cycle() as u128;
@@ -10167,9 +10387,16 @@ fn test_scenario_five(use_nakamoto: bool) {
 
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer_config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     info!(
         "Scenario five: submitting extend and aggregate commit txs. Target height: {}",
@@ -10225,8 +10452,9 @@ fn test_scenario_five(use_nakamoto: bool) {
 
     let cycle_id = next_reward_cycle;
     // Generate next cycle aggregate public key
-    peer_config.aggregate_public_key = Some(
+    peer_config.chain_config.aggregate_public_key = Some(
         peer_config
+            .chain_config
             .test_signers
             .unwrap()
             .generate_aggregate_key(cycle_id as u64),
@@ -10239,7 +10467,11 @@ fn test_scenario_five(use_nakamoto: bool) {
         &alice.private_key,
         alice.nonce,
         alice_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -10247,7 +10479,11 @@ fn test_scenario_five(use_nakamoto: bool) {
         &bob.private_key,
         bob.nonce,
         bob_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -10255,7 +10491,11 @@ fn test_scenario_five(use_nakamoto: bool) {
         &carl.private_key,
         carl.nonce,
         carl_index,
-        peer_config.aggregate_public_key.clone().unwrap(),
+        peer_config
+            .chain_config
+            .aggregate_public_key
+            .clone()
+            .unwrap(),
         1,
         next_reward_cycle,
     );
@@ -10266,6 +10506,7 @@ fn test_scenario_five(use_nakamoto: bool) {
 
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64);
     // Submit vote transactions
@@ -10297,7 +10538,10 @@ fn test_scenario_five(use_nakamoto: bool) {
     }
     let approved_key = get_approved_aggregate_key(&mut peer, &latest_block, next_reward_cycle)
         .expect("No approved key found");
-    assert_eq!(approved_key, peer_config.aggregate_public_key.unwrap());
+    assert_eq!(
+        approved_key,
+        peer_config.chain_config.aggregate_public_key.unwrap()
+    );
 
     // Let us start stacking for the following reward cycle
     let current_reward_cycle = peer.get_reward_cycle() as u128;
@@ -10378,9 +10622,16 @@ fn test_scenario_five(use_nakamoto: bool) {
 
     let target_height = peer
         .config
+        .chain_config
         .burnchain
         .reward_cycle_to_block_height(next_reward_cycle as u64)
-        .saturating_sub(peer_config.burnchain.pox_constants.prepare_length as u64)
+        .saturating_sub(
+            peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .prepare_length as u64,
+        )
         .wrapping_add(2);
     // This assertion just makes testing logic a bit easier
     let davids_stackers = &[(grace, grace_lock_period), (heidi, heidi_lock_period)];

--- a/stackslib/src/chainstate/stacks/boot/signers_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/signers_tests.rs
@@ -350,8 +350,8 @@ pub fn prepare_signers_test<'a>(
 
     tenure_change.tenure_consensus_hash = consensus_hash.clone();
     tenure_change.burn_view_consensus_hash = consensus_hash.clone();
-    let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change);
-    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let tenure_change_tx = peer.chain.miner.make_nakamoto_tenure_change(tenure_change);
+    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
     let blocks_and_sizes = peer.make_nakamoto_tenure(
         tenure_change_tx,
@@ -409,8 +409,8 @@ fn advance_blocks(
 
     tenure_change.tenure_consensus_hash = consensus_hash.clone();
     tenure_change.burn_view_consensus_hash = consensus_hash.clone();
-    let tenure_change_tx = peer.miner.make_nakamoto_tenure_change(tenure_change);
-    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+    let tenure_change_tx = peer.chain.miner.make_nakamoto_tenure_change(tenure_change);
+    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
     let recipient_addr = boot_code_addr(false);
     let blocks_and_sizes = peer.make_nakamoto_tenure(
         tenure_change_tx,

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -412,7 +412,7 @@ impl StacksChainState {
 
         block_path.push(to_hex(&block_hash_bytes[0..2]));
         block_path.push(to_hex(&block_hash_bytes[2..4]));
-        block_path.push(format!("{}", index_block_hash));
+        block_path.push(index_block_hash.to_string());
 
         block_path
     }
@@ -9746,7 +9746,7 @@ pub mod test {
             assert_eq!(mblock_info.len(), mblocks.len());
 
             let this_mblock_info = &mblock_info[i];
-            test_debug!("Pass {} (seq {})", &i, &this_mblock_info.sequence);
+            test_debug!("Pass {i} (seq {})", &this_mblock_info.sequence);
 
             assert_eq!(this_mblock_info.consensus_hash, consensus_hash);
             assert_eq!(this_mblock_info.anchored_block_hash, block.block_hash());
@@ -9799,7 +9799,7 @@ pub mod test {
         let mut parent_consensus_hashes = vec![];
 
         for i in 0..32 {
-            test_debug!("Making block {}", i);
+            test_debug!("Making block {i}");
             let privk = StacksPrivateKey::random();
             let block = make_empty_coinbase_block(&privk);
 
@@ -9814,7 +9814,7 @@ pub mod test {
         }
 
         for i in 0..blocks.len() {
-            test_debug!("Making microblock stream {}", i);
+            test_debug!("Making microblock stream {i}");
             // make a sample microblock stream for block i
             let mut mblocks = make_sample_microblock_stream(&privks[i], &blocks[i].block_hash());
             mblocks.truncate(3);
@@ -9852,7 +9852,7 @@ pub mod test {
             .zip(&microblocks)
             .enumerate()
         {
-            test_debug!("Store microblock stream {} to staging", i);
+            test_debug!("Store microblock stream {i} to staging");
             for mblock in mblocks.iter() {
                 test_debug!("Store microblock {}", &mblock.block_hash());
                 store_staging_microblock(
@@ -10025,27 +10025,29 @@ pub mod test {
         .unwrap();
 
         let initial_balance = 1000000000;
-        peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
+        peer_config.chain_config.initial_balances =
+            vec![(addr.to_account_principal(), initial_balance)];
         let recv_addr =
             StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
 
         let mut peer = TestPeer::new(peer_config.clone());
 
-        let chainstate_path = peer.chainstate_path.clone();
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         // NOTE: first_stacks_block_height is the burnchain height at which the node starts mining.
         // The burnchain block at this height will have the VRF key register, but no block-commit.
         // The first burnchain block with a Stacks block is at first_stacks_block_height + 1.
         let (first_stacks_block_height, canonical_sort_id) = {
-            let sn =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let sn = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
             (sn.block_height, sn.sortition_id)
         };
 
         let mut header_hashes = vec![];
         for i in 0..(first_stacks_block_height + 1) {
-            let ic = peer.sortdb.as_ref().unwrap().index_conn();
+            let ic = peer.chain.sortdb.as_ref().unwrap().index_conn();
             let sn = SortitionDB::get_ancestor_snapshot(&ic, i, &canonical_sort_id)
                 .unwrap()
                 .unwrap();
@@ -10060,16 +10062,22 @@ pub mod test {
         }
 
         let last_stacks_block_height = first_stacks_block_height
-            + ((peer_config.burnchain.pox_constants.reward_cycle_length as u64) * 5)
+            + ((peer_config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .reward_cycle_length as u64)
+                * 5)
             + 2;
 
         let mut mblock_nonce = 0;
 
         // make some blocks, up to and including a fractional reward cycle
         for tenure_id in 0..(last_stacks_block_height - first_stacks_block_height) {
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
             assert_eq!(tip.block_height, first_stacks_block_height + tenure_id);
 
@@ -10122,7 +10130,7 @@ pub mod test {
                         &coinbase_tx,
                         BlockBuilderSettings::max_value(),
                         None,
-                        &peer_config.burnchain,
+                        &peer_config.chain_config.burnchain,
                     )
                     .unwrap();
 
@@ -10181,6 +10189,7 @@ pub mod test {
         }
 
         let total_reward_cycles = peer_config
+            .chain_config
             .burnchain
             .block_height_to_reward_cycle(last_stacks_block_height)
             .unwrap();
@@ -10197,14 +10206,20 @@ pub mod test {
 
         // everything is stored, so check each reward cycle
         for i in 0..total_reward_cycles {
-            let start_range = peer_config.burnchain.reward_cycle_to_block_height(i);
+            let start_range = peer_config
+                .chain_config
+                .burnchain
+                .reward_cycle_to_block_height(i);
             let end_range = cmp::min(
                 header_hashes.len() as u64,
-                peer_config.burnchain.reward_cycle_to_block_height(i + 1),
+                peer_config
+                    .chain_config
+                    .burnchain
+                    .reward_cycle_to_block_height(i + 1),
             );
             let blocks_inv = chainstate
                 .get_blocks_inventory_for_reward_cycle(
-                    &peer_config.burnchain,
+                    &peer_config.chain_config.burnchain,
                     i,
                     &header_hashes[(start_range as usize)..(end_range as usize)],
                 )
@@ -10248,10 +10263,16 @@ pub mod test {
 
         // orphan blocks
         for i in 0..total_reward_cycles {
-            let start_range = peer_config.burnchain.reward_cycle_to_block_height(i);
+            let start_range = peer_config
+                .chain_config
+                .burnchain
+                .reward_cycle_to_block_height(i);
             let end_range = cmp::min(
                 header_hashes.len() as u64,
-                peer_config.burnchain.reward_cycle_to_block_height(i + 1),
+                peer_config
+                    .chain_config
+                    .burnchain
+                    .reward_cycle_to_block_height(i + 1),
             );
             for block_height in start_range..end_range {
                 if let Some(hdr_hash) = &header_hashes[block_height as usize].1 {
@@ -10272,14 +10293,20 @@ pub mod test {
         }
 
         for i in 0..total_reward_cycles {
-            let start_range = peer_config.burnchain.reward_cycle_to_block_height(i);
+            let start_range = peer_config
+                .chain_config
+                .burnchain
+                .reward_cycle_to_block_height(i);
             let end_range = cmp::min(
                 header_hashes.len() as u64,
-                peer_config.burnchain.reward_cycle_to_block_height(i + 1),
+                peer_config
+                    .chain_config
+                    .burnchain
+                    .reward_cycle_to_block_height(i + 1),
             );
             let blocks_inv = chainstate
                 .get_blocks_inventory_for_reward_cycle(
-                    &peer_config.burnchain,
+                    &peer_config.chain_config.burnchain,
                     i,
                     &header_hashes[(start_range as usize)..(end_range as usize)],
                 )
@@ -10302,25 +10329,27 @@ pub mod test {
     #[test]
     fn test_get_parent_block_header() {
         let peer_config = TestPeerConfig::new(function_name!(), 21313, 21314);
-        let burnchain = peer_config.burnchain.clone();
+        let burnchain = peer_config.chain_config.burnchain.clone();
         let mut peer = TestPeer::new(peer_config);
 
-        let chainstate_path = peer.chainstate_path.clone();
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         let num_blocks = 10;
         let first_stacks_block_height = {
-            let sn =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let sn = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
             sn.block_height
         };
 
         let mut last_block_ch: Option<ConsensusHash> = None;
         let mut last_parent_opt: Option<StacksBlock> = None;
         for tenure_id in 0..num_blocks {
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
             assert_eq!(
                 tip.block_height,
@@ -10387,7 +10416,7 @@ pub mod test {
 
             if tenure_id == 0 {
                 let parent_header_opt = StacksChainState::load_parent_block_header(
-                    &peer.sortdb.as_ref().unwrap().index_conn(),
+                    &peer.chain.sortdb.as_ref().unwrap().index_conn(),
                     &blocks_path,
                     &consensus_hash,
                     &stacks_block.block_hash(),
@@ -10395,7 +10424,7 @@ pub mod test {
                 assert!(parent_header_opt.is_err());
             } else {
                 let parent_header_opt = StacksChainState::load_parent_block_header(
-                    &peer.sortdb.as_ref().unwrap().index_conn(),
+                    &peer.chain.sortdb.as_ref().unwrap().index_conn(),
                     &blocks_path,
                     &consensus_hash,
                     &stacks_block.block_hash(),
@@ -10844,31 +10873,37 @@ pub mod test {
             .map(|addr| (addr.to_account_principal(), initial_balance))
             .collect();
         init_balances.push((addr.to_account_principal(), initial_balance));
-        peer_config.initial_balances = init_balances;
+        peer_config.chain_config.initial_balances = init_balances;
         let mut epochs = StacksEpoch::unit_test_2_1(0);
         let last_epoch = epochs.last_mut().unwrap();
         last_epoch.block_limit.runtime = 10_000_000;
-        peer_config.epochs = Some(epochs);
-        peer_config.burnchain.pox_constants.v1_unlock_height = 26;
-        let burnchain = peer_config.burnchain.clone();
+        peer_config.chain_config.epochs = Some(epochs);
+        peer_config
+            .chain_config
+            .burnchain
+            .pox_constants
+            .v1_unlock_height = 26;
+        let burnchain = peer_config.chain_config.burnchain.clone();
 
         let mut peer = TestPeer::new(peer_config);
 
-        let chainstate_path = peer.chainstate_path.clone();
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         let first_stacks_block_height = {
-            let sn =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let sn = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
             sn.block_height
         };
 
         let mut last_block_id = StacksBlockId([0x00; 32]);
         for tenure_id in 0..num_blocks {
             let del_addr = &del_addrs[tenure_id];
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
             assert_eq!(
                 tip.block_height,
@@ -11024,11 +11059,12 @@ pub mod test {
                 );
             }
 
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
-            let sortdb = peer.sortdb.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
             {
                 let chainstate = peer.chainstate();
                 let (mut chainstate_tx, clarity_instance) =
@@ -11061,12 +11097,12 @@ pub mod test {
                 assert_eq!(transfer_stx_ops, expected_transfer_ops);
                 assert_eq!(delegate_stx_ops, expected_del_ops);
             }
-            peer.sortdb.replace(sortdb);
+            peer.chain.sortdb.replace(sortdb);
         }
 
         // all burnchain transactions mined, even if there was no sortition in the burn block in
         // which they were mined.
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
 
         // definitely missing some blocks -- there are empty sortitions
         let stacks_tip =
@@ -11085,7 +11121,7 @@ pub mod test {
                 StacksChainState::get_account(conn, &addr.to_account_principal())
             })
             .unwrap();
-        peer.sortdb.replace(sortdb);
+        peer.chain.sortdb.replace(sortdb);
 
         assert_eq!(
             account.stx_balance.get_total_balance().unwrap(),
@@ -11166,32 +11202,38 @@ pub mod test {
             .map(|addr| (addr.to_account_principal(), initial_balance))
             .collect();
         init_balances.push((addr.to_account_principal(), initial_balance));
-        peer_config.initial_balances = init_balances;
+        peer_config.chain_config.initial_balances = init_balances;
         let mut epochs = StacksEpoch::unit_test_2_1(0);
         let last_epoch = epochs.last_mut().unwrap();
         last_epoch.block_limit.runtime = 10_000_000;
         last_epoch.block_limit.read_length = 10_000_000;
-        peer_config.epochs = Some(epochs);
-        peer_config.burnchain.pox_constants.v1_unlock_height = 26;
-        let burnchain = peer_config.burnchain.clone();
+        peer_config.chain_config.epochs = Some(epochs);
+        peer_config
+            .chain_config
+            .burnchain
+            .pox_constants
+            .v1_unlock_height = 26;
+        let burnchain = peer_config.chain_config.burnchain.clone();
 
         let mut peer = TestPeer::new(peer_config);
 
-        let chainstate_path = peer.chainstate_path.clone();
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         let first_stacks_block_height = {
-            let sn =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let sn = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
             sn.block_height
         };
 
         let mut last_block_id = StacksBlockId([0x00; 32]);
         for tenure_id in 0..num_blocks {
             let del_addr = &del_addrs[tenure_id];
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
             assert_eq!(
                 tip.block_height,
@@ -11704,11 +11746,12 @@ pub mod test {
                 );
             }
 
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
-            let sortdb = peer.sortdb.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
             {
                 let chainstate = peer.chainstate();
                 let (mut chainstate_tx, clarity_instance) =
@@ -11741,12 +11784,12 @@ pub mod test {
                 assert_eq!(transfer_stx_ops, expected_transfer_ops);
                 assert_eq!(delegate_stx_ops, expected_delegate_ops);
             }
-            peer.sortdb.replace(sortdb);
+            peer.chain.sortdb.replace(sortdb);
         }
 
         // all burnchain transactions mined, even if there was no sortition in the burn block in
         // which they were mined.
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
 
         // definitely missing some blocks -- there are empty sortitions
         let stacks_tip =
@@ -11768,7 +11811,7 @@ pub mod test {
                 StacksChainState::get_account(conn, &addr.to_account_principal())
             })
             .unwrap();
-        peer.sortdb.replace(sortdb);
+        peer.chain.sortdb.replace(sortdb);
 
         // skipped tenure 6's TransferSTX
         assert_eq!(

--- a/stackslib/src/chainstate/stacks/db/unconfirmed.rs
+++ b/stackslib/src/chainstate/stacks/db/unconfirmed.rs
@@ -652,18 +652,20 @@ mod test {
 
         let initial_balance = 1000000000;
         let mut peer_config = TestPeerConfig::new(function_name!(), 7000, 7001);
-        peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
-        let burnchain = peer_config.burnchain.clone();
+        peer_config.chain_config.initial_balances =
+            vec![(addr.to_account_principal(), initial_balance)];
+        let burnchain = peer_config.chain_config.burnchain.clone();
 
         let mut peer = TestPeer::new(peer_config);
 
-        let chainstate_path = peer.chainstate_path.clone();
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         let num_blocks = 10;
         let first_stacks_block_height = {
-            let sn =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let sn = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
             sn.block_height
         };
 
@@ -674,9 +676,10 @@ mod test {
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
             // send transactions to the mempool
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
             assert_eq!(
                 tip.block_height,
@@ -754,7 +757,7 @@ mod test {
 
             // build 1-block microblock stream
             let microblocks = {
-                let sortdb = peer.sortdb.take().unwrap();
+                let sortdb = peer.chain.sortdb.take().unwrap();
                 let sort_iconn = sortdb
                     .index_handle_at_block(peer.chainstate(), &canonical_tip)
                     .unwrap();
@@ -813,7 +816,7 @@ mod test {
                     microblock
                 };
 
-                peer.sortdb = Some(sortdb);
+                peer.chain.sortdb = Some(sortdb);
                 vec![microblock]
             };
 
@@ -829,7 +832,7 @@ mod test {
             }
 
             // process microblock stream to generate unconfirmed state
-            let sortdb = peer.sortdb.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
             let iconn = sortdb
                 .index_handle_at_block(peer.chainstate(), &canonical_tip)
                 .unwrap();
@@ -848,14 +851,14 @@ mod test {
                 })
                 .unwrap()
                 .unwrap();
-            peer.sortdb = Some(sortdb);
+            peer.chain.sortdb = Some(sortdb);
 
             // move 1 stx per round
             assert_eq!(recv_balance.amount_unlocked(), (tenure_id + 1) as u128);
             let (canonical_burn, canonical_block) =
                 SortitionDB::get_canonical_stacks_chain_tip_hash(peer.sortdb().conn()).unwrap();
 
-            let sortdb = peer.sortdb.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
             let iconn = sortdb
                 .index_handle_at_block(peer.chainstate(), &canonical_tip)
                 .unwrap();
@@ -869,7 +872,7 @@ mod test {
                     })
                 })
                 .unwrap();
-            peer.sortdb = Some(sortdb);
+            peer.chain.sortdb = Some(sortdb);
 
             assert_eq!(confirmed_recv_balance.amount_unlocked(), tenure_id as u128);
             eprintln!("\nrecv_balance: {}\nconfirmed_recv_balance: {}\nblock header {}: {:?}\ntip: {}/{}\n", recv_balance.amount_unlocked(), confirmed_recv_balance.amount_unlocked(), &stacks_block.block_hash(), &stacks_block.header, &canonical_burn, &canonical_block);
@@ -889,18 +892,20 @@ mod test {
 
         let initial_balance = 1000000000;
         let mut peer_config = TestPeerConfig::new(function_name!(), 7002, 7003);
-        peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
-        let burnchain = peer_config.burnchain.clone();
+        peer_config.chain_config.initial_balances =
+            vec![(addr.to_account_principal(), initial_balance)];
+        let burnchain = peer_config.chain_config.burnchain.clone();
 
         let mut peer = TestPeer::new(peer_config);
 
-        let chainstate_path = peer.chainstate_path.clone();
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         let num_blocks = 10;
         let first_stacks_block_height = {
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
             tip.block_height
         };
 
@@ -911,9 +916,10 @@ mod test {
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
             // send transactions to the mempool
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
             assert_eq!(
                 tip.block_height,
@@ -990,7 +996,7 @@ mod test {
                 StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
 
             // build microblock stream iteratively, and test balances at each additional microblock
-            let sortdb = peer.sortdb.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
             let microblocks = {
                 let sort_iconn = sortdb
                     .index_handle_at_block(peer.chainstate(), &canonical_tip)
@@ -1055,7 +1061,7 @@ mod test {
                 }
                 microblocks
             };
-            peer.sortdb = Some(sortdb);
+            peer.chain.sortdb = Some(sortdb);
 
             // store microblock stream
             for (i, mblock) in microblocks.into_iter().enumerate() {
@@ -1068,7 +1074,7 @@ mod test {
                     .unwrap();
 
                 // process microblock stream to generate unconfirmed state
-                let sortdb = peer.sortdb.take().unwrap();
+                let sortdb = peer.chain.sortdb.take().unwrap();
                 peer.chainstate()
                     .reload_unconfirmed_state(&sortdb.index_handle_at_tip(), canonical_tip.clone())
                     .unwrap();
@@ -1087,7 +1093,7 @@ mod test {
                     )
                     .unwrap()
                     .unwrap();
-                peer.sortdb = Some(sortdb);
+                peer.chain.sortdb = Some(sortdb);
 
                 // move 100 ustx per round -- 10 per mblock
                 assert_eq!(
@@ -1097,7 +1103,7 @@ mod test {
                 let (canonical_burn, canonical_block) =
                     SortitionDB::get_canonical_stacks_chain_tip_hash(peer.sortdb().conn()).unwrap();
 
-                let sortdb = peer.sortdb.take().unwrap();
+                let sortdb = peer.chain.sortdb.take().unwrap();
                 let confirmed_recv_balance = peer
                     .chainstate()
                     .with_read_only_clarity_tx(
@@ -1112,7 +1118,7 @@ mod test {
                         },
                     )
                     .unwrap();
-                peer.sortdb = Some(sortdb);
+                peer.chain.sortdb = Some(sortdb);
 
                 assert_eq!(
                     confirmed_recv_balance.amount_unlocked(),
@@ -1136,25 +1142,27 @@ mod test {
 
         let initial_balance = 1000000000;
         let mut peer_config = TestPeerConfig::new(function_name!(), 7004, 7005);
-        peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
-        peer_config.epochs = Some(EpochList::new(&[StacksEpoch {
+        peer_config.chain_config.initial_balances =
+            vec![(addr.to_account_principal(), initial_balance)];
+        peer_config.chain_config.epochs = Some(EpochList::new(&[StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,
             start_height: 0,
             end_height: (i64::MAX) as u64,
             block_limit: BLOCK_LIMIT_MAINNET_20,
             network_epoch: PEER_VERSION_EPOCH_2_0,
         }]));
-        let burnchain = peer_config.burnchain.clone();
+        let burnchain = peer_config.chain_config.burnchain.clone();
 
         let mut peer = TestPeer::new(peer_config);
-        let chainstate_path = peer.chainstate_path.clone();
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         let num_blocks = 5;
         let num_microblocks = 3;
         let first_stacks_block_height = {
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
             tip.block_height
         };
 
@@ -1170,9 +1178,10 @@ mod test {
                 Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_privkey));
 
             // send transactions to the mempool
-            let tip =
-                SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-                    .unwrap();
+            let tip = SortitionDB::get_canonical_burn_chain_tip(
+                peer.chain.sortdb.as_ref().unwrap().conn(),
+            )
+            .unwrap();
 
             assert_eq!(
                 tip.block_height,
@@ -1284,8 +1293,8 @@ mod test {
                 &stacks_block.block_hash(),
             );
 
-            let mut sortdb = peer.sortdb.take().unwrap();
-            let mut inner_node = peer.stacks_node.take().unwrap();
+            let mut sortdb = peer.chain.sortdb.take().unwrap();
+            let mut inner_node = peer.chain.stacks_node.take().unwrap();
 
             for i in 0..num_microblocks {
                 Relayer::refresh_unconfirmed(&mut inner_node.chainstate, &mut sortdb);
@@ -1368,8 +1377,8 @@ mod test {
                     .unwrap();
             }
 
-            peer.sortdb = Some(sortdb);
-            peer.stacks_node = Some(inner_node);
+            peer.chain.sortdb = Some(sortdb);
+            peer.chain.stacks_node = Some(inner_node);
         }
 
         let (consensus_hash, canonical_block) =
@@ -1378,7 +1387,7 @@ mod test {
             StacksBlockHeader::make_index_block_hash(&consensus_hash, &canonical_block);
 
         // process microblock stream to generate unconfirmed state
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let iconn = sortdb
             .index_handle_at_block(peer.chainstate(), &canonical_tip)
             .unwrap();
@@ -1397,7 +1406,7 @@ mod test {
             })
             .unwrap()
             .unwrap();
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
 
         // all valid txs were processed
         assert_eq!(db_recv_balance.amount_unlocked(), recv_balance);

--- a/stackslib/src/chainstate/stacks/tests/accounting.rs
+++ b/stackslib/src/chainstate/stacks/tests/accounting.rs
@@ -61,7 +61,7 @@ fn test_bad_microblock_fees_pre_v210() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2018, 2019);
-    peer_config.initial_balances = vec![
+    peer_config.chain_config.initial_balances = vec![
         (addr.to_account_principal(), 1000000000),
         (addr_anchored.to_account_principal(), 1000000000),
     ];
@@ -95,8 +95,8 @@ fn test_bad_microblock_fees_pre_v210() {
             network_epoch: PEER_VERSION_EPOCH_2_05,
         },
     ]);
-    peer_config.epochs = Some(epochs);
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.epochs = Some(epochs);
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let num_blocks = 10;
     let mut anchored_sender_nonce = 0;
@@ -109,11 +109,12 @@ fn test_bad_microblock_fees_pre_v210() {
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -123,8 +124,9 @@ fn test_bad_microblock_fees_pre_v210() {
     let mut block_ids = vec![];
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -377,11 +379,11 @@ fn test_bad_microblock_fees_fix_transition() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2020, 2021);
-    peer_config.initial_balances = vec![
+    peer_config.chain_config.initial_balances = vec![
         (addr.to_account_principal(), 1000000000),
         (addr_anchored.to_account_principal(), 1000000000),
     ];
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let epochs = EpochList::new(&[
         StacksEpoch {
@@ -419,7 +421,7 @@ fn test_bad_microblock_fees_fix_transition() {
             network_epoch: PEER_VERSION_EPOCH_2_1,
         },
     ]);
-    peer_config.epochs = Some(epochs);
+    peer_config.chain_config.epochs = Some(epochs);
 
     let num_blocks = 10;
     let mut anchored_sender_nonce = 0;
@@ -432,11 +434,12 @@ fn test_bad_microblock_fees_fix_transition() {
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -446,8 +449,9 @@ fn test_bad_microblock_fees_fix_transition() {
     let mut block_ids = vec![];
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -734,11 +738,11 @@ fn test_get_block_info_v210() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2022, 2023);
-    peer_config.initial_balances = vec![
+    peer_config.chain_config.initial_balances = vec![
         (addr.to_account_principal(), 1000000000),
         (addr_anchored.to_account_principal(), 1000000000),
     ];
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let epochs = EpochList::new(&[
         StacksEpoch {
@@ -776,7 +780,7 @@ fn test_get_block_info_v210() {
             network_epoch: PEER_VERSION_EPOCH_2_1,
         },
     ]);
-    peer_config.epochs = Some(epochs);
+    peer_config.chain_config.epochs = Some(epochs);
 
     let num_blocks = 10;
     let mut anchored_sender_nonce = 0;
@@ -789,11 +793,12 @@ fn test_get_block_info_v210() {
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -802,8 +807,9 @@ fn test_get_block_info_v210() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -996,7 +1002,7 @@ fn test_get_block_info_v210() {
     }
 
     for i in 0..num_blocks {
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let (consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
         let stacks_block_id = StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);
@@ -1073,7 +1079,7 @@ fn test_get_block_info_v210() {
             )
             .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
     }
 }
 
@@ -1105,11 +1111,11 @@ fn test_get_block_info_v210_no_microblocks() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2022, 2023);
-    peer_config.initial_balances = vec![
+    peer_config.chain_config.initial_balances = vec![
         (addr.to_account_principal(), 1000000000),
         (addr_anchored.to_account_principal(), 1000000000),
     ];
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let epochs = EpochList::new(&[
         StacksEpoch {
@@ -1147,7 +1153,7 @@ fn test_get_block_info_v210_no_microblocks() {
             network_epoch: PEER_VERSION_EPOCH_2_1,
         },
     ]);
-    peer_config.epochs = Some(epochs);
+    peer_config.chain_config.epochs = Some(epochs);
 
     let num_blocks = 10;
     let mut anchored_sender_nonce = 0;
@@ -1160,11 +1166,12 @@ fn test_get_block_info_v210_no_microblocks() {
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -1173,8 +1180,9 @@ fn test_get_block_info_v210_no_microblocks() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -1299,7 +1307,7 @@ fn test_get_block_info_v210_no_microblocks() {
     }
 
     for i in 0..num_blocks {
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let (consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
         let stacks_block_id = StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);
@@ -1364,7 +1372,7 @@ fn test_get_block_info_v210_no_microblocks() {
             )
             .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
     }
 }
 
@@ -1425,7 +1433,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
         2024,
         2025,
     );
-    peer_config.initial_balances = vec![
+    peer_config.chain_config.initial_balances = vec![
         (addr.to_account_principal(), 1000000000),
         (addr_anchored.to_account_principal(), 1000000000),
     ];
@@ -1466,8 +1474,8 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
             network_epoch: PEER_VERSION_EPOCH_2_1,
         },
     ]);
-    peer_config.epochs = Some(epochs);
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.epochs = Some(epochs);
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let num_blocks = 10;
     let mut anchored_sender_nonce = 0;
@@ -1480,11 +1488,12 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -1499,8 +1508,9 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -1764,7 +1774,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
 
     let mut recipient_total_reward = 0;
     for i in 0..num_blocks {
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let (consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
         let stacks_block_id = StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);
@@ -1867,11 +1877,11 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
             )
             .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
     }
 
     // finally, verify that the alt. recipient got all the coinbases except the first one
-    let sortdb = peer.sortdb.take().unwrap();
+    let sortdb = peer.chain.sortdb.take().unwrap();
     let (consensus_hash, block_bhh) =
         SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
     let stacks_block_id = StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -58,23 +58,25 @@ use crate::cost_estimates::UnitEstimator;
 #[test]
 fn test_build_anchored_blocks_empty() {
     let peer_config = TestPeerConfig::new(function_name!(), 2000, 2001);
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
     let mut last_block: Option<StacksBlock> = None;
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         assert_eq!(
             tip.block_height,
@@ -157,17 +159,18 @@ fn test_build_anchored_blocks_stx_transfers_single() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2002, 2003);
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -177,8 +180,9 @@ fn test_build_anchored_blocks_stx_transfers_single() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -290,17 +294,18 @@ fn test_build_anchored_blocks_empty_with_builder_timeout() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2022, 2023);
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -310,8 +315,9 @@ fn test_build_anchored_blocks_empty_with_builder_timeout() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -426,16 +432,17 @@ fn test_build_anchored_blocks_stx_transfers_multi() {
     }
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2004, 2005);
-    peer_config.initial_balances = balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -445,8 +452,9 @@ fn test_build_anchored_blocks_stx_transfers_multi() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -586,8 +594,8 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2016, 2017);
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let epochs = EpochList::new(&[
         StacksEpoch {
@@ -618,7 +626,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
             network_epoch: PEER_VERSION_EPOCH_2_05,
         },
     ]);
-    peer_config.epochs = Some(epochs);
+    peer_config.chain_config.epochs = Some(epochs);
 
     let num_blocks = 10;
 
@@ -630,11 +638,12 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -644,8 +653,9 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
     let mut last_block = None;
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -822,8 +832,8 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2018, 2019);
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let epochs = EpochList::new(&[
         StacksEpoch {
@@ -854,7 +864,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
             network_epoch: PEER_VERSION_EPOCH_2_05,
         },
     ]);
-    peer_config.epochs = Some(epochs);
+    peer_config.chain_config.epochs = Some(epochs);
 
     let num_blocks = 10;
 
@@ -866,11 +876,12 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -882,8 +893,9 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -1106,7 +1118,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
         }
 
         last_block_ch = Some(
-            SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
                 .unwrap()
                 .consensus_hash,
         );
@@ -1163,8 +1175,8 @@ fn test_build_anchored_blocks_skip_too_expensive() {
     initial_balances.push((addr_extra.to_account_principal(), 200000000000));
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2006, 2007);
-    peer_config.initial_balances = initial_balances;
-    peer_config.epochs = Some(EpochList::new(&[StacksEpoch {
+    peer_config.chain_config.initial_balances = initial_balances;
+    peer_config.chain_config.epochs = Some(EpochList::new(&[StacksEpoch {
         epoch_id: StacksEpochId::Epoch20,
         start_height: 0,
         end_height: i64::MAX as u64,
@@ -1179,15 +1191,16 @@ fn test_build_anchored_blocks_skip_too_expensive() {
         },
         network_epoch: PEER_VERSION_EPOCH_2_0,
     }]));
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -1197,8 +1210,9 @@ fn test_build_anchored_blocks_skip_too_expensive() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -1238,7 +1252,7 @@ fn test_build_anchored_blocks_skip_too_expensive() {
                 if tenure_id > 0 {
                     let mut expensive_part = vec![];
                     for i in 0..100 {
-                        expensive_part.push(format!("(define-data-var var-{} int 0)", i));
+                        expensive_part.push(format!("(define-data-var var-{i} int 0)"));
                     }
                     let contract = format!(
                         "{}
@@ -1365,18 +1379,18 @@ fn test_build_anchored_blocks_mempool_fee_transaction_too_low() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2032, 2033);
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
     let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
 
-    let tip =
-        SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn()).unwrap();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+        .unwrap();
 
     let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
         |ref mut miner,
@@ -1485,18 +1499,18 @@ fn test_build_anchored_blocks_zero_fee_transaction() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2032, 2033);
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
     let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
 
-    let tip =
-        SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn()).unwrap();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+        .unwrap();
 
     let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
         |ref mut miner,
@@ -1590,12 +1604,12 @@ fn test_build_anchored_blocks_multiple_chaintips() {
     }
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2008, 2009);
-    peer_config.initial_balances = balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     // make a blank chainstate and mempool so we can mine empty blocks
     //  without punishing the correspondingly "too expensive" transactions
@@ -1603,15 +1617,17 @@ fn test_build_anchored_blocks_multiple_chaintips() {
     let mut blank_mempool = MemPoolDB::open_test(false, 1, &blank_chainstate.root_path).unwrap();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -1734,23 +1750,25 @@ fn test_build_anchored_blocks_empty_chaintips() {
     }
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2010, 2011);
-    peer_config.initial_balances = balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -1874,23 +1892,25 @@ fn test_build_anchored_blocks_too_expensive_transactions() {
     }
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2013, 2014);
-    peer_config.initial_balances = balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -2026,15 +2046,16 @@ fn test_build_anchored_blocks_too_expensive_transactions() {
 #[test]
 fn test_build_anchored_blocks_invalid() {
     let peer_config = TestPeerConfig::new(function_name!(), 2014, 2015);
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -2058,7 +2079,7 @@ fn test_build_anchored_blocks_invalid() {
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
         let mut tip =
-            SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
                 .unwrap();
 
         if tenure_id == bad_block_ancestor_tenure {
@@ -2233,24 +2254,26 @@ fn test_build_anchored_blocks_bad_nonces() {
     }
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2012, 2013);
-    peer_config.initial_balances = balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
     for tenure_id in 0..num_blocks {
-        eprintln!("Start tenure {:?}", tenure_id);
+        eprintln!("Start tenure {tenure_id:?}");
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -2482,16 +2505,17 @@ fn test_build_microblock_stream_forks() {
     }
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2014, 2015);
-    peer_config.initial_balances = balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -2500,8 +2524,9 @@ fn test_build_microblock_stream_forks() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -2780,16 +2805,17 @@ fn test_build_microblock_stream_forks_with_descendants() {
     }
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2014, 2015);
-    peer_config.initial_balances = balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -2808,8 +2834,9 @@ fn test_build_microblock_stream_forks_with_descendants() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (mut burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -3027,7 +3054,7 @@ fn test_build_microblock_stream_forks_with_descendants() {
 
                 let mblock_pubkey_hash = Hash160::from_node_public_key(&StacksPublicKey::from_private(&mblock_privks[tenure_id]));
 
-                test_debug!("Produce tenure {} block off of {}/{}", tenure_id, &parent_consensus_hash, &parent_header_hash);
+                test_debug!("Produce tenure {tenure_id} block off of {parent_consensus_hash}/{parent_header_hash}");
 
                 // force tenures 2 and 3 to mine off of forked siblings deeper than the
                 // detected fork
@@ -3249,11 +3276,11 @@ fn test_contract_call_across_clarity_versions() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2024, 2025);
-    peer_config.initial_balances = vec![
+    peer_config.chain_config.initial_balances = vec![
         (addr.to_account_principal(), 1000000000),
         (addr_anchored.to_account_principal(), 1000000000),
     ];
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let epochs = EpochList::new(&[
         StacksEpoch {
@@ -3285,16 +3312,17 @@ fn test_contract_call_across_clarity_versions() {
             network_epoch: PEER_VERSION_EPOCH_2_1,
         },
     ]);
-    peer_config.epochs = Some(epochs);
+    peer_config.chain_config.epochs = Some(epochs);
 
     let num_blocks = 10;
     let mut anchored_sender_nonce = 0;
     let mut peer = TestPeer::new(peer_config);
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -3303,8 +3331,9 @@ fn test_contract_call_across_clarity_versions() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
 
@@ -3706,7 +3735,7 @@ fn test_contract_call_across_clarity_versions() {
 
     // all contracts deployed and called the right number of times, indicating that
     // cross-clarity-version contract calls are doable
-    let sortdb = peer.sortdb.take().unwrap();
+    let sortdb = peer.chain.sortdb.take().unwrap();
     let (consensus_hash, block_bhh) =
         SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
     let stacks_block_id = StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);
@@ -3819,8 +3848,8 @@ fn test_is_tx_problematic() {
     initial_balances.push((addr_extra.to_account_principal(), 200000000000));
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2018, 2019);
-    peer_config.initial_balances = initial_balances;
-    peer_config.epochs = Some(EpochList::new(&[
+    peer_config.chain_config.initial_balances = initial_balances;
+    peer_config.chain_config.epochs = Some(EpochList::new(&[
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,
             start_height: 0,
@@ -3836,15 +3865,16 @@ fn test_is_tx_problematic() {
             network_epoch: PEER_VERSION_EPOCH_2_05,
         },
     ]));
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -3854,8 +3884,9 @@ fn test_is_tx_problematic() {
     let mut last_block = None;
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -4292,8 +4323,8 @@ fn mempool_incorporate_pox_unlocks() {
     let principal = PrincipalData::from(addr.clone());
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2020, 2021);
-    peer_config.initial_balances = initial_balances;
-    peer_config.epochs = Some(EpochList::new(&[
+    peer_config.chain_config.initial_balances = initial_balances;
+    peer_config.chain_config.epochs = Some(EpochList::new(&[
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,
             start_height: 0,
@@ -4316,22 +4347,29 @@ fn mempool_incorporate_pox_unlocks() {
             network_epoch: PEER_VERSION_EPOCH_2_1,
         },
     ]));
-    peer_config.burnchain.pox_constants.v1_unlock_height =
-        peer_config.epochs.as_ref().unwrap()[StacksEpochId::Epoch2_05].end_height as u32 + 1;
-    let pox_constants = peer_config.burnchain.pox_constants.clone();
-    let burnchain = peer_config.burnchain.clone();
+    peer_config
+        .chain_config
+        .burnchain
+        .pox_constants
+        .v1_unlock_height = peer_config.chain_config.epochs.as_ref().unwrap()
+        [StacksEpochId::Epoch2_05]
+        .end_height as u32
+        + 1;
+    let pox_constants = peer_config.chain_config.burnchain.pox_constants.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
-    let first_block_height = peer.sortdb.as_ref().unwrap().first_block_height;
+    let first_block_height = peer.chain.sortdb.as_ref().unwrap().first_block_height;
     let first_pox_cycle = pox_constants
         .block_height_to_reward_cycle(first_block_height, first_stacks_block_height)
         .unwrap();
@@ -4355,8 +4393,9 @@ fn mempool_incorporate_pox_unlocks() {
 
     for tenure_id in 0..num_blocks {
         // send transactions to the mempool
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
             |ref mut miner,
@@ -4527,16 +4566,17 @@ fn test_fee_order_mismatch_nonce_order() {
     .unwrap();
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 2002, 2003);
-    peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height
     };
 
@@ -4545,8 +4585,8 @@ fn test_fee_order_mismatch_nonce_order() {
     let sender_nonce = 0;
 
     // send transactions to the mempool
-    let tip =
-        SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn()).unwrap();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+        .unwrap();
 
     let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
         |ref mut miner,
@@ -4714,9 +4754,10 @@ fn paramaterized_mempool_walk_test(
     );
     let mut peer_config = TestPeerConfig::new(&test_name, 2002, 2003);
 
-    peer_config.initial_balances = vec![];
+    peer_config.chain_config.initial_balances = vec![];
     for (privk, addr) in &key_address_pairs {
         peer_config
+            .chain_config
             .initial_balances
             .push((addr.to_account_principal(), 1000000000));
     }
@@ -4895,9 +4936,10 @@ fn mempool_walk_test_next_nonce_with_highest_fee_rate_strategy() {
 
     let test_name = function_name!();
     let mut peer_config = TestPeerConfig::new(&test_name, 0, 0);
-    peer_config.initial_balances = vec![];
+    peer_config.chain_config.initial_balances = vec![];
     for (privk, addr) in &key_address_pairs {
         peer_config
+            .chain_config
             .initial_balances
             .push((addr.to_account_principal(), 1000000000));
     }
@@ -5145,15 +5187,15 @@ fn run_mempool_walk_strategy_nonce_order_test<F>(
         .collect();
 
     let mut peer_config = TestPeerConfig::new(test_name, 2030, 2031);
-    peer_config.initial_balances = initial_balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.initial_balances = initial_balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-    let tip =
-        SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn()).unwrap();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(peer.chain.sortdb.as_ref().unwrap().conn())
+        .unwrap();
 
     let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
         |ref mut miner,
@@ -5198,7 +5240,7 @@ fn run_mempool_walk_strategy_nonce_order_test<F>(
                             &privk,
                             tx_nonce,
                             200 * (tx_nonce + 1), // Higher nonce = higher fee
-                            &format!("contract-{}", tx_nonce),
+                            &format!("contract-{tx_nonce}"),
                             contract,
                         )
                     })

--- a/stackslib/src/clarity_vm/tests/ephemeral.rs
+++ b/stackslib/src/clarity_vm/tests/ephemeral.rs
@@ -430,8 +430,8 @@ fn test_ephemeral_nakamoto_block_replay_simple() {
     );
 
     // read out all Nakamoto blocks
-    let sortdb = peer.sortdb.take().unwrap();
-    let mut stacks_node = peer.stacks_node.take().unwrap();
+    let sortdb = peer.chain.sortdb.take().unwrap();
+    let mut stacks_node = peer.chain.stacks_node.take().unwrap();
     let naka_tip =
         NakamotoChainState::get_canonical_block_header(stacks_node.chainstate.db(), &sortdb)
             .unwrap()
@@ -733,8 +733,8 @@ fn test_ephemeral_nakamoto_block_replay_smart_contract() {
     let (mut peer, _other_peers) = plan.boot_into_nakamoto_peers(boot_tenures, Some(&observer));
 
     // read out all Nakamoto blocks
-    let sortdb = peer.sortdb.take().unwrap();
-    let mut stacks_node = peer.stacks_node.take().unwrap();
+    let sortdb = peer.chain.sortdb.take().unwrap();
+    let mut stacks_node = peer.chain.stacks_node.take().unwrap();
     let naka_tip =
         NakamotoChainState::get_canonical_block_header(stacks_node.chainstate.db(), &sortdb)
             .unwrap()

--- a/stackslib/src/net/api/tests/blockreplay.rs
+++ b/stackslib/src/net/api/tests/blockreplay.rs
@@ -71,7 +71,7 @@ fn test_block_reply_errors() {
     let test_observer = TestEventObserver::new();
     let mut rpc_test = TestRPC::setup_nakamoto(function_name!(), &test_observer);
 
-    let sort_db = rpc_test.peer_1.sortdb.take().unwrap();
+    let sort_db = rpc_test.peer_1.chain.sortdb.take().unwrap();
     let chainstate = rpc_test.peer_1.chainstate();
 
     let err = handler.block_replay(&sort_db, chainstate).err().unwrap();

--- a/stackslib/src/net/api/tests/getblock_v3.rs
+++ b/stackslib/src/net/api/tests/getblock_v3.rs
@@ -123,11 +123,11 @@ fn test_stream_nakamoto_blocks() {
     .is_err());
 
     let nakamoto_tip = {
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         let ih = sortdb.index_handle(&tip.sortition_id);
         let nakamoto_tip = ih.get_nakamoto_tip().unwrap().unwrap();
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
         nakamoto_tip
     };
 

--- a/stackslib/src/net/api/tests/gettenure.rs
+++ b/stackslib/src/net/api/tests/gettenure.rs
@@ -127,11 +127,11 @@ fn test_stream_nakamoto_tenure() {
     .is_err());
 
     let nakamoto_tip = {
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         let ih = sortdb.index_handle(&tip.sortition_id);
         let nakamoto_tip = ih.get_nakamoto_tip().unwrap().unwrap();
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
         nakamoto_tip
     };
 

--- a/stackslib/src/net/api/tests/gettransaction.rs
+++ b/stackslib/src/net/api/tests/gettransaction.rs
@@ -111,7 +111,7 @@ fn test_try_make_response() {
     dummy_tip.0[0] = dummy_tip.0[0].wrapping_add(1);
 
     let peer = &rpc_test.peer_1;
-    let sortdb = peer.sortdb.as_ref().unwrap();
+    let sortdb = peer.chain.sortdb.as_ref().unwrap();
     let tenure_blocks = rpc_test
         .peer_1
         .chainstate_ref()

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -313,8 +313,8 @@ impl<'a> TestRPC<'a> {
         )
         .unwrap();
 
-        let mut peer_1_config = TestPeerConfig::new(&format!("{}-peer1", test_name), 0, 0);
-        let mut peer_2_config = TestPeerConfig::new(&format!("{}-peer2", test_name), 0, 0);
+        let mut peer_1_config = TestPeerConfig::new(&format!("{test_name}-peer1"), 0, 0);
+        let mut peer_2_config = TestPeerConfig::new(&format!("{test_name}-peer2"), 0, 0);
 
         peer_1_config.private_key = privk1.clone();
         peer_2_config.private_key = privk2.clone();
@@ -349,15 +349,17 @@ impl<'a> TestRPC<'a> {
             StackerDBConfig::noop(),
         );
 
-        let peer_1_indexer = BitcoinIndexer::new_unit_test(&peer_1_config.burnchain.working_dir);
-        let peer_2_indexer = BitcoinIndexer::new_unit_test(&peer_2_config.burnchain.working_dir);
+        let peer_1_indexer =
+            BitcoinIndexer::new_unit_test(&peer_1_config.chain_config.burnchain.working_dir);
+        let peer_2_indexer =
+            BitcoinIndexer::new_unit_test(&peer_2_config.chain_config.burnchain.working_dir);
 
-        peer_1_config.initial_balances = vec![
+        peer_1_config.chain_config.initial_balances = vec![
             (addr1.to_account_principal(), 1000000000),
             (addr2.to_account_principal(), 1000000000),
         ];
 
-        peer_2_config.initial_balances = vec![
+        peer_2_config.chain_config.initial_balances = vec![
             (addr1.to_account_principal(), 1000000000),
             (addr2.to_account_principal(), 1000000000),
         ];
@@ -365,7 +367,7 @@ impl<'a> TestRPC<'a> {
         peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
         peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
 
-        let burnchain = peer_1_config.burnchain.clone();
+        let burnchain = peer_1_config.chain_config.burnchain.clone();
 
         with_peer_1_config(&mut peer_1_config);
         with_peer_2_config(&mut peer_2_config);
@@ -482,8 +484,9 @@ impl<'a> TestRPC<'a> {
             tx.commit().unwrap();
         }
 
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         let mut anchor_cost = ExecutionCost::ZERO;
         let mut anchor_size = 0;
 
@@ -545,7 +548,7 @@ impl<'a> TestRPC<'a> {
 
         // build 1-block microblock stream with the contract-call and the unconfirmed contract
         let microblock = {
-            let sortdb = peer_1.sortdb.take().unwrap();
+            let sortdb = peer_1.chain.sortdb.take().unwrap();
             Relayer::setup_unconfirmed_state(peer_1.chainstate(), &sortdb).unwrap();
             let mblock = {
                 let sort_iconn = sortdb.index_handle_at_tip();
@@ -568,7 +571,7 @@ impl<'a> TestRPC<'a> {
                     .unwrap();
                 microblock
             };
-            peer_1.sortdb = Some(sortdb);
+            peer_1.chain.sortdb = Some(sortdb);
             mblock
         };
 
@@ -597,8 +600,8 @@ impl<'a> TestRPC<'a> {
                 .unwrap();
 
             // process microblock stream to generate unconfirmed state
-            let sortdb1 = peer_1.sortdb.take().unwrap();
-            let sortdb2 = peer_2.sortdb.take().unwrap();
+            let sortdb1 = peer_1.chain.sortdb.take().unwrap();
+            let sortdb2 = peer_2.chain.sortdb.take().unwrap();
             peer_1
                 .chainstate()
                 .reload_unconfirmed_state(&sortdb1.index_handle_at_tip(), canonical_tip.clone())
@@ -607,8 +610,8 @@ impl<'a> TestRPC<'a> {
                 .chainstate()
                 .reload_unconfirmed_state(&sortdb2.index_handle_at_tip(), canonical_tip.clone())
                 .unwrap();
-            peer_1.sortdb = Some(sortdb1);
-            peer_2.sortdb = Some(sortdb2);
+            peer_1.chain.sortdb = Some(sortdb1);
+            peer_2.chain.sortdb = Some(sortdb2);
         }
 
         let mut mempool_txids = vec![];
@@ -684,23 +687,23 @@ impl<'a> TestRPC<'a> {
         mempool_tx.commit().unwrap();
         peer_2.mempool.replace(mempool);
 
-        let peer_1_sortdb = peer_1.sortdb.take().unwrap();
-        let mut peer_1_stacks_node = peer_1.stacks_node.take().unwrap();
+        let peer_1_sortdb = peer_1.chain.sortdb.take().unwrap();
+        let mut peer_1_stacks_node = peer_1.chain.stacks_node.take().unwrap();
         let _ = peer_1
             .network
             .refresh_burnchain_view(&peer_1_sortdb, &mut peer_1_stacks_node.chainstate, false)
             .unwrap();
-        peer_1.sortdb = Some(peer_1_sortdb);
-        peer_1.stacks_node = Some(peer_1_stacks_node);
+        peer_1.chain.sortdb = Some(peer_1_sortdb);
+        peer_1.chain.stacks_node = Some(peer_1_stacks_node);
 
-        let peer_2_sortdb = peer_2.sortdb.take().unwrap();
-        let mut peer_2_stacks_node = peer_2.stacks_node.take().unwrap();
+        let peer_2_sortdb = peer_2.chain.sortdb.take().unwrap();
+        let mut peer_2_stacks_node = peer_2.chain.stacks_node.take().unwrap();
         let _ = peer_2
             .network
             .refresh_burnchain_view(&peer_2_sortdb, &mut peer_2_stacks_node.chainstate, false)
             .unwrap();
-        peer_2.sortdb = Some(peer_2_sortdb);
-        peer_2.stacks_node = Some(peer_2_stacks_node);
+        peer_2.chain.sortdb = Some(peer_2_sortdb);
+        peer_2.chain.stacks_node = Some(peer_2_stacks_node);
 
         // insert some fake Atlas attachment data
         let attachment = Attachment {
@@ -742,8 +745,9 @@ impl<'a> TestRPC<'a> {
             .unwrap();
 
         // next tip, coinbase
-        let tip = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let tip =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
 
         let mut tx_coinbase = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -903,9 +907,10 @@ impl<'a> TestRPC<'a> {
             });
         let mut other_peer = other_peers.pop().unwrap();
 
-        let peer_1_indexer = BitcoinIndexer::new_unit_test(&peer.config.burnchain.working_dir);
+        let peer_1_indexer =
+            BitcoinIndexer::new_unit_test(&peer.config.chain_config.burnchain.working_dir);
         let peer_2_indexer =
-            BitcoinIndexer::new_unit_test(&other_peer.config.burnchain.working_dir);
+            BitcoinIndexer::new_unit_test(&other_peer.config.chain_config.burnchain.working_dir);
 
         let convo_1 = ConversationHttp::new(
             format!("127.0.0.1:{}", peer.config.http_port)
@@ -931,12 +936,12 @@ impl<'a> TestRPC<'a> {
 
         let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb().conn()).unwrap();
         let nakamoto_tip = {
-            let sortdb = peer.sortdb.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
             let tip =
                 NakamotoChainState::get_canonical_block_header(peer.chainstate().db(), &sortdb)
                     .unwrap()
                     .unwrap();
-            peer.sortdb = Some(sortdb);
+            peer.chain.sortdb = Some(sortdb);
             tip
         };
 
@@ -944,14 +949,14 @@ impl<'a> TestRPC<'a> {
         let other_tip =
             SortitionDB::get_canonical_burn_chain_tip(other_peer.sortdb().conn()).unwrap();
         let other_nakamoto_tip = {
-            let sortdb = other_peer.sortdb.take().unwrap();
+            let sortdb = other_peer.chain.sortdb.take().unwrap();
             let tip = NakamotoChainState::get_canonical_block_header(
                 other_peer.chainstate().db(),
                 &sortdb,
             )
             .unwrap()
             .unwrap();
-            other_peer.sortdb = Some(sortdb);
+            other_peer.chain.sortdb = Some(sortdb);
             tip
         };
 
@@ -1006,9 +1011,10 @@ impl<'a> TestRPC<'a> {
             });
         let mut other_peer = other_peers.pop().unwrap();
 
-        let peer_1_indexer = BitcoinIndexer::new_unit_test(&peer.config.burnchain.working_dir);
+        let peer_1_indexer =
+            BitcoinIndexer::new_unit_test(&peer.config.chain_config.burnchain.working_dir);
         let peer_2_indexer =
-            BitcoinIndexer::new_unit_test(&other_peer.config.burnchain.working_dir);
+            BitcoinIndexer::new_unit_test(&other_peer.config.chain_config.burnchain.working_dir);
 
         let convo_1 = ConversationHttp::new(
             format!("127.0.0.1:{}", peer.config.http_port)
@@ -1034,12 +1040,12 @@ impl<'a> TestRPC<'a> {
 
         let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb().conn()).unwrap();
         let nakamoto_tip = {
-            let sortdb = peer.sortdb.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
             let tip =
                 NakamotoChainState::get_canonical_block_header(peer.chainstate().db(), &sortdb)
                     .unwrap()
                     .unwrap();
-            peer.sortdb = Some(sortdb);
+            peer.chain.sortdb = Some(sortdb);
             tip
         };
 
@@ -1047,14 +1053,14 @@ impl<'a> TestRPC<'a> {
         let other_tip =
             SortitionDB::get_canonical_burn_chain_tip(other_peer.sortdb().conn()).unwrap();
         let other_nakamoto_tip = {
-            let sortdb = other_peer.sortdb.take().unwrap();
+            let sortdb = other_peer.chain.sortdb.take().unwrap();
             let tip = NakamotoChainState::get_canonical_block_header(
                 other_peer.chainstate().db(),
                 &sortdb,
             )
             .unwrap()
             .unwrap();
-            other_peer.sortdb = Some(sortdb);
+            other_peer.chain.sortdb = Some(sortdb);
             tip
         };
 
@@ -1127,8 +1133,8 @@ impl<'a> TestRPC<'a> {
             convo_send_recv(&mut convo_1, &mut convo_2);
 
             // hack around the borrow-checker
-            let peer_1_sortdb = peer_1.sortdb.take().unwrap();
-            let mut peer_1_stacks_node = peer_1.stacks_node.take().unwrap();
+            let peer_1_sortdb = peer_1.chain.sortdb.take().unwrap();
+            let mut peer_1_stacks_node = peer_1.chain.stacks_node.take().unwrap();
 
             if unconfirmed_state {
                 Relayer::setup_unconfirmed_state(
@@ -1152,21 +1158,21 @@ impl<'a> TestRPC<'a> {
                     &mut peer_1_mempool,
                     &rpc_args,
                     false,
-                    peer_1.config.txindex,
+                    peer_1.config.chain_config.txindex,
                 );
                 convo_1.chat(&mut node_state).unwrap();
             }
 
-            peer_1.sortdb = Some(peer_1_sortdb);
-            peer_1.stacks_node = Some(peer_1_stacks_node);
+            peer_1.chain.sortdb = Some(peer_1_sortdb);
+            peer_1.chain.stacks_node = Some(peer_1_stacks_node);
             peer_1.mempool = Some(peer_1_mempool);
             peer_2.mempool = Some(peer_2_mempool);
 
             debug!("test_rpc: Peer 2 sends to Peer 1");
 
             // hack around the borrow-checker
-            let peer_2_sortdb = peer_2.sortdb.take().unwrap();
-            let mut peer_2_stacks_node = peer_2.stacks_node.take().unwrap();
+            let peer_2_sortdb = peer_2.chain.sortdb.take().unwrap();
+            let mut peer_2_stacks_node = peer_2.chain.stacks_node.take().unwrap();
             let mut peer_2_mempool = peer_2.mempool.take().unwrap();
 
             let _ = peer_2
@@ -1196,13 +1202,13 @@ impl<'a> TestRPC<'a> {
                     &mut peer_2_mempool,
                     &rpc_args,
                     false,
-                    peer_2.config.txindex,
+                    peer_2.config.chain_config.txindex,
                 );
                 convo_2.chat(&mut node_state).unwrap();
             }
 
-            peer_2.sortdb = Some(peer_2_sortdb);
-            peer_2.stacks_node = Some(peer_2_stacks_node);
+            peer_2.chain.sortdb = Some(peer_2_sortdb);
+            peer_2.chain.stacks_node = Some(peer_2_stacks_node);
             peer_2.mempool = Some(peer_2_mempool);
 
             convo_send_recv(&mut convo_2, &mut convo_1);
@@ -1212,8 +1218,8 @@ impl<'a> TestRPC<'a> {
             // hack around the borrow-checker
             convo_send_recv(&mut convo_1, &mut convo_2);
 
-            let peer_1_sortdb = peer_1.sortdb.take().unwrap();
-            let mut peer_1_stacks_node = peer_1.stacks_node.take().unwrap();
+            let peer_1_sortdb = peer_1.chain.sortdb.take().unwrap();
+            let mut peer_1_stacks_node = peer_1.chain.stacks_node.take().unwrap();
 
             let _ = peer_1
                 .network
@@ -1228,15 +1234,15 @@ impl<'a> TestRPC<'a> {
                 .unwrap();
             }
 
-            peer_1.sortdb = Some(peer_1_sortdb);
-            peer_1.stacks_node = Some(peer_1_stacks_node);
+            peer_1.chain.sortdb = Some(peer_1_sortdb);
+            peer_1.chain.stacks_node = Some(peer_1_stacks_node);
 
             let resp_opt = loop {
                 debug!("Peer 1 try get response");
                 convo_send_recv(&mut convo_1, &mut convo_2);
                 {
-                    let peer_1_sortdb = peer_1.sortdb.take().unwrap();
-                    let mut peer_1_stacks_node = peer_1.stacks_node.take().unwrap();
+                    let peer_1_sortdb = peer_1.chain.sortdb.take().unwrap();
+                    let mut peer_1_stacks_node = peer_1.chain.stacks_node.take().unwrap();
                     let mut peer_1_mempool = peer_1.mempool.take().unwrap();
 
                     let rpc_args = peer_1
@@ -1251,13 +1257,13 @@ impl<'a> TestRPC<'a> {
                         &mut peer_1_mempool,
                         &rpc_args,
                         false,
-                        peer_1.config.txindex,
+                        peer_1.config.chain_config.txindex,
                     );
 
                     convo_1.chat(&mut node_state).unwrap();
 
-                    peer_1.sortdb = Some(peer_1_sortdb);
-                    peer_1.stacks_node = Some(peer_1_stacks_node);
+                    peer_1.chain.sortdb = Some(peer_1_sortdb);
+                    peer_1.chain.stacks_node = Some(peer_1_stacks_node);
                     peer_1.mempool = Some(peer_1_mempool);
                 }
 

--- a/stackslib/src/net/server.rs
+++ b/stackslib/src/net/server.rs
@@ -681,8 +681,8 @@ mod test {
         let view = peer.get_burnchain_view().unwrap();
         let (http_sx, http_rx) = sync_channel(1);
 
-        let network_id = peer.config.network_id;
-        let chainstate_path = peer.chainstate_path.clone();
+        let network_id = peer.config.chain_config.network_id;
+        let chainstate_path = peer.chain.chainstate_path.clone();
 
         let (num_events_sx, num_events_rx) = sync_channel(1);
         let http_thread = thread::spawn(move || {

--- a/stackslib/src/net/tests/convergence.rs
+++ b/stackslib/src/net/tests/convergence.rs
@@ -87,7 +87,7 @@ fn setup_peer_config(
     conf.connection_opts.disable_block_download = true;
 
     let j = i as u32;
-    conf.burnchain.peer_version = PEER_VERSION_TESTNET | (j << 16) | (j << 8) | j; // different non-major versions for each peer
+    conf.chain_config.burnchain.peer_version = PEER_VERSION_TESTNET | (j << 16) | (j << 8) | j; // different non-major versions for each peer
 
     // even-number peers support stacker DBs.
     // odd-number peers do not

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -400,10 +400,11 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
     let peer = make_nakamoto_peer_from_invs(function_name!(), &observer, rc_len as u32, 3, bitvecs);
     let (mut peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-    peer.mine_malleablized_blocks = false;
+    peer.chain.mine_malleablized_blocks = false;
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     let all_sortitions = peer.sortdb().get_all_snapshots().unwrap();
     let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb().conn()).unwrap();
@@ -606,7 +607,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
             reward_cycle: tip_rc,
         };
 
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let sort_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         utd.try_accept_tenure_info(
             &sortdb,
@@ -617,7 +618,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
         )
         .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
 
         assert!(utd.unconfirmed_tenure_start_block.is_some());
 
@@ -681,7 +682,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
             reward_cycle: tip_rc,
         };
 
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let sort_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         utd.try_accept_tenure_info(
             &sortdb,
@@ -692,7 +693,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
         )
         .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
 
         assert!(utd.unconfirmed_tenure_start_block.is_some());
 
@@ -780,7 +781,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
             reward_cycle: tip_rc,
         };
 
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let sort_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         utd.try_accept_tenure_info(
             &sortdb,
@@ -791,7 +792,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
         )
         .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
 
         assert!(utd.unconfirmed_tenure_start_block.is_some());
 
@@ -878,7 +879,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
             reward_cycle: tip_rc,
         };
 
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let sort_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         utd.try_accept_tenure_info(
             &sortdb,
@@ -889,7 +890,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
         )
         .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
 
         assert!(utd.unconfirmed_tenure_start_block.is_some());
 
@@ -955,7 +956,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
             reward_cycle: tip_rc,
         };
 
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let sort_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         utd.try_accept_tenure_info(
             &sortdb,
@@ -966,7 +967,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
         )
         .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
 
         assert!(utd.unconfirmed_tenure_start_block.is_some());
 
@@ -1018,7 +1019,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
             reward_cycle: tip_rc,
         };
 
-        let sortdb = peer.sortdb.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
         let sort_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         utd.try_accept_tenure_info(
             &sortdb,
@@ -1029,7 +1030,7 @@ fn test_nakamoto_unconfirmed_tenure_downloader() {
         )
         .unwrap();
 
-        peer.sortdb = Some(sortdb);
+        peer.chain.sortdb = Some(sortdb);
 
         assert!(utd.unconfirmed_tenure_start_block.is_some());
 
@@ -1325,8 +1326,9 @@ fn test_make_tenure_downloaders() {
     let (mut peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     let all_sortitions = peer.sortdb().get_all_snapshots().unwrap();
     let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb().conn()).unwrap();
@@ -2107,8 +2109,9 @@ fn test_nakamoto_download_run_2_peers() {
     let (mut peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     let all_sortitions = peer.sortdb().get_all_snapshots().unwrap();
     let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb().conn()).unwrap();
@@ -2148,13 +2151,17 @@ fn test_nakamoto_download_run_2_peers() {
         );
         test_debug!("ops = {:?}", &ops);
         let block_header = TestPeer::make_next_burnchain_block(
-            &boot_peer.config.burnchain,
+            &boot_peer.config.chain_config.burnchain,
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
             false,
         );
-        TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
+        TestPeer::add_burnchain_block(
+            &boot_peer.config.chain_config.burnchain,
+            &block_header,
+            ops.clone(),
+        );
     }
 
     let (mut boot_dns_client, boot_dns_thread_handle) = dns_thread_start(100);
@@ -2216,8 +2223,9 @@ fn test_nakamoto_unconfirmed_download_run_2_peers() {
     let (mut peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     let all_sortitions = peer.sortdb().get_all_snapshots().unwrap();
     let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb().conn()).unwrap();
@@ -2255,13 +2263,17 @@ fn test_nakamoto_unconfirmed_download_run_2_peers() {
         );
         test_debug!("ops = {:?}", &ops);
         let block_header = TestPeer::make_next_burnchain_block(
-            &boot_peer.config.burnchain,
+            &boot_peer.config.chain_config.burnchain,
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
             false,
         );
-        TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
+        TestPeer::add_burnchain_block(
+            &boot_peer.config.chain_config.burnchain,
+            &block_header,
+            ops.clone(),
+        );
     }
 
     let (mut boot_dns_client, boot_dns_thread_handle) = dns_thread_start(100);
@@ -2336,8 +2348,9 @@ fn test_nakamoto_microfork_download_run_2_peers() {
         });
     peer.refresh_burnchain_view();
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     // create a microfork
     let naka_tip_ch = peer.network.stacks_tip.consensus_hash.clone();
@@ -2435,13 +2448,17 @@ fn test_nakamoto_microfork_download_run_2_peers() {
         );
         test_debug!("ops = {:?}", &ops);
         let block_header = TestPeer::make_next_burnchain_block(
-            &boot_peer.config.burnchain,
+            &boot_peer.config.chain_config.burnchain,
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
             false,
         );
-        TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
+        TestPeer::add_burnchain_block(
+            &boot_peer.config.chain_config.burnchain,
+            &block_header,
+            ops.clone(),
+        );
     }
 
     let (mut boot_dns_client, boot_dns_thread_handle) = dns_thread_start(100);
@@ -2513,8 +2530,9 @@ fn test_nakamoto_download_run_2_peers_with_one_shadow_block() {
     let (mut peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     // create a shadow block
     let naka_tip_ch = peer.network.stacks_tip.consensus_hash.clone();
@@ -2610,21 +2628,25 @@ fn test_nakamoto_download_run_2_peers_with_one_shadow_block() {
         );
         test_debug!("ops = {:?}", &ops);
         let block_header = TestPeer::make_next_burnchain_block(
-            &boot_peer.config.burnchain,
+            &boot_peer.config.chain_config.burnchain,
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
             false,
         );
-        TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
+        TestPeer::add_burnchain_block(
+            &boot_peer.config.chain_config.burnchain,
+            &block_header,
+            ops.clone(),
+        );
     }
 
     {
-        let mut node = boot_peer.stacks_node.take().unwrap();
+        let mut node = boot_peer.chain.stacks_node.take().unwrap();
         let tx = node.chainstate.staging_db_tx_begin().unwrap();
         tx.add_shadow_block(&shadow_block).unwrap();
         tx.commit().unwrap();
-        boot_peer.stacks_node = Some(node);
+        boot_peer.chain.stacks_node = Some(node);
     }
 
     let (mut boot_dns_client, boot_dns_thread_handle) = dns_thread_start(100);
@@ -2693,8 +2715,9 @@ fn test_nakamoto_download_run_2_peers_shadow_prepare_phase() {
     let (mut peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     // create a shadow block
     let naka_tip_ch = peer.network.stacks_tip.consensus_hash.clone();
@@ -2812,22 +2835,26 @@ fn test_nakamoto_download_run_2_peers_shadow_prepare_phase() {
         );
         test_debug!("ops = {:?}", &ops);
         let block_header = TestPeer::make_next_burnchain_block(
-            &boot_peer.config.burnchain,
+            &boot_peer.config.chain_config.burnchain,
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
             false,
         );
-        TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
+        TestPeer::add_burnchain_block(
+            &boot_peer.config.chain_config.burnchain,
+            &block_header,
+            ops.clone(),
+        );
     }
     {
-        let mut node = boot_peer.stacks_node.take().unwrap();
+        let mut node = boot_peer.chain.stacks_node.take().unwrap();
         let tx = node.chainstate.staging_db_tx_begin().unwrap();
         for shadow_block in shadow_blocks.into_iter() {
             tx.add_shadow_block(&shadow_block).unwrap();
         }
         tx.commit().unwrap();
-        boot_peer.stacks_node = Some(node);
+        boot_peer.chain.stacks_node = Some(node);
     }
 
     let (mut boot_dns_client, boot_dns_thread_handle) = dns_thread_start(100);
@@ -2896,8 +2923,9 @@ fn test_nakamoto_download_run_2_peers_shadow_reward_cycles() {
     let (mut peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     // create a shadow block
     let naka_tip_ch = peer.network.stacks_tip.consensus_hash.clone();
@@ -3015,24 +3043,28 @@ fn test_nakamoto_download_run_2_peers_shadow_reward_cycles() {
             sn.block_height,
             &sn.burn_header_hash
         );
-        test_debug!("ops = {:?}", &ops);
+        test_debug!("ops = {ops:?}");
         let block_header = TestPeer::make_next_burnchain_block(
-            &boot_peer.config.burnchain,
+            &boot_peer.config.chain_config.burnchain,
             sn.block_height,
             &sn.burn_header_hash,
             ops.len() as u64,
             false,
         );
-        TestPeer::add_burnchain_block(&boot_peer.config.burnchain, &block_header, ops.clone());
+        TestPeer::add_burnchain_block(
+            &boot_peer.config.chain_config.burnchain,
+            &block_header,
+            ops.clone(),
+        );
     }
     {
-        let mut node = boot_peer.stacks_node.take().unwrap();
+        let mut node = boot_peer.chain.stacks_node.take().unwrap();
         let tx = node.chainstate.staging_db_tx_begin().unwrap();
         for shadow_block in shadow_blocks.into_iter() {
             tx.add_shadow_block(&shadow_block).unwrap();
         }
         tx.commit().unwrap();
-        boot_peer.stacks_node = Some(node);
+        boot_peer.chain.stacks_node = Some(node);
     }
 
     let (mut boot_dns_client, boot_dns_thread_handle) = dns_thread_start(100);

--- a/stackslib/src/net/tests/inv/nakamoto.rs
+++ b/stackslib/src/net/tests/inv/nakamoto.rs
@@ -153,7 +153,7 @@ fn test_nakamoto_inv_10_tenures_10_sortitions() {
 
     // sanity check -- nakamoto begins at height 37
     assert_eq!(
-        peer.config.epochs,
+        peer.config.chain_config.epochs,
         Some(StacksEpoch::unit_test_3_0_only(37))
     );
 
@@ -161,8 +161,8 @@ fn test_nakamoto_inv_10_tenures_10_sortitions() {
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     assert_eq!(reward_cycle_invs.len(), 10);
 
-    let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-    let sort_db = peer.sortdb.as_mut().unwrap();
+    let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
     let stacks_tip_ch = peer.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bh = peer.network.stacks_tip.block_hash.clone();
 
@@ -235,7 +235,7 @@ fn test_nakamoto_inv_2_tenures_3_sortitions() {
 
     // sanity check -- nakamoto begins at height 37
     assert_eq!(
-        peer.config.epochs,
+        peer.config.chain_config.epochs,
         Some(StacksEpoch::unit_test_3_0_only(37))
     );
 
@@ -243,8 +243,8 @@ fn test_nakamoto_inv_2_tenures_3_sortitions() {
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     assert_eq!(reward_cycle_invs.len(), 8);
 
-    let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-    let sort_db = peer.sortdb.as_mut().unwrap();
+    let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
     let stacks_tip_ch = peer.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bh = peer.network.stacks_tip.block_hash.clone();
 
@@ -310,7 +310,7 @@ fn test_nakamoto_inv_10_extended_tenures_10_sortitions() {
 
     // sanity check -- nakamoto begins at height 37
     assert_eq!(
-        peer.config.epochs,
+        peer.config.chain_config.epochs,
         Some(StacksEpoch::unit_test_3_0_only(37))
     );
 
@@ -318,8 +318,8 @@ fn test_nakamoto_inv_10_extended_tenures_10_sortitions() {
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     assert_eq!(reward_cycle_invs.len(), 10);
 
-    let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-    let sort_db = peer.sortdb.as_mut().unwrap();
+    let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
     let stacks_tip_ch = peer.network.stacks_tip.consensus_hash.clone();
     let stacks_tip_bh = peer.network.stacks_tip.block_hash.clone();
 
@@ -624,8 +624,9 @@ fn test_nakamoto_invs_full() {
     let (peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     eprintln!("{:#?}", &reward_cycle_invs);
     assert_eq!(reward_cycle_invs.len(), 10);
@@ -657,8 +658,9 @@ fn test_nakamoto_invs_alternating() {
     let (peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     eprintln!("{:#?}", &reward_cycle_invs);
     assert_eq!(reward_cycle_invs.len(), 10);
@@ -696,10 +698,11 @@ fn test_nakamoto_invs_sparse() {
     let (peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
-    eprintln!("{:#?}", &reward_cycle_invs);
+    eprintln!("{reward_cycle_invs:#?}");
     assert_eq!(reward_cycle_invs.len(), 12);
     check_inv_messages(bitvecs, 10, nakamoto_start, reward_cycle_invs);
 }
@@ -731,8 +734,9 @@ fn test_nakamoto_invs_different_anchor_blocks() {
     let (peer, reward_cycle_invs) =
         peer_get_nakamoto_invs(peer, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     eprintln!("{:#?}", &reward_cycle_invs);
     assert_eq!(reward_cycle_invs.len(), 12);
@@ -871,15 +875,17 @@ fn test_nakamoto_inv_sync_state_machine() {
         make_nakamoto_peers_from_invs(function_name!(), &observer, 10, 3, bitvecs.clone(), 1);
     let mut other_peer = other_peers.pop().unwrap();
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     let tip = {
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
     };
     let total_rcs = peer
         .config
+        .chain_config
         .burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap()
@@ -909,11 +915,11 @@ fn test_nakamoto_inv_sync_state_machine() {
     // `observer`
     std::thread::scope(|s| {
         s.spawn(|| {
-            let sortdb = other_peer.sortdb.take().unwrap();
+            let sortdb = other_peer.chain.sortdb.take().unwrap();
             inv_machine
                 .process_getnakamotoinv_begins(&mut other_peer.network, &sortdb, false)
                 .unwrap();
-            other_peer.sortdb = Some(sortdb);
+            other_peer.chain.sortdb = Some(sortdb);
 
             let mut last_learned_rc = 0;
             loop {
@@ -942,11 +948,11 @@ fn test_nakamoto_inv_sync_state_machine() {
                     break;
                 }
 
-                let sortdb = other_peer.sortdb.take().unwrap();
+                let sortdb = other_peer.chain.sortdb.take().unwrap();
                 inv_machine
                     .process_getnakamotoinv_begins(&mut other_peer.network, &sortdb, false)
                     .unwrap();
-                other_peer.sortdb = Some(sortdb);
+                other_peer.chain.sortdb = Some(sortdb);
             }
 
             sx.send(true).unwrap();
@@ -995,15 +1001,17 @@ fn test_nakamoto_inv_sync_across_epoch_change() {
         make_nakamoto_peers_from_invs(function_name!(), &observer, 10, 3, bitvecs, 1);
     let mut other_peer = other_peers.pop().unwrap();
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     let tip = {
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
     };
     let total_rcs = peer
         .config
+        .chain_config
         .burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -1135,7 +1143,7 @@ fn test_nakamoto_make_tenure_inv_in_forks() {
         initial_balances,
     );
     peer.refresh_burnchain_view();
-    peer.mine_malleablized_blocks = false;
+    peer.chain.mine_malleablized_blocks = false;
 
     let mut invgen = InvGenerator::new().with_tip_ancestor_search_depth(5);
     let mut invgen_no_cache = InvGenerator::new_no_cache().with_tip_ancestor_search_depth(5);
@@ -1766,7 +1774,7 @@ fn test_nakamoto_make_tenure_inv_in_many_reward_cycles() {
         initial_balances,
     );
     peer.refresh_burnchain_view();
-    peer.mine_malleablized_blocks = false;
+    peer.chain.mine_malleablized_blocks = false;
 
     let mut invgen = InvGenerator::new().with_tip_ancestor_search_depth(5);
     let mut invgen_no_cache = InvGenerator::new_no_cache().with_tip_ancestor_search_depth(5);
@@ -2274,7 +2282,7 @@ fn test_nakamoto_make_tenure_inv_from_old_tips() {
         initial_balances,
     );
     peer.refresh_burnchain_view();
-    peer.mine_malleablized_blocks = false;
+    peer.chain.mine_malleablized_blocks = false;
 
     let sortdb = peer.sortdb_ref().reopen().unwrap();
     let (chainstate, _) = peer.chainstate_ref().reopen().unwrap();
@@ -2371,8 +2379,9 @@ fn test_nakamoto_invs_shadow_blocks() {
         0,
         initial_balances,
     );
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer.config.chain_config.burnchain.pox_constants,
+    );
 
     let mut expected_ids = vec![];
 

--- a/stackslib/src/net/tests/mempool/mod.rs
+++ b/stackslib/src/net/tests/mempool/mod.rs
@@ -48,8 +48,8 @@ fn test_mempool_sync_2_peers() {
         .map(|a| (a.to_account_principal(), 1000000000))
         .collect();
 
-    peer_1_config.initial_balances = initial_balances.clone();
-    peer_2_config.initial_balances = initial_balances;
+    peer_1_config.chain_config.initial_balances = initial_balances.clone();
+    peer_2_config.chain_config.initial_balances = initial_balances;
 
     let mut peer_1 = TestPeer::new(peer_1_config);
     let mut peer_2 = TestPeer::new(peer_2_config);
@@ -59,8 +59,9 @@ fn test_mempool_sync_2_peers() {
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -154,8 +155,9 @@ fn test_mempool_sync_2_peers() {
     }
 
     let num_burn_blocks = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -314,8 +316,8 @@ fn test_mempool_sync_2_peers_paginated() {
         .map(|a| (a.to_account_principal(), 1000000000))
         .collect();
 
-    peer_1_config.initial_balances = initial_balances.clone();
-    peer_2_config.initial_balances = initial_balances;
+    peer_1_config.chain_config.initial_balances = initial_balances.clone();
+    peer_2_config.chain_config.initial_balances = initial_balances;
 
     let mut peer_1 = TestPeer::new(peer_1_config);
     let mut peer_2 = TestPeer::new(peer_2_config);
@@ -325,8 +327,9 @@ fn test_mempool_sync_2_peers_paginated() {
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -408,8 +411,9 @@ fn test_mempool_sync_2_peers_paginated() {
     peer_1.mempool = Some(peer_1_mempool);
 
     let num_burn_blocks = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -503,8 +507,8 @@ fn test_mempool_sync_2_peers_blacklisted() {
         .map(|a| (a.to_account_principal(), 1000000000))
         .collect();
 
-    peer_1_config.initial_balances = initial_balances.clone();
-    peer_2_config.initial_balances = initial_balances;
+    peer_1_config.chain_config.initial_balances = initial_balances.clone();
+    peer_2_config.chain_config.initial_balances = initial_balances;
 
     let mut peer_1 = TestPeer::new(peer_1_config);
     let mut peer_2 = TestPeer::new(peer_2_config);
@@ -514,8 +518,9 @@ fn test_mempool_sync_2_peers_blacklisted() {
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -615,8 +620,9 @@ fn test_mempool_sync_2_peers_blacklisted() {
     peer_2.mempool = Some(peer_2_mempool);
 
     let num_burn_blocks = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -712,8 +718,8 @@ fn test_mempool_sync_2_peers_problematic() {
         .map(|a| (a.to_account_principal(), 1000000000))
         .collect();
 
-    peer_1_config.initial_balances = initial_balances.clone();
-    peer_2_config.initial_balances = initial_balances;
+    peer_1_config.chain_config.initial_balances = initial_balances.clone();
+    peer_2_config.chain_config.initial_balances = initial_balances;
 
     let mut peer_1 = TestPeer::new(peer_1_config);
     let mut peer_2 = TestPeer::new(peer_2_config);
@@ -723,8 +729,9 @@ fn test_mempool_sync_2_peers_problematic() {
 
     let num_blocks = 10;
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -753,7 +760,7 @@ fn test_mempool_sync_2_peers_problematic() {
         let exceeds_repeat_factor = AST_CALL_STACK_DEPTH_BUFFER + (MAX_CALL_STACK_DEPTH as u64);
         let tx_exceeds_body_start = "{ a : ".repeat(exceeds_repeat_factor as usize);
         let tx_exceeds_body_end = "} ".repeat(exceeds_repeat_factor as usize);
-        let tx_exceeds_body = format!("{}u1 {}", tx_exceeds_body_start, tx_exceeds_body_end);
+        let tx_exceeds_body = format!("{tx_exceeds_body_start}u1 {tx_exceeds_body_end}");
 
         let tx = make_contract_tx(
             pk,
@@ -801,8 +808,9 @@ fn test_mempool_sync_2_peers_problematic() {
     peer_2.mempool = Some(peer_2_mempool);
 
     let num_burn_blocks = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 
@@ -909,7 +917,7 @@ pub fn test_mempool_storage_nakamoto() {
 
     let mut total_blocks = 0;
     let mut all_txs = vec![];
-    let stx_miner_key = peer.miner.nakamoto_miner_key();
+    let stx_miner_key = peer.chain.miner.nakamoto_miner_key();
     let stx_miner_addr = StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
@@ -919,8 +927,12 @@ pub fn test_mempool_storage_nakamoto() {
     .unwrap();
 
     // duplicate handles to the chainstates so we can submit txs
-    let mut mempool =
-        MemPoolDB::open_test(false, peer.config.network_id, &peer.chainstate_path).unwrap();
+    let mut mempool = MemPoolDB::open_test(
+        false,
+        peer.config.chain_config.network_id,
+        &peer.chain.chainstate_path,
+    )
+    .unwrap();
     let (mut chainstate, _) = peer.chainstate().reopen().unwrap();
     let sortdb = peer.sortdb().reopen().unwrap();
 
@@ -935,9 +947,10 @@ pub fn test_mempool_storage_nakamoto() {
         tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
         let tenure_change_tx = peer
+            .chain
             .miner
             .make_nakamoto_tenure_change(tenure_change.clone());
-        let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+        let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
         debug!("Next burnchain block: {}", &consensus_hash);
 
@@ -1017,8 +1030,8 @@ pub fn test_mempool_storage_nakamoto() {
     }
 
     let tip = {
-        let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-        let sort_db = peer.sortdb.as_mut().unwrap();
+        let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+        let sort_db = peer.chain.sortdb.as_mut().unwrap();
         NakamotoChainState::get_canonical_block_header(chainstate.db(), sort_db)
             .unwrap()
             .unwrap()
@@ -1092,15 +1105,17 @@ fn test_mempool_sync_2_peers_nakamoto_paginated() {
     );
     let mut peer_2 = other_peers.pop().unwrap();
 
-    let nakamoto_start =
-        NakamotoBootPlan::nakamoto_first_tenure_height(&peer_1.config.burnchain.pox_constants);
+    let nakamoto_start = NakamotoBootPlan::nakamoto_first_tenure_height(
+        &peer_1.config.chain_config.burnchain.pox_constants,
+    );
 
     let tip = {
-        let sort_db = peer_1.sortdb.as_mut().unwrap();
+        let sort_db = peer_1.chain.sortdb.as_mut().unwrap();
         SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
     };
     let total_rcs = peer_1
         .config
+        .chain_config
         .burnchain
         .block_height_to_reward_cycle(tip.block_height)
         .unwrap();
@@ -1196,8 +1211,9 @@ fn test_mempool_sync_2_peers_nakamoto_paginated() {
     peer_1.mempool = Some(peer_1_mempool);
 
     let num_burn_blocks = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn =
+            SortitionDB::get_canonical_burn_chain_tip(peer_1.chain.sortdb.as_ref().unwrap().conn())
+                .unwrap();
         sn.block_height + 1
     };
 

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -37,7 +37,7 @@ use stacks_common::types::chainstate::{
     StacksPublicKey, TrieHash,
 };
 use stacks_common::types::net::PeerAddress;
-use stacks_common::types::{Address, StacksEpochId};
+use stacks_common::types::Address;
 use stacks_common::util::hash::Sha512Trunc256Sum;
 use stacks_common::util::secp256k1::MessageSignature;
 
@@ -50,8 +50,7 @@ use crate::chainstate::nakamoto::test_signers::TestSigners;
 use crate::chainstate::nakamoto::tests::get_account;
 use crate::chainstate::nakamoto::tests::node::TestStacker;
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoBlockHeader, NakamotoChainState};
-use crate::chainstate::stacks::address::PoxAddress;
-use crate::chainstate::stacks::boot::test::{key_to_stacks_addr, make_pox_4_lockup_chain_id};
+use crate::chainstate::stacks::boot::test::key_to_stacks_addr;
 use crate::chainstate::stacks::boot::{
     MINERS_NAME, SIGNERS_VOTING_FUNCTION_NAME, SIGNERS_VOTING_NAME,
 };
@@ -73,7 +72,6 @@ use crate::net::{
     PingData, StackerDBPushChunkData, StacksMessage, StacksMessageType, StacksNodeState,
 };
 use crate::util_lib::boot::boot_code_id;
-use crate::util_lib::signed_structured_data::pox4::make_pox_4_signer_key_signature;
 
 /// One step of a simulated Nakamoto node's bootup procedure.
 #[derive(Debug, PartialEq, Clone)]
@@ -109,10 +107,10 @@ pub struct NakamotoBootPlan {
 impl NakamotoBootPlan {
     pub fn new(test_name: &str) -> Self {
         let (test_signers, test_stackers) = TestStacker::common_signing_set();
-        let pox_constants = TestPeerConfig::default().burnchain.pox_constants;
+        let default_config = TestChainstateConfig::default();
         Self {
             test_name: test_name.to_string(),
-            pox_constants: TestPeerConfig::default().burnchain.pox_constants,
+            pox_constants: default_config.burnchain.pox_constants,
             private_key: StacksPrivateKey::from_seed(&[2]),
             initial_balances: vec![],
             test_stackers,
@@ -121,10 +119,64 @@ impl NakamotoBootPlan {
             num_peers: 0,
             add_default_balance: true,
             malleablized_blocks: true,
-            network_id: TestPeerConfig::default().network_id,
+            network_id: default_config.network_id,
             txindex: false,
             epochs: None,
         }
+    }
+
+    // Builds a TestChainstateConfig with shared parameters
+    fn build_nakamoto_chainstate_config(&self) -> TestChainstateConfig {
+        let mut chainstate_config = TestChainstateConfig::new(&self.test_name);
+        chainstate_config.network_id = self.network_id;
+        chainstate_config.txindex = self.txindex;
+
+        let addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&self.private_key)],
+        )
+        .unwrap();
+
+        let default_epoch = StacksEpoch::unit_test_3_0_only(
+            (self.pox_constants.pox_4_activation_height
+                + self.pox_constants.reward_cycle_length
+                + 1)
+            .into(),
+        );
+        chainstate_config.epochs = Some(self.epochs.clone().unwrap_or(default_epoch));
+        chainstate_config.initial_balances = vec![];
+        if self.add_default_balance {
+            chainstate_config
+                .initial_balances
+                .push((addr.to_account_principal(), 1_000_000_000_000_000_000));
+        }
+        chainstate_config
+            .initial_balances
+            .extend(self.initial_balances.clone());
+
+        let fee_payment_balance = 10_000;
+        let stacker_balances = self.test_stackers.iter().map(|test_stacker| {
+            (
+                PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key)),
+                u64::try_from(test_stacker.amount).expect("Stacking amount too large"),
+            )
+        });
+        let signer_balances = self.test_stackers.iter().map(|test_stacker| {
+            (
+                PrincipalData::from(key_to_stacks_addr(&test_stacker.signer_private_key)),
+                fee_payment_balance,
+            )
+        });
+
+        chainstate_config.initial_balances.extend(stacker_balances);
+        chainstate_config.initial_balances.extend(signer_balances);
+        chainstate_config.test_signers = Some(self.test_signers.clone());
+        chainstate_config.test_stackers = Some(self.test_stackers.clone());
+        chainstate_config.burnchain.pox_constants = self.pox_constants.clone();
+
+        chainstate_config
     }
 
     pub fn with_private_key(mut self, privk: StacksPrivateKey) -> Self {
@@ -266,8 +318,8 @@ impl NakamotoBootPlan {
         for (i, peer) in other_peers.iter_mut().enumerate() {
             peer.next_burnchain_block(burn_ops.to_vec());
 
-            let sortdb = peer.sortdb.take().unwrap();
-            let mut node = peer.stacks_node.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
+            let mut node = peer.chain.stacks_node.take().unwrap();
 
             let sort_tip = SortitionDB::get_canonical_sortition_tip(sortdb.conn()).unwrap();
             let mut sort_handle = sortdb.index_handle(&sort_tip);
@@ -276,10 +328,9 @@ impl NakamotoBootPlan {
 
             for block in blocks {
                 debug!(
-                    "Apply block {} (sighash {}) to peer {} ({})",
+                    "Apply block {} (sighash {}) to peer {i} ({})",
                     &block.block_id(),
                     &block.header.signer_signature_hash(),
-                    i,
                     &peer.to_neighbor().addr
                 );
                 let block_id = block.block_id();
@@ -294,29 +345,25 @@ impl NakamotoBootPlan {
                     NakamotoBlockObtainMethod::Pushed,
                 )
                 .unwrap();
-                if accepted.is_accepted() {
-                    test_debug!("Accepted Nakamoto block {block_id} to other peer {}", i);
-                    peer.coord.handle_new_nakamoto_stacks_block().unwrap();
-                } else {
-                    panic!(
-                        "Did NOT accept Nakamoto block {block_id} to other peer {}",
-                        i
-                    );
-                }
+                assert!(
+                    accepted.is_accepted(),
+                    "Did NOT accept Nakamoto block {block_id} to other peer {i}"
+                );
+                test_debug!("Accepted Nakamoto block {block_id} to other peer {i}");
+                peer.chain.coord.handle_new_nakamoto_stacks_block().unwrap();
 
                 possible_chain_tips.insert(block.block_id());
 
                 // process it
-                peer.coord.handle_new_stacks_block().unwrap();
-                peer.coord.handle_new_nakamoto_stacks_block().unwrap();
+                peer.chain.coord.handle_new_stacks_block().unwrap();
+                peer.chain.coord.handle_new_nakamoto_stacks_block().unwrap();
             }
 
             for block in malleablized_blocks {
                 debug!(
-                    "Apply malleablized block {} (sighash {}) to peer {} ({})",
+                    "Apply malleablized block {} (sighash {}) to peer {i} ({})",
                     &block.block_id(),
                     &block.header.signer_signature_hash(),
-                    i,
                     &peer.to_neighbor().addr
                 );
                 let block_id = block.block_id();
@@ -331,28 +378,22 @@ impl NakamotoBootPlan {
                     NakamotoBlockObtainMethod::Pushed,
                 )
                 .unwrap();
-                if accepted.is_accepted() {
-                    test_debug!(
-                        "Accepted malleablized Nakamoto block {block_id} to other peer {}",
-                        i
-                    );
-                    peer.coord.handle_new_nakamoto_stacks_block().unwrap();
-                } else {
-                    panic!(
-                        "Did NOT accept malleablized Nakamoto block {block_id} to other peer {}",
-                        i
-                    );
-                }
+                assert!(
+                    accepted.is_accepted(),
+                    "Did NOT accept malleablized Nakamoto block {block_id} to other peer {i}"
+                );
+                test_debug!("Accepted malleablized Nakamoto block {block_id} to other peer {i}");
+                peer.chain.coord.handle_new_nakamoto_stacks_block().unwrap();
 
                 possible_chain_tips.insert(block.block_id());
 
                 // process it
-                peer.coord.handle_new_stacks_block().unwrap();
-                peer.coord.handle_new_nakamoto_stacks_block().unwrap();
+                peer.chain.coord.handle_new_stacks_block().unwrap();
+                peer.chain.coord.handle_new_nakamoto_stacks_block().unwrap();
             }
 
-            peer.sortdb = Some(sortdb);
-            peer.stacks_node = Some(node);
+            peer.chain.sortdb = Some(sortdb);
+            peer.chain.stacks_node = Some(node);
             peer.refresh_burnchain_view();
 
             assert!(possible_chain_tips.contains(&peer.network.stacks_tip.block_id()));
@@ -362,525 +403,67 @@ impl NakamotoBootPlan {
     /// Make a chainstate and transition it into the Nakamoto epoch.
     /// The node needs to be stacking; otherwise, Nakamoto won't activate.
     pub fn boot_nakamoto_chainstate(
-        mut self,
+        self,
         observer: Option<&TestEventObserver>,
     ) -> TestChainstate<'_> {
-        let mut chainstate_config = TestChainstateConfig::new(&self.test_name);
-        chainstate_config.txindex = self.txindex;
-        chainstate_config.network_id = self.network_id;
-
-        let addr = StacksAddress::from_public_keys(
-            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-            &AddressHashMode::SerializeP2PKH,
-            1,
-            &vec![StacksPublicKey::from_private(&self.private_key)],
-        )
-        .unwrap();
-
-        let default_epoch = StacksEpoch::unit_test_3_0_only(
-            (self.pox_constants.pox_4_activation_height
-                + self.pox_constants.reward_cycle_length
-                + 1)
-            .into(),
-        );
-        chainstate_config.epochs = Some(self.epochs.clone().unwrap_or(default_epoch));
-        chainstate_config.initial_balances = vec![];
-        if self.add_default_balance {
-            chainstate_config
-                .initial_balances
-                .push((addr.to_account_principal(), 1_000_000_000_000_000_000));
-        }
-        chainstate_config
-            .initial_balances
-            .append(&mut self.initial_balances.clone());
-
-        // Create some balances for test Stackers
-        // They need their stacking amount + enough to pay fees
-        let fee_payment_balance = 10_000;
-        let stacker_balances = self.test_stackers.iter().map(|test_stacker| {
-            (
-                PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key)),
-                u64::try_from(test_stacker.amount).expect("Stacking amount too large"),
-            )
-        });
-        let signer_balances = self.test_stackers.iter().map(|test_stacker| {
-            (
-                PrincipalData::from(key_to_stacks_addr(&test_stacker.signer_private_key)),
-                fee_payment_balance,
-            )
-        });
-
-        chainstate_config.initial_balances.extend(stacker_balances);
-        chainstate_config.initial_balances.extend(signer_balances);
-        chainstate_config.test_signers = Some(self.test_signers.clone());
-        chainstate_config.test_stackers = Some(self.test_stackers.clone());
-        chainstate_config.burnchain.pox_constants = self.pox_constants.clone();
-        let mut chain = TestChainstate::new_with_observer(chainstate_config.clone(), observer);
-
+        let chainstate_config = self.build_nakamoto_chainstate_config();
+        let mut chain = TestChainstate::new_with_observer(chainstate_config, observer);
         chain.mine_malleablized_blocks = self.malleablized_blocks;
-
-        self.advance_to_nakamoto_chainstate(&mut chain);
-        chain
-    }
-
-    /// Bring a TestChainstate into the Nakamoto Epoch
-    fn advance_to_nakamoto_chainstate(&mut self, chain: &mut TestChainstate) {
         let mut chain_nonce = 0;
-        let addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&self.private_key));
-        let default_pox_addr =
-            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes().clone());
-
-        let mut sortition_height = chain.get_burn_block_height();
-        debug!("\n\n======================");
-        debug!(
-            "PoxConstants = {:#?}",
-            &chain.config.burnchain.pox_constants
-        );
-        debug!("tip = {sortition_height}");
-        debug!("========================\n\n");
-
-        let epoch_25_height = chain
-            .config
-            .epochs
-            .as_ref()
-            .unwrap()
-            .iter()
-            .find(|e| e.epoch_id == StacksEpochId::Epoch25)
-            .unwrap()
-            .start_height;
-
-        let epoch_30_height = chain
-            .config
-            .epochs
-            .as_ref()
-            .unwrap()
-            .iter()
-            .find(|e| e.epoch_id == StacksEpochId::Epoch30)
-            .unwrap()
-            .start_height;
-
-        // advance to just past pox-4 instantiation
-        let mut blocks_produced = false;
-        while sortition_height <= epoch_25_height {
-            chain.tenure_with_txs(&[], &mut chain_nonce);
-            sortition_height = chain.get_burn_block_height();
-            blocks_produced = true;
-        }
-
-        // need to produce at least 1 block before making pox-4 lockups:
-        //  the way `burn-block-height` constant works in Epoch 2.5 is such
-        //  that if its the first block produced, this will be 0 which will
-        //  prevent the lockups from being valid.
-        if !blocks_produced {
-            chain.tenure_with_txs(&[], &mut chain_nonce);
-            sortition_height = chain.get_burn_block_height();
-        }
-
-        debug!("\n\n======================");
-        debug!("Make PoX-4 lockups");
-        debug!("========================\n\n");
-
-        let reward_cycle = chain
-            .config
-            .burnchain
-            .block_height_to_reward_cycle(sortition_height)
-            .unwrap();
-
-        // Make all the test Stackers stack
-        let stack_txs: Vec<_> = chain
-            .config
-            .test_stackers
-            .clone()
-            .unwrap_or_default()
-            .iter()
-            .map(|test_stacker| {
-                let pox_addr = test_stacker
-                    .pox_addr
-                    .clone()
-                    .unwrap_or(default_pox_addr.clone());
-                let max_amount = test_stacker.max_amount.unwrap_or(u128::MAX);
-                let signature = make_pox_4_signer_key_signature(
-                    &pox_addr,
-                    &test_stacker.signer_private_key,
-                    reward_cycle.into(),
-                    &crate::util_lib::signed_structured_data::pox4::Pox4SignatureTopic::StackStx,
-                    chain.config.network_id,
-                    12,
-                    max_amount,
-                    1,
-                )
-                .unwrap()
-                .to_rsv();
-                make_pox_4_lockup_chain_id(
-                    &test_stacker.stacker_private_key,
-                    0,
-                    test_stacker.amount,
-                    &pox_addr,
-                    12,
-                    &StacksPublicKey::from_private(&test_stacker.signer_private_key),
-                    sortition_height + 1,
-                    Some(signature),
-                    max_amount,
-                    1,
-                    chain.config.network_id,
-                )
-            })
-            .collect();
-
-        let mut stacks_block = chain.tenure_with_txs(&stack_txs, &mut chain_nonce);
-
-        let (stacks_tip_ch, stacks_tip_bh) =
-            SortitionDB::get_canonical_stacks_chain_tip_hash(chain.sortdb().conn()).unwrap();
-        let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-        assert_eq!(stacks_block, stacks_tip);
-
-        debug!("\n\n======================");
-        debug!("Advance to the Prepare Phase");
-        debug!("========================\n\n");
-        while !chain.config.burnchain.is_in_prepare_phase(sortition_height) {
-            let (stacks_tip_ch, stacks_tip_bh) =
-                SortitionDB::get_canonical_stacks_chain_tip_hash(chain.sortdb().conn()).unwrap();
-            let old_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-            stacks_block = chain.tenure_with_txs(&[], &mut chain_nonce);
-
-            let (stacks_tip_ch, stacks_tip_bh) =
-                SortitionDB::get_canonical_stacks_chain_tip_hash(chain.sortdb().conn()).unwrap();
-            let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-            assert_ne!(old_tip, stacks_tip);
-            sortition_height = chain.get_burn_block_height();
-        }
-
-        debug!("\n\n======================");
-        debug!("Advance to Epoch 3.0");
-        debug!("========================\n\n");
-
-        // advance to the start of epoch 3.0
-        while sortition_height < epoch_30_height - 1 {
-            let (stacks_tip_ch, stacks_tip_bh) =
-                SortitionDB::get_canonical_stacks_chain_tip_hash(chain.sortdb().conn()).unwrap();
-            let old_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-            chain.tenure_with_txs(&[], &mut chain_nonce);
-
-            let (stacks_tip_ch, stacks_tip_bh) =
-                SortitionDB::get_canonical_stacks_chain_tip_hash(chain.sortdb().conn()).unwrap();
-            let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-            assert_ne!(old_tip, stacks_tip);
-            sortition_height = chain.get_burn_block_height();
-        }
-
-        debug!("\n\n======================");
-        debug!("Welcome to Nakamoto!");
-        debug!("========================\n\n");
+        chain.advance_to_nakamoto_epoch(&self.private_key, &mut chain_nonce);
+        chain
     }
 
     /// Make a peer and transition it into the Nakamoto epoch.
     /// The node needs to be stacking; otherwise, Nakamoto won't activate.
-    fn boot_nakamoto_peers(
-        mut self,
+    /// Boot a TestPeer and followers into the Nakamoto epoch
+    pub fn boot_nakamoto_peers(
+        self,
         observer: Option<&TestEventObserver>,
     ) -> (TestPeer<'_>, Vec<TestPeer<'_>>) {
         let mut peer_config = TestPeerConfig::new(&self.test_name, 0, 0);
-        peer_config.network_id = self.network_id;
+        peer_config.chain_config = self.build_nakamoto_chainstate_config();
         peer_config.private_key = self.private_key.clone();
-        peer_config.txindex = self.txindex;
-
-        let addr = StacksAddress::from_public_keys(
-            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-            &AddressHashMode::SerializeP2PKH,
-            1,
-            &vec![StacksPublicKey::from_private(&self.private_key)],
-        )
-        .unwrap();
-
-        // reward cycles are 5 blocks long
-        // first 25 blocks are boot-up
-        // reward cycle 6 instantiates pox-3
-        // we stack in reward cycle 7 so pox-3 is evaluated to find reward set participation
+        peer_config.connection_opts.auth_token = Some("password".to_string());
         peer_config
             .stacker_dbs
             .push(boot_code_id(MINERS_NAME, false));
-        peer_config.epochs = Some(StacksEpoch::unit_test_3_0_only(
-            (self.pox_constants.pox_4_activation_height
-                + self.pox_constants.reward_cycle_length
-                + 1)
-            .into(),
-        ));
-        peer_config.initial_balances = vec![];
-        if self.add_default_balance {
-            peer_config
-                .initial_balances
-                .push((addr.to_account_principal(), 1_000_000_000_000_000_000));
-        }
-        peer_config
-            .initial_balances
-            .append(&mut self.initial_balances.clone());
-        peer_config.connection_opts.auth_token = Some("password".to_string());
 
-        // Create some balances for test Stackers
-        // They need their stacking amount + enough to pay fees
-        let fee_payment_balance = 10_000;
-        let stacker_balances = self.test_stackers.iter().map(|test_stacker| {
-            (
-                PrincipalData::from(key_to_stacks_addr(&test_stacker.stacker_private_key)),
-                u64::try_from(test_stacker.amount).expect("Stacking amount too large"),
-            )
-        });
-        let signer_balances = self.test_stackers.iter().map(|test_stacker| {
-            (
-                PrincipalData::from(key_to_stacks_addr(&test_stacker.signer_private_key)),
-                fee_payment_balance,
-            )
-        });
-
-        peer_config.initial_balances.extend(stacker_balances);
-        peer_config.initial_balances.extend(signer_balances);
-        peer_config.test_signers = Some(self.test_signers.clone());
-        peer_config.test_stackers = Some(self.test_stackers.clone());
-        peer_config.burnchain.pox_constants = self.pox_constants.clone();
         let mut peer = TestPeer::new_with_observer(peer_config.clone(), observer);
-
-        peer.mine_malleablized_blocks = self.malleablized_blocks;
+        peer.chain.mine_malleablized_blocks = self.malleablized_blocks;
 
         let mut other_peers = vec![];
         for i in 0..self.num_peers {
             let mut other_config = peer_config.clone();
-            other_config.test_name = format!("{}.follower", &peer.config.test_name);
+            other_config.chain_config.test_name =
+                format!("{}.follower", &peer_config.chain_config.test_name);
             other_config.server_port = 0;
             other_config.http_port = 0;
-            other_config.test_stackers = peer.config.test_stackers.clone();
+            other_config.chain_config.test_stackers =
+                peer_config.chain_config.test_stackers.clone();
             other_config.private_key = StacksPrivateKey::from_seed(&(i as u128).to_be_bytes());
-
             other_config.add_neighbor(&peer.to_neighbor());
 
             let mut other_peer = TestPeer::new_with_observer(other_config, None);
-            other_peer.mine_malleablized_blocks = self.malleablized_blocks;
-
+            other_peer.chain.mine_malleablized_blocks = self.malleablized_blocks;
             other_peers.push(other_peer);
         }
 
-        self.advance_to_nakamoto(&mut peer, &mut other_peers);
-        (peer, other_peers)
-    }
-
-    /// Bring a TestPeer into the Nakamoto Epoch
-    fn advance_to_nakamoto(&mut self, peer: &mut TestPeer, other_peers: &mut [TestPeer]) {
         let mut peer_nonce = 0;
         let mut other_peer_nonces = vec![0; other_peers.len()];
-        let addr = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&self.private_key));
-        let default_pox_addr =
-            PoxAddress::from_legacy(AddressHashMode::SerializeP2PKH, addr.bytes().clone());
 
-        let mut sortition_height = peer.get_burn_block_height();
-        debug!("\n\n======================");
-        debug!("PoxConstants = {:#?}", &peer.config.burnchain.pox_constants);
-        debug!("tip = {}", sortition_height);
-        debug!("========================\n\n");
-
-        let epoch_25_height = peer
-            .config
-            .epochs
-            .as_ref()
-            .unwrap()
-            .iter()
-            .find(|e| e.epoch_id == StacksEpochId::Epoch25)
-            .unwrap()
-            .start_height;
-
-        let epoch_30_height = peer
-            .config
-            .epochs
-            .as_ref()
-            .unwrap()
-            .iter()
-            .find(|e| e.epoch_id == StacksEpochId::Epoch30)
-            .unwrap()
-            .start_height;
-
-        // advance to just past pox-4 instantiation
-        let mut blocks_produced = false;
-        while sortition_height <= epoch_25_height {
-            peer.tenure_with_txs(&[], &mut peer_nonce);
-            for (other_peer, other_peer_nonce) in
-                other_peers.iter_mut().zip(other_peer_nonces.iter_mut())
-            {
-                other_peer.tenure_with_txs(&[], other_peer_nonce);
-            }
-
-            sortition_height = peer.get_burn_block_height();
-            blocks_produced = true;
-        }
-
-        // need to produce at least 1 block before making pox-4 lockups:
-        //  the way `burn-block-height` constant works in Epoch 2.5 is such
-        //  that if its the first block produced, this will be 0 which will
-        //  prevent the lockups from being valid.
-        if !blocks_produced {
-            peer.tenure_with_txs(&[], &mut peer_nonce);
-            for (other_peer, other_peer_nonce) in
-                other_peers.iter_mut().zip(other_peer_nonces.iter_mut())
-            {
-                other_peer.tenure_with_txs(&[], other_peer_nonce);
-            }
-
-            sortition_height = peer.get_burn_block_height();
-        }
-
-        debug!("\n\n======================");
-        debug!("Make PoX-4 lockups");
-        debug!("========================\n\n");
-
-        let reward_cycle = peer
-            .config
-            .burnchain
-            .block_height_to_reward_cycle(sortition_height)
-            .unwrap();
-
-        // Make all the test Stackers stack
-        let stack_txs: Vec<_> = peer
-            .config
-            .test_stackers
-            .clone()
-            .unwrap_or_default()
-            .iter()
-            .map(|test_stacker| {
-                let pox_addr = test_stacker
-                    .pox_addr
-                    .clone()
-                    .unwrap_or(default_pox_addr.clone());
-                let max_amount = test_stacker.max_amount.unwrap_or(u128::MAX);
-                let signature = make_pox_4_signer_key_signature(
-                    &pox_addr,
-                    &test_stacker.signer_private_key,
-                    reward_cycle.into(),
-                    &crate::util_lib::signed_structured_data::pox4::Pox4SignatureTopic::StackStx,
-                    peer.config.network_id,
-                    12,
-                    max_amount,
-                    1,
-                )
-                .unwrap()
-                .to_rsv();
-                make_pox_4_lockup_chain_id(
-                    &test_stacker.stacker_private_key,
-                    0,
-                    test_stacker.amount,
-                    &pox_addr,
-                    12,
-                    &StacksPublicKey::from_private(&test_stacker.signer_private_key),
-                    sortition_height + 1,
-                    Some(signature),
-                    max_amount,
-                    1,
-                    peer.config.network_id,
-                )
-            })
-            .collect();
-
-        let mut old_tip = peer.network.stacks_tip.clone();
-        let mut stacks_block = peer.tenure_with_txs(&stack_txs, &mut peer_nonce);
-
-        let (stacks_tip_ch, stacks_tip_bh) =
-            SortitionDB::get_canonical_stacks_chain_tip_hash(peer.sortdb().conn()).unwrap();
-        let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-        assert_eq!(peer.network.stacks_tip.block_id(), stacks_tip);
-        if old_tip.block_id() != stacks_tip {
-            old_tip.burnchain_height = peer.network.parent_stacks_tip.burnchain_height;
-            assert_eq!(old_tip, peer.network.parent_stacks_tip);
-        }
-
+        // Advance primary peer and other peers to Nakamoto epoch
+        peer.chain
+            .advance_to_nakamoto_epoch(&self.private_key, &mut peer_nonce);
         for (other_peer, other_peer_nonce) in
             other_peers.iter_mut().zip(other_peer_nonces.iter_mut())
         {
-            let mut old_tip = other_peer.network.stacks_tip.clone();
-            other_peer.tenure_with_txs(&stack_txs, other_peer_nonce);
-
-            let (stacks_tip_ch, stacks_tip_bh) =
-                SortitionDB::get_canonical_stacks_chain_tip_hash(other_peer.sortdb().conn())
-                    .unwrap();
-            let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-            assert_eq!(other_peer.network.stacks_tip.block_id(), stacks_tip);
-            if old_tip.block_id() != stacks_tip {
-                old_tip.burnchain_height = other_peer.network.parent_stacks_tip.burnchain_height;
-                assert_eq!(old_tip, other_peer.network.parent_stacks_tip);
-            }
+            other_peer
+                .chain
+                .advance_to_nakamoto_epoch(&self.private_key, other_peer_nonce);
         }
 
-        debug!("\n\n======================");
-        debug!("Advance to the Prepare Phase");
-        debug!("========================\n\n");
-        while !peer.config.burnchain.is_in_prepare_phase(sortition_height) {
-            let mut old_tip = peer.network.stacks_tip.clone();
-            stacks_block = peer.tenure_with_txs(&[], &mut peer_nonce);
-
-            let (stacks_tip_ch, stacks_tip_bh) =
-                SortitionDB::get_canonical_stacks_chain_tip_hash(peer.sortdb().conn()).unwrap();
-            let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-            assert_eq!(peer.network.stacks_tip.block_id(), stacks_tip);
-            if old_tip.block_id() != stacks_tip {
-                old_tip.burnchain_height = peer.network.parent_stacks_tip.burnchain_height;
-                assert_eq!(old_tip, peer.network.parent_stacks_tip);
-            }
-            other_peers
-                .iter_mut()
-                .zip(other_peer_nonces.iter_mut())
-                .for_each(|(peer, nonce)| {
-                    let mut old_tip = peer.network.stacks_tip.clone();
-                    peer.tenure_with_txs(&[], nonce);
-
-                    let (stacks_tip_ch, stacks_tip_bh) =
-                        SortitionDB::get_canonical_stacks_chain_tip_hash(peer.sortdb().conn())
-                            .unwrap();
-                    let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-                    assert_eq!(peer.network.stacks_tip.block_id(), stacks_tip);
-                    if old_tip.block_id() != stacks_tip {
-                        old_tip.burnchain_height = peer.network.parent_stacks_tip.burnchain_height;
-                        assert_eq!(old_tip, peer.network.parent_stacks_tip);
-                    }
-                });
-            sortition_height = peer.get_burn_block_height();
-        }
-
-        debug!("\n\n======================");
-        debug!("Advance to Epoch 3.0");
-        debug!("========================\n\n");
-
-        // advance to the start of epoch 3.0
-        while sortition_height < epoch_30_height - 1 {
-            let mut old_tip = peer.network.stacks_tip.clone();
-            peer.tenure_with_txs(&[], &mut peer_nonce);
-
-            let (stacks_tip_ch, stacks_tip_bh) =
-                SortitionDB::get_canonical_stacks_chain_tip_hash(peer.sortdb().conn()).unwrap();
-            let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-            assert_eq!(peer.network.stacks_tip.block_id(), stacks_tip);
-            if old_tip.block_id() != stacks_tip {
-                old_tip.burnchain_height = peer.network.parent_stacks_tip.burnchain_height;
-                assert_eq!(old_tip, peer.network.parent_stacks_tip);
-            }
-
-            for (other_peer, other_peer_nonce) in
-                other_peers.iter_mut().zip(other_peer_nonces.iter_mut())
-            {
-                let mut old_tip = peer.network.stacks_tip.clone();
-                other_peer.tenure_with_txs(&[], other_peer_nonce);
-
-                let (stacks_tip_ch, stacks_tip_bh) =
-                    SortitionDB::get_canonical_stacks_chain_tip_hash(other_peer.sortdb().conn())
-                        .unwrap();
-                let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bh);
-                assert_eq!(other_peer.network.stacks_tip.block_id(), stacks_tip);
-                if old_tip.block_id() != stacks_tip {
-                    old_tip.burnchain_height =
-                        other_peer.network.parent_stacks_tip.burnchain_height;
-                    assert_eq!(old_tip, other_peer.network.parent_stacks_tip);
-                }
-            }
-            sortition_height = peer.get_burn_block_height();
-        }
-
-        debug!("\n\n======================");
-        debug!("Welcome to Nakamoto!");
-        debug!("========================\n\n");
+        (peer, other_peers)
     }
 
     pub fn boot_into_nakamoto_peers(
@@ -926,6 +509,7 @@ impl NakamotoBootPlan {
                         blocks_since_last_tenure,
                     );
                     let tenure_change_tx = peer
+                        .chain
                         .miner
                         .make_nakamoto_tenure_change(tenure_change_extend.clone());
 
@@ -988,7 +572,7 @@ impl NakamotoBootPlan {
                         .collect();
 
                     let malleablized_blocks =
-                        std::mem::replace(&mut peer.malleablized_blocks, vec![]);
+                        std::mem::replace(&mut peer.chain.malleablized_blocks, vec![]);
                     for mblk in malleablized_blocks.iter() {
                         malleablized_block_ids.insert(mblk.block_id());
                     }
@@ -1020,10 +604,11 @@ impl NakamotoBootPlan {
                     last_tenure_change = Some(tenure_change.clone());
 
                     let tenure_change_tx = peer
+                        .chain
                         .miner
                         .make_nakamoto_tenure_change(tenure_change.clone());
 
-                    let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+                    let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
                     debug!("\n\nNew tenure: {}\n\n", &consensus_hash);
 
@@ -1087,7 +672,7 @@ impl NakamotoBootPlan {
                         .collect();
 
                     let malleablized_blocks =
-                        std::mem::replace(&mut peer.malleablized_blocks, vec![]);
+                        std::mem::replace(&mut peer.chain.malleablized_blocks, vec![]);
                     for mblk in malleablized_blocks.iter() {
                         malleablized_block_ids.insert(mblk.block_id());
                     }
@@ -1111,8 +696,8 @@ impl NakamotoBootPlan {
 
         // check that our tenure-extends have been getting applied
         let (highest_tenure, sort_tip) = {
-            let chainstate = &mut peer.stacks_node.as_mut().unwrap().chainstate;
-            let sort_db = peer.sortdb.as_mut().unwrap();
+            let chainstate = &mut peer.chain.stacks_node.as_mut().unwrap().chainstate;
+            let sort_db = peer.chain.sortdb.as_mut().unwrap();
             let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
             let tenure = NakamotoChainState::get_ongoing_tenure(
                 &mut chainstate.index_conn(),
@@ -1149,8 +734,18 @@ impl NakamotoBootPlan {
         // transaction in `all_blocks` ran to completion
         if let Some(observer) = observer {
             let mut observed_blocks = observer.get_blocks();
-            let mut block_idx = (peer.config.burnchain.pox_constants.pox_4_activation_height
-                + peer.config.burnchain.pox_constants.reward_cycle_length
+            let mut block_idx = (peer
+                .config
+                .chain_config
+                .burnchain
+                .pox_constants
+                .pox_4_activation_height
+                + peer
+                    .config
+                    .chain_config
+                    .burnchain
+                    .pox_constants
+                    .reward_cycle_length
                 - 25) as usize;
 
             // filter out observed blocks that are malleablized
@@ -1206,8 +801,8 @@ impl NakamotoBootPlan {
         // verify that all other peers kept pace with this peer
         for other_peer in other_peers.iter_mut() {
             let (other_highest_tenure, other_sort_tip) = {
-                let chainstate = &mut other_peer.stacks_node.as_mut().unwrap().chainstate;
-                let sort_db = other_peer.sortdb.as_mut().unwrap();
+                let chainstate = &mut other_peer.chain.stacks_node.as_mut().unwrap().chainstate;
+                let sort_db = other_peer.chain.sortdb.as_mut().unwrap();
                 let tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
                 let tenure = NakamotoChainState::get_ongoing_tenure(
                     &mut chainstate.index_conn(),
@@ -2055,8 +1650,8 @@ fn test_update_highest_stacks_height_of_neighbors(
         old_height.map(|h| (SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080), h));
     peer.network.highest_stacks_neighbor = prev_highest_neighbor;
 
-    let peer_sortdb = peer.sortdb.take().unwrap();
-    let mut peer_stacks_node = peer.stacks_node.take().unwrap();
+    let peer_sortdb = peer.chain.sortdb.take().unwrap();
+    let mut peer_stacks_node = peer.chain.stacks_node.take().unwrap();
     let mut peer_mempool = peer.mempool.take().unwrap();
     let rpc_args = RPCHandlerArgsType::make_default();
     let mut node_state = StacksNodeState::new(

--- a/stackslib/src/net/tests/neighbors.rs
+++ b/stackslib/src/net/tests/neighbors.rs
@@ -322,7 +322,7 @@ fn test_step_walk_1_neighbor_bad_epoch() {
 
         // peer 1 thinks its always epoch 2.0
         peer_1_config.peer_version = 0x18000000;
-        peer_1_config.epochs = Some(EpochList::new(&[StacksEpoch {
+        peer_1_config.chain_config.epochs = Some(EpochList::new(&[StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,
             start_height: 0,
             end_height: STACKS_EPOCH_MAX,
@@ -332,7 +332,7 @@ fn test_step_walk_1_neighbor_bad_epoch() {
 
         // peer 2 thinks its always epoch 2.05
         peer_2_config.peer_version = 0x18000005;
-        peer_2_config.epochs = Some(EpochList::new(&[StacksEpoch {
+        peer_2_config.chain_config.epochs = Some(EpochList::new(&[StacksEpoch {
             epoch_id: StacksEpochId::Epoch2_05,
             start_height: 0,
             end_height: STACKS_EPOCH_MAX,
@@ -1401,7 +1401,7 @@ fn test_step_walk_2_neighbors_rekey() {
         peer_2_config.connection_opts.disable_inv_sync = true;
         peer_2_config.connection_opts.disable_block_download = true;
 
-        let first_block_height = peer_1_config.current_block + 1;
+        let first_block_height = peer_1_config.chain_config.current_block + 1;
 
         // make keys expire soon
         peer_1_config.private_key_expire = first_block_height + 3;
@@ -1500,13 +1500,13 @@ fn test_step_walk_2_neighbors_different_networks() {
         let mut peer_1_config = TestPeerConfig::new(function_name!(), 0, 0);
         let peer_2_config = TestPeerConfig::new(function_name!(), 0, 0);
 
-        peer_1_config.network_id = peer_2_config.network_id + 1;
+        peer_1_config.chain_config.network_id = peer_2_config.chain_config.network_id + 1;
 
         let mut peer_1 = TestPeer::new(peer_1_config);
         let mut peer_2 = TestPeer::new(peer_2_config);
 
         let mut peer_1_neighbor = peer_1.to_neighbor();
-        peer_1_neighbor.addr.network_id = peer_2.config.network_id;
+        peer_1_neighbor.addr.network_id = peer_2.config.chain_config.network_id;
 
         peer_1.add_neighbor(&mut peer_2.to_neighbor(), None, true);
         peer_2.add_neighbor(&mut peer_1_neighbor, None, true);

--- a/stackslib/src/net/tests/relay/epoch2x.rs
+++ b/stackslib/src/net/tests/relay/epoch2x.rs
@@ -564,12 +564,11 @@ fn test_get_blocks_and_microblocks_3_peers_push_available() {
                 peer_configs[2].add_neighbor(&peer_1);
             },
             |num_blocks, ref mut peers| {
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -581,12 +580,12 @@ fn test_get_blocks_and_microblocks_3_peers_push_available() {
                     // cycle, since pushing block/microblock
                     // announcements in reward cycles the remote
                     // peer doesn't know about won't work.
-                    let tip = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let tip =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     if peers[0]
                         .config
+                        .chain_config
                         .burnchain
                         .block_height_to_reward_cycle(tip.block_height)
                         .unwrap()
@@ -607,10 +606,9 @@ fn test_get_blocks_and_microblocks_3_peers_push_available() {
                         peers[i].next_burnchain_block_raw(burn_ops.clone());
                     }
 
-                    let sn = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let sn =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     block_data.push((
                         sn.consensus_hash.clone(),
                         Some(stacks_block),
@@ -628,7 +626,7 @@ fn test_get_blocks_and_microblocks_3_peers_push_available() {
                 // work, and for (Micro)BlocksAvailable messages to be accepted
                 let peer_1_nk = peers[1].to_neighbor().addr;
                 let peer_2_nk = peers[2].to_neighbor().addr;
-                let bc = peers[1].config.burnchain.clone();
+                let bc = peers[1].config.chain_config.burnchain.clone();
                 match peers[2].network.inv_state {
                     Some(ref mut inv_state) => {
                         if inv_state.get_stats(&peer_1_nk).is_none() {
@@ -656,12 +654,11 @@ fn test_get_blocks_and_microblocks_3_peers_push_available() {
                     }
                 }
 
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -860,12 +857,9 @@ fn push_block(
         dest
     );
 
-    let sn = SortitionDB::get_block_snapshot_consensus(
-        peer.sortdb.as_ref().unwrap().conn(),
-        &consensus_hash,
-    )
-    .unwrap()
-    .unwrap();
+    let sn = SortitionDB::get_block_snapshot_consensus(peer.sortdb_ref().conn(), &consensus_hash)
+        .unwrap()
+        .unwrap();
     let consensus_hash = sn.consensus_hash;
 
     let msg = StacksMessageType::Blocks(BlocksData {
@@ -887,12 +881,9 @@ fn broadcast_block(
         block.block_hash(),
     );
 
-    let sn = SortitionDB::get_block_snapshot_consensus(
-        peer.sortdb.as_ref().unwrap().conn(),
-        &consensus_hash,
-    )
-    .unwrap()
-    .unwrap();
+    let sn = SortitionDB::get_block_snapshot_consensus(peer.sortdb_ref().conn(), &consensus_hash)
+        .unwrap()
+        .unwrap();
     let consensus_hash = sn.consensus_hash;
 
     let msg = StacksMessageType::Blocks(BlocksData {
@@ -1091,12 +1082,11 @@ fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(
                 }
             },
             |num_blocks, ref mut peers| {
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -1104,12 +1094,12 @@ fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(
                 // build up block data to replicate
                 let mut block_data = vec![];
                 for _ in 0..num_blocks {
-                    let tip = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let tip =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     if peers[0]
                         .config
+                        .chain_config
                         .burnchain
                         .block_height_to_reward_cycle(tip.block_height)
                         .unwrap()
@@ -1129,10 +1119,9 @@ fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(
                         peers[i].next_burnchain_block_raw(burn_ops.clone());
                     }
 
-                    let sn = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let sn =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     block_data.push((
                         sn.consensus_hash.clone(),
                         Some(stacks_block),
@@ -1203,8 +1192,7 @@ fn test_get_blocks_and_microblocks_2_peers_push_blocks_and_microblocks(
 
                     if let Some((consensus_hash, block, microblocks)) = data_to_push {
                         test_debug!(
-                            "Push block {}/{} and microblocks",
-                            &consensus_hash,
+                            "Push block {consensus_hash}/{} and microblocks",
                             block.block_hash()
                         );
 
@@ -1399,12 +1387,11 @@ fn test_get_blocks_and_microblocks_upload_blocks_http() {
                 let peer_1 = peer_configs[1].to_neighbor();
             },
             |num_blocks, ref mut peers| {
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -1416,12 +1403,12 @@ fn test_get_blocks_and_microblocks_upload_blocks_http() {
                     // cycle, since pushing block/microblock
                     // announcements in reward cycles the remote
                     // peer doesn't know about won't work.
-                    let tip = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let tip =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     if peers[0]
                         .config
+                        .chain_config
                         .burnchain
                         .block_height_to_reward_cycle(tip.block_height)
                         .unwrap()
@@ -1442,10 +1429,9 @@ fn test_get_blocks_and_microblocks_upload_blocks_http() {
                         peers[i].next_burnchain_block_raw(burn_ops.clone());
                     }
 
-                    let sn = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let sn =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     block_data.push((
                         sn.consensus_hash.clone(),
                         Some(stacks_block),
@@ -1595,20 +1581,28 @@ fn test_get_blocks_and_microblocks_2_peers_push_transactions() {
                 let initial_balances = vec![
                     (
                         PrincipalData::from(
-                            peer_configs[0].spending_account.origin_address().unwrap(),
+                            peer_configs[0]
+                                .chain_config
+                                .spending_account
+                                .origin_address()
+                                .unwrap(),
                         ),
                         1000000,
                     ),
                     (
                         PrincipalData::from(
-                            peer_configs[1].spending_account.origin_address().unwrap(),
+                            peer_configs[1]
+                                .chain_config
+                                .spending_account
+                                .origin_address()
+                                .unwrap(),
                         ),
                         1000000,
                     ),
                 ];
 
-                peer_configs[0].initial_balances = initial_balances.clone();
-                peer_configs[1].initial_balances = initial_balances;
+                peer_configs[0].chain_config.initial_balances = initial_balances.clone();
+                peer_configs[1].chain_config.initial_balances = initial_balances;
 
                 let peer_0 = peer_configs[0].to_neighbor();
                 let peer_1 = peer_configs[1].to_neighbor();
@@ -1617,12 +1611,11 @@ fn test_get_blocks_and_microblocks_2_peers_push_transactions() {
                 peer_configs[1].add_neighbor(&peer_0);
             },
             |num_blocks, ref mut peers| {
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -1630,12 +1623,12 @@ fn test_get_blocks_and_microblocks_2_peers_push_transactions() {
                 // build up block data to replicate
                 let mut block_data = vec![];
                 for b in 0..num_blocks {
-                    let tip = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let tip =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     if peers[0]
                         .config
+                        .chain_config
                         .burnchain
                         .block_height_to_reward_cycle(tip.block_height)
                         .unwrap()
@@ -1659,10 +1652,9 @@ fn test_get_blocks_and_microblocks_2_peers_push_transactions() {
                         }
                     }
 
-                    let sn = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let sn =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     block_data.push((
                         sn.consensus_hash.clone(),
                         Some(stacks_block),
@@ -1971,12 +1963,18 @@ fn test_get_blocks_and_microblocks_peers_broadcast() {
                 }
 
                 let initial_balances = vec![(
-                    PrincipalData::from(peer_configs[0].spending_account.origin_address().unwrap()),
+                    PrincipalData::from(
+                        peer_configs[0]
+                            .chain_config
+                            .spending_account
+                            .origin_address()
+                            .unwrap(),
+                    ),
                     1000000,
                 )];
 
                 for i in 0..peer_configs.len() {
-                    peer_configs[i].initial_balances = initial_balances.clone();
+                    peer_configs[i].chain_config.initial_balances = initial_balances.clone();
                 }
 
                 // connectivity
@@ -1988,12 +1986,11 @@ fn test_get_blocks_and_microblocks_peers_broadcast() {
                 }
             },
             |num_blocks, ref mut peers| {
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -2001,12 +1998,12 @@ fn test_get_blocks_and_microblocks_peers_broadcast() {
                 // build up block data to replicate
                 let mut block_data = vec![];
                 for _ in 0..num_blocks {
-                    let tip = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let tip =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     if peers[0]
                         .config
+                        .chain_config
                         .burnchain
                         .block_height_to_reward_cycle(tip.block_height)
                         .unwrap()
@@ -2026,10 +2023,9 @@ fn test_get_blocks_and_microblocks_peers_broadcast() {
                         peers[i].next_burnchain_block_raw(burn_ops.clone());
                     }
 
-                    let sn = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let sn =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
 
                     block_data.push((
                         sn.consensus_hash.clone(),
@@ -2300,12 +2296,11 @@ fn test_get_blocks_and_microblocks_2_peers_antientropy() {
                 peer_configs[1].add_neighbor(&peer_0);
             },
             |num_blocks, ref mut peers| {
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -2313,12 +2308,12 @@ fn test_get_blocks_and_microblocks_2_peers_antientropy() {
                 // build up block data to replicate
                 let mut block_data = vec![];
                 for _ in 0..num_blocks {
-                    let tip = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let tip =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     if peers[0]
                         .config
+                        .chain_config
                         .burnchain
                         .block_height_to_reward_cycle(tip.block_height)
                         .unwrap()
@@ -2338,10 +2333,9 @@ fn test_get_blocks_and_microblocks_2_peers_antientropy() {
                         peers[i].next_burnchain_block_raw(burn_ops.clone());
                     }
 
-                    let sn = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let sn =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     block_data.push((
                         sn.consensus_hash.clone(),
                         Some(stacks_block),
@@ -2355,10 +2349,8 @@ fn test_get_blocks_and_microblocks_2_peers_antientropy() {
                 for i in 1..peers.len() {
                     peers[i].next_burnchain_block_raw(vec![]);
                 }
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let sn = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 block_data.push((sn.consensus_hash.clone(), None, None));
 
                 block_data
@@ -2432,12 +2424,11 @@ fn test_get_blocks_and_microblocks_2_peers_buffered_messages() {
                 peer_configs[1].add_neighbor(&peer_0);
             },
             |num_blocks, ref mut peers| {
-                let tip = SortitionDB::get_canonical_burn_chain_tip(
-                    peers[0].sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
+                let tip = SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                    .unwrap();
                 let this_reward_cycle = peers[0]
                     .config
+                    .chain_config
                     .burnchain
                     .block_height_to_reward_cycle(tip.block_height)
                     .unwrap();
@@ -2445,10 +2436,9 @@ fn test_get_blocks_and_microblocks_2_peers_buffered_messages() {
                 // build up block data to replicate
                 let mut block_data = vec![];
                 for block_num in 0..num_blocks {
-                    let tip = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let tip =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     let (mut burn_ops, stacks_block, microblocks) = peers[0].make_default_tenure();
 
                     let (_, burn_header_hash, consensus_hash) =
@@ -2467,10 +2457,9 @@ fn test_get_blocks_and_microblocks_2_peers_buffered_messages() {
                         all_sortitions.push(burn_ops.clone());
                     }
 
-                    let sn = SortitionDB::get_canonical_burn_chain_tip(
-                        peers[0].sortdb.as_ref().unwrap().conn(),
-                    )
-                    .unwrap();
+                    let sn =
+                        SortitionDB::get_canonical_burn_chain_tip(peers[0].sortdb_ref().conn())
+                            .unwrap();
                     block_data.push((
                         sn.consensus_hash.clone(),
                         Some(stacks_block),
@@ -2515,12 +2504,12 @@ fn test_get_blocks_and_microblocks_2_peers_buffered_messages() {
                     debug!(
                         "Push at {}, need {}",
                         tip.anchored_header.height()
-                            - peers[1].config.burnchain.first_block_height
+                            - peers[1].config.chain_config.burnchain.first_block_height
                             - 1,
                         *pushed_i
                     );
                     if tip.anchored_header.height()
-                        - peers[1].config.burnchain.first_block_height
+                        - peers[1].config.chain_config.burnchain.first_block_height
                         - 1
                         == *pushed_i as u64
                     {
@@ -2543,14 +2532,13 @@ fn test_get_blocks_and_microblocks_2_peers_buffered_messages() {
                         *pushed_i += 1;
                     }
                     debug!(
-                        "Sortition at {}, need {}",
+                        "Sortition at {}, need {i}",
                         tip.anchored_header.height()
-                            - peers[1].config.burnchain.first_block_height
-                            - 1,
-                        *i
+                            - peers[1].config.chain_config.burnchain.first_block_height
+                            - 1
                     );
                     if tip.anchored_header.height()
-                        - peers[1].config.burnchain.first_block_height
+                        - peers[1].config.chain_config.burnchain.first_block_height
                         - 1
                         == *i as u64
                     {
@@ -2569,7 +2557,7 @@ fn test_get_blocks_and_microblocks_2_peers_buffered_messages() {
                         for ((event_id, _neighbor_key), pending) in
                             peers[1].network.pending_messages.iter()
                         {
-                            debug!("Pending at {} is ({}, {})", *i, event_id, pending.len());
+                            debug!("Pending at {i} is ({event_id}, {})", pending.len());
                             if !pending.is_empty() {
                                 update_sortition = true;
                             }
@@ -2732,8 +2720,8 @@ fn process_new_blocks_rejects_problematic_asts() {
     let initial_balances = vec![(addr.to_account_principal(), 100000000000)];
 
     let mut peer_config = TestPeerConfig::new(function_name!(), 32019, 32020);
-    peer_config.initial_balances = initial_balances;
-    peer_config.epochs = Some(EpochList::new(&[
+    peer_config.chain_config.initial_balances = initial_balances;
+    peer_config.chain_config.epochs = Some(EpochList::new(&[
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,
             start_height: 0,
@@ -2749,18 +2737,17 @@ fn process_new_blocks_rejects_problematic_asts() {
             network_epoch: PEER_VERSION_EPOCH_2_05,
         },
     ]));
-    let burnchain = peer_config.burnchain.clone();
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     // activate new AST rules right away
     let mut peer = TestPeer::new(peer_config);
-    let sortdb = peer.sortdb.take().unwrap();
-    peer.sortdb = Some(sortdb);
+    let sortdb = peer.chain.sortdb.take().unwrap();
+    peer.chain.sortdb = Some(sortdb);
 
-    let chainstate_path = peer.chainstate_path.clone();
+    let chainstate_path = peer.chain.chainstate_path.clone();
 
     let first_stacks_block_height = {
-        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn())
-            .unwrap();
+        let sn = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb_ref().conn()).unwrap();
         sn.block_height
     };
 
@@ -2775,8 +2762,7 @@ fn process_new_blocks_rejects_problematic_asts() {
         bytes.len() as u64
     };
 
-    let tip =
-        SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn()).unwrap();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb_ref().conn()).unwrap();
 
     let mblock_privk = StacksPrivateKey::random();
 
@@ -2838,8 +2824,7 @@ fn process_new_blocks_rejects_problematic_asts() {
     let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
     peer.process_stacks_epoch(&block, &consensus_hash, &[]);
 
-    let tip =
-        SortitionDB::get_canonical_burn_chain_tip(peer.sortdb.as_ref().unwrap().conn()).unwrap();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(peer.sortdb_ref().conn()).unwrap();
 
     let (burn_ops, bad_block, mut microblocks) = peer.make_tenure(
         |ref mut miner,
@@ -3087,12 +3072,12 @@ fn process_new_blocks_rejects_problematic_asts() {
         .confirmed_microblocks
         .push((new_consensus_hash.clone(), vec![bad_mblock], 234));
 
-    let mut sortdb = peer.sortdb.take().unwrap();
+    let mut sortdb = peer.chain.sortdb.take().unwrap();
     let (processed_blocks, processed_mblocks, relay_mblocks, bad_neighbors) =
         Relayer::process_new_blocks(
             &mut network_result,
             &mut sortdb,
-            &mut peer.stacks_node.as_mut().unwrap().chainstate,
+            &mut peer.chain.stacks_node.as_mut().unwrap().chainstate,
             None,
         )
         .unwrap();
@@ -3107,7 +3092,7 @@ fn process_new_blocks_rejects_problematic_asts() {
     let txs_relayed = Relayer::process_transactions(
         &mut network_result,
         &sortdb,
-        &mut peer.stacks_node.as_mut().unwrap().chainstate,
+        &mut peer.chain.stacks_node.as_mut().unwrap().chainstate,
         peer.mempool.as_mut().unwrap(),
         None,
     )
@@ -3148,8 +3133,8 @@ fn test_block_pay_to_contract_gated_at_v210() {
             network_epoch: PEER_VERSION_EPOCH_2_1,
         },
     ]);
-    peer_config.epochs = Some(epochs);
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.epochs = Some(epochs);
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
@@ -3233,8 +3218,8 @@ fn test_block_pay_to_contract_gated_at_v210() {
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
         let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
 
-        let sortdb = peer.sortdb.take().unwrap();
-        let mut node = peer.stacks_node.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
+        let mut node = peer.chain.stacks_node.take().unwrap();
         match Relayer::process_new_anchored_block(
             &sortdb.index_conn(),
             &mut node.chainstate,
@@ -3247,11 +3232,11 @@ fn test_block_pay_to_contract_gated_at_v210() {
             }
             Err(chainstate_error::InvalidStacksBlock(_)) => {}
             Err(e) => {
-                panic!("Got unexpected error {:?}", &e);
+                panic!("Got unexpected error {e:?}");
             }
         };
-        peer.sortdb = Some(sortdb);
-        peer.stacks_node = Some(node);
+        peer.chain.sortdb = Some(sortdb);
+        peer.chain.stacks_node = Some(node);
     }
 
     // *now* it should succeed, since tenure 28 was in epoch 2.1
@@ -3259,8 +3244,8 @@ fn test_block_pay_to_contract_gated_at_v210() {
 
     let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
 
-    let sortdb = peer.sortdb.take().unwrap();
-    let mut node = peer.stacks_node.take().unwrap();
+    let sortdb = peer.chain.sortdb.take().unwrap();
+    let mut node = peer.chain.stacks_node.take().unwrap();
     match Relayer::process_new_anchored_block(
         &sortdb.index_conn(),
         &mut node.chainstate,
@@ -3279,8 +3264,8 @@ fn test_block_pay_to_contract_gated_at_v210() {
             panic!("Got unexpected error {:?}", &e);
         }
     };
-    peer.sortdb = Some(sortdb);
-    peer.stacks_node = Some(node);
+    peer.chain.sortdb = Some(sortdb);
+    peer.chain.stacks_node = Some(node);
 }
 
 #[test]
@@ -3288,7 +3273,13 @@ fn test_block_versioned_smart_contract_gated_at_v210() {
     let mut peer_config = TestPeerConfig::new(function_name!(), 4248, 4249);
 
     let initial_balances = vec![(
-        PrincipalData::from(peer_config.spending_account.origin_address().unwrap()),
+        PrincipalData::from(
+            peer_config
+                .chain_config
+                .spending_account
+                .origin_address()
+                .unwrap(),
+        ),
         1000000,
     )];
 
@@ -3323,9 +3314,9 @@ fn test_block_versioned_smart_contract_gated_at_v210() {
         },
     ]);
 
-    peer_config.epochs = Some(epochs);
-    peer_config.initial_balances = initial_balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.epochs = Some(epochs);
+    peer_config.chain_config.initial_balances = initial_balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
 
@@ -3412,8 +3403,8 @@ fn test_block_versioned_smart_contract_gated_at_v210() {
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
         let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
 
-        let sortdb = peer.sortdb.take().unwrap();
-        let mut node = peer.stacks_node.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
+        let mut node = peer.chain.stacks_node.take().unwrap();
         match Relayer::process_new_anchored_block(
             &sortdb.index_conn(),
             &mut node.chainstate,
@@ -3422,16 +3413,16 @@ fn test_block_versioned_smart_contract_gated_at_v210() {
             123,
         ) {
             Ok(x) => {
-                eprintln!("{:?}", &stacks_block);
+                eprintln!("{stacks_block:?}");
                 panic!("Stored pay-to-contract stacks block before epoch 2.1");
             }
             Err(chainstate_error::InvalidStacksBlock(_)) => {}
             Err(e) => {
-                panic!("Got unexpected error {:?}", &e);
+                panic!("Got unexpected error {e:?}");
             }
         };
-        peer.sortdb = Some(sortdb);
-        peer.stacks_node = Some(node);
+        peer.chain.sortdb = Some(sortdb);
+        peer.chain.stacks_node = Some(node);
     }
 
     // *now* it should succeed, since tenure 28 was in epoch 2.1
@@ -3439,28 +3430,23 @@ fn test_block_versioned_smart_contract_gated_at_v210() {
 
     let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
 
-    let sortdb = peer.sortdb.take().unwrap();
-    let mut node = peer.stacks_node.take().unwrap();
-    match Relayer::process_new_anchored_block(
+    let sortdb = peer.chain.sortdb.take().unwrap();
+    let mut node = peer.chain.stacks_node.take().unwrap();
+    let x = Relayer::process_new_anchored_block(
         &sortdb.index_conn(),
         &mut node.chainstate,
         &consensus_hash,
         &stacks_block,
         123,
-    ) {
-        Ok(x) => {
-            assert_eq!(
-                x,
-                BlockAcceptResponse::Accepted,
-                "Failed to process valid versioned smart contract block"
-            );
-        }
-        Err(e) => {
-            panic!("Got unexpected error {:?}", &e);
-        }
-    };
-    peer.sortdb = Some(sortdb);
-    peer.stacks_node = Some(node);
+    )
+    .unwrap_or_else(|e| panic!("Got unexpected error {e:?}"));
+    assert_eq!(
+        x,
+        BlockAcceptResponse::Accepted,
+        "Failed to process valid versioned smart contract block"
+    );
+    peer.chain.sortdb = Some(sortdb);
+    peer.chain.stacks_node = Some(node);
 }
 
 #[test]
@@ -3468,7 +3454,13 @@ fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
     let mut peer_config = TestPeerConfig::new(function_name!(), 4250, 4251);
 
     let initial_balances = vec![(
-        PrincipalData::from(peer_config.spending_account.origin_address().unwrap()),
+        PrincipalData::from(
+            peer_config
+                .chain_config
+                .spending_account
+                .origin_address()
+                .unwrap(),
+        ),
         1000000,
     )];
 
@@ -3503,9 +3495,9 @@ fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
         },
     ]);
 
-    peer_config.epochs = Some(epochs);
-    peer_config.initial_balances = initial_balances;
-    let burnchain = peer_config.burnchain.clone();
+    peer_config.chain_config.epochs = Some(epochs);
+    peer_config.chain_config.initial_balances = initial_balances;
+    let burnchain = peer_config.chain_config.burnchain.clone();
 
     let mut peer = TestPeer::new(peer_config);
     let versioned_contract_opt: RefCell<Option<StacksTransaction>> = RefCell::new(None);
@@ -3599,8 +3591,8 @@ fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
         let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
         let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
 
-        let sortdb = peer.sortdb.take().unwrap();
-        let mut node = peer.stacks_node.take().unwrap();
+        let sortdb = peer.chain.sortdb.take().unwrap();
+        let mut node = peer.chain.stacks_node.take().unwrap();
 
         // the empty block should be accepted
         match Relayer::process_new_anchored_block(
@@ -3623,7 +3615,7 @@ fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
         };
 
         // process it
-        peer.coord.handle_new_stacks_block().unwrap();
+        peer.chain.coord.handle_new_stacks_block().unwrap();
 
         // the mempool would reject a versioned contract transaction, since we're not yet at
         // tenure 28
@@ -3648,16 +3640,16 @@ fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
             }
         };
 
-        peer.sortdb = Some(sortdb);
-        peer.stacks_node = Some(node);
+        peer.chain.sortdb = Some(sortdb);
+        peer.chain.stacks_node = Some(node);
     }
 
     // *now* it should succeed, since tenure 28 was in epoch 2.1
     let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
     let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops);
 
-    let sortdb = peer.sortdb.take().unwrap();
-    let mut node = peer.stacks_node.take().unwrap();
+    let sortdb = peer.chain.sortdb.take().unwrap();
+    let mut node = peer.chain.stacks_node.take().unwrap();
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
     match Relayer::process_new_anchored_block(
@@ -3680,7 +3672,7 @@ fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
     };
 
     // process it
-    peer.coord.handle_new_stacks_block().unwrap();
+    peer.chain.coord.handle_new_stacks_block().unwrap();
 
     // the mempool would accept a versioned contract transaction, since we're not yet at
     // tenure 28
@@ -3696,8 +3688,8 @@ fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
         panic!("will_admit_mempool_tx {:?}", &e);
     };
 
-    peer.sortdb = Some(sortdb);
-    peer.stacks_node = Some(node);
+    peer.chain.sortdb = Some(sortdb);
+    peer.chain.stacks_node = Some(node);
 }
 
 // TODO: process bans

--- a/stackslib/src/net/tests/relay/nakamoto.rs
+++ b/stackslib/src/net/tests/relay/nakamoto.rs
@@ -33,6 +33,7 @@ use crate::chainstate::nakamoto::NakamotoBlockHeader;
 use crate::chainstate::stacks::test::{make_codec_test_block, make_codec_test_microblock};
 use crate::chainstate::stacks::tests::TestStacksNode;
 use crate::chainstate::stacks::*;
+use crate::chainstate::tests::TestChainstate;
 use crate::core::*;
 use crate::net::relay::{AcceptedNakamotoBlocks, ProcessedNetReceipts, Relayer};
 use crate::net::stackerdb::StackerDBs;
@@ -60,13 +61,13 @@ impl ExitedPeer {
         Self {
             config: peer.config,
             network: peer.network,
-            sortdb: peer.sortdb,
-            miner: peer.miner,
-            stacks_node: peer.stacks_node,
+            sortdb: peer.chain.sortdb,
+            miner: peer.chain.miner,
+            stacks_node: peer.chain.stacks_node,
             relayer: peer.relayer,
             mempool: peer.mempool,
-            chainstate_path: peer.chainstate_path,
-            indexer: peer.indexer,
+            chainstate_path: peer.chain.chainstate_path,
+            indexer: peer.chain.indexer,
         }
     }
 
@@ -91,7 +92,7 @@ impl ExitedPeer {
             ibd,
             100,
             &RPCHandlerArgs::default(),
-            self.config.txindex,
+            self.config.chain_config.txindex,
         )?;
         let receipts_res = self.relayer.process_network_result(
             self.network.get_local_peer(),
@@ -180,8 +181,8 @@ impl SeedNode {
         )
         .unwrap();
 
-        let mut test_signers = peer.config.test_signers.take().unwrap();
-        let test_stackers = peer.config.test_stackers.take().unwrap();
+        let mut test_signers = peer.config.chain_config.test_signers.take().unwrap();
+        let test_stackers = peer.config.chain_config.test_stackers.take().unwrap();
 
         let mut all_blocks: Vec<NakamotoBlock> = vec![];
 
@@ -208,9 +209,10 @@ impl SeedNode {
             tenure_change.burn_view_consensus_hash = consensus_hash.clone();
 
             let tenure_change_tx = peer
+                .chain
                 .miner
                 .make_nakamoto_tenure_change(tenure_change.clone());
-            let coinbase_tx = peer.miner.make_nakamoto_coinbase(None, vrf_proof);
+            let coinbase_tx = peer.chain.miner.make_nakamoto_coinbase(None, vrf_proof);
 
             let num_blocks: usize = (thread_rng().gen::<usize>() % 10) + 1;
 
@@ -264,8 +266,8 @@ impl SeedNode {
 
             // relay these blocks
             let local_peer = peer.network.get_local_peer().clone();
-            let sortdb = peer.sortdb.take().unwrap();
-            let stacks_node = peer.stacks_node.take().unwrap();
+            let sortdb = peer.chain.sortdb.take().unwrap();
+            let stacks_node = peer.chain.stacks_node.take().unwrap();
 
             peer.relayer.relay_epoch3_blocks(
                 &local_peer,
@@ -276,8 +278,8 @@ impl SeedNode {
                 }],
             );
 
-            peer.sortdb = Some(sortdb);
-            peer.stacks_node = Some(stacks_node);
+            peer.chain.sortdb = Some(sortdb);
+            peer.chain.stacks_node = Some(stacks_node);
 
             // send the blocks to the unit test as well
             if comms
@@ -291,11 +293,12 @@ impl SeedNode {
 
             // if we're starting a new reward cycle, then save the current one
             let tip = {
-                let sort_db = peer.sortdb.as_mut().unwrap();
+                let sort_db = peer.chain.sortdb.as_mut().unwrap();
                 SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap()
             };
             if peer
                 .config
+                .chain_config
                 .burnchain
                 .is_reward_cycle_start(tip.block_height)
             {
@@ -305,8 +308,8 @@ impl SeedNode {
             all_blocks.append(&mut blocks);
         }
 
-        peer.config.test_signers = Some(test_signers);
-        peer.config.test_stackers = Some(test_stackers);
+        peer.config.chain_config.test_signers = Some(test_signers);
+        peer.config.chain_config.test_stackers = Some(test_stackers);
 
         let exited_peer = ExitedPeer::from_test_peer(peer);
 
@@ -534,7 +537,7 @@ fn test_no_buffer_ready_nakamoto_blocks() {
     let peer_nk = peer.to_neighbor().addr;
     let mut follower = followers.pop().unwrap();
 
-    let test_path = TestPeer::make_test_path(&follower.config);
+    let test_path = TestChainstate::make_test_path(&follower.config.chain_config);
     let stackerdb_path = format!("{}/stacker_db.sqlite", &test_path);
     let follower_stacker_dbs = StackerDBs::connect(&stackerdb_path, true).unwrap();
     let mut follower_relayer = Relayer::from_p2p(&mut follower.network, follower_stacker_dbs);
@@ -570,8 +573,8 @@ fn test_no_buffer_ready_nakamoto_blocks() {
                 Some(SeedData::Blocks(blocks)) => {
                     debug!("Follower got Nakamoto blocks {:?}", &blocks);
 
-                    let mut sortdb = follower.sortdb.take().unwrap();
-                    let mut node = follower.stacks_node.take().unwrap();
+                    let mut sortdb = follower.chain.sortdb.take().unwrap();
+                    let mut node = follower.chain.stacks_node.take().unwrap();
 
                     let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
 
@@ -728,8 +731,8 @@ fn test_no_buffer_ready_nakamoto_blocks() {
                         ));
                     }
 
-                    follower.stacks_node = Some(node);
-                    follower.sortdb = Some(sortdb);
+                    follower.chain.stacks_node = Some(node);
+                    follower.chain.sortdb = Some(sortdb);
                 }
                 Some(SeedData::Exit(exited)) => {
                     debug!("Follower got seed exit");
@@ -739,20 +742,24 @@ fn test_no_buffer_ready_nakamoto_blocks() {
                 }
             }
 
-            follower.coord.handle_new_burnchain_block().unwrap();
-            follower.coord.handle_new_stacks_block().unwrap();
-            follower.coord.handle_new_nakamoto_stacks_block().unwrap();
+            follower.chain.coord.handle_new_burnchain_block().unwrap();
+            follower.chain.coord.handle_new_stacks_block().unwrap();
+            follower
+                .chain
+                .coord
+                .handle_new_nakamoto_stacks_block()
+                .unwrap();
         }
 
         // compare chain tips
-        let sortdb = follower.sortdb.take().unwrap();
-        let stacks_node = follower.stacks_node.take().unwrap();
+        let sortdb = follower.chain.sortdb.take().unwrap();
+        let stacks_node = follower.chain.stacks_node.take().unwrap();
         let follower_burn_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         let follower_stacks_tip =
             NakamotoChainState::get_canonical_block_header(stacks_node.chainstate.db(), &sortdb)
                 .unwrap();
-        follower.stacks_node = Some(stacks_node);
-        follower.sortdb = Some(sortdb);
+        follower.chain.stacks_node = Some(stacks_node);
+        follower.chain.sortdb = Some(sortdb);
 
         let mut exited_peer = exited_peer.unwrap();
         let sortdb = exited_peer.sortdb.take().unwrap();
@@ -785,7 +792,7 @@ fn test_buffer_nonready_nakamoto_blocks() {
     let peer_nk = peer.to_neighbor().addr;
     let mut follower = followers.pop().unwrap();
 
-    let test_path = TestPeer::make_test_path(&follower.config);
+    let test_path = TestChainstate::make_test_path(&follower.config.chain_config);
     let stackerdb_path = format!("{}/stacker_db.sqlite", &test_path);
     let follower_stacker_dbs = StackerDBs::connect(&stackerdb_path, true).unwrap();
     let mut follower_relayer = Relayer::from_p2p(&mut follower.network, follower_stacker_dbs);
@@ -850,8 +857,8 @@ fn test_buffer_nonready_nakamoto_blocks() {
                     debug!("Follower got Nakamoto blocks {:?}", &blocks);
                     all_blocks.push(blocks.clone());
 
-                    let sortdb = follower.sortdb.take().unwrap();
-                    let node = follower.stacks_node.take().unwrap();
+                    let sortdb = follower.chain.sortdb.take().unwrap();
+                    let node = follower.chain.stacks_node.take().unwrap();
 
                     // we will need to buffer this since the sortition for these blocks hasn't been
                     // processed yet
@@ -908,8 +915,8 @@ fn test_buffer_nonready_nakamoto_blocks() {
                         true,
                     );
 
-                    follower.stacks_node = Some(node);
-                    follower.sortdb = Some(sortdb);
+                    follower.chain.stacks_node = Some(node);
+                    follower.chain.sortdb = Some(sortdb);
                 }
                 Some(SeedData::Exit(exited)) => {
                     debug!("Follower got seed exit");
@@ -928,8 +935,8 @@ fn test_buffer_nonready_nakamoto_blocks() {
                     }
 
                     // process the last buffered messages
-                    let mut sortdb = follower.sortdb.take().unwrap();
-                    let mut node = follower.stacks_node.take().unwrap();
+                    let mut sortdb = follower.chain.sortdb.take().unwrap();
+                    let mut node = follower.chain.stacks_node.take().unwrap();
 
                     if let Some(mut network_result) = network_result.take() {
                         follower_relayer.process_new_epoch3_blocks(
@@ -943,8 +950,8 @@ fn test_buffer_nonready_nakamoto_blocks() {
                         );
                     }
 
-                    follower.stacks_node = Some(node);
-                    follower.sortdb = Some(sortdb);
+                    follower.chain.stacks_node = Some(node);
+                    follower.chain.sortdb = Some(sortdb);
 
                     network_result = follower
                         .step_with_ibd_and_dns(true, Some(&mut follower_dns_client))
@@ -957,8 +964,8 @@ fn test_buffer_nonready_nakamoto_blocks() {
             }
 
             if let Some(mut network_result) = network_result.take() {
-                let mut sortdb = follower.sortdb.take().unwrap();
-                let mut node = follower.stacks_node.take().unwrap();
+                let mut sortdb = follower.chain.sortdb.take().unwrap();
+                let mut node = follower.chain.stacks_node.take().unwrap();
                 let num_processed = follower_relayer.process_new_epoch3_blocks(
                     follower.network.get_local_peer(),
                     &mut network_result,
@@ -969,24 +976,28 @@ fn test_buffer_nonready_nakamoto_blocks() {
                     None,
                 );
                 info!("Processed {} unsolicited Nakamoto blocks", num_processed);
-                follower.stacks_node = Some(node);
-                follower.sortdb = Some(sortdb);
+                follower.chain.stacks_node = Some(node);
+                follower.chain.sortdb = Some(sortdb);
             }
 
-            follower.coord.handle_new_burnchain_block().unwrap();
-            follower.coord.handle_new_stacks_block().unwrap();
-            follower.coord.handle_new_nakamoto_stacks_block().unwrap();
+            follower.chain.coord.handle_new_burnchain_block().unwrap();
+            follower.chain.coord.handle_new_stacks_block().unwrap();
+            follower
+                .chain
+                .coord
+                .handle_new_nakamoto_stacks_block()
+                .unwrap();
         }
 
         // compare chain tips
-        let sortdb = follower.sortdb.take().unwrap();
-        let stacks_node = follower.stacks_node.take().unwrap();
+        let sortdb = follower.chain.sortdb.take().unwrap();
+        let stacks_node = follower.chain.stacks_node.take().unwrap();
         let follower_burn_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
         let follower_stacks_tip =
             NakamotoChainState::get_canonical_block_header(stacks_node.chainstate.db(), &sortdb)
                 .unwrap();
-        follower.stacks_node = Some(stacks_node);
-        follower.sortdb = Some(sortdb);
+        follower.chain.stacks_node = Some(stacks_node);
+        follower.chain.sortdb = Some(sortdb);
 
         let mut exited_peer = exited_peer.unwrap();
         let sortdb = exited_peer.sortdb.take().unwrap();
@@ -1024,7 +1035,7 @@ fn test_nakamoto_boot_node_from_block_push() {
     let peer_nk = peer.to_neighbor().addr;
     let mut follower = followers.pop().unwrap();
 
-    let test_path = TestPeer::make_test_path(&follower.config);
+    let test_path = TestChainstate::make_test_path(&follower.config.chain_config);
     let stackerdb_path = format!("{}/stacker_db.sqlite", &test_path);
     let follower_stacker_dbs = StackerDBs::connect(&stackerdb_path, true).unwrap();
 
@@ -1074,9 +1085,13 @@ fn test_nakamoto_boot_node_from_block_push() {
                 }
             }
 
-            follower.coord.handle_new_burnchain_block().unwrap();
-            follower.coord.handle_new_stacks_block().unwrap();
-            follower.coord.handle_new_nakamoto_stacks_block().unwrap();
+            follower.chain.coord.handle_new_burnchain_block().unwrap();
+            follower.chain.coord.handle_new_stacks_block().unwrap();
+            follower
+                .chain
+                .coord
+                .handle_new_nakamoto_stacks_block()
+                .unwrap();
         }
 
         // recover exited peer and get its chain tips
@@ -1100,8 +1115,8 @@ fn test_nakamoto_boot_node_from_block_push() {
                 .unwrap();
 
             // compare chain tips
-            let sortdb = follower.sortdb.take().unwrap();
-            let stacks_node = follower.stacks_node.take().unwrap();
+            let sortdb = follower.chain.sortdb.take().unwrap();
+            let stacks_node = follower.chain.stacks_node.take().unwrap();
             let follower_burn_tip =
                 SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
             let follower_stacks_tip = NakamotoChainState::get_canonical_block_header(
@@ -1109,8 +1124,8 @@ fn test_nakamoto_boot_node_from_block_push() {
                 &sortdb,
             )
             .unwrap();
-            follower.stacks_node = Some(stacks_node);
-            follower.sortdb = Some(sortdb);
+            follower.chain.stacks_node = Some(stacks_node);
+            follower.chain.sortdb = Some(sortdb);
 
             debug!("{}: Follower sortition tip: {:?}", i, &follower_burn_tip);
             debug!("{}: Seed sortition tip: {:?}", i, &exited_peer_burn_tip);

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.2.0.0.1"
-stacks_signer_version = "3.2.0.0.1.1"
+stacks_node_version = "3.2.0.0.2"
+stacks_signer_version = "3.2.0.0.2.0"


### PR DESCRIPTION
Make TestPeer use TestChainstate underneath the hood and remove some duplication. I think a lot of tests could be updated to just use TestChainstate (a lot odn't seem to actually need a full TestPeer) but leaving for another PR.