### PR TITLE
aac: update epoch list configuration from epoch20

### DIFF
--- a/stackslib/src/chainstate/tests/consensus.rs
+++ b/stackslib/src/chainstate/tests/consensus.rs
@@ -864,7 +864,6 @@ impl ConsensusTest<'_> {
             NakamotoChainState::get_canonical_block_header(stacks_node.chainstate.db(), &sortdb)
                 .unwrap()
                 .unwrap();
-        let pox_constants = PoxConstants::test_default();
         let sig_hash = nakamoto_block.header.signer_signature_hash();
         debug!(
             "--------- Processing block {sig_hash} ---------";
@@ -911,20 +910,26 @@ impl ConsensusTest<'_> {
     ) -> Vec<ExpectedResult> {
         // Validate blocks
         for (epoch_id, blocks) in epoch_blocks.iter() {
-            assert!(
-                !matches!(
-                    *epoch_id,
-                    StacksEpochId::Epoch10
-                        | StacksEpochId::Epoch20
-                        | StacksEpochId::Epoch2_05
-                        | StacksEpochId::Epoch21
-                        | StacksEpochId::Epoch22
-                        | StacksEpochId::Epoch23
-                        | StacksEpochId::Epoch24
-                        | StacksEpochId::Epoch25
-                ),
-                "Pre-Nakamoto Tenures are not Supported"
+            assert_ne!(
+                *epoch_id,
+                StacksEpochId::Epoch10,
+                "Epoch10 is not supported!"
             );
+
+            let is_epoch2X = matches!(
+                *epoch_id,
+                StacksEpochId::Epoch20
+                    | StacksEpochId::Epoch2_05
+                    | StacksEpochId::Epoch21
+                    | StacksEpochId::Epoch22
+                    | StacksEpochId::Epoch23
+                    | StacksEpochId::Epoch24
+                    | StacksEpochId::Epoch25
+            );
+            if is_epoch2X {
+                panic!("TODO: need chainstate update to work with pre-naka");
+            }
+
             assert!(
                 !blocks.is_empty(),
                 "Each epoch must have at least one block"


### PR DESCRIPTION
### Description

This PR is mainly a wrap-up of what we discussed during our last internal sync. It introduce a very small change concerning the epoch list creation, taking into account epoch 2.X.

Here a sum-up of the points we discussed:
- The epoch list should be configured starting from Epoch 2.0.
- We can safely use a +1 strategy to move between Epoch 2.X, since we plan to refactor the Test Harness so that all test transactions for Epoch 2.X fit within a single block
- The only transactions we need to execute in Epoch 2.X are contract deployments.
- There is no immediate need to make the epoch list “dynamic” (in terms of burn height configuration) as a test input for now. The optional epoch-related parameters already provided by `contract_deploy_consensus_test!` and `contract_call_consensus_test!`  macros should be sufficient. 

If this reasoning is correct, considering the small change introduced in this PR would we prefer to integrate it directly into #6608 instead?
Otherwise, I’m happy to adjust and implement any missing pieces based on your feedback.

### Applicable issues

- fixes #6567

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
