### PR TITLE
Implement `as contract?` and Allowances

### DIFF
--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
@@ -39,7 +39,7 @@ mod assets;
 mod conversions;
 mod maps;
 mod options;
-pub(crate) mod post_conditions;
+pub mod post_conditions;
 mod sequences;
 
 #[allow(clippy::large_enum_variant)]

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -2197,6 +2197,7 @@ fn link_host_functions(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Vm
     link_exit_as_contract_pre_v4_fn(linker)?;
     link_enter_as_contract_post_v4_fn(linker)?;
     link_exit_as_contract_post_v4_fn(linker)?;
+    link_cleanup_as_contract_post_v4_fn(linker)?;
     link_with_all_assets_unsafe_fn(linker)?;
     link_with_ft_fn(linker)?;
     link_with_nft_fn(linker)?;
@@ -3511,13 +3512,13 @@ fn link_exit_as_contract_post_v4_fn(
                 match check_allowances(&owner, allowances, asset_map, epoch)? {
                     None => {
                         caller.data_mut().global_context.commit()?;
-                        Ok((1i32, 0i64, 0i64)) // no violation
+                        Ok((0i64, 0i64, 1i32)) // no violation
                     }
                     Some(violation_index) => {
                         caller.data_mut().global_context.roll_back()?;
                         let lo = violation_index as i64;
                         let hi = (violation_index >> 64) as i64;
-                        Ok((0i32, lo, hi)) // violation — Wasm returns (err index)
+                        Ok((lo, hi, 0i32)) // violation — Wasm returns (err index)
                     }
                 }
             },
@@ -3526,6 +3527,34 @@ fn link_exit_as_contract_post_v4_fn(
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
                 "exit_as_contract_post_v4".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `cleanup_as_contract_post_v4`, into the Wasm module.
+/// This function is after before processing the inner-expression of
+/// `as-contract?`, and is used to restore the caller and sender in the case where
+/// an inner-expresion failed.
+fn link_cleanup_as_contract_post_v4_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), Error> {
+    linker
+        .func_wrap(
+            "clarity",
+            "cleanup_as_contract_post_v4",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                caller.data_mut().pop_sender()?;
+                caller.data_mut().pop_caller()?;
+                caller.data_mut().global_context.roll_back()?;
+
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            Error::Wasm(WasmError::UnableToLinkHostFunction(
+                "cleanup_as_contract".to_string(),
                 e,
             ))
         })

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1,5 +1,7 @@
 use std::io::{Cursor, Write as _};
 
+use clarity_types::types::MAX_VALUE_SIZE;
+use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::util::hash::{Keccak256Hash, Sha512Sum, Sha512Trunc256Sum};
@@ -21,8 +23,13 @@ use super::types::{
 use super::{CallStack, ClarityVersion, ContractName, ExecutionState, SymbolicExpression};
 use crate::vm::analysis::ContractAnalysis;
 use crate::vm::ast::build_ast;
-use crate::vm::contexts::{GlobalContext, InvocationContext};
-use crate::vm::errors::{RuntimeCheckErrorKind, RuntimeError, VmExecutionError, WasmError};
+use crate::vm::contexts::{AssetMap, GlobalContext, InvocationContext};
+use crate::vm::errors::{
+    RuntimeCheckErrorKind, RuntimeError, StaticCheckErrorKind, VmExecutionError, WasmError,
+};
+use crate::vm::functions::post_conditions::{
+    Allowance, FtAllowance, NftAllowance, StackingAllowance, StxAllowance,
+};
 use crate::vm::types::{
     BufferLength, SequenceSubtype, SequencedValue, StringSubtype, TypeSignature, TypeSignatureExt,
 };
@@ -60,7 +67,7 @@ enum StxErrorCodes {
     SENDER_IS_NOT_TX_SENDER = 4,
 }
 
-/// The context used when making calls into the Wasm module.
+// The context used when making calls into the Wasm module.
 pub struct ClarityWasmContext<'a, 'b> {
     pub global_context: &'a mut GlobalContext<'b>,
     contract_context: Option<&'a ContractContext>,
@@ -75,6 +82,8 @@ pub struct ClarityWasmContext<'a, 'b> {
     caller_stack: Vec<PrincipalData>,
     /// Stack of block hashes, used for `at-block` expressions.
     bhh_stack: Vec<StacksBlockId>,
+    /// Stack of asset contexts, used for `with-*` expressions.
+    pub asset_context_stack: Vec<Vec<Allowance>>,
 
     /// Contract analysis data, used for typing information, and only available
     /// when initializing a contract. Should always be `Some` when initializing
@@ -103,6 +112,7 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             sender_stack: vec![],
             caller_stack: vec![],
             bhh_stack: vec![],
+            asset_context_stack: vec![],
             contract_analysis,
         }
     }
@@ -127,11 +137,12 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             sender_stack: vec![],
             caller_stack: vec![],
             bhh_stack: vec![],
+            asset_context_stack: vec![],
             contract_analysis,
         }
     }
 
-    fn push_sender(&mut self, sender: PrincipalData) {
+    pub fn push_sender(&mut self, sender: PrincipalData) {
         if let Some(current) = self.sender.take() {
             self.sender_stack.push(current);
         }
@@ -147,7 +158,7 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             })
     }
 
-    fn push_caller(&mut self, caller: PrincipalData) {
+    pub fn push_caller(&mut self, caller: PrincipalData) {
         if let Some(current) = self.caller.take() {
             self.caller_stack.push(current);
         }
@@ -163,7 +174,7 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             })
     }
 
-    fn push_at_block(&mut self, bhh: StacksBlockId) {
+    pub fn push_at_block(&mut self, bhh: StacksBlockId) {
         self.bhh_stack.push(bhh);
     }
 
@@ -173,6 +184,83 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             .ok_or(VmExecutionError::Wasm(WasmError::WasmGeneratorError(
                 "Could not pop at_block".to_string(),
             )))
+    }
+
+    pub fn push_as_contract(&mut self) {
+        self.asset_context_stack.push(Vec::new());
+    }
+
+    pub fn pop_as_contract(&mut self) -> Option<Vec<Allowance>> {
+        self.asset_context_stack.pop()
+    }
+
+    pub fn push_asset_context_unsafe(&mut self) {
+        self.asset_context_stack
+            .last_mut()
+            .unwrap()
+            .push(Allowance::All);
+    }
+
+    pub fn push_asset_context_ft(
+        &mut self,
+        contract: QualifiedContractIdentifier,
+        token: String,
+        allowed_amount: u128,
+    ) {
+        if self.asset_context_stack.is_empty() {
+            self.asset_context_stack.push(vec![]);
+        }
+        self.asset_context_stack
+            .last_mut()
+            .unwrap()
+            .push(Allowance::Ft(FtAllowance {
+                asset: AssetIdentifier {
+                    contract_identifier: contract,
+                    asset_name: ClarityName::try_from(token).unwrap(),
+                },
+                amount: allowed_amount,
+            }));
+    }
+
+    pub fn push_asset_context_nft(
+        &mut self,
+        asset_identifier: AssetIdentifier,
+        allowed_identifiers: Vec<clarity_types::Value>,
+    ) {
+        if self.asset_context_stack.is_empty() {
+            self.asset_context_stack.push(vec![]);
+        }
+        self.asset_context_stack
+            .last_mut()
+            .unwrap()
+            .push(Allowance::Nft(NftAllowance {
+                asset: asset_identifier,
+                asset_ids: allowed_identifiers,
+            }));
+    }
+
+    pub fn push_asset_context_stacking(&mut self, allowed_amount: u128) {
+        if self.asset_context_stack.is_empty() {
+            self.asset_context_stack.push(vec![]);
+        }
+        self.asset_context_stack
+            .last_mut()
+            .unwrap()
+            .push(Allowance::Stacking(StackingAllowance {
+                amount: allowed_amount,
+            }));
+    }
+
+    pub fn push_asset_context_stx(&mut self, allowed_amount: u128) {
+        if self.asset_context_stack.is_empty() {
+            self.asset_context_stack.push(vec![]);
+        }
+        self.asset_context_stack
+            .last_mut()
+            .unwrap()
+            .push(Allowance::Stx(StxAllowance {
+                amount: allowed_amount,
+            }));
     }
 
     /// Return an immutable reference to the contract_context
@@ -2188,8 +2276,15 @@ fn link_host_functions(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Vm
     link_is_in_regtest_fn(linker)?;
     link_is_in_mainnet_fn(linker)?;
     link_chain_id_fn(linker)?;
-    link_enter_as_contract_fn(linker)?;
-    link_exit_as_contract_fn(linker)?;
+    link_enter_as_contract_original_fn(linker)?;
+    link_exit_as_contract_original_fn(linker)?;
+    link_enter_as_contract_new_fn(linker)?;
+    link_exit_as_contract_new_fn(linker)?;
+    link_with_all_assets_unsafe_fn(linker)?;
+    link_with_ft_fn(linker)?;
+    link_with_nft_fn(linker)?;
+    link_with_stacking_fn(linker)?;
+    link_with_stx_fn(linker)?;
     link_stx_get_balance_fn(linker)?;
     link_stx_account_fn(linker)?;
     link_stx_burn_fn(linker)?;
@@ -3382,16 +3477,16 @@ fn link_chain_id_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
         })
 }
 
