### PR TITLE
chore: make storage keys public

### DIFF
--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -47,8 +47,8 @@ use crate::vm::types::{
 };
 
 pub const STORE_CONTRACT_SRC_INTERFACE: bool = true;
-const TENURE_HEIGHT_KEY: &str = "_stx-data::tenure_height";
-const CLARITY_STORAGE_BLOCK_TIME_KEY: &str = "_stx-data::clarity_storage::block_time";
+pub const TENURE_HEIGHT_KEY: &str = "_stx-data::tenure_height";
+pub const CLARITY_STORAGE_BLOCK_TIME_KEY: &str = "_stx-data::clarity_storage::block_time";
 
 pub type StacksEpoch = GenericStacksEpoch<ExecutionCost>;
 


### PR DESCRIPTION
Clarinet needs both of these keys for the memory datastore