### PR TITLE
Make is_wellformed_tenure_*_block return Error and remove custom conversions

### DIFF
--- a/contrib/stacks-inspect/src/lib.rs
+++ b/contrib/stacks-inspect/src/lib.rs
@@ -1105,12 +1105,7 @@ fn replay_block_nakamoto(
     };
 
     // find commit and sortition burns if this is a tenure-start block
-    let Ok(new_tenure) = block.is_wellformed_tenure_start_block() else {
-        return Err(ChainstateError::InvalidStacksBlock(
-            "Invalid Nakamoto block: invalid tenure change tx(s)".into(),
-        ));
-    };
-
+    let new_tenure = block.is_wellformed_tenure_start_block()?;
     let (commit_burn, sortition_burn) = if new_tenure {
         // find block-commit to get commit-burn
         let block_commit = SortitionDB::get_block_commit(

--- a/stackslib/src/chainstate/nakamoto/staging_blocks.rs
+++ b/stackslib/src/chainstate/nakamoto/staging_blocks.rs
@@ -598,12 +598,7 @@ impl NakamotoStagingBlocksTx<'_> {
         signing_weight: u32,
         obtain_method: NakamotoBlockObtainMethod,
     ) -> Result<(), ChainstateError> {
-        let Ok(tenure_start) = block.is_wellformed_tenure_start_block() else {
-            return Err(ChainstateError::InvalidStacksBlock(
-                "Tried to store a tenure-start block that is not well-formed".into(),
-            ));
-        };
-
+        let tenure_start = block.is_wellformed_tenure_start_block()?;
         let burn_attachable = burn_attachable || {
             // if it's burn_attachable before, it's burn_attachable always
             self.conn()

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -310,7 +310,10 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_vrf_proof(), None);
     assert!(!block.validate_transactions_static(false, 0x80000000, StacksEpochId::Epoch30)); // empty blocks not allowed
@@ -320,8 +323,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![tenure_change_tx.clone()],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Err(()));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -333,8 +342,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![coinbase_tx.clone()],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -347,8 +362,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![tenure_change_tx.clone(), invalid_coinbase_tx],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -364,8 +385,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
             coinbase_tx.clone(),
         ],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -377,8 +404,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![coinbase_tx.clone(), tenure_change_tx.clone()],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -394,8 +427,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
             tenure_change_tx.clone(),
         ],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -411,8 +450,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
             coinbase_tx.clone(),
         ],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -425,8 +470,11 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![tenure_change_tx.clone(), coinbase_tx.clone()],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Ok(true));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(block.is_wellformed_tenure_start_block(), Ok(true)));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), Some(&coinbase_tx));
     assert_eq!(
         block.get_tenure_change_tx_payload(),
@@ -442,8 +490,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![tenure_extend_tx.clone()],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Ok(false));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(true));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Ok(false)
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(true)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(
@@ -459,8 +513,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![tenure_extend_tx.clone(), stx_transfer.clone()],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Ok(false));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(true));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Ok(false)
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(true)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(
@@ -475,8 +535,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![tenure_extend_tx.clone(), tenure_extend_tx.clone()],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Err(()));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -488,8 +554,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header: header.clone(),
         txs: vec![stx_transfer, tenure_extend_tx],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Err(()));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);
@@ -501,8 +573,14 @@ pub fn test_nakamoto_first_tenure_block_syntactic_validation() {
         header,
         txs: vec![tenure_change_tx.clone(), tenure_change_tx, coinbase_tx],
     };
-    assert_eq!(block.is_wellformed_tenure_start_block(), Err(()));
-    assert_eq!(block.is_wellformed_tenure_extend_block(), Ok(false));
+    assert!(matches!(
+        block.is_wellformed_tenure_start_block(),
+        Err(ChainstateError::InvalidStacksBlock(_))
+    ));
+    assert!(matches!(
+        block.is_wellformed_tenure_extend_block(),
+        Ok(false)
+    ));
     assert_eq!(block.get_coinbase_tx(), None);
     assert_eq!(block.get_tenure_change_tx_payload(), None);
     assert_eq!(block.get_tenure_extend_tx_payload(), None);

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -108,9 +108,7 @@ impl NakamotoStagingBlocksConnRef<'_> {
         let Some((block, ..)) = self.get_nakamoto_block(tip)? else {
             return Ok(None);
         };
-        if block.is_wellformed_tenure_start_block().map_err(|_| {
-            ChainstateError::InvalidStacksBlock("Malformed tenure-start block".into())
-        })? {
+        if block.is_wellformed_tenure_start_block()? {
             // we're done
             return Ok(Some(vec![block]));
         }
@@ -124,9 +122,7 @@ impl NakamotoStagingBlocksConnRef<'_> {
                 return Ok(None);
             };
 
-            let is_tenure_start = block.is_wellformed_tenure_start_block().map_err(|e| {
-                ChainstateError::InvalidStacksBlock("Malformed tenure-start block".into())
-            })?;
+            let is_tenure_start = block.is_wellformed_tenure_start_block()?;
             cursor = block.header.parent_block_id.clone();
             tenure.push(block);
 


### PR DESCRIPTION
I am investigating the conversion of `ChainstateError::{Error variant}` to `ChainstateError::InvalidStacksBlock(String)` and I noticed these `is_wellformed_*` fns were written with an empty error and were all being mapped to `ChainstateError::InvalidStacksBlock(String)` with slightly different String messages so I made them return a consistent `InvalidStacksBlock` error and removed some redundant checks in `validate_transactions_static` 