### PR TITLE
chore: marf trie test to rstest

### DIFF
--- a/stackslib/src/chainstate/stacks/index/marf.rs
+++ b/stackslib/src/chainstate/stacks/index/marf.rs
@@ -155,24 +155,6 @@ impl MARFOpenOpts {
         self.compress = compression;
         self
     }
-
-    #[cfg(test)]
-    pub fn all() -> Vec<MARFOpenOpts> {
-        vec![
-            MARFOpenOpts::new(TrieHashCalculationMode::Immediate, "noop", false),
-            MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", false),
-            MARFOpenOpts::new(TrieHashCalculationMode::Immediate, "noop", true),
-            MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true),
-            MARFOpenOpts::new(TrieHashCalculationMode::Immediate, "noop", false)
-                .with_compression(true),
-            MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", false)
-                .with_compression(true),
-            MARFOpenOpts::new(TrieHashCalculationMode::Immediate, "noop", true)
-                .with_compression(true),
-            MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true)
-                .with_compression(true),
-        ]
-    }
 }
 
 ///

--- a/stackslib/src/chainstate/stacks/index/test/mod.rs
+++ b/stackslib/src/chainstate/stacks/index/test/mod.rs
@@ -403,4 +403,16 @@ pub mod opts {
             OPTS_NOOP_DEF_EXT_COMP.clone(),
         ]
     });
+
+    #[template]
+    #[rstest]
+    #[case::imm(&opts::OPTS_NOOP_IMM)]
+    #[case::imm_ext(&opts::OPTS_NOOP_IMM_EXT)]
+    #[case::imm_comp(&opts::OPTS_NOOP_IMM_COMP)]
+    #[case::imm_ext_comp(&opts::OPTS_NOOP_IMM_EXT_COMP)]
+    #[case::def(&opts::OPTS_NOOP_DEF)]
+    #[case::def_ext(&opts::OPTS_NOOP_DEF_EXT)]
+    #[case::def_comp(&opts::OPTS_NOOP_DEF_COMP)]
+    #[case::def_ext_comp(&opts::OPTS_NOOP_DEF_EXT_COMP)]
+    pub fn tpl_all_opts_noop(#[case] marf_opts: &MARFOpenOpts) {}
 }

--- a/stackslib/src/chainstate/stacks/index/test/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/test/trie.rs
@@ -1,5 +1,5 @@
 // Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
