### PR TITLE
aac: convert runtime check "expectable" errors to "unrechable"

### DIFF
--- a/clarity-types/src/errors/analysis.rs
+++ b/clarity-types/src/errors/analysis.rs
@@ -560,9 +560,8 @@ pub enum RuntimeCheckErrorKind {
     /// Type signature nesting depth exceeds the allowed limit during analysis.
     TypeSignatureTooDeep,
 
-    // Unexpected interpreter behavior
     /// Unexpected condition or failure in the type-checker, indicating a catastrophic bug or invalid state.
-    ExpectsRejectable(String),
+    Unreachable(String),
 
     // List typing errors
     /// List elements have mismatched types, violating type consistency.
@@ -652,7 +651,7 @@ pub struct StaticCheckError {
 impl RuntimeCheckErrorKind {
     /// This check indicates that the transaction should be rejected.
     pub fn rejectable(&self) -> bool {
-        matches!(self, RuntimeCheckErrorKind::ExpectsRejectable(_))
+        matches!(self, RuntimeCheckErrorKind::Unreachable(_))
     }
 }
 
@@ -801,20 +800,20 @@ impl From<ClarityTypeError> for RuntimeCheckErrorKind {
             | ClarityTypeError::InvalidTypeDescription
             | ClarityTypeError::NoSuchTupleField(_, _)
             | ClarityTypeError::EmptyTuplesNotAllowed
-            | ClarityTypeError::ResponseTypeMismatch { .. } => Self::ExpectsRejectable(format!(
+            | ClarityTypeError::ResponseTypeMismatch { .. } => Self::Unreachable(format!(
                 "Unexpected error type during runtime analysis: {err}"
             )),
             ClarityTypeError::InvariantViolation(_)
             | ClarityTypeError::InvalidPrincipalVersion(_)
-            | ClarityTypeError::SupertypeTooLarge => Self::ExpectsRejectable(format!(
+            | ClarityTypeError::SupertypeTooLarge => Self::Unreachable(format!(
                 "Unexpected error type during runtime analysis: {err}"
             )),
             ClarityTypeError::CouldNotDetermineType => Self::CouldNotDetermineType,
             ClarityTypeError::UnsupportedTypeInEpoch(ty, epoch) => {
-                Self::ExpectsRejectable(format!("{ty} should not be used in {epoch}"))
+                Self::Unreachable(format!("{ty} should not be used in {epoch}"))
             }
             ClarityTypeError::UnsupportedEpoch(epoch) => {
-                Self::ExpectsRejectable(format!("{epoch} is not supported"))
+                Self::Unreachable(format!("{epoch} is not supported"))
             }
         }
     }
@@ -899,10 +898,10 @@ impl From<CostErrors> for RuntimeCheckErrorKind {
             CostErrors::CostContractLoadFailure => {
                 RuntimeCheckErrorKind::CostComputationFailed("Failed to load cost contract".into())
             }
-            CostErrors::InterpreterFailure => RuntimeCheckErrorKind::ExpectsRejectable(
+            CostErrors::InterpreterFailure => RuntimeCheckErrorKind::Unreachable(
                 "Unexpected interpreter failure in cost computation".into(),
             ),
-            CostErrors::Expect(s) => RuntimeCheckErrorKind::ExpectsRejectable(s),
+            CostErrors::Expect(s) => RuntimeCheckErrorKind::Unreachable(s),
             CostErrors::ExecutionTimeExpired => RuntimeCheckErrorKind::ExecutionTimeExpired,
         }
     }
@@ -953,49 +952,45 @@ impl From<CommonCheckErrorKind> for RuntimeCheckErrorKind {
                 RuntimeCheckErrorKind::IncorrectArgumentCount(expected, args)
             }
             CommonCheckErrorKind::RequiresAtLeastArguments(expected, args) => {
-                RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                RuntimeCheckErrorKind::Unreachable(format!(
                     "Requires at least args: {expected} got {args}"
                 ))
             }
             CommonCheckErrorKind::RequiresAtMostArguments(expected, args) => {
-                RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                RuntimeCheckErrorKind::Unreachable(format!(
                     "Requires at most args: {expected} got {args}"
                 ))
             }
             CommonCheckErrorKind::TooManyFunctionParameters(found, allowed) => {
-                RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                RuntimeCheckErrorKind::Unreachable(format!(
                     "Too many function params: found {found}, allowed {allowed}"
                 ))
             }
             CommonCheckErrorKind::ExpectedName => {
-                RuntimeCheckErrorKind::ExpectsRejectable("Expected name".to_string())
+                RuntimeCheckErrorKind::Unreachable("Expected name".to_string())
             }
             CommonCheckErrorKind::DefineFunctionBadSignature => {
-                RuntimeCheckErrorKind::ExpectsRejectable(
-                    "Define function bad signature".to_string(),
-                )
+                RuntimeCheckErrorKind::Unreachable("Define function bad signature".to_string())
             }
             CommonCheckErrorKind::ExpectedTraitIdentifier => {
-                RuntimeCheckErrorKind::ExpectsRejectable("Expected trait identifier".to_string())
+                RuntimeCheckErrorKind::Unreachable("Expected trait identifier".to_string())
             }
             CommonCheckErrorKind::DefineTraitDuplicateMethod(s) => {
-                RuntimeCheckErrorKind::ExpectsRejectable(format!(
-                    "Define trait duplicate method: {s}"
-                ))
+                RuntimeCheckErrorKind::Unreachable(format!("Define trait duplicate method: {s}"))
             }
             CommonCheckErrorKind::TraitTooManyMethods(found, allowed) => {
-                RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                RuntimeCheckErrorKind::Unreachable(format!(
                     "Trait too many methods: found {found}, allowed {allowed}"
                 ))
             }
             CommonCheckErrorKind::DefineTraitBadSignature => {
-                RuntimeCheckErrorKind::ExpectsRejectable("Define trait bad signature".to_string())
+                RuntimeCheckErrorKind::Unreachable("Define trait bad signature".to_string())
             }
             CommonCheckErrorKind::BadSyntaxBinding(e) => {
-                RuntimeCheckErrorKind::ExpectsRejectable(format!("Bad syntax binding: {e}"))
+                RuntimeCheckErrorKind::Unreachable(format!("Bad syntax binding: {e}"))
             }
             CommonCheckErrorKind::UnknownTypeName(name) => {
-                RuntimeCheckErrorKind::ExpectsRejectable(format!("Unknown type name: {name}"))
+                RuntimeCheckErrorKind::Unreachable(format!("Unknown type name: {name}"))
             }
         }
     }

--- a/clarity/fuzz/fuzz_targets/fuzz_sanitize.rs
+++ b/clarity/fuzz/fuzz_targets/fuzz_sanitize.rs
@@ -245,7 +245,7 @@ pub fn strict_admits(me: &TypeSignature, x: &ClarityValue) -> Result<bool, Runti
         }
         TypeSignature::CallableType(_)
         | TypeSignature::ListUnionType(_)
-        | TypeSignature::TraitReferenceType(_) => Err(RuntimeCheckErrorKind::ExpectsRejectable(
+        | TypeSignature::TraitReferenceType(_) => Err(RuntimeCheckErrorKind::Unreachable(
             "Trait reference unknown".into(),
         )),
     }

--- a/clarity/fuzz/fuzz_targets/fuzz_value_sanitize.rs
+++ b/clarity/fuzz/fuzz_targets/fuzz_value_sanitize.rs
@@ -251,7 +251,7 @@ pub fn strict_admits(me: &TypeSignature, x: &ClarityValue) -> Result<bool, Runti
         }
         TypeSignature::CallableType(_)
         | TypeSignature::ListUnionType(_)
-        | TypeSignature::TraitReferenceType(_) => Err(RuntimeCheckErrorKind::ExpectsRejectable(
+        | TypeSignature::TraitReferenceType(_) => Err(RuntimeCheckErrorKind::Unreachable(
             "Trait reference unknown".into(),
         )),
     }

--- a/clarity/src/vm/callables.rs
+++ b/clarity/src/vm/callables.rs
@@ -329,13 +329,13 @@ impl DefinedFunction {
         let trait_name = trait_identifier.name.to_string();
         let constraining_trait = contract_defining_trait
             .lookup_trait_definition(&trait_name)
-            .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
                 "Trait reference unknown: {trait_name}"
             )))?;
         let expected_sig =
             constraining_trait
                 .get(&self.name)
-                .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
                     "Trait method unknown: {trait_name}.{}",
                     self.name
                 )))?;

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1170,7 +1170,7 @@ impl<'a, 'b, 'hooks> Environment<'a, 'b, 'hooks> {
             if !allow_private && !func.is_public() {
                 return Err(RuntimeCheckErrorKind::NoSuchPublicFunction(contract_identifier.to_string(), tx_name.to_string()).into());
             } else if read_only && !func.is_read_only() {
-                return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!("Public function not read-only: {contract_identifier} {tx_name}")).into());
+                return Err(RuntimeCheckErrorKind::Unreachable(format!("Public function not read-only: {contract_identifier} {tx_name}")).into());
             }
 
             let args: Result<Vec<Value>, VmExecutionError> = args.iter()
