### PR TITLE
fix: only log "Proceeding to mine blocks" when node is a miner

### DIFF
--- a/stacks-node/src/run_loop/neon.rs
+++ b/stacks-node/src/run_loop/neon.rs
@@ -1083,9 +1083,15 @@ impl RunLoop {
 
                     // at tip, and not downloading. proceed to mine.
                     if last_tenure_sortition_height != sortition_db_height {
-                        info!(
-                            "Runloop: Synchronized full burnchain up to height {sortition_db_height}. Proceeding to mine blocks"
-                        );
+                        if is_miner {
+                            info!(
+                                "Runloop: Synchronized full burnchain up to height {sortition_db_height}. Proceeding to mine blocks"
+                            );
+                        } else {
+                            info!(
+                                "Runloop: Synchronized full burnchain up to height {sortition_db_height}."
+                            );
+                        }
                         last_tenure_sortition_height = sortition_db_height;
                     }
 


### PR DESCRIPTION
## Summary

The neon run loop unconditionally logs `"Proceeding to mine blocks"` when synchronized to the burn chain tip, even for follower nodes that are not configured to mine. This is misleading for operators running non-mining nodes.

The nakamoto run loop already has the correct `is_miner` guard — this brings the neon run loop into parity.

## Changes

- Wrap the `"Proceeding to mine blocks"` log in `neon.rs` with an `if is_miner` check
- Non-miners now log `"Synchronized full burnchain up to height {n}."` (without the mining message)

## Test plan

- [x] Log-only change — no functional impact
- [x] Matches existing pattern in `nakamoto.rs` (lines 715-722)

Closes #4944

🤖 Generated with [Claude Code](https://claude.com/claude-code)