-/// Link host interface function, `enter_as_contract`, into the Wasm module.
+/// Link host interface function, `enter_as_contract_original`, into the Wasm module.
 /// This function is called before processing the inner-expression of
 /// `as-contract`.
-fn link_enter_as_contract_fn(
+fn link_enter_as_contract_original_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "enter_as_contract",
+            "enter_as_contract_original",
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 let contract_principal: PrincipalData = caller
                     .data()
@@ -3406,22 +3501,22 @@ fn link_enter_as_contract_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "enter_as_contract".to_string(),
+                "enter_as_contract_original".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `exit_as_contract`, into the Wasm module.
+/// Link host interface function, `exit_as_contract_original`, into the Wasm module.
 /// This function is after before processing the inner-expression of
 /// `as-contract`, and is used to restore the caller and sender.
-fn link_exit_as_contract_fn(
+fn link_exit_as_contract_original_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "exit_as_contract",
+            "exit_as_contract_original",
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 caller.data_mut().pop_sender()?;
                 caller.data_mut().pop_caller()?;
@@ -3431,7 +3526,481 @@ fn link_exit_as_contract_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "exit_as_contract".to_string(),
+                "exit_as_contract_original".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `enter_as_contract_new`, into the Wasm module.
+/// This function is called before processing the allowances and inner-expression of
+/// `as-contract?`.
+fn link_enter_as_contract_new_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "enter_as_contract_new",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                let contract_principal: PrincipalData = caller
+                    .data()
+                    .contract_context()
+                    .contract_identifier
+                    .clone()
+                    .into();
+                caller.data_mut().global_context.begin();
+                caller.data_mut().push_as_contract();
+                caller.data_mut().push_sender(contract_principal.clone());
+                caller.data_mut().push_caller(contract_principal);
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "enter_as_contract_new".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `exit_as_contract_new`, into the Wasm module.
+/// This function is after before processing the inner-expression of
+/// `as-contract?`, and is used to restore the caller, sender and check allowances.
+fn link_exit_as_contract_new_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "exit_as_contract_new",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                // we need to restore the current caller and sender. We pop both and check if we did set
+                // them correctly before. We keep the sender (current-contract) as owner for checking the
+                // allowances.
+                let owner = {
+                    let owner = caller.data_mut().pop_sender();
+                    let _ = caller.data_mut().pop_caller()?;
+                    owner?
+                };
+
+                let allowances = caller.data_mut().pop_as_contract().unwrap_or_default();
+
+                let asset_map = caller.data_mut().global_context.get_readonly_asset_map()?;
+
+                match check_allowances(&owner, allowances, asset_map)? {
+                    None => {
+                        caller.data_mut().global_context.commit()?;
+                        Ok((1i32, 0i32, 0i64, 0i64)) // no violation
+                    }
+                    Some(violation_index) => {
+                        caller.data_mut().global_context.roll_back()?;
+                        let lo = violation_index as i64;
+                        let hi = (violation_index >> 64) as i64;
+                        Ok((0i32, 0i32, lo, hi)) // violation — Wasm returns (err index)
+                    }
+                }
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "exit_as_contract_new".to_string(),
+                e,
+            ))
+        })
+}
+
+// Checker function for the asset allowances
+fn check_allowances(
+    owner: &PrincipalData,
+    allowances: Vec<Allowance>,
+    assets: &AssetMap,
+) -> Result<Option<u128>, VmExecutionError> {
+    const MAX_ALLOWANCES: usize = 128;
+    let mut stx_allowances: Vec<(usize, u128)> = Vec::new();
+    let mut ft_allowances: HashMap<AssetIdentifier, Vec<(usize, u128)>> = HashMap::new();
+    let mut nft_allowances: HashMap<AssetIdentifier, (usize, Vec<Value>)> = HashMap::new();
+    let mut stacking_allowances: Vec<(usize, u128)> = Vec::new();
+
+    for (i, allowance) in allowances.into_iter().enumerate() {
+        match allowance {
+            Allowance::All => return Ok(None),
+            Allowance::Stx(stx) => {
+                stx_allowances.push((i, stx.amount));
+            }
+            Allowance::Ft(ft) => {
+                ft_allowances
+                    .entry(ft.asset)
+                    .or_default()
+                    .push((i, ft.amount));
+            }
+            Allowance::Nft(nft) => {
+                let (_, vec) = nft_allowances
+                    .entry(nft.asset)
+                    .or_insert_with(|| (i, Vec::new()));
+                vec.extend(nft.asset_ids);
+            }
+            Allowance::Stacking(stacking) => {
+                stacking_allowances.push((i, stacking.amount));
+            }
+        }
+    }
+
+    let idx_to_u128 = |idx: usize| {
+        u128::try_from(idx).map_err(|_| VmExecutionError::Wasm(WasmError::AllowanceIndexOverflow))
+    };
+
+    // Check STX movements
+    if let Some(stx_moved) = assets.get_stx(owner) {
+        if stx_allowances.is_empty() {
+            return Ok(Some(MAX_ALLOWANCES as u128));
+        }
+        for (index, allowance) in &stx_allowances {
+            if stx_moved > *allowance {
+                return Ok(Some(idx_to_u128(*index)?));
+            }
+        }
+    }
+
+    // Check STX burns
+    if let Some(stx_burned) = assets.get_stx_burned(owner) {
+        if stx_allowances.is_empty() {
+            return Ok(Some(MAX_ALLOWANCES as u128));
+        }
+        for (index, allowance) in &stx_allowances {
+            if stx_burned > *allowance {
+                return Ok(Some(idx_to_u128(*index)?));
+            }
+        }
+    }
+
+    // Check FT movements
+    if let Some(ft_moved) = assets.get_all_fungible_tokens(owner) {
+        for (asset, amount_moved) in ft_moved {
+            let mut merged: Vec<(usize, u128)> = Vec::new();
+
+            if let Some(v) = ft_allowances.get(asset) {
+                merged.extend(v.iter().cloned());
+            }
+            if let Some(wildcard_vec) = ft_allowances.get(&AssetIdentifier {
+                contract_identifier: asset.contract_identifier.clone(),
+                asset_name: ClarityName::from_literal("*"),
+            }) {
+                merged.extend(wildcard_vec.iter().cloned());
+            }
+
+            if merged.is_empty() {
+                return Ok(Some(MAX_ALLOWANCES as u128));
+            }
+
+            merged.sort_by_key(|(idx, _)| *idx);
+
+            for (index, allowance) in merged {
+                if *amount_moved > allowance {
+                    return Ok(Some(idx_to_u128(index)?));
+                }
+            }
+        }
+    }
+
+    // Check NFT movements
+    if let Some(nft_moved) = assets.get_all_nonfungible_tokens(owner) {
+        for (asset, ids_moved) in nft_moved {
+            let Some((index, allowed_ids)) = nft_allowances.get(asset) else {
+                return Ok(Some(MAX_ALLOWANCES as u128));
+            };
+            for id in ids_moved {
+                if !allowed_ids.contains(id) {
+                    return Ok(Some(idx_to_u128(*index)?));
+                }
+            }
+        }
+    }
+
+    // Check stacking
+    if let Some(stacking_amount) = assets.get_stacking(owner) {
+        if stacking_allowances.is_empty() {
+            return Ok(Some(MAX_ALLOWANCES as u128));
+        }
+        for (index, allowance) in &stacking_allowances {
+            if stacking_amount > *allowance {
+                return Ok(Some(idx_to_u128(*index)?));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Link host interface function, `with_all_assets_unsafe`, into the Wasm module.
+/// This function is called before processing the inner-expression of
+/// `with-all-assets-unsafe`.
+fn link_with_all_assets_unsafe_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "with_all_assets_unsafe",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                caller.data_mut().push_asset_context_unsafe();
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "with_all_assets_unsafe".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `with_ft`, into the Wasm module.
+/// This function is called before processing the inner-expression of
+/// `with-ft`. The asset identifier and allowance should already be written to memory.
+fn link_with_ft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "with_ft",
+            |mut caller: Caller<'_, ClarityWasmContext>,
+             contract_id_offset: i32,
+             contract_id_length: i32,
+             token_name_offset: i32,
+             token_name_length: i32,
+             amount_lo: i64,
+             amount_hi: i64| {
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(WasmError::MemoryNotFound)?;
+
+                let epoch = caller.data().global_context.epoch_id;
+
+                let token_name_value = read_from_wasm(
+                    memory,
+                    &mut caller,
+                    &TypeSignature::STRING_ASCII_MAX,
+                    token_name_offset,
+                    token_name_length,
+                    epoch,
+                )?;
+                let token_name = token_name_value.expect_ascii()?;
+
+                let allowed_amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
+
+                let contract_principal = read_from_wasm(
+                    memory,
+                    &mut caller,
+                    &TypeSignature::PrincipalType,
+                    contract_id_offset,
+                    contract_id_length,
+                    epoch,
+                )?;
+                let contract_id = match &contract_principal {
+                    Value::Principal(PrincipalData::Contract(contract_id)) => contract_id,
+                    _ => {
+                        return Err(RuntimeCheckErrorKind::ContractCallExpectName.into());
+                    }
+                };
+
+                if token_name != "*" {
+                    let asset_name = ClarityName::try_from(token_name.clone())?;
+                    let contract = caller
+                        .data_mut()
+                        .global_context
+                        .database
+                        .get_contract(contract_id)?;
+                    contract
+                        .meta_ft
+                        .contains_key(&asset_name)
+                        .then_some(())
+                        .ok_or_else(|| {
+                            WasmError::Expect(
+                                StaticCheckErrorKind::NoSuchFT(token_name.clone()).to_string(),
+                            )
+                        })?;
+                }
+
+                caller.data_mut().push_asset_context_ft(
+                    contract_id.clone(),
+                    token_name,
+                    allowed_amount,
+                );
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "with_ft".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `with_nft`, into the Wasm module.
+/// This function is called before processing the inner-expression of
+/// `with-nft`. The asset identifier and allowance should already be written to memory.
+fn link_with_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "with_nft",
+            |mut caller: Caller<'_, ClarityWasmContext>,
+             contract_id_offset: i32,
+             contract_id_length: i32,
+             token_name_offset: i32,
+             token_name_length: i32,
+             identifiers_offset: i32,
+             identifiers_length: i32| {
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(WasmError::MemoryNotFound)?;
+
+                let epoch = caller.data().global_context.epoch_id;
+
+                let token_name = read_from_wasm(
+                    memory,
+                    &mut caller,
+                    &TypeSignature::STRING_ASCII_MAX,
+                    token_name_offset,
+                    token_name_length,
+                    epoch,
+                )?
+                .expect_ascii()?;
+                let asset_name = ClarityName::try_from(token_name.clone())?;
+
+                let key_type = caller
+                    .data()
+                    .contract_context()
+                    .meta_nft
+                    .get(&asset_name)
+                    .ok_or_else(|| {
+                        WasmError::Expect(
+                            StaticCheckErrorKind::NoSuchNFT(token_name.clone()).to_string(),
+                        )
+                    })?
+                    .key_type
+                    .clone();
+
+                // Compute a safe max list length from the entry's serialized value size.
+                // ListTypeData::inner_size() = entry_size * max_len + type_overhead,
+                // so we need (MAX_VALUE_SIZE - type_overhead) / entry_size to stay
+                // within bounds and avoid ValueTooLarge.
+                let entry_size = key_type.size()?;
+                let max_list_len = (MAX_VALUE_SIZE.saturating_sub(entry_size + 5)) / entry_size;
+
+                let identifiers_value = read_from_wasm(
+                    memory,
+                    &mut caller,
+                    &TypeSignature::SequenceType(SequenceSubtype::ListType(
+                        ListTypeData::new_list(key_type, max_list_len)?,
+                    )),
+                    identifiers_offset,
+                    identifiers_length,
+                    epoch,
+                )?;
+                let allowed_identifiers = identifiers_value.expect_list()?;
+
+                let contract_principal = read_from_wasm(
+                    memory,
+                    &mut caller,
+                    &TypeSignature::PrincipalType,
+                    contract_id_offset,
+                    contract_id_length,
+                    epoch,
+                )?;
+                let contract_id = match &contract_principal {
+                    Value::Principal(PrincipalData::Contract(contract_id)) => contract_id,
+                    _ => {
+                        return Err(RuntimeCheckErrorKind::ContractCallExpectName.into());
+                    }
+                };
+
+                if token_name != "*" {
+                    let contract = caller
+                        .data_mut()
+                        .global_context
+                        .database
+                        .get_contract(contract_id)?;
+                    contract
+                        .meta_nft
+                        .contains_key(&asset_name)
+                        .then_some(())
+                        .ok_or_else(|| {
+                            WasmError::Expect(
+                                StaticCheckErrorKind::NoSuchNFT(token_name).to_string(),
+                            )
+                        })?;
+                }
+
+                let asset_identifier = AssetIdentifier {
+                    contract_identifier: contract_id.clone(),
+                    asset_name,
+                };
+
+                caller
+                    .data_mut()
+                    .push_asset_context_nft(asset_identifier, allowed_identifiers);
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "with_nft".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `with_stacking`, into the Wasm module.
+/// This function is called before processing the inner-expression of
+/// `with-stacking`. The allowance should already be written to memory.
+fn link_with_stacking_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "with_stacking",
+            |mut caller: Caller<'_, ClarityWasmContext>, allowance_lo: i64, allowance_hi: i64| {
+                let allowance = ((allowance_hi as u128) << 64) | ((allowance_lo as u64) as u128);
+
+                caller.data_mut().push_asset_context_stacking(allowance);
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "with_stacking".to_string(),
+                e,
+            ))
+        })
+}
+
+/// Link host interface function, `with_stx`, into the Wasm module.
+/// This function is called before processing the inner-expression of
+/// `with-stx`. The allowance should already be written to memory.
+fn link_with_stx_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "with_stx",
+            |mut caller: Caller<'_, ClarityWasmContext>, amount_lo: i64, amount_hi: i64| {
+                let allowed_amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
+
+                caller.data_mut().push_asset_context_stx(allowed_amount);
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "with_stx".to_string(),
                 e,
             ))
         })
@@ -3453,7 +4022,7 @@ fn link_stx_get_balance_fn(
                 let memory = caller
                     .get_export("memory")
                     .and_then(|export| export.into_memory())
-                    .ok_or(VmExecutionError::Wasm(WasmError::MemoryNotFound))?;
+                    .ok_or(WasmError::MemoryNotFound)?;
 
                 let epoch = caller.data_mut().global_context.epoch_id;
 

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -1,7 +1,6 @@
 use std::io::{Cursor, Write as _};
 
 use clarity_types::types::MAX_VALUE_SIZE;
-use hashbrown::HashMap;
 use stacks_common::types::StacksEpochId;
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::util::hash::{Keccak256Hash, Sha512Sum, Sha512Trunc256Sum};
@@ -23,12 +22,12 @@ use super::types::{
 use super::{CallStack, ClarityVersion, ContractName, ExecutionState, SymbolicExpression};
 use crate::vm::analysis::ContractAnalysis;
 use crate::vm::ast::build_ast;
-use crate::vm::contexts::{AssetMap, GlobalContext, InvocationContext};
+use crate::vm::contexts::{GlobalContext, InvocationContext};
 use crate::vm::errors::{
     RuntimeCheckErrorKind, RuntimeError, StaticCheckErrorKind, VmExecutionError, WasmError,
 };
 use crate::vm::functions::post_conditions::{
-    Allowance, FtAllowance, NftAllowance, StackingAllowance, StxAllowance,
+    Allowance, FtAllowance, NftAllowance, StackingAllowance, StxAllowance, check_allowances,
 };
 use crate::vm::types::{
     BufferLength, SequenceSubtype, SequencedValue, StringSubtype, TypeSignature, TypeSignatureExt,
@@ -3471,11 +3470,7 @@ fn link_enter_as_contract_post_v4_fn(
                 caller.data_mut().push_sender(contract_principal.clone());
                 caller.data_mut().push_caller(contract_principal);
 
-                // Return an ExternRef wrapping a Mutex<Vec<Allowance>> for the
-                // With* host functions to push allowances into.
-                Some(ExternRef::new(std::sync::Mutex::new(
-                    Vec::<Allowance>::new(),
-                )))
+                Some(ExternRef::new(AllowanceContext::new()))
             },
         )
         .map(|_| ())
@@ -3498,6 +3493,8 @@ fn link_exit_as_contract_post_v4_fn(
             "clarity",
             "exit_as_contract_post_v4",
             |mut caller: Caller<'_, ClarityWasmContext>, allowance_ref: Option<ExternRef>| {
+                let epoch = caller.data().global_context.epoch_id;
+
                 // we need to restore the current caller and sender. We pop both and check if we did set
                 // them correctly before. We keep the sender (current-contract) as owner for checking the
                 // allowances.
@@ -3507,12 +3504,11 @@ fn link_exit_as_contract_post_v4_fn(
                     owner?
                 };
 
-                // Extract allowances from the ExternRef
-                let allowances = extract_allowances(&allowance_ref)?;
+                let allowances = AllowanceContext::extract(&allowance_ref)?;
 
                 let asset_map = caller.data_mut().global_context.get_readonly_asset_map()?;
 
-                match check_allowances(&owner, allowances, asset_map)? {
+                match check_allowances(&owner, allowances, asset_map, epoch)? {
                     None => {
                         caller.data_mut().global_context.commit()?;
                         Ok((1i32, 0i64, 0i64)) // no violation
@@ -3535,177 +3531,43 @@ fn link_exit_as_contract_post_v4_fn(
         })
 }
 
-type AllowanceContext = std::sync::Mutex<Vec<Allowance>>;
+/// Holds the list of allowances for an `as-contract?` block.
+/// Passed through WASM as an `ExternRef` handle.
+/// Needs a `Mutex` because `ExternRef` only gives us a shared
+/// reference, but we still need to mutate the list.
+struct AllowanceContext(std::sync::Mutex<Vec<Allowance>>);
 
-fn get_allowance_context(
-    externref: &Option<ExternRef>,
-) -> Result<&AllowanceContext, VmExecutionError> {
-    let externref = externref.as_ref().ok_or_else(|| {
-        VmExecutionError::Wasm(WasmError::WasmGeneratorError(
-            "allowance context is missing".to_string(),
-        ))
-    })?;
-    externref
-        .data()
-        .downcast_ref::<AllowanceContext>()
-        .ok_or_else(|| {
+impl AllowanceContext {
+    fn new() -> Self {
+        Self(std::sync::Mutex::new(Vec::new()))
+    }
+
+    fn from_externref(externref: &Option<ExternRef>) -> Result<&Self, VmExecutionError> {
+        let externref = externref.as_ref().ok_or_else(|| {
             VmExecutionError::Wasm(WasmError::WasmGeneratorError(
-                "allowance context has wrong type".to_string(),
+                "allowance context is missing".to_string(),
             ))
-        })
-}
-
-/// Extract the allowances from an ExternRef, consuming the contents.
-fn extract_allowances(externref: &Option<ExternRef>) -> Result<Vec<Allowance>, VmExecutionError> {
-    let ctx = get_allowance_context(externref)?;
-    let result = ctx.lock().unwrap().drain(..).collect();
-    Ok(result)
-}
-
-/// Add an allowance to the current as-contract? context.
-fn push_allowance(
-    externref: &Option<ExternRef>,
-    allowance: Allowance,
-) -> Result<(), wasmtime::Error> {
-    let ctx = get_allowance_context(externref)?;
-    ctx.lock().unwrap().push(allowance);
-    Ok(())
-}
-
-// Checker function for the asset allowances
-fn check_allowances(
-    owner: &PrincipalData,
-    allowances: Vec<Allowance>,
-    assets: &AssetMap,
-) -> Result<Option<u128>, VmExecutionError> {
-    const MAX_ALLOWANCES: usize = 128;
-    let mut stx_allowances: Vec<(usize, u128)> = Vec::new();
-    let mut ft_allowances: HashMap<AssetIdentifier, Vec<(usize, u128)>> = HashMap::new();
-    let mut nft_allowances: HashMap<AssetIdentifier, (usize, Vec<Value>)> = HashMap::new();
-    let mut stacking_allowances: Vec<(usize, u128)> = Vec::new();
-
-    for (i, allowance) in allowances.into_iter().enumerate() {
-        match allowance {
-            Allowance::All => return Ok(None),
-            Allowance::Stx(stx) => {
-                stx_allowances.push((i, stx.amount));
-            }
-            Allowance::Ft(ft) => {
-                ft_allowances
-                    .entry(ft.asset)
-                    .or_default()
-                    .push((i, ft.amount));
-            }
-            Allowance::Nft(nft) => {
-                let (_, vec) = nft_allowances
-                    .entry(nft.asset)
-                    .or_insert_with(|| (i, Vec::new()));
-                vec.extend(nft.asset_ids);
-            }
-            Allowance::Stacking(stacking) => {
-                stacking_allowances.push((i, stacking.amount));
-            }
-        }
+        })?;
+        externref
+            .data()
+            .downcast_ref::<AllowanceContext>()
+            .ok_or_else(|| {
+                VmExecutionError::Wasm(WasmError::WasmGeneratorError(
+                    "allowance context has wrong type".to_string(),
+                ))
+            })
     }
 
-    let idx_to_u128 = |idx: usize| {
-        u128::try_from(idx).map_err(|_| VmExecutionError::Wasm(WasmError::AllowanceIndexOverflow))
-    };
-
-    // Check STX movements
-    if let Some(stx_moved) = assets.get_stx(owner) {
-        if stx_allowances.is_empty() {
-            return Ok(Some(MAX_ALLOWANCES as u128));
-        }
-        for (index, allowance) in &stx_allowances {
-            if stx_moved > *allowance {
-                return Ok(Some(idx_to_u128(*index)?));
-            }
-        }
+    fn push(externref: &Option<ExternRef>, allowance: Allowance) -> Result<(), VmExecutionError> {
+        let ctx = Self::from_externref(externref)?;
+        ctx.0.lock().unwrap().push(allowance);
+        Ok(())
     }
 
-    // Check STX burns
-    if let Some(stx_burned) = assets.get_stx_burned(owner) {
-        if stx_allowances.is_empty() {
-            return Ok(Some(MAX_ALLOWANCES as u128));
-        }
-        for (index, allowance) in &stx_allowances {
-            if stx_burned > *allowance {
-                return Ok(Some(idx_to_u128(*index)?));
-            }
-        }
+    fn extract(externref: &Option<ExternRef>) -> Result<Vec<Allowance>, VmExecutionError> {
+        let ctx = Self::from_externref(externref)?;
+        Ok(std::mem::take(&mut *ctx.0.lock().unwrap()))
     }
-
-    // Check FT movements
-    if let Some(ft_moved) = assets.get_all_fungible_tokens(owner) {
-        for (asset, amount_moved) in ft_moved {
-            let mut merged: Vec<(usize, u128)> = Vec::new();
-
-            if let Some(v) = ft_allowances.get(asset) {
-                merged.extend(v.iter().cloned());
-            }
-            if let Some(wildcard_vec) = ft_allowances.get(&AssetIdentifier {
-                contract_identifier: asset.contract_identifier.clone(),
-                asset_name: ClarityName::from_literal("*"),
-            }) {
-                merged.extend(wildcard_vec.iter().cloned());
-            }
-
-            if merged.is_empty() {
-                return Ok(Some(MAX_ALLOWANCES as u128));
-            }
-
-            merged.sort_by_key(|(idx, _)| *idx);
-
-            for (index, allowance) in merged {
-                if *amount_moved > allowance {
-                    return Ok(Some(idx_to_u128(index)?));
-                }
-            }
-        }
-    }
-
-    // Check NFT movements
-    if let Some(nft_moved) = assets.get_all_nonfungible_tokens(owner) {
-        for (asset, ids_moved) in nft_moved {
-            // Build merged allowance list: exact-match + wildcard entries for the same contract
-            let mut merged: Vec<(usize, &Vec<Value>)> = Vec::new();
-            if let Some((index, allowance_vec)) = nft_allowances.get(asset) {
-                merged.push((*index, allowance_vec));
-            }
-            if let Some((index, allowance_vec)) = nft_allowances.get(&AssetIdentifier {
-                contract_identifier: asset.contract_identifier.clone(),
-                asset_name: ClarityName::from_literal("*"),
-            }) {
-                merged.push((*index, allowance_vec));
-            }
-
-            if merged.is_empty() {
-                return Ok(Some(MAX_ALLOWANCES as u128));
-            }
-            for id in ids_moved {
-                for (index, allowed_ids) in &merged {
-                    if !allowed_ids.contains(id) {
-                        return Ok(Some(idx_to_u128(*index)?));
-                    }
-                }
-            }
-        }
-    }
-
-    // Check stacking
-    if let Some(stacking_amount) = assets.get_stacking(owner) {
-        if stacking_allowances.is_empty() {
-            return Ok(Some(MAX_ALLOWANCES as u128));
-        }
-        for (index, allowance) in &stacking_allowances {
-            if stacking_amount > *allowance {
-                return Ok(Some(idx_to_u128(*index)?));
-            }
-        }
-    }
-
-    Ok(None)
 }
 
 /// Link host interface function, `with_all_assets_unsafe`, into the Wasm module.
@@ -3719,7 +3581,9 @@ fn link_with_all_assets_unsafe_fn(
             "clarity",
             "with_all_assets_unsafe",
             |_caller: Caller<'_, ClarityWasmContext>, allowance_ref: Option<ExternRef>| {
-                push_allowance(&allowance_ref, Allowance::All)
+                AllowanceContext::push(&allowance_ref, Allowance::All)?;
+
+                Ok(())
             },
         )
         .map(|_| ())
@@ -3799,7 +3663,7 @@ fn link_with_ft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExec
                         })?;
                 }
 
-                push_allowance(
+                AllowanceContext::push(
                     &allowance_ref,
                     Allowance::Ft(FtAllowance {
                         asset: AssetIdentifier {
@@ -3808,7 +3672,9 @@ fn link_with_ft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExec
                         },
                         amount: allowed_amount,
                     }),
-                )
+                )?;
+
+                Ok(())
             },
         )
         .map(|_| ())
@@ -3929,7 +3795,10 @@ fn link_with_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
                 let entry_size = key_type.size()?;
                 let max_list_len = (MAX_VALUE_SIZE.saturating_sub(entry_size + 5)) / entry_size;
 
-                // Read the list of allowed NFT identifiers from WASM memory.
+                // We use read_from_wasm (not read_identifier_from_wasm) because
+                // this is a typed list of NFT key values, not a string identifier.
+                // The wildcard ("*") case also requires this since the key type
+                // is resolved dynamically from the target contract.
                 let identifiers_value = read_from_wasm(
                     memory,
                     &mut caller,
@@ -3947,13 +3816,15 @@ fn link_with_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
                     asset_name,
                 };
 
-                push_allowance(
+                AllowanceContext::push(
                     &allowance_ref,
                     Allowance::Nft(NftAllowance {
                         asset: asset_identifier,
                         asset_ids: allowed_identifiers,
                     }),
-                )
+                )?;
+
+                Ok(())
             },
         )
         .map(|_| ())
@@ -3979,10 +3850,12 @@ fn link_with_stacking_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
              allowance_hi: i64| {
                 let allowance = ((allowance_hi as u128) << 64) | ((allowance_lo as u64) as u128);
 
-                push_allowance(
+                AllowanceContext::push(
                     &allowance_ref,
                     Allowance::Stacking(StackingAllowance { amount: allowance }),
-                )
+                )?;
+
+                Ok(())
             },
         )
         .map(|_| ())
@@ -4008,12 +3881,14 @@ fn link_with_stx_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
              amount_hi: i64| {
                 let allowed_amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
 
-                push_allowance(
+                AllowanceContext::push(
                     &allowance_ref,
                     Allowance::Stx(StxAllowance {
                         amount: allowed_amount,
                     }),
-                )
+                )?;
+
+                Ok(())
             },
         )
         .map(|_| ())

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -3454,7 +3454,7 @@ fn link_exit_as_contract_fn(
 }
 
 /// Link host interface function, `enter_as_contract_safe`, into the Wasm module.
-/// This function is called before processing the allowances and inner-expression of
+/// This function is called before processing the allowances and inner-expressions of
 /// `as-contract?`.
 fn link_enter_as_contract_safe_fn(
     linker: &mut Linker<ClarityWasmContext>,
@@ -3487,7 +3487,7 @@ fn link_enter_as_contract_safe_fn(
 }
 
 /// Link host interface function, `exit_as_contract_safe`, into the Wasm module.
-/// This function is after before processing the inner-expression of
+/// This function is called after processing the inner-expressions of
 /// `as-contract?`, and is used to restore the caller, sender and check allowances.
 fn link_exit_as_contract_safe_fn(
     linker: &mut Linker<ClarityWasmContext>,
@@ -3536,7 +3536,7 @@ fn link_exit_as_contract_safe_fn(
 }
 
 /// Link host interface function, `cleanup_as_contract_safe`, into the Wasm module.
-/// This function is after before processing the inner-expression of
+/// This function is called after processing the inner-expressions of
 /// `as-contract?`, and is used to restore the caller and sender in the case where
 /// an inner-expresion failed.
 fn link_cleanup_as_contract_safe_fn(
@@ -3561,7 +3561,7 @@ fn link_cleanup_as_contract_safe_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "cleanup_as_contract".to_string(),
+                "cleanup_as_contract_safe".to_string(),
                 e,
             ))
         })

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -2193,11 +2193,11 @@ fn link_host_functions(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Vm
     link_is_in_regtest_fn(linker)?;
     link_is_in_mainnet_fn(linker)?;
     link_chain_id_fn(linker)?;
-    link_enter_as_contract_pre_v4_fn(linker)?;
-    link_exit_as_contract_pre_v4_fn(linker)?;
-    link_enter_as_contract_post_v4_fn(linker)?;
-    link_exit_as_contract_post_v4_fn(linker)?;
-    link_cleanup_as_contract_post_v4_fn(linker)?;
+    link_enter_as_contract_fn(linker)?;
+    link_exit_as_contract_fn(linker)?;
+    link_enter_as_contract_safe_fn(linker)?;
+    link_exit_as_contract_safe_fn(linker)?;
+    link_cleanup_as_contract_safe_fn(linker)?;
     link_enter_restrict_assets_fn(linker)?;
     link_exit_restrict_assets_fn(linker)?;
     link_cleanup_restrict_assets_fn(linker)?;
@@ -3398,16 +3398,16 @@ fn link_chain_id_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
         })
 }
 
-/// Link host interface function, `enter_as_contract_pre_v4`, into the Wasm module.
+/// Link host interface function, `enter_as_contract`, into the Wasm module.
 /// This function is called before processing the inner-expression of
 /// `as-contract`.
-fn link_enter_as_contract_pre_v4_fn(
+fn link_enter_as_contract_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "enter_as_contract_pre_v4",
+            "enter_as_contract",
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 let contract_principal: PrincipalData = caller
                     .data()
@@ -3422,22 +3422,22 @@ fn link_enter_as_contract_pre_v4_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "enter_as_contract_pre_v4".to_string(),
+                "enter_as_contract".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `exit_as_contract_pre_v4`, into the Wasm module.
+/// Link host interface function, `exit_as_contract`, into the Wasm module.
 /// This function is after before processing the inner-expression of
 /// `as-contract`, and is used to restore the caller and sender.
-fn link_exit_as_contract_pre_v4_fn(
+fn link_exit_as_contract_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "exit_as_contract_pre_v4",
+            "exit_as_contract",
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 caller.data_mut().pop_sender()?;
                 caller.data_mut().pop_caller()?;
@@ -3447,22 +3447,22 @@ fn link_exit_as_contract_pre_v4_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "exit_as_contract_pre_v4".to_string(),
+                "exit_as_contract".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `enter_as_contract_post_v4`, into the Wasm module.
+/// Link host interface function, `enter_as_contract_safe`, into the Wasm module.
 /// This function is called before processing the allowances and inner-expression of
 /// `as-contract?`.
-fn link_enter_as_contract_post_v4_fn(
+fn link_enter_as_contract_safe_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "enter_as_contract_post_v4",
+            "enter_as_contract_safe",
             |mut caller: Caller<'_, ClarityWasmContext>| -> Option<ExternRef> {
                 let contract_principal: PrincipalData = caller
                     .data()
@@ -3480,22 +3480,22 @@ fn link_enter_as_contract_post_v4_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "enter_as_contract_post_v4".to_string(),
+                "enter_as_contract_safe".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `exit_as_contract_post_v4`, into the Wasm module.
+/// Link host interface function, `exit_as_contract_safe`, into the Wasm module.
 /// This function is after before processing the inner-expression of
 /// `as-contract?`, and is used to restore the caller, sender and check allowances.
-fn link_exit_as_contract_post_v4_fn(
+fn link_exit_as_contract_safe_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "exit_as_contract_post_v4",
+            "exit_as_contract_safe",
             |mut caller: Caller<'_, ClarityWasmContext>, allowance_ref: Option<ExternRef>| {
                 let epoch = caller.data().global_context.epoch_id;
 
@@ -3529,23 +3529,23 @@ fn link_exit_as_contract_post_v4_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "exit_as_contract_post_v4".to_string(),
+                "exit_as_contract_safe".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `cleanup_as_contract_post_v4`, into the Wasm module.
+/// Link host interface function, `cleanup_as_contract_safe`, into the Wasm module.
 /// This function is after before processing the inner-expression of
 /// `as-contract?`, and is used to restore the caller and sender in the case where
 /// an inner-expresion failed.
-fn link_cleanup_as_contract_post_v4_fn(
+fn link_cleanup_as_contract_safe_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "cleanup_as_contract_post_v4",
+            "cleanup_as_contract_safe",
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 caller.data_mut().pop_sender()?;
                 caller.data_mut().pop_caller()?;

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -2198,6 +2198,9 @@ fn link_host_functions(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Vm
     link_enter_as_contract_post_v4_fn(linker)?;
     link_exit_as_contract_post_v4_fn(linker)?;
     link_cleanup_as_contract_post_v4_fn(linker)?;
+    link_enter_restrict_assets_fn(linker)?;
+    link_exit_restrict_assets_fn(linker)?;
+    link_cleanup_restrict_assets_fn(linker)?;
     link_with_all_assets_unsafe_fn(linker)?;
     link_with_ft_fn(linker)?;
     link_with_nft_fn(linker)?;
@@ -3538,7 +3541,7 @@ fn link_exit_as_contract_post_v4_fn(
 /// an inner-expresion failed.
 fn link_cleanup_as_contract_post_v4_fn(
     linker: &mut Linker<ClarityWasmContext>,
-) -> Result<(), Error> {
+) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
@@ -3553,8 +3556,104 @@ fn link_cleanup_as_contract_post_v4_fn(
         )
         .map(|_| ())
         .map_err(|e| {
-            Error::Wasm(WasmError::UnableToLinkHostFunction(
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
                 "cleanup_as_contract".to_string(),
+                e,
+            ))
+        })
+}
+
+fn link_enter_restrict_assets_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "enter_restrict_assets",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                caller.data_mut().global_context.begin();
+
+                Some(ExternRef::new(AllowanceContext::new()))
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "enter_restrict_assets".to_string(),
+                e,
+            ))
+        })
+}
+
+fn link_exit_restrict_assets_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "exit_restrict_assets",
+            |mut caller: Caller<'_, ClarityWasmContext>,
+             asset_owner_offset: i32,
+             asset_owner_length: i32,
+             allowance_ref: Option<ExternRef>| {
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(WasmError::MemoryNotFound)?;
+                let epoch = caller.data().global_context.epoch_id;
+                let owner = read_from_wasm(
+                    memory,
+                    &mut caller,
+                    &TypeSignature::PrincipalType,
+                    asset_owner_offset,
+                    asset_owner_length,
+                    epoch,
+                )?
+                .expect_principal()?;
+                let allowances = AllowanceContext::extract(&allowance_ref)?;
+
+                let asset_map = caller.data_mut().global_context.get_readonly_asset_map()?;
+
+                match check_allowances(&owner, allowances, asset_map, epoch)? {
+                    None => {
+                        caller.data_mut().global_context.commit()?;
+                        Ok((0i64, 0i64, 1i32)) // no violation
+                    }
+                    Some(violation_index) => {
+                        caller.data_mut().global_context.roll_back()?;
+                        let lo = violation_index as i64;
+                        let hi = (violation_index >> 64) as i64;
+                        Ok((lo, hi, 0i32)) // violation — Wasm returns (err index)
+                    }
+                }
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "exit_restrict_assets".to_string(),
+                e,
+            ))
+        })
+}
+
+fn link_cleanup_restrict_assets_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "cleanup_restrict_assets",
+            |mut caller: Caller<'_, ClarityWasmContext>| {
+                caller.data_mut().global_context.roll_back()?;
+
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "cleanup_restrict_assets".to_string(),
                 e,
             ))
         })

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -82,9 +82,6 @@ pub struct ClarityWasmContext<'a, 'b> {
     caller_stack: Vec<PrincipalData>,
     /// Stack of block hashes, used for `at-block` expressions.
     bhh_stack: Vec<StacksBlockId>,
-    /// Stack of asset contexts, used for `with-*` expressions.
-    pub asset_context_stack: Vec<Vec<Allowance>>,
-
     /// Contract analysis data, used for typing information, and only available
     /// when initializing a contract. Should always be `Some` when initializing
     /// a contract, and `None` otherwise.
@@ -112,7 +109,6 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             sender_stack: vec![],
             caller_stack: vec![],
             bhh_stack: vec![],
-            asset_context_stack: vec![],
             contract_analysis,
         }
     }