@@ -1338,7 +1338,7 @@ impl<'a, 'b, 'hooks> Environment<'a, 'b, 'hooks> {
                 .database
                 .has_contract(&contract_identifier)
             {
-                return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                return Err(RuntimeCheckErrorKind::Unreachable(format!(
                     "Contract already exists: {contract_identifier}"
                 ))
                 .into());
@@ -1876,7 +1876,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
                 self.commit()?;
                 Ok(result)
             } else {
-                Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                Err(RuntimeCheckErrorKind::Unreachable(format!(
                     "Public function must return response: {}",
                     TypeSignature::type_of(&result)?
                 ))
@@ -2506,7 +2506,7 @@ mod test {
 
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Contract already exists: S1G2081040G2081040G2081040G208105NK8PE5.dup".to_string()
             ))
         );

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -1538,10 +1538,8 @@ impl ClarityDatabase<'_> {
         let key = ClarityDatabase::make_metadata_key(StoreType::VariableMeta, variable_name);
 
         map_no_contract_as_none(self.fetch_metadata(contract_identifier, &key))?.ok_or(
-            RuntimeCheckErrorKind::ExpectsRejectable(format!(
-                "No such data variable: {variable_name}"
-            ))
-            .into(),
+            RuntimeCheckErrorKind::Unreachable(format!("No such data variable: {variable_name}"))
+                .into(),
         )
     }
 
@@ -1682,9 +1680,8 @@ impl ClarityDatabase<'_> {
     ) -> Result<DataMapMetadata, VmExecutionError> {
         let key = ClarityDatabase::make_metadata_key(StoreType::DataMapMeta, map_name);
 
-        map_no_contract_as_none(self.fetch_metadata(contract_identifier, &key))?.ok_or(
-            RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")).into(),
-        )
+        map_no_contract_as_none(self.fetch_metadata(contract_identifier, &key))?
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")).into())
     }
 
     pub fn make_key_for_data_map_entry(
@@ -2047,9 +2044,8 @@ impl ClarityDatabase<'_> {
     ) -> Result<FungibleTokenMetadata, VmExecutionError> {
         let key = ClarityDatabase::make_metadata_key(StoreType::FungibleTokenMeta, token_name);
 
-        map_no_contract_as_none(self.fetch_metadata(contract_identifier, &key))?.ok_or(
-            RuntimeCheckErrorKind::ExpectsRejectable(format!("No such FT: {token_name}")).into(),
-        )
+        map_no_contract_as_none(self.fetch_metadata(contract_identifier, &key))?
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!("No such FT: {token_name}")).into())
     }
 
     pub fn create_non_fungible_token(
@@ -2074,9 +2070,8 @@ impl ClarityDatabase<'_> {
     ) -> Result<NonFungibleTokenMetadata, VmExecutionError> {
         let key = ClarityDatabase::make_metadata_key(StoreType::NonFungibleTokenMeta, token_name);
 
-        map_no_contract_as_none(self.fetch_metadata(contract_identifier, &key))?.ok_or(
-            RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {token_name}")).into(),
-        )
+        map_no_contract_as_none(self.fetch_metadata(contract_identifier, &key))?
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!("No such NFT: {token_name}")).into())
     }
 
     pub fn checked_increase_token_supply(

--- a/clarity/src/vm/functions/arithmetic.rs
+++ b/clarity/src/vm/functions/arithmetic.rs
@@ -601,7 +601,7 @@ pub fn native_bitwise_left_shift(input: Value, pos: Value) -> Result<Value, VmEx
                 let result = input.wrapping_shl(shamt);
                 Ok(Value::UInt(result))
             }
-            _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Union type error {}",
                 TypeSignature::type_of(&input)?
             ))
@@ -630,7 +630,7 @@ pub fn native_bitwise_right_shift(input: Value, pos: Value) -> Result<Value, VmE
                 let result = input.wrapping_shr(shamt);
                 Ok(Value::UInt(result))
             }
-            _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Union type error {}",
                 TypeSignature::type_of(&input)?
             ))

--- a/clarity/src/vm/functions/assets.rs
+++ b/clarity/src/vm/functions/assets.rs
@@ -181,7 +181,7 @@ pub fn special_stx_transfer(
     {
         stx_transfer_consolidated(env, from, to, amount, memo)
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into())
     }
 }
 
@@ -207,7 +207,7 @@ pub fn special_stx_transfer_memo(
     {
         stx_transfer_consolidated(env, from, to, amount, memo)
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into())
     }
 }
 
@@ -291,7 +291,7 @@ pub fn special_stx_burn(
 
         env.add_memory(TypeSignature::PrincipalType.size()?.into())?;
         env.add_memory(STXBalance::unlocked_and_v1_size.try_into().map_err(|_| {
-            RuntimeCheckErrorKind::ExpectsRejectable(
+            RuntimeCheckErrorKind::Unreachable(
                 "BUG: STXBalance::unlocked_and_v1_size does not fit into a u64".into(),
             )
         })?)?;
@@ -313,7 +313,7 @@ pub fn special_stx_burn(
 
         Ok(Value::okay_true())
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into())
     }
 }
 