-// Copyright (C) 2020-2022 Stacks Open Internet Foundation
+// Copyright (C) 2020-2026 Stacks Open Internet Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/stackslib/src/chainstate/stacks/index/test/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/test/trie.rs
@@ -1191,10 +1191,10 @@ fn trie_cursor_splice_leaf_4(marf_opts: &MARFOpenOpts) {
             let mut c =
                 TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
 
-            test_debug!("Start splice-insert at {:?}", &c);
+            test_debug!("Start splice-insert at {c:?}");
             let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
 
-            test_debug!("Splice leaf pattern={} at {:?}", 192 + k, &c);
+            test_debug!("Splice leaf pattern={} at {c:?}", 192 + k);
             f.open_block(&block_header).unwrap();
 
             test_debug!("Splicing Node @ {}", nodeptr.ptr());
@@ -1280,10 +1280,10 @@ fn trie_cursor_splice_leaf_2(marf_opts: &MARFOpenOpts) {
             let mut c =
                 TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
 
-            test_debug!("Start splice-insert at {:?}", &c);
+            test_debug!("Start splice-insert at {c:?}");
             let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
 
-            test_debug!("Splice leaf pattern={} at {:?}", 192 + k, &c);
+            test_debug!("Splice leaf pattern={} at {c:?}", 192 + k);
             f.open_block(&block_header).unwrap();
             let new_ptr = Trie::test_splice_leaf(
                 &mut f,
@@ -1337,7 +1337,7 @@ where
     .unwrap();
 
     for i in 0..count {
-        test_debug!("{}", i);
+        test_debug!("{i}");
         let path = path_gen(i);
         let triepath = TrieHash::from_bytes(&path).unwrap();
         let value = TrieLeaf::new(

--- a/stackslib/src/chainstate/stacks/index/test/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/test/trie.rs
@@ -58,170 +58,18 @@ fn walk_to_insertion_point(
     panic!("Encountered a loop in the trie");
 }
 
-#[test]
-fn trie_cursor_try_attach_leaf() {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        test_debug!("With MARF opts {:?}", &marf_opts);
-        for node_id in [
-            TrieNodeID::Node4,
-            TrieNodeID::Node16,
-            TrieNodeID::Node48,
-            TrieNodeID::Node256,
-        ]
-        .iter()
-        {
-            let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
-            let mut f = f_store.transaction().unwrap();
-
-            let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
-            MARF::format(&mut f, &block_header).unwrap();
-
-            // used to short-circuit block-height lookups, so that we don't
-            //   mess up these tests expected trie structures.
-            f.test_genesis_block.replace(block_header.clone());
-
-            let path_segments = vec![
-                (vec![], 0),
-                (vec![], 1),
-                (vec![], 2),
-                (vec![], 3),
-                (vec![], 4),
-                (vec![], 5),
-                (vec![], 6),
-                (vec![], 7),
-                (vec![], 8),
-                (vec![], 9),
-                (vec![], 10),
-                (vec![], 11),
-                (vec![], 12),
-                (vec![], 13),
-                (vec![], 14),
-                (vec![], 15),
-                (vec![], 16),
-                (vec![], 17),
-                (vec![], 18),
-                (vec![], 19),
-                (vec![], 20),
-                (vec![], 21),
-                (vec![], 22),
-                (vec![], 23),
-                (vec![], 24),
-                (vec![], 25),
-                (vec![], 26),
-                (vec![], 27),
-                (vec![], 28),
-                (vec![], 29),
-                (vec![], 30),
-                (vec![], 31),
-            ];
-            let (nodes, node_ptrs, hashes) =
-                make_node_path(&mut f, node_id.to_u8(), &path_segments, [31u8; 40].to_vec());
-
-            let mut ptrs = vec![];
-
-            // append a leaf to each node
-            for i in 0..32 {
-                let mut path = vec![
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[i] = 32;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                // end of path -- cursor points to the insertion point.
-                // all nodes have space,
-                f.open_block(&block_header).unwrap();
-                let ptr_opt_res = Trie::test_try_attach_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[i as u8; 40]),
-                    &mut node,
-                );
-                assert!(ptr_opt_res.is_ok());
-
-                let ptr_opt = ptr_opt_res.unwrap();
-                assert!(ptr_opt.is_some());
-
-                let ptr = ptr_opt.unwrap();
-                ptrs.push(ptr);
-
-                let update_res = Trie::update_root_hash(&mut f, &c);
-                assert!(update_res.is_ok());
-
-                // we must be able to query it now
-                let leaf_opt_res = MARF::get_path(
-                    &mut f,
-                    &block_header,
-                    &TrieHash::from_bytes(&path[..]).unwrap(),
-                );
-                assert!(leaf_opt_res.is_ok());
-
-                let leaf_opt = leaf_opt_res.unwrap();
-                assert!(leaf_opt.is_some());
-
-                let leaf = leaf_opt.unwrap();
-                assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[i as u8; 40]));
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[i as u8; 40]);
-                }
-            }
-
-            // look up each leaf we inserted
-            for i in 0..32 {
-                let mut path = vec![
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[i] = 32;
-
-                let leaf_opt_res = MARF::get_path(
-                    &mut f,
-                    &block_header,
-                    &TrieHash::from_bytes(&path[..]).unwrap(),
-                );
-                assert!(leaf_opt_res.is_ok());
-
-                let leaf_opt = leaf_opt_res.unwrap();
-                assert!(leaf_opt.is_some());
-
-                let leaf = leaf_opt.unwrap();
-                assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[i as u8; 40]));
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[i as u8; 40]);
-                }
-            }
-
-            // each ptr must be a node with two children
-            for i in 0..32 {
-                let ptr = &ptrs[i];
-                let (node, hash) = f.read_nodetype(ptr).unwrap();
-                match node {
-                    TrieNodeType::Node4(ref data) => assert_eq!(count_children(&data.ptrs), 2),
-                    TrieNodeType::Node16(ref data) => assert_eq!(count_children(&data.ptrs), 2),
-                    TrieNodeType::Node48(ref data) => assert_eq!(count_children(&data.ptrs), 2),
-                    TrieNodeType::Node256(ref data) => {
-                        assert_eq!(count_children(&data.ptrs), 2)
-                    }
-                    node_type => panic!("Unexpected node type: {node_type:?}"),
-                };
-            }
-
-            dump_trie(&mut f);
-        }
-    }
-}
-
-#[test]
-fn trie_cursor_promote_leaf_to_node4() {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        let mut f_store = TrieFileStorage::new_memory(marf_opts).unwrap();
+#[apply(opts::tpl_all_opts_noop)]
+fn trie_cursor_try_attach_leaf(marf_opts: &MARFOpenOpts) {
+    test_debug!("With MARF opts {marf_opts:?}");
+    for node_id in [
+        TrieNodeID::Node4,
+        TrieNodeID::Node16,
+        TrieNodeID::Node48,
+        TrieNodeID::Node256,
+    ]
+    .iter()
+    {
+        let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
         let mut f = f_store.transaction().unwrap();
 
         let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
@@ -231,69 +79,47 @@ fn trie_cursor_promote_leaf_to_node4() {
         //   mess up these tests expected trie structures.
         f.test_genesis_block.replace(block_header.clone());
 
-        let (node, root_hash) = Trie::read_root(&mut f).unwrap();
-
-        // add a single leaf
-        let mut c = TrieCursor::new(
-            &TrieHash::from_bytes(&[
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                23, 24, 25, 26, 27, 28, 29, 30, 31,
-            ])
-            .unwrap(),
-            f.root_trieptr(),
-        );
-
-        let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-        f.open_block(&block_header).unwrap();
-        Trie::test_try_attach_leaf(
-            &mut f,
-            &mut c,
-            &mut TrieLeaf::new(&[], &[128; 40]),
-            &mut node,
-        )
-        .unwrap()
-        .unwrap();
-        Trie::update_root_hash(&mut f, &c).unwrap();
-
-        assert_eq!(
-            MARF::get_path(
-                &mut f,
-                &block_header,
-                &TrieHash::from_bytes(&[
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31
-                ])
-                .unwrap()
-            )
-            .unwrap()
-            .unwrap(),
-            TrieLeaf::new(
-                &[
-                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                    23, 24, 25, 26, 27, 28, 29, 30, 31
-                ],
-                &[128; 40]
-            )
-        );
-
-        // without a MARF commit, merkle tests will fail in deferred mode
-        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-            merkle_test(
-                &mut f,
-                &[
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ],
-                &[128; 40],
-            );
-        }
+        let path_segments = vec![
+            (vec![], 0),
+            (vec![], 1),
+            (vec![], 2),
+            (vec![], 3),
+            (vec![], 4),
+            (vec![], 5),
+            (vec![], 6),
+            (vec![], 7),
+            (vec![], 8),
+            (vec![], 9),
+            (vec![], 10),
+            (vec![], 11),
+            (vec![], 12),
+            (vec![], 13),
+            (vec![], 14),
+            (vec![], 15),
+            (vec![], 16),
+            (vec![], 17),
+            (vec![], 18),
+            (vec![], 19),
+            (vec![], 20),
+            (vec![], 21),
+            (vec![], 22),
+            (vec![], 23),
+            (vec![], 24),
+            (vec![], 25),
+            (vec![], 26),
+            (vec![], 27),
+            (vec![], 28),
+            (vec![], 29),
+            (vec![], 30),
+            (vec![], 31),
+        ];
+        let (nodes, node_ptrs, hashes) =
+            make_node_path(&mut f, node_id.to_u8(), &path_segments, [31u8; 40].to_vec());
 
         let mut ptrs = vec![];
 
-        // add more leaves -- unzip this path completely
-        for i in 1..32 {
-            // add a leaf that would go after the prior leaf
+        // append a leaf to each node
+        for i in 0..32 {
             let mut path = vec![
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -302,27 +128,29 @@ fn trie_cursor_promote_leaf_to_node4() {
 
             let mut c =
                 TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
 
-            let (nodeptr, node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-            // end of path -- cursor points to the insertion point
-            let mut leaf_data = match node {
-                TrieNodeType::Leaf(ref data) => data.clone(),
-                _ => panic!("not a leaf"),
-            };
-
+            // end of path -- cursor points to the insertion point.
+            // all nodes have space,
             f.open_block(&block_header).unwrap();
-            let ptr = Trie::test_promote_leaf_to_node4(
+            let ptr_opt_res = Trie::test_try_attach_leaf(
                 &mut f,
                 &mut c,
-                &mut leaf_data,
-                &mut TrieLeaf::new(&[], &[(i + 128) as u8; 40]),
-            )
-            .unwrap();
+                &mut TrieLeaf::new(&[], &[i as u8; 40]),
+                &mut node,
+            );
+            assert!(ptr_opt_res.is_ok());
+
+            let ptr_opt = ptr_opt_res.unwrap();
+            assert!(ptr_opt.is_some());
+
+            let ptr = ptr_opt.unwrap();
             ptrs.push(ptr);
 
-            Trie::update_root_hash(&mut f, &c).unwrap();
+            let update_res = Trie::update_root_hash(&mut f, &c);
+            assert!(update_res.is_ok());
 
-            // make sure we can query it again
+            // we must be able to query it now
             let leaf_opt_res = MARF::get_path(
                 &mut f,
                 &block_header,
@@ -334,16 +162,16 @@ fn trie_cursor_promote_leaf_to_node4() {
             assert!(leaf_opt.is_some());
 
             let leaf = leaf_opt.unwrap();
-            assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[(i + 128) as u8; 40]));
+            assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[i as u8; 40]));
 
             // without a MARF commit, merkle tests will fail in deferred mode
             if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                merkle_test(&mut f, &path, &[(i + 128) as u8; 40]);
+                merkle_test(&mut f, &path, &[i as u8; 40]);
             }
         }
 
         // look up each leaf we inserted
-        for i in 1..31 {
+        for i in 0..32 {
             let mut path = vec![
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -361,21 +189,26 @@ fn trie_cursor_promote_leaf_to_node4() {
             assert!(leaf_opt.is_some());
 
             let leaf = leaf_opt.unwrap();
-            assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[(i + 128) as u8; 40]));
+            assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[i as u8; 40]));
 
             // without a MARF commit, merkle tests will fail in deferred mode
             if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                merkle_test(&mut f, &path, &[(i + 128) as u8; 40]);
+                merkle_test(&mut f, &path, &[i as u8; 40]);
             }
         }
 
         // each ptr must be a node with two children
-        for ptr in ptrs.iter().take(31) {
+        for i in 0..32 {
+            let ptr = &ptrs[i];
             let (node, hash) = f.read_nodetype(ptr).unwrap();
             match node {
                 TrieNodeType::Node4(ref data) => assert_eq!(count_children(&data.ptrs), 2),
-                TrieNodeType::Node256(ref data) => assert_eq!(count_children(&data.ptrs), 2),
-                _ => panic!("Unexpected node type"),
+                TrieNodeType::Node16(ref data) => assert_eq!(count_children(&data.ptrs), 2),
+                TrieNodeType::Node48(ref data) => assert_eq!(count_children(&data.ptrs), 2),
+                TrieNodeType::Node256(ref data) => {
+                    assert_eq!(count_children(&data.ptrs), 2)
+                }
+                node_type => panic!("Unexpected node type: {node_type:?}"),
             };
         }
 
@@ -383,113 +216,378 @@ fn trie_cursor_promote_leaf_to_node4() {
     }
 }
 
-#[test]
-fn trie_cursor_promote_node4_to_node16() {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        let mut f_store = TrieFileStorage::new_memory(marf_opts).unwrap();
-        let mut f = f_store.transaction().unwrap();
+#[apply(opts::tpl_all_opts_noop)]
+fn trie_cursor_promote_leaf_to_node4(marf_opts: &MARFOpenOpts) {
+    let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
+    let mut f = f_store.transaction().unwrap();
 
-        let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
-        MARF::format(&mut f, &block_header).unwrap();
-        // used to short-circuit block-height lookups, so that we don't
-        //   mess up these tests expected trie structures.
-        f.test_genesis_block.replace(block_header.clone());
+    let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+    MARF::format(&mut f, &block_header).unwrap();
 
-        let path_segments = vec![
-            (vec![], 0),
-            (vec![], 1),
-            (vec![], 2),
-            (vec![], 3),
-            (vec![], 4),
-            (vec![], 5),
-            (vec![], 6),
-            (vec![], 7),
-            (vec![], 8),
-            (vec![], 9),
-            (vec![], 10),
-            (vec![], 11),
-            (vec![], 12),
-            (vec![], 13),
-            (vec![], 14),
-            (vec![], 15),
-            (vec![], 16),
-            (vec![], 17),
-            (vec![], 18),
-            (vec![], 19),
-            (vec![], 20),
-            (vec![], 21),
-            (vec![], 22),
-            (vec![], 23),
-            (vec![], 24),
-            (vec![], 25),
-            (vec![], 26),
-            (vec![], 27),
-            (vec![], 28),
-            (vec![], 29),
-            (vec![], 30),
-            (vec![], 31),
+    // used to short-circuit block-height lookups, so that we don't
+    //   mess up these tests expected trie structures.
+    f.test_genesis_block.replace(block_header.clone());
+
+    let (node, root_hash) = Trie::read_root(&mut f).unwrap();
+
+    // add a single leaf
+    let mut c = TrieCursor::new(
+        &TrieHash::from_bytes(&[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ])
+        .unwrap(),
+        f.root_trieptr(),
+    );
+
+    let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+    f.open_block(&block_header).unwrap();
+    Trie::test_try_attach_leaf(
+        &mut f,
+        &mut c,
+        &mut TrieLeaf::new(&[], &[128; 40]),
+        &mut node,
+    )
+    .unwrap()
+    .unwrap();
+    Trie::update_root_hash(&mut f, &c).unwrap();
+
+    assert_eq!(
+        MARF::get_path(
+            &mut f,
+            &block_header,
+            &TrieHash::from_bytes(&[
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31
+            ])
+            .unwrap()
+        )
+        .unwrap()
+        .unwrap(),
+        TrieLeaf::new(
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31
+            ],
+            &[128; 40]
+        )
+    );
+
+    // without a MARF commit, merkle tests will fail in deferred mode
+    if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+        merkle_test(
+            &mut f,
+            &[
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
+            ],
+            &[128; 40],
+        );
+    }
+
+    let mut ptrs = vec![];
+
+    // add more leaves -- unzip this path completely
+    for i in 1..32 {
+        // add a leaf that would go after the prior leaf
+        let mut path = vec![
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
         ];
-        let (nodes, node_ptrs, hashes) =
-            make_node4_path(&mut f, &path_segments, [31u8; 40].to_vec());
+        path[i] = 32;
 
-        let (node, root_hash) = Trie::read_root(&mut f).unwrap();
+        let mut c = TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
 
-        // fill each node4
-        for k in 0..31 {
-            for j in 0..3 {
-                let mut path = [
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[k] = j + 32;
+        let (nodeptr, node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+        // end of path -- cursor points to the insertion point
+        let mut leaf_data = match node {
+            TrieNodeType::Leaf(ref data) => data.clone(),
+            _ => panic!("not a leaf"),
+        };
 
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+        f.open_block(&block_header).unwrap();
+        let ptr = Trie::test_promote_leaf_to_node4(
+            &mut f,
+            &mut c,
+            &mut leaf_data,
+            &mut TrieLeaf::new(&[], &[(i + 128) as u8; 40]),
+        )
+        .unwrap();
+        ptrs.push(ptr);
 
-                f.open_block(&block_header).unwrap();
-                Trie::test_try_attach_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[128 + j; 40]),
-                    &mut node,
-                )
-                .unwrap()
-                .unwrap();
-                Trie::update_root_hash(&mut f, &c).unwrap();
+        Trie::update_root_hash(&mut f, &c).unwrap();
 
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
-                );
+        // make sure we can query it again
+        let leaf_opt_res = MARF::get_path(
+            &mut f,
+            &block_header,
+            &TrieHash::from_bytes(&path[..]).unwrap(),
+        );
+        assert!(leaf_opt_res.is_ok());
 
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[j + 128; 40]);
-                }
-            }
+        let leaf_opt = leaf_opt_res.unwrap();
+        assert!(leaf_opt.is_some());
+
+        let leaf = leaf_opt.unwrap();
+        assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[(i + 128) as u8; 40]));
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(i + 128) as u8; 40]);
         }
