### PR TITLE
Add tests for the tenure parent check fix

### DIFF
--- a/changelog.d/tests-for-parent-ch.added
+++ b/changelog.d/tests-for-parent-ch.added
@@ -1,0 +1,1 @@
+Add tests for handling of bad block commits (vtxindex=0, wrong parent).

--- a/stacks-node/src/nakamoto_node/relayer.rs
+++ b/stacks-node/src/nakamoto_node/relayer.rs
@@ -1209,7 +1209,7 @@ impl RelayerThread {
             .get_active()
             .ok_or_else(|| NakamotoNodeError::NoVRFKeyActive)?;
 
-        let commit = LeaderBlockCommitOp {
+        let mut commit = LeaderBlockCommitOp {
             // NOTE: to be filled in
             treatment: vec![],
             // NOTE: PoX sunset has been disabled prior to taking effect
@@ -1242,6 +1242,43 @@ impl RelayerThread {
             block_height: 0,
             burn_header_hash: BurnchainHeaderHash::zero(),
         };
+
+        if std::env::var("FAULT_INJECTION_BLOCK_COMMIT_VTXINDEX_SENTINEL") == Ok("1".to_string()) {
+            info!("Zeroing parent_vtxindex");
+            commit.parent_vtxindex = 0;
+        }
+
+        if std::env::var("FAULT_INJECTION_BLOCK_COMMIT_PARENT_SENTINEL") == Ok("1".to_string()) {
+            info!("Altering parent_block_ptr");
+            commit.parent_block_ptr = commit.parent_block_ptr.saturating_sub(1);
+
+            let parent_tenure_tip_id = highest_tenure_start_block_header
+                .anchored_header
+                .as_stacks_nakamoto()
+                .unwrap()
+                .parent_block_id
+                .clone();
+
+            let parent_tenure_tip =
+                NakamotoChainState::get_block_header(&self.chainstate.db(), &parent_tenure_tip_id)
+                    .unwrap()
+                    .unwrap();
+
+            let parent_tip_vrf_proof = NakamotoChainState::get_block_vrf_proof(
+                &mut self.chainstate.index_conn(),
+                &stacks_tip,
+                &parent_tenure_tip.consensus_hash,
+            )
+            .unwrap()
+            .unwrap();
+
+            info!(
+                "Altering new_seed from {} to {}",
+                &commit.new_seed,
+                &VRFSeed::from_proof(&parent_tip_vrf_proof)
+            );
+            commit.new_seed = VRFSeed::from_proof(&parent_tip_vrf_proof);
+        }
 
         Ok(LastCommit::new(
             commit,

--- a/stacks-node/src/tests/signer/mod.rs
+++ b/stacks-node/src/tests/signer/mod.rs
@@ -609,9 +609,9 @@ impl<Z: SpawnedSignerTrait> SignerTest<Z> {
         info!("Latest sortition: {sortition_latest:?}");
         info!("Prior sortition: {sortition_prior:?}");
 
-        assert_eq!(
-            sortition_latest.last_sortition_ch,
-            sortition_latest.stacks_parent_ch
+        assert!(
+            std::env::var("FAULT_INJECTION_BLOCK_COMMIT_PARENT_SENTINEL") == Ok("1".to_string())
+                || sortition_latest.last_sortition_ch == sortition_latest.stacks_parent_ch
         );
         let latest_block = self
             .stacks_client
@@ -646,9 +646,13 @@ impl<Z: SpawnedSignerTrait> SignerTest<Z> {
                     panic!();
                 };
                 assert_eq!(Some(current_miner_pkh), sortition_latest.miner_pk_hash160);
-                assert_eq!(parent_tenure_id, sortition_prior.consensus_hash);
-                assert_eq!(parent_tenure_last_block, latest_block_id);
-                assert_eq!(parent_tenure_last_block_height, latest_block.height());
+                if std::env::var("FAULT_INJECTION_BLOCK_COMMIT_PARENT_SENTINEL")
+                    != Ok("1".to_string())
+                {
+                    assert_eq!(parent_tenure_id, sortition_prior.consensus_hash);
+                    assert_eq!(parent_tenure_last_block, latest_block_id);
+                    assert_eq!(parent_tenure_last_block_height, latest_block.height());
+                }
             });
     }
 

--- a/stacks-node/src/tests/signer/v0/mod.rs
+++ b/stacks-node/src/tests/signer/v0/mod.rs
@@ -8341,18 +8341,153 @@ fn test_vtxindex_zero_acceptance() {
 
     // Wait for signers to reject the block with InvalidParentBlock
     wait_for(30, || {
-        let found = get_stackerdb_signer_messages()
-            .into_iter()
-            .any(|(_chunk, message)| {
-                matches!(
-                    &message,
-                    SignerMessage::BlockResponse(BlockResponse::Rejected(rejection))
-                        if rejection.response_data.reject_reason == RejectReason::InvalidParentBlock
-                )
-            });
-        Ok(found)
+        let chunks = test_observer::get_stackerdb_chunks();
+        for chunk in chunks.into_iter().flat_map(|chunk| chunk.modified_slots) {
+            let Ok(message) = SignerMessage::consensus_deserialize(&mut chunk.data.as_slice())
+            else {
+                continue;
+            };
+            if let SignerMessage::BlockResponse(BlockResponse::Rejected(rejection)) = &message {
+                if rejection.response_data.reject_reason == RejectReason::InvalidParentBlock {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
     })
     .expect("Expected block to be rejected with InvalidParentBlock");
 
     signer_test.shutdown();
+}
+
+/// Test that when one miner wins a sortition with a bad block commit (vtxindex=0, wrong parent),
+/// signers reject that miner's proposals and the previous miner continues via tenure extend.
+#[test]
+fn test_vtxindex_zero_two_miners() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    info!("------------------------- Test Setup -------------------------");
+    let num_signers = 5;
+
+    let block_proposal_timeout = Duration::from_secs(10);
+    let tenure_extend_wait_timeout = block_proposal_timeout;
+
+    let mut miners = MultipleMinerTest::new_with_config_modifications(
+        num_signers,
+        0,
+        |signer_config| {
+            signer_config.block_proposal_timeout = block_proposal_timeout;
+        },
+        |config| {
+            config.miner.tenure_extend_wait_timeout = tenure_extend_wait_timeout;
+            config.miner.block_commit_delay = Duration::from_secs(0);
+        },
+        |config| {
+            config.miner.block_commit_delay = Duration::from_secs(0);
+        },
+    );
+
+    let (conf_1, _conf_2) = miners.get_node_configs();
+    let (mining_pkh_1, _mining_pkh_2) = miners.get_miner_public_key_hashes();
+
+    // Pause miner 2 before boot so miner 1 wins initial sortitions.
+    miners.pause_commits_miner_2();
+    miners.boot_to_epoch_3();
+
+    let sortdb = conf_1.get_burnchain().open_sortition_db(true).unwrap();
+    let epoch_34_height =
+        conf_1.burnchain.epochs.as_ref().unwrap()[StacksEpochId::Epoch34].start_height;
+
+    info!("------------------------- Mine to 3.4 start height -------------------------");
+    miners.signer_test.run_until_burnchain_height_nakamoto(
+        Duration::from_secs(60),
+        epoch_34_height,
+        num_signers,
+    );
+
+    info!("------------------------- Miner 1 mines a normal tenure -------------------------");
+    // Pause miner 1 too so we can control commits precisely
+    miners.pause_commits_miner_1();
+
+    miners
+        .mine_bitcoin_block_and_tenure_change_tx(&sortdb, TenureChangeCause::BlockFound, 60)
+        .expect("Miner 1 should mine a normal tenure");
+    verify_sortition_winner(&sortdb, &mining_pkh_1);
+    let stacks_height_before = miners.get_peer_stacks_tip_height();
+
+    info!("------------------------- Miner 2 submits bad commit -------------------------");
+    // Enable fault injection BEFORE miner 2 submits its commit.
+    // Miner 1's commits are already paused so it won't be affected.
+    std::env::set_var("FAULT_INJECTION_BLOCK_COMMIT_VTXINDEX_SENTINEL", "1");
+    std::env::set_var("FAULT_INJECTION_BLOCK_COMMIT_PARENT_SENTINEL", "1");
+
+    // Let miner 2 submit a commit (it will be bad due to fault injection)
+    miners.submit_commit_miner_2(&sortdb);
+
+    // Disable fault injection now that the bad commit is submitted
+    std::env::remove_var("FAULT_INJECTION_BLOCK_COMMIT_VTXINDEX_SENTINEL");
+    std::env::remove_var("FAULT_INJECTION_BLOCK_COMMIT_PARENT_SENTINEL");
+
+    info!("------------------------- Miner 2 wins sortition with bad commit -------------------------");
+    test_observer::clear();
+
+    // Mine a bitcoin block so miner 2's bad commit wins the sortition
+    miners
+        .mine_bitcoin_blocks_and_confirm(&sortdb, 1, 60)
+        .expect("Failed to mine bitcoin block");
+
+    info!("------------------------- Verify signers reject miner 2's proposals -------------------------");
+    // Wait for signers to reject miner 2's block with InvalidParentBlock
+    wait_for(60, || {
+        let chunks = test_observer::get_stackerdb_chunks();
+        for chunk in chunks.into_iter().flat_map(|chunk| chunk.modified_slots) {
+            let Ok(message) = SignerMessage::consensus_deserialize(&mut chunk.data.as_slice())
+            else {
+                continue;
+            };
+            if let SignerMessage::BlockResponse(BlockResponse::Rejected(rejection)) = &message {
+                if rejection.response_data.reject_reason == RejectReason::InvalidParentBlock {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    })
+    .expect("Expected miner 2's block to be rejected with InvalidParentBlock");
+
+    info!("------------------------- Verify miner 1 extends its tenure -------------------------");
+    // After the block_proposal_timeout expires, signers will accept a tenure extend
+    // from miner 1 (the previous tenure's miner) since miner 2's tenure was rejected.
+    let (mining_pk_1, _) = miners.get_miner_public_keys();
+    wait_for(tenure_extend_wait_timeout.as_secs() + 30, || {
+        Ok(miners.get_peer_stacks_tip_height() > stacks_height_before
+            && last_block_contains_tenure_change_tx(TenureChangeCause::Extended))
+    })
+    .expect("Expected miner 1 to produce a tenure extend");
+
+    // Verify the tenure extend block was actually produced by miner 1
+    let header = get_nakamoto_headers(&conf_1)
+        .into_iter()
+        .last()
+        .unwrap()
+        .anchored_header
+        .as_stacks_nakamoto()
+        .unwrap()
+        .clone();
+    mining_pk_1
+        .verify(
+            header.miner_signature_hash().as_bytes(),
+            &header.miner_signature,
+        )
+        .expect("Tenure extend block should be signed by miner 1");
+
+    info!("Chain continued successfully via tenure extend after bad miner was rejected");
+    miners.shutdown();
 }

--- a/stacks-node/src/tests/signer/v0/mod.rs
+++ b/stacks-node/src/tests/signer/v0/mod.rs
@@ -8429,7 +8429,7 @@ fn test_vtxindex_zero_two_miners() {
     std::env::set_var("FAULT_INJECTION_BLOCK_COMMIT_PARENT_SENTINEL", "1");
 
     // Let miner 2 submit a commit (it will be bad due to fault injection)
-    miners.submit_commit_miner_2(&sortdb);
+    miners.ensure_commit_miner_2(&sortdb);
 
     // Disable fault injection now that the bad commit is submitted
     std::env::remove_var("FAULT_INJECTION_BLOCK_COMMIT_VTXINDEX_SENTINEL");

--- a/stacks-node/src/tests/signer/v0/mod.rs
+++ b/stacks-node/src/tests/signer/v0/mod.rs
@@ -8300,3 +8300,59 @@ fn burn_block_payload_includes_pox_transactions() {
 
     assert_eq!(total_per_recipient, total_per_recipient_from_transactions);
 }
+
+#[test]
+fn test_vtxindex_zero_acceptance() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    info!("------------------------- Test Setup -------------------------");
+    let num_signers = 5;
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new(num_signers, vec![]);
+    let timeout = Duration::from_secs(200);
+    signer_test.boot_to_epoch_3();
+    let epoch_34_height = signer_test
+        .running_nodes
+        .conf
+        .burnchain
+        .epochs
+        .as_ref()
+        .unwrap()[StacksEpochId::Epoch34]
+        .start_height;
+
+    info!("------------------------- Mine to 3.4 start height -------------------------");
+    signer_test.run_until_burnchain_height_nakamoto(timeout, epoch_34_height, num_signers);
+
+    std::env::set_var("FAULT_INJECTION_BLOCK_COMMIT_VTXINDEX_SENTINEL", "1");
+    std::env::set_var("FAULT_INJECTION_BLOCK_COMMIT_PARENT_SENTINEL", "1");
+
+    // Mine 1 tenure successfully
+    signer_test.mine_and_verify_confirmed_naka_block(Duration::from_secs(30), num_signers, true);
+
+    // Now, the block commits will be invalid, so blocks should be rejected by the signers
+    test_observer::clear();
+    signer_test.mine_bitcoin_block();
+
+    // Wait for signers to reject the block with InvalidParentBlock
+    wait_for(30, || {
+        let found = get_stackerdb_signer_messages()
+            .into_iter()
+            .any(|(_chunk, message)| {
+                matches!(
+                    &message,
+                    SignerMessage::BlockResponse(BlockResponse::Rejected(rejection))
+                        if rejection.response_data.reject_reason == RejectReason::InvalidParentBlock
+                )
+            });
+        Ok(found)
+    })
+    .expect("Expected block to be rejected with InvalidParentBlock");
+
+    signer_test.shutdown();
+}

--- a/stacks-signer/src/chainstate/v1.rs
+++ b/stacks-signer/src/chainstate/v1.rs
@@ -460,6 +460,7 @@ impl SortitionsView {
         client: &StacksClient,
     ) -> Result<(), RejectReason> {
         // Check that the tenure change's prev_tenure matches the sortition's known parent tenure.
+        // This catches block commits with bad parent_block_ptr (e.g., vtxindex=0 exploit).
         let parent_tenure_id = &proposed_by.state().data.parent_tenure_id;
         if &tenure_change.prev_tenure_consensus_hash != parent_tenure_id {
             warn!(

--- a/stacks-signer/src/chainstate/v2.rs
+++ b/stacks-signer/src/chainstate/v2.rs
@@ -167,16 +167,6 @@ impl GlobalStateView {
         }
 
         if let Some(tenure_change) = block.get_tenure_change_tx_payload() {
-            if &tenure_change.prev_tenure_consensus_hash != parent_tenure_id {
-                warn!(
-                    "Block commit parent tenure mismatch: the block commit's parent_block_ptr does not correspond to the actual parent tenure";
-                    "committed_parent_tenure" => %parent_tenure_id,
-                    "actual_parent_tenure" => %tenure_change.prev_tenure_consensus_hash,
-                    "consensus_hash" => %block.header.consensus_hash,
-                    "signer_signature_hash" => %block.header.signer_signature_hash(),
-                );
-                return Err(RejectReason::InvalidParentBlock);
-            }
             Self::validate_tenure_change_payload(
                 tenure_change,
                 block,
@@ -315,6 +305,7 @@ impl GlobalStateView {
         config: &ProposalEvalConfig,
     ) -> Result<(), RejectReason> {
         // Check that the tenure change's prev_tenure matches the signer's known parent tenure.
+        // This catches block commits with bad parent_block_ptr (e.g., vtxindex=0 exploit).
         if &tenure_change.prev_tenure_consensus_hash != parent_tenure_id {
             warn!(
                 "Block commit parent tenure mismatch: the block commit's parent_block_ptr does not correspond to the actual parent tenure";

--- a/stacks-signer/src/chainstate/v2.rs
+++ b/stacks-signer/src/chainstate/v2.rs
@@ -167,6 +167,16 @@ impl GlobalStateView {
         }
 
         if let Some(tenure_change) = block.get_tenure_change_tx_payload() {
+            if &tenure_change.prev_tenure_consensus_hash != parent_tenure_id {
+                warn!(
+                    "Block commit parent tenure mismatch: the block commit's parent_block_ptr does not correspond to the actual parent tenure";
+                    "committed_parent_tenure" => %parent_tenure_id,
+                    "actual_parent_tenure" => %tenure_change.prev_tenure_consensus_hash,
+                    "consensus_hash" => %block.header.consensus_hash,
+                    "signer_signature_hash" => %block.header.signer_signature_hash(),
+                );
+                return Err(RejectReason::InvalidParentBlock);
+            }
             Self::validate_tenure_change_payload(
                 tenure_change,
                 block,


### PR DESCRIPTION
This fix was added in 3.4 but tests were omitted for security reasons. Now that all nodes must be updated, we can push the tests.