@@ -328,7 +328,7 @@ pub fn special_mint_token(
 
     let token_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
@@ -341,7 +341,7 @@ pub fn special_mint_token(
         }
 
         let ft_info = env.contract_context.meta_ft.get(token_name).ok_or(
-            RuntimeCheckErrorKind::ExpectsRejectable(format!("No such FT: {token_name}")),
+            RuntimeCheckErrorKind::Unreachable(format!("No such FT: {token_name}")),
         )?;
 
         env.global_context.database.checked_increase_token_supply(
@@ -380,7 +380,7 @@ pub fn special_mint_token(
 
         Ok(Value::okay_true())
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad mint FT args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad mint FT args".to_string()).into())
     }
 }
 
@@ -393,16 +393,20 @@ pub fn special_mint_asset_v200(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
     let asset = eval(&args[1], env, context)?;
     let to = eval(&args[2], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     runtime_cost(
@@ -471,16 +475,20 @@ pub fn special_mint_asset_v205(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
     let asset = eval(&args[1], env, context)?;
     let to = eval(&args[2], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     let asset_size = asset
@@ -546,7 +554,7 @@ pub fn special_transfer_asset_v200(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
@@ -554,9 +562,13 @@ pub fn special_transfer_asset_v200(
     let from = eval(&args[2], env, context)?;
     let to = eval(&args[3], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     runtime_cost(
@@ -628,7 +640,7 @@ pub fn special_transfer_asset_v200(
 
         Ok(Value::okay_true())
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer NFT args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad transfer NFT args".to_string()).into())
     }
 }
 
@@ -643,7 +655,7 @@ pub fn special_transfer_asset_v205(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
@@ -651,9 +663,13 @@ pub fn special_transfer_asset_v205(
     let from = eval(&args[2], env, context)?;
     let to = eval(&args[3], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     let asset_size = asset
@@ -724,7 +740,7 @@ pub fn special_transfer_asset_v205(
 
         Ok(Value::okay_true())
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer NFT args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad transfer NFT args".to_string()).into())
     }
 }
 
@@ -739,7 +755,7 @@ pub fn special_transfer_token(
 
     let token_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
@@ -762,7 +778,7 @@ pub fn special_transfer_token(
         }
 
         let ft_info = env.contract_context.meta_ft.get(token_name).ok_or(
-            RuntimeCheckErrorKind::ExpectsRejectable(format!("No such FT: {token_name}")),
+            RuntimeCheckErrorKind::Unreachable(format!("No such FT: {token_name}")),
         )?;
 
         let from_bal = env.global_context.database.get_ft_balance(
@@ -829,7 +845,7 @@ pub fn special_transfer_token(
 
         Ok(Value::okay_true())
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer FT args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad transfer FT args".to_string()).into())
     }
 }
 
@@ -844,7 +860,7 @@ pub fn special_get_balance(
 
     let token_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
@@ -852,7 +868,7 @@ pub fn special_get_balance(
 
     if let Value::Principal(ref principal) = owner {
         let ft_info = env.contract_context.meta_ft.get(token_name).ok_or(
-            RuntimeCheckErrorKind::ExpectsRejectable(format!("No such FT: {token_name}")),
+            RuntimeCheckErrorKind::Unreachable(format!("No such FT: {token_name}")),
         )?;
 
         let balance = env.global_context.database.get_ft_balance(
@@ -880,15 +896,19 @@ pub fn special_get_owner_v200(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
     let asset = eval(&args[1], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     runtime_cost(
@@ -930,15 +950,19 @@ pub fn special_get_owner_v205(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
     let asset = eval(&args[1], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     let asset_size = asset
@@ -979,7 +1003,7 @@ pub fn special_get_token_supply(
 
     let token_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
@@ -1001,7 +1025,7 @@ pub fn special_burn_token(
 
     let token_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
@@ -1057,7 +1081,7 @@ pub fn special_burn_token(
 
         Ok(Value::okay_true())
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad burn FT args".to_string()).into())
+        Err(RuntimeCheckErrorKind::Unreachable("Bad burn FT args".to_string()).into())
     }
 }
 
@@ -1072,16 +1096,20 @@ pub fn special_burn_asset_v200(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
     let asset = eval(&args[1], env, context)?;
     let sender = eval(&args[2], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     runtime_cost(
@@ -1164,16 +1192,20 @@ pub fn special_burn_asset_v205(
 
     let asset_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad token name".to_string(),
         ))?;
 
     let asset = eval(&args[1], env, context)?;
     let sender = eval(&args[2], env, context)?;
 
-    let nft_metadata = env.contract_context.meta_nft.get(asset_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such NFT: {asset_name}")),
-    )?;
+    let nft_metadata =
+        env.contract_context
+            .meta_nft
+            .get(asset_name)
+            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
+                "No such NFT: {asset_name}"
+            )))?;
     let expected_asset_type = &nft_metadata.key_type;
 
     let asset_size = asset

--- a/clarity/src/vm/functions/conversions.rs
+++ b/clarity/src/vm/functions/conversions.rs
@@ -357,7 +357,7 @@ pub fn from_consensus_buff(
                 return Ok(Value::none());
             }
             return Err(
-                RuntimeCheckErrorKind::ExpectsRejectable("UnexpectedSerialization".into()).into(),
+                RuntimeCheckErrorKind::Unreachable("UnexpectedSerialization".into()).into(),
             );
         }
         Err(_) => return Ok(Value::none()),

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -71,7 +71,7 @@ pub fn special_contract_call(
 
     let function_name = args[1]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
     let rest_args_slice = &args[2..];
@@ -117,9 +117,7 @@ pub fn special_contract_call(
                     // This error case indicates a bad implementation. Only traits should be
                     // added to callable_contracts.
                     let trait_identifier = trait_data.trait_identifier.as_ref().ok_or(
-                        RuntimeCheckErrorKind::ExpectsRejectable(
-                            "Expected trait identifier".to_string(),
-                        ),
+                        RuntimeCheckErrorKind::Unreachable("Expected trait identifier".to_string()),
                     )?;
 
                     // Attempt to short circuit the dynamic dispatch checks:
@@ -154,7 +152,7 @@ pub fn special_contract_call(
 
                         // Check read/write compatibility
                         if env.global_context.is_read_only() {
-                            return Err(RuntimeCheckErrorKind::ExpectsRejectable(
+                            return Err(RuntimeCheckErrorKind::Unreachable(
                                 "Trait based contract call in read-only".to_string(),
                             )
                             .into());
@@ -178,11 +176,11 @@ pub fn special_contract_call(
                         // Retrieve the expected method signature
                         let constraining_trait = contract_context_defining_trait
                             .lookup_trait_definition(&trait_name)
-                            .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                            .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
                                 "Trait reference unknown: {trait_name}"
                             )))?;
                         let expected_sig = constraining_trait.get(function_name).ok_or(
-                            RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                            RuntimeCheckErrorKind::Unreachable(format!(
                                 "Trait method unknown: {trait_name}.{function_name}"
                             )),
                         )?;
@@ -243,14 +241,14 @@ pub fn special_fetch_variable_v200(
 
     let var_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_var.get(var_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such data variable: {var_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such data variable: {var_name}")),
     )?;
 
     runtime_cost(
@@ -276,14 +274,14 @@ pub fn special_fetch_variable_v205(
 
     let var_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_var.get(var_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such data variable: {var_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such data variable: {var_name}")),
     )?;
 
     let epoch = *env.epoch();
@@ -308,10 +306,9 @@ pub fn special_set_variable_v200(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(2, args)?;
@@ -320,14 +317,14 @@ pub fn special_set_variable_v200(
 
     let var_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_var.get(var_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such data variable: {var_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such data variable: {var_name}")),
     )?;
 
     runtime_cost(
@@ -353,10 +350,9 @@ pub fn special_set_variable_v205(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(2, args)?;
@@ -365,14 +361,14 @@ pub fn special_set_variable_v205(
 
     let var_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_var.get(var_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such data variable: {var_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such data variable: {var_name}")),
     )?;
 
     let epoch = *env.epoch();
@@ -402,7 +398,7 @@ pub fn special_fetch_entry_v200(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
@@ -411,7 +407,7 @@ pub fn special_fetch_entry_v200(
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     runtime_cost(
@@ -437,7 +433,7 @@ pub fn special_fetch_entry_v205(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
@@ -446,7 +442,7 @@ pub fn special_fetch_entry_v205(
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     let epoch = *env.epoch();
@@ -504,10 +500,9 @@ pub fn special_set_entry_v200(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(3, args)?;
@@ -518,14 +513,14 @@ pub fn special_set_entry_v200(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     runtime_cost(
@@ -552,10 +547,9 @@ pub fn special_set_entry_v205(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(3, args)?;
@@ -566,14 +560,14 @@ pub fn special_set_entry_v205(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     let epoch = *env.epoch();
@@ -600,10 +594,9 @@ pub fn special_insert_entry_v200(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(3, args)?;
@@ -614,14 +607,14 @@ pub fn special_insert_entry_v200(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     runtime_cost(
@@ -649,10 +642,9 @@ pub fn special_insert_entry_v205(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(3, args)?;
@@ -663,14 +655,14 @@ pub fn special_insert_entry_v205(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     let epoch = *env.epoch();
@@ -697,10 +689,9 @@ pub fn special_delete_entry_v200(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(2, args)?;
@@ -709,14 +700,14 @@ pub fn special_delete_entry_v200(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     runtime_cost(
@@ -742,10 +733,9 @@ pub fn special_delete_entry_v205(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if env.global_context.is_read_only() {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(
-            "Write attempted in read-only".to_string(),
-        )
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()).into(),
+        );
     }
 
     check_argument_count(2, args)?;
@@ -754,14 +744,14 @@ pub fn special_delete_entry_v205(
 
     let map_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
     let contract = &env.contract_context.contract_identifier;
 
     let data_types = env.contract_context.meta_data_map.get(map_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("No such map: {map_name}")),
+        RuntimeCheckErrorKind::Unreachable(format!("No such map: {map_name}")),
     )?;
 
     let epoch = *env.epoch();
@@ -815,14 +805,14 @@ pub fn special_get_block_info(
     // Handle the block property name input arg.
     let property_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Get block info expect property name".to_string(),
         ))?;
 
     let version = env.contract_context.get_clarity_version();
 
     let block_info_prop = BlockInfoProperty::lookup_by_name_at_version(property_name, version)
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Get block info expect property name".to_string(),
         ))?;
 
@@ -973,12 +963,12 @@ pub fn special_get_burn_block_info(
     // Handle the block property name input arg.
     let property_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Get block info expect property name".to_string(),
         ))?;
 
     let block_info_prop = BurnBlockInfoProperty::lookup_by_name(property_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "No such burn block info property: {property_name}"
         )),
     )?;
@@ -1063,7 +1053,7 @@ pub fn special_get_burn_block_info(
 ///
 /// # Errors:
 /// - [`RuntimeCheckErrorKind::IncorrectArgumentCount`] if there aren't 2 arguments.
-/// - [`RuntimeCheckErrorKind::ExpectsRejectable`] if `args[0]` isn't a ClarityName and a [`StacksBlockInfoProperty`].
+/// - [`RuntimeCheckErrorKind::Unreachable`] if `args[0]` isn't a ClarityName and a [`StacksBlockInfoProperty`].
 /// - [`RuntimeCheckErrorKind::TypeValueError`] if `args[1]` doesn't evaluate to a `uint`.
 /// - [`RuntimeCheckErrorKind`] cost errors (e.g., `CostOverflow`, `CostBalanceExceeded`) from [`runtime_cost`].
 /// - [`VmExecutionError`] propagated from [`eval`] when evaluating `args[1]`.
@@ -1081,12 +1071,12 @@ pub fn special_get_stacks_block_info(
     // Handle the block property name input arg.
     let property_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Get stacks block info expect property name".to_string(),
         ))?;
 
     let block_info_prop = StacksBlockInfoProperty::lookup_by_name(property_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "No such stacks block info property: {property_name}"
         )),
     )?;
@@ -1169,14 +1159,12 @@ pub fn special_get_tenure_info(
     // Handle the block property name input arg.
     let property_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Get tenure info expect property name".to_string(),
         ))?;
 
     let block_info_prop = TenureInfoProperty::lookup_by_name(property_name).ok_or(
-        RuntimeCheckErrorKind::ExpectsRejectable(
-            "Get tenure info expect property name".to_string(),
-        ),
+        RuntimeCheckErrorKind::Unreachable("Get tenure info expect property name".to_string()),
     )?;
 
     // Handle the block-height input arg.

--- a/clarity/src/vm/functions/define.rs
+++ b/clarity/src/vm/functions/define.rs
@@ -141,16 +141,15 @@ fn handle_define_function(
     let (function_symbol, arg_symbols) =
         signature
             .split_first()
-            .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+            .ok_or(RuntimeCheckErrorKind::Unreachable(
                 "Define function bad signature".to_string(),
             ))?;
 
-    let function_name =
-        function_symbol
-            .match_atom()
-            .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
-                "Expected name".to_string(),
-            ))?;
+    let function_name = function_symbol
+        .match_atom()
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
+            "Expected name".to_string(),
+        ))?;
 
     check_legal_define(function_name, env.contract_context)?;
 
@@ -543,7 +542,7 @@ mod test {
             .unwrap_err();
 
         assert_eq!(
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Bad syntax binding: NotList(Eval, 0)".to_string()
             )),
             err,
@@ -602,7 +601,7 @@ mod test {
         let err = handle_define_trait(&"bad-trait".into(), &trait_body, &mut env).unwrap_err();
 
         assert_eq!(
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Too many function params: found 257, allowed 256".to_string()
             )),
             err

--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -629,7 +629,7 @@ fn native_eq(args: Vec<Value>, env: &mut Environment) -> Result<Value, VmExecuti
 fn native_begin(mut args: Vec<Value>) -> Result<Value, VmExecutionError> {
     match args.pop() {
         Some(v) => Ok(v),
-        None => Err(RuntimeCheckErrorKind::ExpectsRejectable(
+        None => Err(RuntimeCheckErrorKind::Unreachable(
             "Requires at least args: 1 got 0".to_string(),
         )
         .into()),
@@ -773,7 +773,7 @@ fn special_let(
     // parse and eval the bindings.
     let bindings = args[0]
         .match_list()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad let syntax".to_string(),
         ))?;
 
@@ -856,7 +856,7 @@ fn special_contract_of(
     let contract_ref = match &args[0].expr {
         SymbolicExpressionType::Atom(contract_ref) => contract_ref,
         _ => {
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(
+            return Err(RuntimeCheckErrorKind::Unreachable(
                 "Contract of expects trait".to_string(),
             )
             .into());
@@ -877,7 +877,7 @@ fn special_contract_of(
             &trait_data.contract_identifier
         }
         _ => {
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(
+            return Err(RuntimeCheckErrorKind::Unreachable(
                 "Contract of expects trait".to_string(),
             )
             .into());
@@ -946,7 +946,7 @@ mod test {
         let err = special_contract_of(&[non_atom], &mut env, &context).unwrap_err();
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Contract of expects trait".to_string()
             ))
         );
@@ -991,7 +991,7 @@ mod test {
 
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Contract of expects trait".to_string()
             ))
         );
@@ -1034,7 +1034,7 @@ mod test {
         let err = special_let(&args, &mut env, &context).unwrap_err();
 
         assert_eq!(
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Bad let syntax".to_string()
             )),
             err
@@ -1082,14 +1082,14 @@ mod test {
 
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Get tenure info expect property name".to_string()
             ))
         );
     }
 
     /// If we bypass static analysis and pass a non-atom as the property name to `get-burn-block-info?`,
-    /// the runtime returns `ExpectsRejectable`.
+    /// the runtime returns [`RuntimeCheckErrorKind::Unreachable`].
     #[apply(test_clarity_versions)]
     fn special_get_burn_block_info_expected_property_name(
         #[case] version: ClarityVersion,
@@ -1131,14 +1131,14 @@ mod test {
 
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Get block info expect property name".to_string()
             ))
         );
     }
 
     /// If we bypass static analysis and pass a non-atom to `get-stacks-block-info?`,
-    /// the runtime returns `ExpectsRejectable`.
+    /// the runtime returns [`RuntimeCheckErrorKind::Unreachable`].
     #[apply(test_clarity_versions)]
     fn special_get_stacks_block_info_expect_property_name_non_atom(
         #[case] version: ClarityVersion,
@@ -1178,14 +1178,14 @@ mod test {
 
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Get stacks block info expect property name".to_string()
             ))
         );
     }
 
     /// If we bypass static analysis and pass an atom for a non existing property to `get-stacks-block-info?`,
-    /// the runtime returns `ExpectsRejectable`.
+    /// the runtime returns [`RuntimeCheckErrorKind::Unreachable`].
     #[apply(test_clarity_versions)]
     fn special_get_stacks_block_info_no_such_property(
         #[case] version: ClarityVersion,
@@ -1226,14 +1226,14 @@ mod test {
 
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "No such stacks block info property: not-a-valid-stacks-prop".to_string()
             ))
         );
     }
 
     /// If we bypass static analysis and pass an atom for a non existing property to `get-burn-block-info?`,
-    /// the runtime returns `ExpectsRejectable`.
+    /// the runtime returns [`RuntimeCheckErrorKind::Unreachable`].
     #[apply(test_clarity_versions)]
     fn special_get_burn_block_info_no_such_property(
         #[case] version: ClarityVersion,
@@ -1275,7 +1275,7 @@ mod test {
 
         assert_eq!(
             err,
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "No such burn block info property: not-a-valid-burn-prop".to_string()
             ))
         );

--- a/clarity/src/vm/functions/options.rs
+++ b/clarity/src/vm/functions/options.rs
@@ -36,7 +36,7 @@ fn inner_unwrap(to_unwrap: Value) -> Result<Option<Value>, VmExecutionError> {
             }
         }
         _ => {
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            return Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Expected optional or response value: {to_unwrap}"
             ))
             .into());
@@ -56,7 +56,7 @@ fn inner_unwrap_err(to_unwrap: Value) -> Result<Option<Value>, VmExecutionError>
             }
         }
         _ => {
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            return Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Expected response value: {to_unwrap}"
             ))
             .into());
@@ -112,7 +112,7 @@ pub fn native_try_ret(input: Value) -> Result<Value, VmExecutionError> {
                 Err(EarlyReturnError::UnwrapFailed(Box::new(short_return_val)).into())
             }
         }
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected optional or response value: {input}"
         ))
         .into()),
@@ -163,7 +163,7 @@ fn special_match_opt(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if args.len() != 3 {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Bad match option syntax: args {} != 3",
             args.len()
         )))?;
@@ -172,9 +172,7 @@ fn special_match_opt(
     let bind_name = args[0]
         .match_atom()
         .ok_or_else(|| {
-            RuntimeCheckErrorKind::ExpectsRejectable(
-                "Bad match option syntax: expected name".to_string(),
-            )
+            RuntimeCheckErrorKind::Unreachable("Bad match option syntax: expected name".to_string())
         })?
         .clone();
     let some_branch = &args[1];
@@ -193,7 +191,7 @@ fn special_match_resp(
     context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     if args.len() != 4 {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Bad match response syntax: args {} != 4",
             args.len()
         )))?;
@@ -202,7 +200,7 @@ fn special_match_resp(
     let ok_bind_name = args[0]
         .match_atom()
         .ok_or_else(|| {
-            RuntimeCheckErrorKind::ExpectsRejectable(
+            RuntimeCheckErrorKind::Unreachable(
                 "Bad match response syntax: expected name".to_string(),
             )
         })?
@@ -211,7 +209,7 @@ fn special_match_resp(
     let err_bind_name = args[2]
         .match_atom()
         .ok_or_else(|| {
-            RuntimeCheckErrorKind::ExpectsRejectable(
+            RuntimeCheckErrorKind::Unreachable(
                 "Bad match response syntax: expected name".to_string(),
             )
         })?
@@ -239,7 +237,7 @@ pub fn special_match(
     match input {
         Value::Response(data) => special_match_resp(data, &args[1..], env, context),
         Value::Optional(data) => special_match_opt(data, &args[1..], env, context),
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Bad match input: {}",
             TypeSignature::type_of(&input)?
         ))
@@ -254,7 +252,7 @@ pub fn native_some(input: Value) -> Result<Value, VmExecutionError> {
 fn is_some(input: Value) -> Result<bool, RuntimeCheckErrorKind> {
     match input {
         Value::Optional(ref data) => Ok(data.data.is_some()),
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected option value: {input}"
         ))),
     }
@@ -263,7 +261,7 @@ fn is_some(input: Value) -> Result<bool, RuntimeCheckErrorKind> {
 fn is_okay(input: Value) -> Result<bool, RuntimeCheckErrorKind> {
     match input {
         Value::Response(data) => Ok(data.committed),
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected response value: {input}"
         ))),
     }
@@ -299,9 +297,8 @@ pub fn native_default_to(default: Value, input: Value) -> Result<Value, VmExecut
             Some(data) => Ok(*data),
             None => Ok(default),
         },
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected option value: {input}"
-        ))
-        .into()),
+        _ => Err(
+            RuntimeCheckErrorKind::Unreachable(format!("Expected option value: {input}")).into(),
+        ),
     }
 }

--- a/clarity/src/vm/functions/post_conditions.rs
+++ b/clarity/src/vm/functions/post_conditions.rs
@@ -102,27 +102,26 @@ fn eval_allowance(
 ) -> Result<Allowance, VmExecutionError> {
     let list = allowance_expr
         .match_list()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Non functional application".to_string(),
         ))?;
     let (name_expr, rest) = list
         .split_first()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Non functional application".to_string(),
         ))?;
     let name = name_expr
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Bad function name".to_string(),
         ))?;
     let Some(ref native_function) = NativeFunctions::lookup_by_name_at_version(
         name,
         env.contract_context.get_clarity_version(),
     ) else {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected allowance expr: {name}"
-        ))
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable(format!("Expected allowance expr: {name}")).into(),
+        );
     };
 
     match native_function {
@@ -238,10 +237,9 @@ fn eval_allowance(
             }
             Ok(Allowance::All)
         }
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected allowance expr: {name}"
-        ))
-        .into()),
+        _ => Err(
+            RuntimeCheckErrorKind::Unreachable(format!("Expected allowance expr: {name}")).into(),
+        ),
     }
 }
 
@@ -260,7 +258,7 @@ pub fn special_restrict_assets(
     let asset_owner_expr = &args[0];
     let allowance_list = args[1]
         .match_list()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected list of allowances: for restrict-assets? as argument 2".to_string(),
         ))?;
     let body_exprs = &args[2..];
@@ -274,7 +272,7 @@ pub fn special_restrict_assets(
     runtime_cost(ClarityCostFunction::RestrictAssets, env, allowance_len)?;
 
     if allowance_len > MAX_ALLOWANCES {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        return Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Too many allowances: got {allowance_len}, allowed {MAX_ALLOWANCES}"
         ))
         .into());
@@ -350,7 +348,7 @@ pub fn special_as_contract(
 
     let allowance_list = args[0]
         .match_list()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected list of allowances: for as-contract? as argument 1".to_string(),
         ))?;
     let body_exprs = &args[1..];
@@ -642,7 +640,7 @@ pub fn special_allowance(
     _env: &mut Environment,
     _context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
-    Err(RuntimeCheckErrorKind::ExpectsRejectable("Allowance expr not allowed".to_string()).into())
+    Err(RuntimeCheckErrorKind::Unreachable("Allowance expr not allowed".to_string()).into())
 }
 
 #[cfg(test)]
@@ -693,7 +691,7 @@ mod test {
         let err = eval_allowance(&allowance_expr, &mut env, &context).unwrap_err();
 
         assert_eq!(
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Non functional application".to_string()
             )),
             err

--- a/clarity/src/vm/functions/sequences.rs
+++ b/clarity/src/vm/functions/sequences.rs
@@ -62,7 +62,7 @@ pub fn special_filter(
 
     let function_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
@@ -96,7 +96,7 @@ pub fn special_filter(
                 })?;
         }
         _ => {
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            return Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Expected sequence: {}",
                 TypeSignature::type_of(&sequence)?
             ))
@@ -117,7 +117,7 @@ pub fn special_fold(
 
     let function_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
@@ -142,7 +142,7 @@ pub fn special_fold(
                     context,
                 )
             }),
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::type_of(&sequence)?
         ))
