### PR TITLE
docs/test: add rustdoc and unit tests for util_lib utility functions

### DIFF
--- a/stackslib/src/util_lib/mod.rs
+++ b/stackslib/src/util_lib/mod.rs
@@ -12,6 +12,14 @@ pub mod test {
 
     use stacks_common::util::{get_epoch_time_secs, sleep_ms};
 
+    /// Executes a closure with a specified timeout.
+    ///
+    /// Spawns a new thread to run `test_func`. If the function does not complete
+    /// within `timeout_secs`, the process panics.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `test_func` exceeds `timeout_secs` or if the spawned thread panics.
     pub fn with_timeout<F>(timeout_secs: u64, test_func: F)
     where
         F: FnOnce() + std::marker::Send + 'static + panic::UnwindSafe,
@@ -46,9 +54,7 @@ pub mod test {
     #[test]
     fn test_test_timeout() {
         with_timeout(2000000, || {
-            eprintln!("timeout test start...");
             sleep_ms(1000);
-            eprintln!("timeout test end");
         })
     }
 
@@ -56,7 +62,6 @@ pub mod test {
     #[should_panic]
     fn test_test_timeout_timeout() {
         with_timeout(1, || {
-            eprintln!("timeout panic test start...");
             sleep_ms(1000 * 1000);
         })
     }


### PR DESCRIPTION
### Description

Added Rustdoc and unit tests for `util_lib` (mod, boot, db, signed_structured_data).
- Fixed `boot_code_id` test logic.
- Removed `eprintln!` and unused imports.
- Verified with `fmt`, `clippy`, and `test`.

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo