### PR TITLE
Adding linux/arm64 to the arch list for manual docker builds

### DIFF
--- a/.github/workflows/image-build-source.yml
+++ b/.github/workflows/image-build-source.yml
@@ -8,7 +8,7 @@ on:
 
 ## Define which docker arch to build for
 env:
-  docker_platforms: "linux/amd64"
+  docker_platforms: "linux/amd64,linux/arm64"
   docker-org: blockstack
 
 concurrency:
@@ -69,7 +69,6 @@ jobs:
             STACKS_NODE_VERSION=${{ env.GITHUB_SHA_SHORT }}
             GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-            TARGET_CPU=x86-64-v3
           push: ${{ env.DOCKER_PUSH }}
 
       ## Generate docker image attestation(s)


### PR DESCRIPTION
ref https://github.com/stacks-network/stacks-core/issues/6556

cc @hugoclrd 

This change adds a second arch to the docker image built manually. it will now build amd64 and arm64 variants, at the expense of taking quite a long time - in a single testrun, it took about 120 minutes. 

this could be sped up by throwing hardware at it, but i also have another idea for a longer term fix that this workflow would also benefit from. 