@@ -161,7 +161,7 @@ pub fn special_map(
 
     let function_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
     let function = lookup_function(function_name, env)?;
@@ -197,7 +197,7 @@ pub fn special_map(
                 }
             }
             _ => {
-                return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                return Err(RuntimeCheckErrorKind::Unreachable(format!(
                     "Expected sequence: {}",
                     TypeSignature::type_of(&sequence)?
                 ))
@@ -264,10 +264,9 @@ pub fn special_append(
                 data,
             })))
         }
-        _ => Err(
-            RuntimeCheckErrorKind::ExpectsRejectable("Expected list application".to_string())
-                .into(),
-        ),
+        _ => {
+            Err(RuntimeCheckErrorKind::Unreachable("Expected list application".to_string()).into())
+        }
     }
 }
 
@@ -293,7 +292,7 @@ pub fn special_concat_v200(
         (Value::Sequence(seq), Value::Sequence(other_seq)) => seq.concat(env.epoch(), other_seq)?,
         (Value::Sequence(_), other_value) => {
             // The first value is a sequence, but the second is not
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            return Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Expected sequence: {}",
                 TypeSignature::type_of(&other_value)?
             ))
@@ -301,7 +300,7 @@ pub fn special_concat_v200(
         }
         (value, _) => {
             // The first value is not a sequence (the other may not be as well, but just error on the first)
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            return Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Expected sequence: {}",
                 TypeSignature::type_of(value)?
             ))