@@ -137,7 +133,6 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             sender_stack: vec![],
             caller_stack: vec![],
             bhh_stack: vec![],
-            asset_context_stack: vec![],
             contract_analysis,
         }
     }
@@ -184,83 +179,6 @@ impl<'a, 'b> ClarityWasmContext<'a, 'b> {
             .ok_or(VmExecutionError::Wasm(WasmError::WasmGeneratorError(
                 "Could not pop at_block".to_string(),
             )))
-    }
-
-    pub fn push_as_contract(&mut self) {
-        self.asset_context_stack.push(Vec::new());
-    }
-
-    pub fn pop_as_contract(&mut self) -> Option<Vec<Allowance>> {
-        self.asset_context_stack.pop()
-    }
-
-    pub fn push_asset_context_unsafe(&mut self) {
-        self.asset_context_stack
-            .last_mut()
-            .unwrap()
-            .push(Allowance::All);
-    }
-
-    pub fn push_asset_context_ft(
-        &mut self,
-        contract: QualifiedContractIdentifier,
-        token: String,
-        allowed_amount: u128,
-    ) {
-        if self.asset_context_stack.is_empty() {
-            self.asset_context_stack.push(vec![]);
-        }
-        self.asset_context_stack
-            .last_mut()
-            .unwrap()
-            .push(Allowance::Ft(FtAllowance {
-                asset: AssetIdentifier {
-                    contract_identifier: contract,
-                    asset_name: ClarityName::try_from(token).unwrap(),
-                },
-                amount: allowed_amount,
-            }));
-    }
-
-    pub fn push_asset_context_nft(
-        &mut self,
-        asset_identifier: AssetIdentifier,
-        allowed_identifiers: Vec<clarity_types::Value>,
-    ) {
-        if self.asset_context_stack.is_empty() {
-            self.asset_context_stack.push(vec![]);
-        }
-        self.asset_context_stack
-            .last_mut()
-            .unwrap()
-            .push(Allowance::Nft(NftAllowance {
-                asset: asset_identifier,
-                asset_ids: allowed_identifiers,
-            }));
-    }
-
-    pub fn push_asset_context_stacking(&mut self, allowed_amount: u128) {
-        if self.asset_context_stack.is_empty() {
-            self.asset_context_stack.push(vec![]);
-        }
-        self.asset_context_stack
-            .last_mut()
-            .unwrap()
-            .push(Allowance::Stacking(StackingAllowance {
-                amount: allowed_amount,
-            }));
-    }
-
-    pub fn push_asset_context_stx(&mut self, allowed_amount: u128) {
-        if self.asset_context_stack.is_empty() {
-            self.asset_context_stack.push(vec![]);
-        }
-        self.asset_context_stack
-            .last_mut()
-            .unwrap()
-            .push(Allowance::Stx(StxAllowance {
-                amount: allowed_amount,
-            }));
     }
 
     /// Return an immutable reference to the contract_context
@@ -2276,10 +2194,10 @@ fn link_host_functions(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Vm
     link_is_in_regtest_fn(linker)?;
     link_is_in_mainnet_fn(linker)?;
     link_chain_id_fn(linker)?;
-    link_enter_as_contract_original_fn(linker)?;
-    link_exit_as_contract_original_fn(linker)?;
-    link_enter_as_contract_new_fn(linker)?;
-    link_exit_as_contract_new_fn(linker)?;
+    link_enter_as_contract_pre_v4_fn(linker)?;
+    link_exit_as_contract_pre_v4_fn(linker)?;
+    link_enter_as_contract_post_v4_fn(linker)?;
+    link_exit_as_contract_post_v4_fn(linker)?;
     link_with_all_assets_unsafe_fn(linker)?;
     link_with_ft_fn(linker)?;
     link_with_nft_fn(linker)?;
@@ -3477,16 +3395,16 @@ fn link_chain_id_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
         })
 }
 
-/// Link host interface function, `enter_as_contract_original`, into the Wasm module.
+/// Link host interface function, `enter_as_contract_pre_v4`, into the Wasm module.
 /// This function is called before processing the inner-expression of
 /// `as-contract`.
-fn link_enter_as_contract_original_fn(
+fn link_enter_as_contract_pre_v4_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "enter_as_contract_original",
+            "enter_as_contract_pre_v4",
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 let contract_principal: PrincipalData = caller
                     .data()
@@ -3501,22 +3419,22 @@ fn link_enter_as_contract_original_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "enter_as_contract_original".to_string(),
+                "enter_as_contract_pre_v4".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `exit_as_contract_original`, into the Wasm module.
+/// Link host interface function, `exit_as_contract_pre_v4`, into the Wasm module.
 /// This function is after before processing the inner-expression of
 /// `as-contract`, and is used to restore the caller and sender.
-fn link_exit_as_contract_original_fn(
+fn link_exit_as_contract_pre_v4_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "exit_as_contract_original",
+            "exit_as_contract_pre_v4",
             |mut caller: Caller<'_, ClarityWasmContext>| {
                 caller.data_mut().pop_sender()?;
                 caller.data_mut().pop_caller()?;
@@ -3526,23 +3444,23 @@ fn link_exit_as_contract_original_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "exit_as_contract_original".to_string(),
+                "exit_as_contract_pre_v4".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `enter_as_contract_new`, into the Wasm module.
+/// Link host interface function, `enter_as_contract_post_v4`, into the Wasm module.
 /// This function is called before processing the allowances and inner-expression of
 /// `as-contract?`.
-fn link_enter_as_contract_new_fn(
+fn link_enter_as_contract_post_v4_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "enter_as_contract_new",
-            |mut caller: Caller<'_, ClarityWasmContext>| {
+            "enter_as_contract_post_v4",
+            |mut caller: Caller<'_, ClarityWasmContext>| -> Option<ExternRef> {
                 let contract_principal: PrincipalData = caller
                     .data()
                     .contract_context()
@@ -3550,31 +3468,36 @@ fn link_enter_as_contract_new_fn(
                     .clone()
                     .into();
                 caller.data_mut().global_context.begin();
-                caller.data_mut().push_as_contract();
                 caller.data_mut().push_sender(contract_principal.clone());
                 caller.data_mut().push_caller(contract_principal);
+
+                // Return an ExternRef wrapping a Mutex<Vec<Allowance>> for the
+                // With* host functions to push allowances into.
+                Some(ExternRef::new(std::sync::Mutex::new(
+                    Vec::<Allowance>::new(),
+                )))
             },
         )
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "enter_as_contract_new".to_string(),
+                "enter_as_contract_post_v4".to_string(),
                 e,
             ))
         })
 }
 
