### PR TITLE
remove suspected copy&paste code that makes some tests flaky

### DIFF
--- a/stacks-node/src/tests/signer/v0/tenure_extend.rs
+++ b/stacks-node/src/tests/signer/v0/tenure_extend.rs
@@ -2764,20 +2764,12 @@ fn burn_block_height_behavior() {
     let deployer_addr = tests::to_addr(&deployer_sk);
     let tx_fee = 10000;
     let deploy_fee = 200000;
-    let block_proposal_timeout = Duration::from_secs(20);
-    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(
         num_signers,
         vec![
             (sender_addr, send_amt + send_fee),
             (deployer_addr.clone(), deploy_fee + tx_fee * 3),
         ],
-        |config| {
-            // make the duration long enough that the miner will be marked as malicious
-            config.block_proposal_timeout = block_proposal_timeout;
-        },
-        |_| {},
-        None,
-        None,
     );
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
@@ -3943,18 +3935,8 @@ fn empty_sortition_before_approval() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let block_proposal_timeout = Duration::from_secs(20);
-    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
-        num_signers,
-        vec![(sender_addr, send_amt + send_fee)],
-        |config| {
-            // make the duration long enough that the miner will be marked as malicious
-            config.block_proposal_timeout = block_proposal_timeout;
-        },
-        |_| {},
-        None,
-        None,
-    );
+    let signer_test: SignerTest<SpawnedSigner> =
+        SignerTest::new(num_signers, vec![(sender_addr, send_amt + send_fee)]);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
     signer_test.boot_to_epoch_3();
@@ -4083,18 +4065,8 @@ fn empty_sortition_before_proposal() {
     let send_amt = 100;
     let send_fee = 180;
     let recipient = PrincipalData::from(StacksAddress::burn_address(false));
-    let block_proposal_timeout = Duration::from_secs(20);
-    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
-        num_signers,
-        vec![(sender_addr, send_amt + send_fee)],
-        |config| {
-            // make the duration long enough that the miner will be marked as malicious
-            config.block_proposal_timeout = block_proposal_timeout;
-        },
-        |_| {},
-        None,
-        None,
-    );
+    let signer_test: SignerTest<SpawnedSigner> =
+        SignerTest::new(num_signers, vec![(sender_addr, send_amt + send_fee)]);
     let http_origin = format!("http://{}", &signer_test.running_nodes.conf.node.rpc_bind);
 
     let skip_commit_op = signer_test


### PR DESCRIPTION
I came across this when debugging the very flaky `empty_sortition_before_proposal` test.

This comment, "make the duration long enough that the miner will be marked as malicious" exists five times throughout the code base. I assume it originates from `empty_tenure_delayed` (which is *actually* testing that signers mark a miner as malicious) and just got copied and pasted elsewhere as new integration tests were created.

The test failures I've looked at (e.g. [this one](https://github.com/stacks-network/stacks-core/actions/runs/22151861320/job/64275113289?pr=6762)) occur because the signers have indeed marked the miner as malicious, but the test is waiting for the block to be accepted. My assumption (which may absolutely be wrong) is that this code is not supposed to be here.