@@ -342,7 +341,7 @@ pub fn special_concat_v205(
         }
         _ => {
             runtime_cost(ClarityCostFunction::Concat, env, 1)?;
-            return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+            return Err(RuntimeCheckErrorKind::Unreachable(format!(
                 "Expected sequence: {}",
                 TypeSignature::type_of(&wrapped_seq)?,
             ))
@@ -368,7 +367,7 @@ pub fn special_as_max_len(
         let sequence_len = match sequence {
             Value::Sequence(ref sequence_data) => sequence_data.len() as u128,
             _ => {
-                return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                return Err(RuntimeCheckErrorKind::Unreachable(format!(
                     "Expected sequence: {}",
                     TypeSignature::type_of(&sequence)?
                 ))
@@ -396,7 +395,7 @@ pub fn special_as_max_len(
 pub fn native_len(sequence: Value) -> Result<Value, VmExecutionError> {
     match sequence {
         Value::Sequence(sequence_data) => Ok(Value::UInt(sequence_data.len() as u128)),
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::type_of(&sequence)?
         ))
@@ -411,7 +410,7 @@ pub fn native_index_of(sequence: Value, to_find: Value) -> Result<Value, VmExecu
             None => Ok(Value::none()),
         }
     } else {
-        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::type_of(&sequence)?
         ))
@@ -423,7 +422,7 @@ pub fn native_element_at(sequence: Value, index: Value) -> Result<Value, VmExecu
     let sequence_data = if let Value::Sequence(sequence_data) = sequence {
         sequence_data
     } else {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        return Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::type_of(&sequence)?
         ))
@@ -491,9 +490,7 @@ pub fn special_slice(
                     seq.slice(env.epoch(), left_position as usize, right_position as usize)?;
                 Ok(Value::some(seq_value)?)
             }
-            _ => {
-                Err(RuntimeCheckErrorKind::ExpectsRejectable("Bad type construction".into()).into())
-            }
+            _ => Err(RuntimeCheckErrorKind::Unreachable("Bad type construction".into()).into()),
         }
     })();
 
@@ -522,10 +519,9 @@ pub fn special_replace_at(
     let expected_elem_type = if let TypeSignature::SequenceType(seq_subtype) = &seq_type {
         seq_subtype.unit_type()
     } else {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected sequence: {seq_type}"
-        ))
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {seq_type}")).into(),
+        );
     };
     let index_val = eval(&args[1], env, context)?;
     let new_element = eval(&args[2], env, context)?;
@@ -555,10 +551,9 @@ pub fn special_replace_at(
     };
 
     let Value::Sequence(data) = seq else {
-        return Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected sequence: {seq_type}"
-        ))
-        .into());
+        return Err(
+            RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {seq_type}")).into(),
+        );
     };
     let seq_len = data.len();
     if index >= seq_len {

--- a/clarity/src/vm/functions/tuples.rs
+++ b/clarity/src/vm/functions/tuples.rs
@@ -51,7 +51,7 @@ pub fn tuple_get(
 
     let arg_name = args[0]
         .match_atom()
-        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
+        .ok_or(RuntimeCheckErrorKind::Unreachable(
             "Expected name".to_string(),
         ))?;
 
@@ -69,7 +69,7 @@ pub fn tuple_get(
                             )
                         })?)
                     } else {
-                        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+                        Err(RuntimeCheckErrorKind::Unreachable(format!(
                             "Expected tuple: {}",
                             TypeSignature::type_of(&data)?
                         ))
@@ -83,7 +83,7 @@ pub fn tuple_get(
             runtime_cost(ClarityCostFunction::TupleGet, env, tuple_data.len())?;
             Ok(tuple_data.get_owned(arg_name)?)
         }
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected tuple: {}",
             TypeSignature::type_of(&value)?
         ))
@@ -94,7 +94,7 @@ pub fn tuple_get(
 pub fn tuple_merge(base: Value, update: Value) -> Result<Value, VmExecutionError> {
     let initial_values = match base {
         Value::Tuple(initial_values) => Ok(initial_values),
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected tuple: {}",
             TypeSignature::type_of(&base)?
         ))),
@@ -102,7 +102,7 @@ pub fn tuple_merge(base: Value, update: Value) -> Result<Value, VmExecutionError
 
     let new_values = match update {
         Value::Tuple(new_values) => Ok(new_values),
-        _ => Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected tuple: {}",
             TypeSignature::type_of(&update)?
         ))),

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -195,10 +195,7 @@ fn lookup_variable(
                 Ok(Value::CallableContract(callable_data.clone()))
             }
         } else {
-            Err(
-                RuntimeCheckErrorKind::ExpectsRejectable(format!("Undefined variable: {name}"))
-                    .into(),
-            )
+            Err(RuntimeCheckErrorKind::Unreachable(format!("Undefined variable: {name}")).into())
         }
     }
 }
@@ -346,31 +343,33 @@ pub fn eval(
         env.global_context.eval_hooks = Some(eval_hooks);
     }
 
