### PR TITLE
feat(cli): fix duplicate binary name in stacks-signer version and fix typos

### DIFF
--- a/clarity-types/src/representations.rs
+++ b/clarity-types/src/representations.rs
@@ -108,7 +108,7 @@ impl StacksMessageCodec for ClarityName {
         // must encode a valid string
         let s = String::from_utf8(bytes).map_err(|_e| {
             codec_error::DeserializeError(
-                "Failed to parse Clarity name: could not contruct from utf8".to_string(),
+                "Failed to parse Clarity name: could not construct from utf8".to_string(),
             )
         })?;
 

--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -82,7 +82,7 @@ lazy_static! {
     /// The version string for the signer
     pub static ref VERSION_STRING: String = {
         let pkg_version = option_env!("STACKS_NODE_VERSION").or(Some(STACKS_SIGNER_VERSION));
-        version_string("stacks-signer", pkg_version)
+        version_string("", pkg_version).trim().to_string()
     };
 }
 

--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -273,7 +273,7 @@ impl StacksMessageCodec for SignerMessage {
     }
 }
 
-/// Work around for the fact that a lot of the structs being desierialized are not defined in messages.rs
+/// Work around for the fact that a lot of the structs being deserialized are not defined in messages.rs
 pub trait StacksMessageCodecExtensions: Sized {
     /// Serialize the struct to the provided writer
     fn inner_consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError>;
@@ -326,7 +326,7 @@ impl StacksMessageCodec for PeerInfo {
         // must encode a valid string
         let server_version = String::from_utf8(bytes).map_err(|_e| {
             CodecError::DeserializeError(
-                "Failed to parse server version name: could not contruct from utf8".to_string(),
+                "Failed to parse server version name: could not construct from utf8".to_string(),
             )
         })?;
         let pox_consensus = read_next::<ConsensusHash, _>(fd)?;

--- a/stackslib/src/util_lib/strings.rs
+++ b/stackslib/src/util_lib/strings.rs
@@ -156,7 +156,7 @@ impl StacksMessageCodec for UrlString {
         // must encode a valid string
         let s = String::from_utf8(bytes).map_err(|_e| {
             codec_error::DeserializeError(
-                "Failed to parse URL string: could not contruct from utf8".to_string(),
+                "Failed to parse URL string: could not construct from utf8".to_string(),
             )
         })?;
 


### PR DESCRIPTION
### Overview
This PR improves the `stacks-signer` CLI user experience and performs general codebase maintenance by addressing two separate "good first issues".

### Changes
- **Fix Duplicate Version Output (#5874)**: Updated `libsigner` to prevent the binary name from being printed twice when running `--version`. 
- **Codebase Typo Fixes (#5292)**: Corrected several typos (`desierialized` -> `deserialized`, `contruct` -> `construct`) across `libsigner`, `clarity-types`, and `stackslib`.

### Related Issues
- Closes #5874
- Closes #5292

*(Note: During implementation, I verified that #6558 is already correctly handled in the current master branch)*