### PR TITLE
Log if a test failure might have been prevented with a longer timeout

### DIFF
--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -775,20 +775,20 @@ pub fn wait_for<F>(timeout_secs: u64, mut check: F) -> Result<(), String>
 where
     F: FnMut() -> Result<bool, String>,
 {
-    let start = Instant::now();
-    let desired_end = start + Duration::from_secs(timeout_secs);
-    let extended_end = start + Duration::from_secs(2 * timeout_secs);
+    let desired_timeout = Duration::from_secs(timeout_secs);
+    let extended_timeout = Duration::from_secs(2 * timeout_secs);
+    let stopwatch = Instant::now();
     while !check()? {
-        if Instant::now() > extended_end {
+        if stopwatch.elapsed() > extended_timeout {
             break;
         }
         thread::sleep(Duration::from_millis(500));
     }
-    let end = Instant::now();
-    if end > desired_end {
-        if end <= extended_end {
-            let seconds_taken = (end - start).as_secs();
-            info!("TIMEOUT POSSIBLY TOO LOW: Operation failed to complete in the allotted {} seconds but would have succeed after {}", timeout_secs, seconds_taken);
+    let elapsed = stopwatch.elapsed();
+    if elapsed > desired_timeout {
+        if elapsed <= extended_timeout {
+            let seconds_taken = elapsed.as_secs();
+            info!("TIMEOUT POSSIBLY TOO LOW: Operation failed to complete in the allotted {timeout_secs} seconds but would have succeeded after {seconds_taken}");
         }
         error!("Timed out waiting for check to process");
         return Err("Timed out".into());

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -750,28 +750,48 @@ where
 {
     eprintln!("Issuing bitcoin block");
     btc_controller.build_next_block(1);
-    let start = Instant::now();
-    while !check(btc_controller)? {
-        if start.elapsed() > Duration::from_secs(timeout_secs) {
-            error!("Timed out waiting for block to process, trying to continue test");
-            return Err("Timed out".into());
-        }
-        thread::sleep(Duration::from_millis(100));
+    if wait_for(timeout_secs, || check(btc_controller)).is_err() {
+        error!("Timed out waiting for block to process, trying to continue test");
+        return Err("Timed out".into());
     }
     Ok(())
 }
 
+/// Returns an error if it takes longer than the given number of seconds
+/// for the check to pass, but will actually wait twice as long, in order
+/// to check if a longer timeout would've made the test pass (or at least
+/// continue).
+///
+/// The purpose of this is to end up with "TIMEOUT POSSIBLY TOO LOW" in
+/// the integration test logs in CI, giving a hint at which flaky tests
+/// may simply need a little more time.
+///
+/// Even if the check eventually succeeds, it is still an error if it
+/// took longer than the `timeout_secs` argument! This is not meant as
+/// a blanket "make everything wait twice as long" thing; it's meant
+/// as a tool to help with investigating flaky tests, and may be removed
+/// again at any time.
 pub fn wait_for<F>(timeout_secs: u64, mut check: F) -> Result<(), String>
 where
     F: FnMut() -> Result<bool, String>,
 {
     let start = Instant::now();
+    let desired_end = start + Duration::from_secs(timeout_secs);
+    let extended_end = start + Duration::from_secs(2 * timeout_secs);
     while !check()? {
-        if start.elapsed() > Duration::from_secs(timeout_secs) {
-            error!("Timed out waiting for check to process");
-            return Err("Timed out".into());
+        if Instant::now() > extended_end {
+            break;
         }
         thread::sleep(Duration::from_millis(500));
+    }
+    let end = Instant::now();
+    if end > desired_end {
+        if end <= extended_end {
+            let seconds_taken = (end - start).as_secs();
+            info!("TIMEOUT POSSIBLY TOO LOW: Operation failed to complete in the allotted {} seconds but would have succeed after {}", timeout_secs, seconds_taken);
+        }
+        error!("Timed out waiting for check to process");
+        return Err("Timed out".into());
     }
     Ok(())
 }


### PR DESCRIPTION
This is an idea I had for helping with investigating flaky tests.

The vast majority of integration test failures are timeouts, where we wait for a certain amount of time for a condition (e.g. a block to be mined), and if the condition isn't fulfilled within the time it was given, the test fails.

Sometimes the reason might be something like a race condition (e.g. the block had already been mined by the time we started the check loop), but sometimes it's simply that the allotted timeout wasn't enough. This is especially likely because tests are usually slower in CI than when they're being run locally.

It's not uncommon to reduce flakiness by increasing certain timeouts (e.g #6770, #6769), but it's annoying to investigate whether that would even be a viable fix, or if something else should be done.

My suggestion in this PR is to modify our `wait_for` helper to silently try twice as long, and log a message "TIMEOUT POSSIBLY TOO LOW" if the condition wasn't fulfilled in time, but eventually it would have succeeded. It's still a failure if this happens -- this isn't meant to simply double all the timeouts. It's meant to give us hints where a simple timeout increase might help, and where a flaky test needs more thorough investigation.

Yes, this does mean it increases the runtime of those tests (just like a blanket 2x for all timeouts would), but it's only the *failing* tests where that's the case, and if this helps us with reducing test failures overall by making investigations easier, I think that's worth it.

And this doesn't have to live forever -- I'm happy to remove this again if it ends up outliving its usefulness.