+    }
 
-        test_debug!("");
-        test_debug!("");
-        test_debug!("");
+    // look up each leaf we inserted
+    for i in 1..31 {
+        let mut path = vec![
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        path[i] = 32;
 
-        let mut ptrs = vec![];
+        let leaf_opt_res = MARF::get_path(
+            &mut f,
+            &block_header,
+            &TrieHash::from_bytes(&path[..]).unwrap(),
+        );
+        assert!(leaf_opt_res.is_ok());
 
-        // promote each node4 to a node16
-        for k in 1..31 {
+        let leaf_opt = leaf_opt_res.unwrap();
+        assert!(leaf_opt.is_some());
+
+        let leaf = leaf_opt.unwrap();
+        assert_eq!(leaf, TrieLeaf::new(&path[i + 1..], &[(i + 128) as u8; 40]));
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(i + 128) as u8; 40]);
+        }
+    }
+
+    // each ptr must be a node with two children
+    for ptr in ptrs.iter().take(31) {
+        let (node, hash) = f.read_nodetype(ptr).unwrap();
+        match node {
+            TrieNodeType::Node4(ref data) => assert_eq!(count_children(&data.ptrs), 2),
+            TrieNodeType::Node256(ref data) => assert_eq!(count_children(&data.ptrs), 2),
+            _ => panic!("Unexpected node type"),
+        };
+    }
+
+    dump_trie(&mut f);
+}
+
+#[apply(opts::tpl_all_opts_noop)]
+fn trie_cursor_promote_node4_to_node16(marf_opts: &MARFOpenOpts) {
+    let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
+    let mut f = f_store.transaction().unwrap();
+
+    let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+    MARF::format(&mut f, &block_header).unwrap();
+    // used to short-circuit block-height lookups, so that we don't
+    //   mess up these tests expected trie structures.
+    f.test_genesis_block.replace(block_header.clone());
+
+    let path_segments = vec![
+        (vec![], 0),
+        (vec![], 1),
+        (vec![], 2),
+        (vec![], 3),
+        (vec![], 4),
+        (vec![], 5),
+        (vec![], 6),
+        (vec![], 7),
+        (vec![], 8),
+        (vec![], 9),
+        (vec![], 10),
+        (vec![], 11),
+        (vec![], 12),
+        (vec![], 13),
+        (vec![], 14),
+        (vec![], 15),
+        (vec![], 16),
+        (vec![], 17),
+        (vec![], 18),
+        (vec![], 19),
+        (vec![], 20),
+        (vec![], 21),
+        (vec![], 22),
+        (vec![], 23),
+        (vec![], 24),
+        (vec![], 25),
+        (vec![], 26),
+        (vec![], 27),
+        (vec![], 28),
+        (vec![], 29),
+        (vec![], 30),
+        (vec![], 31),
+    ];
+    let (nodes, node_ptrs, hashes) = make_node4_path(&mut f, &path_segments, [31u8; 40].to_vec());
+
+    let (node, root_hash) = Trie::read_root(&mut f).unwrap();
+
+    // fill each node4
+    for k in 0..31 {
+        for j in 0..3 {
             let mut path = [
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                 23, 24, 25, 26, 27, 28, 29, 30, 31,
             ];
-            path[k] = 128;
+            path[k] = j + 32;
+
+            let mut c =
+                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+            f.open_block(&block_header).unwrap();
+            Trie::test_try_attach_leaf(
+                &mut f,
+                &mut c,
+                &mut TrieLeaf::new(&[], &[128 + j; 40]),
+                &mut node,
+            )
+            .unwrap()
+            .unwrap();
+            Trie::update_root_hash(&mut f, &c).unwrap();
+
+            // should have inserted
+            assert_eq!(
+                MARF::get_path(
+                    &mut f,
+                    &block_header,
+                    &TrieHash::from_bytes(&path[..]).unwrap()
+                )
+                .unwrap()
+                .unwrap(),
+                TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
+            );
+
+            // without a MARF commit, merkle tests will fail in deferred mode
+            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+                merkle_test(&mut f, &path, &[j + 128; 40]);
+            }
+        }
+    }
+
+    test_debug!("");
+    test_debug!("");
+    test_debug!("");
+
+    let mut ptrs = vec![];
+
+    // promote each node4 to a node16
+    for k in 1..31 {
+        let mut path = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        path[k] = 128;
+
+        let mut c = TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+        let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+        f.open_block(&block_header).unwrap();
+        let new_ptr = Trie::test_insert_leaf(
+            &mut f,
+            &mut c,
+            &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+            &mut node,
+        )
+        .unwrap();
+        ptrs.push(new_ptr);
+
+        Trie::update_root_hash(&mut f, &c).unwrap();
+
+        // should have inserted
+        assert_eq!(
+            MARF::get_path(
+                &mut f,
+                &block_header,
+                &TrieHash::from_bytes(&path[..]).unwrap()
+            )
+            .unwrap()
+            .unwrap(),
+            TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+        );
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
+        }
+    }
+
+    // each ptr we got should point to a node16 with 5 children
+    for ptr in ptrs.iter() {
+        let (node, hash) = f.read_nodetype(ptr).unwrap();
+        if let TrieNodeType::Node16(data) = &node {
+            assert_eq!(count_children(&data.ptrs), 5);
+        } else {
+            panic!("Unexpected node type");
+        }
+    }
+
+    dump_trie(&mut f);
+}
+
+#[apply(opts::tpl_all_opts_noop)]
+fn trie_cursor_promote_node16_to_node48(marf_opts: &MARFOpenOpts) {
+    let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
+    let mut f = f_store.transaction().unwrap();
+
+    let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+    MARF::format(&mut f, &block_header).unwrap();
+    // used to short-circuit block-height lookups, so that we don't
+    //   mess up these tests expected trie structures.
+    f.test_genesis_block.replace(block_header.clone());
+
+    let path_segments = vec![
+        (vec![], 0),
+        (vec![], 1),
+        (vec![], 2),
+        (vec![], 3),
+        (vec![], 4),
+        (vec![], 5),
+        (vec![], 6),
+        (vec![], 7),
+        (vec![], 8),
+        (vec![], 9),
+        (vec![], 10),
+        (vec![], 11),
+        (vec![], 12),
+        (vec![], 13),
+        (vec![], 14),
+        (vec![], 15),
+        (vec![], 16),
+        (vec![], 17),
+        (vec![], 18),
+        (vec![], 19),
+        (vec![], 20),
+        (vec![], 21),
+        (vec![], 22),
+        (vec![], 23),
+        (vec![], 24),
+        (vec![], 25),
+        (vec![], 26),
+        (vec![], 27),
+        (vec![], 28),
+        (vec![], 29),
+        (vec![], 30),
+        (vec![], 31),
+    ];
+    let (nodes, node_ptrs, hashes) = make_node4_path(&mut f, &path_segments, [31u8; 40].to_vec());
+
+    let (node, root_hash) = Trie::read_root(&mut f).unwrap();
+
+    // fill each node4
+    for k in 0..31 {
+        for j in 0..3 {
+            let mut path = [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
+            ];
+            path[k] = j + 32;
 
             let mut c =
                 TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
@@ -497,14 +595,14 @@ fn trie_cursor_promote_node4_to_node16() {
             let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
 
             f.open_block(&block_header).unwrap();
-            let new_ptr = Trie::test_insert_leaf(
+            Trie::test_try_attach_leaf(
                 &mut f,
                 &mut c,
-                &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+                &mut TrieLeaf::new(&[], &[128 + j; 40]),
                 &mut node,
             )
+            .unwrap()
             .unwrap();
-            ptrs.push(new_ptr);
 
             Trie::update_root_hash(&mut f, &c).unwrap();
 
@@ -517,22 +615,619 @@ fn trie_cursor_promote_node4_to_node16() {
                 )
                 .unwrap()
                 .unwrap(),
-                TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+                TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
+            );
+
+            // without a MARF commit, merkle tests will fail in deferred mode
+            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+                merkle_test(&mut f, &path, &[j + 128; 40]);
+            }
+        }
+    }
+
+    test_debug!("");
+    test_debug!("promote all node4 to node16");
+    test_debug!("");
+
+    let mut ptrs = vec![];
+
+    // promote each node4 to a node16 by inserting one more leaf
+    for k in 1..31 {
+        let mut path = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        path[k] = 128;
+
+        let mut c = TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+        let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+        f.open_block(&block_header).unwrap();
+        let new_ptr = Trie::test_insert_leaf(
+            &mut f,
+            &mut c,
+            &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+            &mut node,
+        )
+        .unwrap();
+        ptrs.push(new_ptr);
+
+        Trie::update_root_hash(&mut f, &c).unwrap();
+
+        // should have inserted
+        assert_eq!(
+            MARF::get_path(
+                &mut f,
+                &block_header,
+                &TrieHash::from_bytes(&path[..]).unwrap()
+            )
+            .unwrap()
+            .unwrap(),
+            TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+        );
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
+        }
+    }
+
+    // each ptr we got should point to a node16 with 5 children
+    for ptr in ptrs.iter() {
+        let (node, hash) = f.read_nodetype(ptr).unwrap();
+        if let TrieNodeType::Node16(ref data) = node {
+            assert_eq!(count_children(&data.ptrs), 5);
+        } else {
+            panic!("Unexpected node type");
+        }
+    }
+
+    // fill each node16 with leaves
+    for k in 0..31 {
+        for j in 0..11 {
+            let mut path = [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
+            ];
+            path[k] = j + 40;
+
+            let mut c =
+                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+            f.open_block(&block_header).unwrap();
+            Trie::test_try_attach_leaf(
+                &mut f,
+                &mut c,
+                &mut TrieLeaf::new(&[], &[128 + j; 40]),
+                &mut node,
+            )
+            .unwrap()
+            .unwrap();
+
+            Trie::update_root_hash(&mut f, &c).unwrap();
+
+            // should have inserted
+            assert_eq!(
+                MARF::get_path(
+                    &mut f,
+                    &block_header,
+                    &TrieHash::from_bytes(&path[..]).unwrap()
+                )
+                .unwrap()
+                .unwrap(),
+                TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
+            );
+
+            // without a MARF commit, merkle tests will fail in deferred mode
+            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+                merkle_test(&mut f, &path, &[j + 128; 40]);
+            }
+        }
+    }
+
+    test_debug!("");
+    test_debug!("promote all node16 to node48");
+    test_debug!("");
+
+    ptrs.clear();
+
+    // promote each node16 to a node48 by inserting one more leaf
+    for k in 1..31 {
+        let mut path = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        path[k] = 129;
+
+        let mut c = TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+        let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+        f.open_block(&block_header).unwrap();
+
+        let new_ptr = Trie::test_insert_leaf(
+            &mut f,
+            &mut c,
+            &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+            &mut node,
+        )
+        .unwrap();
+        ptrs.push(new_ptr);
+
+        Trie::update_root_hash(&mut f, &c).unwrap();
+
+        // should have inserted
+        assert_eq!(
+            MARF::get_path(
+                &mut f,
+                &block_header,
+                &TrieHash::from_bytes(&path[..]).unwrap()
+            )
+            .unwrap()
+            .unwrap(),
+            TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+        );
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
+        }
+    }
+
+    // each ptr we got should point to a node48 with 17 children
+    for ptr in ptrs.iter() {
+        let (node, hash) = f.read_nodetype(ptr).unwrap();
+        if let TrieNodeType::Node48(ref data) = node {
+            assert_eq!(count_children(&data.ptrs), 17);
+        } else {
+            panic!("Unexpected node type");
+        }
+    }
+
+    dump_trie(&mut f);
+}
+
+#[apply(opts::tpl_all_opts_noop)]
+fn trie_cursor_promote_node48_to_node256(marf_opts: &MARFOpenOpts) {
+    let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
+    let mut f = f_store.transaction().unwrap();
+
+    let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+    MARF::format(&mut f, &block_header).unwrap();
+    // used to short-circuit block-height lookups, so that we don't
+    //   mess up these tests expected trie structures.
+    f.test_genesis_block.replace(block_header.clone());
+
+    let path_segments = vec![
+        (vec![], 0),
+        (vec![], 1),
+        (vec![], 2),
+        (vec![], 3),
+        (vec![], 4),
+        (vec![], 5),
+        (vec![], 6),
+        (vec![], 7),
+        (vec![], 8),
+        (vec![], 9),
+        (vec![], 10),
+        (vec![], 11),
+        (vec![], 12),
+        (vec![], 13),
+        (vec![], 14),
+        (vec![], 15),
+        (vec![], 16),
+        (vec![], 17),
+        (vec![], 18),
+        (vec![], 19),
+        (vec![], 20),
+        (vec![], 21),
+        (vec![], 22),
+        (vec![], 23),
+        (vec![], 24),
+        (vec![], 25),
+        (vec![], 26),
+        (vec![], 27),
+        (vec![], 28),
+        (vec![], 29),
+        (vec![], 30),
+        (vec![], 31),
+    ];
+    let (nodes, node_ptrs, hashes) = make_node4_path(&mut f, &path_segments, [31u8; 40].to_vec());
+
+    let (node, root_hash) = Trie::read_root(&mut f).unwrap();
+
+    // fill each node4
+    for k in 0..31 {
+        for j in 0..3 {
+            let mut path = [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
+            ];
+            path[k] = j + 32;
+
+            let mut c =
+                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+            f.open_block(&block_header).unwrap();
+            Trie::test_try_attach_leaf(
+                &mut f,
+                &mut c,
+                &mut TrieLeaf::new(&[], &[128 + j; 40]),
+                &mut node,
+            )
+            .unwrap()
+            .unwrap();
+
+            Trie::update_root_hash(&mut f, &c).unwrap();
+
+            // should have inserted
+            assert_eq!(
+                MARF::get_path(
+                    &mut f,
+                    &block_header,
+                    &TrieHash::from_bytes(&path[..]).unwrap()
+                )
+                .unwrap()
+                .unwrap(),
+                TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
+            );
+
+            // without a MARF commit, merkle tests will fail in deferred mode
+            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+                merkle_test(&mut f, &path, &[j + 128; 40]);
+            }
+        }
+    }
+
+    test_debug!("");
+    test_debug!("promote all node4 to node16");
+    test_debug!("");
+
+    let mut ptrs = vec![];
+
+    // promote each node4 to a node16 by inserting one more leaf
+    for k in 1..31 {
+        let mut path = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        path[k] = 128;
+
+        let mut c = TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+        let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+        f.open_block(&block_header).unwrap();
+        let new_ptr = Trie::test_insert_leaf(
+            &mut f,
+            &mut c,
+            &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+            &mut node,
+        )
+        .unwrap();
+        ptrs.push(new_ptr);
+
+        Trie::update_root_hash(&mut f, &c).unwrap();
+
+        // should have inserted
+        assert_eq!(
+            MARF::get_path(
+                &mut f,
+                &block_header,
+                &TrieHash::from_bytes(&path[..]).unwrap()
+            )
+            .unwrap()
+            .unwrap(),
+            TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+        );
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
+        }
+    }
+
+    // each ptr we got should point to a node16 with 5 children
+    for ptr in ptrs.iter() {
+        let (node, hash) = f.read_nodetype(ptr).unwrap();
+        if let TrieNodeType::Node16(ref data) = node {
+            assert_eq!(count_children(&data.ptrs), 5);
+        } else {
+            panic!("Unexpected node type");
+        }
+    }
+
+    // fill each node16 with leaves
+    for k in 0..31 {
+        for j in 0..11 {
+            let mut path = [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
+            ];
+            path[k] = j + 40;
+
+            let mut c =
+                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+            f.open_block(&block_header).unwrap();
+            Trie::test_try_attach_leaf(
+                &mut f,
+                &mut c,
+                &mut TrieLeaf::new(&[], &[128 + j; 40]),
+                &mut node,
+            )
+            .unwrap()
+            .unwrap();
+            Trie::update_root_hash(&mut f, &c).unwrap();
+
+            // should have inserted
+            assert_eq!(
+                MARF::get_path(
+                    &mut f,
+                    &block_header,
+                    &TrieHash::from_bytes(&path[..]).unwrap()
+                )
+                .unwrap()
+                .unwrap(),
+                TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
+            );
+
+            // without a MARF commit, merkle tests will fail in deferred mode
+            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+                merkle_test(&mut f, &path, &[j + 128; 40]);
+            }
+        }
+    }
+
+    test_debug!("");
+    test_debug!("promote all node16 to node48");
+    test_debug!("");
+
+    ptrs.clear();
+
+    // promote each node16 to a node48 by inserting one more leaf
+    for k in 1..31 {
+        let mut path = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        path[k] = 129;
+
+        let mut c = TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+        let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+        f.open_block(&block_header).unwrap();
+        let new_ptr = Trie::test_insert_leaf(
+            &mut f,
+            &mut c,
+            &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+            &mut node,
+        )
+        .unwrap();
+        ptrs.push(new_ptr);
+
+        Trie::update_root_hash(&mut f, &c).unwrap();
+
+        // should have inserted
+        assert_eq!(
+            MARF::get_path(
+                &mut f,
+                &block_header,
+                &TrieHash::from_bytes(&path[..]).unwrap()
+            )
+            .unwrap()
+            .unwrap(),
+            TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+        );
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
+        }
+    }
+
+    // each ptr we got should point to a node48 with 17 children
+    for ptr in ptrs.iter() {
+        let (node, hash) = f.read_nodetype(ptr).unwrap();
+        if let TrieNodeType::Node48(ref data) = node {
+            assert_eq!(count_children(&data.ptrs), 17);
+        } else {
+            panic!("Unexpected node type");
+        }
+    }
+
+    // fill each node48 with leaves
+    for k in 0..31 {
+        for j in 0..31 {
+            let mut path = [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
+            ];
+            path[k] = j + 90;
+
+            let mut c =
+                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+            f.open_block(&block_header).unwrap();
+            Trie::test_try_attach_leaf(
+                &mut f,
+                &mut c,
+                &mut TrieLeaf::new(&[], &[128 + j; 40]),
+                &mut node,
+            )
+            .unwrap()
+            .unwrap();
+
+            Trie::update_root_hash(&mut f, &c).unwrap();
+
+            // should have inserted
+            assert_eq!(
+                MARF::get_path(
+                    &mut f,
+                    &block_header,
+                    &TrieHash::from_bytes(&path[..]).unwrap()
+                )
+                .unwrap()
+                .unwrap(),
+                TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
+            );
+
+            // without a MARF commit, merkle tests will fail in deferred mode
+            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+                merkle_test(&mut f, &path, &[j + 128; 40]);
+            }
+        }
+    }
+
+    test_debug!("");
+    test_debug!("promote all node48 to node256");
+    test_debug!("");
+
+    ptrs.clear();
+
+    // promote each node48 to a node256 by inserting one more leaf
+    for k in 1..31 {
+        let mut path = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        path[k] = 130;
+
+        let mut c = TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+        let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+        f.open_block(&block_header).unwrap();
+        let new_ptr = Trie::test_insert_leaf(
+            &mut f,
+            &mut c,
+            &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+            &mut node,
+        )
+        .unwrap();
+        ptrs.push(new_ptr);
+
+        Trie::update_root_hash(&mut f, &c).unwrap();
+
+        // should have inserted
+        assert_eq!(
+            MARF::get_path(
+                &mut f,
+                &block_header,
+                &TrieHash::from_bytes(&path[..]).unwrap()
+            )
+            .unwrap()
+            .unwrap(),
+            TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+        );
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
+            merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
+        }
+    }
+
+    // each ptr we got should point to a node256 with 49 children
+    for ptr in ptrs.iter() {
+        let (node, hash) = f.read_nodetype(ptr).unwrap();
+        if let TrieNodeType::Node256(ref data) = node {
+            assert_eq!(count_children(&data.ptrs), 49);
+        } else {
+            panic!("Unexpected node type");
+        }
+    }
+
+    dump_trie(&mut f);
+}
+
+#[apply(opts::tpl_all_opts_noop)]
+fn trie_cursor_splice_leaf_4(marf_opts: &MARFOpenOpts) {
+    for node_id in [
+        TrieNodeID::Node4,
+        TrieNodeID::Node16,
+        TrieNodeID::Node48,
+        TrieNodeID::Node256,
+    ]
+    .iter()
+    {
+        let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
+        let mut f = f_store.transaction().unwrap();
+
+        let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+        MARF::format(&mut f, &block_header).unwrap();
+
+        // used to short-circuit block-height lookups, so that we don't
+        //   mess up these tests expected trie structures.
+        f.test_genesis_block.replace(block_header.clone());
+
+        let path_segments = vec![
+            (vec![0, 1, 2, 3], 4),
+            (vec![5, 6, 7, 8], 9),
+            (vec![10, 11, 12, 13], 14),
+            (vec![15, 16, 17, 18], 19),
+            (vec![20, 21, 22, 23], 24),
+            (vec![25, 26, 27, 28], 29),
+            (vec![30], 31),
+        ];
+
+        let (nodes, node_ptrs, hashes) =
+            make_node_path(&mut f, node_id.to_u8(), &path_segments, [31u8; 40].to_vec());
+
+        // splice in a node in each path segment
+        for k in 0..5 {
+            let mut path = vec![
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
+            ];
+            path[5 * k + 2] = 32;
+
+            let mut c =
+                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
+
+            test_debug!("Start splice-insert at {:?}", &c);
+            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
+
+            test_debug!("Splice leaf pattern={} at {:?}", 192 + k, &c);
+            f.open_block(&block_header).unwrap();
+
+            eprintln!("Splicing Node @ {}", nodeptr.ptr());
+            eprintln!("Splicing Node @ {:x}", c.chr().unwrap());
+
+            let new_ptr = Trie::test_splice_leaf(
+                &mut f,
+                &mut c,
+                &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
+                &mut node,
+            )
+            .unwrap();
+
+            Trie::update_root_hash(&mut f, &c).unwrap();
+
+            // should have inserted
+            assert_eq!(
+                MARF::get_path(
+                    &mut f,
+                    &block_header,
+                    &TrieHash::from_bytes(&path[..]).unwrap()
+                )
+                .unwrap()
+                .unwrap(),
+                TrieLeaf::new(&path[5 * k + 3..], &[192 + k as u8; 40])
             );
 
             // without a MARF commit, merkle tests will fail in deferred mode
             if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
                 merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-            }
-        }
-
-        // each ptr we got should point to a node16 with 5 children
-        for ptr in ptrs.iter() {
-            let (node, hash) = f.read_nodetype(ptr).unwrap();
-            if let TrieNodeType::Node16(data) = &node {
-                assert_eq!(count_children(&data.ptrs), 5);
-            } else {
-                panic!("Unexpected node type");
             }
         }
 
@@ -540,130 +1235,66 @@ fn trie_cursor_promote_node4_to_node16() {
     }
 }
 
