### PR TITLE
fix(clarity_vm): make `slice?` runtime cost linear

### DIFF
--- a/clarity/src/vm/costs/costs_3.rs
+++ b/clarity/src/vm/costs/costs_3.rs
@@ -715,7 +715,7 @@ impl CostValues for Costs3 {
     }
 
     fn cost_slice(n: u64) -> Result<ExecutionCost, VmExecutionError> {
-        Ok(ExecutionCost::runtime(448))
+        Ok(ExecutionCost::runtime(linear(n, 1, 448)))
     }
 
     fn cost_to_consensus_buff(n: u64) -> Result<ExecutionCost, VmExecutionError> {

--- a/stackslib/src/chainstate/stacks/boot/costs-3.clar
+++ b/stackslib/src/chainstate/stacks/boot/costs-3.clar
@@ -614,7 +614,7 @@
     })
 
 (define-read-only (cost_slice (n uint))
-    (runtime u448))
+    (runtime (linear n u1 u448)))
 
 (define-read-only (cost_to_consensus_buff (n uint))
     (runtime (linear n u1 u233)))

--- a/stackslib/src/chainstate/stacks/boot/costs-4.clar
+++ b/stackslib/src/chainstate/stacks/boot/costs-4.clar
@@ -614,7 +614,7 @@
     })
 
 (define-read-only (cost_slice (n uint))
-    (runtime u448))
+    (runtime (linear n u1 u448)))
 
 (define-read-only (cost_to_consensus_buff (n uint))
     (runtime (linear n u1 u233)))

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -2013,3 +2013,35 @@ fn test_cost_change() {
 
     assert_eq!(result_33_large, result_33_small);
 }
+
+#[test]
+fn test_slice_cost_scales_with_size() {
+    let use_mainnet = false;
+
+    let cost_small = with_owned_env(StacksEpochId::Epoch30, use_mainnet, |mut owned_env| {
+        setup_cost_tracked_test(use_mainnet, ClarityVersion::Clarity2, &mut owned_env);
+        test_program_cost(
+            "(slice? 0x0001020304050607080910 u0 u5)", // 5 byte slice
+            ClarityVersion::Clarity2,
+            &mut owned_env,
+            0,
+        )
+    });
+
+    let cost_large = with_owned_env(StacksEpochId::Epoch30, use_mainnet, |mut owned_env| {
+        setup_cost_tracked_test(use_mainnet, ClarityVersion::Clarity2, &mut owned_env);
+        test_program_cost(
+            "(slice? 0x0001020304050607080910 u0 u10)", // 10 byte slice
+            ClarityVersion::Clarity2,
+            &mut owned_env,
+            0,
+        )
+    });
+
+    assert!(
+        cost_large.runtime > cost_small.runtime,
+        "Larger slice should cost more: large={}, small={}",
+        cost_large.runtime,
+        cost_small.runtime
+    );
+}


### PR DESCRIPTION
### Description

Update the Clarity `slice?` runtime cost model from a constant to a linear function of the slice size, matching the function’s actual O(n) behavior. 

### Applicable issues

- Fixes #6833

### Additional Info

The execution cost of `slice?` better aligns with the actual work performed, but contracts that use lots of large `slice?` calls will incur higher runtime costs than before (intended). Also, coefficients use a conservative `linear(n, 1, 448)` shape.

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo