### PR TITLE
test: allow sub-second poll time

### DIFF
--- a/changelog.d/poll_time_secs.changed
+++ b/changelog.d/poll_time_secs.changed
@@ -1,0 +1,1 @@
+Set `poll_time_secs` in integration test configuration to `0` to speedup tests.

--- a/stacks-node/src/run_loop/nakamoto.rs
+++ b/stacks-node/src/run_loop/nakamoto.rs
@@ -33,7 +33,7 @@ use stacks::core::StacksEpochId;
 use stacks::net::atlas::{AtlasConfig, AtlasDB, Attachment};
 use stacks_common::types::PublicKey;
 use stacks_common::util::hash::Hash160;
-use stacks_common::util::{get_epoch_time_secs, sleep_ms};
+use stacks_common::util::{get_epoch_time_ms, sleep_ms};
 use stx_genesis::GenesisData;
 
 use crate::burnchains::make_bitcoin_indexer;
@@ -526,7 +526,7 @@ impl RunLoop {
         debug!("Runloop: Begin main runloop starting a burnchain block {sortition_db_height}");
 
         let mut last_tenure_sortition_height = 0;
-        let mut poll_deadline = 0;
+        let mut poll_deadline: u128 = 0;
 
         loop {
             if !globals.keep_running() {
@@ -585,11 +585,14 @@ impl RunLoop {
                     break;
                 }
 
-                if poll_deadline > get_epoch_time_secs() {
-                    sleep_ms(1_000);
+                let now_ms = get_epoch_time_ms();
+                if poll_deadline > now_ms {
+                    let remaining = (poll_deadline - now_ms) as u64;
+                    sleep_ms(remaining.min(1_000));
                     continue;
                 }
-                poll_deadline = get_epoch_time_secs() + self.config().burnchain.poll_time_secs;
+                poll_deadline =
+                    now_ms + u128::from(self.config().burnchain.effective_poll_time_ms());
 
                 let (next_burnchain_tip, tip_burnchain_height) =
                     match burnchain.sync(Some(target_burnchain_block_height)) {

--- a/stacks-node/src/syncctl.rs
+++ b/stacks-node/src/syncctl.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use stacks::burnchains::{Burnchain, Error as burnchain_error};
-use stacks_common::util::{get_epoch_time_secs, sleep_ms};
+use stacks_common::util::{get_epoch_time_ms, sleep_ms};
 
 use crate::burnchains::BurnchainTip;
 use crate::Config;
@@ -64,10 +64,10 @@ impl PoxSyncWatchdogComms {
         self.last_ibd.load(Ordering::SeqCst)
     }
 
-    fn interruptable_sleep(&self, secs: u64) -> Result<(), burnchain_error> {
-        let deadline = secs + get_epoch_time_secs();
-        while get_epoch_time_secs() < deadline {
-            sleep_ms(1000);
+    fn interruptable_sleep(&self, millis: u64) -> Result<(), burnchain_error> {
+        let deadline = u128::from(millis) + get_epoch_time_ms();
+        while get_epoch_time_ms() < deadline {
+            sleep_ms(millis.min(1_000));
             if !self.should_keep_running() {
                 return Err(burnchain_error::CoordinatorClosed);
             }
@@ -101,7 +101,7 @@ impl PoxSyncWatchdogComms {
 /// unless it's reasonably sure that it has processed all Stacks blocks for this reward cycle.
 /// This struct monitors the Stacks chainstate to make this determination.
 pub struct PoxSyncWatchdog {
-    /// time between burnchain syncs in steady state
+    /// time between burnchain syncs in steady state, in milliseconds
     steady_state_burnchain_sync_interval: u64,
     /// handle to relayer thread that informs the watchdog when the P2P state-machine does stuff
     relayer_comms: PoxSyncWatchdogComms,
@@ -114,7 +114,7 @@ impl PoxSyncWatchdog {
         config: &Config,
         watchdog_comms: PoxSyncWatchdogComms,
     ) -> Result<PoxSyncWatchdog, String> {
-        let burnchain_poll_time = config.burnchain.poll_time_secs;
+        let burnchain_poll_time = config.burnchain.effective_poll_time_ms();
         let unconditionally_download = config.node.pox_sync_sample_secs == 0;
 
         Ok(PoxSyncWatchdog {

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -722,7 +722,7 @@ pub fn naka_neon_integration_conf(seed: Option<&[u8]>) -> (Config, StacksAddress
     }
 
     conf.burnchain.magic_bytes = MagicBytes::from([b'T', b'3'].as_ref());
-    conf.burnchain.poll_time_secs = 0;
+    conf.burnchain.poll_time_ms = Some(100);
     conf.node.pox_sync_sample_secs = 0;
 
     conf.miner.first_attempt_time_ms = i64::MAX as u64;

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -722,7 +722,7 @@ pub fn naka_neon_integration_conf(seed: Option<&[u8]>) -> (Config, StacksAddress
     }
 
     conf.burnchain.magic_bytes = MagicBytes::from([b'T', b'3'].as_ref());
-    conf.burnchain.poll_time_secs = 1;
+    conf.burnchain.poll_time_secs = 0;
     conf.node.pox_sync_sample_secs = 0;
 
     conf.miner.first_attempt_time_ms = i64::MAX as u64;

--- a/stacks-node/src/tests/neon_integrations.rs
+++ b/stacks-node/src/tests/neon_integrations.rs
@@ -161,7 +161,7 @@ fn inner_neon_integration_test_conf(seed: Option<Vec<u8>>) -> (Config, StacksAdd
         .magic_bytes;
     assert_eq!(magic_bytes.as_bytes(), b"T2");
     conf.burnchain.magic_bytes = magic_bytes;
-    conf.burnchain.poll_time_secs = 0;
+    conf.burnchain.poll_time_ms = Some(100);
     conf.node.pox_sync_sample_secs = 0;
 
     conf.miner.first_attempt_time_ms = i64::MAX as u64;

--- a/stacks-node/src/tests/neon_integrations.rs
+++ b/stacks-node/src/tests/neon_integrations.rs
@@ -161,7 +161,7 @@ fn inner_neon_integration_test_conf(seed: Option<Vec<u8>>) -> (Config, StacksAdd
         .magic_bytes;
     assert_eq!(magic_bytes.as_bytes(), b"T2");
     conf.burnchain.magic_bytes = magic_bytes;
-    conf.burnchain.poll_time_secs = 1;
+    conf.burnchain.poll_time_secs = 0;
     conf.node.pox_sync_sample_secs = 0;
 
     conf.miner.first_attempt_time_ms = i64::MAX as u64;

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -1417,10 +1417,21 @@ pub struct BurnchainConfig {
     /// The default value of 10 seconds is mainly intended for testing purposes.
     /// It's suggested to set this to a higher value for mainnet, e.g., 300 seconds
     /// (5 minutes).
+    ///
+    /// If [`BurnchainConfig::poll_time_ms`] is set, it takes priority over this field.
     /// ---
     /// @default: `10`
     /// @units: seconds
     pub poll_time_secs: u64,
+    /// The interval, in milliseconds, at which the node polls the bitcoin node for
+    /// new blocks and state updates.
+    ///
+    /// When set, this takes priority over [`BurnchainConfig::poll_time_secs`],
+    /// allowing sub-second poll intervals (e.g. 100 ms for integration tests).
+    /// ---
+    /// @default: `None`
+    /// @units: milliseconds
+    pub poll_time_ms: Option<u64>,
     /// The default fee rate in sats/vByte to use when estimating fees for miners
     /// to submit bitcoin transactions (like block commits or leader key registrations).
     /// ---
@@ -1647,6 +1658,7 @@ impl BurnchainConfig {
             local_mining_public_key: None,
             process_exit_at_block_height: None,
             poll_time_secs: 10, // TODO: this is a testnet specific value.
+            poll_time_ms: None,
             satoshis_per_byte: DEFAULT_SATS_PER_VB,
             max_rbf: DEFAULT_MAX_RBF_RATE,
             leader_key_tx_estimated_size: OP_TX_LEADER_KEY_ESTIM_SIZE,
@@ -1700,6 +1712,14 @@ impl BurnchainConfig {
     pub fn get_epoch_list(&self) -> EpochList<ExecutionCost> {
         StacksEpoch::get_epochs(self.get_bitcoin_network().1, self.epochs.as_ref())
     }
+
+    /// Returns the effective poll interval in milliseconds.
+    /// If `poll_time_ms` is set, it takes priority; otherwise falls back to
+    /// `poll_time_secs * 1000`.
+    pub fn effective_poll_time_ms(&self) -> u64 {
+        self.poll_time_ms
+            .unwrap_or(self.poll_time_secs.saturating_mul(1000))
+    }
 }
 
 #[derive(Clone, Deserialize, Default, Debug)]
@@ -1744,6 +1764,7 @@ pub struct BurnchainConfigFile {
     pub local_mining_public_key: Option<String>,
     pub process_exit_at_block_height: Option<u64>,
     pub poll_time_secs: Option<u64>,
+    pub poll_time_ms: Option<u64>,
     pub satoshis_per_byte: Option<u64>,
     pub leader_key_tx_estimated_size: Option<u64>,
     pub block_commit_tx_estimated_size: Option<u64>,
@@ -1857,6 +1878,7 @@ impl BurnchainConfigFile {
             poll_time_secs: self
                 .poll_time_secs
                 .unwrap_or(default_burnchain_config.poll_time_secs),
+            poll_time_ms: self.poll_time_ms.or(default_burnchain_config.poll_time_ms),
             satoshis_per_byte: self
                 .satoshis_per_byte
                 .unwrap_or(default_burnchain_config.satoshis_per_byte),


### PR DESCRIPTION
~~I don't think there is any downside to setting this to zero for tests and it should give us some speedup.~~

Zero does not allow enough time for other threads. The second commit here allows sub-second poll time and defaults to 100ms.