### PR TITLE
feat: improve type-checking cost computation in epoch 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Changed
 
 - Renamed Clarity 4's new `block-time` to `stacks-block-time`
+- Improve cost-tracking for type-checking function arguments in epoch 3.3 (see [#6425](https://github.com/stacks-network/stacks-core/issues/6425))
 
 ## [3.2.0.0.2]
 

--- a/clarity/src/vm/callables.rs
+++ b/clarity/src/vm/callables.rs
@@ -146,12 +146,18 @@ impl DefinedFunction {
             self.arguments.len(),
         )?;
 
-        for arg_type in self.arg_types.iter() {
-            runtime_cost(
-                ClarityCostFunction::InnerTypeCheckCost,
-                env,
-                arg_type.size()?,
-            )?;
+        if env.epoch().uses_arg_size_for_cost() {
+            for arg in args.iter() {
+                runtime_cost(ClarityCostFunction::InnerTypeCheckCost, env, arg.size()?)?;
+            }
+        } else {
+            for arg_type in self.arg_types.iter() {
+                runtime_cost(
+                    ClarityCostFunction::InnerTypeCheckCost,
+                    env,
+                    arg_type.size()?,
+                )?;
+            }
         }
 
         let mut context = LocalContext::new();

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -789,6 +789,27 @@ impl StacksEpochId {
             StacksEpochId::Epoch33 => true,
         }
     }
+
+    /// Before Epoch 3.3, the cost for arguments to functions was based on the
+    /// parameter type, not the actual size of the argument passed in. This
+    /// resulted in over-charging for arguments smaller than the maximum size
+    /// permitted for the parameter.
+    pub fn uses_arg_size_for_cost(&self) -> bool {
+        match self {
+            StacksEpochId::Epoch10
+            | StacksEpochId::Epoch20
+            | StacksEpochId::Epoch2_05
+            | StacksEpochId::Epoch21
+            | StacksEpochId::Epoch22
+            | StacksEpochId::Epoch23
+            | StacksEpochId::Epoch24
+            | StacksEpochId::Epoch25
+            | StacksEpochId::Epoch30
+            | StacksEpochId::Epoch31
+            | StacksEpochId::Epoch32 => false,
+            StacksEpochId::Epoch33 => true,
+        }
+    }
 }
 
 impl std::fmt::Display for StacksEpochId {

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -27,11 +27,13 @@ use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::functions::NativeFunctions;
 use clarity::vm::representations::SymbolicExpression;
 use clarity::vm::test_util::{
-    execute, execute_on_network, symbols_from_values, TEST_BURN_STATE_DB, TEST_BURN_STATE_DB_21,
-    TEST_HEADER_DB,
+    execute, execute_on_network, generate_test_burn_state_db, symbols_from_values,
+    TEST_BURN_STATE_DB, TEST_BURN_STATE_DB_21, TEST_HEADER_DB,
 };
 use clarity::vm::tests::test_only_mainnet_to_chain_id;
-use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, Value};
+use clarity::vm::types::{
+    PrincipalData, QualifiedContractIdentifier, StandardPrincipalData, Value,
+};
 use clarity::vm::{ClarityVersion, ContractName};
 use lazy_static::lazy_static;
 use stacks_common::types::chainstate::StacksBlockId;
@@ -84,7 +86,9 @@ pub fn get_simple_test(function: &NativeFunctions) -> Option<&'static str> {
         BuffToUIntBe => "(buff-to-uint-be 0x00000000000000000000000000000001)",
         IsStandard => "(is-standard 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6)",
         PrincipalDestruct => "(principal-destruct? 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6)",
-        PrincipalConstruct => "(principal-construct? 0x1a 0x164247d6f2b425ac5771423ae6c80c754f7172b0)",
+        PrincipalConstruct => {
+            "(principal-construct? 0x1a 0x164247d6f2b425ac5771423ae6c80c754f7172b0)"
+        }
         StringToInt => r#"(string-to-int? "-1")"#,
         StringToUInt => r#"(string-to-uint? "1")"#,
         IntToAscii => r#"(int-to-ascii 1)"#,
@@ -112,12 +116,18 @@ pub fn get_simple_test(function: &NativeFunctions) -> Option<&'static str> {
         Sha512 => "(sha512 1)",
         Sha512Trunc256 => "(sha512/256 1)",
         Keccak256 => "(keccak256 1)",
-        Secp256k1Recover => "(secp256k1-recover? 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301)",
-        Secp256k1Verify => "(secp256k1-verify 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301 0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)",
+        Secp256k1Recover => {
+            "(secp256k1-recover? 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301)"
+        }
+        Secp256k1Verify => {
+            "(secp256k1-verify 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301 0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)"
+        }
         Print => "(print 1)",
         ContractCall => "(contract-call? .contract-other foo-exec 1)",
         ContractOf => "(contract-of contract)",
-        PrincipalOf => "(principal-of? 0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)",
+        PrincipalOf => {
+            "(principal-of? 0x03adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110)"
+        }
         AsContract => "(as-contract 1)",
         GetBlockInfo => "(get-block-info? time u1)",
         GetBurnBlockInfo => "(get-burn-block-info? header-hash u1)",
@@ -140,15 +150,25 @@ pub fn get_simple_test(function: &NativeFunctions) -> Option<&'static str> {
         MintToken => "(nft-mint? nft-foo 1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
         GetTokenBalance => "(ft-get-balance ft-foo 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
         GetAssetOwner => "(nft-get-owner? nft-foo 1)",
-        TransferToken => "(ft-transfer? ft-foo u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
-        TransferAsset => "(nft-transfer? nft-foo 1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
+        TransferToken => {
+            "(ft-transfer? ft-foo u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)"
+        }
+        TransferAsset => {
+            "(nft-transfer? nft-foo 1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)"
+        }
         BurnToken => "(ft-burn? ft-foo u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
         BurnAsset => "(nft-burn? nft-foo 1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
         GetTokenSupply => "(ft-get-supply ft-foo)",
-        AtBlock => "(at-block 0x55c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee 1)",   // first stacksblockid
+        AtBlock => {
+            "(at-block 0x55c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee 1)"
+        } // first stacksblockid
         GetStxBalance => "(stx-get-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
-        StxTransfer => r#"(stx-transfer? u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)"#,
-        StxTransferMemo => r#"(stx-transfer-memo? u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 0x89995432)"#,
+        StxTransfer => {
+            r#"(stx-transfer? u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)"#
+        }
+        StxTransferMemo => {
+            r#"(stx-transfer-memo? u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR 0x89995432)"#
+        }
         StxBurn => "(stx-burn? u1 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
         StxGetAccount => "(stx-account 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)",
         BitwiseAnd => "(bit-and 2 3)",
@@ -169,7 +189,11 @@ pub fn get_simple_test(function: &NativeFunctions) -> Option<&'static str> {
         AsContractSafe => "(as-contract? () (+ u1 u2))",
         // These expressions are not usable in this context, since they are
         // only allowed within `restrict-assets?` or `as-contract?`
-        AllowanceWithStx | AllowanceWithFt | AllowanceWithNft | AllowanceWithStacking | AllowanceAll => return None,
+        AllowanceWithStx
+        | AllowanceWithFt
+        | AllowanceWithNft
+        | AllowanceWithStacking
+        | AllowanceAll => return None,
     };
     Some(s)
 }
