### PR TITLE
refactor: replace lazy_static! with std::sync::LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ exclude = ["contrib/tools/config-docs-generator"]
 [workspace.dependencies]
 ed25519-dalek = { version = "2.1.1", default-features = false }
 hashbrown = { version = "0.15.2", features = ["serde"] }
-lazy_static = "1.4.0"
 rand_core = "0.6.4"
 rand = "0.8"
 rand_chacha = "0.3.1"

--- a/clarity-types/Cargo.toml
+++ b/clarity-types/Cargo.toml
@@ -10,7 +10,6 @@ keywords = [ "stacks", "stx", "bitcoin", "crypto", "blockstack", "decentralized"
 readme = "README.md"
 
 [dependencies]
-lazy_static = { workspace = true }
 regex = { version = "1", default-features = false }
 rusqlite = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/clarity-types/src/representations.rs
+++ b/clarity-types/src/representations.rs
@@ -18,7 +18,8 @@ use std::fmt;
 use std::io::{Read, Write};
 use std::ops::Deref;
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use regex::Regex;
 use stacks_common::codec::{Error as codec_error, StacksMessageCodec, read_next, write_next};
 
@@ -30,36 +31,36 @@ pub const CONTRACT_MIN_NAME_LENGTH: usize = 1;
 pub const CONTRACT_MAX_NAME_LENGTH: usize = 40;
 pub const MAX_STRING_LEN: u8 = 128;
 
-lazy_static! {
-    pub static ref STANDARD_PRINCIPAL_REGEX_STRING: String =
-        "[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}".into();
-    pub static ref CONTRACT_NAME_REGEX_STRING: String = format!(
+pub static STANDARD_PRINCIPAL_REGEX_STRING: LazyLock<String> =
+    LazyLock::new(|| "[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}".into());
+pub static CONTRACT_NAME_REGEX_STRING: LazyLock<String> = LazyLock::new(|| {
+    format!(
         r#"([a-zA-Z](([a-zA-Z0-9]|[-_])){{{},{}}})"#,
         CONTRACT_MIN_NAME_LENGTH - 1,
         // NOTE: this is deliberate.  Earlier versions of the node will accept contract principals whose names are up to
         // 128 bytes.  This behavior must be preserved for backwards-compatibility.
         MAX_STRING_LEN - 1
-    );
-    pub static ref CONTRACT_PRINCIPAL_REGEX_STRING: String = format!(
+    )
+});
+pub static CONTRACT_PRINCIPAL_REGEX_STRING: LazyLock<String> = LazyLock::new(|| {
+    format!(
         r#"{}(\.){}"#,
         *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING
-    );
-    pub static ref PRINCIPAL_DATA_REGEX_STRING: String = format!(
+    )
+});
+pub static PRINCIPAL_DATA_REGEX_STRING: LazyLock<String> = LazyLock::new(|| {
+    format!(
         "({})|({})",
         *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_PRINCIPAL_REGEX_STRING
-    );
-    pub static ref CLARITY_NAME_REGEX_STRING: String =
-        "^[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*])*$|^[-+=/*]$|^[<>]=?$".into();
-    pub static ref CLARITY_NAME_REGEX: Regex =
-    {
-        Regex::new(CLARITY_NAME_REGEX_STRING.as_str()).unwrap()
-    };
-    pub static ref CONTRACT_NAME_REGEX: Regex =
-    {
-        Regex::new(format!("^{}$|^__transient$", CONTRACT_NAME_REGEX_STRING.as_str()).as_str())
-            .unwrap()
-    };
-}
+    )
+});
+pub static CLARITY_NAME_REGEX_STRING: LazyLock<String> =
+    LazyLock::new(|| "^[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*])*$|^[-+=/*]$|^[<>]=?$".into());
+pub static CLARITY_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(CLARITY_NAME_REGEX_STRING.as_str()).unwrap());
+pub static CONTRACT_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(format!("^{}$|^__transient$", CONTRACT_NAME_REGEX_STRING.as_str()).as_str()).unwrap()
+});
 
 guarded_string!(
     ClarityName,

--- a/clarity-types/src/types/serialization.rs
+++ b/clarity-types/src/types/serialization.rs
@@ -16,7 +16,8 @@
 use std::io::{Read, Write};
 use std::{cmp, error, str};
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use stacks_common::codec::{Error as codec_error, StacksMessageCodec};
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::{hex_bytes, to_hex};
@@ -48,12 +49,10 @@ pub enum SerializationError {
     UnexpectedSerialization,
 }
 
-lazy_static! {
-    pub static ref NONE_SERIALIZATION_LEN: u64 = {
-        #[allow(clippy::unwrap_used)]
-        u64::try_from(Value::none().serialize_to_vec().unwrap().len()).unwrap()
-    };
-}
+pub static NONE_SERIALIZATION_LEN: LazyLock<u64> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    u64::try_from(Value::none().serialize_to_vec().unwrap().len()).unwrap()
+});
 
 /// Deserialization uses a specific epoch for passing to the type signature checks
 /// The reason this is pinned to Epoch21 is so that values stored before epoch-2.4

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -22,7 +22,6 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"
-lazy_static = { workspace = true }
 integer-sqrt = "0.1.3"
 slog = { workspace = true }
 stacks_common = { package = "stacks-common", path = "../stacks-common", default-features = false }

--- a/clarity/src/vm/ast/parser/v1.rs
+++ b/clarity/src/vm/ast/parser/v1.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use regex::{Captures, Regex};
 use stacks_common::util::hash::hex_bytes;
 
@@ -107,26 +108,32 @@ fn get_lines_at(input: &str) -> Vec<usize> {
     out
 }
 
-lazy_static! {
-    pub static ref STANDARD_PRINCIPAL_REGEX: String =
-        "[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}".into();
-    pub static ref CONTRACT_NAME_REGEX: String = format!(
+pub static STANDARD_PRINCIPAL_REGEX: LazyLock<String> =
+    LazyLock::new(|| "[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}".into());
+pub static CONTRACT_NAME_REGEX: LazyLock<String> = LazyLock::new(|| {
+    format!(
         r#"([a-zA-Z](([a-zA-Z0-9]|[-_])){{{},{}}})"#,
         CONTRACT_MIN_NAME_LENGTH - 1,
         CONTRACT_MAX_NAME_LENGTH - 1
-    );
-    pub static ref CONTRACT_PRINCIPAL_REGEX: String = format!(
+    )
+});
+pub static CONTRACT_PRINCIPAL_REGEX: LazyLock<String> = LazyLock::new(|| {
+    format!(
         r#"{}(\.){}"#,
         *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX
-    );
-    pub static ref PRINCIPAL_DATA_REGEX: String = format!(
+    )
+});
+pub static PRINCIPAL_DATA_REGEX: LazyLock<String> = LazyLock::new(|| {
+    format!(
         "({})|({})",
         *STANDARD_PRINCIPAL_REGEX, *CONTRACT_PRINCIPAL_REGEX
-    );
-    pub static ref CLARITY_NAME_REGEX: String =
-        format!(r#"([[:word:]]|[-!?+<>=/*]){{1,{MAX_STRING_LEN}}}"#);
+    )
+});
+pub static CLARITY_NAME_REGEX: LazyLock<String> =
+    LazyLock::new(|| format!(r#"([[:word:]]|[-!?+<>=/*]){{1,{MAX_STRING_LEN}}}"#));
 
-    static ref lex_matchers: Vec<LexMatcher> = vec![
+static LEX_MATCHERS: LazyLock<Vec<LexMatcher>> = LazyLock::new(|| {
+    vec![
         LexMatcher::new(
             r#"u"(?P<value>((\\")|([[ -~]&&[^"]]))*)""#,
             TokenType::StringUTF8Literal,
@@ -181,8 +188,8 @@ lazy_static! {
             &format!("(?P<value>{})", *CLARITY_NAME_REGEX),
             TokenType::Variable,
         ),
-    ];
-}
+    ]
+});
 
 /// Lex the contract, permitting nesting of lists and tuples up to
 /// `depth_limits.max_nesting_depth()`.
@@ -215,7 +222,7 @@ fn inner_lex(input: &str, depth_limits: StackDepthLimits) -> ParseResult<Vec<(Le
 
         did_match = false;
         let current_slice = &input[munch_index..];
-        for matcher in lex_matchers.iter() {
+        for matcher in LEX_MATCHERS.iter() {
             if let Some(captures) = matcher.matcher.captures(current_slice) {
                 let whole_match = captures.get(0).ok_or(ParseErrorKind::InterpreterFailure)?;
                 assert_eq!(whole_match.start(), 0);

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -24,7 +24,8 @@ use costs_2::Costs2;
 use costs_2_testnet::Costs2Testnet;
 use costs_3::Costs3;
 use costs_4::Costs4;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use serde::{Deserialize, Serialize};
 use stacks_common::types::StacksEpochId;
 
@@ -63,21 +64,19 @@ pub const COSTS_2_NAME: &str = "costs-2";
 pub const COSTS_3_NAME: &str = "costs-3";
 pub const COSTS_4_NAME: &str = "costs-4";
 
-lazy_static! {
-    static ref COST_TUPLE_TYPE_SIGNATURE: TypeSignature = {
-        #[allow(clippy::expect_used)]
-        TypeSignature::TupleType(
-            TupleTypeSignature::try_from(vec![
-                ("runtime".into(), TypeSignature::UIntType),
-                ("write_length".into(), TypeSignature::UIntType),
-                ("write_count".into(), TypeSignature::UIntType),
-                ("read_count".into(), TypeSignature::UIntType),
-                ("read_length".into(), TypeSignature::UIntType),
-            ])
-            .expect("BUG: failed to construct type signature for cost tuple"),
-        )
-    };
-}
+static COST_TUPLE_TYPE_SIGNATURE: LazyLock<TypeSignature> = LazyLock::new(|| {
+    #[allow(clippy::expect_used)]
+    TypeSignature::TupleType(
+        TupleTypeSignature::try_from(vec![
+            ("runtime".into(), TypeSignature::UIntType),
+            ("write_length".into(), TypeSignature::UIntType),
+            ("write_count".into(), TypeSignature::UIntType),
+            ("read_count".into(), TypeSignature::UIntType),
+            ("read_length".into(), TypeSignature::UIntType),
+        ])
+        .expect("BUG: failed to construct type signature for cost tuple"),
+    )
+});
 
 pub fn runtime_cost<T: TryInto<u64>, C: CostTracker>(
     cost_function: ClarityCostFunction,

--- a/contrib/clarity-cli/Cargo.toml
+++ b/contrib/clarity-cli/Cargo.toml
@@ -9,7 +9,6 @@ clarity = { path = "../../clarity", default-features = false }
 stackslib = { package = "stackslib", path = "../../stackslib", default-features = false }
 stacks-common = { path = "../../stacks-common", default-features = false }
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }
-lazy_static = { version = "1.4.0", default-features = false }
 serde = { version = "1" }
 serde_derive = "1"
 serde_json = { workspace = true }

--- a/contrib/clarity-cli/src/lib.rs
+++ b/contrib/clarity-cli/src/lib.rs
@@ -34,7 +34,7 @@ use clarity::vm::{
     ClarityVersion, ContractContext, ContractName, SymbolicExpression, Value, analysis, ast,
     eval_all,
 };
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use rand::Rng;
 use rusqlite::{Connection, OpenFlags};
 use serde::Deserialize;
@@ -62,32 +62,37 @@ use stackslib::core::{BLOCK_LIMIT_MAINNET_205, HELIUM_BLOCK_LIMIT_20, StacksEpoc
 use stackslib::util_lib::boot::{boot_code_addr, boot_code_id};
 use stackslib::util_lib::db::{FromColumn, sqlite_open};
 
-lazy_static! {
-    pub static ref STACKS_BOOT_CODE_MAINNET_2_1: [(&'static str, &'static str); 10] = [
-        ("pox", &BOOT_CODE_POX_MAINNET),
-        ("lockup", BOOT_CODE_LOCKUP),
-        ("costs", BOOT_CODE_COSTS),
-        ("cost-voting", BOOT_CODE_COST_VOTING_MAINNET),
-        ("bns", BOOT_CODE_BNS),
-        ("genesis", BOOT_CODE_GENESIS),
-        ("costs-2", BOOT_CODE_COSTS_2),
-        ("pox-2", &POX_2_MAINNET_CODE),
-        ("costs-3", BOOT_CODE_COSTS_3),
-        ("costs-4", BOOT_CODE_COSTS_4),
-    ];
-    pub static ref STACKS_BOOT_CODE_TESTNET_2_1: [(&'static str, &'static str); 10] = [
-        ("pox", &BOOT_CODE_POX_TESTNET),
-        ("lockup", BOOT_CODE_LOCKUP),
-        ("costs", BOOT_CODE_COSTS),
-        ("cost-voting", &BOOT_CODE_COST_VOTING_TESTNET),
-        ("bns", BOOT_CODE_BNS),
-        ("genesis", BOOT_CODE_GENESIS),
-        ("costs-2", BOOT_CODE_COSTS_2_TESTNET),
-        ("pox-2", &POX_2_TESTNET_CODE),
-        ("costs-3", BOOT_CODE_COSTS_3),
-        ("costs-4", BOOT_CODE_COSTS_4),
-    ];
-}
+pub static STACKS_BOOT_CODE_MAINNET_2_1: LazyLock<[(&'static str, &'static str); 10]> =
+    LazyLock::new(|| {
+        [
+            ("pox", &BOOT_CODE_POX_MAINNET),
+            ("lockup", BOOT_CODE_LOCKUP),
+            ("costs", BOOT_CODE_COSTS),
+            ("cost-voting", BOOT_CODE_COST_VOTING_MAINNET),
+            ("bns", BOOT_CODE_BNS),
+            ("genesis", BOOT_CODE_GENESIS),
+            ("costs-2", BOOT_CODE_COSTS_2),
+            ("pox-2", &POX_2_MAINNET_CODE),
+            ("costs-3", BOOT_CODE_COSTS_3),
+            ("costs-4", BOOT_CODE_COSTS_4),
+        ]
+    });
+
+pub static STACKS_BOOT_CODE_TESTNET_2_1: LazyLock<[(&'static str, &'static str); 10]> =
+    LazyLock::new(|| {
+        [
+            ("pox", &BOOT_CODE_POX_TESTNET),
+            ("lockup", BOOT_CODE_LOCKUP),
+            ("costs", BOOT_CODE_COSTS),
+            ("cost-voting", &BOOT_CODE_COST_VOTING_TESTNET),
+            ("bns", BOOT_CODE_BNS),
+            ("genesis", BOOT_CODE_GENESIS),
+            ("costs-2", BOOT_CODE_COSTS_2_TESTNET),
+            ("pox-2", &POX_2_TESTNET_CODE),
+            ("costs-3", BOOT_CODE_COSTS_3),
+            ("costs-4", BOOT_CODE_COSTS_4),
+        ]
+    });
 
 #[cfg(test)]
 macro_rules! panic_test {

--- a/libsigner/Cargo.toml
+++ b/libsigner/Cargo.toml
@@ -18,7 +18,6 @@ path = "./src/libsigner.rs"
 [dependencies]
 clarity = { path = "../clarity" }
 hashbrown = { workspace = true }
-lazy_static = "1.4.0"
 libc = "0.2"
 libstackerdb = { path = "../libstackerdb" }
 serde = "1"

--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -48,11 +48,11 @@ pub mod v0;
 use std::cmp::Eq;
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::sync::LazyLock;
 
 use blockstack_lib::version_string;
 use clarity::codec::StacksMessageCodec;
 use clarity::vm::types::QualifiedContractIdentifier;
-use lazy_static::lazy_static;
 use stacks_common::versions::STACKS_SIGNER_VERSION;
 
 pub use crate::error::{EventError, RPCError};
@@ -78,13 +78,11 @@ pub trait SignerMessage<T: MessageSlotID>: StacksMessageCodec {
     fn msg_id(&self) -> Option<T>;
 }
 
-lazy_static! {
-    /// The version string for the signer
-    pub static ref VERSION_STRING: String = {
-        let pkg_version = option_env!("STACKS_NODE_VERSION").or(Some(STACKS_SIGNER_VERSION));
-        version_string("stacks-signer", pkg_version)
-    };
-}
+/// The version string for the signer
+pub static VERSION_STRING: LazyLock<String> = LazyLock::new(|| {
+    let pkg_version = option_env!("STACKS_NODE_VERSION").or(Some(STACKS_SIGNER_VERSION));
+    version_string("stacks-signer", pkg_version)
+});
 
 #[test]
 fn test_version_string() {

--- a/stacks-common/Cargo.toml
+++ b/stacks-common/Cargo.toml
@@ -34,7 +34,6 @@ chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
 curve25519-dalek = { version = "4.1.3", default-features = false, features = ["serde"] }
 ed25519-dalek = { workspace = true }
 hashbrown = { workspace = true }
-lazy_static = { workspace = true }
 ripemd = { version = "0.1.1", default-features = false }
 serde = { workspace = true , features = ["derive"] }
 serde_derive = { workspace = true }

--- a/stacks-common/src/util/log.rs
+++ b/stacks-common/src/util/log.rs
@@ -15,18 +15,17 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::io::Write;
+use std::sync::LazyLock;
 use std::time::{Duration, SystemTime};
 use std::{env, io, thread};
 
 use chrono::prelude::*;
-use lazy_static::lazy_static;
 use slog::{Drain, Level, Logger, OwnedKVList, Record, KV};
 use slog_term::{CountingWriter, Decorator, RecordDecorator, Serializer};
 
-lazy_static! {
-    pub static ref LOGGER: Logger = make_logger();
-    pub static ref STACKS_LOG_FORMAT_TIME: Option<String> = env::var("STACKS_LOG_FORMAT_TIME").ok();
-}
+pub static LOGGER: LazyLock<Logger> = LazyLock::new(|| make_logger());
+pub static STACKS_LOG_FORMAT_TIME: LazyLock<Option<String>> =
+    LazyLock::new(|| env::var("STACKS_LOG_FORMAT_TIME").ok());
 struct TermFormat<D: Decorator> {
     decorator: D,
     pretty_print: bool,
@@ -267,9 +266,7 @@ fn inner_get_loglevel() -> slog::Level {
     }
 }
 
-lazy_static! {
-    static ref LOGLEVEL: slog::Level = inner_get_loglevel();
-}
+static LOGLEVEL: LazyLock<slog::Level> = LazyLock::new(|| inner_get_loglevel());
 
 pub fn get_loglevel() -> slog::Level {
     *LOGLEVEL

--- a/stacks-node/Cargo.toml
+++ b/stacks-node/Cargo.toml
@@ -7,7 +7,6 @@ resolver = "2"
 rust-version = "1.61"
 
 [dependencies]
-lazy_static = "1.4.0"
 pico-args = "0.5.0"
 serde = "1"
 serde_derive = "1"

--- a/stacks-node/src/event_dispatcher.rs
+++ b/stacks-node/src/event_dispatcher.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use std::path::PathBuf;
 #[cfg(test)]
 use std::sync::mpsc::channel;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 use std::sync::LazyLock;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
@@ -29,8 +29,6 @@ use std::time::{Duration, SystemTime};
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::events::{FTEventType, NFTEventType, STXEventType};
 use clarity::vm::types::{AssetIdentifier, QualifiedContractIdentifier};
-#[cfg(any(test, feature = "testing"))]
-use lazy_static::lazy_static;
 use rand::Rng;
 use serde_json::json;
 use stacks::burnchains::{PoxConstants, Txid};
@@ -81,11 +79,10 @@ use crate::event_dispatcher::db::PendingPayload;
 #[cfg(test)]
 mod tests;
 
+/// Do not announce a signed/mined block to the network when set to true.
 #[cfg(any(test, feature = "testing"))]
-lazy_static! {
-    /// Do not announce a signed/mined block to the network when set to true.
-    pub static ref TEST_SKIP_BLOCK_ANNOUNCEMENT: TestFlag<bool> = TestFlag::default();
-}
+pub static TEST_SKIP_BLOCK_ANNOUNCEMENT: LazyLock<TestFlag<bool>> =
+    LazyLock::new(TestFlag::default);
 
 #[derive(Debug)]
 enum EventDispatcherError {

--- a/stacks-node/src/tests/integrations.rs
+++ b/stacks-node/src/tests/integrations.rs
@@ -12,7 +12,7 @@ use clarity::vm::types::{
     QualifiedContractIdentifier, ResponseData, StacksAddressExtensions, TupleData,
 };
 use clarity::vm::{ClarityVersion, Value};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use pinny::tag;
 use reqwest;
 use serde_json::json;
@@ -159,9 +159,7 @@ const IMPL_TRAIT_CONTRACT: &str = "
         (define-public (fn-1 (x uint)) (ok u1))
        ";
 
-lazy_static! {
-    static ref HTTP_BINDING: Mutex<Option<String>> = Mutex::new(None);
-}
+static HTTP_BINDING: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
 
 #[tag(slow)]
 #[test]
@@ -1940,14 +1938,14 @@ fn bad_contract_tx_rollback() {
     run_loop.start(num_rounds).unwrap();
 }
 
-lazy_static! {
-    static ref EXPENSIVE_CONTRACT: String = make_expensive_contract(
+static EXPENSIVE_CONTRACT: LazyLock<String> = LazyLock::new(|| {
+    make_expensive_contract(
         "(define-private (inner-loop (x int)) (begin
            (map sha256 list-9)
            0))",
-        ""
-    );
-}
+        "",
+    )
+});
 
 fn make_expensive_contract(inner_loop: &str, other_decl: &str) -> String {
     let mut contract = "(define-constant list-0 (list 0))".to_string();

--- a/stacks-node/src/tests/mempool.rs
+++ b/stacks-node/src/tests/mempool.rs
@@ -5,7 +5,7 @@ use clarity::vm::database::NULL_BURN_STATE_DB;
 use clarity::vm::representations::ContractName;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
 use clarity::vm::Value;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use stacks::chainstate::stacks::db::blocks::MemPoolRejection;
 use stacks::chainstate::stacks::{
     Error as ChainstateError, StacksBlockHeader, StacksMicroblockHeader, StacksPrivateKey,
@@ -73,9 +73,7 @@ pub fn make_bad_stacks_transfer(
     buf
 }
 
-lazy_static! {
-    static ref CHAINSTATE_PATH: Mutex<Option<String>> = Mutex::new(None);
-}
+static CHAINSTATE_PATH: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
 
 #[test]
 fn mempool_setup_chainstate() {

--- a/stacks-node/src/tests/mod.rs
+++ b/stacks-node/src/tests/mod.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::events::STXEventType;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use neon_integrations::test_observer::EVENT_OBSERVER_PORT;
 use rand::Rng;
 use stacks::chainstate::burn::ConsensusHash;
@@ -78,27 +78,27 @@ pub const SK_3: &str = "cb95ddd0fe18ec57f4f3533b95ae564b3f1ae063dbf75b46334bd862
 
 pub const ADDR_4: &str = "ST31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZZ239N96";
 
-lazy_static! {
-    pub static ref PUBLISH_CONTRACT: Vec<u8> = make_contract_publish(
+pub static PUBLISH_CONTRACT: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    make_contract_publish(
         &StacksPrivateKey::from_hex(
-            "043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3"
+            "043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3",
         )
         .unwrap(),
         0,
         10,
         CHAIN_ID_TESTNET,
         "store",
-        STORE_CONTRACT
-    );
-}
+        STORE_CONTRACT,
+    )
+});
 
-lazy_static! {
-    static ref USED_PORTS: Mutex<HashSet<u16>> = Mutex::new({
+static USED_PORTS: LazyLock<Mutex<HashSet<u16>>> = LazyLock::new(|| {
+    Mutex::new({
         let mut set = HashSet::new();
         set.insert(EVENT_OBSERVER_PORT);
         set
-    });
-}
+    })
+});
 
 /// Generate a random port number between 1024 and 65534 (inclusive) and insert it into the USED_PORTS set.
 /// Returns the generated port number.

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -29,7 +29,7 @@ use clarity::vm::representations::ContractName;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
 use clarity::vm::{ClarityName, ClarityVersion, Value};
 use http_types::headers::AUTHORIZATION;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use libsigner::v0::messages::{
     MessageSlotID, RejectReason, SignerMessage as SignerMessageV0, StateMachineUpdate,
     StateMachineUpdateContent, StateMachineUpdateMinerState,
@@ -146,101 +146,101 @@ use stacks::config::DEFAULT_MAX_TENURE_BYTES;
 
 use crate::clarity::vm::clarity::ClarityConnection;
 
-lazy_static! {
-    pub static ref NAKAMOTO_INTEGRATION_EPOCHS: [StacksEpoch; 13] = [
+pub static NAKAMOTO_INTEGRATION_EPOCHS: LazyLock<[StacksEpoch; 13]> = LazyLock::new(|| {
+    [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
             end_height: 0,
             block_limit: BLOCK_LIMIT_MAINNET_10,
-            network_epoch: PEER_VERSION_EPOCH_1_0
+            network_epoch: PEER_VERSION_EPOCH_1_0,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,
             start_height: 0,
             end_height: 1,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_2_0
+            network_epoch: PEER_VERSION_EPOCH_2_0,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch2_05,
             start_height: 1,
             end_height: 2,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_2_05
+            network_epoch: PEER_VERSION_EPOCH_2_05,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch21,
             start_height: 2,
             end_height: 3,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_2_1
+            network_epoch: PEER_VERSION_EPOCH_2_1,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch22,
             start_height: 3,
             end_height: 4,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_2_2
+            network_epoch: PEER_VERSION_EPOCH_2_2,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch23,
             start_height: 4,
             end_height: 5,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_2_3
+            network_epoch: PEER_VERSION_EPOCH_2_3,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch24,
             start_height: 5,
             end_height: 201,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_2_4
+            network_epoch: PEER_VERSION_EPOCH_2_4,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch25,
             start_height: 201,
             end_height: 231,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_2_5
+            network_epoch: PEER_VERSION_EPOCH_2_5,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch30,
             start_height: 231,
             end_height: 241,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_3_0
+            network_epoch: PEER_VERSION_EPOCH_3_0,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch31,
             start_height: 241,
             end_height: 251,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_3_1
+            network_epoch: PEER_VERSION_EPOCH_3_1,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch32,
             start_height: 251,
             end_height: 252,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_3_2
+            network_epoch: PEER_VERSION_EPOCH_3_2,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch33,
             start_height: 252,
             end_height: 253,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_3_2
+            network_epoch: PEER_VERSION_EPOCH_3_2,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch34,
             start_height: 253,
             end_height: STACKS_EPOCH_MAX,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_3_3
+            network_epoch: PEER_VERSION_EPOCH_3_3,
         },
-    ];
-}
+    ]
+});
 
 pub static TEST_SIGNING: Mutex<Option<TestSigningChannel>> = Mutex::new(None);
 

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -24,7 +24,6 @@ backoff = "0.4"
 clarity = { path = "../clarity" }
 clap = { version = "4.1.1", features = ["derive", "env"] }
 hashbrown = { workspace = true }
-lazy_static = "1.4.0"
 libsigner = { path = "../libsigner" }
 libstackerdb = { path = "../libstackerdb" }
 prometheus = { version = "0.9", optional = true }

--- a/stacks-signer/src/monitoring/prometheus.rs
+++ b/stacks-signer/src/monitoring/prometheus.rs
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-use lazy_static::lazy_static;
 use prometheus::{
     gather, histogram_opts, opts, register_histogram_vec, register_int_counter,
     register_int_counter_vec, register_int_gauge, Encoder, HistogramVec, IntCounter, IntCounterVec,
@@ -25,85 +24,143 @@ use prometheus::{
 
 use crate::v0::signer_state::LocalStateMachine;
 
-lazy_static! {
-    pub static ref STACKS_TIP_HEIGHT_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static STACKS_TIP_HEIGHT_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_signer_stacks_node_height",
         "The current height of the Stacks node"
     ))
-    .unwrap();
-    pub static ref BLOCK_VALIDATION_RESPONSES: IntCounterVec = register_int_counter_vec!(
+    .unwrap()
+});
+
+pub static BLOCK_VALIDATION_RESPONSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
         "stacks_signer_block_validation_responses",
         "The number of block validation responses. `response_type` is either 'accepted' or 'rejected'",
         &["response_type"]
     )
-    .unwrap();
-    pub static ref BLOCK_RESPONSES_SENT: IntCounterVec = register_int_counter_vec!(
+    .unwrap()
+});
+
+pub static BLOCK_RESPONSES_SENT: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
         "stacks_signer_block_responses_sent",
         "The number of block responses sent. `response_type` is either 'accepted' or 'rejected'",
         &["response_type"]
     )
-    .unwrap();
-    pub static ref BLOCK_PROPOSALS_RECEIVED: IntCounter = register_int_counter!(opts!(
+    .unwrap()
+});
+
+pub static BLOCK_PROPOSALS_RECEIVED: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_signer_block_proposals_received",
         "The number of block proposals received by the signer"
     ))
-    .unwrap();
-    pub static ref BLOCK_PRE_COMMITS_SENT: IntCounter = register_int_counter!(opts!(
+    .unwrap()
+});
+
+pub static BLOCK_PRE_COMMITS_SENT: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_signer_block_pre_commits_sent",
         "The number of block pre-commits sent by the signer"
     ))
-    .unwrap();
-    pub static ref CURRENT_REWARD_CYCLE: IntGauge = register_int_gauge!(opts!(
+    .unwrap()
+});
+
+pub static CURRENT_REWARD_CYCLE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_signer_current_reward_cycle",
         "The current reward cycle"
-    )).unwrap();
-    pub static ref SIGNER_STX_BALANCE: IntGauge = register_int_gauge!(opts!(
+    ))
+    .unwrap()
+});
+
+pub static SIGNER_STX_BALANCE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_signer_stx_balance",
         "The current STX balance of the signer"
-    )).unwrap();
-    pub static ref SIGNER_NONCE: IntGauge = register_int_gauge!(opts!(
+    ))
+    .unwrap()
+});
+
+pub static SIGNER_NONCE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_signer_nonce",
         "The current nonce of the signer"
-    )).unwrap();
+    ))
+    .unwrap()
+});
 
-    pub static ref SIGNER_RPC_CALL_LATENCIES_HISTOGRAM: HistogramVec = register_histogram_vec!(histogram_opts!(
-        "stacks_signer_node_rpc_call_latencies_histogram",
-        "Time (seconds) measuring round-trip RPC call latency to the Stacks node"
-        // Will use DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0] by default
-    ), &["path"]).unwrap();
+pub static SIGNER_RPC_CALL_LATENCIES_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        histogram_opts!(
+            "stacks_signer_node_rpc_call_latencies_histogram",
+            "Time (seconds) measuring round-trip RPC call latency to the Stacks node"
+            // Will use DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0] by default
+        ),
+        &["path"]
+    )
+    .unwrap()
+});
 
-    pub static ref SIGNER_BLOCK_VALIDATION_LATENCIES_HISTOGRAM: HistogramVec = register_histogram_vec!(histogram_opts!(
-        "stacks_signer_block_validation_latencies_histogram",
-        "Time (seconds) measuring block validation time reported by the Stacks node",
-        vec![0.005, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0]
-    ), &[]).unwrap();
+pub static SIGNER_BLOCK_VALIDATION_LATENCIES_HISTOGRAM: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        register_histogram_vec!(
+            histogram_opts!(
+                "stacks_signer_block_validation_latencies_histogram",
+                "Time (seconds) measuring block validation time reported by the Stacks node",
+                vec![0.005, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0]
+            ),
+            &[]
+        )
+        .unwrap()
+    });
 
