### PR TITLE
fix(clarity): Allow traits to be used at top-level in the same contract

### DIFF
--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -128,18 +128,25 @@ pub fn special_contract_call(
                     } else {
                         let trait_name = trait_identifier.name.to_string();
 
-                        // Retrieve, from the trait definition, the expected method signature
-                        let contract_defining_trait = env
-                            .global_context
-                            .database
-                            .get_contract(&trait_identifier.contract_identifier)
-                            .map_err(|_e| {
-                                RuntimeCheckErrorKind::NoSuchContract(
-                                    trait_identifier.contract_identifier.to_string(),
-                                )
-                            })?;
-                        let contract_context_defining_trait =
-                            contract_defining_trait.contract_context;
+                        // Retrieve, from the trait definition, the expected method signature.
+                        // Check if the trait is defined in the contract context.
+                        let contract_context_defining_trait = if trait_identifier
+                            .contract_identifier
+                            == env.contract_context.contract_identifier
+                        {
+                            env.contract_context.clone()
+                        } else {
+                            let contract_defining_trait = env
+                                .global_context
+                                .database
+                                .get_contract(&trait_identifier.contract_identifier)
+                                .map_err(|_e| {
+                                    RuntimeCheckErrorKind::NoSuchContract(
+                                        trait_identifier.contract_identifier.to_string(),
+                                    )
+                                })?;
+                            contract_defining_trait.contract_context
+                        };
 
                         // Retrieve the function that will be invoked
                         let function_to_check = contract_context_to_check

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -129,10 +129,13 @@ pub fn special_contract_call(
                         let trait_name = trait_identifier.name.to_string();
 
                         // Retrieve, from the trait definition, the expected method signature.
-                        // Check if the trait is defined in the contract context.
-                        let contract_context_defining_trait = if trait_identifier
-                            .contract_identifier
-                            == env.contract_context.contract_identifier
+                        // Check if the trait is defined in the contract context (Clarity >= 5).
+                        let contract_context_defining_trait = if env
+                            .contract_context
+                            .get_clarity_version()
+                            .allows_local_trait_lookup()
+                            && trait_identifier.contract_identifier
+                                == env.contract_context.contract_identifier
                         {
                             env.contract_context.clone()
                         } else {

--- a/clarity/src/vm/tests/traits.rs
+++ b/clarity/src/vm/tests/traits.rs
@@ -2070,3 +2070,36 @@ fn test_pass_principal_literal_to_trait(
         );
     }
 }
+
+#[apply(test_clarity_versions)]
+fn test_trait_use_at_top_level_same_contract(
+    version: ClarityVersion,
+    epoch: StacksEpochId,
+    mut env_factory: MemoryEnvironmentGenerator,
+) {
+    let mut owned_env = env_factory.get_env(epoch);
+
+    let contract_foo = "(define-public (foo) (ok true))";
+
+    let contract_bar = "(define-trait trait-1 (
+            (foo () (response bool uint))))
+        (define-private (bar (F <trait-1>))
+            (unwrap-panic (contract-call? F foo)))
+        (bar .c-foo)";
+
+    let placeholder_context =
+        ContractContext::new(QualifiedContractIdentifier::transient(), version);
+    let mut env = owned_env.get_exec_environment(None, None, &placeholder_context);
+
+    env.initialize_contract(
+        QualifiedContractIdentifier::local("c-foo").unwrap(),
+        contract_foo,
+    )
+    .unwrap();
+
+    env.initialize_contract(
+        QualifiedContractIdentifier::local("c-bar").unwrap(),
+        contract_bar,
+    )
+    .expect("should initialize successfully");
+}

--- a/clarity/src/vm/tests/traits.rs
+++ b/clarity/src/vm/tests/traits.rs
@@ -2088,9 +2088,9 @@ fn test_trait_use_at_top_level_same_contract(
             (unwrap-panic (contract-call? F foo)))
         (bar .c-foo)";
 
-    let mut placeholder_context =
+    let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
-    let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
+    let mut env = owned_env.get_exec_environment(None, None, &placeholder_context);
 
     env.initialize_contract(
         QualifiedContractIdentifier::local("c-foo").unwrap(),

--- a/clarity/src/vm/tests/traits.rs
+++ b/clarity/src/vm/tests/traits.rs
@@ -2094,14 +2094,12 @@ fn test_trait_use_at_top_level_same_contract(
     env.initialize_contract(
         QualifiedContractIdentifier::local("c-foo").unwrap(),
         contract_foo,
-        ASTRules::PrecheckSize,
     )
     .unwrap();
 
     let contract_init_result = env.initialize_contract(
         QualifiedContractIdentifier::local("c-bar").unwrap(),
         contract_bar,
-        ASTRules::PrecheckSize,
     );
 
     if version.allows_local_trait_lookup() {

--- a/clarity/src/vm/version.rs
+++ b/clarity/src/vm/version.rs
@@ -51,6 +51,16 @@ impl ClarityVersion {
         ClarityVersion::Clarity5,
     ];
 
+    pub fn allows_local_trait_lookup(&self) -> bool {
+        match self {
+            ClarityVersion::Clarity1
+            | ClarityVersion::Clarity2
+            | ClarityVersion::Clarity3
+            | ClarityVersion::Clarity4 => false,
+            ClarityVersion::Clarity5 => true,
+        }
+    }
+
     pub fn default_for_epoch(epoch_id: StacksEpochId) -> ClarityVersion {
         match epoch_id {
             StacksEpochId::Epoch10 => {


### PR DESCRIPTION
### Description

Update trait lookup during `contract-call?` to check the current contract's context before querying the database, enabling contracts to use their own trait definitions at the top-level during initialization.

### Applicable issues

- Fixes #6831

### Additional Info

The trait lookup now checks the local `ContractContext` first when the trait identifier matches the current contract being initialized, preventing `NoSuchContract` errors during top-level execution.

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo