### PR TITLE
Fix `gettransaction` Bitcoin RPC endpoint

### DIFF
--- a/stacks-node/src/burnchains/rpc/bitcoin_rpc_client/mod.rs
+++ b/stacks-node/src/burnchains/rpc/bitcoin_rpc_client/mod.rs
@@ -56,7 +56,7 @@ mod tests;
 /// Additional fields can be added in the future as needed.
 #[derive(Debug, Clone, Deserialize)]
 pub struct GetTransactionResponse {
-    pub confirmations: u32,
+    pub confirmations: i32,
 }
 
 /// Response returned by the `getdescriptorinfo` RPC call.


### PR DESCRIPTION
The `confirmations` field should be a signed integer, since it goes negative when the transaction is conflicting.