### PR TITLE
fix: remove unsafe set_var from test

### DIFF
--- a/stacks-node/src/tests/signer/v0.rs
+++ b/stacks-node/src/tests/signer/v0.rs
@@ -1921,10 +1921,6 @@ fn sip034_tenure_extend_proposal(allow: bool, extend_types: &[TenureChangeCause]
         return;
     }
 
-    if allow {
-        std::env::set_var("SIGNER_TEST_SIP034", "1");
-    }
-
     tracing_subscriber::registry()
         .with(fmt::layer())
         .with(EnvFilter::from_default_env())


### PR DESCRIPTION
I was bothered by my IDE warning me about this use of "unsafe" code, so I went to refactor it. Turns out this ENV var just isn't used, so it can be removed.