### PR TITLE
chore: remove git branch from version string

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,25 +21,6 @@ fn current_git_hash() -> Option<String> {
     None
 }
 
-fn current_git_branch() -> Option<String> {
-    if option_env!("GIT_BRANCH") == None {
-        let commit = Command::new("git")
-            .arg("rev-parse")
-            .arg("--abbrev-ref")
-            .arg("HEAD")
-            .output();
-        if let Ok(commit) = commit {
-            if let Ok(commit) = String::from_utf8(commit.stdout) {
-                return Some(commit);
-            }
-        }
-    } else {
-        return option_env!("GIT_BRANCH").map(String::from);
-    }
-
-    None
-}
-
 fn is_working_tree_clean() -> bool {
     let status = Command::new("git")
         .arg("diff")

--- a/stackslib/src/lib.rs
+++ b/stackslib/src/lib.rs
@@ -44,7 +44,9 @@ extern crate stacks_common;
 #[macro_use]
 pub extern crate clarity;
 
-use stacks_common::versions::{GIT_BRANCH, GIT_COMMIT, GIT_TREE_CLEAN, STACKS_NODE_VERSION};
+use std::env::consts::{ARCH, OS};
+
+use stacks_common::versions::{GIT_COMMIT, GIT_TREE_CLEAN, STACKS_NODE_VERSION};
 pub use stacks_common::{address, codec, types, util};
 
 #[macro_use]
@@ -82,19 +84,10 @@ const BUILD_TYPE: &str = "release";
 
 pub fn version_string(pkg_name: &str, pkg_version: Option<&str>) -> String {
     let pkg_version = pkg_version.unwrap_or(STACKS_NODE_VERSION);
-    let git_branch = GIT_BRANCH_ENV.unwrap_or_else(|| GIT_BRANCH.unwrap_or(""));
     let git_commit = GIT_COMMIT_ENV.unwrap_or_else(|| GIT_COMMIT.unwrap_or(""));
     let git_tree_clean = GIT_TREE_CLEAN_ENV.unwrap_or_else(|| GIT_TREE_CLEAN.unwrap_or(""));
 
     format!(
-        "{} {} ({}:{}{}, {} build, {} [{}])",
-        pkg_name,
-        pkg_version,
-        git_branch,
-        git_commit,
-        git_tree_clean,
-        BUILD_TYPE,
-        std::env::consts::OS,
-        std::env::consts::ARCH
+        "{pkg_name} {pkg_version} ({git_commit}{git_tree_clean}, {BUILD_TYPE} build, {OS} [{ARCH}])"
     )
 }


### PR DESCRIPTION
This branch name could leak information about a hotfix.