### PR TITLE
Update GitHub templates for stacks-core

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,28 +1,26 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+about: Report a bug in Stacks Core
+labels: bug
 ---
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
 **Steps To Reproduce**
-Please provide detailed instructions (e.g. command line invocation with parameters) to reproduce the behavior.
+Provide detailed instructions to reproduce the behavior (e.g. command line invocation with parameters).
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Environment (please complete the following information):**
- - OS: [e.g. Ubuntu / Debian]
- - Rust version
- - Version of the appropriate binary / software package
+**Environment**
+- OS: [e.g. Ubuntu/Debian/macOS]
+- Rust version:
+- stacks-node version:
+- Network: [mainnet/testnet]
 
-**Additional context**
-Please include any relevant stack traces, error messages and logs.
+**Logs / stack traces**
+Include relevant logs, stack traces, or error messages.
 
-If you are encountering an issue with a smart contract, please include the smart contract code
-that demonstrates the issue.
+**Smart contract details (if applicable)**
+If the issue involves a smart contract, include the contract code and reproduction steps.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,7 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+about: Suggest a new feature or improvement for Stacks Core
+labels: enhancement
 ---
 
 **Is your feature request related to a problem? Please describe.**
@@ -15,6 +12,17 @@ A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
+
+**Area**
+Which area does this relate to?
+- [ ] Consensus/chainstate
+- [ ] P2P networking
+- [ ] VM/Clarity
+- [ ] RPC/API
+- [ ] Stacks Signer
+- [ ] Testing/dev tooling
+- [ ] Documentation
+- [ ] Other (please specify)
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,17 +6,23 @@
   https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
 -->
 
-### Description
+## Title
+```
+[PR Title Here]
+```
 
-### Applicable issues
+## Description
+```
+[PR Description Here]
+```
 
-- fixes #
+## Applicable issues
+- Fixes #
 
-### Additional info (benefits, drawbacks, caveats)
+## Additional info (benefits, drawbacks, caveats)
 
-### Checklist
-
+## Checklist
 - [ ] Test coverage for new or modified code paths
 - [ ] Changelog is updated
 - [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
-- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
+- [ ] New Clarity functions have corresponding PR in `clarity-benchmarking` repo


### PR DESCRIPTION
Refreshed bug and feature issue templates and added PR title/description code blocks while keeping SIP guidance and checklist for stacks-core.