-#[test]
-fn trie_cursor_promote_node16_to_node48() {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        let mut f_store = TrieFileStorage::new_memory(marf_opts).unwrap();
+#[apply(opts::tpl_all_opts_noop)]
+fn trie_cursor_splice_leaf_2(marf_opts: &MARFOpenOpts) {
+    for node_id in [
+        TrieNodeID::Node4,
+        TrieNodeID::Node16,
+        TrieNodeID::Node48,
+        TrieNodeID::Node256,
+    ]
+    .iter()
+    {
+        let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
         let mut f = f_store.transaction().unwrap();
 
         let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
         MARF::format(&mut f, &block_header).unwrap();
+
         // used to short-circuit block-height lookups, so that we don't
         //   mess up these tests expected trie structures.
         f.test_genesis_block.replace(block_header.clone());
 
         let path_segments = vec![
-            (vec![], 0),
-            (vec![], 1),
-            (vec![], 2),
-            (vec![], 3),
-            (vec![], 4),
-            (vec![], 5),
-            (vec![], 6),
-            (vec![], 7),
-            (vec![], 8),
-            (vec![], 9),
-            (vec![], 10),
-            (vec![], 11),
-            (vec![], 12),
-            (vec![], 13),
-            (vec![], 14),
-            (vec![], 15),
-            (vec![], 16),
-            (vec![], 17),
-            (vec![], 18),
-            (vec![], 19),
-            (vec![], 20),
-            (vec![], 21),
-            (vec![], 22),
-            (vec![], 23),
-            (vec![], 24),
-            (vec![], 25),
-            (vec![], 26),
-            (vec![], 27),
-            (vec![], 28),
-            (vec![], 29),
-            (vec![], 30),
-            (vec![], 31),
+            (vec![0, 1], 2),
+            (vec![3, 4], 5),
+            (vec![6, 7], 8),
+            (vec![9, 10], 11),
+            (vec![12, 13], 14),
+            (vec![15, 16], 17),
+            (vec![18, 19], 20),
+            (vec![21, 22], 23),
+            (vec![24, 25], 26),
+            (vec![27, 28], 29),
+            (vec![30], 31),
         ];
+
         let (nodes, node_ptrs, hashes) =
-            make_node4_path(&mut f, &path_segments, [31u8; 40].to_vec());
+            make_node_path(&mut f, node_id.to_u8(), &path_segments, [31u8; 40].to_vec());
 
-        let (node, root_hash) = Trie::read_root(&mut f).unwrap();
-
-        // fill each node4
-        for k in 0..31 {
-            for j in 0..3 {
-                let mut path = [
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[k] = j + 32;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                f.open_block(&block_header).unwrap();
-                Trie::test_try_attach_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[128 + j; 40]),
-                    &mut node,
-                )
-                .unwrap()
-                .unwrap();
-
-                Trie::update_root_hash(&mut f, &c).unwrap();
-
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
-                );
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[j + 128; 40]);
-                }
-            }
-        }
-
-        test_debug!("");
-        test_debug!("promote all node4 to node16");
-        test_debug!("");
-
-        let mut ptrs = vec![];
-
-        // promote each node4 to a node16 by inserting one more leaf
-        for k in 1..31 {
-            let mut path = [
+        // splice in a node in each path segment
+        for k in 0..10 {
+            let mut path = vec![
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                 23, 24, 25, 26, 27, 28, 29, 30, 31,
             ];
-            path[k] = 128;
+            path[3 * k + 1] = 32;
 
             let mut c =
                 TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
 
+            test_debug!("Start splice-insert at {:?}", &c);
             let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
 
+            test_debug!("Splice leaf pattern={} at {:?}", 192 + k, &c);
             f.open_block(&block_header).unwrap();
-            let new_ptr = Trie::test_insert_leaf(
+            let new_ptr = Trie::test_splice_leaf(
                 &mut f,
                 &mut c,
                 &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
                 &mut node,
             )
             .unwrap();
-            ptrs.push(new_ptr);
 
             Trie::update_root_hash(&mut f, &c).unwrap();
 
@@ -676,672 +1307,17 @@ fn trie_cursor_promote_node16_to_node48() {
                 )
                 .unwrap()
                 .unwrap(),
-                TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
+                TrieLeaf::new(&path[3 * k + 2..], &[192 + k as u8; 40])
             );
 
+            // proofs should still work
             // without a MARF commit, merkle tests will fail in deferred mode
             if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
                 merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-            }
-        }
-
-        // each ptr we got should point to a node16 with 5 children
-        for ptr in ptrs.iter() {
-            let (node, hash) = f.read_nodetype(ptr).unwrap();
-            if let TrieNodeType::Node16(ref data) = node {
-                assert_eq!(count_children(&data.ptrs), 5);
-            } else {
-                panic!("Unexpected node type");
-            }
-        }
-
-        // fill each node16 with leaves
-        for k in 0..31 {
-            for j in 0..11 {
-                let mut path = [
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[k] = j + 40;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                f.open_block(&block_header).unwrap();
-                Trie::test_try_attach_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[128 + j; 40]),
-                    &mut node,
-                )
-                .unwrap()
-                .unwrap();
-
-                Trie::update_root_hash(&mut f, &c).unwrap();
-
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
-                );
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[j + 128; 40]);
-                }
-            }
-        }
-
-        test_debug!("");
-        test_debug!("promote all node16 to node48");
-        test_debug!("");
-
-        ptrs.clear();
-
-        // promote each node16 to a node48 by inserting one more leaf
-        for k in 1..31 {
-            let mut path = [
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                23, 24, 25, 26, 27, 28, 29, 30, 31,
-            ];
-            path[k] = 129;
-
-            let mut c =
-                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-            f.open_block(&block_header).unwrap();
-
-            let new_ptr = Trie::test_insert_leaf(
-                &mut f,
-                &mut c,
-                &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
-                &mut node,
-            )
-            .unwrap();
-            ptrs.push(new_ptr);
-
-            Trie::update_root_hash(&mut f, &c).unwrap();
-
-            // should have inserted
-            assert_eq!(
-                MARF::get_path(
-                    &mut f,
-                    &block_header,
-                    &TrieHash::from_bytes(&path[..]).unwrap()
-                )
-                .unwrap()
-                .unwrap(),
-                TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
-            );
-
-            // without a MARF commit, merkle tests will fail in deferred mode
-            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-            }
-        }
-
-        // each ptr we got should point to a node48 with 17 children
-        for ptr in ptrs.iter() {
-            let (node, hash) = f.read_nodetype(ptr).unwrap();
-            if let TrieNodeType::Node48(ref data) = node {
-                assert_eq!(count_children(&data.ptrs), 17);
-            } else {
-                panic!("Unexpected node type");
             }
         }
 
         dump_trie(&mut f);
