### PR TITLE
fix: retry on `ParentNotFound` when mock-mining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Fixed
 
 - When mining, do not try to extend (or initiate) a tenure that did not commit to the ongoing chain tip (see #6744)
+- When mock-mining, retry when hitting the `ParentNotFound` error. This can happen at the beginning of a new tenure, but should resolve with retries.
 
 ## [3.3.0.0.2]
 

--- a/stacks-node/src/nakamoto_node/miner.rs
+++ b/stacks-node/src/nakamoto_node/miner.rs
@@ -746,6 +746,13 @@ impl BlockMinerThread {
                 }
                 Ok(None)
             }
+            Err(NakamotoNodeError::ParentNotFound) if self.config.node.mock_mining => {
+                info!(
+                    "Mock miner could not load parent tenure info yet. Will try again.";
+                );
+                thread::sleep(Duration::from_millis(ABORT_TRY_AGAIN_MS));
+                Ok(None)
+            }
             Err(e) => {
                 warn!("Failed to mine block: {e:?}");
 


### PR DESCRIPTION
### Description

When mock-mining, this error is okay and should resolve on retry once the parent block is available.

I'm not really sure how to test this scenario, so there is no test. I know this problem exists in a running mock miner and I will keep an eye on the problem once this fix is released.

### Applicable issues

- fixes #6172

### Checklist

- [ ] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
