### PR TITLE
Ignore runtime_limit test

### DIFF
--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -84,7 +84,7 @@ sha2 = { version = "0.10" }
 toml = { workspace = true }
 
 [features]
-default = ["rusqlite", "vrf", "developer-mode", "ctrlc-handler", "rand"]
+default = ["rusqlite", "vrf", "developer-mode", "ctrlc-handler", "rand", "clarity-wasm"]
 developer-mode = []
 # Enables graceful shutdown handling for Ctrl+C (SIGINT) signals.
 # This pulls in the `nix` or `winapi` dependency.
@@ -103,3 +103,4 @@ wasm = ["developer-mode", "getrandom"]
 # Wasm-specific features for easier configuration
 wasm-web = ["rand", "getrandom/js", "libsecp256k1/static-context"]
 wasm-deterministic = ["getrandom/custom"]
+clarity-wasm = []

--- a/stacks-node/src/tests/integrations.rs
+++ b/stacks-node/src/tests/integrations.rs
@@ -1996,6 +1996,7 @@ fn make_keys(seed: &str, count: u64) -> Vec<StacksPrivateKey> {
 }
 
 #[test]
+#[cfg(not(feature = "clarity-wasm"))]
 fn block_limit_runtime_test() {
     let mut conf = new_test_conf();
 


### PR DESCRIPTION
This PR adds an ignore flag for `block_limit_runtime_test`. 

This test can be ignored as it is specific to execution cost limits in the interpreter.

fix: https://github.com/stx-labs/clarity-wasm/issues/692