### PR TITLE
chore: set auto target for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 0%
 comment:
   layout: "condensed_header, diff, files, footer"
   hide_project_coverage: false


### PR DESCRIPTION
This sets the target for the codecov status check to `auto`, which will be based off the head branch. Otherwise, we end up punishing PRs for code coverage results that they aren't responsible for (i.e., if the upstream has low coverage, its not the PRs fault).