### PR TITLE
test: increase timeout for tx_replay_budget_exceeded_tenure_extend

### DIFF
--- a/stacks-node/src/tests/signer/v0.rs
+++ b/stacks-node/src/tests/signer/v0.rs
@@ -6769,7 +6769,7 @@ fn tx_replay_budget_exceeded_tenure_extend() {
 
     // Now, wait for the tx replay set to be cleared
     signer_test
-        .wait_for_signer_state_check(30, |state| Ok(state.get_tx_replay_set().is_none()))
+        .wait_for_signer_state_check(60, |state| Ok(state.get_tx_replay_set().is_none()))
         .expect("Timed out waiting for tx replay set to be cleared");
     let mut found_block: Option<StacksBlockEvent> = None;
     wait_for(60, || {


### PR DESCRIPTION
### Description

fix flaky CI run for `tx_replay_budget_exceeded_tenure_extend` due to timeout while clearing tx replay.
Locally the previous timeout is not an issue. It appears that on CI that wait can takes more time to complete succesfully.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
