### PR TITLE
Specify Coveralls build-number as composite of job number and run number to avoid 'job already closed' errors on repeated CI job runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,5 +369,6 @@ jobs:
         with:
           file: ${{ env.REPORT_FILES_DIR }}/code-coverage-report.${{ env.REPORT_FILES_EXT }}
           compare-ref: ${{ github.base_ref }} # defaults to master if this isn't supplied
+          build-number: ${{ github.run_id }}-${{ github.run_attempt }} # include run attempt in build so that repeated CI job runs don't cause a "job already closed" error on upload
           fail-on-error: true
       


### PR DESCRIPTION
### Description

If GitHub CI is re-run manually for the same job #, Coveralls will report an error:

```
📄 Using coverage file: code_coverage_files/code-coverage-report.info
🚀 Posting coverage data to https://coveralls.io/api/v1/jobs
---
Error: Unprocessable Entity
Response: {"message":"Can't add a job to a build that is already closed. Build 24445181804 is closed. See docs.coveralls.io/parallel-builds","error":true}
---
```

So now we specify a custom build # for Coveralls that includes both the job number and the run attempt, to avoid this issue for repeated CI runs of the same job.

### Applicable issues

- N/A

### Additional info (benefits, drawbacks, caveats)

- N/A

### Checklist

- N/A
