### PR TITLE
fix: remove duplicate binary name in signer --version output

### DIFF
--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -79,10 +79,19 @@ pub trait SignerMessage<T: MessageSlotID>: StacksMessageCodec {
 }
 
 lazy_static! {
-    /// The version string for the signer
+    /// The version string for the signer (includes binary name prefix)
     pub static ref VERSION_STRING: String = {
         let pkg_version = option_env!("STACKS_NODE_VERSION").or(Some(STACKS_SIGNER_VERSION));
         version_string("stacks-signer", pkg_version)
+    };
+
+    /// Version info without the binary name prefix, for use with clap's
+    /// `long_version` which already prepends the binary name.
+    pub static ref VERSION_INFO: String = {
+        VERSION_STRING
+            .strip_prefix("stacks-signer ")
+            .unwrap_or(&VERSION_STRING)
+            .to_string()
     };
 }
 

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -29,7 +29,7 @@ use clarity::util::hash::Sha256Sum;
 use clarity::util::secp256k1::MessageSignature;
 use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
 use clarity::vm::Value;
-use libsigner::VERSION_STRING;
+use libsigner::VERSION_INFO;
 use serde::{Deserialize, Serialize};
 use stacks_common::address::{
     b58, AddressHashMode, C32_ADDRESS_VERSION_MAINNET_MULTISIG,
@@ -43,7 +43,7 @@ extern crate alloc;
 
 /// The CLI arguments for the stacks signer
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_version = VERSION_STRING.as_str())]
+#[command(author, version, about, long_version = VERSION_INFO.as_str())]
 pub struct Cli {
     /// Subcommand action to take
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

- Clap's `long_version` attribute automatically prepends the binary name to the version string
- `VERSION_STRING` already includes `"stacks-signer "` as a prefix (from `version_string("stacks-signer", ...)`)
- This caused `stacks-signer --version` to output `stacks-signer stacks-signer 3.3.0.0.5.0 (...)`
- Add `VERSION_INFO` (strips the binary name prefix) and use it for clap's `long_version`
- `VERSION_STRING` is preserved unchanged for peer protocol messages in `v0/messages.rs`

**Before:**
```
stacks-signer stacks-signer 3.3.0.0.5.0 (abc123+, release build, linux [x86_64])
```

**After:**
```
stacks-signer 3.3.0.0.5.0 (abc123+, release build, linux [x86_64])
```

## Test plan

- [ ] Run `stacks-signer --version` and verify no duplicate binary name
- [ ] Run `stacks-signer -V` and verify short version still works
- [ ] Existing `test_version_string` test passes (VERSION_STRING unchanged)

Closes #5874