### PR TITLE
docs(rpc): add missing examples to  parameter definitions

### DIFF
--- a/docs/rpc/components/parameters/deployer-address.yaml
+++ b/docs/rpc/components/parameters/deployer-address.yaml
@@ -5,5 +5,6 @@ required: true
 description: |
   Standard Stacks address (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0`).
   Must be 28-41 characters long using Stacks c32check format.
+example: SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0
 schema:
   $ref: '../schemas/standard-principal.schema.yaml'


### PR DESCRIPTION
**PR Description:**
```
 Parameter definition files were missing parameter-level example
values:

- deployer-address.yaml: adds example Stacks address

These additions make the OpenAPI spec more useful for developers
consuming the API through generated clients or interactive docs.