@@ -205,36 +229,40 @@ where
     let mut tip = first_block.clone();
 
     if epoch >= StacksEpochId::Epoch2_05 {
+        let burn_state_db = generate_test_burn_state_db(StacksEpochId::Epoch2_05);
         let next_block = StacksBlockId([1; 32]);
         let mut clarity_conn =
-            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &TEST_BURN_STATE_DB);
+            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &burn_state_db);
         clarity_conn.initialize_epoch_2_05().unwrap();
         clarity_conn.commit_block();
         tip = next_block.clone();
     }
 
     if epoch >= StacksEpochId::Epoch21 {
+        let burn_state_db = generate_test_burn_state_db(StacksEpochId::Epoch21);
         let next_block = StacksBlockId([2; 32]);
         let mut clarity_conn =
-            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &TEST_BURN_STATE_DB);
+            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &burn_state_db);
         clarity_conn.initialize_epoch_2_1().unwrap();
         clarity_conn.commit_block();
         tip = next_block.clone();
     }
 
     if epoch >= StacksEpochId::Epoch30 {
+        let burn_state_db = generate_test_burn_state_db(StacksEpochId::Epoch30);
         let next_block = StacksBlockId([3; 32]);
         let mut clarity_conn =
-            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &TEST_BURN_STATE_DB);
+            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &burn_state_db);
         clarity_conn.initialize_epoch_3_0().unwrap();
         clarity_conn.commit_block();
         tip = next_block.clone();
     }
 
     if epoch >= StacksEpochId::Epoch33 {
+        let burn_state_db = generate_test_burn_state_db(StacksEpochId::Epoch33);
         let next_block = StacksBlockId([4; 32]);
         let mut clarity_conn =
-            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &TEST_BURN_STATE_DB);
+            clarity_instance.begin_block(&tip, &next_block, &TEST_HEADER_DB, &burn_state_db);
         clarity_conn.initialize_epoch_3_3().unwrap();
         clarity_conn.commit_block();
         tip = next_block.clone();
@@ -242,10 +270,11 @@ where
 
     let mut marf_kv = clarity_instance.destroy();
 
+    let burn_state_db = generate_test_burn_state_db(epoch);
     let mut store = marf_kv.begin(&tip, &StacksBlockId([5; 32]));
 
     to_do(OwnedEnvironment::new_max_limit(
-        store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
+        store.as_clarity_db(&TEST_HEADER_DB, &burn_state_db),
         epoch,
         use_mainnet,
     ))