-    pub static ref SIGNER_BLOCK_RESPONSE_LATENCIES_HISTOGRAM: HistogramVec = register_histogram_vec!(histogram_opts!(
-        "stacks_signer_block_response_latencies_histogram",
-        "Time (seconds) measuring end-to-end time to respond to a block",
-        vec![0.005, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0]
-    ), &[]).unwrap();
+pub static SIGNER_BLOCK_RESPONSE_LATENCIES_HISTOGRAM: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        register_histogram_vec!(
+            histogram_opts!(
+                "stacks_signer_block_response_latencies_histogram",
+                "Time (seconds) measuring end-to-end time to respond to a block",
+                vec![0.005, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0]
+            ),
+            &[]
+        )
+        .unwrap()
+    });
 
-    pub static ref SIGNER_AGREEMENT_STATE_CHANGE_REASONS: IntCounterVec = register_int_counter_vec!(
+pub static SIGNER_AGREEMENT_STATE_CHANGE_REASONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
         "stacks_signer_agreement_state_change_reasons",
         "The number of state machine changes in signer agreement protocol. `reason` can be one of: 'burn_block_arrival', 'stacks_block_arrival', 'inactive_miner', 'protocol_upgrade', 'miner_view_update', 'miner_parent_tenure_update'",
         &["reason"]
-    ).unwrap();
+    )
+    .unwrap()
+});
 
-    pub static ref SIGNER_AGREEMENT_STATE_CONFLICTS: IntCounterVec = register_int_counter_vec!(
+pub static SIGNER_AGREEMENT_STATE_CONFLICTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
         "stacks_signer_agreement_state_conflicts",
         "The number of state machine conflicts in signer agreement protocol. `conflict` can be one of: 'burn_block_delay', 'stacks_block_delay', 'miner_view'",
         &["conflict"]
-    ).unwrap();
+    )
+    .unwrap()
+});
 
-    pub static ref SIGNER_AGREEMENT_CAPITULATION_LATENCIES_HISTOGRAM: HistogramVec = register_histogram_vec!(histogram_opts!(
-        "stacks_signer_agreement_capitulation_latencies_histogram",
-        "Measuring the time (in seconds) for the signer to agree (capitulate) with the signer set",
-        vec![0.0, 1.0, 3.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0]
-    ), &[]).unwrap();
+pub static SIGNER_AGREEMENT_CAPITULATION_LATENCIES_HISTOGRAM: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        register_histogram_vec!(
+            histogram_opts!(
+                "stacks_signer_agreement_capitulation_latencies_histogram",
+                "Measuring the time (in seconds) for the signer to agree (capitulate) with the signer set",
+                vec![0.0, 1.0, 3.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0]
+            ),
+            &[]
+        )
+        .unwrap()
+    });
 
-    pub static ref SIGNER_LOCAL_STATE_MACHINE: Mutex<Option<LocalStateMachine>> = Mutex::new(None);
-}
+pub static SIGNER_LOCAL_STATE_MACHINE: LazyLock<Mutex<Option<LocalStateMachine>>> =
+    LazyLock::new(|| Mutex::new(None));
 
 pub fn gather_metrics_string() -> String {
     let mut buffer = Vec::new();

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -27,7 +27,6 @@ serde_derive = "1"
 ripemd = "0.1.1"
 regex = "1"
 mio = "0.6"
-lazy_static = "1.4.0"
 url = "2.1.0"
 percent-encoding = "2.1.0"
 prometheus = { version = "0.9", optional = true }

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -18,7 +18,7 @@ use std::cmp;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use clarity::vm::clarity::TransactionConnection;
 use clarity::vm::costs::{ExecutionCost, LimitedCostTracker};
@@ -26,7 +26,6 @@ use clarity::vm::database::BurnStateDB;
 use clarity::vm::errors::ClarityEvalError;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use clarity::vm::Value;
-use lazy_static::lazy_static;
 use rusqlite::Connection;
 use stacks_common::address;
 use stacks_common::address::AddressHashMode;
@@ -66,12 +65,13 @@ use crate::util_lib::boot::{boot_code_addr, boot_code_id};
 use crate::util_lib::strings::StacksString;
 use crate::{chainstate, core};
 
-lazy_static! {
-    pub static ref BURN_BLOCK_HEADERS: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
-    pub static ref TXIDS: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
-    pub static ref MBLOCK_PUBKHS: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
-    pub static ref STACKS_BLOCK_HEADERS: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
-}
+pub static BURN_BLOCK_HEADERS: LazyLock<Arc<AtomicU64>> =
+    LazyLock::new(|| Arc::new(AtomicU64::new(1)));
+pub static TXIDS: LazyLock<Arc<AtomicU64>> = LazyLock::new(|| Arc::new(AtomicU64::new(1)));
+pub static MBLOCK_PUBKHS: LazyLock<Arc<AtomicU64>> =
+    LazyLock::new(|| Arc::new(AtomicU64::new(1)));
+pub static STACKS_BLOCK_HEADERS: LazyLock<Arc<AtomicU64>> =
+    LazyLock::new(|| Arc::new(AtomicU64::new(1)));
 
 fn test_path(name: &str) -> String {
     format!(

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -22,7 +22,7 @@ use clarity::vm::costs::ExecutionCost;
 use clarity::vm::events::{STXEventType, STXMintEventData, StacksTransactionEvent};
 use clarity::vm::types::PrincipalData;
 use clarity::vm::{ClarityVersion, Value};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput};
 use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest as Sha2Digest, Sha512_256};
@@ -131,10 +131,11 @@ impl FromSql for HeaderTypeNames {
     }
 }
 
-lazy_static! {
-    pub static ref FIRST_STACKS_BLOCK_ID: StacksBlockId = StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH);
+pub static FIRST_STACKS_BLOCK_ID: LazyLock<StacksBlockId> =
+    LazyLock::new(|| StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH));
 
