### PR TITLE
chore: improve aac test harness (step1)

### DIFF
--- a/clarity/src/vm/version.rs
+++ b/clarity/src/vm/version.rs
@@ -51,6 +51,28 @@ impl ClarityVersion {
         ClarityVersion::Clarity5,
     ];
 
+    /// Returns all [`ClarityVersion`] starting from the given `version` (inclusive)
+    #[cfg(any(test, feature = "testing"))]
+    pub fn since(version: ClarityVersion) -> &'static [ClarityVersion] {
+        let idx = Self::ALL
+            .iter()
+            .position(|&v| v == version)
+            .expect("version not found in ALL");
+
+        &Self::ALL[idx..]
+    }
+
+    /// Returns all [`ClarityVersion`] up to the given `version` (inclusive)
+    #[cfg(any(test, feature = "testing"))]
+    pub fn up_to(version: ClarityVersion) -> &'static [ClarityVersion] {
+        let idx = Self::ALL
+            .iter()
+            .position(|&v| v == version)
+            .expect("version not found in ALL");
+
+        &Self::ALL[..=idx]
+    }
+
     pub fn default_for_epoch(epoch_id: StacksEpochId) -> ClarityVersion {
         match epoch_id {
             StacksEpochId::Epoch10 => {

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -979,6 +979,22 @@ impl StacksEpochId {
 
         &Self::ALL[idx..]
     }
+
+    /// Returns all [`StacksEpochId`] from `start` to `end`, both inclusive.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn between(start: StacksEpochId, end: StacksEpochId) -> &'static [StacksEpochId] {
+        let start_idx = Self::ALL
+            .iter()
+            .position(|&e| e == start)
+            .expect("start epoch not found in ALL");
+        let end_idx = Self::ALL
+            .iter()
+            .position(|&e| e == end)
+            .expect("end epoch not found in ALL");
+        assert!(start_idx <= end_idx, "start epoch must be <= end epoch",);
+
+        &Self::ALL[start_idx..=end_idx]
+    }
 }
 
 impl std::fmt::Display for StacksEpochId {

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -991,7 +991,7 @@ impl StacksEpochId {
             .iter()
             .position(|&e| e == end)
             .expect("end epoch not found in ALL");
-        assert!(start_idx <= end_idx, "start epoch must be <= end epoch",);
+        assert!(start_idx <= end_idx, "start epoch must be <= end epoch");
 
         &Self::ALL[start_idx..=end_idx]
     }

--- a/stackslib/src/chainstate/tests/consensus.rs
+++ b/stackslib/src/chainstate/tests/consensus.rs
@@ -1072,7 +1072,10 @@ impl ContractConsensusTest<'_> {
                 supported_versions
                     .iter()
                     .any(|version| clarity_versions.contains(version)),
-                "Epoch {epoch} does not have any of the requested Clarity versions available",
+                "Epoch {epoch} does not have any of the requested Clarity versions available. \
+                 Requested: {:?}. Supported for this epoch: {:?}",
+                clarity_versions,
+                supported_versions,
             );
         }
         let min_deploy_epoch = deploy_epochs.iter().min().unwrap();

--- a/stackslib/src/chainstate/tests/consensus.rs
+++ b/stackslib/src/chainstate/tests/consensus.rs
@@ -1053,13 +1053,19 @@ impl ContractConsensusTest<'_> {
         contract_code: &str,
         function_name: &str,
         function_args: &[ClarityValue],