-    }
-}
-
-#[test]
-fn trie_cursor_promote_node48_to_node256() {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        let mut f_store = TrieFileStorage::new_memory(marf_opts).unwrap();
-        let mut f = f_store.transaction().unwrap();
-
-        let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
-        MARF::format(&mut f, &block_header).unwrap();
-        // used to short-circuit block-height lookups, so that we don't
-        //   mess up these tests expected trie structures.
-        f.test_genesis_block.replace(block_header.clone());
-
-        let path_segments = vec![
-            (vec![], 0),
-            (vec![], 1),
-            (vec![], 2),
-            (vec![], 3),
-            (vec![], 4),
-            (vec![], 5),
-            (vec![], 6),
-            (vec![], 7),
-            (vec![], 8),
-            (vec![], 9),
-            (vec![], 10),
-            (vec![], 11),
-            (vec![], 12),
-            (vec![], 13),
-            (vec![], 14),
-            (vec![], 15),
-            (vec![], 16),
-            (vec![], 17),
-            (vec![], 18),
-            (vec![], 19),
-            (vec![], 20),
-            (vec![], 21),
-            (vec![], 22),
-            (vec![], 23),
-            (vec![], 24),
-            (vec![], 25),
-            (vec![], 26),
-            (vec![], 27),
-            (vec![], 28),
-            (vec![], 29),
-            (vec![], 30),
-            (vec![], 31),
-        ];
-        let (nodes, node_ptrs, hashes) =
-            make_node4_path(&mut f, &path_segments, [31u8; 40].to_vec());
-
-        let (node, root_hash) = Trie::read_root(&mut f).unwrap();
-
-        // fill each node4
-        for k in 0..31 {
-            for j in 0..3 {
-                let mut path = [
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[k] = j + 32;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                f.open_block(&block_header).unwrap();
-                Trie::test_try_attach_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[128 + j; 40]),
-                    &mut node,
-                )
-                .unwrap()
-                .unwrap();
-
-                Trie::update_root_hash(&mut f, &c).unwrap();
-
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
-                );
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[j + 128; 40]);
-                }
-            }
-        }
-
-        test_debug!("");
-        test_debug!("promote all node4 to node16");
-        test_debug!("");
-
-        let mut ptrs = vec![];
-
-        // promote each node4 to a node16 by inserting one more leaf
-        for k in 1..31 {
-            let mut path = [
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                23, 24, 25, 26, 27, 28, 29, 30, 31,
-            ];
-            path[k] = 128;
-
-            let mut c =
-                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-            f.open_block(&block_header).unwrap();
-            let new_ptr = Trie::test_insert_leaf(
-                &mut f,
-                &mut c,
-                &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
-                &mut node,
-            )
-            .unwrap();
-            ptrs.push(new_ptr);
-
-            Trie::update_root_hash(&mut f, &c).unwrap();
-
-            // should have inserted
-            assert_eq!(
-                MARF::get_path(
-                    &mut f,
-                    &block_header,
-                    &TrieHash::from_bytes(&path[..]).unwrap()
-                )
-                .unwrap()
-                .unwrap(),
-                TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
-            );
-
-            // without a MARF commit, merkle tests will fail in deferred mode
-            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-            }
-        }
-
-        // each ptr we got should point to a node16 with 5 children
-        for ptr in ptrs.iter() {
-            let (node, hash) = f.read_nodetype(ptr).unwrap();
-            if let TrieNodeType::Node16(ref data) = node {
-                assert_eq!(count_children(&data.ptrs), 5);
-            } else {
-                panic!("Unexpected node type");
-            }
-        }
-
-        // fill each node16 with leaves
-        for k in 0..31 {
-            for j in 0..11 {
-                let mut path = [
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[k] = j + 40;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                f.open_block(&block_header).unwrap();
-                Trie::test_try_attach_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[128 + j; 40]),
-                    &mut node,
-                )
-                .unwrap()
-                .unwrap();
-                Trie::update_root_hash(&mut f, &c).unwrap();
-
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
-                );
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[j + 128; 40]);
-                }
-            }
-        }
-
-        test_debug!("");
-        test_debug!("promote all node16 to node48");
-        test_debug!("");
-
-        ptrs.clear();
-
-        // promote each node16 to a node48 by inserting one more leaf
-        for k in 1..31 {
-            let mut path = [
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                23, 24, 25, 26, 27, 28, 29, 30, 31,
-            ];
-            path[k] = 129;
-
-            let mut c =
-                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-            f.open_block(&block_header).unwrap();
-            let new_ptr = Trie::test_insert_leaf(
-                &mut f,
-                &mut c,
-                &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
-                &mut node,
-            )
-            .unwrap();
-            ptrs.push(new_ptr);
-
-            Trie::update_root_hash(&mut f, &c).unwrap();
-
-            // should have inserted
-            assert_eq!(
-                MARF::get_path(
-                    &mut f,
-                    &block_header,
-                    &TrieHash::from_bytes(&path[..]).unwrap()
-                )
-                .unwrap()
-                .unwrap(),
-                TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
-            );
-
-            // without a MARF commit, merkle tests will fail in deferred mode
-            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-            }
-        }
-
-        // each ptr we got should point to a node48 with 17 children
-        for ptr in ptrs.iter() {
-            let (node, hash) = f.read_nodetype(ptr).unwrap();
-            if let TrieNodeType::Node48(ref data) = node {
-                assert_eq!(count_children(&data.ptrs), 17);
-            } else {
-                panic!("Unexpected node type");
-            }
-        }
-
-        // fill each node48 with leaves
-        for k in 0..31 {
-            for j in 0..31 {
-                let mut path = [
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[k] = j + 90;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                f.open_block(&block_header).unwrap();
-                Trie::test_try_attach_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[128 + j; 40]),
-                    &mut node,
-                )
-                .unwrap()
-                .unwrap();
-
-                Trie::update_root_hash(&mut f, &c).unwrap();
-
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[k + 1..], &[128 + j; 40])
-                );
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[j + 128; 40]);
-                }
-            }
-        }
-
-        test_debug!("");
-        test_debug!("promote all node48 to node256");
-        test_debug!("");
-
-        ptrs.clear();
-
-        // promote each node48 to a node256 by inserting one more leaf
-        for k in 1..31 {
-            let mut path = [
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-                23, 24, 25, 26, 27, 28, 29, 30, 31,
-            ];
-            path[k] = 130;
-
-            let mut c =
-                TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-            let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-            f.open_block(&block_header).unwrap();
-            let new_ptr = Trie::test_insert_leaf(
-                &mut f,
-                &mut c,
-                &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
-                &mut node,
-            )
-            .unwrap();
-            ptrs.push(new_ptr);
-
-            Trie::update_root_hash(&mut f, &c).unwrap();
-
-            // should have inserted
-            assert_eq!(
-                MARF::get_path(
-                    &mut f,
-                    &block_header,
-                    &TrieHash::from_bytes(&path[..]).unwrap()
-                )
-                .unwrap()
-                .unwrap(),
-                TrieLeaf::new(&path[k + 1..], &[192 + k as u8; 40])
-            );
-
-            // without a MARF commit, merkle tests will fail in deferred mode
-            if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-            }
-        }
-
-        // each ptr we got should point to a node256 with 49 children
-        for ptr in ptrs.iter() {
-            let (node, hash) = f.read_nodetype(ptr).unwrap();
-            if let TrieNodeType::Node256(ref data) = node {
-                assert_eq!(count_children(&data.ptrs), 49);
-            } else {
-                panic!("Unexpected node type");
-            }
-        }
-
-        dump_trie(&mut f);
-    }
-}
-
-#[test]
-fn trie_cursor_splice_leaf_4() {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        for node_id in [
-            TrieNodeID::Node4,
-            TrieNodeID::Node16,
-            TrieNodeID::Node48,
-            TrieNodeID::Node256,
-        ]
-        .iter()
-        {
-            let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
-            let mut f = f_store.transaction().unwrap();
-
-            let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
-            MARF::format(&mut f, &block_header).unwrap();
-
-            // used to short-circuit block-height lookups, so that we don't
-            //   mess up these tests expected trie structures.
-            f.test_genesis_block.replace(block_header.clone());
-
-            let path_segments = vec![
-                (vec![0, 1, 2, 3], 4),
-                (vec![5, 6, 7, 8], 9),
-                (vec![10, 11, 12, 13], 14),
-                (vec![15, 16, 17, 18], 19),
-                (vec![20, 21, 22, 23], 24),
-                (vec![25, 26, 27, 28], 29),
-                (vec![30], 31),
-            ];
-
-            let (nodes, node_ptrs, hashes) =
-                make_node_path(&mut f, node_id.to_u8(), &path_segments, [31u8; 40].to_vec());
-
-            // splice in a node in each path segment
-            for k in 0..5 {
-                let mut path = vec![
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[5 * k + 2] = 32;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-                test_debug!("Start splice-insert at {:?}", &c);
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                test_debug!("Splice leaf pattern={} at {:?}", 192 + k, &c);
-                f.open_block(&block_header).unwrap();
-
-                eprintln!("Splicing Node @ {}", nodeptr.ptr());
-                eprintln!("Splicing Node @ {:x}", c.chr().unwrap());
-
-                let new_ptr = Trie::test_splice_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
-                    &mut node,
-                )
-                .unwrap();
-
-                Trie::update_root_hash(&mut f, &c).unwrap();
-
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[5 * k + 3..], &[192 + k as u8; 40])
-                );
-
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-                }
-            }
-
-            dump_trie(&mut f);
-        }
-    }
-}
-
-#[test]
-fn trie_cursor_splice_leaf_2() {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        for node_id in [
-            TrieNodeID::Node4,
-            TrieNodeID::Node16,
-            TrieNodeID::Node48,
-            TrieNodeID::Node256,
-        ]
-        .iter()
-        {
-            let mut f_store = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
-            let mut f = f_store.transaction().unwrap();
-
-            let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
-            MARF::format(&mut f, &block_header).unwrap();
-
-            // used to short-circuit block-height lookups, so that we don't
-            //   mess up these tests expected trie structures.
-            f.test_genesis_block.replace(block_header.clone());
-
-            let path_segments = vec![
-                (vec![0, 1], 2),
-                (vec![3, 4], 5),
-                (vec![6, 7], 8),
-                (vec![9, 10], 11),
-                (vec![12, 13], 14),
-                (vec![15, 16], 17),
-                (vec![18, 19], 20),
-                (vec![21, 22], 23),
-                (vec![24, 25], 26),
-                (vec![27, 28], 29),
-                (vec![30], 31),
-            ];
-
-            let (nodes, node_ptrs, hashes) =
-                make_node_path(&mut f, node_id.to_u8(), &path_segments, [31u8; 40].to_vec());
-
-            // splice in a node in each path segment
-            for k in 0..10 {
-                let mut path = vec![
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ];
-                path[3 * k + 1] = 32;
-
-                let mut c =
-                    TrieCursor::new(&TrieHash::from_bytes(&path[..]).unwrap(), f.root_trieptr());
-
-                test_debug!("Start splice-insert at {:?}", &c);
-                let (nodeptr, mut node, node_hash) = walk_to_insertion_point(&mut f, &mut c);
-
-                test_debug!("Splice leaf pattern={} at {:?}", 192 + k, &c);
-                f.open_block(&block_header).unwrap();
-                let new_ptr = Trie::test_splice_leaf(
-                    &mut f,
-                    &mut c,
-                    &mut TrieLeaf::new(&[], &[192 + k as u8; 40]),
-                    &mut node,
-                )
-                .unwrap();
-
-                Trie::update_root_hash(&mut f, &c).unwrap();
-
-                // should have inserted
-                assert_eq!(
-                    MARF::get_path(
-                        &mut f,
-                        &block_header,
-                        &TrieHash::from_bytes(&path[..]).unwrap()
-                    )
-                    .unwrap()
-                    .unwrap(),
-                    TrieLeaf::new(&path[3 * k + 2..], &[192 + k as u8; 40])
-                );
-
-                // proofs should still work
-                // without a MARF commit, merkle tests will fail in deferred mode
-                if f.hash_calculation_mode != TrieHashCalculationMode::Deferred {
-                    merkle_test(&mut f, &path, &[(k + 192) as u8; 40]);
-                }
-            }
-
-            dump_trie(&mut f);
-        }
     }
 }
 

