### PR TITLE
fix(clarity-cli): Make behavior of `eval` without .clar file less confusing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,7 @@
         "args": [
           "build",
           "--bin=clarity-cli",
-          "--package=stackslib"
+          "--package=clarity-cli"
         ],
         "filter": {
           "name": "clarity-cli",


### PR DESCRIPTION
Closes https://github.com/stacks-network/stacks-core/issues/6496.

That issue reported that `clarity-eval SPWHATEVER something.clar` hangs forever, but it turns out that that's only half true. What it's in fact doing is waiting for `stdin` input.

The Clarity program file name is an optional argument, and if it's not given, the program is read from the standard input instead. In the above example command line, `something.clar` is interpreted as the VM state DB directory instead (which is obviously not the caller's intention).

I made three changes:

- The usage message now uses the common format where all optional args are wrapped in square brackets and required args are unwrapped:

  ``` Usage: clarity-cli eval [--costs] [--epoch E] [--clarity_version N] contract-identifier [program.clar] vm-state.db ```
- I also added the info to the help message that without the `program.clar`, things will be read from `stdin`.
- And I changed the order of execution so that the contract ID and the VM DBs are handled first, before the program content is loaded. That way, if the user passes a `something.clar` but (incorrectly) leaves off one of the required args, it immediately causes an error, instead of waiting for the program from `stdin` and *then* erroring.

I also fixed the VSCode launch settings for clarity-cli.