-        clarity_versions: &[ClarityVersion],
+        mut clarity_versions: &[ClarityVersion],
         setup_contracts: &[SetupContract],
     ) -> Self {
         assert!(
             !deploy_epochs.is_empty(),
             "At least one deploy epoch is required"
         );
+
+        // If not specified, enable all clarity versions.
+        if clarity_versions.is_empty() {
+            clarity_versions = ClarityVersion::ALL;
+        }
+
         for epoch in deploy_epochs {
             let supported_versions = clarity_versions_for_epoch(*epoch);
             assert!(

--- a/stackslib/src/chainstate/tests/consensus.rs
+++ b/stackslib/src/chainstate/tests/consensus.rs
@@ -1036,7 +1036,7 @@ impl ContractConsensusTest<'_> {
     /// * `contract_code` - Clarity source code of the contract
     /// * `function_name` - Contract function to test
     /// * `function_args` - Arguments passed to `function_name` on every call
-    /// * `exclude_clarity_versions` - List of Clarity versions to exclude from testing. For each epoch to test, at least one clarity version must be available.
+    /// * `clarity_versions` - List of Clarity versions to include in testing. For each epoch to test, at least one clarity version must be available.
     /// * `setup_contracts` - Contracts that must be deployed before epoch-specific logic runs
     ///
     /// # Panics
@@ -1053,7 +1053,7 @@ impl ContractConsensusTest<'_> {
         contract_code: &str,
         function_name: &str,
         function_args: &[ClarityValue],
-        exclude_clarity_versions: &[ClarityVersion],
+        clarity_versions: &[ClarityVersion],
         setup_contracts: &[SetupContract],
     ) -> Self {
         assert!(
@@ -1065,8 +1065,8 @@ impl ContractConsensusTest<'_> {
             assert!(
                 supported_versions
                     .iter()
-                    .any(|version| !exclude_clarity_versions.contains(version)),
-                "Epoch {epoch} does not have any Clarity versions available after applying exclusions",
+                    .any(|version| clarity_versions.contains(version)),
+                "Epoch {epoch} does not have any of the requested Clarity versions available",
             );
         }
         let min_deploy_epoch = deploy_epochs.iter().min().unwrap();
@@ -1131,15 +1131,15 @@ impl ContractConsensusTest<'_> {
 
             if deploy_epochs.contains(epoch) {
                 let clarity_versions_per_epoch = clarity_versions_for_epoch(*epoch);
-                // Exclude the clarity versions that are in the exclude_clarity_versions list.
-                let clarity_versions = clarity_versions_per_epoch
+                // Keep only the clarity versions that are in the clarity_versions include list.
+                let versions_iter = clarity_versions_per_epoch
                     .iter()
-                    .filter(|v| !exclude_clarity_versions.contains(v));
+                    .filter(|v| clarity_versions.contains(v));
 
                 let epoch_name = format!("Epoch{}", epoch.to_string().replace('.', "_"));
 
                 // Each deployment is a separate TestBlock
-                for &version in clarity_versions {
+                for &version in versions_iter {
                     let version_tag = version.to_string().replace(' ', "");
                     let name = format!("{contract_name}-{epoch_name}-{version_tag}");
                     contract_deploys_per_epoch
@@ -1600,7 +1600,7 @@ impl TestTxFactory {
 /// * `function_args` — Function arguments, provided as a slice of [`ClarityValue`].
 /// * `deploy_epochs` — *(optional)* Epochs in which to deploy the contract. Defaults to all epochs ≥ 2.0.
 /// * `call_epochs` — *(optional)* Epochs in which to call the function. Defaults to [`EPOCHS_TO_TEST`].
-/// * `exclude_clarity_versions` — *(optional)* Clarity versions to exclude from testing. For each epoch to test, at least one clarity version must be available. Defaults to an empty list (all versions tested).
+/// * `clarity_versions` — *(optional)* Clarity versions to include in testing. For each epoch to test, at least one clarity version must be available. Defaults to [`ClarityVersion::ALL`] (all versions tested).
 /// * `setup_contracts` — *(optional)* Slice of [`SetupContract`] values to deploy once before the main contract logic.
 ///
 /// # Example
@@ -1630,7 +1630,7 @@ macro_rules! contract_call_consensus_test {
         function_args: $function_args:expr,
         $(deploy_epochs: $deploy_epochs:expr,)?
         $(call_epochs: $call_epochs:expr,)?
-        $(exclude_clarity_versions: $exclude_clarity_versions:expr,)?
+        $(clarity_versions: $clarity_versions:expr,)?
         $(setup_contracts: $setup_contracts:expr,)?
     ) => {
         {
@@ -1643,8 +1643,8 @@ macro_rules! contract_call_consensus_test {
             $(let call_epochs = $call_epochs;)?
             let setup_contracts: &[$crate::chainstate::tests::consensus::SetupContract] = &[];
             $(let setup_contracts = $setup_contracts;)?
-            let exclude_clarity_versions: &[clarity::vm::ClarityVersion] = &[];
-            $(let exclude_clarity_versions = $exclude_clarity_versions;)?
+            let clarity_versions: &[clarity::vm::ClarityVersion] = clarity::vm::ClarityVersion::ALL;
+            $(let clarity_versions = $clarity_versions;)?
             let contract_test = $crate::chainstate::tests::consensus::ContractConsensusTest::new(
                 function_name!(),
                 vec![],
@@ -1654,7 +1654,7 @@ macro_rules! contract_call_consensus_test {
                 $contract_code,
                 $function_name,
                 $function_args,
-                exclude_clarity_versions,
+                clarity_versions,
                 setup_contracts,
             );
             let result = contract_test.run();
@@ -1682,7 +1682,7 @@ pub(crate) use contract_call_consensus_test;
 /// * `contract_name` — Name of the contract being tested.
 /// * `contract_code` — The Clarity source code of the contract.
 /// * `deploy_epochs` — *(optional)* Epochs in which to deploy the contract. Defaults to [`EPOCHS_TO_TEST`].
-/// * `exclude_clarity_versions` — *(optional)* Clarity versions to exclude from testing. For each epoch to test, at least one clarity version must be available. Defaults to an empty list (all versions tested).
+/// * `clarity_versions` — *(optional)* Clarity versions to include in testing. For each epoch to test, at least one clarity version must be available. Defaults to [`ClarityVersion::ALL`] (all versions tested).
 /// * `setup_contracts` — *(optional)* Slice of [`SetupContract`] values to deploy before the main contract.
 ///
 /// # Example
@@ -1702,7 +1702,7 @@ macro_rules! contract_deploy_consensus_test {
         contract_name: $contract_name:expr,
         contract_code: $contract_code:expr,
         $(deploy_epochs: $deploy_epochs:expr,)?
-        $(exclude_clarity_versions: $exclude_clarity_versions:expr,)?
+        $(clarity_versions: $clarity_versions:expr,)?
         $(setup_contracts: $setup_contracts:expr,)?
     ) => {
         {
@@ -1715,7 +1715,7 @@ macro_rules! contract_deploy_consensus_test {
                 function_args: &[],  // No function calls, just deploys
                 deploy_epochs: deploy_epochs,
                 call_epochs: &[],    // No function calls, just deploys
-                $(exclude_clarity_versions: $exclude_clarity_versions,)?
+                $(clarity_versions: $clarity_versions,)?
                 $(setup_contracts: $setup_contracts,)?
             );
         }

--- a/stackslib/src/chainstate/tests/parse_tests.rs
+++ b/stackslib/src/chainstate/tests/parse_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Stacks Open Internet Foundation
+// Copyright (C) 2025-2026 Stacks Open Internet Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -65,11 +65,17 @@ fn variant_coverage_report(variant: ParseErrorKind) {
 
         TooManyExpressions => Unreachable_ExpectLike,
         ExpressionStackDepthTooDeep { .. } => Tested(vec![
-            test_stack_depth_too_deep_case_2_list_only_parsing,
+            test_stack_depth_too_deep_case_1_tuple_only_parsing,
             test_stack_depth_too_deep_case_2_list_only_parsing,
             test_stack_depth_too_deep_case_3_list_only_checker,
+            test_stack_depth_too_deep_case_4_tuple_only_parsing_latest_limit,
+            test_stack_depth_too_deep_case_5_list_only_parsing_latest_limit,
+            test_stack_depth_too_deep_case_6_list_only_checker_latest_limit,
         ]),
-        VaryExpressionStackDepthTooDeep { .. } => Tested(vec![test_vary_stack_depth_too_deep_checker]),
+        VaryExpressionStackDepthTooDeep { .. } => Tested(vec![
+            test_vary_stack_depth_too_deep_checker,
+            test_vary_stack_depth_too_deep_checker_latest_limit
+        ]),
         FailedParsingIntValue(_) => Tested(vec![test_failed_parsing_int_value]),
         CircularReference(_) => Tested(vec![test_circular_reference]),
         NameAlreadyUsed(_) => Tested(vec![test_named_already_used]),
@@ -267,27 +273,11 @@ fn test_stack_depth_too_deep_case_3_list_only_checker() {
     );
 }
 
-/// ParserError: [`ParseErrorKind::VaryExpressionStackDepthTooDeep`]
-/// Caused by: nested contract body exceeding stack depth limit on checking vary list/tuple ast
-/// Outcome: block rejected pre-3.4, accepted 3.4+.
-#[test]
-fn test_vary_stack_depth_too_deep_checker() {
-    contract_deploy_consensus_test!(
-        contract_name: "my-contract",
-        contract_code: &{
-            let count = StackDepthLimits::for_epoch(StacksEpochId::Epoch33).max_nesting_depth() - 1;
-            let body_start = "(list ".repeat(count as usize);
-            let body_end = ")".repeat(count as usize);
-            format!("{{ a: {body_start}u1 {body_end} }}")
-        },
-    );
-}
-
 /// ParserError: [`ParseErrorKind::ExpressionStackDepthTooDeep`]
 /// Caused by: nested contract body exceeding stack depth limit on parsing tuples
 /// Outcome: block rejected
 #[test]
-fn test_stack_depth_too_deep_case_1_tuple_only_parsing_latest_limit() {
+fn test_stack_depth_too_deep_case_4_tuple_only_parsing_latest_limit() {
     contract_deploy_consensus_test!(
         contract_name: "my-contract",
         contract_code: &{
@@ -305,7 +295,7 @@ fn test_stack_depth_too_deep_case_1_tuple_only_parsing_latest_limit() {
 /// Caused by: nested contract body exceeding stack depth limit on parsing lists
 /// Outcome: block rejected
 #[test]
-fn test_stack_depth_too_deep_case_2_list_only_parsing_latest_limit() {
+fn test_stack_depth_too_deep_case_5_list_only_parsing_latest_limit() {
     contract_deploy_consensus_test!(
         contract_name: "my-contract",
         contract_code: &{
@@ -322,7 +312,7 @@ fn test_stack_depth_too_deep_case_2_list_only_parsing_latest_limit() {
 /// Caused by: nested contract body exceeding stack depth limit on checking lists ast
 /// Outcome: block rejected
 #[test]
-fn test_stack_depth_too_deep_case_3_list_only_checker_latest_limit() {
+fn test_stack_depth_too_deep_case_6_list_only_checker_latest_limit() {
     contract_deploy_consensus_test!(
         contract_name: "my-contract",
         contract_code: &{
@@ -331,6 +321,22 @@ fn test_stack_depth_too_deep_case_3_list_only_checker_latest_limit() {
             let body_start = "(list ".repeat(count as usize);
             let body_end = ")".repeat(count as usize);
             format!("{body_start}u1 {body_end}")
+        },
+    );
+}
+
+/// ParserError: [`ParseErrorKind::VaryExpressionStackDepthTooDeep`]
+/// Caused by: nested contract body exceeding stack depth limit on checking vary list/tuple ast
+/// Outcome: block rejected pre-3.4, accepted 3.4+.
+#[test]
+fn test_vary_stack_depth_too_deep_checker() {
+    contract_deploy_consensus_test!(
+        contract_name: "my-contract",
+        contract_code: &{
+            let count = StackDepthLimits::for_epoch(StacksEpochId::Epoch33).max_nesting_depth() - 1;
+            let body_start = "(list ".repeat(count as usize);
+            let body_end = ")".repeat(count as usize);
+            format!("{{ a: {body_start}u1 {body_end} }}")
         },
     );
 }

--- a/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
@@ -583,9 +583,6 @@ fn runtime_check_error_kind_type_error_ccall() {
     )
     .with_clarity_version(ClarityVersion::Clarity1); // Only works with clarity 1 or 2
 
-    let mut deploy_epochs = StacksEpochId::since(StacksEpochId::Epoch20).to_vec();
-    deploy_epochs.retain(|epoch| *epoch <= StacksEpochId::Epoch33);
-
     contract_call_consensus_test!(
         contract_name: "value-too-large",
         contract_code: "
@@ -608,7 +605,7 @@ fn runtime_check_error_kind_type_error_ccall() {
         (get-shares u999 .pool))",
         function_name: "trigger-error",
         function_args: &[],
-        deploy_epochs: &deploy_epochs,
+        deploy_epochs: StacksEpochId::between(StacksEpochId::Epoch20, StacksEpochId::Epoch33),
         call_epochs: &[StacksEpochId::Epoch33],
         setup_contracts: &[contract_1, contract_2],
     );

--- a/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
@@ -673,7 +673,7 @@ fn runtime_check_error_kind_contract_call_expect_name_cdeploy() {
             (define-constant default-target .contract-2)
 
             (contract-call? default-target ping)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2),
         setup_contracts: &[contract_1, contract_2],
     );
 }
@@ -715,7 +715,7 @@ fn runtime_check_error_kind_contract_call_expect_name_ccall() {
         function_args: &[],
         deploy_epochs: EPOCHS_TO_TEST,
         call_epochs: EPOCHS_TO_TEST,
-        exclude_clarity_versions: &[ClarityVersion::Clarity1],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2),
         setup_contracts: &[contract_1, contract_2],
     );
 }
@@ -746,7 +746,7 @@ fn runtime_check_error_kind_union_type_value_error_cdeploy() {
 
             (define-constant trigger-error
                 (foo .contract-1))",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
         setup_contracts: &[contract_1],
     );
 }
@@ -780,7 +780,7 @@ fn runtime_check_error_kind_union_type_value_error_ccall() {
         function_name: "trigger-runtime-error",
         function_args: &[],
         deploy_epochs: &StacksEpochId::since(StacksEpochId::Epoch33),
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
         setup_contracts: &[contract_1],
     );
 }
@@ -897,7 +897,7 @@ fn runtime_check_error_kind_expected_contract_principal_value_cdeploy() {
                 (as-contract?
                     ((with-ft tx-sender "token" u0))
                     true))"#,
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -917,7 +917,7 @@ fn runtime_check_error_kind_expected_contract_principal_value_ccall() {
         function_name: "trigger-error",
         function_args: &[],
         deploy_epochs: &StacksEpochId::since(StacksEpochId::Epoch33),
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1035,12 +1035,7 @@ fn runtime_check_error_kind_could_not_determine_type_ccall() {
         function_args: &[],
         deploy_epochs: &[StacksEpochId::Epoch23],
         call_epochs: &StacksEpochId::since(StacksEpochId::Epoch24),
-        exclude_clarity_versions: &[
-            ClarityVersion::Clarity1,
-            ClarityVersion::Clarity3,
-            ClarityVersion::Clarity4,
-            ClarityVersion::Clarity5
-        ],
+        clarity_versions: &[ClarityVersion::Clarity2],
         setup_contracts: &[trait_contract, trait_impl],
     );
 }
@@ -1154,7 +1149,7 @@ fn invalid_characters_detected_invalid_ascii() {
                 ;; (0x0d = string-ascii type, 0x00000003 = length 3, then invalid bytes)
                 (from-consensus-buff? (string-ascii 3) 0x0d00000003000102))
         ",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1], // Clarity1 does not support from-consensus-buff?
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2), // Clarity1 does not support from-consensus-buff?
     );
 }
 
@@ -1173,7 +1168,7 @@ fn invalid_characters_detected_invalid_utf8() {
                 ;; (0x0e = string-utf8 type, 0x00000002 = length 2, then invalid UTF-8)
                 (from-consensus-buff? (string-utf8 2) 0x0e00000002fffe))
         ",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1], // Clarity1 does not support from-consensus-buff?
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2), // Clarity1 does not support from-consensus-buff?
     );
 }
 
@@ -1189,7 +1184,7 @@ fn arithmetic_zero_n_log_n_cdeploy() {
         contract_name: "zero-n-log-n-deploy",
         contract_code: "(define-constant overflow (from-consensus-buff? int 0x))",
         deploy_epochs: &StacksEpochId::since(StacksEpochId::Epoch21),
-        exclude_clarity_versions: &[ClarityVersion::Clarity1],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2),
     );
 }
 
@@ -1210,7 +1205,7 @@ fn arithmetic_zero_n_log_n_ccall() {
         function_name: "trigger",
         function_args: &[],
         deploy_epochs: &StacksEpochId::since(StacksEpochId::Epoch21),
-        exclude_clarity_versions: &[ClarityVersion::Clarity1],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2),
     );
 }
 

--- a/stackslib/src/chainstate/tests/runtime_tests.rs
+++ b/stackslib/src/chainstate/tests/runtime_tests.rs
@@ -584,7 +584,7 @@ fn stack_depth_too_deep_call_chain_cdeploy() {
             &contract_code,
             "",
             &[],
-            &[],
+            ClarityVersion::ALL,
             &[],
         )
         .run();
@@ -871,6 +871,6 @@ fn block_time_not_available() {
         function_args: &[ClarityValue::UInt(1)],
         deploy_epochs: &[StacksEpochId::Epoch33],
         call_epochs: &[StacksEpochId::Epoch33],
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     )
 }

--- a/stackslib/src/chainstate/tests/runtime_tests.rs
+++ b/stackslib/src/chainstate/tests/runtime_tests.rs
@@ -668,9 +668,6 @@ fn stack_depth_too_deep_call_chain_ccall() {
 /// [`StaticCheckErrorKind::AtBlockUnavailable`].
 #[test]
 fn unknown_block_header_hash_fork() {
-    let mut deploy_epochs = StacksEpochId::since(StacksEpochId::Epoch20).to_vec();
-    deploy_epochs.retain(|epoch| *epoch <= StacksEpochId::Epoch33);
-
     contract_call_consensus_test!(
         contract_name: "unknown-hash",
         contract_code: "
@@ -684,7 +681,7 @@ fn unknown_block_header_hash_fork() {
 )",
         function_name: "trigger",
         function_args: &[],
-        deploy_epochs: &deploy_epochs,
+        deploy_epochs: StacksEpochId::between(StacksEpochId::Epoch20, StacksEpochId::Epoch33),
         call_epochs: &[StacksEpochId::Epoch33],
     );
 }
@@ -697,9 +694,6 @@ fn unknown_block_header_hash_fork() {
 /// [`StaticCheckErrorKind::AtBlockUnavailable`] during deployment.
 #[test]
 fn bad_block_hash() {
-    let mut deploy_epochs = StacksEpochId::since(StacksEpochId::Epoch20).to_vec();
-    deploy_epochs.retain(|epoch| *epoch <= StacksEpochId::Epoch33);
-
     contract_call_consensus_test!(
         contract_name: "bad-block-hash",
         contract_code: "
@@ -713,7 +707,7 @@ fn bad_block_hash() {
 )",
         function_name: "trigger",
         function_args: &[],
-        deploy_epochs: &deploy_epochs,
+        deploy_epochs: StacksEpochId::between(StacksEpochId::Epoch20, StacksEpochId::Epoch33),
         call_epochs: &[StacksEpochId::Epoch33],
     );
 }

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__parse_tests__stack_depth_too_deep_case_4_tuple_only_parsing_latest_limit.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__parse_tests__stack_depth_too_deep_case_4_tuple_only_parsing_latest_limit.snap
@@ -1,27 +1,26 @@
 ---
 source: stackslib/src/chainstate/tests/parse_tests.rs
 expression: result
-snapshot_kind: text
 ---
 [
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block 06463742c45fb5bd14c8dae6f3e54ed252da6c53c4f8db12971436e13f0b0f36: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block 05b05b9cbd221cffa826b5145b1ccf68e461bce7e7a53e2b66bfaf0605c567f8: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block cf25aa51caa165b19815d8c9f282230a4143add5fb579a0f77f2884656799ed2: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block fb9a9dca00b2816f38102f701d67ea698f6656244c40a9d9c40f2126f83bd463: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block 42f1f4bb9148d50a9b7615d7b68e1a3e0fdc02ab29b99a573e96da192af97954: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block 45f07125c9580bce28d0f52751af8051715a6522ab5901b3c3658e666023f588: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block e362c32cefbf2e43ef1fd34e14c4d9bda9e48064ddaee3ebb730329a301885b9: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block 05a0c2785be41a4073f0306bd828bdf988d8bf984e1f85a48282001df4f1a7c2: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "03afaf1c4b1de2218e4925f28b49e10d77231d608aa7f4b86620f4b8d605c677",
+    marf_hash: "2dff34d3a95049c8df0c6b344ae17d50f7473b2aa01722d202273358c5d40e9a",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -38,7 +37,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 25488,
+          runtime: 14850,
         ),
       ),
     ],
@@ -47,11 +46,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 25488,
+      runtime: 14850,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "c7e38a915d698843d01916d13705e5002b9606583f44c2eaaacd50cf2f7de867",
+    marf_hash: "0ded6f16f85c9c0a275d03969925875e10fc74b540f92bba59589b0c54082301",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -68,7 +67,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 25488,
+          runtime: 14850,
         ),
       ),
     ],
@@ -77,11 +76,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 25488,
+      runtime: 14850,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "998455da6b8d41fedcdaba6f4b8054e2309184477021dbb0c9ca210f95e064ef",
+    marf_hash: "75d52701c5f2d9b48f60208735623561aeb1717340d7fbe5b55e90e587ea4104",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -98,7 +97,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 25488,
+          runtime: 14850,
         ),
       ),
     ],
