### PR TITLE
chore: remove make_lcov from clarity-cli

### DIFF
--- a/stackslib/src/clarity_cli.rs
+++ b/stackslib/src/clarity_cli.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::OsStr;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::{fs, io};
@@ -1893,29 +1892,6 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                     (1, Some(result))
                 }
             }
-        }
-        "make_lcov" => {
-            let mut register_files = vec![];
-            let mut coverage_files = vec![];
-            let coverage_folder = &args[1];
-            let lcov_output_file = &args[2];
-            for folder_entry in
-                fs::read_dir(coverage_folder).expect("Failed to read the coverage folder")
-            {
-                let folder_entry =
-                    folder_entry.expect("Failed to read entry in the coverage folder");
-                let entry_path = folder_entry.path();
-                if entry_path.is_file() {
-                    if entry_path.extension() == Some(OsStr::new("clarcovref")) {
-                        register_files.push(entry_path)
-                    } else if entry_path.extension() == Some(OsStr::new("clarcov")) {
-                        coverage_files.push(entry_path)
-                    }
-                }
-            }
-            CoverageReporter::produce_lcov(lcov_output_file, &register_files, &coverage_files)
-                .expect("Failed to produce an lcov output");
-            (0, None)
         }
         _ => {
             print_usage(invoked_by);


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
This PR removes the `make_lcov` command from `clarity-cli`.

### Applicable issues

- fixes #6669 

### Additional info (benefits, drawbacks, caveats)
- I noticed that `make_lcov` used [CoverageReporter::produce_lcov(...)](https://github.com/stacks-network/stacks-core/blob/develop/clarity/src/vm/coverage.rs#L190-L227) and no other component is using it, however, it's a public API function in an exported module, crate doesn't have `publish = false` in `Cargo.toml` and some external projects might, theoretically, import it.
- This PR doesn't delete [CoverageReporter::produce_lcov(...)](https://github.com/stacks-network/stacks-core/blob/develop/clarity/src/vm/coverage.rs#L190-L227) but we might discuss about removing/deprecating it.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