-/// Link host interface function, `exit_as_contract_new`, into the Wasm module.
+/// Link host interface function, `exit_as_contract_post_v4`, into the Wasm module.
 /// This function is after before processing the inner-expression of
 /// `as-contract?`, and is used to restore the caller, sender and check allowances.
-fn link_exit_as_contract_new_fn(
+fn link_exit_as_contract_post_v4_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
     linker
         .func_wrap(
             "clarity",
-            "exit_as_contract_new",
-            |mut caller: Caller<'_, ClarityWasmContext>| {
+            "exit_as_contract_post_v4",
+            |mut caller: Caller<'_, ClarityWasmContext>, allowance_ref: Option<ExternRef>| {
                 // we need to restore the current caller and sender. We pop both and check if we did set
                 // them correctly before. We keep the sender (current-contract) as owner for checking the
                 // allowances.
@@ -3584,20 +3507,21 @@ fn link_exit_as_contract_new_fn(
                     owner?
                 };
 
-                let allowances = caller.data_mut().pop_as_contract().unwrap_or_default();
+                // Extract allowances from the ExternRef
+                let allowances = extract_allowances(&allowance_ref)?;
 
                 let asset_map = caller.data_mut().global_context.get_readonly_asset_map()?;
 
                 match check_allowances(&owner, allowances, asset_map)? {
                     None => {
                         caller.data_mut().global_context.commit()?;
-                        Ok((1i32, 0i32, 0i64, 0i64)) // no violation
+                        Ok((1i32, 0i64, 0i64)) // no violation
                     }
                     Some(violation_index) => {
                         caller.data_mut().global_context.roll_back()?;
                         let lo = violation_index as i64;
                         let hi = (violation_index >> 64) as i64;
-                        Ok((0i32, 0i32, lo, hi)) // violation — Wasm returns (err index)
+                        Ok((0i32, lo, hi)) // violation — Wasm returns (err index)
                     }
                 }
             },
@@ -3605,10 +3529,47 @@ fn link_exit_as_contract_new_fn(
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "exit_as_contract_new".to_string(),
+                "exit_as_contract_post_v4".to_string(),
                 e,
             ))
         })
+}
+
+type AllowanceContext = std::sync::Mutex<Vec<Allowance>>;
+
+fn get_allowance_context(
+    externref: &Option<ExternRef>,
+) -> Result<&AllowanceContext, VmExecutionError> {
+    let externref = externref.as_ref().ok_or_else(|| {
+        VmExecutionError::Wasm(WasmError::WasmGeneratorError(
+            "allowance context is missing".to_string(),
+        ))
+    })?;
+    externref
+        .data()
+        .downcast_ref::<AllowanceContext>()
+        .ok_or_else(|| {
+            VmExecutionError::Wasm(WasmError::WasmGeneratorError(
+                "allowance context has wrong type".to_string(),
+            ))
+        })
+}
+
+/// Extract the allowances from an ExternRef, consuming the contents.
+fn extract_allowances(externref: &Option<ExternRef>) -> Result<Vec<Allowance>, VmExecutionError> {
+    let ctx = get_allowance_context(externref)?;
+    let result = ctx.lock().unwrap().drain(..).collect();
+    Ok(result)
+}
+
+/// Add an allowance to the current as-contract? context.
+fn push_allowance(
+    externref: &Option<ExternRef>,
+    allowance: Allowance,
+) -> Result<(), wasmtime::Error> {
+    let ctx = get_allowance_context(externref)?;
+    ctx.lock().unwrap().push(allowance);
+    Ok(())
 }
 
 // Checker function for the asset allowances
@@ -3707,12 +3668,26 @@ fn check_allowances(
     // Check NFT movements
     if let Some(nft_moved) = assets.get_all_nonfungible_tokens(owner) {
         for (asset, ids_moved) in nft_moved {
-            let Some((index, allowed_ids)) = nft_allowances.get(asset) else {
+            // Build merged allowance list: exact-match + wildcard entries for the same contract
+            let mut merged: Vec<(usize, &Vec<Value>)> = Vec::new();
+            if let Some((index, allowance_vec)) = nft_allowances.get(asset) {
+                merged.push((*index, allowance_vec));
+            }
+            if let Some((index, allowance_vec)) = nft_allowances.get(&AssetIdentifier {
+                contract_identifier: asset.contract_identifier.clone(),
+                asset_name: ClarityName::from_literal("*"),
+            }) {
+                merged.push((*index, allowance_vec));
+            }
+
+            if merged.is_empty() {
                 return Ok(Some(MAX_ALLOWANCES as u128));
-            };
+            }
             for id in ids_moved {
-                if !allowed_ids.contains(id) {
-                    return Ok(Some(idx_to_u128(*index)?));
+                for (index, allowed_ids) in &merged {
+                    if !allowed_ids.contains(id) {
+                        return Ok(Some(idx_to_u128(*index)?));
+                    }
                 }
             }
         }
@@ -3743,9 +3718,8 @@ fn link_with_all_assets_unsafe_fn(
         .func_wrap(
             "clarity",
             "with_all_assets_unsafe",
-            |mut caller: Caller<'_, ClarityWasmContext>| {
-                caller.data_mut().push_asset_context_unsafe();
-                Ok(())
+            |_caller: Caller<'_, ClarityWasmContext>, allowance_ref: Option<ExternRef>| {
+                push_allowance(&allowance_ref, Allowance::All)
             },
         )
         .map(|_| ())
@@ -3766,6 +3740,7 @@ fn link_with_ft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExec
             "clarity",
             "with_ft",
             |mut caller: Caller<'_, ClarityWasmContext>,
+             allowance_ref: Option<ExternRef>,
              contract_id_offset: i32,
              contract_id_length: i32,
              token_name_offset: i32,
@@ -3824,12 +3799,16 @@ fn link_with_ft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExec
                         })?;
                 }
 
-                caller.data_mut().push_asset_context_ft(
-                    contract_id.clone(),
-                    token_name,
-                    allowed_amount,
-                );
-                Ok(())
+                push_allowance(
+                    &allowance_ref,
+                    Allowance::Ft(FtAllowance {
+                        asset: AssetIdentifier {
+                            contract_identifier: contract_id.clone(),
+                            asset_name: ClarityName::try_from(token_name)?,
+                        },
+                        amount: allowed_amount,
+                    }),
+                )
             },
         )
         .map(|_| ())
@@ -3850,6 +3829,7 @@ fn link_with_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
             "clarity",
             "with_nft",
             |mut caller: Caller<'_, ClarityWasmContext>,
+             allowance_ref: Option<ExternRef>,
              contract_id_offset: i32,
              contract_id_length: i32,
              token_name_offset: i32,
@@ -3874,38 +3854,8 @@ fn link_with_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
                 .expect_ascii()?;
                 let asset_name = ClarityName::try_from(token_name.clone())?;
 
-                let key_type = caller
-                    .data()
-                    .contract_context()
-                    .meta_nft
-                    .get(&asset_name)
-                    .ok_or_else(|| {
-                        WasmError::Expect(
-                            StaticCheckErrorKind::NoSuchNFT(token_name.clone()).to_string(),
-                        )
-                    })?
-                    .key_type
-                    .clone();
-
-                // Compute a safe max list length from the entry's serialized value size.
-                // ListTypeData::inner_size() = entry_size * max_len + type_overhead,
-                // so we need (MAX_VALUE_SIZE - type_overhead) / entry_size to stay
-                // within bounds and avoid ValueTooLarge.
-                let entry_size = key_type.size()?;
-                let max_list_len = (MAX_VALUE_SIZE.saturating_sub(entry_size + 5)) / entry_size;
-
-                let identifiers_value = read_from_wasm(
-                    memory,
-                    &mut caller,
-                    &TypeSignature::SequenceType(SequenceSubtype::ListType(
-                        ListTypeData::new_list(key_type, max_list_len)?,
-                    )),
-                    identifiers_offset,
-                    identifiers_length,
-                    epoch,
-                )?;
-                let allowed_identifiers = identifiers_value.expect_list()?;
-
+                // Read the contract principal first — needed for both wildcard
+                // and non-wildcard paths.
                 let contract_principal = read_from_wasm(
                     memory,
                     &mut caller,
@@ -3921,7 +3871,41 @@ fn link_with_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
                     }
                 };
 