--- a/stackslib/src/chainstate/stacks/index/test/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/test/trie.rs
@@ -1200,8 +1200,8 @@ fn trie_cursor_splice_leaf_4(marf_opts: &MARFOpenOpts) {
             test_debug!("Splice leaf pattern={} at {:?}", 192 + k, &c);
             f.open_block(&block_header).unwrap();
 
-            eprintln!("Splicing Node @ {}", nodeptr.ptr());
-            eprintln!("Splicing Node @ {:x}", c.chr().unwrap());
+            test_debug!("Splicing Node @ {}", nodeptr.ptr());
+            test_debug!("Splicing Node @ {:x}", c.chr().unwrap());
 
             let new_ptr = Trie::test_splice_leaf(
                 &mut f,
@@ -1340,7 +1340,7 @@ where
     .unwrap();
 
     for i in 0..count {
-        eprintln!("{}", i);
+        test_debug!("{}", i);
         let path = path_gen(i);
         let triepath = TrieHash::from_bytes(&path).unwrap();
         let value = TrieLeaf::new(
@@ -1657,7 +1657,7 @@ fn insert_65536_random_deterministic(marf_opts: &MARFOpenOpts) {
             &TrieHash::from_data(if i == 0 { &[] } else { seed.as_slice() }).as_bytes()[0..32],
         );
         seed = path.to_vec();
-        eprintln!("{}", to_hex(&path));
+        test_debug!("{}", to_hex(&path));
         path
     })
 }
@@ -1673,7 +1673,7 @@ fn insert_1024_random_deterministic_merkle_proof(marf_opts: &MARFOpenOpts) {
             &TrieHash::from_data(if i == 0 { &[] } else { seed.as_slice() }).as_bytes()[0..32],
         );
         seed = path.to_vec();
-        eprintln!("{}", to_hex(&path));
+        test_debug!("{}", to_hex(&path));
         path
     })
 }

