### PR TITLE
chore: fix `clippy::useless_vec` due to rust `1.91.0`

### DIFF
--- a/stacks-common/src/util/pipe.rs
+++ b/stacks-common/src/util/pipe.rs
@@ -315,7 +315,7 @@ mod test {
 
     #[test]
     fn test_connection_pipe_oneshot() {
-        let tests = vec![
+        let tests = [
             // .0: the list of vecs to send to the writer
             // .1: the number of bytes to read each time
             // .2: the expected Result<num-bytes-total, error-encountered>


### PR DESCRIPTION
### Description

This patch fix `clippy::useless_vec` warning introduced with the update to rust v`1.91.0`

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