-    let res =
-        match exp.expr {
-            AtomValue(ref value) | LiteralValue(ref value) => Ok(value.clone()),
-            Atom(ref value) => lookup_variable(value, context, env),
-            List(ref children) => {
-                let (function_variable, rest) =
-                    children
-                        .split_first()
-                        .ok_or(RuntimeCheckErrorKind::ExpectsRejectable(
-                            "Non functional application".to_string(),
-                        ))?;
+    let res = match exp.expr {
+        AtomValue(ref value) | LiteralValue(ref value) => Ok(value.clone()),
+        Atom(ref value) => lookup_variable(value, context, env),
+        List(ref children) => {
+            let (function_variable, rest) =
+                children
+                    .split_first()
+                    .ok_or(RuntimeCheckErrorKind::Unreachable(
+                        "Non functional application".to_string(),
+                    ))?;
 
-                let function_name = function_variable.match_atom().ok_or(
-                    RuntimeCheckErrorKind::ExpectsRejectable("Bad function name".to_string()),
-                )?;
-                let f = lookup_function(function_name, env)?;
-                apply(&f, rest, env, context)
-            }
-            TraitReference(_, _) | Field(_) => {
-                return Err(VmInternalError::BadSymbolicRepresentation(
-                    "Unexpected trait reference".into(),
-                )
-                .into());
-            }
-        };
+            let function_name =
+                function_variable
+                    .match_atom()
+                    .ok_or(RuntimeCheckErrorKind::Unreachable(
+                        "Bad function name".to_string(),
+                    ))?;
+            let f = lookup_function(function_name, env)?;
+            apply(&f, rest, env, context)
+        }
+        TraitReference(_, _) | Field(_) => {
+            return Err(VmInternalError::BadSymbolicRepresentation(
+                "Unexpected trait reference".into(),
+            )
+            .into());
+        }
+    };
 
     if let Some(mut eval_hooks) = env.global_context.eval_hooks.take() {
         for hook in eval_hooks.iter_mut() {

--- a/clarity/src/vm/tests/conversions.rs
+++ b/clarity/src/vm/tests/conversions.rs
@@ -621,7 +621,7 @@ fn test_from_consensus_buff_unexpected_serialization_epoch_gate(
     let err = result.expect_err("Epoch33 should treat unexpected serialization as an error");
     assert_eq!(
         err,
-        RuntimeCheckErrorKind::ExpectsRejectable("UnexpectedSerialization".into()).into()
+        RuntimeCheckErrorKind::Unreachable("UnexpectedSerialization".into()).into()
     );
 }
 

--- a/clarity/src/vm/tests/datamaps.rs
+++ b/clarity/src/vm/tests/datamaps.rs
@@ -476,8 +476,7 @@ fn datamap_errors() {
     for program in tests.iter() {
         assert_eq!(
             execute(program).unwrap_err(),
-            RuntimeCheckErrorKind::ExpectsRejectable("No such map: non-existent".to_string())
-                .into()
+            RuntimeCheckErrorKind::Unreachable("No such map: non-existent".to_string()).into()
         );
     }
 }
@@ -653,15 +652,15 @@ fn bad_define_maps() {
         "(define-map lists { name: int } { contents: (list 5 0 int) })",
     ];
     let expected: Vec<ClarityEvalError> = vec![
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Bad syntax binding: {}",
             SyntaxBindingError::tuple_cons_invalid_length(0)
         ))
         .into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Unknown type name: contents".to_string()).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected name".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Unknown type name: contents".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Expected name".to_string()).into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(3, 4).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(
+        RuntimeCheckErrorKind::Unreachable(
             "Unexpected error type during runtime analysis: InvalidTypeDescription".to_string(),
         )
         .into(),
@@ -685,11 +684,11 @@ fn bad_tuples() {
     ];
     let expected = vec![
         RuntimeCheckErrorKind::NameAlreadyUsed("name".into()),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Bad syntax binding: {}", SyntaxBindingError::tuple_cons_not_list(0))),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Bad syntax binding: {}", SyntaxBindingError::tuple_cons_invalid_length(1))),
-        RuntimeCheckErrorKind::ExpectsRejectable("Unexpected error type during runtime analysis: NoSuchTupleField(\"value\", TupleTypeSignature { \"name\": int,})".to_string()),
+        RuntimeCheckErrorKind::Unreachable(format!("Bad syntax binding: {}", SyntaxBindingError::tuple_cons_not_list(0))),
+        RuntimeCheckErrorKind::Unreachable(format!("Bad syntax binding: {}", SyntaxBindingError::tuple_cons_invalid_length(1))),
+        RuntimeCheckErrorKind::Unreachable("Unexpected error type during runtime analysis: NoSuchTupleField(\"value\", TupleTypeSignature { \"name\": int,})".to_string()),
         RuntimeCheckErrorKind::IncorrectArgumentCount(2, 3),
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected name".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Expected name".to_string()),
     ];
 
     for (test, expected_err) in tests.iter().zip(expected.into_iter()) {

--- a/clarity/src/vm/tests/defines.rs
+++ b/clarity/src/vm/tests/defines.rs
@@ -84,7 +84,7 @@ fn test_accept_options(#[case] version: ClarityVersion, #[case] epoch: StacksEpo
     let bad_defun = "(define-private (f (b (optional int int))) (* 10 (default-to 0 b)))";
     assert_eq!(
         execute(bad_defun).unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(
+        RuntimeCheckErrorKind::Unreachable(
             "Unexpected error type during runtime analysis: InvalidTypeDescription".to_string()
         )
         .into()
@@ -112,7 +112,7 @@ fn test_bad_define_names() {
         execute(test1).unwrap_err(),
     );
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected name".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Expected name".to_string()),
         execute(test2).unwrap_err(),
     );
     assert_eq_err(
@@ -136,17 +136,14 @@ fn test_unwrap_ret() {
         execute(test1).unwrap_err(),
     );
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Expected optional or response value: {}",
             Value::Int(1)
         )),
         execute(test2).unwrap_err(),
     );
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected response value: {}",
-            Value::Int(1)
-        )),
+        RuntimeCheckErrorKind::Unreachable(format!("Expected response value: {}", Value::Int(1))),
         execute(test3).unwrap_err(),
     );
     assert_eq!(Ok(Some(Value::Int(1))), execute(test4));
@@ -166,15 +163,15 @@ fn test_define_read_only() {
 
     assert_eq!(Ok(Some(Value::Int(1))), execute(test0));
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable("Write attempted in read-only".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()),
         execute(test1).unwrap_err(),
     );
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable("Write attempted in read-only".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()),
         execute(test2).unwrap_err(),
     );
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable("Write attempted in read-only".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Write attempted in read-only".to_string()),
         execute(test3).unwrap_err(),
     );
 }
