### PR TITLE
fix: apply_evaluted with special functions

### DIFF
--- a/changelog.d/7160-fix-apply-evaluated.fixed
+++ b/changelog.d/7160-fix-apply-evaluated.fixed
@@ -1,0 +1,1 @@
+Improved performance for `fold`, `map`, and `filter` Clarity functions

--- a/clarity/src/vm/functions/sequences.rs
+++ b/clarity/src/vm/functions/sequences.rs
@@ -89,8 +89,13 @@ pub fn special_filter(
             sequence = Value::Sequence(
                 sequence_data
                     .try_retain(&mut |value: Value| -> Result<bool, VmExecutionError> {
-                        let filter_eval =
-                            apply_evaluated(&function, vec![value], exec_state, invoke_ctx)?;
+                        let filter_eval = apply_evaluated(
+                            &function,
+                            vec![value],
+                            exec_state,
+                            invoke_ctx,
+                            context,
+                        )?;
                         if let Value::Bool(include) = filter_eval {
                             Ok(include)
                         } else {
@@ -163,7 +168,13 @@ pub fn special_fold(
         let element = element_result.map_err(|_| {
             VmInternalError::Expect("ERROR: Invalid sequence data successfully constructed".into())
         })?;
-        acc = apply_evaluated(&function, vec![element, acc], exec_state, invoke_ctx)?;
+        acc = apply_evaluated(
+            &function,
+            vec![element, acc],
+            exec_state,
+            invoke_ctx,
+            context,
+        )?;
     }
     Ok(acc)
 }
@@ -239,7 +250,7 @@ pub fn special_map(
         } else {
             previous_len = Some(arguments.len());
         }
-        let res = apply_evaluated(&function, arguments, exec_state, invoke_ctx)?;
+        let res = apply_evaluated(&function, arguments, exec_state, invoke_ctx, context)?;
         mapped_results.push(res);
     }
 

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -414,24 +414,39 @@ pub fn apply(
 /// Like [`apply`], but takes pre-evaluated [`Value`]s, skipping the `eval` + `clone_with_cost`
 /// round-trip for every argument.
 ///
-/// `fold` and `map` already have the element value and accumulator as owned `Value`s; wrapping
+/// `fold`, `map`, and `filter` already have the element values as owned `Value`s; wrapping
 /// them in `SymbolicExpression::atom_value` just to have `eval` clone them back out wastes N
 /// allocations per step.  This function performs the same recursion/stack/memory bookkeeping
 /// as `apply` while bypassing the eval pass entirely.
+///
+/// For [`CallableType::SpecialFunction`]s (e.g. comparison operators `>=`, `<=`, `<`, `>`,
+/// or boolean operators `and`, `or`), the values are wrapped back into
+/// `SymbolicExpression::atom_value` so the special function can evaluate them normally
+/// with `eval`.
 pub fn apply_evaluated(
     function: &CallableType,
     args: Vec<Value>,
     exec_state: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
+    context: &LocalContext,
 ) -> Result<Value, VmExecutionError> {
     let (identifier, track_recursion) = check_call_preconditions(function, exec_state)?;
-    // SpecialFunctions require unevaluated SymbolicExpressions. They cannot appear as
-    // fold/map step functions after type-checking, so this branch is unreachable in practice.
-    if matches!(function, CallableType::SpecialFunction(..)) {
-        return Err(VmInternalError::Expect(
-            "apply_evaluated: SpecialFunction cannot receive pre-evaluated args".into(),
-        )
-        .into());
+
+    // SpecialFunctions require unevaluated SymbolicExpressions. They evaluate their own
+    // arguments (e.g. short-circuit in `and`/`or`). Wrap the pre-evaluated Values back
+    // into atom_value expressions so the special function dispatch works correctly.
+    // This path is hit when built-in operators like >=, <=, <, >, and, or are used as
+    // step functions in fold/map/filter. Note: In this case it works like `apply`.
+    if let CallableType::SpecialFunction(_, function) = function {
+        let sym_args: Vec<SymbolicExpression> = args
+            .into_iter()
+            .map(SymbolicExpression::atom_value)
+            .collect();
+        exec_state.call_stack.insert(&identifier, track_recursion);
+        let mut resp = function(&sym_args, exec_state, invoke_ctx, context);
+        add_stack_trace(&mut resp, exec_state);
+        exec_state.call_stack.remove(&identifier, track_recursion)?;
+        return resp;
     }
 
     let mut used_memory = 0;

--- a/clarity/src/vm/tests/sequences.rs
+++ b/clarity/src/vm/tests/sequences.rs
@@ -1297,3 +1297,96 @@ fn test_expected_list_application() {
         RuntimeCheckErrorKind::Unreachable("Expected list application".to_string()).into();
     assert_eq!(e, execute(test1).unwrap_err());
 }
+
+#[test]
+fn test_map_with_special_functions() {
+    // special function: >=
+    let test = "(map >= (list 3 1 2) (list 1 2 2))";
+    let expected = Value::list_from(vec![
+        Value::Bool(true),  // (>= 3 1)
+        Value::Bool(false), // (>= 1 2)
+        Value::Bool(true),  // (>= 2 2)
+    ])
+    .unwrap();
+    assert_eq!(expected, execute(test).unwrap().unwrap());
+
+    // special function: <=
+    let test = "(map <= (list 3 1 2) (list 1 2 2))";
+    let expected = Value::list_from(vec![
+        Value::Bool(false), // (<= 3 1)
+        Value::Bool(true),  // (<= 1 2)
+        Value::Bool(true),  // (<= 2 2)
+    ])
+    .unwrap();
+    assert_eq!(expected, execute(test).unwrap().unwrap());
+
+    // special function: <
+    let test = "(map < (list 1 5 2) (list 3 3 3))";
+    let expected = Value::list_from(vec![
+        Value::Bool(true),  // (< 1 3)
+        Value::Bool(false), // (< 5 3)
+        Value::Bool(true),  // (< 2 3)
+    ])
+    .unwrap();
+    assert_eq!(expected, execute(test).unwrap().unwrap());
+
+    // special function: >
+    let test = "(map > (list 5 1 3) (list 3 3 3))";
+    let expected = Value::list_from(vec![
+        Value::Bool(true),  // (> 5 3)
+        Value::Bool(false), // (> 1 3)
+        Value::Bool(false), // (> 3 3)
+    ])
+    .unwrap();
+    assert_eq!(expected, execute(test).unwrap().unwrap());
+}
+
+#[test]
+fn test_fold_with_special_functions() {
+    // special function: and
+    //   step 1: (and true true) => true
+    //   step 2: (and false true) => false
+    let test = "(fold and (list true false) true)";
+    assert_eq!(Value::Bool(false), execute(test).unwrap().unwrap());
+
+    // special function: or
+    //   step 1: (or false false) => false
+    //   step 2: (or true false) => true
+    let test = "(fold or (list false true) false)";
+    assert_eq!(Value::Bool(true), execute(test).unwrap().unwrap());
+
+    // Comparison SpecialFunctions (>=, <=, <, >) return bool so they can't
+    // fold over multi-element lists (type mismatch after step 1). Verify
+    // they work for a single-element list where only one step executes.
+
+    // special function: >=
+    let test = "(fold >= (list 3) 1)";
+    assert_eq!(Value::Bool(true), execute(test).unwrap().unwrap());
+
+    // special function: <=
+    let test = "(fold <= (list 1) 3)";
+    assert_eq!(Value::Bool(true), execute(test).unwrap().unwrap());
+
+    // special function: <
+    let test = "(fold < (list 1) 3)";
+    assert_eq!(Value::Bool(true), execute(test).unwrap().unwrap());
+
+    // special function: >
+    let test = "(fold > (list 3) 1)";
+    assert_eq!(Value::Bool(true), execute(test).unwrap().unwrap());
+}
+
+#[test]
+fn test_filter_with_special_functions() {
+    // special function: and
+    //   keeps elements where (and elem) => true
+    let test = "(filter and (list true false true false))";
+    let expected = Value::list_from(vec![Value::Bool(true), Value::Bool(true)]).unwrap();
+    assert_eq!(expected, execute(test).unwrap().unwrap());
+
+    // special function: or
+    //   keeps elements where (or elem) => true
+    let test = "(filter or (list false true false true))";
+    let expected = Value::list_from(vec![Value::Bool(true), Value::Bool(true)]).unwrap();
+    assert_eq!(expected, execute(test).unwrap().unwrap());
+}


### PR DESCRIPTION
### Description

This patch fixes a regression introduced by #7022, where a transaction using special function for map/fold/filter operations is rejected. (NOTE: the issue is only on `develop` branch and not in production)

Here an example using a `develop` build and running a local node reported by @brice-stacks:
- failing tx: https://explorer.hiro.so/txid/0x1ba7a8060c15884f24501fe47fe1548d5a7973d106b2a0432fa5a1c3e7d4be15?chain=mainnet
- Error trace:

  ```
  Apr 16 15:27:52 obynuc stacks-node[204627]: ERRO [1776367672.567222] [stackslib/src/chainstate/stacks/db/transactions.rs:1250] [chains-coordinator:20443] Unexpected error in validating transaction: if included, this will invalidate a block, txid:                          1ba7a8060c15884f24501fe47fe1548d5a7973d106b2a0432fa5a1c3e7d4be15, origin: SP3K198T4PSVAPJT5K3060HXWEDVMKGA2S4TB0K9C, origin_nonce: 84848, contract_name: SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-oracle-v2-3, function_name: update-price-multi, function_args:      [u945272, u2, u74941299828, u100000000, (0xfeeaa01981ca5b42dd7d6eff4f20e820cd57a7a6f987197b82e50cf8664f56c900a3f0a9f7db8d6793457a041fa898f480d5148af982c5404523d53dfedb08a901                                                                                                   0x30f0f354a9a9c25ed24b866014a4f989acd42a6ec5b6070b21ba3c5c68cadb3b0db06ee316046fa460d3a911638d0b15208849c0c8f8935e7aa689e1959d22ee01 0x85c1c7dd01af158c7713c93ecc266f074bcc94115c4e3c9f501c87941708c2a04530528675832bd751f00a9fa8c736461e788badfc889136ef5577a5563ab58100)],    error: Interpreter(Internal(Expect("apply_evaluated: SpecialFunction cannot receive pre-evaluated args")))
  Apr 16 15:27:52 obynuc stacks-node[204627]: WARN [1776367672.567246] [stackslib/src/chainstate/nakamoto/mod.rs:4837] [chains-coordinator:20443] Invalid Stacks block ec2624180404b3c04b9fd97648b4a09f49036636b312b40d56b85c3695831187:                                          ClarityError(Interpreter(Internal(Expect("apply_evaluated: SpecialFunction cannot receive pre-evaluated args"))))
  Apr 16 15:27:52 obynuc stacks-node[204627]: WARN [1776367672.567766] [stackslib/src/chainstate/nakamoto/mod.rs:2093] [chains-coordinator:20443] Failed to append 154ed30b802b856298d0937b309c7022f014f2aa/ec2624180404b3c04b9fd97648b4a09f49036636b312b40d56b85c3695831187:     InvalidStacksBlock("Invalid Stacks block ec2624180404b3c04b9fd97648b4a09f49036636b312b40d56b85c3695831187: ClarityError(Interpreter(Internal(Expect(\"apply_evaluated: SpecialFunction cannot receive pre-evaluated args\"))))"), stacks_block_id:                              f47e1593a7c9b89c574fbfe08da19315540895146c0208eb7e2ed1b540b27add
  ```

Now in case of `SpecialFunction`, `apply_evaluated` behaves like `apply`, while preserving the perfs improvements when dealing with `NativeFunction` and `UserFunction`

Also added unit tests to improve coverage for `map`, `fold`, `filter` combined with special functions.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