@@ -1845,4 +1874,141 @@ fn test_cost_voting_integration_mainnet() {
 fn test_cost_voting_integration_testnet() {
     test_cost_voting_integration(false, ClarityVersion::Clarity1);
     test_cost_voting_integration(false, ClarityVersion::Clarity2);
+}
+
+#[test]
+fn test_cost_change() {
+    let use_mainnet = false;
+
+    let result_32_small = with_owned_env(StacksEpochId::Epoch32, use_mainnet, |mut owned_env| {
+        setup_cost_tracked_test(use_mainnet, ClarityVersion::Clarity3, &mut owned_env);
+
+        let contract = "(define-read-only (execute (bytes (buff 4096))) bytes)";
+
+        let contract_id = QualifiedContractIdentifier::transient();
+
+        owned_env
+            .initialize_versioned_contract(
+                contract_id.clone(),
+                ClarityVersion::Clarity4,
+                &contract,
+                None,
+            )
+            .unwrap();
+
+        let start = owned_env.get_cost_total();
+
+        execute_transaction(
+            &mut owned_env,
+            StandardPrincipalData::transient().into(),
+            &contract_id,
+            "execute",
+            &symbols_from_values(vec![Value::buff_from_byte(0)]),
+        )
+        .unwrap();
+
+        let mut result = owned_env.get_cost_total();
+        result.sub(&start).unwrap();
+        result
+    });
+
+    let result_32_large = with_owned_env(StacksEpochId::Epoch32, use_mainnet, |mut owned_env| {
+        setup_cost_tracked_test(use_mainnet, ClarityVersion::Clarity3, &mut owned_env);
+
+        let contract = "(define-read-only (execute (bytes (buff 8192))) bytes)";
+
+        let contract_id = QualifiedContractIdentifier::transient();
+
+        owned_env
+            .initialize_versioned_contract(
+                contract_id.clone(),
+                ClarityVersion::Clarity4,
+                &contract,
+                None,
+            )
+            .unwrap();
+
+        let start = owned_env.get_cost_total();
+
+        execute_transaction(
+            &mut owned_env,
+            StandardPrincipalData::transient().into(),
+            &contract_id,
+            "execute",
+            &symbols_from_values(vec![Value::buff_from_byte(0)]),
+        )
+        .unwrap();
+
+        let mut result = owned_env.get_cost_total();
+        result.sub(&start).unwrap();
+        result
+    });
+
+    assert!(result_32_large.exceeds(&result_32_small));
+
+    let result_33_small = with_owned_env(StacksEpochId::Epoch33, use_mainnet, |mut owned_env| {
+        setup_cost_tracked_test(use_mainnet, ClarityVersion::Clarity4, &mut owned_env);
+
+        let contract = "(define-read-only (execute (bytes (buff 4096))) bytes)";
+
+        let contract_id = QualifiedContractIdentifier::transient();
+
+        owned_env
+            .initialize_versioned_contract(
+                contract_id.clone(),
+                ClarityVersion::Clarity4,
+                &contract,
+                None,
+            )
+            .unwrap();
+
+        let start = owned_env.get_cost_total();
+
+        execute_transaction(
+            &mut owned_env,
+            StandardPrincipalData::transient().into(),
+            &contract_id,
+            "execute",
+            &symbols_from_values(vec![Value::buff_from_byte(0)]),
+        )
+        .unwrap();
+
+        let mut result = owned_env.get_cost_total();
+        result.sub(&start).unwrap();
+        result
+    });
+
+    let result_33_large = with_owned_env(StacksEpochId::Epoch33, use_mainnet, |mut owned_env| {
+        setup_cost_tracked_test(use_mainnet, ClarityVersion::Clarity4, &mut owned_env);
+
+        let contract = "(define-read-only (execute (bytes (buff 8192))) bytes)";
+
+        let contract_id = QualifiedContractIdentifier::transient();
+
+        owned_env
+            .initialize_versioned_contract(
+                contract_id.clone(),
+                ClarityVersion::Clarity4,
+                &contract,
+                None,
+            )
+            .unwrap();
+
+        let start = owned_env.get_cost_total();
+
+        execute_transaction(
+            &mut owned_env,
+            StandardPrincipalData::transient().into(),
+            &contract_id,
+            "execute",
+            &symbols_from_values(vec![Value::buff_from_byte(0)]),
+        )
+        .unwrap();
+
+        let mut result = owned_env.get_cost_total();
+        result.sub(&start).unwrap();
+        result
+    });
+
+    assert_eq!(result_33_large, result_33_small);
 }


### PR DESCRIPTION
The type-checking should be charged based on the size of the value, not the size of the allowed type (which may be much larger than the actual value passed in). This improvement activates with epoch 3.3.

Fixes #6425