### PR TITLE
Feat/min_size for type sigs

### DIFF
--- a/clarity-types/src/types/signatures.rs
+++ b/clarity-types/src/types/signatures.rs
@@ -22,7 +22,6 @@ use std::{cmp, fmt};
 use serde::{Deserialize, Serialize};
 use stacks_common::types::StacksEpochId;
 
-use crate::errors::CommonCheckErrorKind;
 use crate::representations::{CONTRACT_MAX_NAME_LENGTH, ClarityName, ContractName};
 use crate::types::{
     CharType, ClarityTypeError, MAX_TO_ASCII_BUFFER_LEN, MAX_TO_ASCII_RESULT_LEN, MAX_TYPE_DEPTH,
@@ -1440,16 +1439,16 @@ impl TypeSignature {
         }
     }
 
-    pub fn min_size(&self) -> Result<u32, CommonCheckErrorKind> {
+    pub fn min_size(&self) -> Result<u32, ClarityTypeError> {
         self.inner_min_size()?.ok_or_else(|| {
-            CommonCheckErrorKind::ExpectsAcceptable(
-                "FAIL: .size() overflowed on too large of a type. construction should have failed!"
+            ClarityTypeError::InvariantViolation(
+                "FAIL: .min_size() overflowed on too large of a type. Construction should have failed!"
                     .into(),
             )
         })
     }
 
-    fn inner_min_size(&self) -> Result<Option<u32>, CommonCheckErrorKind> {
+    fn inner_min_size(&self) -> Result<Option<u32>, ClarityTypeError> {
         let out = match self {
             // NoType's may be asked for their size at runtime --
             //  legal constructions like `(ok 1)` have NoType parts (if they have unknown error variant types).
@@ -1457,13 +1456,15 @@ impl TypeSignature {
             IntType => Some(16),
             UIntType => Some(16),
             BoolType => Some(1),
-            PrincipalType => Some(20),
             TupleType(tuple_sig) => tuple_sig.inner_min_size()?,
             SequenceType(SequenceSubtype::BufferType(_))
             | SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(_))) => Some(4),
-            SequenceType(SequenceSubtype::ListType(_)) => Some(5), // 1 for type enum, 4 for max_len
+            // Minimal list value is an empty list, which still carries list type metadata.
+            SequenceType(SequenceSubtype::ListType(list_type)) => list_type.type_size(),
             SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(_))) => Some(4),
-            OptionalType(t) => t.min_size()?.checked_add(WRAPPER_VALUE_SIZE),
+            // Optional types always admit `none`, so minimum size is fixed:
+            // 1 byte for NoType plus wrapper.
+            OptionalType(_) => Some(WRAPPER_VALUE_SIZE + 1),
             ResponseType(v) => {
                 // ResponseTypes are 1 byte for the committed bool,
                 //   plus min(err_type, ok_type)
@@ -1472,8 +1473,18 @@ impl TypeSignature {
                 let s_size = s.min_size()?;
                 cmp::min(t_size, s_size).checked_add(WRAPPER_VALUE_SIZE)
             }
-            CallableType(CallableSubtype::Principal(_)) | ListUnionType(_) => Some(21), // 20+1
-            CallableType(CallableSubtype::Trait(_)) | TraitReferenceType(_) => Some(22), // 20 + 1 + 1
+            PrincipalType | CallableType(CallableSubtype::Principal(_)) | ListUnionType(_) => {
+                // The actual value size is not computed for these types, so we need to just always
+                // return the size that `size()` returns for them, which is the maximum size of a
+                // contract principal with a 128 byte contract name.
+                Some(148)
+            }
+            CallableType(CallableSubtype::Trait(_)) | TraitReferenceType(_) => {
+                // The actual value size is not computed for these types, so we need to just always
+                // return the size that `size()` returns for them, which is the maximum size of a
+                // trait reference with a 128 byte contract name and 128 byte trait name.
+                Some(276)
+            }
         };
         Ok(out)
     }
@@ -1580,7 +1591,7 @@ impl TupleTypeSignature {
     /// Tuple Size:
     ///    size( btreemap<name, value> ) + type_size
     ///    size( btreemap<name, value> ) = 2*map.len() + sum(names) + sum(values)
-    fn inner_min_size(&self) -> Result<Option<u32>, CommonCheckErrorKind> {
+    fn inner_min_size(&self) -> Result<Option<u32>, ClarityTypeError> {
         let Some(mut total_size) = u32::try_from(self.type_map.len())
             .ok()
             .and_then(|x| x.checked_mul(2))


### PR DESCRIPTION
This functionality is needed for the [static cost analysis](https://github.com/stacks-network/stacks-core/pull/6704/changes#diff-1f50be89aa5ec48a91bba1ff74d43f2dd89a008581eca313f259d85e85c7a493R1442)

Splitting this out into a separate PR since it's the only part that touches existing core