### PR TITLE
ci: [TEST] use larger runners for compilation-heavy jobs

### DIFF
--- a/.github/workflows/cargo-hack-check.yml
+++ b/.github/workflows/cargo-hack-check.yml
@@ -30,7 +30,7 @@ jobs:
   # Native targets (Windows/Linux)
   native-targets:
     name: All Crates (Windows/Linux)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: setup
     steps:
       - name: Checkout

--- a/.github/workflows/constants-check.yml
+++ b/.github/workflows/constants-check.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-consts:
     name: Check the constants from stacks-inspect
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     defaults:
       run:
         shell: bash

--- a/.github/workflows/create-cache.yml
+++ b/.github/workflows/create-cache.yml
@@ -49,7 +49,7 @@ jobs:
   ## Cache nextest archives for tests
   nextest-archive:
     name: Test Archive
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs:
       - cargo
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ lto = "thin"
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
+


### PR DESCRIPTION
## DO NOT MERGE — Test PR for CI timing validation

This PR exists solely to validate the impact of larger runners on CI compilation jobs.
It cannot be tested on a personal fork because `ubuntu-latest-m` runners are only
available on org accounts with GitHub Team/Enterprise plans.

**This PR will be closed after timing data is collected.**

---

## What
Switch three compilation-heavy CI jobs from `ubuntu-latest` (2 vCPU, 7GB RAM) to
`ubuntu-latest-m` (4 vCPU, 16GB RAM).

## Why
Rust compilation is CPU-bound. These three jobs are the longest-running compilation tasks:
- nextest-archive: **15m33s** (median) — builds all test binaries
- cargo-hack native-targets: **13m14s** — checks feature combinations
- constants-check: **4m10s** — compiles stacks-inspect from scratch

The release workflow (`release-build.yml`) already uses `ubuntu-latest-m`, confirming
these runners are available to the org.

## The Change
One word change in each of 3 files (`ubuntu-latest` → `ubuntu-latest-m`):
- `.github/workflows/create-cache.yml`: nextest-archive job
- `.github/workflows/cargo-hack-check.yml`: native-targets job
- `.github/workflows/constants-check.yml`: check-consts job

**3 lines changed across 3 files.** Other jobs untouched.

## Metrics to Collect
| Job | Baseline | Expected |
|-----|----------|----------|
| nextest-archive | 15m33s | ~8-10m |
| native-targets | 13m14s | ~7-8m |
| check-consts | 4m10s | ~2-3m |

## Security Checklist
- [x] No new permissions
- [x] No secrets exposure
- [x] Same GitHub-hosted runner images, just more resources
- [x] Release workflow already uses ubuntu-latest-m