### PR TITLE
Update Coveralls upload action to not fail on error, because transient errors sometimes occur and don't need to be addressed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,5 +369,5 @@ jobs:
         with:
           file: ${{ env.REPORT_FILES_DIR }}/code-coverage-report.${{ env.REPORT_FILES_EXT }}
           compare-ref: ${{ github.base_ref }} # defaults to master if this isn't supplied
-          fail-on-error: true
+          fail-on-error: false # If this GitHub step is rerun for the same job #, Coveralls will report an error that the job is closed. Don't fail CI for that case.
       


### PR DESCRIPTION
### Description

If GitHub CI is re-run manually for the same job #, Coveralls will report an error:

```
📄 Using coverage file: code_coverage_files/code-coverage-report.info
🚀 Posting coverage data to https://coveralls.io/api/v1/jobs
---
Error: Unprocessable Entity
Response: {"message":"Can't add a job to a build that is already closed. Build 24445181804 is closed. See docs.coveralls.io/parallel-builds","error":true}
---
```

This is a transient error that does not need to be addressed, and also the only error we've seen so far from the Coveralls upload step. So let's not fail the CI on error so that we can keep a green pipeline and Coveralls does not introduce flakiness.

### Applicable issues

- N/A

### Additional info (benefits, drawbacks, caveats)

It's possible this means Coveralls could silently fail to upload a report, but to-date we've never seen that behavior.

### Checklist

- N/A
