### PR TITLE
test: add integration tests for various tenure-extend scenarios

### DIFF
--- a/stacks-node/src/tests/neon_integrations.rs
+++ b/stacks-node/src/tests/neon_integrations.rs
@@ -37,7 +37,7 @@ use stacks::chainstate::stacks::miner::{
 };
 use stacks::chainstate::stacks::{
     StacksBlock, StacksBlockHeader, StacksMicroblock, StacksPrivateKey, StacksPublicKey,
-    StacksTransaction, TransactionContractCall, TransactionPayload,
+    StacksTransaction, TenureChangeCause, TransactionContractCall, TransactionPayload,
 };
 use stacks::codec::StacksMessageCodec;
 use stacks::config::{EventKeyType, EventObserverConfig, FeeEstimatorName, InitialBalance};
@@ -1562,7 +1562,7 @@ fn get_chain_tip(http_origin: &str) -> (ConsensusHash, BlockHeaderHash) {
     )
 }
 
-fn get_chain_tip_height(http_origin: &str) -> u64 {
+pub fn get_chain_tip_height(http_origin: &str) -> u64 {
     let client = reqwest::blocking::Client::new();
     let path = format!("{http_origin}/v2/info");
     let res = client
@@ -9617,4 +9617,37 @@ fn mock_miner_replay() {
 
     miner_channel.stop_chains_coordinator();
     follower_channel.stop_chains_coordinator();
+}
+
+/// Waits for a tenure change transaction to be observed in the test_observer at the expected height
+pub fn wait_for_tenure_change_tx(
+    timeout_secs: u64,
+    cause: TenureChangeCause,
+    expected_height: u64,
+) -> Result<serde_json::Value, String> {
+    let mut result = None;
+    wait_for(timeout_secs, || {
+        let blocks = test_observer::get_blocks();
+        for block in blocks {
+            let height = block["block_height"].as_u64().unwrap();
+            if height == expected_height {
+                let transactions = block["transactions"].as_array().unwrap();
+                for tx in transactions {
+                    let raw_tx = tx["raw_tx"].as_str().unwrap();
+                    let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+                    let parsed =
+                        StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+                    if let TransactionPayload::TenureChange(payload) = &parsed.payload {
+                        if payload.cause.is_eq(&cause) {
+                            info!("Found tenure change transaction: {parsed:?}");
+                            result = Some(block);
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(false)
+    })?;
+    Ok(result.unwrap())
 }

--- a/stacks-node/src/tests/signer/v0.rs
+++ b/stacks-node/src/tests/signer/v0.rs
@@ -133,7 +133,7 @@ use crate::tests::nakamoto_integrations::{
 use crate::tests::neon_integrations::{
     get_account, get_chain_info, get_chain_info_opt, get_sortition_info, get_sortition_info_ch,
     next_block_and_wait, run_until_burnchain_height, submit_tx, submit_tx_fallible, test_observer,
-    TestProxy,
+    wait_for_tenure_change_tx, TestProxy,
 };
 use crate::tests::signer::commands::*;
 use crate::tests::signer::SpawnedSignerTrait;
@@ -1226,39 +1226,6 @@ pub fn verify_sortition_winner(sortdb: &SortitionDB, miner_pkh: &Hash160) {
     let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
     assert!(tip.sortition);
     assert_eq!(&tip.miner_pk_hash.unwrap(), miner_pkh);
-}
-
-/// Waits for a tenure change transaction to be observed in the test_observer at the expected height
-fn wait_for_tenure_change_tx(
-    timeout_secs: u64,
-    cause: TenureChangeCause,
-    expected_height: u64,
-) -> Result<serde_json::Value, String> {
-    let mut result = None;
-    wait_for(timeout_secs, || {
-        let blocks = test_observer::get_blocks();
-        for block in blocks {
-            let height = block["block_height"].as_u64().unwrap();
-            if height == expected_height {
-                let transactions = block["transactions"].as_array().unwrap();
-                for tx in transactions {
-                    let raw_tx = tx["raw_tx"].as_str().unwrap();
-                    let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-                    let parsed =
-                        StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
-                    if let TransactionPayload::TenureChange(payload) = &parsed.payload {
-                        if payload.cause.is_eq(&cause) {
-                            info!("Found tenure change transaction: {parsed:?}");
-                            result = Some(block);
-                            return Ok(true);
-                        }
-                    }
-                }
-            }
-        }
-        Ok(false)
-    })?;
-    Ok(result.unwrap())
 }
 
 /// Waits for a block proposal to be observed in the test_observer stackerdb chunks at the expected height


### PR DESCRIPTION
This adds a simple new integration test to ensure that the miner has the expected behavior when it should extend, in three different scenarios:
1. An empty Bitcoin block with no commits, even though the miner had submitted a valid commit
2. A Bitcoin block with an old commit from the previous tenure
3. An empty Bitcoin block with no commits, and the miner never submitted one.

This was in response to a stall where it seemed that a miner failed to extend its tenure after a Bitcoin block with no block commits in it. Unfortunately, it seems my test was not creative enough to find any issue and we don't have the logs from that miner.