### PR TITLE
fix: correct typos across codebase

### DIFF
--- a/clarity-types/src/representations.rs
+++ b/clarity-types/src/representations.rs
@@ -106,7 +106,7 @@ impl StacksMessageCodec for ClarityName {
         // must encode a valid string
         let s = String::from_utf8(bytes).map_err(|_e| {
             codec_error::DeserializeError(
-                "Failed to parse Clarity name: could not contruct from utf8".to_string(),
+                "Failed to parse Clarity name: could not construct from utf8".to_string(),
             )
         })?;
 

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -88,7 +88,7 @@ pub enum AssetMapEntry {
 }
 
 /**
-The AssetMap is used to track which assets have been transfered from whom
+The AssetMap is used to track which assets have been transferred from whom
 during the execution of a transaction.
 */
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -559,7 +559,7 @@ impl fmt::Display for AssetMap {
         }
         for (principal, principal_map) in self.asset_map.iter() {
             for (asset, transfer) in principal_map.iter() {
-                write!(f, "{principal} transfered [")?;
+                write!(f, "{principal} transferred [")?;
                 for t in transfer {
                     write!(f, "{t}, ")?;
                 }

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2207,7 +2207,7 @@ const MINT_TOKEN: SpecialAPI = SpecialAPI {
     output_type: "(response bool uint)",
     signature: "(ft-mint? token-name amount recipient)",
     description: "`ft-mint?` is used to increase the token balance for the `recipient` principal for a token
-type defined using `define-fungible-token`. The increased token balance is _not_ transfered from another principal, but
+type defined using `define-fungible-token`. The increased token balance is _not_ transferred from another principal, but
 rather minted.
 
 If a non-positive amount is provided to mint, this function returns `(err 1)`. Otherwise, on successfully mint, it
@@ -2339,7 +2339,7 @@ const BURN_TOKEN: SpecialAPI = SpecialAPI {
     output_type: "(response bool uint)",
     signature: "(ft-burn? token-name amount sender)",
     description: "`ft-burn?` is used to decrease the token balance for the `sender` principal for a token
-type defined using `define-fungible-token`. The decreased token balance is _not_ transfered to another principal, but
+type defined using `define-fungible-token`. The decreased token balance is _not_ transferred to another principal, but
 rather destroyed, reducing the circulating supply.
 
 On a successful burn, it returns `(ok true)`. The burn may fail with error code:

--- a/contrib/boot-contracts-stateful-prop-tests/tests/pox-4/pox_CommandModel.ts
+++ b/contrib/boot-contracts-stateful-prop-tests/tests/pox-4/pox_CommandModel.ts
@@ -126,7 +126,7 @@ export class Stub {
               burnBlockHeight,
         );
 
-        // Get the operator's pool stackers that no longer have partially commited
+        // Get the operator's pool stackers that no longer have partially committed
         // STX for the next reward cycle by comparing their unlock height to
         // the next reward cycle's first block (only if the wallet is an operator).
         const stackersToRemoveAmountToCommit = wallet.lockedAddresses.filter((
@@ -167,7 +167,7 @@ export class Stub {
           wallet.lockedAddresses.splice(expStackerIndex, 1);
         });
 
-        // For each pool stacker that no longer have partially commited STX for
+        // For each pool stacker that no longer have partially committed STX for
         // the next reward cycle, decrement the operator's amountToCommit
         // (partial-stacked) by the stacker's amountLocked.
         stackersToRemoveAmountToCommit.forEach((expStacker) => {

--- a/libsigner/src/events.rs
+++ b/libsigner/src/events.rs
@@ -184,7 +184,7 @@ pub enum SignerEvent<T: SignerEventTrait> {
     SignerMessages {
         /// The signer set to which the message belongs (either 0 or 1)
         signer_set: u32,
-        /// Each message of type `T` is paired with the `StacksPublicKey` of the slot from which it was retreived
+        /// Each message of type `T` is paired with the `StacksPublicKey` of the slot from which it was retrieved
         messages: Vec<(StacksPublicKey, T)>,
         /// the time at which this event was received by the signer's event processor
         received_time: SystemTime,

--- a/libsigner/src/tests/signer_state.rs
+++ b/libsigner/src/tests/signer_state.rs
@@ -212,7 +212,7 @@ fn determine_latest_supported_signer_protocol_versions() {
         panic!("Unexpected state machine update message version");
     };
 
-    // Let's update 3 signers (60 percent) to support seperate but greater protocol versions
+    // Let's update 3 signers (60 percent) to support separate but greater protocol versions
     for (i, address) in addresses.into_iter().skip(1).take(3).enumerate() {
         let new_version = local_update.local_supported_signer_protocol_version + i as u64 + 1;
         let new_update = StateMachineUpdateMessage::new(

--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -273,7 +273,7 @@ impl StacksMessageCodec for SignerMessage {
     }
 }
 
-/// Work around for the fact that a lot of the structs being desierialized are not defined in messages.rs
+/// Work around for the fact that a lot of the structs being deserialized are not defined in messages.rs
 pub trait StacksMessageCodecExtensions: Sized {
     /// Serialize the struct to the provided writer
     fn inner_consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), CodecError>;
@@ -326,7 +326,7 @@ impl StacksMessageCodec for PeerInfo {
         // must encode a valid string
         let server_version = String::from_utf8(bytes).map_err(|_e| {
             CodecError::DeserializeError(
-                "Failed to parse server version name: could not contruct from utf8".to_string(),
+                "Failed to parse server version name: could not construct from utf8".to_string(),
             )
         })?;
         let pox_consensus = read_next::<ConsensusHash, _>(fd)?;

--- a/stacks-common/src/types/chainstate.rs
+++ b/stacks-common/src/types/chainstate.rs
@@ -85,7 +85,7 @@ impl TrieHash {
     }
 
     /// Convert to a String that can be used in e.g. sqlite
-    /// If we did not implement this seperate from Display,
+    /// If we did not implement this separate from Display,
     /// we would use the stacks_common::util::hash::to_hex function
     /// which is the unrolled version of this function.
     #[allow(clippy::inherent_to_string_shadow_display)]

--- a/stacks-node/src/run_loop/neon.rs
+++ b/stacks-node/src/run_loop/neon.rs
@@ -908,7 +908,7 @@ impl RunLoop {
                 let peer_network = node.join();
 
                 // Data that will be passed to Nakamoto run loop
-                // Only gets transfered on clean shutdown of neon run loop
+                // Only gets transferred on clean shutdown of neon run loop
                 let data_to_naka = Neon2NakaData::new(globals, peer_network);
 
                 info!("Exiting stacks-node");
@@ -1031,7 +1031,7 @@ impl RunLoop {
                                 let peer_network = node.join();
 
                                 // Data that will be passed to Nakamoto run loop
-                                // Only gets transfered on clean shutdown of neon run loop
+                                // Only gets transferred on clean shutdown of neon run loop
                                 let data_to_naka = Neon2NakaData::new(globals, peer_network);
 
                                 info!("Exiting stacks-node");
@@ -1103,7 +1103,7 @@ impl RunLoop {
                             let peer_network = node.join();
 
                             // Data that will be passed to Nakamoto run loop
-                            // Only gets transfered on clean shutdown of neon run loop
+                            // Only gets transferred on clean shutdown of neon run loop
                             let data_to_naka = Neon2NakaData::new(globals, peer_network);
 
                             info!("Exiting stacks-node");

--- a/stacks-node/src/tests/integrations.rs
+++ b/stacks-node/src/tests/integrations.rs
@@ -1298,7 +1298,7 @@ fn contract_stx_transfer() {
                         &chain_tip.metadata.consensus_hash,
                         chain_tip.metadata.anchored_header.block_hash(),
                     );
-                    // check that 1000 stx _was_ transfered to the contract principal
+                    // check that 1000 stx _was_ transferred to the contract principal
                     assert_eq!(
                         chain_state
                             .with_read_only_clarity_tx(
@@ -1348,7 +1348,7 @@ fn contract_stx_transfer() {
                     //   the second publish _should have been rejected_
                     assert_eq!(chain_tip.block.txs.len(), 2);
 
-                    // check that 1 stx was transfered to SK_2 via the contract-call
+                    // check that 1 stx was transferred to SK_2 via the contract-call
                     let cur_tip = (
                         &chain_tip.metadata.consensus_hash,
                         chain_tip.metadata.anchored_header.block_hash(),
@@ -1589,7 +1589,7 @@ fn mine_transactions_out_of_order() {
                     assert_eq!(chain_tip.metadata.stacks_block_height, 5);
                     assert_eq!(chain_tip.block.txs.len(), 5);
 
-                    // check that 1000 stx _was_ transfered to the contract principal
+                    // check that 1000 stx _was_ transferred to the contract principal
                     let curr_tip = (
                         &chain_tip.metadata.consensus_hash,
                         chain_tip.metadata.anchored_header.block_hash(),
@@ -1883,7 +1883,7 @@ fn bad_contract_tx_rollback() {
                         &chain_tip.metadata.consensus_hash,
                         chain_tip.metadata.anchored_header.block_hash(),
                     );
-                    // check that 1000 stx _was_ transfered to the contract principal
+                    // check that 1000 stx _was_ transferred to the contract principal
                     assert_eq!(
                         chain_state
                             .with_read_only_clarity_tx(

--- a/stacks-node/src/tests/signer/v0/mod.rs
+++ b/stacks-node/src/tests/signer/v0/mod.rs
@@ -3527,7 +3527,7 @@ fn duplicate_signers() {
     let accepted = signer_accepted_responses
         .iter()
         .min_by_key(|accepted| accepted.signer_signature_hash.clone())
-        .expect("No `BlockResponse::Accepted` messages recieved");
+        .expect("No `BlockResponse::Accepted` messages received");
     let selected_sighash = accepted.signer_signature_hash.clone();
 
     // Filter only resonses for selected block and collect unique pubkeys and signatures

--- a/stacks-node/src/tests/signer/v0/tx_replay.rs
+++ b/stacks-node/src/tests/signer/v0/tx_replay.rs
@@ -1442,7 +1442,7 @@ fn tx_replay_rejected_when_forking_across_reward_cycle() {
 /// - Trigger a Bitcoin fork
 /// - Verify that signers stay into tx replay state [Tx1]
 /// - In the end, let the miner solve the Tx Replay Set
-fn tx_replay_with_fork_occured_before_starting_replaying_txs() {
+fn tx_replay_with_fork_occurred_before_starting_replaying_txs() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
     }

--- a/stacks-signer/src/signerdb.rs
+++ b/stacks-signer/src/signerdb.rs
@@ -336,7 +336,7 @@ impl BlockInfo {
         )
     }
 
-    /// Check if the block is pre-commited, locally accepted or locally rejected
+    /// Check if the block is pre-committed, locally accepted or locally rejected
     pub fn is_locally_finalized(&self) -> bool {
         matches!(
             self.state,

--- a/stackslib/src/burnchains/bitcoin/indexer.rs
+++ b/stackslib/src/burnchains/bitcoin/indexer.rs
@@ -1118,7 +1118,7 @@ impl BurnchainIndexer for BitcoinIndexer {
         Ok(new_height)
     }
 
-    /// Drop headers after a given height -- i.e. to accomodate a reorg
+    /// Drop headers after a given height -- i.e. to accommodate a reorg
     fn drop_headers(&mut self, new_height: u64) -> Result<(), burnchain_error> {
         let mut spv_client = SpvClient::new(
             &self.config.spv_headers_path,

--- a/stackslib/src/burnchains/burnchain.rs
+++ b/stackslib/src/burnchains/burnchain.rs
@@ -307,7 +307,7 @@ impl BurnchainStateTransition {
         let window_start_height = window_end_height + 1 - (windowed_block_commits.len() as u64);
         let mut burn_blocks = vec![false; windowed_block_commits.len()];
 
-        // set burn_blocks flags to accomodate prepare phases and PoX sunset
+        // set burn_blocks flags to accommodate prepare phases and PoX sunset
         for (i, b) in burn_blocks.iter_mut().enumerate() {
             if PoxConstants::has_pox_sunset(epoch_id)
                 && burnchain

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -1342,7 +1342,7 @@ impl<'a> SortitionHandleTx<'a> {
             .map(|result| result.is_some())
     }
 
-    /// Get the latest block snapshot on this fork where a sortition occured.
+    /// Get the latest block snapshot on this fork where a sortition occurred.
     /// Search snapshots up to (but excluding) the given block height.
     /// Will always return a snapshot -- even if it's the initial sentinel snapshot.
     pub fn get_last_snapshot_with_sortition(
@@ -2212,7 +2212,7 @@ impl<'a> SortitionHandleConn<'a> {
         Ok(Some((block_commit, stacks_chain_tip)))
     }
 
-    /// Get the latest block snapshot on this fork where a sortition occured.
+    /// Get the latest block snapshot on this fork where a sortition occurred.
     /// Search snapshots up to (but excluding) the given block height.
     /// Will always return a snapshot -- even if it's the initial sentinel snapshot.
     pub fn get_last_snapshot_with_sortition(
@@ -2258,7 +2258,7 @@ impl<'a> SortitionHandleConn<'a> {
         })
     }
 
-    /// Get the latest block snapshot on this fork where a sortition occured.
+    /// Get the latest block snapshot on this fork where a sortition occurred.
     pub fn get_last_snapshot_with_sortition_from_tip(&self) -> Result<BlockSnapshot, db_error> {
         let ancestor_hash =
             match self.get_indexed(&self.context.chain_tip, db_keys::last_sortition())? {
@@ -5247,7 +5247,7 @@ impl SortitionDB {
         }
     }
 
-    /// Get the latest block snapshot on this fork where a sortition occured.
+    /// Get the latest block snapshot on this fork where a sortition occurred.
     /// Search snapshots up to (but excluding) the given block height.
     /// Will always return a snapshot -- even if it's the initial sentinel snapshot.
     pub fn get_last_snapshot_with_sortition_tx(

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -396,8 +396,8 @@ impl LeaderBlockCommitOp {
                 return Err(op_error::InvalidInput);
             }
 
-            // compute the total amount transfered/burned, and check that the burn amount
-            //   is expected given the amount transfered.
+            // compute the total amount transferred/burned, and check that the burn amount
+            //   is expected given the amount transferred.
             let burn_fee = pox_fee
                 .expect("A 0-len output should have already errored")
                 .checked_mul(u64::try_from(OUTPUTS_PER_COMMIT).expect(">2^64 outputs per commit")) // total commitment is the pox_amount * outputs

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -869,7 +869,7 @@ impl StacksChainState {
     /// * contains the block height of the block with the slashed microblock public key hash
     /// * contains the microblock public key hash
     /// * contains the sender that reported the poison-microblock
-    /// * contains the sequence number at which the fork occured
+    /// * contains the sequence number at which the fork occurred
     pub fn handle_poison_microblock(
         env: &mut Environment,
         mblock_header_1: &StacksMicroblockHeader,

--- a/stackslib/src/chainstate/tests/consensus.rs
+++ b/stackslib/src/chainstate/tests/consensus.rs
@@ -1128,7 +1128,7 @@ impl ContractConsensusTest<'_> {
 
                 let epoch_name = format!("Epoch{}", epoch.to_string().replace('.', "_"));
 
-                // Each deployment is a seperate TestBlock
+                // Each deployment is a separate TestBlock
                 for &version in clarity_versions {
                     let version_tag = version.to_string().replace(' ', "");
                     let name = format!("{contract_name}-{epoch_name}-{version_tag}");

--- a/stackslib/src/config/chain_data.rs
+++ b/stackslib/src/config/chain_data.rs
@@ -132,7 +132,7 @@ impl MinerStats {
         let window_start_height = window_end_height + 1 - (windowed_block_commits.len() as u64);
         let mut burn_blocks = vec![false; windowed_block_commits.len()];
 
-        // set burn_blocks flags to accomodate prepare phases and PoX sunset
+        // set burn_blocks flags to accommodate prepare phases and PoX sunset
         for (i, b) in burn_blocks.iter_mut().enumerate() {
             if burnchain.is_in_prepare_phase(window_start_height + (i as u64)) {
                 // must burn

--- a/stackslib/src/net/neighbors/walk.rs
+++ b/stackslib/src/net/neighbors/walk.rs
@@ -974,7 +974,7 @@ impl<DB: NeighborWalkDB, NC: NeighborComms> NeighborWalk<DB, NC> {
         Ok(true)
     }
 
-    /// Begin getting the neighors of cur_neighbor's neighbors.
+    /// Begin getting the neighbors of cur_neighbor's neighbors.
     /// ReplyHandleP2Ps should be reply handles for Handshake requests.
     pub fn neighbor_handshakes_begin(
         &mut self,

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -587,7 +587,7 @@ pub struct PeerNetwork {
     public_ip_reply_handle: Option<ReplyHandleP2P>,
     public_ip_retries: u64,
 
-    // how many loops of the state-machine have occured?
+    // how many loops of the state-machine have occurred?
     // Used to coordinate with the chain synchronization logic to ensure that the node has at least
     // begun to download blocks after fetching the next reward cycles' sortitions.
     pub num_state_machine_passes: u64,
@@ -5782,7 +5782,7 @@ mod test {
                     thread::sleep(time::Duration::from_millis(500));
                 }
 
-                // peer_2 had better have recieved that ping
+                // peer_2 had better have received that ping
                 let mut got_ping = false;
                 for (_, convo) in peer_2.network.peers.iter() {
                     got_ping = got_ping

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -1896,7 +1896,7 @@ impl Relayer {
         true
     }
 
-    /// Process blocks and microblocks that we recieved, both downloaded (confirmed) and streamed
+    /// Process blocks and microblocks that we received, both downloaded (confirmed) and streamed
     /// (unconfirmed). Returns:
     /// * set of consensus hashes that elected the newly-discovered blocks, and the blocks, so we can turn them into BlocksAvailable / BlocksData messages
     /// * set of confirmed microblock consensus hashes for newly-discovered microblock streams, and the streams, so we can turn them into MicroblocksAvailable / MicroblocksData messages

--- a/stackslib/src/net/rpc.rs
+++ b/stackslib/src/net/rpc.rs
@@ -55,7 +55,7 @@ pub struct ConversationHttp {
     total_request_count: u64,
     /// number of messages sent
     total_reply_count: u64,
-    /// absolute timestamp of the last time we recieved at least 1 byte
+    /// absolute timestamp of the last time we received at least 1 byte
     last_request_timestamp: u64,
     /// absolute timestamp of the last time we sent at least 1 byte
     last_response_timestamp: u64,

--- a/stackslib/src/util_lib/strings.rs
+++ b/stackslib/src/util_lib/strings.rs
@@ -155,7 +155,7 @@ impl StacksMessageCodec for UrlString {
         // must encode a valid string
         let s = String::from_utf8(bytes).map_err(|_e| {
             codec_error::DeserializeError(
-                "Failed to parse URL string: could not contruct from utf8".to_string(),
+                "Failed to parse URL string: could not construct from utf8".to_string(),
             )
         })?;
 


### PR DESCRIPTION
## Summary

Fix 39 spelling errors across 25 files in comments, doc strings, and error messages. No changes to database columns, struct field names, or SQL schemas.

**Typos fixed:**
| Typo | Correction | Count |
|------|-----------|-------|
| desierialized | deserialized | 1 |
| contruct | construct | 3 |
| accomodate | accommodate | 3 |
| occured | occurred | 5 + 1 test fn |
| recieved | received | 4 |
| seperate | separate | 3 |
| transfered | transferred | 10 |
| neighor | neighbor | 1 |
| retreive | retrieve | 1 |
| commited | committed | 3 |
| pre-commited | pre-committed | 1 |

## Test plan

- [x] Comment and doc-only changes — no functional impact
- [x] One test function renamed (`tx_replay_with_fork_occured_...` → `tx_replay_with_fork_occurred_...`) — only referenced by `#[test]` attribute
- [x] No database column/field names modified

Closes #5292