-    pub static ref NAKAMOTO_CHAINSTATE_SCHEMA_1: Vec<String> = vec![
+pub static NAKAMOTO_CHAINSTATE_SCHEMA_1: LazyLock<Vec<String>> = LazyLock::new(|| {
+    vec![
     r#"
     -- Table for storing calculated reward sets. This must be in the Chainstate DB because calculation occurs
     --   during block processing.
@@ -214,8 +215,8 @@ lazy_static! {
     r#"
     UPDATE db_config SET version = "4";
     "#.into(),
-    ];
-}
+    ]
+});
 
 pub static NAKAMOTO_CHAINSTATE_SCHEMA_2: &[&str] = &[
     NAKAMOTO_TENURES_SCHEMA_2,

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 use clarity::util::get_epoch_time_secs;
 use clarity::vm::analysis::arithmetic_checker::ArithmeticOnlyChecker;
@@ -13,7 +14,6 @@ use clarity::vm::types::{
     TupleData, Value,
 };
 use clarity::vm::version::ClarityVersion;
-use lazy_static::lazy_static;
 use stacks_common::address::AddressHashMode;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, SortitionId, StacksAddress, StacksBlockId, VRFSeed,
@@ -45,35 +45,44 @@ use crate::util_lib::boot::{boot_code_addr, boot_code_id};
 
 const USTX_PER_HOLDER: u128 = 1_000_000;
 
-lazy_static! {
-    pub static ref FIRST_INDEX_BLOCK_HASH: StacksBlockId = StacksBlockHeader::make_index_block_hash(
+pub static FIRST_INDEX_BLOCK_HASH: LazyLock<StacksBlockId> = LazyLock::new(|| {
+    StacksBlockHeader::make_index_block_hash(
         &FIRST_BURNCHAIN_CONSENSUS_HASH,
-        &FIRST_STACKS_BLOCK_HASH
-    );
-    pub static ref POX_CONTRACT_TESTNET: QualifiedContractIdentifier = boot_code_id("pox", false);
-    pub static ref POX_2_CONTRACT_TESTNET: QualifiedContractIdentifier =
-        boot_code_id("pox-2", false);
-    pub static ref COST_VOTING_CONTRACT_TESTNET: QualifiedContractIdentifier =
-        boot_code_id("cost-voting", false);
-    pub static ref USER_KEYS: Vec<StacksPrivateKey> =
-        (0..50).map(|_| StacksPrivateKey::random()).collect();
-    pub static ref POX_ADDRS: Vec<Value> = (0..50u64)
-        .map(|ix| execute(&format!(
-            "{{ version: 0x00, hashbytes: 0x000000000000000000000000{} }}",
-            &to_hex(&ix.to_le_bytes())
-        )))
-        .collect();
-    pub static ref MINER_KEY: StacksPrivateKey = StacksPrivateKey::random();
-    pub static ref MINER_ADDR: StacksAddress = StacksAddress::from_public_keys(
+        &FIRST_STACKS_BLOCK_HASH,
+    )
+});
+pub static POX_CONTRACT_TESTNET: LazyLock<QualifiedContractIdentifier> =
+    LazyLock::new(|| boot_code_id("pox", false));
+pub static POX_2_CONTRACT_TESTNET: LazyLock<QualifiedContractIdentifier> =
+    LazyLock::new(|| boot_code_id("pox-2", false));
+pub static COST_VOTING_CONTRACT_TESTNET: LazyLock<QualifiedContractIdentifier> =
+    LazyLock::new(|| boot_code_id("cost-voting", false));
+pub static USER_KEYS: LazyLock<Vec<StacksPrivateKey>> =
+    LazyLock::new(|| (0..50).map(|_| StacksPrivateKey::random()).collect());
+pub static POX_ADDRS: LazyLock<Vec<Value>> = LazyLock::new(|| {
+    (0..50u64)
+        .map(|ix| {
+            execute(&format!(
+                "{{ version: 0x00, hashbytes: 0x000000000000000000000000{} }}",
+                &to_hex(&ix.to_le_bytes())
+            ))
+        })
+        .collect()
+});
+pub static MINER_KEY: LazyLock<StacksPrivateKey> = LazyLock::new(StacksPrivateKey::random);
+pub static MINER_ADDR: LazyLock<StacksAddress> = LazyLock::new(|| {
+    StacksAddress::from_public_keys(
         C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         &AddressHashMode::SerializeP2PKH,
         1,
         &vec![StacksPublicKey::from_private(&MINER_KEY.clone())],
     )
-    .unwrap();
-    static ref LIQUID_SUPPLY: u128 = USTX_PER_HOLDER * (POX_ADDRS.len() as u128);
-    static ref MIN_THRESHOLD: u128 = *LIQUID_SUPPLY / super::test::TESTNET_STACKING_THRESHOLD_25;
-}
+    .unwrap()
+});
+static LIQUID_SUPPLY: LazyLock<u128> =
+    LazyLock::new(|| USTX_PER_HOLDER * (POX_ADDRS.len() as u128));
+static MIN_THRESHOLD: LazyLock<u128> =
+    LazyLock::new(|| *LIQUID_SUPPLY / super::test::TESTNET_STACKING_THRESHOLD_25);
 
 pub struct ClarityTestSim {
     marf: MarfedKV,

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -30,7 +30,7 @@ use clarity::vm::types::{
     PrincipalData, QualifiedContractIdentifier, StandardPrincipalData, TupleData, Value,
 };
 use clarity::vm::{Environment, SymbolicExpression};
-use lazy_static::lazy_static;
+
 use serde::Deserialize;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
@@ -112,38 +112,43 @@ pub static TEST_SIP_031_ADDR: LazyLock<TestFlag<Option<StacksAddress>>> =
 
 pub mod docs;
 
-lazy_static! {
-    pub static ref BOOT_CODE_POX_MAINNET: String =
-        format!("{BOOT_CODE_POX_MAINNET_CONSTS}\n{BOOT_CODE_POX_BODY}");
-    pub static ref BOOT_CODE_POX_TESTNET: String =
-        format!("{BOOT_CODE_POX_TESTNET_CONSTS}\n{BOOT_CODE_POX_BODY}");
-    pub static ref POX_2_MAINNET_CODE: String =
-        format!("{BOOT_CODE_POX_MAINNET_CONSTS}\n{POX_2_BODY}");
-    pub static ref POX_2_TESTNET_CODE: String =
-        format!("{BOOT_CODE_POX_TESTNET_CONSTS}\n{POX_2_BODY}");
-    pub static ref POX_3_MAINNET_CODE: String =
-        format!("{BOOT_CODE_POX_MAINNET_CONSTS}\n{POX_3_BODY}");
-    pub static ref POX_3_TESTNET_CODE: String =
-        format!("{BOOT_CODE_POX_TESTNET_CONSTS}\n{POX_3_BODY}");
-    pub static ref POX_4_CODE: String = POX_4_BODY.to_string();
-    pub static ref BOOT_CODE_COST_VOTING_TESTNET: String = make_testnet_cost_voting();
-    pub static ref STACKS_BOOT_CODE_MAINNET: [(&'static str, &'static str); 6] = [
-        ("pox", &BOOT_CODE_POX_MAINNET),
-        ("lockup", BOOT_CODE_LOCKUP),
-        ("costs", BOOT_CODE_COSTS),
-        ("cost-voting", BOOT_CODE_COST_VOTING_MAINNET),
-        ("bns", BOOT_CODE_BNS),
-        ("genesis", BOOT_CODE_GENESIS),
-    ];
-    pub static ref STACKS_BOOT_CODE_TESTNET: [(&'static str, &'static str); 6] = [
-        ("pox", &BOOT_CODE_POX_TESTNET),
-        ("lockup", BOOT_CODE_LOCKUP),
-        ("costs", BOOT_CODE_COSTS),
-        ("cost-voting", &BOOT_CODE_COST_VOTING_TESTNET),
-        ("bns", BOOT_CODE_BNS),
-        ("genesis", BOOT_CODE_GENESIS),
-    ];
-}
+pub static BOOT_CODE_POX_MAINNET: LazyLock<String> =
+    LazyLock::new(|| format!("{BOOT_CODE_POX_MAINNET_CONSTS}\n{BOOT_CODE_POX_BODY}"));
+pub static BOOT_CODE_POX_TESTNET: LazyLock<String> =
+    LazyLock::new(|| format!("{BOOT_CODE_POX_TESTNET_CONSTS}\n{BOOT_CODE_POX_BODY}"));
+pub static POX_2_MAINNET_CODE: LazyLock<String> =
+    LazyLock::new(|| format!("{BOOT_CODE_POX_MAINNET_CONSTS}\n{POX_2_BODY}"));
+pub static POX_2_TESTNET_CODE: LazyLock<String> =
+    LazyLock::new(|| format!("{BOOT_CODE_POX_TESTNET_CONSTS}\n{POX_2_BODY}"));
+pub static POX_3_MAINNET_CODE: LazyLock<String> =
+    LazyLock::new(|| format!("{BOOT_CODE_POX_MAINNET_CONSTS}\n{POX_3_BODY}"));
+pub static POX_3_TESTNET_CODE: LazyLock<String> =
+    LazyLock::new(|| format!("{BOOT_CODE_POX_TESTNET_CONSTS}\n{POX_3_BODY}"));
+pub static POX_4_CODE: LazyLock<String> = LazyLock::new(|| POX_4_BODY.to_string());
+pub static BOOT_CODE_COST_VOTING_TESTNET: LazyLock<String> =
+    LazyLock::new(|| make_testnet_cost_voting());
+pub static STACKS_BOOT_CODE_MAINNET: LazyLock<[(&'static str, &'static str); 6]> =
+    LazyLock::new(|| {
+        [
+            ("pox", &BOOT_CODE_POX_MAINNET),
+            ("lockup", BOOT_CODE_LOCKUP),
+            ("costs", BOOT_CODE_COSTS),
+            ("cost-voting", BOOT_CODE_COST_VOTING_MAINNET),
+            ("bns", BOOT_CODE_BNS),
+            ("genesis", BOOT_CODE_GENESIS),
+        ]
+    });
+pub static STACKS_BOOT_CODE_TESTNET: LazyLock<[(&'static str, &'static str); 6]> =
+    LazyLock::new(|| {
+        [
+            ("pox", &BOOT_CODE_POX_TESTNET),
+            ("lockup", BOOT_CODE_LOCKUP),
+            ("costs", BOOT_CODE_COSTS),
+            ("cost-voting", &BOOT_CODE_COST_VOTING_TESTNET),
+            ("bns", BOOT_CODE_BNS),
+            ("genesis", BOOT_CODE_GENESIS),
+        ]
+    });
 
 fn make_testnet_cost_voting() -> String {
     BOOT_CODE_COST_VOTING_MAINNET

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -35,7 +35,8 @@ use clarity::vm::types::{
     PrincipalData, QualifiedContractIdentifier, StandardPrincipalData, Value,
 };
 use clarity::vm::{ClarityVersion, ContractName};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::StacksEpochId;
 
@@ -45,12 +46,10 @@ use crate::clarity_vm::database::marf::MarfedKV;
 use crate::core::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH};
 use crate::util_lib::boot::boot_code_id;
 
-lazy_static! {
-    static ref COST_VOTING_MAINNET_CONTRACT: QualifiedContractIdentifier =
-        boot_code_id("cost-voting", true);
-    static ref COST_VOTING_TESTNET_CONTRACT: QualifiedContractIdentifier =
-        boot_code_id("cost-voting", false);
-}
+static COST_VOTING_MAINNET_CONTRACT: LazyLock<QualifiedContractIdentifier> =
+    LazyLock::new(|| boot_code_id("cost-voting", true));
+static COST_VOTING_TESTNET_CONTRACT: LazyLock<QualifiedContractIdentifier> =
+    LazyLock::new(|| boot_code_id("cost-voting", false));
 
 pub fn get_simple_test(function: &NativeFunctions) -> Option<&'static str> {
     use clarity::vm::functions::NativeFunctions::*;

--- a/stackslib/src/core/mod.rs
+++ b/stackslib/src/core/mod.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 use std::str::FromStr;
 
 use clarity::vm::costs::ExecutionCost;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 pub use stacks_common::consts::MICROSTACKS_PER_STACKS;
 use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
 pub use stacks_common::types::StacksEpochId;
@@ -143,10 +143,8 @@ pub const BITCOIN_REGTEST_FIRST_BLOCK_HASH: &str =
 pub const FIRST_STACKS_BLOCK_HASH: BlockHeaderHash = BlockHeaderHash([0u8; 32]);
 pub const EMPTY_MICROBLOCK_PARENT_HASH: BlockHeaderHash = BlockHeaderHash([0u8; 32]);
 
-lazy_static! {
-    pub static ref FIRST_STACKS_BLOCK_ID: StacksBlockId =
-        StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH);
-}
+pub static FIRST_STACKS_BLOCK_ID: LazyLock<StacksBlockId> =
+    LazyLock::new(|| StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH));
 
 pub const BOOT_BLOCK_HASH: BlockHeaderHash = BlockHeaderHash([0xff; 32]);
 pub const BURNCHAIN_BOOT_CONSENSUS_HASH: ConsensusHash = ConsensusHash([0xff; 20]);
@@ -250,8 +248,8 @@ pub fn check_fault_injection(fault_name: &str) -> bool {
     env::var(fault_name) == Ok("1".to_string())
 }
 
-lazy_static! {
-    pub static ref STACKS_EPOCHS_MAINNET: EpochList = EpochList::new(&[
+pub static STACKS_EPOCHS_MAINNET: LazyLock<EpochList> = LazyLock::new(|| {
+    EpochList::new(&[
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -343,11 +341,11 @@ lazy_static! {
             block_limit: BLOCK_LIMIT_MAINNET_21,
             network_epoch: PEER_VERSION_EPOCH_3_4
         },
-    ]);
-}
+    ])
+});
 
-lazy_static! {
-    pub static ref STACKS_EPOCHS_TESTNET: EpochList = EpochList::new(&[
+pub static STACKS_EPOCHS_TESTNET: LazyLock<EpochList> = LazyLock::new(|| {
+    EpochList::new(&[
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -439,11 +437,11 @@ lazy_static! {
             block_limit: BLOCK_LIMIT_MAINNET_21,
             network_epoch: PEER_VERSION_EPOCH_3_4
         },
-    ]);
-}
+    ])
+});
 
-lazy_static! {
-    pub static ref STACKS_EPOCHS_REGTEST: EpochList = EpochList::new(&[
+pub static STACKS_EPOCHS_REGTEST: LazyLock<EpochList> = LazyLock::new(|| {
+    EpochList::new(&[
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -535,8 +533,8 @@ lazy_static! {
             block_limit: BLOCK_LIMIT_MAINNET_21,
             network_epoch: PEER_VERSION_EPOCH_3_4
         },
-    ]);
-}
+    ])
+});
 
 /// Stacks 2.05 epoch marker.  All block-commits in 2.05 must have a memo bitfield with this value
 /// *or greater*.

--- a/stackslib/src/monitoring/mod.rs
+++ b/stackslib/src/monitoring/mod.rs
@@ -16,6 +16,7 @@
 
 use std::error::Error;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use std::{fmt, fs};
 
 use clarity::vm::costs::ExecutionCost;
@@ -33,9 +34,8 @@ use crate::util_lib::db::{sqlite_open, DBConn, Error as DatabaseError};
 mod prometheus;
 
 #[cfg(feature = "monitoring_prom")]
-lazy_static::lazy_static! {
-    static ref GLOBAL_BURNCHAIN_SIGNER: std::sync::Mutex<Option<BurnchainSigner>> = std::sync::Mutex::new(None);
-}
+static GLOBAL_BURNCHAIN_SIGNER: LazyLock<std::sync::Mutex<Option<BurnchainSigner>>> =
+    LazyLock::new(|| std::sync::Mutex::new(None));
 
 pub fn increment_rpc_calls_counter() {
     #[cfg(feature = "monitoring_prom")]

--- a/stackslib/src/monitoring/prometheus.rs
+++ b/stackslib/src/monitoring/prometheus.rs
@@ -14,253 +14,342 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use prometheus::{
     histogram_opts, labels, opts, register_gauge, register_histogram, register_histogram_vec,
     register_int_counter, register_int_counter_vec, register_int_gauge, Gauge, Histogram,
     HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge,
 };
 
-lazy_static! {
-    pub static ref RPC_CALL_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static RPC_CALL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_rpc_requests_total",
         "Total number of RPC requests made.",
         labels! {"handler" => "all",}
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref RPC_CALL_LATENCIES_HISTOGRAM: HistogramVec = register_histogram_vec!(histogram_opts!(
+pub static RPC_CALL_LATENCIES_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(histogram_opts!(
         "stacks_node_rpc_call_latencies_histogram",
         "Time (seconds) measuring RPC calls latency"
         // Will use DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0] by default
-    ), &["path"]).unwrap();
+    ), &["path"]).unwrap()
+});
 
-    pub static ref STX_BLOCKS_RECEIVED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static STX_BLOCKS_RECEIVED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_stx_blocks_received_total",
         "Total number of Stacks blocks received"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref STX_MICRO_BLOCKS_RECEIVED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static STX_MICRO_BLOCKS_RECEIVED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_stx_micro_blocks_received_total",
         "Total number of Stacks micro blocks received"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref STX_BLOCKS_SERVED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static STX_BLOCKS_SERVED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_stx_blocks_served_total",
         "Total number of Stacks blocks served"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref STX_MICRO_BLOCKS_SERVED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static STX_MICRO_BLOCKS_SERVED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_stx_micro_blocks_served_total",
         "Total number of Stacks micro blocks served"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref STX_CONFIRMED_MICRO_BLOCKS_SERVED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static STX_CONFIRMED_MICRO_BLOCKS_SERVED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_stx_confirmed_micro_blocks_served_total",
         "Total number of Stacks blocks served"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref TXS_RECEIVED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static TXS_RECEIVED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_transactions_received_total",
         "Total number of transactions received and relayed"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref BTC_BLOCKS_RECEIVED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static BTC_BLOCKS_RECEIVED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_btc_blocks_received_total",
         "Total number of blocks processed from the burnchain"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref BTC_OPS_SENT_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static BTC_OPS_SENT_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_btc_ops_sent_total",
         "Total number of ops (key registrations, block commits, user burn supports) submitted to the burnchain"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref STX_BLOCKS_PROCESSED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static STX_BLOCKS_PROCESSED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_stx_blocks_processed_total",
         "Total number of stacks blocks processed"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref STX_BLOCKS_MINED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static STX_BLOCKS_MINED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_stx_blocks_mined_total",
         "Total number of stacks blocks mined by node"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref WARNING_EMITTED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static WARNING_EMITTED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_warning_emitted_total",
         "Total number of warning logs emitted by node"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref ERRORS_EMITTED_COUNTER: IntCounter = register_int_counter!(opts!(
+pub static ERRORS_EMITTED_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_errors_emitted_total",
         "Total number of error logs emitted by node"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_BLOCK_READ_COUNT: Gauge = register_gauge!(opts!(
+pub static LAST_BLOCK_READ_COUNT: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_block_read_count",
         "`execution_cost_read_count` for the last block observed."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_BLOCK_WRITE_COUNT: Gauge = register_gauge!(opts!(
+pub static LAST_BLOCK_WRITE_COUNT: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_block_write_count",
         "`execution_cost_write_count` for the last block observed."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_BLOCK_READ_LENGTH: Gauge = register_gauge!(opts!(
+pub static LAST_BLOCK_READ_LENGTH: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_block_read_length",
         "`execution_cost_read_length` for the last block observed."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_BLOCK_WRITE_LENGTH: Gauge = register_gauge!(opts!(
+pub static LAST_BLOCK_WRITE_LENGTH: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_block_write_length",
         "`execution_cost_write_length` for the last block observed."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_BLOCK_RUNTIME: Gauge = register_gauge!(opts!(
+pub static LAST_BLOCK_RUNTIME: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_block_runtime",
         "`execution_cost_runtime` for the last block observed."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_BLOCK_TRANSACTION_COUNT: IntGauge = register_int_gauge!(opts!(
+pub static LAST_BLOCK_TRANSACTION_COUNT: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_last_block_transaction_count",
         "Number of transactions in the last block."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_MINED_BLOCK_READ_COUNT: Gauge = register_gauge!(opts!(
+pub static LAST_MINED_BLOCK_READ_COUNT: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_mined_block_read_count",
         "`execution_cost_read_count` for the last mined block produced."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_MINED_BLOCK_WRITE_COUNT: Gauge = register_gauge!(opts!(
+pub static LAST_MINED_BLOCK_WRITE_COUNT: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_mined_block_write_count",
         "`execution_cost_write_count` for the last mined block produced."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_MINED_BLOCK_READ_LENGTH: Gauge = register_gauge!(opts!(
+pub static LAST_MINED_BLOCK_READ_LENGTH: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_mined_block_read_length",
         "`execution_cost_read_length` for the last mined block produced."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_MINED_BLOCK_WRITE_LENGTH: Gauge = register_gauge!(opts!(
+pub static LAST_MINED_BLOCK_WRITE_LENGTH: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_mined_block_write_length",
         "`execution_cost_write_length` for the last mined block produced."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_MINED_BLOCK_RUNTIME: Gauge = register_gauge!(opts!(
+pub static LAST_MINED_BLOCK_RUNTIME: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_last_mined_block_runtime",
         "`execution_cost_runtime` for the last mined block produced."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref LAST_MINED_BLOCK_TRANSACTION_COUNT: IntGauge = register_int_gauge!(opts!(
+pub static LAST_MINED_BLOCK_TRANSACTION_COUNT: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_last_mined_block_transaction_count",
         "Number of transactions in the last mined block."
-    )).unwrap();
+    )).unwrap()
+});
 
-
-    pub static ref ACTIVE_MINERS_COUNT_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static ACTIVE_MINERS_COUNT_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_active_miners_total",
         "Total number of active miners"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref STACKS_TIP_HEIGHT_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static STACKS_TIP_HEIGHT_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_stacks_tip_height",
         "Stacks chain tip height"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref BURNCHAIN_HEIGHT_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static BURNCHAIN_HEIGHT_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_burn_block_height",
         "Burnchain tip height"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref INBOUND_NEIGHBORS_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static INBOUND_NEIGHBORS_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_neighbors_inbound",
         "Total count of current known inbound neighbors"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref OUTBOUND_NEIGHBORS_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static OUTBOUND_NEIGHBORS_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_neighbors_outbound",
         "Total count of current known outbound neighbors"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref INBOUND_BANDWIDTH_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static INBOUND_BANDWIDTH_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_bandwidth_inbound",
         "Total inbound bandwidth total in bytes"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref OUTBOUND_BANDWIDTH_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static OUTBOUND_BANDWIDTH_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_bandwidth_outbound",
         "Total outbound bandwidth total in bytes"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref INBOUND_RPC_BANDWIDTH_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static INBOUND_RPC_BANDWIDTH_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_rpc_bandwidth_inbound",
         "Total RPC inbound bandwidth in bytes"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref OUTBOUND_RPC_BANDWIDTH_GAUGE: IntGauge = register_int_gauge!(opts!(
+pub static OUTBOUND_RPC_BANDWIDTH_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_rpc_bandwidth_outbound",
         "Total RPC outbound bandwidth in bytes"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref MSG_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+pub static MSG_COUNTER_VEC: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
         "stacks_node_message_count",
         "Stacks message count by type of message",
         &["name"]
-    ).unwrap();
+    ).unwrap()
+});
 
-
-    pub static ref STX_MEMPOOL_GC: IntCounter = register_int_counter!(opts!(
+pub static STX_MEMPOOL_GC: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_node_mempool_gc_count",
         "Total count of all mempool garbage collections"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref CONTRACT_CALLS_PROCESSED_COUNT: IntCounter = register_int_counter!(opts!(
+pub static CONTRACT_CALLS_PROCESSED_COUNT: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(opts!(
         "stacks_contract_calls_processed",
         "Total count of processed contract calls"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref MEMPOOL_OUTSTANDING_TXS: IntGauge = register_int_gauge!(opts!(
+pub static MEMPOOL_OUTSTANDING_TXS: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_mempool_outstanding_txs",
         "Number of still-unprocessed transactions received by this node since it started",
         labels! {"handler" => "all",}
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref MEMPOOL_TX_CONFIRM_TIME: Histogram = register_histogram!(histogram_opts!(
+pub static MEMPOOL_TX_CONFIRM_TIME: LazyLock<Histogram> = LazyLock::new(|| {
+    register_histogram!(histogram_opts!(
         "stacks_node_mempool_tx_confirm_times",
         "Time (seconds) between when a tx was received by this node's mempool and when a tx was first processed in a block",
         vec![300.0, 600.0, 900.0, 1200.0, 1500.0, 1800.0, 2100.0, 2400.0, 2700.0, 3000.0, 3600.0, 4200.0, 4800.0, 6000.0],
         labels! {"handler".to_string() => "all".to_string(),}
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref COMPUTED_RELATIVE_MINER_SCORE: Gauge = register_gauge!(opts!(
+pub static COMPUTED_RELATIVE_MINER_SCORE: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "stacks_node_computed_relative_miner_score",
         "Percentage of the u256 range that this miner is assigned in a particular round of sortition"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref COMPUTED_MINER_COMMITMENT_HIGH: IntGauge = register_int_gauge!(opts!(
+pub static COMPUTED_MINER_COMMITMENT_HIGH: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_computed_miner_commitment_high",
         "High 64 bits of a miner's effective commitment (min of the miner's previous commitment and their median commitment)"
-    )).unwrap();
+    )).unwrap()
+});
 
-     pub static ref COMPUTED_MINER_COMMITMENT_LOW: IntGauge = register_int_gauge!(opts!(
+pub static COMPUTED_MINER_COMMITMENT_LOW: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_computed_miner_commitment_low",
         "Low 64 bits of a miner's effective commitment (min of the miner's previous commitment and their median commitment)"
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref MINER_CURRENT_MEDIAN_COMMITMENT_HIGH: IntGauge = register_int_gauge!(opts!(
+pub static MINER_CURRENT_MEDIAN_COMMITMENT_HIGH: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_miner_current_median_commitment_high",
         "High 64 bits of a miner's median commitment over the mining commitment window."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref MINER_CURRENT_MEDIAN_COMMITMENT_LOW: IntGauge = register_int_gauge!(opts!(
+pub static MINER_CURRENT_MEDIAN_COMMITMENT_LOW: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(opts!(
         "stacks_node_miner_current_median_commitment_low",
         "Low 64 bits of a miner's median commitment over the mining commitment window."
-    )).unwrap();
+    )).unwrap()
+});
 
-    pub static ref MINER_STOP_REASON_TOTAL: IntCounterVec = register_int_counter_vec!(
+pub static MINER_STOP_REASON_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
         "stacks_node_miner_stop_reason_total",
         "Total number of times the miner stopped for each reason",
         &["reason"]
-    ).unwrap();
-}
+    ).unwrap()
+});
 
 pub fn new_rpc_call_timer(path: &str) -> HistogramTimer {
     let histogram = RPC_CALL_LATENCIES_HISTOGRAM.with_label_values(&[path]);

--- a/stackslib/src/net/api/getclaritymetadata.rs
+++ b/stackslib/src/net/api/getclaritymetadata.rs
@@ -21,7 +21,7 @@ use clarity::vm::representations::{
 };
 use clarity::vm::types::QualifiedContractIdentifier;
 use clarity::vm::ContractName;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use regex::{Captures, Regex};
 use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::types::net::PeerHost;
@@ -36,16 +36,18 @@ use crate::net::httpcore::{
 };
 use crate::net::{Error as NetError, StacksNodeState, TipRequest};
 
-lazy_static! {
-    static ref CLARITY_NAME_NO_BOUNDARIES_REGEX_STRING: String = format!(
+static CLARITY_NAME_NO_BOUNDARIES_REGEX_STRING: LazyLock<String> = LazyLock::new(|| {
+    format!(
         "([a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*])*|[-+=/*]|[<>]=?){{1,{}}}",
         MAX_STRING_LEN
-    );
-    static ref METADATA_KEY_REGEX_STRING: String = format!(
+    )
+});
+static METADATA_KEY_REGEX_STRING: LazyLock<String> = LazyLock::new(|| {
+    format!(
         r"vm-metadata::(?P<data_type>(\d{{1,2}}))::(?P<var_name>(contract|contract-size|contract-src|contract-data-size|{}))",
         *CLARITY_NAME_NO_BOUNDARIES_REGEX_STRING,
-    );
-}
+    )
+});
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ClarityMetadataResponse {

--- a/stackslib/src/net/atlas/mod.rs
+++ b/stackslib/src/net/atlas/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::hash::Hash;
 
 use clarity::vm::types::{QualifiedContractIdentifier, SequenceData, Value};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use regex::Regex;
 use serde::de::{Deserialize, Error as de_Error};
 use serde::ser::Serialize;
@@ -45,9 +45,8 @@ pub const MAX_RETRY_DELAY: u64 = 600; // seconds
 ///  waiting for attachments to be processed.
 pub const ATTACHMENTS_CHANNEL_SIZE: usize = 5;
 
-lazy_static! {
-    pub static ref BNS_CHARS_REGEX: Regex = Regex::new("^([a-z0-9]|[-_])*$").unwrap();
-}
+pub static BNS_CHARS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new("^([a-z0-9]|[-_])*$").unwrap());
 
 const ATTACHMENTS_MAX_SIZE_MIN: u32 = 1_048_576;
 const MAX_UNINSTANTIATED_ATTACHMENTS_MIN: u32 = 50_000;

--- a/stackslib/src/net/stackerdb/config.rs
+++ b/stackslib/src/net/stackerdb/config.rs
@@ -44,7 +44,7 @@ use clarity::vm::types::{
     SequenceSubtype, TupleTypeSignature, TypeSignature, Value as ClarityValue,
 };
 use clarity::vm::ClarityName;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
 use stacks_common::types::net::PeerAddress;
 use stacks_common::types::StacksEpochId;
@@ -61,59 +61,60 @@ use crate::net::{Error as NetError, NeighborAddress};
 
 const MAX_HINT_REPLICAS: u32 = 128;
 
-lazy_static! {
-    pub static ref REQUIRED_FUNCTIONS: [(ClarityName, Vec<TypeSignature>, TypeSignature); 2] = [
-        (
-            STACKERDB_SLOTS_FUNCTION.into(),
-            vec![],
-            TypeSignature::new_response(
-                ListTypeData::new_list(
-                    TupleTypeSignature::try_from(vec![
-                        ("signer".into(), TypeSignature::PrincipalType),
-                        ("num-slots".into(), TypeSignature::UIntType)
-                    ])
-                    .expect("FATAL: failed to construct signer list type")
+pub static REQUIRED_FUNCTIONS: LazyLock<[(ClarityName, Vec<TypeSignature>, TypeSignature); 2]> =
+    LazyLock::new(|| {
+        [
+            (
+                STACKERDB_SLOTS_FUNCTION.into(),
+                vec![],
+                TypeSignature::new_response(
+                    ListTypeData::new_list(
+                        TupleTypeSignature::try_from(vec![
+                            ("signer".into(), TypeSignature::PrincipalType),
+                            ("num-slots".into(), TypeSignature::UIntType)
+                        ])
+                        .expect("FATAL: failed to construct signer list type")
+                        .into(),
+                        STACKERDB_PAGE_LIST_MAX
+                    )
+                    .expect("FATAL: could not construct signer list type")
                     .into(),
-                    STACKERDB_PAGE_LIST_MAX
-                )
-                .expect("FATAL: could not construct signer list type")
-                .into(),
-                TypeSignature::UIntType
-            ).expect("FATAL: failed to construct response with signer slots"),
-        ),
-        (
-            STACKERDB_CONFIG_FUNCTION.into(),
-            vec![],
-            TypeSignature::new_response(
-                TypeSignature::TupleType(
-                    TupleTypeSignature::try_from(vec![
-                        ("chunk-size".into(), TypeSignature::UIntType),
-                        ("write-freq".into(), TypeSignature::UIntType),
-                        ("max-writes".into(), TypeSignature::UIntType),
-                        ("max-neighbors".into(), TypeSignature::UIntType),
-                        ("hint-replicas".into(), ListTypeData::new_list(
-                            TypeSignature::TupleType(
-                                TupleTypeSignature::try_from(vec![
-                                    ("addr".into(), ListTypeData::new_list(TypeSignature::UIntType, 16)
-                                        .expect("FATAL: invalid IP address list")
-                                        .into()),
-                                    ("port".into(), TypeSignature::UIntType),
-                                    ("public-key-hash".into(),
-                                        // can't use BUFF_20 here because it's also in a
-                                        // lazy_static! block
-                                        TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength::try_from(20u32).expect("FATAL: could not create (buff 20)"))))
-                                ])
-                                .expect("FATAL: unable to construct hint-replicas type")
-                                ),
-                            MAX_HINT_REPLICAS)
-                            .expect("FATAL: failed to construct hint-replicas list type")
-                            .into())
-                    ]).expect("FATAL: unable to construct config type")),
-                TypeSignature::UIntType
-            ).expect("FATAL: unable to construct config response type")
-        )
-    ];
-}
+                    TypeSignature::UIntType
+                ).expect("FATAL: failed to construct response with signer slots"),
+            ),
+            (
+                STACKERDB_CONFIG_FUNCTION.into(),
+                vec![],
+                TypeSignature::new_response(
+                    TypeSignature::TupleType(
+                        TupleTypeSignature::try_from(vec![
+                            ("chunk-size".into(), TypeSignature::UIntType),
+                            ("write-freq".into(), TypeSignature::UIntType),
+                            ("max-writes".into(), TypeSignature::UIntType),
+                            ("max-neighbors".into(), TypeSignature::UIntType),
+                            ("hint-replicas".into(), ListTypeData::new_list(
+                                TypeSignature::TupleType(
+                                    TupleTypeSignature::try_from(vec![
+                                        ("addr".into(), ListTypeData::new_list(TypeSignature::UIntType, 16)
+                                            .expect("FATAL: invalid IP address list")
+                                            .into()),
+                                        ("port".into(), TypeSignature::UIntType),
+                                        ("public-key-hash".into(),
+                                            // can't use BUFF_20 here because it's also in a
+                                            // LazyLock static
+                                            TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength::try_from(20u32).expect("FATAL: could not create (buff 20)"))))
+                                    ])
+                                    .expect("FATAL: unable to construct hint-replicas type")
+                                    ),
+                                MAX_HINT_REPLICAS)
+                                .expect("FATAL: failed to construct hint-replicas list type")
+                                .into())
+                        ]).expect("FATAL: unable to construct config type")),
+                    TypeSignature::UIntType
+                ).expect("FATAL: unable to construct config response type")
+            )
+        ]
+    });
 
 impl StackerDBConfig {
     /// Check that a smart contract is consistent with being a StackerDB controller.

--- a/stackslib/src/util_lib/strings.rs
+++ b/stackslib/src/util_lib/strings.rs
@@ -23,7 +23,8 @@ use clarity::vm::errors::ClarityTypeError;
 use clarity::vm::representations::{
     ClarityName, ContractName, MAX_STRING_LEN as CLARITY_MAX_STRING_LENGTH,
 };
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use regex::Regex;
 use stacks_common::codec::{
     read_next, write_next, Error as codec_error, StacksMessageCodec, MAX_MESSAGE_LEN,
@@ -31,10 +32,8 @@ use stacks_common::codec::{
 use stacks_common::util::retry::BoundReader;
 use url;
 
-lazy_static! {
-    static ref URL_STRING_REGEX: Regex =
-        Regex::new(r#"^[a-zA-Z0-9._~:/?#\[\]@!$&'()*+,;%=-]*$"#).unwrap();
-}
+static URL_STRING_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^[a-zA-Z0-9._~:/?#\[\]@!$&'()*+,;%=-]*$"#).unwrap());
 
 guarded_string!(
     UrlString,


### PR DESCRIPTION
## Summary

Replace all `lazy_static!` macro usages across the codebase with `std::sync::LazyLock` from the standard library (stable since Rust 1.80). This eliminates the external `lazy_static` dependency from all 9 crates that used it.

## Changes

**34 files changed across 9 crates:**

| Crate | Files | Statics converted |
|-------|-------|-------------------|
| stackslib | 12 | ~35 (boot code, epochs, prometheus metrics, regex, test data) |
| stacks-common | 1 | 3 (logger, log format, log level) |
| clarity | 2 | 7 (cost types, regex patterns, lexer matchers) |
| clarity-types | 2 | 8 (regex strings, serialization constants) |
| libsigner | 1 | 1 (version string) |
| stacks-node | 5 | 8 (test flags, test data, prometheus metrics) |
| stacks-signer | 1 | 14 (prometheus metrics) |
| contrib/clarity-cli | 1 | 2 (boot code arrays) |

**Cargo.toml changes:** Removed `lazy_static` from `[dependencies]` in all 9 crate Cargo.tomls and from `[workspace.dependencies]` in the workspace root.

## Test plan

- [x] Mechanical conversion — `LazyLock<T>` implements `Deref<Target = T>` identically to `lazy_static` statics, so all access patterns are unchanged
- [x] No remaining references to `lazy_static` in any `.rs` source file
- [x] `Cargo.lock` references are from transitive dependencies only (third-party crates)

Closes #5035

🤖 Generated with [Claude Code](https://claude.com/claude-code)