--- a/stackslib/src/chainstate/stacks/index/test/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/test/trie.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_variables)]
-#![allow(unused_assignments)]
-
 use super::*;
 use crate::chainstate::stacks::index::{ClarityMarfTrieId, *};
 

--- a/stackslib/src/chainstate/stacks/index/test/trie.rs
+++ b/stackslib/src/chainstate/stacks/index/test/trie.rs
@@ -1345,31 +1345,83 @@ fn trie_cursor_splice_leaf_2() {
     }
 }
 
-fn insert_n_test<F>(filename: &str, merkle_check: bool, count: u32, mut path_gen: F)
+fn insert_n_test<F>(marf_opts: &MARFOpenOpts, merkle_check: bool, count: u32, mut path_gen: F)
 where
     F: FnMut(u32) -> [u8; 32],
 {
-    for marf_opts in MARFOpenOpts::all().into_iter() {
-        let f = TrieFileStorage::new_memory(marf_opts).unwrap();
+    let f = TrieFileStorage::new_memory(marf_opts.clone()).unwrap();
 
-        let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
-        let mut marf = MARF::from_storage(f);
-        marf.begin(&BlockHeaderHash::sentinel(), &block_header)
-            .unwrap();
-        MARF::get_block_height(
-            &mut marf.borrow_storage_backend(),
-            &block_header,
-            &block_header,
-        )
-        .unwrap()
+    let block_header = BlockHeaderHash::from_bytes(&[0u8; 32]).unwrap();
+    let mut marf = MARF::from_storage(f);
+    marf.begin(&BlockHeaderHash::sentinel(), &block_header)
         .unwrap();
+    MARF::get_block_height(
+        &mut marf.borrow_storage_backend(),
+        &block_header,
+        &block_header,
+    )
+    .unwrap()
+    .unwrap();
 
-        for i in 0..count {
-            eprintln!("{}", i);
-            let path = path_gen(i);
-            let triepath = TrieHash::from_bytes(&path).unwrap();
-            let value = TrieLeaf::new(
-                &[],
+    for i in 0..count {
+        eprintln!("{}", i);
+        let path = path_gen(i);
+        let triepath = TrieHash::from_bytes(&path).unwrap();
+        let value = TrieLeaf::new(
+            &[],
+            &[
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                (i / 256) as u8,
+                (i % 256) as u8,
+            ],
+        );
+        marf.insert_raw(triepath, value).unwrap();
+
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if merkle_check
+            && marf.borrow_storage_backend().hash_calculation_mode
+                != TrieHashCalculationMode::Deferred
+        {
+            merkle_test(
+                &mut marf.borrow_storage_backend(),
+                &path,
                 &[
                     0,
                     0,
@@ -1413,72 +1465,70 @@ where
                     (i % 256) as u8,
                 ],
             );
-            marf.insert_raw(triepath, value).unwrap();
-
-            // without a MARF commit, merkle tests will fail in deferred mode
-            if merkle_check
-                && marf.borrow_storage_backend().hash_calculation_mode
-                    != TrieHashCalculationMode::Deferred
-            {
-                merkle_test(
-                    &mut marf.borrow_storage_backend(),
-                    &path,
-                    &[
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        (i / 256) as u8,
-                        (i % 256) as u8,
-                    ],
-                );
-            }
         }
+    }
 
-        for i in 0..count {
-            let path = path_gen(i);
-            let triepath = TrieHash::from_bytes(&path).unwrap();
-            let value =
-                MARF::get_path(&mut marf.borrow_storage_backend(), &block_header, &triepath)
-                    .unwrap()
-                    .unwrap();
-            assert_eq!(
-                value.data.to_vec(),
-                [
+    for i in 0..count {
+        let path = path_gen(i);
+        let triepath = TrieHash::from_bytes(&path).unwrap();
+        let value = MARF::get_path(&mut marf.borrow_storage_backend(), &block_header, &triepath)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            value.data.to_vec(),
+            [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                (i / 256) as u8,
+                (i % 256) as u8
+            ]
+            .to_vec()
+        );
+        // without a MARF commit, merkle tests will fail in deferred mode
+        if merkle_check
+            && marf.borrow_storage_backend().hash_calculation_mode
+                != TrieHashCalculationMode::Deferred
+        {
+            merkle_test(
+                &mut marf.borrow_storage_backend(),
+                &path,
+                &[
                     0,
                     0,
                     0,
@@ -1518,69 +1568,16 @@ where
                     0,
                     0,
                     (i / 256) as u8,
-                    (i % 256) as u8
-                ]
-                .to_vec()
+                    (i % 256) as u8,
+                ],
             );
-            // without a MARF commit, merkle tests will fail in deferred mode
-            if merkle_check
-                && marf.borrow_storage_backend().hash_calculation_mode
-                    != TrieHashCalculationMode::Deferred
-            {
-                merkle_test(
-                    &mut marf.borrow_storage_backend(),
-                    &path,
-                    &[
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        (i / 256) as u8,
-                        (i % 256) as u8,
-                    ],
-                );
-            }
         }
     }
 }
 
-#[test]
-fn insert_1024_seq_low() {
-    insert_n_test("/tmp/rust_marf_insert_1024_seq_low", true, 1024, |i| {
+#[apply(opts::tpl_all_opts_noop)]
+fn insert_1024_seq_low(marf_opts: &MARFOpenOpts) {
+    insert_n_test(marf_opts, true, 1024, |i| {
         [
             0,
             1,
@@ -1618,9 +1615,9 @@ fn insert_1024_seq_low() {
     })
 }
 
-#[test]
-fn insert_1024_seq_high() {
-    insert_n_test("/tmp/rust_marf_insert_1024_seq_high", true, 1024, |i| {
+#[apply(opts::tpl_all_opts_noop)]
+fn insert_1024_seq_high(marf_opts: &MARFOpenOpts) {
+    insert_n_test(marf_opts, true, 1024, |i| {
         [
             (i / 256) as u8,
             (i % 256) as u8,
@@ -1658,9 +1655,9 @@ fn insert_1024_seq_high() {
     })
 }
 
-#[test]
-fn insert_1024_seq_mid() {
-    insert_n_test("/tmp/rust_marf_insert_1024_seq_mid", true, 1024, |i| {
+#[apply(opts::tpl_all_opts_noop)]
+fn insert_1024_seq_mid(marf_opts: &MARFOpenOpts) {
+    insert_n_test(marf_opts, true, 1024, |i| {
         let i0 = i / 256;
         let i1 = (i % 256) / 32;
         let i2 = (i % 256) % 32;
@@ -1672,45 +1669,35 @@ fn insert_1024_seq_mid() {
     })
 }
 
-#[test]
+#[apply(opts::tpl_all_opts_noop)]
 #[ignore]
-fn insert_65536_random_deterministic() {
+fn insert_65536_random_deterministic(marf_opts: &MARFOpenOpts) {
     // deterministic random insert of 65536 keys
     let mut seed = TrieHash::EMPTY.as_bytes().to_vec();
 
-    insert_n_test(
-        "/tmp/rust_marf_insert_65536_random_deterministic",
-        false,
-        65536,
-        |i| {
-            let mut path = [0; 32];
-            path.copy_from_slice(
-                &TrieHash::from_data(if i == 0 { &[] } else { seed.as_slice() }).as_bytes()[0..32],
-            );
-            seed = path.to_vec();
-            eprintln!("{}", to_hex(&path));
-            path
-        },
-    )
+    insert_n_test(marf_opts, false, 65536, |i| {
+        let mut path = [0; 32];
+        path.copy_from_slice(
+            &TrieHash::from_data(if i == 0 { &[] } else { seed.as_slice() }).as_bytes()[0..32],
+        );
+        seed = path.to_vec();
+        eprintln!("{}", to_hex(&path));
+        path
+    })
 }
 
-#[test]
-fn insert_1024_random_deterministic_merkle_proof() {
+#[apply(opts::tpl_all_opts_noop)]
+fn insert_1024_random_deterministic_merkle_proof(marf_opts: &MARFOpenOpts) {
     // deterministic random insert of 1024 keys
     let mut seed = TrieHash::EMPTY.as_bytes().to_vec();
 
-    insert_n_test(
-        "/tmp/rust_marf_insert_1024_random_deterministic_merkle_proof",
-        true,
-        1024,
-        |i| {
-            let mut path = [0; 32];
-            path.copy_from_slice(
-                &TrieHash::from_data(if i == 0 { &[] } else { seed.as_slice() }).as_bytes()[0..32],
-            );
-            seed = path.to_vec();
-            eprintln!("{}", to_hex(&path));
-            path
-        },
-    )
+    insert_n_test(marf_opts, true, 1024, |i| {
+        let mut path = [0; 32];
+        path.copy_from_slice(
+            &TrieHash::from_data(if i == 0 { &[] } else { seed.as_slice() }).as_bytes()[0..32],
+        );
+        seed = path.to_vec();
+        eprintln!("{}", to_hex(&path));
+        path
+    })
 }


### PR DESCRIPTION
### Description

This patch refactor `trie.rs` tests to use `rstest`. 
It is a follow-up work from marf compression PRs.

NOTE: the diff noise in `test/trie.rs` comes from whitespace and indentation changes after removing some internal test loops (in favor of `rstest` mechanism), no functional changes have been introduced. That noise could be significantly reduced configuring Git/GitHub to ignore/hide whitespace differences. 

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
