### PR TITLE
fix: `block_rejection_timeout_steps` truncation collisions 

### DIFF
--- a/stacks-node/src/nakamoto_node/signer_coordinator.rs
+++ b/stacks-node/src/nakamoto_node/signer_coordinator.rs
@@ -78,7 +78,7 @@ pub struct SignerCoordinator {
 /// Helper function to build block_rejection_timeout_steps BTreeMap from config.
 ///
 /// When multiple percentages truncate to the same rejections_amount
-/// (common with small total_weight), keeps the longest timeout (from the lowest percentage).
+/// (common with small total_weight), keeps the longest timeout.
 fn build_block_rejection_timeout_steps(
     total_weight: u32,
     config_steps: &HashMap<u32, Duration>,


### PR DESCRIPTION
### Description

In short: The fix logs a warning and preserves the max timeout in case a collision happen when computing `block_rejection_timeout_steps`.

Long explanation:
This PR fixes an intermittent bug that @matteojug reported in an sBTC testing environment. The test can be found [here](https://github.com/stacks-sbtc/sbtc/tree/tmp/stacks-testcontainer) and launched with:

`cargo test --package signer --test integration --features testing -- containers::test_stacks --exact --nocapture`

The stacks-node miner spawned by docker compose was sometimes:
1. Sending a block proposal
2. Timing out immediately without waiting for the reply from the signer
3. Repeating this loop forever


The bug is caused here:

https://github.com/stacks-network/stacks-core/blob/bc00b295883a108748696a15b24a44772298efa1/stacks-node/src/nakamoto_node/signer_coordinator.rs#L116-L122

The issue has two parts:

1. Truncation may cause key collisions

   The default `MinerConfig.block_rejection_timeout_steps` is `{ 0: 180, 10: 90, 20: 45, 30: 0 }` (percentages mapped to timeout seconds).
   
   The computation of `rejections_amount` truncates the result. For small values of `total_weight`, multiple percentages can map to the same key. For example, with `total_weight = 1`:
   
0% of 1 = 0.00 -> 0
10% of 1 = 0.10 -> 0
20% of 1 = 0.20 -> 0
30% of 1 = 0.30 -> 0

   
   All four percentages truncate to the same key 0.

2. HashMap iteration order is non-deterministic

   The code iterates over `block_rejection_timeout_steps`, which is a `HashMap`. When multiple percentages map to the same `rejections_amount`, the last one processed overwrites all previous entries.
   
   Since `HashMap` iteration order is non-deterministic, the behavior varies between runs:
   - If `(0, 180)` is processed last: timeout is 180 seconds (works correctly)
   - If `(30, 0)` is processed last: timeout is 0 seconds (immediate timeout loop)


I verified this was the case by querying the `.signers` contract in the docker environment:
```
# Get the current reward cycle
CYCLE=$(curl -s http://localhost:20443/v2/pox | jq '.reward_cycle_id')

# Build the Clarity uint argument (0x01 prefix + 32 hex chars)
ARG=$(printf '0x01%032x' $CYCLE)

# Query the signers contract
curl -s -X POST http://localhost:20443/v2/contracts/call-read/ST000000000000000000002AMW42H/signers/get-signers \
  -H "Content-Type: application/json" \
  -d "{\"sender\": \"ST000000000000000000002AMW42H\", \"arguments\": [\"$ARG\"]}"
```

Resulted in: `(some ((tuple (signer ST24VB7FBXCBV6P0SRDSPSW0Y2J9XHDXNHW9Q8S7H) (weight u1))))`

This confirms `total_weight = 1`, which causes all percentage thresholds to collide at key 0.


### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