-                if token_name != "*" {
+                // We need the NFT's key type to know how to read the identifiers list.
+                let key_type = if token_name == "*" {
+                    // Wildcard: grab the key type from the first NFT in the
+                    // target contract (the type checker already verified this).
+                    let contract = caller
+                        .data_mut()
+                        .global_context
+                        .database
+                        .get_contract(contract_id)?;
+                    contract
+                        .meta_nft
+                        .values()
+                        .next()
+                        .ok_or_else(|| {
+                            WasmError::Expect(
+                                StaticCheckErrorKind::NoSuchNFT(token_name.clone()).to_string(),
+                            )
+                        })?
+                        .key_type
+                        .clone()
+                } else {
+                    // Named NFT: get the key type from the current contract.
+                    let nft_info = caller
+                        .data()
+                        .contract_context()
+                        .meta_nft
+                        .get(&asset_name)
+                        .ok_or_else(|| {
+                            WasmError::Expect(
+                                StaticCheckErrorKind::NoSuchNFT(token_name.clone()).to_string(),
+                            )
+                        })?;
+                    let key_type = nft_info.key_type.clone();
+
+                    // Make sure this NFT also exists in the target contract.
                     let contract = caller
                         .data_mut()
                         .global_context
@@ -3936,17 +3920,40 @@ fn link_with_nft_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
                                 StaticCheckErrorKind::NoSuchNFT(token_name).to_string(),
                             )
                         })?;
-                }
+
+                    key_type
+                };
+
+                // Figure out the max number of identifiers that fit within
+                // MAX_VALUE_SIZE so we don't hit a ValueTooLarge error.
+                let entry_size = key_type.size()?;
+                let max_list_len = (MAX_VALUE_SIZE.saturating_sub(entry_size + 5)) / entry_size;
+
+                // Read the list of allowed NFT identifiers from WASM memory.
+                let identifiers_value = read_from_wasm(
+                    memory,
+                    &mut caller,
+                    &TypeSignature::SequenceType(SequenceSubtype::ListType(
+                        ListTypeData::new_list(key_type, max_list_len)?,
+                    )),
+                    identifiers_offset,
+                    identifiers_length,
+                    epoch,
+                )?;
+                let allowed_identifiers = identifiers_value.expect_list()?;
 
                 let asset_identifier = AssetIdentifier {
                     contract_identifier: contract_id.clone(),
                     asset_name,
                 };
 
-                caller
-                    .data_mut()
-                    .push_asset_context_nft(asset_identifier, allowed_identifiers);
-                Ok(())
+                push_allowance(
+                    &allowance_ref,
+                    Allowance::Nft(NftAllowance {
+                        asset: asset_identifier,
+                        asset_ids: allowed_identifiers,
+                    }),
+                )
             },
         )
         .map(|_| ())
@@ -3966,11 +3973,16 @@ fn link_with_stacking_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
         .func_wrap(
             "clarity",
             "with_stacking",
-            |mut caller: Caller<'_, ClarityWasmContext>, allowance_lo: i64, allowance_hi: i64| {
+            |_caller: Caller<'_, ClarityWasmContext>,
+             allowance_ref: Option<ExternRef>,
+             allowance_lo: i64,
+             allowance_hi: i64| {
                 let allowance = ((allowance_hi as u128) << 64) | ((allowance_lo as u64) as u128);
 
-                caller.data_mut().push_asset_context_stacking(allowance);
-                Ok(())
+                push_allowance(
+                    &allowance_ref,
+                    Allowance::Stacking(StackingAllowance { amount: allowance }),
+                )
             },
         )
         .map(|_| ())
@@ -3990,11 +4002,18 @@ fn link_with_stx_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExe
         .func_wrap(
             "clarity",
             "with_stx",
-            |mut caller: Caller<'_, ClarityWasmContext>, amount_lo: i64, amount_hi: i64| {
+            |_caller: Caller<'_, ClarityWasmContext>,
+             allowance_ref: Option<ExternRef>,
+             amount_lo: i64,
+             amount_hi: i64| {
                 let allowed_amount = ((amount_hi as u128) << 64) | ((amount_lo as u64) as u128);
 
-                caller.data_mut().push_asset_context_stx(allowed_amount);
-                Ok(())
+                push_allowance(
+                    &allowance_ref,
+                    Allowance::Stx(StxAllowance {
+                        amount: allowed_amount,
+                    }),
+                )
             },
         )
         .map(|_| ())

--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -3547,8 +3547,12 @@ fn link_cleanup_as_contract_safe_fn(
             "clarity",
             "cleanup_as_contract_safe",
             |mut caller: Caller<'_, ClarityWasmContext>| {
-                caller.data_mut().pop_sender()?;
-                caller.data_mut().pop_caller()?;
+                // we need to restore the current caller and sender. We pop both and check if we did set
+                // them correctly before.
+                let sender = caller.data_mut().pop_sender();
+                let _ = caller.data_mut().pop_caller()?;
+                let _ = sender?;
+
                 caller.data_mut().global_context.roll_back()?;
 
                 Ok(())

--- a/clarity/src/vm/errors.rs
+++ b/clarity/src/vm/errors.rs
@@ -221,6 +221,8 @@ pub enum WasmError {
     Runtime(wasmtime::Error),
     /// Type description is invalid or malformed, preventing proper type-checking.
     InvalidTypeDescription,
+    AllowanceViolation(u128),
+    AllowanceIndexOverflow,
     Expect(String),
 }
 
@@ -263,6 +265,8 @@ impl fmt::Display for WasmError {
             }
             WasmError::Runtime(e) => write!(f, "Runtime error: {e}"),
             WasmError::InvalidTypeDescription => write!(f, "Invalid type description"),
+            WasmError::AllowanceIndexOverflow => write!(f, "Index couldn't fit into u128"),
+            WasmError::AllowanceViolation(idx) => write!(f, "Index {idx} couldn't fit into u128"),
             WasmError::Expect(s) => write!(f, "{s}"),
         }
     }

--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -81,7 +81,7 @@ pub mod crypto;
 mod database;
 pub mod define;
 mod options;
-mod post_conditions;
+pub mod post_conditions;
 pub mod principals;
 mod sequences;
 pub mod tuples;

--- a/clarity/src/vm/functions/post_conditions.rs
+++ b/clarity/src/vm/functions/post_conditions.rs
@@ -468,7 +468,7 @@ pub fn special_as_contract(
 /// corresponding allowance return a `Some` with an index of the violated
 /// allowance, or 128 if an asset with no allowance caused the violation. If all
 /// allowances are satisfied, return `Ok(None)`.
-fn check_allowances(
+pub fn check_allowances(
     owner: &PrincipalData,
     allowances: Vec<Allowance>,
     assets: &AssetMap,

--- a/clarity/src/vm/functions/post_conditions.rs
+++ b/clarity/src/vm/functions/post_conditions.rs
@@ -36,24 +36,24 @@ use crate::vm::{LocalContext, eval};
 
 #[derive(Debug)]
 pub struct StxAllowance {
-    amount: u128,
+    pub amount: u128,
 }
 
 #[derive(Debug)]
 pub struct FtAllowance {
-    asset: AssetIdentifier,
-    amount: u128,
+    pub asset: AssetIdentifier,
+    pub amount: u128,
 }
 
 #[derive(Debug)]
 pub struct NftAllowance {
-    asset: AssetIdentifier,
-    asset_ids: Vec<Value>,
+    pub asset: AssetIdentifier,
+    pub asset_ids: Vec<Value>,
 }
 
 #[derive(Debug)]
 pub struct StackingAllowance {
-    amount: u128,
+    pub amount: u128,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR is related to the code duplication on `clarity-wasm` and changes to public necessary crates.

Related issues: https://github.com/stx-labs/clarity-wasm/issues/764, https://github.com/stx-labs/clarity-wasm/issues/768, https://github.com/stx-labs/clarity-wasm/issues/769, https://github.com/stx-labs/clarity-wasm/issues/770, https://github.com/stx-labs/clarity-wasm/issues/771, https://github.com/stx-labs/clarity-wasm/issues/772.

Update: this PR also targets `restrict-assets?` since the implementation is **very** similar to `as-contract?`.

Update2: many of the file changes here are due to a formatter change. You can ignore the changes from dd0b4c2 for the review.