### PR TITLE
Chore: Merge 3.3.0.0.5 release to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,23 +11,28 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 - Setup for epoch 3.4 and Clarity version 5. Epoch 3.4 is currently set to activate at Bitcoin height 3,400,000 (very far in the future) until an activation height is selected. Clarity will activate with epoch 3.4.
 
+## [3.3.0.0.5]
+
+### Added
+
+- New endpoint `/v3/blocks/simulate/{block_id}` allows to simulate the execution of a specific block with a brand new set of transactions
+- Improved block validation in `stacks-inspect`.
+
+### Changed
+
+- Removed `validate-naka-block` option in `stacks-inspect`, merging it with `validate-block` so that users do not need to differentiate between the two.
+
 ## [3.3.0.0.4]
 
 ### Added
 
 - New `/v3/tenures/tip_metadata` endpoint for returning some metadata along with the normal tenure tip information.
-- New endpoint `/v3/blocks/simulate/{block_id}` allows to simulate the execution of a specific block with a brand new set of transactions
 
 ## [3.3.0.0.3]
 
 ### Added
 
 - In the `/v3/transaction/{txid}` RPC endpoint, added `block_height` and `is_canonical` to the response.
-- Improved block validation in `stacks-inspect`.
-
-### Changed
-
-- Removed `validate-naka-block` option in `stacks-inspect`, merging it with `validate-block` so that users do not need to differentiate between the two.
 
 ### Fixed
 

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -79,7 +79,7 @@ use stacks::core::{
     PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05,
     PEER_VERSION_EPOCH_2_1, PEER_VERSION_EPOCH_2_2, PEER_VERSION_EPOCH_2_3, PEER_VERSION_EPOCH_2_4,
     PEER_VERSION_EPOCH_2_5, PEER_VERSION_EPOCH_3_0, PEER_VERSION_EPOCH_3_1, PEER_VERSION_EPOCH_3_2,
-    PEER_VERSION_TESTNET,
+    PEER_VERSION_EPOCH_3_3, PEER_VERSION_TESTNET,
 };
 use stacks::libstackerdb::{SlotMetadata, StackerDBChunkData};
 use stacks::net::api::callreadonly::CallReadOnlyRequestBody;
@@ -237,7 +237,7 @@ lazy_static! {
             start_height: 253,
             end_height: STACKS_EPOCH_MAX,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_3_2
+            network_epoch: PEER_VERSION_EPOCH_3_3
         },
     ];
 }

--- a/stacks-signer/CHANGELOG.md
+++ b/stacks-signer/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-
 ## [Unreleased]
+
+## [3.3.0.0.5.0]
 
 ### Changed
 

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -4636,6 +4636,15 @@ impl NakamotoChainState {
             ));
         }
 
+        if parent_chain_tip.stacks_block_height.saturating_add(1) != block.header.chain_length {
+            warn!("Error processing nakamoto block: Parent height does not agree with block chain length";
+                  "parent_chain_tip.block_height" => %parent_chain_tip.stacks_block_height,
+                  "block.header.chain_length" => &block.header.chain_length);
+            return Err(ChainstateError::InvalidStacksBlock(
+                "Parent block height does not agree with child block".into(),
+            ));
+        }
+
         // look up this block's sortition's burnchain block hash and height.
         // It must exist in the same Bitcoin fork as our `burn_dbconn`.
         let tenure_block_snapshot =

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -546,6 +546,21 @@ impl NakamotoBlockProposal {
             });
         }
 
+        if self.block.header.chain_length
+            != parent_stacks_header.stacks_block_height.saturating_add(1)
+        {
+            warn!(
+                "Rejected block proposal";
+                "reason" => "Block height is non-contiguous with parent",
+                "block_height" => self.block.header.chain_length,
+                "parent_block_height" => parent_stacks_header.stacks_block_height,
+            );
+            return Err(BlockValidateRejectReason {
+                reason_code: ValidateRejectCode::InvalidBlock,
+                reason: "Block height is non-contiguous with parent".into(),
+            });
+        }
+
         let tenure_change = self
             .block
             .txs

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.3.0.0.4"
-stacks_signer_version = "3.3.0.0.4.0"
+stacks_node_version = "3.3.0.0.5"
+stacks_signer_version = "3.3.0.0.5.0"


### PR DESCRIPTION
This merges the 3.3.0.0.5 release to develop.

The only real merge conflicts were in the `CHANGELOG.md`