### PR TITLE
feat: discount contract-call call stack depth

### DIFF
--- a/clarity/src/vm/callables.rs
+++ b/clarity/src/vm/callables.rs
@@ -396,7 +396,7 @@ impl CallableType {
 }
 
 impl FunctionIdentifier {
-    fn new_native_function(name: &str) -> FunctionIdentifier {
+    pub(crate) fn new_native_function(name: &str) -> FunctionIdentifier {
         let identifier = format!("_native_:{}", name);
         FunctionIdentifier { identifier }
     }

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use std::mem::replace;
 
 use hashbrown::{HashMap, HashSet};
+use lazy_static::lazy_static;
 use serde::Serialize;
 use serde_json::json;
 use stacks_common::consts::CHAIN_ID_TESTNET;
@@ -1901,6 +1902,11 @@ impl Default for CallStack {
     }
 }
 
+lazy_static! {
+    static ref CONTRACT_CALL_FUNCTION_IDENTIFIER: FunctionIdentifier =
+        FunctionIdentifier::new_native_function("special_contract-call");
+}
+
 impl CallStack {
     pub fn new() -> CallStack {
         CallStack {
@@ -1911,7 +1917,11 @@ impl CallStack {
     }
 
     pub fn depth(&self) -> usize {
-        self.stack.len() + self.apply_depth
+        self.stack
+            .iter()
+            .filter(|id| **id != *CONTRACT_CALL_FUNCTION_IDENTIFIER)
+            .count()
+            + self.apply_depth
     }
 
     pub fn contains(&self, function: &FunctionIdentifier) -> bool {


### PR DESCRIPTION
_This PR is in draft pending research on prior issues and decisions around MAX_CALL_STACK_DEPTH and alternative approaches to the stated motivation below._

### Description

Currently, the `MAX_CALL_STACK_DEPTH` check in `clarity::vm::apply` prohibits function evaluation when the environment's CallStack stack depth (+ `apply_depth`) is greater than `u64`.

When evaluating a function, we push it's identifier onto the environment's `CallStack` stack.

When evaluating a function defined in another contract, we push two identifiers onto the stack: one corresponding to `contract-call?` and then one corresponding to the user-defined function in the contract. 

This is one more function identifier than would be needed to call a function defined in the same contract.

This PR makes the call-stack-depth cost the same for functions defined in the same contract and functions defined in other contracts.

It does this by discounting `contract-call?` function identifiers when calculating `CallStack::depth()`.

The motivation for doing so is to make it easier to build interoperable defi contracts that have functions that would otherwise fail evaulation due to the `MAX_CALL_STACK_DEPTH` check.

### Applicable issues

None

### Additional info (benefits, drawbacks, caveats)

#### Cons to current approach:
- Changes visibility of the `FunctionIdentifier::new_native_function` method from private to `pub(crate)`: this was necessary for creating the global ref of the contract call identifier in `vm::contexts` (I tried using the `functions::lookup_reserved_functions` function, which is already public, but that returns a CallableType that's not thread safe). This might be deemed ok, but it's an additional consideration for the contract exposed by the `vm::functions` module that we would ideally not have to make.

- The meaning of `CallStack::depth()` is now slightly muddied: this method appears to have only one call site, being the call stack depth check in `vm::apply()`, so I modified it directly. However, the name "depth" suggests at a return value that is now no longer accurate to expectations: the value returned is probably more accurately described as "depth cost". We could change the name of the function to reflect this.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
