### PR TITLE
Fix error string when converting string to ClarityVersion

### DIFF
--- a/clarity/src/vm/version.rs
+++ b/clarity/src/vm/version.rs
@@ -3,8 +3,6 @@ use std::str::FromStr;
 
 use stacks_common::types::StacksEpochId;
 
-use crate::vm::errors::{RuntimeError, VmExecutionError};
-
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub enum ClarityVersion {
     Clarity1,
@@ -58,9 +56,9 @@ impl ClarityVersion {
 }
 
 impl FromStr for ClarityVersion {
-    type Err = VmExecutionError;
+    type Err = &'static str;
 
-    fn from_str(version: &str) -> Result<ClarityVersion, VmExecutionError> {
+    fn from_str(version: &str) -> Result<ClarityVersion, &'static str> {
         let s = version.to_string().to_lowercase();
         if s == "clarity1" {
             Ok(ClarityVersion::Clarity1)
@@ -71,11 +69,7 @@ impl FromStr for ClarityVersion {
         } else if s == "clarity4" {
             Ok(ClarityVersion::Clarity4)
         } else {
-            Err(RuntimeError::TypeParseFailure(
-                "Invalid clarity version. Valid versions are: Clarity1, Clarity2, Clarity3, Clarity4."
-                    .to_string(),
-            )
-            .into())
+            Err("Invalid clarity version. Valid versions are: Clarity1, Clarity2, Clarity3, Clarity4.")
         }
     }
 }

--- a/stackslib/src/clarity_cli.rs
+++ b/stackslib/src/clarity_cli.rs
@@ -1030,7 +1030,7 @@ fn parse_clarity_version_flag(argv: &mut Vec<String>, epoch: StacksEpochId) -> C
         if let Some(s) = optarg {
             friendly_expect(
                 s.parse::<ClarityVersion>(),
-                &format!("Invalid clarity version: {}", s),
+                &format!("Invalid clarity version: {s}"),
             )
         } else {
             ClarityVersion::default_for_epoch(epoch)


### PR DESCRIPTION
When writing clarity RuntimeError tests, I saw this. Fixed error message and also removed the use of VmExecutionError(RuntimeError). This error is not really meant to be used for input parsing/config parsing errors which is what it basically is in clarity-cli. Changed it to be just a string. Makes life easier for me and I think its actually more correct. Happy for push back on this though.