### PR TITLE
Fix get_stacks_block_header_info_by_burn_header_* and get_highest_canonical_block_header_from_candidates determinism

### DIFF
--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -2819,11 +2819,13 @@ impl NakamotoChainState {
     ) -> Result<Option<StacksHeaderInfo>, ChainstateError> {
         let canonical_sortition_handle = sort_db.index_handle_at_tip();
         for candidate in candidates.into_iter() {
-            let Some(ref candidate_ch) = candidate.burn_view else {
-                // this is an epoch 2.x header, no burn view to check
-                return Ok(Some(candidate));
-            };
-            let in_canonical_fork = canonical_sortition_handle.processed_block(&candidate_ch)?;
+            // if burn_view is None, then this is an epoch 2.x header, and since epoch 2.x tenure's correspond
+            // to a single stacks block, we can use the miner's tenure sortition as a proxy for canonicity.
+            let candidate_ch = candidate
+                .burn_view
+                .as_ref()
+                .unwrap_or(&candidate.consensus_hash);
+            let in_canonical_fork = canonical_sortition_handle.processed_block(candidate_ch)?;
             if in_canonical_fork {
                 return Ok(Some(candidate));
             }

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -2343,6 +2343,82 @@ fn test_make_miners_stackerdb_config() {
 }
 
 #[test]
+fn test_get_highest_canonical_block_header_from_candidates_epoch2_deterministic() {
+    let (mut test_signers, test_stackers) = TestStacker::common_signing_set();
+    let mut peer = boot_nakamoto(
+        function_name!(),
+        vec![],
+        &mut test_signers,
+        &test_stackers,
+        None,
+    );
+
+    let sort_db = peer.chain.sortdb.as_mut().unwrap();
+    let tip_snapshot = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn()).unwrap();
+    let canonical_ch = tip_snapshot.consensus_hash.clone();
+
+    let epoch2_proof_bytes = hex_bytes("9275df67a68c8745c0ff97b48201ee6db447f7c93b23ae24cdc2400f52fdb08a1a6ac7ec71bf9c9c76e96ee4675ebff60625af28718501047bfd87b810c2d2139b73c23bd69de66360953a642c2a330a").unwrap();
+    let epoch2_proof = VRFProof::from_bytes(&epoch2_proof_bytes[..]).unwrap();
+
+    let mut candidates = Vec::new();
+    // Make the middle candidate the canonical one.
+    let canonical_index = 5;
+    for i in 0..10 {
+        let work = 110u64.saturating_sub(i as u64);
+        let header = StacksBlockHeader {
+            version: 0,
+            total_work: StacksWorkScore { burn: 1, work },
+            proof: epoch2_proof.clone(),
+            parent_block: BlockHeaderHash([(0x11 + i as u8); 32]),
+            parent_microblock: BlockHeaderHash([0x00; 32]),
+            parent_microblock_sequence: 0,
+            tx_merkle_root: Sha512Trunc256Sum([(0x22 + i as u8); 32]),
+            state_index_root: TrieHash([(0x33 + i as u8); 32]),
+            microblock_pubkey_hash: Hash160([(0x44 + i as u8); 20]),
+        };
+
+        // Make sure the candidate with the correct consensus hash is selected based on the first in the list (i.e.
+        // the one with the highest stacks block height as well as correct consensus hash)
+        let consensus_hash = if i >= canonical_index {
+            canonical_ch.clone()
+        } else {
+            ConsensusHash([(0x50 + i as u8); 20])
+        };
+
+        let candidate = StacksHeaderInfo {
+            anchored_header: StacksBlockHeaderTypes::Epoch2(header),
+            microblock_tail: None,
+            // Make the stacks block height decrease with each candidate, since get_highest_canonical_block_header_from_candidates
+            // expects a height-ordered list of candidates
+            stacks_block_height: work,
+            index_root: TrieHash([(0x60 + i as u8); 32]),
+            consensus_hash,
+            burn_header_hash: tip_snapshot.burn_header_hash.clone(),
+            burn_header_height: tip_snapshot.block_height as u32,
+            burn_header_timestamp: tip_snapshot.burn_header_timestamp,
+            anchored_block_size: 120 + i as u64,
+            burn_view: None,
+            total_tenure_size: 0,
+        };
+        candidates.push(candidate);
+    }
+    let canonical_candidate = candidates[canonical_index].clone();
+    let selected =
+        NakamotoChainState::get_highest_canonical_block_header_from_candidates(sort_db, candidates)
+            .unwrap()
+            .expect("Expected a canonical epoch2 header");
+
+    assert_eq!(
+        selected.anchored_header.block_hash(),
+        canonical_candidate.anchored_header.block_hash()
+    );
+    assert_eq!(
+        selected.stacks_block_height,
+        canonical_candidate.stacks_block_height
+    );
+}
+
+#[test]
 fn parse_vote_for_aggregate_public_key_valid() {
     let signer_private_key = StacksPrivateKey::random();
     let mainnet = false;

--- a/stackslib/src/chainstate/stacks/db/headers.rs
+++ b/stackslib/src/chainstate/stacks/db/headers.rs
@@ -251,12 +251,17 @@ impl StacksChainState {
     }
 
     /// Get a stacks header info by its sortition's burnchain header hash.
-    /// If there are multiple at a given burn view, all will be returned.
+    /// If there are multiple at a given burn view, all will be returned by stacks block height descending.
     pub fn get_stacks_block_header_info_by_burn_header_hash(
         conn: &Connection,
         burnchain_header_hash: &BurnchainHeaderHash,
     ) -> Result<Vec<StacksHeaderInfo>, Error> {
-        let sql = "SELECT * FROM block_headers WHERE burn_header_hash = ?1";
+        let sql = "
+            SELECT *
+            FROM block_headers
+            WHERE burn_header_hash = ?1
+            ORDER BY block_height DESC
+        ";
         let out = query_rows(conn, sql, &[&burnchain_header_hash])?;
         if !out.is_empty() {
             return Ok(out);
@@ -265,12 +270,17 @@ impl StacksChainState {
     }
 
     /// Get a stacks header info by its sortition's burn block height
-    /// If there are multiple at a given burn view, all will be returned.
+    /// If there are multiple at a given burn height, all will be returned by stacks block height descending.
     pub fn get_stacks_block_header_info_by_burn_header_height(
         conn: &Connection,
         burn_header_height: u64,
     ) -> Result<Vec<StacksHeaderInfo>, Error> {
-        let sql = "SELECT * FROM block_headers WHERE burn_header_height = ?1";
+        let sql = "
+            SELECT * 
+            FROM block_headers 
+            WHERE burn_header_height = ?1
+            ORDER BY block_height DESC
+        ";
         let out = query_rows(conn, sql, &[&burn_header_height])?;
         if !out.is_empty() {
             return Ok(out);


### PR DESCRIPTION
@brice-stacks found a bug in my changes in [this PR](https://github.com/stacks-network/stacks-core/pull/6818). 
Specifically get_highest_canonical_block_header_from_candidates expects an ordered list by stacks block height descending. I think the check on processed_block for epoch 2.x candidates MAY be redundant but wanted to be extra explicit/sure.