@@ -107,11 +106,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 25488,
+      runtime: 14850,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "4bbe1f4121abe91951f926d1e460050159dc2dc1fe560b442eb7c08fc7c7ef55",
+    marf_hash: "e5a1cd9281f1e1d45cd2be3afd2bf1a7346581b05413ac9b5fffd71ff26927f1",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -128,7 +127,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 25488,
+          runtime: 14850,
         ),
       ),
     ],
@@ -137,11 +136,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 25488,
+      runtime: 14850,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "34a4cfa7de94244544efbcd002d0f18c4aff501e00827abb242ff69769d39cd4",
+    marf_hash: "493649a81c567d96521f590cdd3f93fa9fe1e68b51b17b962271bed4f249102a",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -158,7 +157,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 25488,
+          runtime: 14850,
         ),
       ),
     ],
@@ -167,7 +166,7 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 25488,
+      runtime: 14850,
     ),
   )),
 ]

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__parse_tests__stack_depth_too_deep_case_5_list_only_parsing_latest_limit.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__parse_tests__stack_depth_too_deep_case_5_list_only_parsing_latest_limit.snap
@@ -1,27 +1,26 @@
 ---
 source: stackslib/src/chainstate/tests/parse_tests.rs
 expression: result
-snapshot_kind: text
 ---
 [
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block 05b05b9cbd221cffa826b5145b1ccf68e461bce7e7a53e2b66bfaf0605c567f8: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block 06463742c45fb5bd14c8dae6f3e54ed252da6c53c4f8db12971436e13f0b0f36: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block fb9a9dca00b2816f38102f701d67ea698f6656244c40a9d9c40f2126f83bd463: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block cf25aa51caa165b19815d8c9f282230a4143add5fb579a0f77f2884656799ed2: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block 45f07125c9580bce28d0f52751af8051715a6522ab5901b3c3658e666023f588: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block 42f1f4bb9148d50a9b7615d7b68e1a3e0fdc02ab29b99a573e96da192af97954: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Failure(ExpectedFailureOutput(
     evaluated_epoch: Epoch33,
-    error: "Invalid Stacks block 05a0c2785be41a4073f0306bd828bdf988d8bf984e1f85a48282001df4f1a7c2: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
+    error: "Invalid Stacks block e362c32cefbf2e43ef1fd34e14c4d9bda9e48064ddaee3ebb730329a301885b9: ClarityError(Parse(ParseError { err: ExpressionStackDepthTooDeep { max_depth: 64 }, pre_expressions: None, diagnostic: Diagnostic { level: Error, message: \"AST has too deep of an expression nesting. The maximum stack depth is 64\", spans: [], suggestion: None } }))",
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "2dff34d3a95049c8df0c6b344ae17d50f7473b2aa01722d202273358c5d40e9a",
+    marf_hash: "03afaf1c4b1de2218e4925f28b49e10d77231d608aa7f4b86620f4b8d605c677",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -38,7 +37,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 14850,
+          runtime: 25488,
         ),
       ),
     ],
