### PR TITLE
Feat: update the default signer extend timeout to 60s

### DIFF
--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+
+## [Unreleased]
+
+### Changed
+
+- Reduced default tenure-extend idle timer from 120 seconds to 60 seconds
+
 ## [3.3.0.0.4.0]
 
 ### Fixed

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -42,7 +42,9 @@ const BLOCK_PROPOSAL_VALIDATION_TIMEOUT_MS: u64 = 120_000;
 const DEFAULT_FIRST_PROPOSAL_BURN_BLOCK_TIMING_SECS: u64 = 60;
 const DEFAULT_TENURE_LAST_BLOCK_PROPOSAL_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_DRY_RUN: bool = false;
-const TENURE_IDLE_TIMEOUT_SECS: u64 = 120;
+/// Default number of idle seconds before the signer will accept a
+///  tenure extend from the miner
+const TENURE_IDLE_TIMEOUT_SECS: u64 = 60;
 const READ_COUNT_IDLE_TIMEOUT_SECS: u64 = 20;
 const DEFAULT_REORG_ATTEMPTS_ACTIVITY_TIMEOUT_MS: u64 = 200_000;
 /// Default number of seconds to add to the tenure extend time, after computing the idle timeout,


### PR DESCRIPTION
This updates the default signer extend idle timer to 60s -- in observing signer node utilization, the current setting of 120s is very pessimistic, and nodes today can handle lower idle times.