### PR TITLE
fix(CI): update redocly to fix OpenAPI validation

### DIFF
--- a/.github/workflows/stacks-core-tests.yml
+++ b/.github/workflows/stacks-core-tests.yml
@@ -70,7 +70,7 @@ jobs:
           output: "./openapi-docs.html"
           config: "./docs/rpc/redocly.yaml"
           validate: "true"
-          redocly-version: "1.34"
+          redocly-version: "2.19"
 
   ## Generate and upload node configuration documentation
   node-config-docsgen:


### PR DESCRIPTION
We're running into [this issue](https://github.com/Redocly/redocly-cli/issues/2573):

https://github.com/stacks-network/stacks-core/actions/runs/22146712132/job/64027936265?pr=6762

Redocly have released an update to pin their `styled-components` dependency to a version that doesn't have this problem.

For us, this is a major version bump, so let's see if it still works in CI.
