### PR TITLE
aac: convert static check "expectable" errors to "unrechable"

### DIFF
--- a/clarity-types/src/errors/analysis.rs
+++ b/clarity-types/src/errors/analysis.rs
@@ -249,9 +249,8 @@ pub enum StaticCheckErrorKind {
     /// Supertype (i.e. common denominator between two types) exceeds the maximum allowed size or complexity.
     SupertypeTooLarge,
 
-    // Unexpected interpreter behavior
     /// Unexpected condition or failure in the type-checker, indicating a bug or invalid state.
-    ExpectsRejectable(String),
+    Unreachable(String),
 
     // Match expression errors
     /// Invalid syntax in an `option` match expression.
@@ -659,7 +658,7 @@ impl StaticCheckErrorKind {
     pub fn rejectable_in_epoch(&self, epoch: StacksEpochId) -> bool {
         match self {
             StaticCheckErrorKind::SupertypeTooLarge => epoch.rejects_supertype_too_large(),
-            StaticCheckErrorKind::ExpectsRejectable(_) => true,
+            StaticCheckErrorKind::Unreachable(_) => true,
             _ => false,
         }
     }
@@ -725,7 +724,7 @@ impl From<ClarityTypeError> for StaticCheckErrorKind {
             | ClarityTypeError::InvalidAsciiCharacter(_)
             | ClarityTypeError::InvalidUtf8Encoding
             | ClarityTypeError::InvariantViolation(_)
-            | ClarityTypeError::InvalidPrincipalVersion(_) => Self::ExpectsRejectable(format!(
+            | ClarityTypeError::InvalidPrincipalVersion(_) => Self::Unreachable(format!(
                 "Unexpected error type during static analysis: {err}"
             )),
             ClarityTypeError::CouldNotDetermineSerializationType => {
@@ -733,10 +732,10 @@ impl From<ClarityTypeError> for StaticCheckErrorKind {
             }
             ClarityTypeError::CouldNotDetermineType => Self::CouldNotDetermineType,
             ClarityTypeError::UnsupportedTypeInEpoch(ty, epoch) => {
-                Self::ExpectsRejectable(format!("{ty} should not be used in {epoch}"))
+                Self::Unreachable(format!("{ty} should not be used in {epoch}"))
             }
             ClarityTypeError::UnsupportedEpoch(epoch) => {
-                Self::ExpectsRejectable(format!("{epoch} is not supported"))
+                Self::Unreachable(format!("{epoch} is not supported"))
             }
         }
     }
@@ -872,10 +871,10 @@ impl From<CostErrors> for StaticCheckErrorKind {
             CostErrors::CostContractLoadFailure => {
                 StaticCheckErrorKind::CostComputationFailed("Failed to load cost contract".into())
             }
-            CostErrors::InterpreterFailure => StaticCheckErrorKind::ExpectsRejectable(
+            CostErrors::InterpreterFailure => StaticCheckErrorKind::Unreachable(
                 "Unexpected interpreter failure in cost computation".into(),
             ),
-            CostErrors::Expect(s) => StaticCheckErrorKind::ExpectsRejectable(s),
+            CostErrors::Expect(s) => StaticCheckErrorKind::Unreachable(s),
             CostErrors::ExecutionTimeExpired => StaticCheckErrorKind::ExecutionTimeExpired,
         }
     }
@@ -1102,7 +1101,7 @@ impl DiagnosableError for StaticCheckErrorKind {
     fn message(&self) -> String {
         match &self {
             StaticCheckErrorKind::SupertypeTooLarge => "supertype of two types is too large".into(),
-            StaticCheckErrorKind::ExpectsRejectable(s) => format!("unexpected and unacceptable interpreter behavior: {s}"),
+            StaticCheckErrorKind::Unreachable(s) => format!("unexpected and unacceptable interpreter behavior: {s}"),
             StaticCheckErrorKind::BadMatchOptionSyntax(source) =>
                 format!("match on a optional type uses the following syntax: (match input some-name if-some-expression if-none-expression). Caused by: {}",
                         source.message()),

--- a/clarity/src/vm/analysis/analysis_db.rs
+++ b/clarity/src/vm/analysis/analysis_db.rs
@@ -51,11 +51,11 @@ impl<'a> AnalysisDatabase<'a> {
         self.begin();
         let result = f(self).or_else(|e| {
             self.roll_back()
-                .map_err(|e| StaticCheckErrorKind::ExpectsRejectable(format!("{e:?}")))?;
+                .map_err(|e| StaticCheckErrorKind::Unreachable(format!("{e:?}")))?;
             Err(e)
         })?;
         self.commit()
-            .map_err(|e| StaticCheckErrorKind::ExpectsRejectable(format!("{e:?}")))?;
+            .map_err(|e| StaticCheckErrorKind::Unreachable(format!("{e:?}")))?;
         Ok(result)
     }
 
@@ -66,13 +66,13 @@ impl<'a> AnalysisDatabase<'a> {
     pub fn commit(&mut self) -> Result<(), StaticCheckError> {
         self.store
             .commit()
-            .map_err(|e| StaticCheckErrorKind::ExpectsRejectable(format!("{e:?}")).into())
+            .map_err(|e| StaticCheckErrorKind::Unreachable(format!("{e:?}")).into())
     }
 
     pub fn roll_back(&mut self) -> Result<(), StaticCheckError> {
         self.store
             .rollback()
-            .map_err(|e| StaticCheckErrorKind::ExpectsRejectable(format!("{e:?}")).into())
+            .map_err(|e| StaticCheckErrorKind::Unreachable(format!("{e:?}")).into())
     }
 
     pub fn storage_key() -> &'static str {
@@ -108,8 +108,7 @@ impl<'a> AnalysisDatabase<'a> {
             .flatten()
             .map(|x| {
                 ContractAnalysis::deserialize(&x).map_err(|_| {
-                    StaticCheckErrorKind::ExpectsRejectable("Bad data deserialized from DB".into())
-                        .into()
+                    StaticCheckErrorKind::Unreachable("Bad data deserialized from DB".into()).into()
                 })
             })
             .transpose()
@@ -129,7 +128,7 @@ impl<'a> AnalysisDatabase<'a> {
             .flatten()
             .map(|x| {
                 ContractAnalysis::deserialize(&x).map_err(|_| {
-                    StaticCheckErrorKind::ExpectsRejectable("Bad data deserialized from DB".into())
+                    StaticCheckErrorKind::Unreachable("Bad data deserialized from DB".into())
                 })
             })
             .transpose()?
@@ -154,7 +153,7 @@ impl<'a> AnalysisDatabase<'a> {
 
         self.store
             .insert_metadata(contract_identifier, key, &contract.serialize())
-            .map_err(|e| StaticCheckErrorKind::ExpectsRejectable(format!("{e:?}")))?;
+            .map_err(|e| StaticCheckErrorKind::Unreachable(format!("{e:?}")))?;
         Ok(())
     }
 

--- a/clarity/src/vm/analysis/contract_interface_builder/mod.rs
+++ b/clarity/src/vm/analysis/contract_interface_builder/mod.rs
@@ -278,7 +278,7 @@ impl ContractInterfaceFunction {
                             FunctionType::Fixed(FixedFunction { returns, .. }) => {
                                 ContractInterfaceAtomType::from_type_signature(returns)
                             }
-                            _ => return Err(StaticCheckErrorKind::ExpectsRejectable(
+                            _ => return Err(StaticCheckErrorKind::Unreachable(
                                 "Contract functions should only have fixed function return types!"
                                     .into(),
                             )
@@ -290,7 +290,7 @@ impl ContractInterfaceFunction {
                             ContractInterfaceFunctionArg::from_function_args(args)
                         }
                         _ => {
-                            return Err(StaticCheckErrorKind::ExpectsRejectable(
+                            return Err(StaticCheckErrorKind::Unreachable(
                                 "Contract functions should only have fixed function arguments!"
                                     .into(),
                             )
@@ -402,7 +402,7 @@ impl ContractInterface {
 
     pub fn serialize(&self) -> Result<String, StaticCheckError> {
         serde_json::to_string(self).map_err(|_| {
-            StaticCheckErrorKind::ExpectsRejectable("Failed to serialize contract interface".into())
+            StaticCheckErrorKind::Unreachable("Failed to serialize contract interface".into())
                 .into()
         })
     }

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -57,7 +57,7 @@ pub fn mem_type_check(
 ) -> Result<(Option<TypeSignature>, ContractAnalysis), StaticCheckError> {
     let contract_identifier = QualifiedContractIdentifier::transient();
     let contract = build_ast(&contract_identifier, snippet, &mut (), version, epoch)
-        .map_err(|e| StaticCheckErrorKind::ExpectsRejectable(format!("Failed to build AST: {e}")))?
+        .map_err(|e| StaticCheckErrorKind::Unreachable(format!("Failed to build AST: {e}")))?
         .expressions;
 
     let mut marf = MemoryBackingStore::new();
@@ -79,11 +79,9 @@ pub fn mem_type_check(
             let first_type = x
                 .type_map
                 .as_ref()
-                .ok_or_else(|| {
-                    StaticCheckErrorKind::ExpectsRejectable("Should be non-empty".into())
-                })?
+                .ok_or_else(|| StaticCheckErrorKind::Unreachable("Should be non-empty".into()))?
                 .get_type_expected(x.expressions.last().ok_or_else(|| {
-                    StaticCheckErrorKind::ExpectsRejectable("Should be non-empty".into())
+                    StaticCheckErrorKind::Unreachable("Should be non-empty".into())
                 })?)
                 .cloned();
             Ok((first_type, x))
@@ -155,7 +153,7 @@ pub fn run_analysis(
                 TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db, build_type_map)
             }
             StacksEpochId::Epoch10 => {
-                return Err(StaticCheckErrorKind::ExpectsRejectable(
+                return Err(StaticCheckErrorKind::Unreachable(
                     "Epoch 1.0 is not a valid epoch for analysis".into(),
                 )
                 .into());

--- a/clarity/src/vm/analysis/type_checker/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/mod.rs
@@ -49,10 +49,9 @@ impl FunctionType {
             | StacksEpochId::Epoch32
             | StacksEpochId::Epoch33
             | StacksEpochId::Epoch34 => self.check_args_2_1(accounting, args, clarity_version),
-            StacksEpochId::Epoch10 => Err(StaticCheckErrorKind::ExpectsRejectable(
-                "Epoch10 is not supported".into(),
-            )
-            .into()),
+            StacksEpochId::Epoch10 => {
+                Err(StaticCheckErrorKind::Unreachable("Epoch10 is not supported".into()).into())
+            }
         }
     }
 
@@ -79,10 +78,9 @@ impl FunctionType {
             | StacksEpochId::Epoch34 => {
                 self.check_args_by_allowing_trait_cast_2_1(db, clarity_version, func_args)
             }
-            StacksEpochId::Epoch10 => Err(StaticCheckErrorKind::ExpectsRejectable(
-                "Epoch10 is not supported".into(),
-            )
-            .into()),
+            StacksEpochId::Epoch10 => {
+                Err(StaticCheckErrorKind::Unreachable("Epoch10 is not supported".into()).into())
+            }
         }
     }
 }

--- a/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/mod.rs
@@ -249,7 +249,7 @@ impl FunctionType {
 
                 Ok(TypeSignature::BoolType)
             }
-            FunctionType::Binary(_, _, _) => Err(StaticCheckErrorKind::ExpectsRejectable(
+            FunctionType::Binary(_, _, _) => Err(StaticCheckErrorKind::Unreachable(
                 "Binary type should not be reached in 2.05".into(),
             )
             .into()),
@@ -264,10 +264,9 @@ impl FunctionType {
         let (expected_args, returns) = match self {
             FunctionType::Fixed(FixedFunction { args, returns }) => (args, returns),
             _ => {
-                return Err(StaticCheckErrorKind::ExpectsRejectable(
-                    "Unexpected function type".into(),
-                )
-                .into());
+                return Err(
+                    StaticCheckErrorKind::Unreachable("Unexpected function type".into()).into(),
+                );
             }
         };
         check_argument_count(expected_args.len(), func_args)?;
@@ -340,13 +339,13 @@ fn type_reserved_variable(variable_name: &str) -> Result<Option<TypeSignature>, 
             BlockHeight => TypeSignature::UIntType,
             BurnBlockHeight => TypeSignature::UIntType,
             NativeNone => TypeSignature::new_option(no_type())
-                .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+                .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             NativeTrue => TypeSignature::BoolType,
             NativeFalse => TypeSignature::BoolType,
             TotalLiquidMicroSTX => TypeSignature::UIntType,
             Regtest => TypeSignature::BoolType,
             TxSponsor | Mainnet | ChainId | StacksBlockHeight | TenureHeight | StacksBlockTime | CurrentContract => {
-                return Err(StaticCheckErrorKind::ExpectsRejectable(
+                return Err(StaticCheckErrorKind::Unreachable(
                     "tx-sponsor, mainnet, chain-id, stacks-block-height, tenure-height, stacks-block-time, and current-contract should not reach here in 2.05".into(),
                 )
                 .into())
@@ -437,9 +436,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                 }
                 Err(e) => Err(e),
             })?
-            .ok_or_else(|| {
-                StaticCheckErrorKind::ExpectsRejectable("Expected a depth result".into())
-            })?;
+            .ok_or_else(|| StaticCheckErrorKind::Unreachable("Expected a depth result".into()))?;
         }
 
         runtime_cost(ClarityCostFunction::AnalysisStorage, self, size)?;
@@ -610,7 +607,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         )?;
 
         if self.function_return_tracker.is_some() {
-            return Err(StaticCheckErrorKind::ExpectsRejectable(
+            return Err(StaticCheckErrorKind::Unreachable(
                 "Interpreter error: Previous function define left dirty typecheck state.".into(),
             )
             .into());

--- a/clarity/src/vm/analysis/type_checker/v2_05/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/natives/mod.rs
@@ -510,7 +510,7 @@ fn check_principal_of(
     checker.type_check_expects(&args[0], context, &TypeSignature::BUFFER_33)?;
     Ok(
         TypeSignature::new_response(TypeSignature::PrincipalType, TypeSignature::UIntType)
-            .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+            .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
     )
 }
 
@@ -524,7 +524,7 @@ fn check_secp256k1_recover(
     checker.type_check_expects(&args[1], context, &TypeSignature::BUFFER_65)?;
     Ok(
         TypeSignature::new_response(TypeSignature::BUFFER_33, TypeSignature::UIntType)
-            .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+            .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
     )
 }
 
@@ -604,7 +604,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::IntType,
                     ClarityName::try_from("value".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -615,7 +615,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::UIntType,
                     ClarityName::try_from("value".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -626,7 +626,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::BoolType,
                     ClarityName::try_from("value".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -679,7 +679,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::PrincipalType,
                     ClarityName::try_from("owner".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -691,7 +691,7 @@ impl TypedNativeFunction {
                     FunctionArg::new(
                         TypeSignature::UIntType,
                         ClarityName::try_from("amount".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -699,7 +699,7 @@ impl TypedNativeFunction {
                     FunctionArg::new(
                         TypeSignature::PrincipalType,
                         ClarityName::try_from("sender".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -707,7 +707,7 @@ impl TypedNativeFunction {
                     FunctionArg::new(
                         TypeSignature::PrincipalType,
                         ClarityName::try_from("recipient".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -717,14 +717,14 @@ impl TypedNativeFunction {
                     TypeSignature::BoolType,
                     TypeSignature::UIntType,
                 )
-                .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+                .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             }))),
             StxBurn => Simple(SimpleNativeFunction(FunctionType::Fixed(FixedFunction {
                 args: vec![
                     FunctionArg::new(
                         TypeSignature::UIntType,
                         ClarityName::try_from("amount".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -732,7 +732,7 @@ impl TypedNativeFunction {
                     FunctionArg::new(
                         TypeSignature::PrincipalType,
                         ClarityName::try_from("sender".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -742,7 +742,7 @@ impl TypedNativeFunction {
                     TypeSignature::BoolType,
                     TypeSignature::UIntType,
                 )
-                .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+                .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             }))),
             GetTokenBalance => Special(SpecialNativeFunction(&assets::check_special_get_balance)),
             GetAssetOwner => Special(SpecialNativeFunction(&assets::check_special_get_owner)),
@@ -840,7 +840,7 @@ impl TypedNativeFunction {
             | AllowanceWithStacking
             | AllowanceAll
             | Secp256r1Verify => {
-                return Err(StaticCheckErrorKind::ExpectsRejectable(
+                return Err(StaticCheckErrorKind::Unreachable(
                     "Clarity 2+ keywords should not show up in 2.05".into(),
                 ));
             }

--- a/clarity/src/vm/analysis/type_checker/v2_05/natives/sequences.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/natives/sequences.rs
@@ -404,16 +404,14 @@ pub fn check_special_element_at(
         ))),
         TypeSignature::SequenceType(StringType(ASCII(_))) => Ok(TypeSignature::OptionalType(
             Box::new(TypeSignature::SequenceType(StringType(ASCII(
-                BufferLength::try_from(1u32).map_err(|_| {
-                    StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into())
-                })?,
+                BufferLength::try_from(1u32)
+                    .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             )))),
         )),
         TypeSignature::SequenceType(StringType(UTF8(_))) => Ok(TypeSignature::OptionalType(
             Box::new(TypeSignature::SequenceType(StringType(UTF8(
-                StringUTF8Length::try_from(1u32).map_err(|_| {
-                    StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into())
-                })?,
+                StringUTF8Length::try_from(1u32)
+                    .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             )))),
         )),
         _ => Err(StaticCheckErrorKind::ExpectedSequence(Box::new(collection_type)).into()),

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -219,7 +219,7 @@ impl FunctionType {
                     (cost, return_type)
                 } else {
                     let return_type = accumulated_type
-                        .ok_or_else(|| StaticCheckErrorKind::ExpectsRejectable("Failed to set accumulated type for arg indices >= 1 in variadic arithmetic".into()).into());
+                        .ok_or_else(|| StaticCheckErrorKind::Unreachable("Failed to set accumulated type for arg indices >= 1 in variadic arithmetic".into()).into());
                     let check_result = return_type.and_then(|return_type| {
                         if arg_type != return_type {
                             Err(StaticCheckErrorKind::TypeError(
@@ -568,10 +568,9 @@ impl FunctionType {
         let (expected_args, returns) = match self {
             FunctionType::Fixed(FixedFunction { args, returns }) => (args, returns),
             _ => {
-                return Err(StaticCheckErrorKind::ExpectsRejectable(
-                    "Unexpected function type".into(),
-                )
-                .into());
+                return Err(
+                    StaticCheckErrorKind::Unreachable("Unexpected function type".into()).into(),
+                );
             }
         };
         check_argument_count(expected_args.len(), func_args)?;
@@ -595,9 +594,7 @@ impl FunctionType {
                                 &StacksEpochId::Epoch21,
                             )
                             .map_err(|_| {
-                                StaticCheckErrorKind::ExpectsRejectable(
-                                    "Failed to get trait".into(),
-                                )
+                                StaticCheckErrorKind::Unreachable("Failed to get trait".into())
                             })?
                             .ok_or(StaticCheckErrorKind::NoSuchContract(
                                 trait_id.contract_identifier.to_string(),
@@ -1026,14 +1023,14 @@ fn type_reserved_variable(
         let var_type = match variable {
             TxSender => TypeSignature::PrincipalType,
             TxSponsor => TypeSignature::new_option(TypeSignature::PrincipalType)
-                .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad construction".into()))?,
+                .map_err(|_| StaticCheckErrorKind::Unreachable("Bad construction".into()))?,
             ContractCaller => TypeSignature::PrincipalType,
             BlockHeight => TypeSignature::UIntType,
             StacksBlockHeight => TypeSignature::UIntType,
             TenureHeight => TypeSignature::UIntType,
             BurnBlockHeight => TypeSignature::UIntType,
             NativeNone => TypeSignature::new_option(no_type())
-                .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad construction".into()))?,
+                .map_err(|_| StaticCheckErrorKind::Unreachable("Bad construction".into()))?,
             NativeTrue => TypeSignature::BoolType,
             NativeFalse => TypeSignature::BoolType,
             TotalLiquidMicroSTX => TypeSignature::UIntType,
@@ -1133,9 +1130,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
                 }
                 Err(e) => Err(e),
             })?
-            .ok_or_else(|| {
-                StaticCheckErrorKind::ExpectsRejectable("Expected a depth result".into())
-            })?;
+            .ok_or_else(|| StaticCheckErrorKind::Unreachable("Expected a depth result".into()))?;
         }
 
         runtime_cost(ClarityCostFunction::AnalysisStorage, self, size)?;
@@ -1341,7 +1336,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         )?;
 
         if self.function_return_tracker.is_some() {
-            return Err(StaticCheckErrorKind::ExpectsRejectable(
+            return Err(StaticCheckErrorKind::Unreachable(
                 "Interpreter error: Previous function define left dirty typecheck state.".into(),
             )
             .into());

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/assets.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/assets.rs
@@ -237,7 +237,7 @@ pub fn check_special_stx_transfer_memo(
     let to_type: TypeSignature = TypeSignature::PrincipalType;
     let memo_type: TypeSignature = TypeSignature::SequenceType(SequenceSubtype::BufferType(
         BufferLength::try_from(TOKEN_TRANSFER_MEMO_LENGTH as u32)
-            .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+            .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
     ));
 
     runtime_cost(ClarityCostFunction::AnalysisTypeLookup, checker, 0)?;

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/conversions.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/conversions.rs
@@ -110,7 +110,7 @@ pub fn check_special_to_ascii(
     };
     Ok(
         TypeSignature::new_response(result_type, TypeSignature::UIntType).map_err(|_| {
-            StaticCheckErrorKind::ExpectsRejectable(
+            StaticCheckErrorKind::Unreachable(
                 "FATAL: Legal Clarity response type marked invalid".into(),
             )
         })?,

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
@@ -431,7 +431,7 @@ fn check_special_equals(
 
     // check if there was a least supertype failure.
     arg_type.ok_or_else(|| {
-        StaticCheckErrorKind::ExpectsRejectable(
+        StaticCheckErrorKind::Unreachable(
             "Arg type should be set because arguments checked for >= 1".into(),
         )
     })??;
@@ -692,7 +692,7 @@ fn check_principal_of(
     checker.type_check_expects(&args[0], context, &TypeSignature::BUFFER_33)?;
     Ok(
         TypeSignature::new_response(TypeSignature::PrincipalType, TypeSignature::UIntType)
-            .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+            .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
     )
 }
 
@@ -724,13 +724,13 @@ fn check_principal_construct(
                 ("error_code".into(), TypeSignature::UIntType),
                 (
                     "value".into(),
-                    TypeSignature::new_option(TypeSignature::PrincipalType).map_err(|_| StaticCheckErrorKind::ExpectsRejectable("FATAL: failed to create (optional principal) type signature".into()))?,
+                    TypeSignature::new_option(TypeSignature::PrincipalType).map_err(|_| StaticCheckErrorKind::Unreachable("FATAL: failed to create (optional principal) type signature".into()))?,
                 ),
             ])
-            .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("FAIL: PrincipalConstruct failed to initialize type signature".into()))?
+            .map_err(|_| StaticCheckErrorKind::Unreachable("FAIL: PrincipalConstruct failed to initialize type signature".into()))?
             .into()
         )
-        .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("FATAL: failed to create `(response principal { error_code: uint, principal: (optional principal) })` type signature".into()))?
+        .map_err(|_| StaticCheckErrorKind::Unreachable("FATAL: failed to create `(response principal { error_code: uint, principal: (optional principal) })` type signature".into()))?
     )
 }
 
@@ -744,7 +744,7 @@ fn check_secp256k1_recover(
     checker.type_check_expects(&args[1], context, &TypeSignature::BUFFER_65)?;
     Ok(
         TypeSignature::new_response(TypeSignature::BUFFER_33, TypeSignature::UIntType)
-            .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+            .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
     )
 }
 
@@ -817,9 +817,7 @@ fn check_get_burn_block_info(
 
     Ok(TypeSignature::new_option(
         block_info_prop.type_result().map_err(|_| {
-            StaticCheckErrorKind::ExpectsRejectable(
-                "FAILED to type valid burn info property".into(),
-            )
+            StaticCheckErrorKind::Unreachable("FAILED to type valid burn info property".into())
         })?,
     )?)
 }
@@ -918,7 +916,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::IntType,
                     ClarityName::try_from("value".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -929,7 +927,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::UIntType,
                     ClarityName::try_from("value".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -940,7 +938,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::PrincipalType,
                     ClarityName::try_from("value".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -952,11 +950,11 @@ impl TypedNativeFunction {
                     args: vec![FunctionArg::new(
                         TypeSignature::SequenceType(SequenceSubtype::BufferType(
                             BufferLength::try_from(16_u32).map_err(|_| {
-                                StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into())
+                                StaticCheckErrorKind::Unreachable("Bad constructor".into())
                             })?,
                         )),
                         ClarityName::try_from("value".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -969,11 +967,11 @@ impl TypedNativeFunction {
                     args: vec![FunctionArg::new(
                         TypeSignature::SequenceType(SequenceSubtype::BufferType(
                             BufferLength::try_from(16_u32).map_err(|_| {
-                                StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into())
+                                StaticCheckErrorKind::Unreachable("Bad constructor".into())
                             })?,
                         )),
                         ClarityName::try_from("value".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -1009,7 +1007,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::BoolType,
                     ClarityName::try_from("value".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -1062,7 +1060,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::PrincipalType,
                     ClarityName::try_from("owner".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -1074,7 +1072,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::PrincipalType,
                     ClarityName::try_from("principal".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -1093,14 +1091,12 @@ impl TypedNativeFunction {
                                     TypeSignature::CONTRACT_NAME_STRING_ASCII_MAX,
                                 )
                                 .map_err(|_| {
-                                    StaticCheckErrorKind::ExpectsRejectable(
-                                        "Bad constructor".into(),
-                                    )
+                                    StaticCheckErrorKind::Unreachable("Bad constructor".into())
                                 })?,
                             ),
                         ])
                         .map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: PrincipalDestruct failed to initialize type signature"
                                     .into(),
                             )
@@ -1116,7 +1112,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::PrincipalType,
                     ClarityName::try_from("owner".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -1127,7 +1123,7 @@ impl TypedNativeFunction {
                     ("unlock-height".into(), TypeSignature::UIntType),
                 ])
                 .map_err(|_| {
-                    StaticCheckErrorKind::ExpectsRejectable(
+                    StaticCheckErrorKind::Unreachable(
                         "FAIL: StxGetAccount failed to initialize type signature".into(),
                     )
                 })?
@@ -1138,7 +1134,7 @@ impl TypedNativeFunction {
                     FunctionArg::new(
                         TypeSignature::UIntType,
                         ClarityName::try_from("amount".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -1146,7 +1142,7 @@ impl TypedNativeFunction {
                     FunctionArg::new(
                         TypeSignature::PrincipalType,
                         ClarityName::try_from("sender".to_owned()).map_err(|_| {
-                            StaticCheckErrorKind::ExpectsRejectable(
+                            StaticCheckErrorKind::Unreachable(
                                 "FAIL: ClarityName failed to accept default arg name".into(),
                             )
                         })?,
@@ -1156,7 +1152,7 @@ impl TypedNativeFunction {
                     TypeSignature::BoolType,
                     TypeSignature::UIntType,
                 )
-                .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+                .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             }))),
             StxTransfer => Special(SpecialNativeFunction(&assets::check_special_stx_transfer)),
             StxTransferMemo => Special(SpecialNativeFunction(
@@ -1239,7 +1235,7 @@ impl TypedNativeFunction {
                 args: vec![FunctionArg::new(
                     TypeSignature::PrincipalType,
                     ClarityName::try_from("contract".to_owned()).map_err(|_| {
-                        StaticCheckErrorKind::ExpectsRejectable(
+                        StaticCheckErrorKind::Unreachable(
                             "FAIL: ClarityName failed to accept default arg name".into(),
                         )
                     })?,
@@ -1248,7 +1244,7 @@ impl TypedNativeFunction {
                     TypeSignature::BUFFER_32,
                     TypeSignature::UIntType,
                 )
-                .map_err(|_| StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into()))?,
+                .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             }))),
             ToAscii => Special(SpecialNativeFunction(&conversions::check_special_to_ascii)),
             RestrictAssets => Special(SpecialNativeFunction(

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/sequences.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/sequences.rs
@@ -455,16 +455,14 @@ pub fn check_special_element_at(
         ))),
         TypeSignature::SequenceType(StringType(ASCII(_))) => Ok(TypeSignature::OptionalType(
             Box::new(TypeSignature::SequenceType(StringType(ASCII(
-                BufferLength::try_from(1u32).map_err(|_| {
-                    StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into())
-                })?,
+                BufferLength::try_from(1u32)
+                    .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             )))),
         )),
         TypeSignature::SequenceType(StringType(UTF8(_))) => Ok(TypeSignature::OptionalType(
             Box::new(TypeSignature::SequenceType(StringType(UTF8(
-                StringUTF8Length::try_from(1u32).map_err(|_| {
-                    StaticCheckErrorKind::ExpectsRejectable("Bad constructor".into())
-                })?,
+                StringUTF8Length::try_from(1u32)
+                    .map_err(|_| StaticCheckErrorKind::Unreachable("Bad constructor".into()))?,
             )))),
         )),
         _ => Err(StaticCheckErrorKind::ExpectedSequence(Box::new(collection_type)).into()),

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -321,15 +321,15 @@ pub trait TransactionConnection: ClarityConnection {
             let result = db.insert_contract(identifier, contract_analysis);
             match result {
                 Ok(_) => {
-                    let result = db.commit().map_err(|e| {
-                        StaticCheckErrorKind::ExpectsRejectable(format!("{e:?}")).into()
-                    });
+                    let result = db
+                        .commit()
+                        .map_err(|e| StaticCheckErrorKind::Unreachable(format!("{e:?}")).into());
                     (cost_tracker, result)
                 }
                 Err(e) => {
-                    let result = db.roll_back().map_err(|e| {
-                        StaticCheckErrorKind::ExpectsRejectable(format!("{e:?}")).into()
-                    });
+                    let result = db
+                        .roll_back()
+                        .map_err(|e| StaticCheckErrorKind::Unreachable(format!("{e:?}")).into());
                     if result.is_err() {
                         (cost_tracker, result)
                     } else {

--- a/stackslib/src/chainstate/tests/static_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/static_analysis_tests.rs
@@ -68,7 +68,7 @@ fn variant_coverage_report(variant: StaticCheckErrorKind) {
         TypeSignatureTooDeep => Tested(vec![static_check_error_type_signature_too_deep]),
         ExpectedName => Tested(vec![static_check_error_expected_name]),
         SupertypeTooLarge => Tested(vec![static_check_error_supertype_too_large]),
-        ExpectsRejectable(_) => Unreachable_ExpectLike,
+        Unreachable(_) => Unreachable_ExpectLike,
         BadMatchOptionSyntax(static_check_error_kind) => {
             Tested(vec![static_check_error_bad_match_option_syntax])
         }


### PR DESCRIPTION
### Description

This patch convert static analysis check errors `StaticCheckErrorKind::ExpectsAcceptable` and `StaticCheckErrorKind::ExpectsRejectable` to `StaticCheckErrorKind::Unreachable`. The change is done in two steps:
- Convert ExpectsAcceptable to ExpectsRejectable  (commit: 0af50b5dc0906a1b41365bf98aac0e9ca227bde6)
- Rename ExpectsRejectable to Unreachable (commit: d64275948b3b449407fc5d1a6a79c35326501a97)

I have a question about `StaticCheckErrorKind`.
In `static_analysis_tests.rs`, we currently have a set of errors marked as unreachable because we weren’t able to trigger them through consensus testing:

* `TypeAlreadyAnnotatedFailure`
* `CheckerImplementationFailure`
* `ContractAlreadyExists`
* `MaxLengthOverflow`
* `MaxContextDepthReached`
* `NoSuchTrait`
* `ExpectedTraitIdentifier`

Should we squash these into Unrechable, similar to what we did for RuntimeCheckErrorKind in this PR: https://github.com/stacks-network/stacks-core/pull/6862, or keep them as they are, considering that there aren’t too many?

### Applicable issues

- fixes #[#119](https://github.com/stx-labs/core-epics/issues/119)

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