@@ -47,11 +46,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 14850,
+      runtime: 25488,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "0ded6f16f85c9c0a275d03969925875e10fc74b540f92bba59589b0c54082301",
+    marf_hash: "c7e38a915d698843d01916d13705e5002b9606583f44c2eaaacd50cf2f7de867",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -68,7 +67,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 14850,
+          runtime: 25488,
         ),
       ),
     ],
@@ -77,11 +76,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 14850,
+      runtime: 25488,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "75d52701c5f2d9b48f60208735623561aeb1717340d7fbe5b55e90e587ea4104",
+    marf_hash: "998455da6b8d41fedcdaba6f4b8054e2309184477021dbb0c9ca210f95e064ef",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -98,7 +97,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 14850,
+          runtime: 25488,
         ),
       ),
     ],
@@ -107,11 +106,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 14850,
+      runtime: 25488,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "e5a1cd9281f1e1d45cd2be3afd2bf1a7346581b05413ac9b5fffd71ff26927f1",
+    marf_hash: "4bbe1f4121abe91951f926d1e460050159dc2dc1fe560b442eb7c08fc7c7ef55",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -128,7 +127,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 14850,
+          runtime: 25488,
         ),
       ),
     ],
@@ -137,11 +136,11 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 14850,
+      runtime: 25488,
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "493649a81c567d96521f590cdd3f93fa9fe1e68b51b17b962271bed4f249102a",
+    marf_hash: "34a4cfa7de94244544efbcd002d0f18c4aff501e00827abb242ff69769d39cd4",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -158,7 +157,7 @@ snapshot_kind: text
           write_count: 0,
           read_length: 0,
           read_count: 0,
