### PR TITLE
Remove second cache in bitcoin tests

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -32,11 +32,6 @@ jobs:
         with:
           btc-version: "25.0"
 
-      - name: Build Test Archive
-        run: |
-          set -euo pipefail
-          cargo nextest archive --archive-file ~/test_archive.tar.zst --bin stacks-node
-
       - name: List ignored tests
         id: list
         run: |


### PR DESCRIPTION
Removes the duplicate cache step in bitcoin-tests that reproduces the already existing `test_archive.tar.zst`, built only with `stacks-node` as opposed to the existing (and downloaded) cache built with all binaries. 

comparing develop to the branch being PR'ed here (which is develop with the cache step removed) i see both ci runs of bitcoin-tests result in 266 tests to be run. 

This branch simply uses the already existing nextest cache that is built for all CI runs in the `Create Test Cache` job (and is subsequently used for all test runs vs rebuilding). 

`develop`: https://github.com/wileyj/stacks-core/actions/runs/21649775746/job/62412455861#step:7:35
`chore/dedupe_bitcoin_test_cache`: https://github.com/wileyj/stacks-core/actions/runs/21650652585/job/62415354269#step:6:35

because there are so many tests being run though, both actions will take quite a bit of time to run completely - but it does result in a few minutes saved before the tests start (00:09:45 vs 00:02:07 - 7 minutes and 38 seconds faster). 

small improvement, but worth doing. 