### PR TITLE
use larger runner for release binaries

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -62,7 +62,7 @@ jobs:
       inputs.node_tag != '' ||
       inputs.signer_tag != ''
     name: Build Binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs:
       - andon-cord
     permissions:


### PR DESCRIPTION
use larger runner for release binaries