### PR TITLE
chore: cleanup state machine update log

### DIFF
--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -1000,8 +1000,11 @@ impl Signer {
         update: &StateMachineUpdate,
         received_time: &SystemTime,
     ) {
+        let replay_txids = update.content.replay_txids();
+        let pubkey = signer_public_key.to_hex();
         info!(
-            "{self}: Received state machine update from signer {signer_public_key:?}: {update:?}"
+            "{self}: Received state machine update from signer {pubkey}: {update}";
+            "replay_txids" => ?replay_txids
         );
         let address = StacksAddress::p2pkh(self.mainnet, signer_public_key);
         // Store the state machine update so we can reload it if we crash


### PR DESCRIPTION
The existing log is too verbose, especially when there are replay transactions. This tightens it up a bit.

Example of current log (this is just one log line):
```
Cycle #126 Signer #13: Received state machine update from signer Secp256k1PublicKey { key: PublicKey(4468163be7430e67fa767567bd24b3f705d05a678a80a1ea498eddbaa8e562923f79fa75881a98313f7e62f74f460d6fe49bebb00b88ce7284c60fbe61a2ee6a), compressed: true }: StateMachineUpdate { active_signer_protocol_version: 1, local_supported_signer_protocol_version: 1, content: V1 { burn_block: 96aa93f36b20d0f0c9a2b6f0e9263690ea0877f1, burn_block_height: 931521, current_miner: ActiveMiner { current_miner_pkh: c1f59a0c335255bd37da58b20f5f62a470679ee0, tenure_id: aeb0983309bda2963ee46489a200f7d6a5279f9b, parent_tenure_id: 4a7178e2bb4e0d3a45020f590cc282c246a7feed, parent_tenure_last_block: e6cdbdae37a1d188a52dc94cac57aed8b7f49c198a113e4c637b11369b0c8dda, parent_tenure_last_block_height: 5781399 }, replay_transactions: [StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: e8272552a31b343c9c41d01c9d67512b857f1fd8, nonce: 2144, tx_fee: 234811, key_encoding: Compressed, signature: 0149761cb534bece0f98c501622e2334f27f7adb2837a3bb906a7b73e17dfc9791024dcaa33fce04b3159acbf5e8aba3e1d36244a9be5c1d526b9a09486d6aea09 })), anchor_mode: Any, post_condition_mode: Allow, post_conditions: [], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 20, bytes: 4e91b0982dbe4ae49bb9394b1f339fb7144beee6 }, contract_name: ContractName("xyk-core-v-1-2"), function_name: ClarityName("swap-y-for-x"), function_args: [Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR), name: ContractName("xyk-pool-sbtc-stx-v-1-1") })), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4), name: ContractName("sbtc-token") })), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR), name: ContractName("token-stx-v-1-2") })), UInt(2000000000), UInt(745110)] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 840995cd859e15012a6836cd4185207528933d49, nonce: 28825, tx_fee: 364, key_encoding: Compressed, signature: 01de7dd9a7bcebd40030fcd342114af2649573a51fa7a8d7d6d0e41e70586e122242bd22d10d047d956260a7ffffbd638c145301551b987c8cbf629c4c5eb32c70 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP2728B2NG5E4P60KH8Y8D65298XS7TYD0306RFSX)), 1364, 31303030393939340000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 59923f7d6153931583e8643ee2bf8735010452d1, nonce: 511, tx_fee: 4705, key_encoding: Compressed, signature: 001b61ff5e7cb31d5fa24d1c91dae62a1f75221b7cecef19efbd3dc989c47dcdf74ce41aeecd1c2ebb89b6ade3e3784d3b0e6422ceaee7f3709a5e83cf9ef5f6b1 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [Nonfungible(Standard(StacksAddress { version: 22, bytes: 59923f7d6153931583e8643ee2bf8735010452d1 }), AssetInfo { contract_address: StacksAddress { version: 22, bytes: ef954ae47291ceb9b9c6274ffc49ac521dfccc2f }, contract_name: ContractName("thisisnumberone-v2"), asset_name: ClarityName("my-nft") }, UInt(253), Sent)], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 22, bytes: 2bcf9762d5b90bc36dc1b4759b1727690f92ddd3 }, contract_name: ContractName("marketplace-v4"), function_name: ClarityName("list-asset"), function_args: [Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP3QSAJQ4EA8WXEDSRRKMZZ29NH91VZ6C5X88FGZQ), name: ContractName("thisisnumberone-v2") })), UInt(253), UInt(50000000), UInt(200)] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176858, tx_fee: 180, key_encoding: Compressed, signature: 01f495d4a9b13b82b4e7e35052f6f7e73f9a6324b13831f961e0b1cb1bc2d41a324b33957403980ae51a9ec98d3d17d7a9b874e21ffc935ff78ce1230cf6d8bb22 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: a26392d8d7f66f70a6981f4c1e0d87dc4fb0b1a7, nonce: 51220, tx_fee: 601, key_encoding: Compressed, signature: 00b01106316b19a3e9351761ba940c351a4d204195c5eb07b8e3ae8136dc87ac195acb662ffeb277c7e666f3bef3a1273995a4352606905afe7ee5e57b47c5597b })), anchor_mode: Any, post_condition_mode: Allow, post_conditions: [], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 22, bytes: a26392d8d7f66f70a6981f4c1e0d87dc4fb0b1a7 }, contract_name: ContractName("ruse"), function_name: ClarityName("r2"), function_args: [Sequence(Buffer(09c38419141327000e27110009111411f00000000b893519141327000e27110109111411f0000000149f10c90229110609111411f0000000f00000000c24f7c90a294d00024d110809111411f00000001a750ca8120827010e27110009111411f00000000a772eb410144d00024d110809111411f0000000)), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP2H674PRTZV6YW56K0FMR7GDGZE4ZC5HMYZ3CDEV), name: ContractName("site") }))] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 5d8ffc103cdd8ab3b76c9e486a2c7a1b0fad0000, nonce: 387, tx_fee: 6000, key_encoding: Compressed, signature: 00d98c7c9f112a0cd49b32d25f0374c4b18c29e71328fc66824ff08553101459aa1ab294b3a7b52a6e925f8e6c23d0bd0ac0b018198ac70368f3ec08b02974fce1 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP1FJWRAS8NQBRHFPRCKFGZ9B1AZPGC2XDP1Y20F5)), 75000000, 31303136323335373633000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: e8272552a31b343c9c41d01c9d67512b857f1fd8, nonce: 2145, tx_fee: 234811, key_encoding: Compressed, signature: 01b7a9e43ac331fdbe8ce49dff821e5b600ed85a5e06749f9f98db7fd16c8109db37f3aeba848cedddfe33d64832abe186bc48f7093ea1f98de1ed0dddf2891386 })), anchor_mode: Any, post_condition_mode: Allow, post_conditions: [], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 20, bytes: 4e91b0982dbe4ae49bb9394b1f339fb7144beee6 }, contract_name: ContractName("xyk-core-v-1-2"), function_name: ClarityName("swap-x-for-y"), function_args: [Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR), name: ContractName("xyk-pool-stx-aeusdc-v-1-2") })), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR), name: ContractName("token-stx-v-1-2") })), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K), name: ContractName("token-aeusdc") })), UInt(2000000000), UInt(672252058)] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176859, tx_fee: 180, key_encoding: Compressed, signature: 0046eb2a7da188ab97327f76922e5178315c8cf2cf6a6d919c0b3f885c402ca51147e6e4924d5e2959a977cad8f66a4ce11b2462572e9b1c0a55c632838b2c2fec })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: a26392d8d7f66f70a6981f4c1e0d87dc4fb0b1a7, nonce: 51221, tx_fee: 600, key_encoding: Compressed, signature: 01b505da72242bc06b8f8f29a3860a435a421f2c1d12479a2ec90709ce0af8389546e59e5d4eb8c6dc6a54a8ac486e109d587d7f1882d2da94b66fa4c0d3b865e5 })), anchor_mode: Any, post_condition_mode: Allow, post_conditions: [], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 22, bytes: a26392d8d7f66f70a6981f4c1e0d87dc4fb0b1a7 }, contract_name: ContractName("gowf"), function_name: ClarityName("rw"), function_args: [Sequence(Buffer(09b53d19141327000e27110009111411f00000000b710219141327000e27110109111411f000000014882cc90229110609111411f0000000f00000001a42a3a8120827010e27110009111411f0000000)), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP2H674PRTZV6YW56K0FMR7GDGZE4ZC5HMYZ3CDEV), name: ContractName("site") }))] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: f2bba6df751755ab9ac1df8b387d981cfe265cdf, nonce: 2176858, tx_fee: 180, key_encoding: Compressed, signature: 00de35fff79ad5c9a7a473793a83314c86e290d336fae78b824a56827858f7f85029f7be77ca949a7063bad12e4edd10488674cb9e4b568865a30633b236881083 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 3bd7ed83d1935c5be98b636d34e3ed690cf28e9d, nonce: 163, tx_fee: 500, key_encoding: Compressed, signature: 00679fdd57136b7915d8ae5cc15cf2fe03f67ff0f814c8bffad80f9489ab04f2d3286598a7cab475ffb615c4a7f2702ce7bd1f79e18388b3dbab1baf45ec8bffe1 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3933SW09N2NX7VPQFF839V5EJP75DMKCAESFFBW)), 73737188, 31323334000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 8e242c55815c4b18138a3c8698a24a3b93ebcd00, nonce: 4456, tx_fee: 364, key_encoding: Compressed, signature: 00db3e634ba850c4e24eff860d0676c33ac98087c37f50d8d19228b66df7af5d322f40080e46a1f2fb9f73c46e3aba05c6c85c215ef008074c6776047a43df1373 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3125QHD69Q9H142EVKZMYDN60NNJQ7MXF1XJ5W8)), 1000, 31303030393939340000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 43c2c303463f6a49f51702b16284d50a8af248bd, nonce: 2108, tx_fee: 30000, key_encoding: Compressed, signature: 01bf2390dfd342c3265b444f643efe37a1650cb634f0d42812b778a17ba5bf990636cd4a90527e6be789d2e5a01ab633c71c645651c134174cc543caaa4c859e3d })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [Fungible(Standard(StacksAddress { version: 22, bytes: 43c2c303463f6a49f51702b16284d50a8af248bd }), AssetInfo { contract_address: StacksAddress { version: 22, bytes: dd9e06ecadedbec9b0bf347710b86b22345d734c }, contract_name: ContractName("token-tusdc-v-0-2"), asset_name: ClarityName("tUSDC") }, SentLe, 7271281669), Fungible(Contract(StacksAddress { version: 22, bytes: dd9e06ecadedbec9b0bf347710b86b22345d734c }, ContractName("dlmm-pool-h-v-0-1")), AssetInfo { contract_address: StacksAddress { version: 22, bytes: dd9e06ecadedbec9b0bf347710b86b22345d734c }, contract_name: ContractName("token-tbtc-v-0-2"), asset_name: ClarityName("tBTC") }, SentGe, 7434488)], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 22, bytes: dd9e06ecadedbec9b0bf347710b86b22345d734c }, contract_name: ContractName("dlmm-swap-router-v-0-3"), function_name: ClarityName("swap-simple-multi"), function_args: [Sequence(List(ListData { data: [Tuple(TupleData { type_signature: TupleTypeSignature { "amount": uint, "max-steps": uint, "min-received": uint, "pool-trait": principal, "x-for-y": bool, "x-token-trait": principal, "y-token-trait": principal,}, data_map: {ClarityName("amount"): UInt(7271281669), ClarityName("max-steps"): UInt(6), ClarityName("min-received"): UInt(7434487), ClarityName("pool-trait"): Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X), name: ContractName("dlmm-pool-h-v-0-1") })), ClarityName("x-for-y"): Bool(true), ClarityName("x-token-trait"): Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X), name: ContractName("token-tusdc-v-0-2") })), ClarityName("y-token-trait"): Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP3ESW1QCNQPVXJDGQWT7E45RDCH38QBK9HEJSX4X), name: ContractName("token-tbtc-v-0-2") }))} })], type_signature: ListTypeData { max_len: 1, entry_type: TupleType(TupleTypeSignature { "amount": uint, "max-steps": uint, "min-received": uint, "pool-trait": principal, "x-for-y": bool, "x-token-trait": principal, "y-token-trait": principal,}) } }))] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: f2bba6df751755ab9ac1df8b387d981cfe265cdf, nonce: 2176859, tx_fee: 180, key_encoding: Compressed, signature: 01705f39dedd2457cad6cc65294ac5dba46ccb4fa0bb5b9fdcf67d2d6f1b3c2e066de35b01f87aa4d42ecac305f652351070b3590864253f44fc8206b655ce6be2 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 82e98279bc0f17457066f1285a0fa6d196284b41, nonce: 312172, tx_fee: 417, key_encoding: Compressed, signature: 00cbe605c00013d97fa8ab04a099e2b9cda6080aba883f2314b6837f061f494f437cb4ec2d7c7d2599409c0584f0687b72c98ac327bd1db14b05d38b378a05ebcc })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 22, bytes: 82e98279bc0f17457066f1285a0fa6d196284b41 }, contract_name: ContractName("blocksurvey-proof-of-submission"), function_name: ClarityName("proof-of-submission"), function_args: [Sequence(String(u"ea911f955a0c34924c3b37d4c31d1a8349e313de4b6b5b6d349f1dd5a26edeb7")), Sequence(String(u"a3b8891730953c3483f4fb7a5f145b66284978ed0d1c215ff03277e808993c2f")), Sequence(String(u"70841699015b95326c5214502aea68c8d8e9f8df89ec99e2188e818e2c043237")), UInt(417)] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(OrderIndependentMultisig(OrderIndependentMultisigSpendingCondition { hash_mode: P2SH, signer: f6decc7cfff2a413bd7cd4f53c25ad7fd1899acc, nonce: 3419, tx_fee: 135125, fields: [PublicKey(Secp256k1PublicKey { key: PublicKey(d793d25402d69153f44cc337525a7b1efbec9c7d19d4271116907b6654d2204068bcedcf0355ffcb3bd667c4f8bf5f7ddd4208fc621fe1af528bc30c3e092907), compressed: true }), Signature(Compressed, 0066c3b0957b410583a0c64a8bdca52749d9c9b29e297dc9bebac43d12b4c42ff301e77033ddbe913f47b5eaf8166ae731a9c99f3b37a57446aad81ec9b0f9d3d1), Signature(Compressed, 0155a2414d4ed202357d96938487cdbdf9c629e257375f8a6882715375ece61b792dec090344b7d6b65052f349d249f69b58c078153dcbfa910e23b7c4ee4f3d61), PublicKey(Secp256k1PublicKey { key: PublicKey(9c8b3115f154ca30385949b50102562d301a4d9ece0ffe7393ca858196fe1ece06ade7bbcb51f2ffc197b6ce509deb002a57916dd9fc33a718757b3547ccdcf5), compressed: true }), Signature(Compressed, 01ebc34de644c1d60a8b231e3d72fedc64deed09e5ed62c195c2761f5fc57af90a7578ac383d07321f8c0524e571f1f87b09e15078d5614d8b41bc934f7e952ed5), Signature(Compressed, 004a7163fe92c48e6dd2322df497d513271f48ca6d7f64918ea9731954a834edf3653fd11ec653add4bb87ac9feed7e8a05a7920444f760faef1418bd6e44c199d), Signature(Compressed, 019129c6b3ddad297fed0573e37d80c67b7c40684b58c4c2935af256eb46d1e72f461297afe48211632fb186f4a5a05b96f9517a72061b46269e36fcb51de04464), Signature(Compressed, 018ce66def8738edfe2c86a439b569b18d6282fd16d5e801086dcb01fc4b014a62534d727860d0d3782eead6223f0f174c58b9274ead280d4188cc7f52b19f6829), Signature(Compressed, 01d95248e1904e1530a46d45c7feb8e38bd073a15093b50e1ab1e918c97764a5734f31ef427ac5d757f1f6c6327b3093913dee0984b7f391125bb1ebb72d691019), Signature(Compressed, 013e039ea223967270431e70d2024ab15345d14dc513ae83e224f867725575103b4ef8de759af628bf1c5eba8f593fcea30b2bbcc10f3ec499d24a5156fad7eb6e), Signature(Compressed, 00c85a0c1c8c2b27acd53b05ec3fe3195fa92f98dd600749fa5afa6e988fd9bb924610d19a73610ae84a9d969e0f3cf8548cc853ed12743202c832de90d749e5af), Signature(Compressed, 00f4a08259c807228cd6ae3ed0f7976c7f515b814c5912036f2ebc3e077827c8ff57cb0444039f46cc9012efcf023127132b152fc0a282a2f7195cfd0a423233ed), PublicKey(Secp256k1PublicKey { key: PublicKey(4ac27f88bd797ce9d2ec989c8187b931c61f6376b754b0ffc146606ae94e2ed95dde9adc61dd7ebf2454a2ff1b09863574b41106ae0050a6e5fb42ce93eac82f), compressed: true }), PublicKey(Secp256k1PublicKey { key: PublicKey(81a438cdcbb40703133cbded03135e80b3faffe4a12e993aae1060b2cbdb8eed6f78fe26c06b8ca3a90d5fac070ac677e574978ff723c2a39a128c9333ac6a6d), compressed: true })], signatures_required: 10 })), anchor_mode: Any, post_condition_mode: Allow, post_conditions: [], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 20, bytes: f6decc7cfff2a413bd7cd4f53c25ad7fd1899acc }, contract_name: ContractName("sbtc-deposit"), function_name: ClarityName("complete-deposit-wrapper"), function_args: [Sequence(Buffer(a7ab4ad469dad17a72eea6ffe0e8b24fb928554bbaba16f9fa3c8461f7cd95c4)), UInt(0), UInt(47469765), Principal(Standard(StandardPrincipalData(SP1M2T0M9NWKTHJNFMPCCQMEGHF82DG935TMEJ50E))), Sequence(Buffer(0000000000000000000062ec312763a6e9ea3da4a511fb66200c25edb7f4dcbf)), UInt(931519), Sequence(Buffer(03d427994219e1e45a14f4779725988b893fbd2a790802b467df9d455784e9c2))] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176860, tx_fee: 180, key_encoding: Compressed, signature: 009eef3cded6b1b4abbe12d3accdbd1b57e29eefe5c26eb7d6fe7836f5b5515d7e63417632835706096df739d3b1231ef357832c90000bc03927f97b3547bbf303 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176861, tx_fee: 180, key_encoding: Compressed, signature: 01e467e109d53977a3faa382e9dbf40140939a1e1daa413b9d9892458a414ca0c117bef98e58a4f954e1ecddaa61ad006c3f43334b5cd9d88119f9bb9aaaece1c1 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: f2bba6df751755ab9ac1df8b387d981cfe265cdf, nonce: 2176860, tx_fee: 180, key_encoding: Compressed, signature: 0152a4fbf994c06f5d623a112fe752308d8a9bfd81bdbbb83637b5d3d8e0bd29ec746f1b960e743220db080dd369584a9a537332816a1c41d4f6bd7e0f57808629 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: f2bba6df751755ab9ac1df8b387d981cfe265cdf, nonce: 2176861, tx_fee: 180, key_encoding: Compressed, signature: 013619a9deb34d2b224e49d44bb636c839bca5f25c8776bcc1c63c98a86ed717e14fc6ac45a1b8123ab9420d8df69656734e142c5839936c3566f3f0da57b77022 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176862, tx_fee: 180, key_encoding: Compressed, signature: 005a09da64d29e286fc9d0fee2831cb1951d8994b7737cc6b585596b9f07bb621a520782625a60718a4f8be0fe47f7f1233f3257f13ad17d777b4e565daf6ab87a })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: f2bba6df751755ab9ac1df8b387d981cfe265cdf, nonce: 2176862, tx_fee: 180, key_encoding: Compressed, signature: 01e133372488650b3449c27b6d9ad02e84460e0aca63177e2c1c8f35849bc0aa204988c667ff795d139deacbaf91b0b5174417fa8e11672702efd689804206d639 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176863, tx_fee: 180, key_encoding: Compressed, signature: 00398a872bcbe32b17e6f8c865bfc1222cef627976323a818eeb104aa268bbe22611a7ad6548a2ce6b71cb9131d1fbb65672fb1ede9c168b117c60f9ee32b23e7a })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: f2bba6df751755ab9ac1df8b387d981cfe265cdf, nonce: 2176863, tx_fee: 180, key_encoding: Compressed, signature: 0146138a5ed5ee57779b783f55a1bc527bbd847d7e9451b4899609d8e818ec28023d2bceb68557bdee314fa7fe6adbfce56aebae953888be43357c3013bfe4c1b0 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176864, tx_fee: 180, key_encoding: Compressed, signature: 00f02d17bb2323bdd900879a73160516ab26d532d59b0e692c81b99928eccc46791430ddd26796acd2233bb281e579f9edd04d2f4411a4dfa59d27bf5bd1afde61 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: f2bba6df751755ab9ac1df8b387d981cfe265cdf, nonce: 2176864, tx_fee: 180, key_encoding: Compressed, signature: 019b680993391a42a49be64b507f937031c0d5eca03feedfbbbab25ee99f0da3c906d7560340c2d83d0f1393c6207c898293f4ee5ba3136311aebee26f9c98a120 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 840995cd859e15012a6836cd4185207528933d49, nonce: 28826, tx_fee: 404, key_encoding: Compressed, signature: 0009b9ba41776bd58b05f7ce9dc0f9912dbe19745b6c7d9b7c7b6a4852b396a130337beef8e2b81599e0b19a63a1998390611331eadb41a7b8857cdd7c4afca85e })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP39YE21CX0XBPBHGCJM0BYSS5ZVPR1NGFXRSFFBW)), 1404, 31323334000000000000000000000000000000000000000000000000000000000000) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: 70b0ecc5506ca577da45b6f7bd86d05f54b918bf, nonce: 7873, tx_fee: 12503, key_encoding: Compressed, signature: 0196a5964b9950c50b86842726f90a98062566c96d962d478c6d663667a46d210d781e465a47e716a7d021a4883513ecb4dbf9f5ea54dfeb4cc7366fb1b4359531 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [Fungible(Standard(StacksAddress { version: 22, bytes: 70b0ecc5506ca577da45b6f7bd86d05f54b918bf }), AssetInfo { contract_address: StacksAddress { version: 22, bytes: 64f7e7dacc4fb5d0a49893f7e5312676b31dca46 }, contract_name: ContractName("gus-token"), asset_name: ClarityName("gus") }, SentEq, 14746379000000), Fungible(Contract(StacksAddress { version: 22, bytes: 402da2c079e5d31d58b9cfc7286d1b1eb2f7834e }, ContractName("amm-vault-v2-01")), AssetInfo { contract_address: StacksAddress { version: 22, bytes: 402da2c079e5d31d58b9cfc7286d1b1eb2f7834e }, contract_name: ContractName("token-alex"), asset_name: ClarityName("alex") }, SentGe, 0), Fungible(Standard(StacksAddress { version: 22, bytes: 70b0ecc5506ca577da45b6f7bd86d05f54b918bf }), AssetInfo { contract_address: StacksAddress { version: 22, bytes: 402da2c079e5d31d58b9cfc7286d1b1eb2f7834e }, contract_name: ContractName("token-alex"), asset_name: ClarityName("alex") }, SentGe, 0), STX(Contract(StacksAddress { version: 22, bytes: 402da2c079e5d31d58b9cfc7286d1b1eb2f7834e }, ContractName("amm-vault-v2-01")), SentGe, 68101425)], payload: ContractCall(TransactionContractCall { address: StacksAddress { version: 22, bytes: 402da2c079e5d31d58b9cfc7286d1b1eb2f7834e }, contract_name: ContractName("amm-pool-v2-01"), function_name: ClarityName("swap-helper-a"), function_args: [Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM), name: ContractName("token-wgus") })), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM), name: ContractName("token-alex") })), Principal(Contract(QualifiedContractIdentifier { issuer: StandardPrincipalData(SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM), name: ContractName("token-wstx-v2") })), UInt(100000000), UInt(100000000), UInt(1474637900000000), Optional(OptionalData { data: Some(UInt(6810142573)) })] }) }, StacksTransaction { version: Mainnet, chain_id: 1, auth: Standard(Singlesig(SinglesigSpendingCondition { hash_mode: P2PKH, signer: fbd9a1702f4ecc44fc01f1894c72fcbb23a53ce8, nonce: 2176865, tx_fee: 180, key_encoding: Compressed, signature: 0042fa21b697657f75e818a43415c65d42d3dc9a5cbf7e489cc7a1957f166ee6a8030e97acf77c4999116e1c0eb45f70ebb8c2eab43440e868393530fd2e3b9b47 })), anchor_mode: Any, post_condition_mode: Deny, post_conditions: [], payload: TokenTransfer(Standard(StandardPrincipalData(SP3SBQ9PZEMBNBAWTR7FRPE3XK0EFW9JWVX4G80S2)), 1, 00000000000000000000000000000000000000000000000000000000000000000000) }] }, no_manual_construct: PhantomData<()> } 
```