@@ -227,7 +224,7 @@ fn test_recursive_panic(#[case] version: ClarityVersion, #[case] epoch: StacksEp
 #[test]
 fn test_bad_variables() {
     let test0 = "(+ a 1)";
-    let expected = RuntimeCheckErrorKind::ExpectsRejectable("Undefined variable: a".to_string());
+    let expected = RuntimeCheckErrorKind::Unreachable("Undefined variable: a".to_string());
     assert_eq_err(expected, execute(test0).unwrap_err());
 
     let test1 = "(foo 2 1)";
@@ -235,12 +232,11 @@ fn test_bad_variables() {
     assert_eq_err(expected, execute(test1).unwrap_err());
 
     let test2 = "((lambda (x y) 1) 2 1)";
-    let expected = RuntimeCheckErrorKind::ExpectsRejectable("Bad function name".to_string());
+    let expected = RuntimeCheckErrorKind::Unreachable("Bad function name".to_string());
     assert_eq_err(expected, execute(test2).unwrap_err());
 
     let test4 = "()";
-    let expected =
-        RuntimeCheckErrorKind::ExpectsRejectable("Non functional application".to_string());
+    let expected = RuntimeCheckErrorKind::Unreachable("Non functional application".to_string());
     assert_eq_err(expected, execute(test4).unwrap_err());
 }
 
@@ -284,8 +280,7 @@ fn test_variable_shadowing() {
 #[test]
 fn test_define_parse_panic() {
     let tests = "(define-private () 1)";
-    let expected =
-        RuntimeCheckErrorKind::ExpectsRejectable("Define function bad signature".to_string());
+    let expected = RuntimeCheckErrorKind::Unreachable("Define function bad signature".to_string());
     assert_eq_err(expected, execute(tests).unwrap_err());
 }
 
@@ -293,7 +288,7 @@ fn test_define_parse_panic() {
 fn test_define_parse_panic_2() {
     let tests = "(define-private (a b (d)) 1)";
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Bad syntax binding: {}",
             SyntaxBindingError::eval_binding_not_list(0)
         )),
@@ -451,7 +446,7 @@ fn test_define_fungible_token_arg_count() {
     let test3 = "(define-fungible-token foo u2 u3)";
 
     assert_eq_err(
-        RuntimeCheckErrorKind::ExpectsRejectable("Requires at least args: 1 got 0".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Requires at least args: 1 got 0".to_string()),
         execute(test0).unwrap_err(),
     );
     execute(test1).unwrap();

--- a/clarity/src/vm/tests/post_conditions.rs
+++ b/clarity/src/vm/tests/post_conditions.rs
@@ -1683,7 +1683,7 @@ fn restrict_assets_too_many_allowances() {
             .join(" ")
     );
     let max_allowances_err: ClarityEvalError =
-        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(format!(
             "Too many allowances: got {}, allowed {MAX_ALLOWANCES}",
             MAX_ALLOWANCES + 1
         )))
@@ -1701,7 +1701,7 @@ fn expected_allowance_expr_error() {
     let snippet = "(restrict-assets? tx-sender ((bad-fn u1)) true)";
 
     let expected_error: ClarityEvalError = VmExecutionError::RuntimeCheck(
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected allowance expr: bad-fn".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Expected allowance expr: bad-fn".to_string()),
     )
     .into();
 
@@ -1720,7 +1720,7 @@ fn expected_allowance_expr_error_unhandled_native() {
     let snippet = "(restrict-assets? tx-sender ((tx-sender u1)) true)";
 
     let expected_error: ClarityEvalError = VmExecutionError::RuntimeCheck(
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected allowance expr: tx-sender".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Expected allowance expr: tx-sender".to_string()),
     )
     .into();
 
@@ -1736,7 +1736,7 @@ fn allowance_expr_not_allowed() {
     let snippet = "(with-stx u1)";
 
     let expected: ClarityEvalError = VmExecutionError::RuntimeCheck(
-        RuntimeCheckErrorKind::ExpectsRejectable("Allowance expr not allowed".to_string()),
+        RuntimeCheckErrorKind::Unreachable("Allowance expr not allowed".to_string()),
     )
     .into();
 
@@ -1757,7 +1757,7 @@ fn restrict_assets_expected_list_of_allowances() {
         )
     "#;
     let expected_error: ClarityEvalError =
-        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
             "Expected list of allowances: for restrict-assets? as argument 2".to_string(),
         ))
         .into();
@@ -1780,7 +1780,7 @@ fn as_contract_expected_list_of_allowances() {
 
     // The argument is `u42` (not a list), so we expect this error
     let expected_error: ClarityEvalError =
-        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
             "Expected list of allowances: for as-contract? as argument 1".to_string(),
         ))
         .into();

--- a/clarity/src/vm/tests/sequences.rs
+++ b/clarity/src/vm/tests/sequences.rs
@@ -104,7 +104,7 @@ fn test_index_of() {
     ];
 
     let bad_expected = [
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::IntType
         )),
@@ -168,7 +168,7 @@ fn test_element_at() {
     let bad = ["(element-at 3 u1)", "(element-at (list 1 2 3) 1)"];
 
     let bad_expected = [
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::IntType
         )),
@@ -553,8 +553,7 @@ fn test_slice_utf8() {
 
 #[test]
 fn test_slice_type_errors() {
-    let bad_type_error =
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad type construction".into()).into();
+    let bad_type_error = RuntimeCheckErrorKind::Unreachable("Bad type construction".into()).into();
     assert_eq!(execute_v2("(slice? 3 u0 u1)").unwrap_err(), bad_type_error);
 
     assert_eq!(
@@ -612,7 +611,7 @@ fn test_simple_list_concat() {
 
     assert_eq!(
         execute("(concat (list 1) 3)").unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::IntType
         ))
@@ -653,7 +652,7 @@ fn test_simple_buff_concat() {
 
     assert_eq!(
         execute("(concat 0x31 3)").unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Expected sequence: {}",
             TypeSignature::IntType
         ))
@@ -750,7 +749,7 @@ fn test_simple_list_replace_at() {
     // The sequence input has the wrong type
     assert_eq!(
         execute_v2("(replace-at? 0 u0 (list 0))").unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Expected sequence: {IntType}")).into()
+        RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {IntType}")).into()
     );
 
     // The type of the index should be uint.
@@ -813,7 +812,7 @@ fn test_simple_buff_replace_at() {
     // The sequence input has the wrong type
     assert_eq!(
         execute_v2("(replace-at? 33 u0 0x00)").unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Expected sequence: {IntType}")).into()
+        RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {IntType}")).into()
     );
 
     // The type of the index should be uint.
@@ -890,7 +889,7 @@ fn test_simple_string_ascii_replace_at() {
     // The sequence input has the wrong type
     assert_eq!(
         execute_v2("(replace-at? 33 u0 \"c\")").unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Expected sequence: {IntType}")).into()
+        RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {IntType}")).into()
     );
 
     // The type of the index should be uint.
@@ -971,7 +970,7 @@ fn test_simple_string_utf8_replace_at() {
     // The sequence input has the wrong type
     assert_eq!(
         execute_v2("(replace-at? 33 u0 u\"c\")").unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Expected sequence: {IntType}")).into()
+        RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {IntType}")).into()
     );
 
     // The type of the index should be uint.
@@ -1048,7 +1047,7 @@ fn test_simple_buff_assert_max_len() {
 
     assert_eq!(
         execute("(as-max-len? 1 u3)").unwrap_err(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Expected sequence: {IntType}")).into()
+        RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {IntType}")).into()
     );
 
     assert_eq!(
@@ -1253,12 +1252,12 @@ fn test_construct_bad_list(#[case] version: ClarityVersion, #[case] epoch: Stack
 fn test_eval_func_arg_panic() {
     let test1 = "(fold (lambda (x y) (* x y)) (list 1 2 3 4) 1)";
     let e: ClarityEvalError =
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected name".to_string()).into();
+        RuntimeCheckErrorKind::Unreachable("Expected name".to_string()).into();
     assert_eq!(e, execute(test1).unwrap_err());
 
     let test2 = "(map (lambda (x) (* x x)) (list 1 2 3 4))";
     let e: ClarityEvalError =
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected name".to_string()).into();
+        RuntimeCheckErrorKind::Unreachable("Expected name".to_string()).into();
     assert_eq!(e, execute(test2).unwrap_err());
 
     let test3 = "(map square (list 1 2 3 4) 2)";
@@ -1272,7 +1271,7 @@ fn test_eval_func_arg_panic() {
 
     let test5 = "(map + (list 1 2 3 4) 2)";
     let e: ClarityEvalError =
-        RuntimeCheckErrorKind::ExpectsRejectable(format!("Expected sequence: {IntType}")).into();
+        RuntimeCheckErrorKind::Unreachable(format!("Expected sequence: {IntType}")).into();
     assert_eq!(e, execute(test5).unwrap_err());
 }
 
@@ -1282,6 +1281,6 @@ fn test_expected_list_application() {
     // first argument is NOT a list
     let test1 = "(append u1 u2)";
     let e: ClarityEvalError =
-        RuntimeCheckErrorKind::ExpectsRejectable("Expected list application".to_string()).into();
+        RuntimeCheckErrorKind::Unreachable("Expected list application".to_string()).into();
     assert_eq!(e, execute(test1).unwrap_err());
 }

--- a/clarity/src/vm/tests/simple_apply_eval.rs
+++ b/clarity/src/vm/tests/simple_apply_eval.rs
@@ -311,7 +311,7 @@ fn test_from_consensus_buff_type_checks() {
         ),
         (
             "(from-consensus-buff? 2 0x10)",
-            "RuntimeCheck(ExpectsRejectable(\"Unexpected error type during runtime analysis: InvalidTypeDescription\"))",
+            "RuntimeCheck(Unreachable(\"Unexpected error type during runtime analysis: InvalidTypeDescription\"))",
         ),
     ];
 
@@ -1248,48 +1248,33 @@ fn test_options_errors() {
 
     let expectations: &[ClarityEvalError] = &[
         RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected option value: {}",
-            Value::Bool(true)
-        ))
-        .into(),
+        RuntimeCheckErrorKind::Unreachable(format!("Expected option value: {}", Value::Bool(true)))
+            .into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Expected response value: {}",
             Value::Bool(true)
         ))
         .into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        RuntimeCheckErrorKind::Unreachable(format!(
             "Expected response value: {}",
             Value::Bool(true)
         ))
         .into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected option value: {}",
-            Value::Bool(true)
-        ))
-        .into(),
+        RuntimeCheckErrorKind::Unreachable(format!("Expected option value: {}", Value::Bool(true)))
+            .into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(2, 3).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected option value: {}",
-            Value::Bool(true)
-        ))
-        .into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected tuple: {}",
-            TypeSignature::IntType
-        ))
-        .into(),
-        RuntimeCheckErrorKind::ExpectsRejectable(format!(
-            "Expected tuple: {}",
-            TypeSignature::IntType
-        ))
-        .into(),
+        RuntimeCheckErrorKind::Unreachable(format!("Expected option value: {}", Value::Bool(true)))
+            .into(),
+        RuntimeCheckErrorKind::Unreachable(format!("Expected tuple: {}", TypeSignature::IntType))
+            .into(),
+        RuntimeCheckErrorKind::Unreachable(format!("Expected tuple: {}", TypeSignature::IntType))
+            .into(),
     ];
 
     for (program, expectation) in tests.iter().zip(expectations.iter()) {
@@ -1314,15 +1299,15 @@ fn test_stx_ops_errors() {
 
     let expectations: &[ClarityEvalError] = &[
         RuntimeCheckErrorKind::IncorrectArgumentCount(3, 2).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(4, 3).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into(),
         RuntimeCheckErrorKind::IncorrectArgumentCount(2, 1).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("Bad transfer STX args".to_string()).into(),
+        RuntimeCheckErrorKind::Unreachable("Bad transfer STX args".to_string()).into(),
     ];
 
     for (program, expectation) in tests.iter().zip(expectations.iter()) {
@@ -1493,7 +1478,7 @@ fn test_option_destructs() {
     let expectations: &[Result<Value, ClarityEvalError>] = &[
         Ok(Value::Int(1)),
         Ok(Value::Int(1)),
-        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected response value: {}",
             Value::some(Value::Int(2)).unwrap()
         ))
@@ -1513,12 +1498,12 @@ fn test_option_destructs() {
         Ok(Value::Int(9)),
         Ok(Value::Int(2)),
         Ok(Value::Int(8)),
-        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Bad match input: {}",
             TypeSignature::IntType
         ))
         .into()),
-        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Bad match input: {}",
             TypeSignature::IntType
         ))
@@ -1536,7 +1521,7 @@ fn test_option_destructs() {
         ),
         Ok(Value::Bool(true)),
         Err(RuntimeCheckErrorKind::IncorrectArgumentCount(1, 2).into()),
-        Err(RuntimeCheckErrorKind::ExpectsRejectable(format!(
+        Err(RuntimeCheckErrorKind::Unreachable(format!(
             "Expected optional or response value: {}",
             Value::Int(1)
         ))
@@ -1668,8 +1653,7 @@ fn test_bad_lets() {
         RuntimeCheckErrorKind::NameAlreadyUsed("tx-sender".to_string()).into(),
         RuntimeCheckErrorKind::NameAlreadyUsed("*".to_string()).into(),
         RuntimeCheckErrorKind::NameAlreadyUsed("a".to_string()).into(),
-        RuntimeCheckErrorKind::ExpectsRejectable("No such data variable: cursor".to_string())
-            .into(),
+        RuntimeCheckErrorKind::Unreachable("No such data variable: cursor".to_string()).into(),
         RuntimeCheckErrorKind::NameAlreadyUsed("true".to_string()).into(),
         RuntimeCheckErrorKind::NameAlreadyUsed("false".to_string()).into(),
     ];

--- a/clarity/src/vm/tests/traits.rs
+++ b/clarity/src/vm/tests/traits.rs
@@ -726,7 +726,7 @@ fn test_readwrite_dynamic_dispatch(
             .unwrap_err();
 
         assert_eq!(
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Trait based contract call in read-only".to_string()
             ),),
             err_result
@@ -783,7 +783,7 @@ fn test_readwrite_violation_dynamic_dispatch(
             )
             .unwrap_err();
         assert_eq!(
-            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectsRejectable(
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(
                 "Trait based contract call in read-only".to_string()
             ),),
             err_result

--- a/clarity/src/vm/tests/variables.rs
+++ b/clarity/src/vm/tests/variables.rs
@@ -80,9 +80,7 @@ fn test_block_height(
         let err = eval_result.unwrap_err();
         assert_eq!(
             ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-                RuntimeCheckErrorKind::ExpectsRejectable(
-                    "Undefined variable: block-height".to_string()
-                )
+                RuntimeCheckErrorKind::Unreachable("Undefined variable: block-height".to_string())
             )),
             err
         );
@@ -141,7 +139,7 @@ fn test_stacks_block_height(
         let err = eval_result.unwrap_err();
         assert_eq!(
             ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-                RuntimeCheckErrorKind::ExpectsRejectable(
+                RuntimeCheckErrorKind::Unreachable(
                     "Undefined variable: stacks-block-height".to_string()
                 )
             )),
@@ -202,9 +200,7 @@ fn test_tenure_height(
         let err = eval_result.unwrap_err();
         assert_eq!(
             ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-                RuntimeCheckErrorKind::ExpectsRejectable(
-                    "Undefined variable: tenure-height".to_string()
-                )
+                RuntimeCheckErrorKind::Unreachable("Undefined variable: tenure-height".to_string())
             )),
             err
         );
@@ -1219,7 +1215,7 @@ fn test_block_time(
         let err = eval_result.unwrap_err();
         assert_eq!(
             ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-                RuntimeCheckErrorKind::ExpectsRejectable(
+                RuntimeCheckErrorKind::Unreachable(
                     "Undefined variable: stacks-block-time".to_string()
                 )
             )),
@@ -1347,7 +1343,7 @@ fn test_current_contract(
         let err = eval_result.unwrap_err();
         assert_eq!(
             ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-                RuntimeCheckErrorKind::ExpectsRejectable(
+                RuntimeCheckErrorKind::Unreachable(
                     "Undefined variable: current-contract".to_string()
                 )
             )),

--- a/clarity/src/vm/types/mod.rs
+++ b/clarity/src/vm/types/mod.rs
@@ -103,7 +103,7 @@ impl BurnBlockInfoProperty {
                                 ("hashbytes".into(), TypeSignature::BUFFER_32),
                             ])
                             .map_err(|_| {
-                                RuntimeCheckErrorKind::ExpectsRejectable(
+                                RuntimeCheckErrorKind::Unreachable(
                                     "FATAL: bad type signature for pox addr".into(),
                                 )
                             })?,
@@ -111,17 +111,13 @@ impl BurnBlockInfoProperty {
                         2,
                     )
                     .map_err(|_| {
-                        RuntimeCheckErrorKind::ExpectsRejectable(
-                            "FATAL: bad list type signature".into(),
-                        )
+                        RuntimeCheckErrorKind::Unreachable("FATAL: bad list type signature".into())
                     })?,
                 ),
                 ("payout".into(), TypeSignature::UIntType),
             ])
             .map_err(|_| {
-                RuntimeCheckErrorKind::ExpectsRejectable(
-                    "FATAL: bad type signature for pox addr".into(),
-                )
+                RuntimeCheckErrorKind::Unreachable("FATAL: bad type signature for pox addr".into())
             })?
             .into(),
         };

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -716,78 +716,75 @@ mod test {
         let bad_type_descriptions = [
             (
                 "(tuple)",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: EmptyTuplesNotAllowed"
                         .to_string(),
                 ),
             ),
             (
                 "(list int int)",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),
             ("(list 4294967296 int)", ValueTooLarge),
             (
                 "(list 50 bazel)",
-                ExpectsRejectable("Unknown type name: bazel".into()),
+                Unreachable("Unknown type name: bazel".into()),
             ),
             (
                 "(buff)",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),
             ("(buff 4294967296)", ValueTooLarge),
             (
                 "(buff int)",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),
             (
                 "(response int)",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),
             (
                 "(optional bazel)",
-                ExpectsRejectable("Unknown type name: bazel".into()),
+                Unreachable("Unknown type name: bazel".into()),
             ),
             (
                 "(response bazel int)",
-                ExpectsRejectable("Unknown type name: bazel".into()),
+                Unreachable("Unknown type name: bazel".into()),
             ),
             (
                 "(response int bazel)",
-                ExpectsRejectable("Unknown type name: bazel".into()),
+                Unreachable("Unknown type name: bazel".into()),
             ),
-            (
-                "bazel",
-                ExpectsRejectable("Unknown type name: bazel".into()),
-            ),
+            ("bazel", Unreachable("Unknown type name: bazel".into())),
             (
                 "()",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),
             (
                 "(1234)",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),
             (
                 "(int 3 int)",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),
             (
                 "1234",
-                ExpectsRejectable(
+                Unreachable(
                     "Unexpected error type during runtime analysis: InvalidTypeDescription".into(),
                 ),
             ),

--- a/stackslib/src/chainstate/stacks/db/contracts.rs
+++ b/stackslib/src/chainstate/stacks/db/contracts.rs
@@ -49,9 +49,9 @@ impl StacksChainState {
             .with_clarity_db_readonly(|ref mut db| {
                 match db.lookup_variable_unknown_descriptor(contract_id, data_var, &epoch) {
                     Ok(c) => Ok(Some(c)),
-                    Err(VmExecutionError::RuntimeCheck(
-                        RuntimeCheckErrorKind::ExpectsRejectable(_),
-                    )) => Ok(None),
+                    Err(VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::Unreachable(_))) => {
+                        Ok(None)
+                    }
                     Err(e) => Err(ClarityError::Interpreter(e)),
                 }
             })

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -10866,9 +10866,7 @@ pub mod test {
         ))) = err
         {
             assert_eq!(
-                RuntimeCheckErrorKind::ExpectsRejectable(
-                    "Trait reference unknown: foo".to_string()
-                ),
+                RuntimeCheckErrorKind::Unreachable("Trait reference unknown: foo".to_string()),
                 runtime_check_err
             );
         } else {
@@ -10929,9 +10927,7 @@ pub mod test {
         ))) = err
         {
             assert_eq!(
-                RuntimeCheckErrorKind::ExpectsRejectable(
-                    "Trait reference unknown: foo".to_string()
-                ),
+                RuntimeCheckErrorKind::Unreachable("Trait reference unknown: foo".to_string()),
                 runtime_check_err
             );
         } else {

--- a/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
@@ -86,7 +86,7 @@ fn variant_coverage_report(variant: RuntimeCheckErrorKind) {
             runtime_check_error_kind_type_signature_too_deep_cdeploy,
             runtime_check_error_kind_type_signature_too_deep_ccall
         ]),
-        ExpectsRejectable(_) => Unreachable_ExpectLike,
+        Unreachable(_) => Unreachable_ExpectLike,
         ListTypesMustMatch => Tested(vec![runtime_check_error_kind_list_types_must_match_cdeploy]),
         TypeError(_, _) => Tested(vec![
             runtime_check_error_kind_type_error_cdeploy,


### PR DESCRIPTION
### Description

This patch convert runtime analysis check errors `RuntimeCheckErrorKind::ExpectsAcceptable` and `RuntimeCheckErrorKind::ExpectsRejectable` to `RuntimeCheckErrorKind::Unreachable`. The change is done in two steps:
- Convert ExpectsAcceptable to ExpectsRejectable  (commit: 70d1f707cacaec637fc605050959efb64ad17b9c)
- Rename ExpectsRejectable to Unreachable (commit: 2d79b571dc105d2910ad9eddee857e049dc5e304)

### Applicable issues

- fixes #[#119](https://github.com/stx-labs/core-epics/issues/119)

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