-          runtime: 14850,
+          runtime: 25488,
         ),
       ),
     ],
@@ -167,7 +166,7 @@ snapshot_kind: text
       write_count: 0,
       read_length: 0,
       read_count: 0,
-      runtime: 14850,
+      runtime: 25488,
     ),
   )),
 ]

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__parse_tests__stack_depth_too_deep_case_6_list_only_checker_latest_limit.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__parse_tests__stack_depth_too_deep_case_6_list_only_checker_latest_limit.snap
@@ -1,7 +1,6 @@
 ---
 source: stackslib/src/chainstate/tests/parse_tests.rs
 expression: result
-snapshot_kind: text
 ---
 [
   Failure(ExpectedFailureOutput(

--- a/stackslib/src/chainstate/tests/static_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/static_analysis_tests.rs
@@ -548,7 +548,7 @@ fn static_check_error_unknown_type_name() {
         contract_code: "
         (define-public (trigger)
             (ok (from-consensus-buff? foo 0x00)))",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2),
     );
 }
 
@@ -633,7 +633,7 @@ fn static_check_error_could_not_determine_serialization_type() {
         (define-trait trait-b ((pong () (response bool bool))))
         (define-public (trigger (first <trait-a>) (second <trait-b>))
             (ok (to-consensus-buff? (list first second))))",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2),
     );
 }
 
@@ -1093,18 +1093,14 @@ fn static_check_error_bad_map_name() {
 /// StaticCheckErrorKind: [`StaticCheckErrorKind::GetBlockInfoExpectPropertyName`]
 /// Caused by: calling `get-block-info` with a non-atom property argument.
 /// Outcome: block accepted.
-/// Note: Only Clarity 1 and 2 will trigger this error. Clarity 3 and 4
+/// Note: Only Clarity 1 and 2 will trigger this error. Clarity 3+
 ///       will trigger a [`RuntimeCheckErrorKind::UnknownFunction`].
 #[test]
 fn static_check_error_get_block_info_expect_property_name() {
     contract_deploy_consensus_test!(
         contract_name: "info-exp-prop-name",
         contract_code: "(get-block-info? u1 u0)",
-        exclude_clarity_versions: &[
-            ClarityVersion::Clarity3,
-            ClarityVersion::Clarity4,
-            ClarityVersion::Clarity5
-        ],
+        clarity_versions: ClarityVersion::up_to(ClarityVersion::Clarity2),
     );
 }
 
@@ -1118,7 +1114,7 @@ fn static_check_error_get_burn_block_info_expect_property_name() {
     contract_deploy_consensus_test!(
         contract_name: "burn-exp-prop-name",
         contract_code: "(get-burn-block-info? u1 u0)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity2),
     );
 }
 
@@ -1132,7 +1128,7 @@ fn static_check_error_get_stacks_block_info_expect_property_name() {
     contract_deploy_consensus_test!(
         contract_name: "stacks-exp-prop-name",
         contract_code: "(get-stacks-block-info? u1 u0)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity3),
     );
 }
 
@@ -1146,7 +1142,7 @@ fn static_check_error_get_tenure_info_expect_property_name() {
     contract_deploy_consensus_test!(
         contract_name: "tenure-exp-prop-name",
         contract_code: "(get-tenure-info? u1 u0)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity3),
     );
 }
 
@@ -1160,7 +1156,7 @@ fn static_check_error_no_such_tenure_info_property() {
     contract_deploy_consensus_test!(
         contract_name: "no-such-tenure-info",
         contract_code: "(get-tenure-info? none u1)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity3),
     );
 }
 
@@ -1222,9 +1218,6 @@ fn static_check_error_write_attempted_in_read_only() {
 ///       contract fails earlier with `UnknownFunction("at-block")`.
 #[test]
 fn static_check_error_at_block_closure_must_be_read_only() {
-    let mut exclude_clarity_versions = ClarityVersion::ALL.to_vec();
-    exclude_clarity_versions.retain(|version| *version > ClarityVersion::Clarity4);
-
     contract_deploy_consensus_test!(
         contract_name: "closure-must-be-ro",
         contract_code: "
@@ -1232,7 +1225,7 @@ fn static_check_error_at_block_closure_must_be_read_only() {
         (define-private (foo-bar)
             (at-block (sha256 0)
                (var-set foo 0)))",
-        exclude_clarity_versions: &exclude_clarity_versions,
+        clarity_versions: ClarityVersion::up_to(ClarityVersion::Clarity4),
     );
 }
 
@@ -1243,8 +1236,6 @@ fn static_check_error_at_block_closure_must_be_read_only() {
 ///       contract fails earlier with `UnknownFunction("at-block")`.
 #[test]
 fn static_check_error_at_block_unavailable() {
-    let mut exclude_clarity_versions = ClarityVersion::ALL.to_vec();
-    exclude_clarity_versions.retain(|version| *version > ClarityVersion::Clarity4);
     contract_deploy_consensus_test!(
         contract_name: "at-block-unavailable",
         contract_code: "
@@ -1252,7 +1243,7 @@ fn static_check_error_at_block_unavailable() {
             (ok (at-block 0x0101010101010101010101010101010101010101010101010101010101010101
                     u1)))",
         deploy_epochs: &StacksEpochId::since(StacksEpochId::Epoch34),
-        exclude_clarity_versions: &exclude_clarity_versions,
+        clarity_versions: ClarityVersion::up_to(ClarityVersion::Clarity4),
     );
 }
 
@@ -1266,7 +1257,7 @@ fn static_check_error_allowance_expr_not_allowed() {
     contract_deploy_consensus_test!(
         contract_name: "allow-expr-not-allo",
         contract_code: "(with-stx u1)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1280,7 +1271,7 @@ fn static_check_error_expected_list_of_allowances() {
     contract_deploy_consensus_test!(
         contract_name: "exp-list-of-allowances",
         contract_code: "(restrict-assets? tx-sender u1 true)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1294,7 +1285,7 @@ fn static_check_error_expected_allowance_expr() {
     contract_deploy_consensus_test!(
         contract_name: "exp-allowa-expr",
         contract_code: "(restrict-assets? tx-sender ((not true)) true)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1308,7 +1299,7 @@ fn static_check_error_with_all_allowance_not_allowed() {
     contract_deploy_consensus_test!(
         contract_name: "all-allow-not-allowed",
         contract_code: "(restrict-assets? tx-sender ((with-all-assets-unsafe)) true)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1322,7 +1313,7 @@ fn static_check_error_with_all_allowance_not_alone() {
     contract_deploy_consensus_test!(
         contract_name: "all-allow-not-alone",
         contract_code: "(as-contract? ((with-all-assets-unsafe) (with-stx u1000)) true)",
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1336,7 +1327,7 @@ fn static_check_error_with_nft_expected_list_of_identifiers() {
     contract_deploy_consensus_test!(
         contract_name: "with-nft-exp-ident",
         contract_code: r#"(restrict-assets? tx-sender ((with-nft tx-sender "token-name" tx-sender)) true)"#,
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1355,7 +1346,7 @@ fn static_check_error_max_identifier_length_exceeded() {
                 .collect::<Vec<_>>()
                 .join(" ")
         ),
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 
@@ -1374,7 +1365,7 @@ fn static_check_error_too_many_allowances() {
                 .collect::<Vec<_>>()
                 .join(" ")
         ),
-        exclude_clarity_versions: &[ClarityVersion::Clarity1, ClarityVersion::Clarity2, ClarityVersion::Clarity3],
+        clarity_versions: ClarityVersion::since(ClarityVersion::Clarity4),
     );
 }
 


### PR DESCRIPTION
### Description

This PR add small improvements to the AAC test harness:
- Convert clarity version configuration from "exclusion" to "inclusion"
- Introduce utility methods to select clarity versions: `ClarityVersion::since(..)`, `ClarityVersion::up_to(..)` and refactor interested consensus tests
- Add utility method for further select epoch version: `StacksEpochId::between(..)` and refactor interested consensus tests

Futhermore, it does some housekeeping on `parse_error.rs`  tests, where some tests weren't linked to error variant coverage documentation.

NOTE: no impact on test snapshot result, except for the change related to `parse_error.rs` housekeeping where 3 tests were renamed and the related snapshot file names are changed.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
