### PR TITLE
refactor: Make a couple fields in libsigner `pub`

### DIFF
--- a/changelog.d/libsigner-mock-signature-pub.changed
+++ b/changelog.d/libsigner-mock-signature-pub.changed
@@ -1,0 +1,1 @@
+Exposed `MockSignature::signature` field and `MockProposal::signer_signature_hash()` method as `pub` in `libsigner::v0::messages`, enabling external consumers (observer/indexer tooling) to recover signer pubkeys from mock signer messages without maintaining a local copy of these types.

--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -400,7 +400,7 @@ impl MockProposal {
     }
 
     /// The signature hash including the miner's signature. Used by signers.
-    fn signer_signature_hash(&self) -> Sha256Sum {
+    pub fn signer_signature_hash(&self) -> Sha256Sum {
         let domain_tuple =
             make_structured_data_domain("mock-signer", "1.0.0", self.peer_info.network_id);
         let data_tuple = Value::Tuple(
@@ -459,7 +459,7 @@ impl StacksMessageCodec for MockProposal {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MockSignature {
     /// The signer's signature across the mock proposal
-    signature: MessageSignature,
+    pub signature: MessageSignature,
     /// The mock block proposal that was signed across
     pub mock_proposal: MockProposal,
     /// The signature metadata


### PR DESCRIPTION
### Description

Make a couple things in libsigner `pub`

This allows us to completely remove the redundant `stacks-codec` code (2000+ lines) from Clarinet that were required in `components/observer` to recover signer pubkeys (see stx-labs/clarinet#2370)

### Applicable issues

- Follow up to #6981
- Required by stx-labs/clarinet#2370

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
