### PR TITLE
Docs: add property testing to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 ### Checklist
 
 - [ ] Test coverage for new or modified code paths
-- [ ] For new Clarity features or consensus changes, add property tests (see `docs/property-testing.md`)
+- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
 - [ ] Changelog is updated
-- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
+- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
 - [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo


### PR DESCRIPTION
This adds a property testing checklist item to the PR template for this repo.