### PR TITLE
chore: update `block-time` --> `stacks-block-time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## Unreleased
+
+### Changed
+
+- Renamed Clarity 4's new `block-time` to `stacks-block-time`
+
 ## [3.2.0.0.2]
 
 ### Added

--- a/clarity/src/vm/analysis/arithmetic_checker/mod.rs
+++ b/clarity/src/vm/analysis/arithmetic_checker/mod.rs
@@ -143,7 +143,7 @@ impl ArithmeticOnlyChecker<'_> {
             match native_var {
                 ContractCaller | TxSender | TotalLiquidMicroSTX | BlockHeight | BurnBlockHeight
                 | Regtest | TxSponsor | Mainnet | ChainId | StacksBlockHeight | TenureHeight
-                | BlockTime | CurrentContract => Err(Error::VariableForbidden(native_var)),
+                | StacksBlockTime | CurrentContract => Err(Error::VariableForbidden(native_var)),
                 NativeNone | NativeTrue | NativeFalse => Ok(()),
             }
         } else {

--- a/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
@@ -330,9 +330,9 @@ fn type_reserved_variable(variable_name: &str) -> Result<Option<TypeSignature>, 
             NativeFalse => TypeSignature::BoolType,
             TotalLiquidMicroSTX => TypeSignature::UIntType,
             Regtest => TypeSignature::BoolType,
-            TxSponsor | Mainnet | ChainId | StacksBlockHeight | TenureHeight | BlockTime | CurrentContract => {
+            TxSponsor | Mainnet | ChainId | StacksBlockHeight | TenureHeight | StacksBlockTime | CurrentContract => {
                 return Err(CheckErrors::Expects(
-                    "tx-sponsor, mainnet, chain-id, stacks-block-height, tenure-height, block-time, and current-contract should not reach here in 2.05".into(),
+                    "tx-sponsor, mainnet, chain-id, stacks-block-height, tenure-height, stacks-block-time, and current-contract should not reach here in 2.05".into(),
                 )
                 .into())
             }

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -1023,7 +1023,7 @@ fn type_reserved_variable(
             Mainnet => TypeSignature::BoolType,
             ChainId => TypeSignature::UIntType,
             CurrentContract => TypeSignature::PrincipalType,
-            BlockTime => TypeSignature::UIntType,
+            StacksBlockTime => TypeSignature::UIntType,
         };
         Ok(Some(var_type))
     } else {

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -154,13 +154,13 @@ At the start of epoch 3.0, `tenure-height` will return the same value as `block-
 };
 
 const BLOCK_TIME_KEYWORD: SimpleKeywordAPI = SimpleKeywordAPI {
-    name: "block-time",
-    snippet: "block-time",
+    name: "stacks-block-time",
+    snippet: "stacks-block-time",
     output_type: "uint",
     description: "Returns the Unix timestamp (in seconds) of the current Stacks block. Introduced
 in Clarity 4. Provides access to the timestamp of the current block, which is
 not available with `get-stacks-block-info?`.",
-    example: "(>= block-time u1755820800) ;; returns true if current block timestamp is at or after 2025-07-22.",
+    example: "(>= stacks-block-time u1755820800) ;; returns true if current block timestamp is at or after 2025-07-22.",
 };
 
 const TX_SENDER_KEYWORD: SimpleKeywordAPI = SimpleKeywordAPI {
@@ -2700,7 +2700,7 @@ pub fn make_keyword_reference(variable: &NativeVariables) -> Option<KeywordAPI> 
         NativeVariables::ChainId => CHAINID_KEYWORD.clone(),
         NativeVariables::TxSponsor => TX_SPONSOR_KEYWORD.clone(),
         NativeVariables::CurrentContract => CURRENT_CONTRACT_KEYWORD.clone(),
-        NativeVariables::BlockTime => BLOCK_TIME_KEYWORD.clone(),
+        NativeVariables::StacksBlockTime => BLOCK_TIME_KEYWORD.clone(),
     };
     Some(KeywordAPI {
         name: keyword.name,

--- a/clarity/src/vm/tests/variables.rs
+++ b/clarity/src/vm/tests/variables.rs
@@ -1110,7 +1110,7 @@ fn test_block_time(
     epoch: StacksEpochId,
     mut tl_env_factory: TopLevelMemoryEnvironmentGenerator,
 ) {
-    let contract = "(define-read-only (test-func) block-time)";
+    let contract = "(define-read-only (test-func) stacks-block-time)";
 
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
@@ -1125,11 +1125,11 @@ fn test_block_time(
         type_check_version(&contract_identifier, &mut exprs, db, true, epoch, version)
     });
 
-    // block-time should only be available in Clarity 4
+    // stacks-block-time should only be available in Clarity 4
     if version < ClarityVersion::Clarity4 {
         let err = analysis.unwrap_err();
         assert_eq!(
-            CheckErrors::UndefinedVariable("block-time".to_string()),
+            CheckErrors::UndefinedVariable("stacks-block-time".to_string()),
             *err.err
         );
     } else {
@@ -1156,7 +1156,9 @@ fn test_block_time(
     if version < ClarityVersion::Clarity4 {
         let err = eval_result.unwrap_err();
         assert_eq!(
-            Error::Unchecked(CheckErrors::UndefinedVariable("block-time".to_string(),)),
+            Error::Unchecked(CheckErrors::UndefinedVariable(
+                "stacks-block-time".to_string(),
+            )),
             err
         );
     } else {
@@ -1173,11 +1175,11 @@ fn test_block_time_in_expressions() {
 
     let contract = r#"
         (define-read-only (time-comparison (threshold uint))
-            (>= block-time threshold))
+            (>= stacks-block-time threshold))
         (define-read-only (time-arithmetic)
-            (+ block-time u100))
+            (+ stacks-block-time u100))
         (define-read-only (time-in-response)
-            (ok block-time))
+            (ok stacks-block-time))
     "#;
 
     let placeholder_context =

--- a/clarity/src/vm/variables.rs
+++ b/clarity/src/vm/variables.rs
@@ -40,7 +40,7 @@ define_versioned_named_enum_with_max!(NativeVariables(ClarityVersion) {
     ChainId("chain-id", ClarityVersion::Clarity2, None),
     StacksBlockHeight("stacks-block-height", ClarityVersion::Clarity3, None),
     TenureHeight("tenure-height", ClarityVersion::Clarity3, None),
-    BlockTime("block-time", ClarityVersion::Clarity4, None),
+    StacksBlockTime("stacks-block-time", ClarityVersion::Clarity4, None),
     CurrentContract("current-contract", ClarityVersion::Clarity4, None)
 });
 
@@ -140,7 +140,7 @@ pub fn lookup_reserved_variable(
                 let contract = env.contract_context.contract_identifier.clone();
                 Ok(Some(Value::Principal(PrincipalData::Contract(contract))))
             }
-            NativeVariables::BlockTime => {
+            NativeVariables::StacksBlockTime => {
                 runtime_cost(ClarityCostFunction::FetchVar, env, 1)?;
                 let block_time = env.global_context.database.get_current_block_time()?;
                 Ok(Some(Value::UInt(u128::from(block_time))))

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -15046,7 +15046,7 @@ fn contract_limit_percentage_mempool_strategy_low_limit() {
 
 #[test]
 #[ignore]
-/// Verify the block timestamp using `block-time`.
+/// Verify the block timestamp using `stacks-block-time`.
 fn check_block_time_keyword() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
@@ -15153,25 +15153,25 @@ fn check_block_time_keyword() {
     let mut sender_nonce = 0;
     let contract_name = "test-contract";
     let contract = r#"
-(define-constant deploy-time block-time)
+(define-constant deploy-time stacks-block-time)
 (define-constant deploy-height stacks-block-height)
 (define-read-only (get-current-time)
-  block-time
+  stacks-block-time
 )
 (define-read-only (get-ihh (height uint)) (get-stacks-block-info? id-header-hash height))
 (define-read-only (get-time (height uint)) (get-stacks-block-info? time height))
 (define-read-only (get-height) stacks-block-height)
 (define-read-only (get-previous-time (height uint))
   (ok (at-block (unwrap! (get-stacks-block-info? id-header-hash height) (err u100))
-    block-time
+    stacks-block-time
   ))
 )
 (define-public (get-current-time-call)
-  (ok block-time)
+  (ok stacks-block-time)
 )
 (define-public (get-previous-time-call (height uint))
   (ok (at-block (unwrap! (get-stacks-block-info? id-header-hash height) (err u100))
-    block-time
+    stacks-block-time
   ))
 )
 "#;
@@ -15217,7 +15217,7 @@ fn check_block_time_keyword() {
     let current_time = current_time_value.expect_u128().unwrap();
     assert!(
         current_time > deploy_time,
-        "block-time should be greater than the time at deployment"
+        "stacks-block-time should be greater than the time at deployment"
     );
 
     let previous_time_result = call_read_only(
@@ -15288,13 +15288,16 @@ fn check_block_time_keyword() {
                 match contract_call.function_name.as_str() {
                     "get-current-time-call" => {
                         info!("Current time: {}", time);
-                        assert!(time > current_time, "block-time should have advanced");
+                        assert!(
+                            time > current_time,
+                            "stacks-block-time should have advanced"
+                        );
                     }
                     "get-previous-time-call" => {
                         info!("Previous time: {}", time);
                         assert_eq!(
                             time, deploy_time,
-                            "block-time should be the same as at deployment"
+                            "stacks-block-time should be the same as at deployment"
                         );
                     }
                     _ => panic!("Unexpected contract call"),


### PR DESCRIPTION
This is both more clear and more consistent, since it matches `stacks-block-height`. Thanks for the suggestion @hugoclrd!