### PR TITLE
perf: implement a tx-scoped `contract_size`-limited FIFO cache for loaded contracts

### DIFF
--- a/changelog.d/7212-per-tx-contract-caching.added
+++ b/changelog.d/7212-per-tx-contract-caching.added
@@ -1,0 +1,1 @@
+Introduced caching for contracts loaded/parsed within the context of a single Clarity transaction, reducing resource usage for many calls to the same contract.

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1151,7 +1151,7 @@ impl<'a, 'b, 'hooks> ExecutionState<'a, 'b, 'hooks> {
 
         let result = {
             let nested_view = InvocationContext {
-                contract_context: &contract.contract_context,
+                contract_context: &contract,
                 sender: invoke_ctx.sender.clone(),
                 caller: invoke_ctx.caller.clone(),
                 sponsor: invoke_ctx.sponsor.clone(),
@@ -1275,10 +1275,13 @@ impl<'a, 'b, 'hooks> ExecutionState<'a, 'b, 'hooks> {
 
         self.global_context.add_memory(contract_size)?;
 
+        // NOTE: When contract caching is used, then the memory counters here will drop the
+        // `contract_size` after the contract execution has completed, but the contracts will remain
+        // in the cache (up to the cache eviction policy's limits).
         finally_drop_memory!(self.global_context, contract_size; {
             let contract = self.global_context.database.get_contract(contract_identifier)?;
 
-            let func = contract.contract_context.lookup_function(tx_name)
+            let func = contract.lookup_function(tx_name)
                 .ok_or_else(|| { RuntimeCheckErrorKind::UndefinedFunction(tx_name.to_string()) })?;
             if !allow_private && !func.is_public() {
                 return Err(RuntimeCheckErrorKind::NoSuchPublicFunction(contract_identifier.to_string(), tx_name.to_string()).into());
@@ -1314,7 +1317,7 @@ impl<'a, 'b, 'hooks> ExecutionState<'a, 'b, 'hooks> {
                 return Err(RuntimeCheckErrorKind::CircularReference(vec![func_identifier.to_string()]).into())
             }
             self.call_stack.insert(&func_identifier, true);
-            let res = self.execute_function_as_transaction(invoke_ctx, &func, &args, Some(&contract.contract_context), allow_private);
+            let res = self.execute_function_as_transaction(invoke_ctx, &func, &args, Some(&*contract), allow_private);
             self.call_stack.remove(&func_identifier, true)?;
 
             match res {
@@ -1481,7 +1484,7 @@ impl<'a, 'b, 'hooks> ExecutionState<'a, 'b, 'hooks> {
 
         match result {
             Ok(contract) => {
-                let data_size = contract.contract_context.data_size;
+                let data_size = contract.data_size;
                 self.global_context
                     .database
                     .insert_contract(&contract_identifier, contract)?;
@@ -1869,7 +1872,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
         &mut self,
         sender: PrincipalData,
         sponsor: Option<PrincipalData>,
-        contract_context: ContractContext,
+        contract_context: &ContractContext,
         f: F,
     ) -> std::result::Result<A, E>
     where
@@ -1887,7 +1890,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
                 call_stack: &mut callstack,
             };
             let invoke_ctx = InvocationContext {
-                contract_context: &contract_context,
+                contract_context,
                 sender: Some(sender.clone()),
                 caller: Some(sender),
                 sponsor,

--- a/clarity/src/vm/contracts.rs
+++ b/clarity/src/vm/contracts.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use stacks_common::types::StacksEpochId;
+use std::ops::Deref;
+use std::sync::Arc;
 
 use crate::vm::ast::ContractAST;
 use crate::vm::contexts::{ContractContext, GlobalContext};
@@ -23,13 +24,23 @@ use crate::vm::eval_all;
 use crate::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use crate::vm::version::ClarityVersion;
 
-#[derive(Serialize, Deserialize)]
+/// A parsed, shared contract.
+// TODO: We could clean this up more; maybe rename to `SharedContract` to make the inner `Arc` more
+// explicit, move the `initialize_from_ast` logic to a constructor on `ContractContext` and locate
+// this type in the `contexts` module, etc.
+#[derive(Clone)]
 pub struct Contract {
-    pub contract_context: ContractContext,
+    contract_context: Arc<ContractContext>,
 }
 
-// AARON: this is an increasingly useless wrapper around a ContractContext struct.
-//          will probably be removed soon.
+impl Deref for Contract {
+    type Target = ContractContext;
+
+    fn deref(&self) -> &ContractContext {
+        &self.contract_context
+    }
+}
+
 impl Contract {
     pub fn initialize_from_ast(
         contract_identifier: QualifiedContractIdentifier,
@@ -49,10 +60,16 @@ impl Contract {
         )?;
 
         contract_context.is_deploying = false;
-        Ok(Contract { contract_context })
+        Ok(Contract {
+            contract_context: Arc::new(contract_context),
+        })
     }
+}
 
-    pub fn canonicalize_types(&mut self, epoch: &StacksEpochId) -> Result<(), VmExecutionError> {
-        self.contract_context.canonicalize_types(epoch)
+impl From<ContractContext> for Contract {
+    fn from(contract_context: ContractContext) -> Self {
+        Self {
+            contract_context: Arc::new(contract_context),
+        }
     }
 }

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -28,7 +28,8 @@ use stacks_common::types::StacksEpochId;
 
 use super::errors::{RuntimeCheckErrorKind, RuntimeError};
 use crate::boot_util::boot_code_id;
-use crate::vm::contexts::{ContractContext, ExecutionState, GlobalContext, InvocationContext};
+use crate::vm::contexts::{ExecutionState, GlobalContext, InvocationContext};
+use crate::vm::contracts::Contract;
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 pub use crate::vm::costs::errors::CostErrors;
 pub use crate::vm::costs::execution_cost::{CostOverflowingMath, ExecutionCost};
@@ -345,7 +346,7 @@ impl CostStateSummary {
 /// This struct holds all of the data required for non-free LimitedCostTracker instances
 pub struct TrackerData {
     cost_function_references: HashMap<&'static ClarityCostFunction, ClarityCostFunctionEvaluator>,
-    cost_contracts: HashMap<QualifiedContractIdentifier, ContractContext>,
+    cost_contracts: HashMap<QualifiedContractIdentifier, Contract>,
     contract_call_circuits:
         HashMap<(QualifiedContractIdentifier, ClarityName), ClarityCostFunctionReference>,
     total: ExecutionCost,
@@ -969,9 +970,8 @@ impl TrackerData {
                 ClarityCostFunctionReference::new(boot_costs_id.clone(), f.get_name())
             });
             if !cost_contracts.contains_key(&cost_function_ref.contract_id) {
-                let contract_context = match clarity_db.get_contract(&cost_function_ref.contract_id)
-                {
-                    Ok(contract) => contract.contract_context,
+                let contract = match clarity_db.get_contract(&cost_function_ref.contract_id) {
+                    Ok(contract) => contract,
                     Err(e) => {
                         error!("Failed to load intended Clarity cost contract";
                                "contract" => %cost_function_ref.contract_id,
@@ -982,7 +982,7 @@ impl TrackerData {
                         return Err(CostErrors::CostContractLoadFailure);
                     }
                 };
-                cost_contracts.insert(cost_function_ref.contract_id.clone(), contract_context);
+                cost_contracts.insert(cost_function_ref.contract_id.clone(), contract);
             }
 
             if cost_function_ref.contract_id == boot_costs_id {
@@ -997,8 +997,8 @@ impl TrackerData {
 
         for (_, circuit_target) in self.contract_call_circuits.iter() {
             if !cost_contracts.contains_key(&circuit_target.contract_id) {
-                let contract_context = match clarity_db.get_contract(&circuit_target.contract_id) {
-                    Ok(contract) => contract.contract_context,
+                let contract = match clarity_db.get_contract(&circuit_target.contract_id) {
+                    Ok(contract) => contract,
                     Err(e) => {
                         error!("Failed to load intended Clarity cost contract";
                                "contract" => %boot_costs_id.to_string(),
@@ -1009,7 +1009,7 @@ impl TrackerData {
                         return Err(CostErrors::CostContractLoadFailure);
                     }
                 };
-                cost_contracts.insert(circuit_target.contract_id.clone(), contract_context);
+                cost_contracts.insert(circuit_target.contract_id.clone(), contract);
             }
         }
 

--- a/clarity/src/vm/database/caching/mod.rs
+++ b/clarity/src/vm/database/caching/mod.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub use weight_limited_fifo::WeightLimitedFifo;
+
+use crate::vm::contracts::Contract;
+use crate::vm::types::QualifiedContractIdentifier;
+
+mod weight_limited_fifo;
+
+/// Default aggregate `load_cost_size` budget for the contract cache: 5 MiB.
+///
+/// ## Background
+///
+/// Estimated for a resident memory size inflation of roughly 3-5× source, so this caps worst-case
+/// parsed resident memory at ~15-25 MB per tx, which is well below the counting-allocator
+/// threshold, and above most known, realistic tx working sets.
+///
+/// The vector this limit aims to mitigate is where a malicious or buggy contract calls
+/// `contract-call?` on a large number of large, unique contracts, allowing the cache to grow
+/// without clear bounds. A transaction OOM'ing a node is largely mitigated by the counting
+/// allocator abort callback, however, and this mechanism serves as a conservative & deterministic
+/// policy for if/when costs are optimized to account for cached reads.
+pub const DEFAULT_CONTRACT_CACHE_BYTE_LIMIT: u64 = 5 * 1024 * 1024;
+/// A parsed contract and its load-cost size.
+#[derive(Clone)]
+pub struct CachedContract {
+    pub contract: Contract,
+    /// `contract_size + data_size`, the consensus-bearing [`LoadContract`][lc] cost value, also
+    /// used as the cache eviction weight.
+    ///
+    /// [lc]: crate::vm::costs::cost_functions::ClarityCostFunction::LoadContract
+    pub load_cost_size: u64,
+}
+
+/// Container for per-transaction cached data consulted during Clarity execution.
+pub struct ClarityExecutionCache {
+    /// Memoization cache for parsed contracts loaded during the transaction.
+    ///
+    /// Bounded by aggregate `load_cost_size`; entries are evicted in FIFO order when the budget
+    /// is exceeded. See the `weight_limited_fifo` module for cache mechanics and counter
+    /// semantics.
+    pub contracts: WeightLimitedFifo<QualifiedContractIdentifier, CachedContract>,
+}
+
+impl Default for ClarityExecutionCache {
+    fn default() -> Self {
+        Self {
+            contracts: WeightLimitedFifo::new(DEFAULT_CONTRACT_CACHE_BYTE_LIMIT),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vm::contexts::ContractContext;
+    use crate::vm::version::ClarityVersion;
+
+    #[test]
+    fn cached_contract_clone_shares_arc_payload() {
+        // Cloning a `CachedContract` should result in a shallow clone. Verified by deref'ing both
+        // clones through `Contract`'s `Deref` and checking pointer equality on the underlying
+        // `ContractContext`.
+        let id = QualifiedContractIdentifier::local("shared").unwrap();
+        let entry = CachedContract {
+            contract: ContractContext::new(id, ClarityVersion::Clarity4).into(),
+            load_cost_size: 0,
+        };
+        let clone = entry.clone();
+        assert!(std::ptr::eq(&*entry.contract, &*clone.contract));
+    }
+}

--- a/clarity/src/vm/database/caching/weight_limited_fifo.rs
+++ b/clarity/src/vm/database/caching/weight_limited_fifo.rs
@@ -1,0 +1,491 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+
+/// Entry in the `WeightLimitedFifo` cache, storing the value and its weight.
+struct Entry<V> {
+    value: V,
+    weight: u64,
+}
+
+/// FIFO cache bounded by the sum of per-entry weights.
+pub struct WeightLimitedFifo<K, V> {
+    /// Source of truth for membership.
+    entries: HashMap<K, Entry<V>>,
+    /// Insertion order, front = oldest. Each key appears exactly once.
+    order: VecDeque<K>,
+    total_weight: u64,
+    weight_limit: u64,
+    hits: u64,
+    misses: u64,
+}
+
+impl<K, V> WeightLimitedFifo<K, V>
+where
+    K: Eq + Hash + Clone,
+{
+    pub fn new(weight_limit: u64) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            total_weight: 0,
+            weight_limit,
+            hits: 0,
+            misses: 0,
+        }
+    }
+
+    pub fn weight_limit(&self) -> u64 {
+        self.weight_limit
+    }
+
+    pub fn total_weight(&self) -> u64 {
+        self.total_weight
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn hits(&self) -> u64 {
+        self.hits
+    }
+
+    pub fn misses(&self) -> u64 {
+        self.misses
+    }
+
+    /// Look up `key`. Updates hit/miss counters. Does not change insertion order.
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        match self.entries.get(key) {
+            Some(entry) => {
+                self.hits = self.hits.saturating_add(1);
+                Some(&entry.value)
+            }
+            None => {
+                self.misses = self.misses.saturating_add(1);
+                None
+            }
+        }
+    }
+
+    /// Look up `key` without touching counters.
+    pub fn peek(&self, key: &K) -> Option<&V> {
+        self.entries.get(key).map(|e| &e.value)
+    }
+
+    /// Insert `(key, value)` with the given `weight`. Re-insert moves the key to the back.
+    /// Returns `false` only when `weight > weight_limit`; rejection leaves the cache untouched.
+    ///
+    /// `weight == 0` is normalized to `1` so distinct zero-weight entries can't grow the cache
+    /// without bound.
+    pub fn insert(&mut self, key: K, value: V, weight: u64) -> bool {
+        let weight = weight.max(1);
+        if weight > self.weight_limit {
+            return false;
+        }
+
+        // Re-insert: drop the old entry (debit weight + remove from queue) before inserting fresh.
+        if let Some(old) = self.entries.remove(&key) {
+            self.total_weight = self.total_weight.saturating_sub(old.weight);
+            // O(n) scan; acceptable at expected cache sizes (tens of entries).
+            if let Some(pos) = self.order.iter().position(|k| k == &key) {
+                self.order.remove(pos);
+            }
+        }
+
+        // Evict from the front until the new entry fits.
+        while self.total_weight.saturating_add(weight) > self.weight_limit {
+            let Some(front_key) = self.order.pop_front() else {
+                debug_assert!(false, "non-empty queue expected: weight ≤ limit");
+                break;
+            };
+            if let Some(evicted) = self.entries.remove(&front_key) {
+                self.total_weight = self.total_weight.saturating_sub(evicted.weight);
+            }
+        }
+
+        self.order.push_back(key.clone());
+        self.entries.insert(key, Entry { value, weight });
+        self.total_weight = self.total_weight.saturating_add(weight);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_cache() {
+        let cache: WeightLimitedFifo<u32, u32> = WeightLimitedFifo::new(100);
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.total_weight(), 0);
+        assert_eq!(cache.weight_limit(), 100);
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        let mut cache: WeightLimitedFifo<u32, u32> = WeightLimitedFifo::new(100);
+        assert_eq!(cache.get(&42), None);
+    }
+
+    #[test]
+    fn insert_then_get_hits() {
+        let mut cache = WeightLimitedFifo::new(100);
+        assert!(cache.insert(1u32, 'a', 10));
+        assert_eq!(cache.get(&1), Some(&'a'));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.total_weight(), 10);
+    }
+
+    #[test]
+    fn fifo_eviction_in_insertion_order() {
+        // Budget fits exactly 3 entries of weight 10; the 4th evicts the oldest-inserted.
+        let mut cache = WeightLimitedFifo::new(30);
+        cache.insert(1u32, 'a', 10);
+        cache.insert(2, 'b', 10);
+        cache.insert(3, 'c', 10);
+        cache.insert(4, 'd', 10);
+
+        assert_eq!(cache.get(&1), None, "oldest-inserted evicted");
+        assert_eq!(cache.get(&2), Some(&'b'));
+        assert_eq!(cache.get(&3), Some(&'c'));
+        assert_eq!(cache.get(&4), Some(&'d'));
+        assert_eq!(cache.total_weight(), 30);
+    }
+
+    #[test]
+    fn get_does_not_promote() {
+        // Getting the oldest entry does not save it from the next eviction.
+        let mut cache = WeightLimitedFifo::new(30);
+        cache.insert(1u32, 'a', 10);
+        cache.insert(2, 'b', 10);
+        cache.insert(3, 'c', 10);
+
+        let _ = cache.get(&1); // no-op for ordering
+        cache.insert(4, 'd', 10); // still evicts the oldest-inserted: `1`
+
+        assert_eq!(cache.get(&1), None, "get did not promote");
+        assert_eq!(cache.get(&2), Some(&'b'));
+        assert_eq!(cache.get(&3), Some(&'c'));
+        assert_eq!(cache.get(&4), Some(&'d'));
+    }
+
+    #[test]
+    fn variable_weight_evicts_multiple_to_fit() {
+        let mut cache = WeightLimitedFifo::new(100);
+        cache.insert(1u32, 'a', 30);
+        cache.insert(2, 'b', 30);
+        cache.insert(3, 'c', 30);
+        // total = 90. Insert weight-50 entry:
+        //   90 + 50 > 100 → evict `1`, total = 60.
+        //   60 + 50 > 100 → evict `2`, total = 30.
+        //   30 + 50 ≤ 100 → stop.
+        cache.insert(4, 'd', 50);
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.get(&3), Some(&'c'));
+        assert_eq!(cache.get(&4), Some(&'d'));
+        assert_eq!(cache.total_weight(), 80);
+    }
+
+    #[test]
+    fn oversized_entry_rejected() {
+        let mut cache = WeightLimitedFifo::new(50);
+        assert!(!cache.insert(1u32, 'a', 100), "weight > limit rejected");
+        assert!(cache.is_empty());
+
+        cache.insert(2, 'b', 30);
+        assert!(!cache.insert(3, 'c', 100));
+        assert_eq!(
+            cache.get(&2),
+            Some(&'b'),
+            "rejection preserves existing entries"
+        );
+        assert_eq!(cache.total_weight(), 30);
+    }
+
+    #[test]
+    fn reinsert_same_key_moves_to_back() {
+        // After re-insert, the key is at the tail of the queue, so a subsequent eviction takes the
+        // next-oldest instead.
+        let mut cache = WeightLimitedFifo::new(30);
+        cache.insert(1u32, 'a', 10);
+        cache.insert(2, 'b', 10);
+        cache.insert(3, 'c', 10);
+        cache.insert(1, 'A', 10); // re-insert moves 1 to back; order: 2, 3, 1
+
+        cache.insert(4, 'd', 10); // evicts 2 (now the oldest), not 1
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.get(&1), Some(&'A'));
+        assert_eq!(cache.get(&3), Some(&'c'));
+        assert_eq!(cache.get(&4), Some(&'d'));
+    }
+
+    #[test]
+    fn reinsert_with_heavier_weight_evicts_others() {
+        // Replacing `1` (10 → 30) overflows the 40-budget; `2` (next oldest) gets evicted.
+        let mut cache = WeightLimitedFifo::new(40);
+        cache.insert(1u32, 'a', 10);
+        cache.insert(2, 'b', 10);
+        cache.insert(3, 'c', 10);
+        cache.insert(1, 'A', 30);
+
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.get(&1), Some(&'A'));
+        assert_eq!(cache.get(&3), Some(&'c'));
+        assert!(cache.total_weight() <= 40);
+    }
+
+    #[test]
+    fn peek_returns_value_without_changing_order() {
+        let mut cache = WeightLimitedFifo::new(30);
+        cache.insert(1u32, 'a', 10);
+        cache.insert(2, 'b', 10);
+        cache.insert(3, 'c', 10);
+
+        assert_eq!(cache.peek(&1), Some(&'a'));
+
+        cache.insert(4, 'd', 10);
+        assert_eq!(cache.get(&1), None, "peek did not move 1 in the queue");
+        assert_eq!(cache.get(&2), Some(&'b'));
+        assert_eq!(cache.get(&3), Some(&'c'));
+        assert_eq!(cache.get(&4), Some(&'d'));
+    }
+
+    #[test]
+    fn get_updates_hit_and_miss_counters() {
+        let mut cache = WeightLimitedFifo::new(100);
+        cache.insert(1u32, 'a', 10);
+
+        let _ = cache.get(&1); // hit
+        let _ = cache.get(&1); // hit
+        let _ = cache.get(&2); // miss
+        let _ = cache.get(&3); // miss
+        let _ = cache.get(&3); // miss
+
+        assert_eq!(cache.hits(), 2);
+        assert_eq!(cache.misses(), 3);
+    }
+
+    #[test]
+    fn peek_does_not_touch_counters() {
+        let mut cache = WeightLimitedFifo::new(100);
+        cache.insert(1u32, 'a', 10);
+
+        let _ = cache.peek(&1);
+        let _ = cache.peek(&2);
+        let _ = cache.peek(&1);
+
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 0);
+    }
+
+    #[test]
+    fn peek_miss_returns_none() {
+        let cache: WeightLimitedFifo<u32, char> = WeightLimitedFifo::new(10);
+        assert_eq!(cache.peek(&42), None);
+    }
+
+    #[test]
+    fn eviction_drops_payload_immediately() {
+        use std::sync::Arc;
+
+        let mut cache = WeightLimitedFifo::new(10);
+        let payload = Arc::new(vec![0u8; 1024]);
+        let weak = Arc::downgrade(&payload);
+
+        cache.insert(1u32, payload, 10);
+        assert_eq!(weak.strong_count(), 1);
+
+        cache.insert(2u32, Arc::new(vec![]), 10);
+
+        assert_eq!(
+            weak.strong_count(),
+            0,
+            "evicted payload must drop immediately",
+        );
+    }
+
+    #[test]
+    fn single_capacity_entry() {
+        let mut cache = WeightLimitedFifo::new(10);
+        cache.insert(1u32, 'a', 10);
+        assert_eq!(cache.get(&1), Some(&'a'));
+        cache.insert(2, 'b', 10);
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), Some(&'b'));
+    }
+
+    #[test]
+    fn zero_capacity_rejects_everything() {
+        let mut cache: WeightLimitedFifo<u32, char> = WeightLimitedFifo::new(0);
+        assert!(!cache.insert(1, 'a', 1));
+        assert!(!cache.insert(2, 'b', 0));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn zero_weight_is_normalized_to_one() {
+        let mut cache = WeightLimitedFifo::new(3);
+        cache.insert(1u32, 'a', 0);
+        cache.insert(2, 'b', 0);
+        cache.insert(3, 'c', 0);
+        assert_eq!(cache.total_weight(), 3, "weight-0 entries count as 1");
+
+        cache.insert(4, 'd', 0);
+        assert_eq!(cache.len(), 3);
+        assert_eq!(cache.get(&1), None, "weight-0 entries FIFO-evict normally");
+        assert_eq!(cache.get(&4), Some(&'d'));
+    }
+
+    #[test]
+    fn queue_stays_in_sync_with_entries_after_reinserts() {
+        // Repeatedly re-inserting the same key must not leave stale queue positions.
+        let mut cache = WeightLimitedFifo::new(100);
+        for _ in 0..50 {
+            cache.insert(1u32, 'a', 10);
+        }
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.order.len(), 1);
+        assert_eq!(cache.total_weight(), 10);
+    }
+}
+
+#[cfg(test)]
+mod property_tests {
+    use pinny::tag;
+    use proptest::prelude::*;
+
+    use super::*;
+
+    /// Naive Vec-based FIFO oracle: `entries[0]` is oldest, `entries[len-1]` is newest; `get` does
+    /// not move; `insert` removes prior position (if any), appends, then trims from the front until
+    /// total weight fits.
+    #[derive(Default)]
+    struct OracleFifo {
+        entries: Vec<(u32, u32, u64)>,
+        weight_limit: u64,
+    }
+
+    impl OracleFifo {
+        fn new(weight_limit: u64) -> Self {
+            Self {
+                entries: Vec::new(),
+                weight_limit,
+            }
+        }
+
+        fn total_weight(&self) -> u64 {
+            self.entries.iter().map(|(_, _, w)| *w).sum()
+        }
+
+        fn get(&self, key: u32) -> Option<u32> {
+            self.entries
+                .iter()
+                .find(|(k, _, _)| *k == key)
+                .map(|(_, v, _)| *v)
+        }
+
+        fn insert(&mut self, key: u32, value: u32, weight: u64) -> bool {
+            let weight = weight.max(1);
+            if weight > self.weight_limit {
+                return false;
+            }
+            if let Some(pos) = self.entries.iter().position(|(k, _, _)| *k == key) {
+                self.entries.remove(pos);
+            }
+            self.entries.push((key, value, weight));
+            while self.total_weight() > self.weight_limit {
+                self.entries.remove(0);
+            }
+            true
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    enum Op {
+        Get(u32),
+        Insert(u32, u32, u64),
+    }
+
+    fn arbitrary_op() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            (0..15u32).prop_map(Op::Get),
+            (0..15u32, 0..1000u32, 1..=12u64).prop_map(|(k, v, w)| Op::Insert(k, v, w)),
+        ]
+    }
+
+    #[tag(t_prop)]
+    #[test]
+    fn matches_oracle_under_random_ops() {
+        let weight_limit = 50;
+        proptest!(|(ops in prop::collection::vec(arbitrary_op(), 1..200))| {
+            let mut cache = WeightLimitedFifo::new(weight_limit);
+            let mut oracle = OracleFifo::new(weight_limit);
+
+            for op in ops {
+                match op {
+                    Op::Get(k) => {
+                        let actual = cache.get(&k).copied();
+                        let expected = oracle.get(k);
+                        prop_assert_eq!(actual, expected);
+                    }
+                    Op::Insert(k, v, w) => {
+                        let actual = cache.insert(k, v, w);
+                        let expected = oracle.insert(k, v, w);
+                        prop_assert_eq!(actual, expected);
+                    }
+                }
+                prop_assert_eq!(cache.total_weight(), oracle.total_weight());
+                prop_assert_eq!(cache.len(), oracle.entries.len());
+                prop_assert!(cache.total_weight() <= weight_limit);
+            }
+        });
+    }
+
+    #[tag(t_prop)]
+    #[test]
+    fn fifo_order_matches_oracle() {
+        let weight_limit = 30;
+        proptest!(|(ops in prop::collection::vec(arbitrary_op(), 1..150))| {
+            let mut cache = WeightLimitedFifo::new(weight_limit);
+            let mut oracle = OracleFifo::new(weight_limit);
+
+            for op in ops {
+                match op {
+                    Op::Get(k) => { let _ = cache.get(&k); let _ = oracle.get(k); }
+                    Op::Insert(k, v, w) => { cache.insert(k, v, w); oracle.insert(k, v, w); }
+                }
+            }
+
+            let oracle_keys: std::collections::HashSet<u32> =
+                oracle.entries.iter().map(|(k, _, _)| *k).collect();
+            for k in 0u32..15 {
+                let in_cache = cache.peek(&k).is_some();
+                let in_oracle = oracle_keys.contains(&k);
+                prop_assert_eq!(in_cache, in_oracle, "membership disagrees on key {}", k);
+            }
+        });
+    }
+}

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -817,9 +817,9 @@ impl<'a> ClarityDatabase<'a> {
 
     /// `LoadContract` cost size (`contract_size + data_size`).
     ///
-    /// When a cache is attached to this instance and the store isn't restargeted by e.g.
-    /// `at-block`, this method attempts to serve values via a passive cache lookup. Cache hits do
-    /// not update FIFO counters, and misses fall through to reading from the backing store.
+    /// When a cache is attached to this instance and the store isn't retargeted by e.g. `at-block`,
+    /// this method attempts to serve values via a passive cache lookup. Cache hits do not update
+    /// FIFO counters, and misses fall through to reading from the backing store.
     pub fn get_contract_size(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -903,9 +903,10 @@ impl<'a> ClarityDatabase<'a> {
         Ok(contract_context.into())
     }
 
-    /// Check for any pending metadata writes to the metadata keys used by the contract cache,
-    /// signalling that the data we just read can still be subject to rollback and thus should
-    /// not be cached.
+    /// Check for any pending metadata writes to the metadata keys used for loading/materializing a
+    /// [`Contract`] from the backing store and calculating its `LoadContract` costs.
+    ///
+    /// This is used for defensive checks in e.g. [`Self::get_contract`].
     fn has_pending_metadata_for_contract(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
@@ -946,7 +947,8 @@ impl<'a> ClarityDatabase<'a> {
 
         // Defensive check: this is not expected on the ordinary contract-call path, but we include
         // it conservatively as this is a lower-level DB API which can be reached while a rollback
-        // layer contains pending metadata.
+        // layer contains pending metadata (e.g., if the cache were ever reused across transaction
+        // boundaries).
         let is_pending = self.has_pending_metadata_for_contract(contract_identifier);
 
         // Only populate the cache on reads at tip and when there are no pending writes to relevant

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -29,8 +29,10 @@ use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum, to_hex};
 use super::clarity_store::SpecialCaseHandler;
 use super::key_value_wrapper::ValueResult;
 use crate::vm::analysis::{AnalysisDatabase, ContractAnalysis};
+use crate::vm::contexts::ContractContext;
 use crate::vm::contracts::Contract;
 use crate::vm::costs::{CostOverflowingMath, ExecutionCost};
+use crate::vm::database::caching::{CachedContract, ClarityExecutionCache};
 use crate::vm::database::structures::{
     ClarityDeserializable, ClaritySerializable, DataMapMetadata, DataVariableMetadata,
     FungibleTokenMetadata, NonFungibleTokenMetadata, STXBalance, STXBalanceSnapshot,
@@ -50,6 +52,7 @@ pub const CLARITY_STORAGE_BLOCK_TIME_KEY: &str = "_stx-data::clarity_storage::bl
 
 pub type StacksEpoch = GenericStacksEpoch<ExecutionCost>;
 
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum StoreType {
     DataMap = 0x00,
@@ -115,6 +118,16 @@ impl ContractDataVarName {
             Self::ContractDataSize => "contract-data-size",
         }
     }
+
+    pub fn metadata_key(&self) -> String {
+        ClarityDatabase::make_metadata_key(StoreType::Contract, self.as_str())
+    }
+}
+
+impl AsRef<str> for ContractDataVarName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
 }
 
 impl TryFrom<&str> for ContractDataVarName {
@@ -136,6 +149,10 @@ pub struct ClarityDatabase<'a> {
     pub store: RollbackWrapper<'a>,
     headers_db: &'a dyn HeadersDB,
     burn_state_db: &'a dyn BurnStateDB,
+    /// Optional per-tx execution-cache container attached via [`Self::with_cache`].
+    /// Exclusive borrow — the contained caches have no interior mutability, so the borrow
+    /// checker enforces single-writer for the lifetime of this database.
+    execution_cache: Option<&'a mut ClarityExecutionCache>,
 }
 
 pub trait HeadersDB {
@@ -449,6 +466,7 @@ impl<'a> ClarityDatabase<'a> {
             store: RollbackWrapper::new(store),
             headers_db,
             burn_state_db,
+            execution_cache: None,
         }
     }
 
@@ -461,7 +479,14 @@ impl<'a> ClarityDatabase<'a> {
             store,
             headers_db,
             burn_state_db,
+            execution_cache: None,
         }
+    }
+
+    /// Attach a [`ClarityExecutionCache`] to this instance for the duration of its lifetime.
+    pub fn with_cache(mut self, cache: &'a mut ClarityExecutionCache) -> Self {
+        self.execution_cache = Some(cache);
+        self
     }
 
     pub fn initialize(&mut self) {}
@@ -759,27 +784,27 @@ impl<'a> ClarityDatabase<'a> {
             .transpose()
     }
 
-    pub fn get_contract_size(
+    /// Read and sum the `contract-size` and `contract-data-size` metadata entries for the given
+    /// contract, returning the total size for the contract as needed for `LoadContract` cost
+    /// calculations.
+    ///
+    /// Reads through the rollback-aware metadata layer; does not consult or populate the cache.
+    fn read_contract_size(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
     ) -> Result<u64, VmExecutionError> {
-        let key = ClarityDatabase::make_metadata_key(
-            StoreType::Contract,
-            ContractDataVarName::ContractSize.as_str(),
-        );
-        let contract_size: u64 =
-            self.fetch_metadata(contract_identifier, &key)?
-                .ok_or_else(|| {
-                    VmInternalError::Expect(
+        let contract_size_key = ContractDataVarName::ContractSize.metadata_key();
+        let contract_size: u64 = self
+            .fetch_metadata(contract_identifier, &contract_size_key)?
+            .ok_or_else(|| {
+                VmInternalError::Expect(
             "Failed to read non-consensus contract metadata, even though contract exists in MARF."
         .into())
-                })?;
-        let key = ClarityDatabase::make_metadata_key(
-            StoreType::Contract,
-            ContractDataVarName::ContractDataSize.as_str(),
-        );
+            })?;
+
+        let data_size_key = ContractDataVarName::ContractDataSize.metadata_key();
         let data_size: u64 = self
-            .fetch_metadata(contract_identifier, &key)?
+            .fetch_metadata(contract_identifier, &data_size_key)?
             .ok_or_else(|| {
                 VmInternalError::Expect(
             "Failed to read non-consensus contract metadata, even though contract exists in MARF."
@@ -788,6 +813,24 @@ impl<'a> ClarityDatabase<'a> {
 
         // u64 overflow is _checked_ on insert into contract-data-size
         Ok(data_size + contract_size)
+    }
+
+    /// `LoadContract` cost size (`contract_size + data_size`).
+    ///
+    /// When a cache is attached to this instance and the store isn't restargeted by e.g.
+    /// `at-block`, this method attempts to serve values via a passive cache lookup. Cache hits do
+    /// not update FIFO counters, and misses fall through to reading from the backing store.
+    pub fn get_contract_size(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+    ) -> Result<u64, VmExecutionError> {
+        if !self.store.is_retargeted()
+            && let Some(cached) = self.peek_cached_contract(contract_identifier)
+        {
+            return Ok(cached.load_cost_size);
+        }
+
+        self.read_contract_size(contract_identifier)
     }
 
     /// used for adding the memory usage of `define-constant` variables.
@@ -822,11 +865,9 @@ impl<'a> ClarityDatabase<'a> {
         contract_identifier: &QualifiedContractIdentifier,
         contract: Contract,
     ) -> Result<(), VmExecutionError> {
-        let key = ClarityDatabase::make_metadata_key(
-            StoreType::Contract,
-            ContractDataVarName::Contract.as_str(),
-        );
-        self.insert_metadata(contract_identifier, &key, &contract)?;
+        let key = ContractDataVarName::Contract.metadata_key();
+
+        self.insert_metadata(contract_identifier, &key, &*contract)?;
         Ok(())
     }
 
@@ -838,20 +879,117 @@ impl<'a> ClarityDatabase<'a> {
         self.store.has_metadata_entry(contract_identifier, &key)
     }
 
+    /// Read and deserialize the contract blob from the backing store, canonicalizing its types to
+    /// the current epoch.
+    ///
+    /// Reads through the rollback-aware metadata layer; does not consult or populate the contract
+    /// cache.
+    fn read_contract(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+    ) -> Result<Contract, VmExecutionError> {
+        let contract_key = ContractDataVarName::Contract.metadata_key();
+        let mut contract_context = self
+            .fetch_metadata::<ContractContext>(contract_identifier, &contract_key)?
+            .ok_or_else(|| {
+                VmInternalError::Expect(
+            "Failed to read non-consensus contract metadata, even though contract exists in MARF."
+            .into())
+            })?;
+
+        let epoch = self.get_clarity_epoch_version()?;
+        contract_context.canonicalize_types(&epoch)?;
+
+        Ok(contract_context.into())
+    }
+
+    /// Check for any pending metadata writes to the metadata keys used by the contract cache,
+    /// signalling that the data we just read can still be subject to rollback and thus should
+    /// not be cached.
+    fn has_pending_metadata_for_contract(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+    ) -> bool {
+        let contract_key = ContractDataVarName::Contract.metadata_key();
+        let size_key = ContractDataVarName::ContractSize.metadata_key();
+        let data_size_key = ContractDataVarName::ContractDataSize.metadata_key();
+
+        self.store.has_pending_metadata(
+            contract_identifier,
+            &[&contract_key, &size_key, &data_size_key],
+        )
+    }
+
+    /// Load a parsed contract, returning a canonicalized [`Contract`].
+    ///
+    /// Consults the attached cache when attached and the store is not retargeted; on a miss the
+    /// contract is read from the backing store and inserted into the cache before being returned.
+    ///
+    /// The cache is bypassed entirely during `(at-block ...)` retargeting; those reads hit the
+    /// backing store and are not cached, since they reflect a different chainstate view.
+    ///
+    /// Reads served from uncommitted pending metadata (e.g. a contract deployed earlier in the same
+    /// rollback layer but not yet committed to the backing store) are not cached.
     pub fn get_contract(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
     ) -> Result<Contract, VmExecutionError> {
-        let key = ClarityDatabase::make_metadata_key(
-            StoreType::Contract,
-            ContractDataVarName::Contract.as_str(),
-        );
-        let mut data: Contract = self.fetch_metadata(contract_identifier, &key)?
-            .ok_or_else(|| VmInternalError::Expect(
-                "Failed to read non-consensus contract metadata, even though contract exists in MARF."
-                .into()))?;
-        data.canonicalize_types(&self.get_clarity_epoch_version()?)?;
-        Ok(data)
+        let retargeted = self.store.is_retargeted();
+
+        // Attempt to serve from cache ONLY if we are reading at chain tip (not retargeted).
+        if !retargeted && let Some(entry) = self.cached_contract(contract_identifier) {
+            return Ok(entry.contract.clone());
+        }
+
+        // Miss path: read from store, then (when applicable) populate the cache.
+        let contract = self.read_contract(contract_identifier)?;
+
+        // Defensive check: this is not expected on the ordinary contract-call path, but we include
+        // it conservatively as this is a lower-level DB API which can be reached while a rollback
+        // layer contains pending metadata.
+        let is_pending = self.has_pending_metadata_for_contract(contract_identifier);
+
+        // Only populate the cache on reads at tip and when there are no pending writes to relevant
+        // metadata keys.
+        if !retargeted && !is_pending {
+            let load_cost_size = self.read_contract_size(contract_identifier)?;
+
+            self.cache_contract(
+                contract_identifier.clone(),
+                CachedContract {
+                    contract: contract.clone(),
+                    load_cost_size,
+                },
+            );
+        }
+
+        Ok(contract)
+    }
+
+    /// Borrow the cached contract entry for the provided [`QualifiedContractIdentifier`] if a cache
+    /// is attached to this [`ClarityDatabase`] instance and the contract cache contains it.
+    ///
+    /// On cache hit, hit/miss counters are updated, but FIFO ordering is unchanged.
+    ///
+    /// Returns [`None`] if no cache is attached or the cache does not contain the entry.
+    fn cached_contract(&mut self, id: &QualifiedContractIdentifier) -> Option<&CachedContract> {
+        self.execution_cache.as_deref_mut()?.contracts.get(id)
+    }
+
+    /// Borrow the cached contract entry for the provided [`QualifiedContractIdentifier`] if a cache
+    /// is attached to this [`ClarityDatabase`] instance, without altering FIFO counters.
+    ///
+    /// Returns [`None`] if no cache is attached or the cache does not contain the entry.
+    fn peek_cached_contract(&self, id: &QualifiedContractIdentifier) -> Option<&CachedContract> {
+        self.execution_cache.as_deref()?.contracts.peek(id)
+    }
+
+    /// Insert an entry into the cache if one is attached; otherwise this is a no-op.
+    fn cache_contract(&mut self, id: QualifiedContractIdentifier, entry: CachedContract) {
+        let weight = entry.load_cost_size;
+        if let Some(cache) = self.execution_cache.as_deref_mut() {
+            cache.contracts.insert(id, entry, weight);
+        }
     }
 
     pub fn ustx_liquid_supply_key() -> &'static str {
@@ -2559,6 +2697,155 @@ fn checked_decrease_token_supply_underflow() {
     );
 
     db.commit().unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vm::database::MemoryBackingStore;
+    use crate::vm::version::ClarityVersion;
+
+    /// Deploy a minimal stub contract under `id` in its own committed db transaction.
+    #[track_caller]
+    fn deploy_stub_contract(db: &mut ClarityDatabase, id: &QualifiedContractIdentifier) {
+        db.begin();
+        let contract = ContractContext::new(id.clone(), ClarityVersion::Clarity2).into();
+        db.insert_contract_hash(id, "(define-public (noop) (ok true))")
+            .expect("insert_contract_hash");
+        db.set_contract_data_size(id, 0)
+            .expect("set_contract_data_size");
+        db.insert_contract(id, contract).expect("insert_contract");
+        db.commit().expect("commit stub contract");
+    }
+
+    #[test]
+    fn get_contract_populates_cache_on_miss() {
+        let mut cache = ClarityExecutionCache::default();
+        let mut store = MemoryBackingStore::new();
+        let id = QualifiedContractIdentifier::local("cached").unwrap();
+
+        // Deploy outside the cache attachment so the cache starts empty.
+        deploy_stub_contract(&mut store.as_clarity_db(), &id);
+
+        // Each `db` block scopes the exclusive borrow on `cache` so we can inspect counters
+        // between calls.
+        let first = {
+            let mut db = store.as_clarity_db().with_cache(&mut cache);
+            db.begin();
+            let entry = db.get_contract(&id).expect("load contract");
+            db.roll_back().unwrap();
+            entry
+        };
+        assert_eq!(first.contract_identifier, id);
+        assert_eq!(cache.contracts.misses(), 1);
+        assert_eq!(cache.contracts.hits(), 0);
+
+        let second = {
+            let mut db = store.as_clarity_db().with_cache(&mut cache);
+            db.begin();
+            let entry = db.get_contract(&id).expect("cached load");
+            db.roll_back().unwrap();
+            entry
+        };
+        // Both `Contract`s should deref to the same underlying `ContractContext`, confirming the
+        // cached entry's Arc was shared rather than deserialized fresh.
+        assert!(
+            std::ptr::eq(&*first, &*second),
+            "second call should share the cached Arc, not a fresh deserialization",
+        );
+        assert_eq!(cache.contracts.hits(), 1);
+        assert_eq!(cache.contracts.misses(), 1);
+    }
+
+    #[test]
+    fn get_contract_load_cost_size_serves_from_cache() {
+        let mut cache = ClarityExecutionCache::default();
+        let mut store = MemoryBackingStore::new();
+        let id = QualifiedContractIdentifier::local("size-cached").unwrap();
+        deploy_stub_contract(&mut store.as_clarity_db(), &id);
+
+        // Prime the cache via `get_contract`, then capture the expected size separately.
+        let expected_size = {
+            let mut db = store.as_clarity_db().with_cache(&mut cache);
+            db.begin();
+            let _contract = db.get_contract(&id).expect("prime cache");
+            let s = db.read_contract_size(&id).unwrap();
+            db.roll_back().unwrap();
+            s
+        };
+        let counters_after_prime = (cache.contracts.hits(), cache.contracts.misses());
+
+        // Subsequent `get_contract_size` must come from the cache, and being a passive `peek` it
+        // must not bump hit/miss counters.
+        let size = {
+            let mut db = store.as_clarity_db().with_cache(&mut cache);
+            db.begin();
+            let s = db.get_contract_size(&id).expect("load_cost_size");
+            db.roll_back().unwrap();
+            s
+        };
+        assert_eq!(size, expected_size);
+        assert_eq!(
+            (cache.contracts.hits(), cache.contracts.misses()),
+            counters_after_prime,
+            "passive size lookup must not alter hit/miss counters",
+        );
+    }
+
+    #[test]
+    fn get_contract_load_cost_size_falls_back_without_cache() {
+        let mut store = MemoryBackingStore::new();
+        let id = QualifiedContractIdentifier::local("no-cache").unwrap();
+        deploy_stub_contract(&mut store.as_clarity_db(), &id);
+
+        let mut db = store.as_clarity_db();
+        db.begin();
+        let size = db.get_contract_size(&id).expect("load_cost_size");
+        let expected = db.read_contract_size(&id).unwrap();
+        assert_eq!(size, expected);
+        db.roll_back().unwrap();
+    }
+
+    /// A contract deployed in an uncommitted rollback layer is visible via `get_contract` (pending
+    /// metadata is served), but it must not be cached: if the surrounding context rolls back, a
+    /// cached entry would point at a contract that no longer exists on the backing store, and the
+    /// next lookup in the same tx would falsely succeed.
+    #[test]
+    fn get_contract_does_not_cache_pending_writes() {
+        let mut cache = ClarityExecutionCache::default();
+        let mut store = MemoryBackingStore::new();
+        let id = QualifiedContractIdentifier::local("pending").unwrap();
+
+        // Deploy + load inside a rollback layer, then discard the layer.
+        {
+            let mut db = store.as_clarity_db().with_cache(&mut cache);
+            db.begin();
+            let contract = ContractContext::new(id.clone(), ClarityVersion::Clarity2).into();
+            db.insert_contract_hash(&id, "(define-public (noop) (ok true))")
+                .expect("insert_contract_hash");
+            db.set_contract_data_size(&id, 0)
+                .expect("set_contract_data_size");
+            db.insert_contract(&id, contract).expect("insert_contract");
+            let _ = db
+                .get_contract(&id)
+                .expect("pending-state load should succeed via uncommitted metadata");
+            db.roll_back().unwrap();
+        }
+
+        // The rolled-back contract must not be served from cache on a subsequent lookup. The
+        // backing store also doesn't have it (the deploy was never committed), so the lookup must
+        // error.
+        {
+            let mut db = store.as_clarity_db().with_cache(&mut cache);
+            db.begin();
+            let result = db.get_contract(&id);
+            assert!(
+                result.is_err(),
+                "rolled-back contract must not be served from cache after rollback",
+            );
+            db.roll_back().unwrap();
+        }
+    }
 }
 
 #[test]

--- a/clarity/src/vm/database/key_value_wrapper.rs
+++ b/clarity/src/vm/database/key_value_wrapper.rs
@@ -334,7 +334,12 @@ impl RollbackWrapper<'_> {
         Ok(())
     }
 
-    ///
+    /// Returns whether or not the wrapper is currently retargeted to another block by e.g. an
+    /// `at-block` scope.
+    pub fn is_retargeted(&self) -> bool {
+        !self.query_pending_data
+    }
+
     /// `query_pending_data` indicates whether the rollback wrapper should query the rollback
     ///    wrapper's pending data on reads. This is set to `false` during (at-block ...) closures,
     ///    and `true` otherwise.
@@ -594,5 +599,28 @@ impl RollbackWrapper<'_> {
         key: &str,
     ) -> bool {
         matches!(self.get_metadata(contract, key), Ok(Some(_)))
+    }
+
+    /// Returns `true` if any of the given metadata keys for `contract` has an uncommitted edit in
+    /// the rollback stack (i.e. would be served from pending data rather than the backing store on
+    /// a `get_metadata` call).
+    ///
+    /// Used by caching implementations to avoid caching reads whose metadata could later be rolled
+    /// back.
+    pub fn has_pending_metadata(
+        &self,
+        contract: &QualifiedContractIdentifier,
+        keys: &[&str],
+    ) -> bool {
+        // Retargeted wrappers always read from the backing store, so pending metadata is
+        // irrelevant.
+        if self.is_retargeted() {
+            return false;
+        }
+
+        keys.iter().any(|key| {
+            let metadata_key = (contract.clone(), (*key).to_string());
+            self.metadata_lookup_map.contains_key(&metadata_key)
+        })
     }
 }

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -16,6 +16,7 @@
 #[cfg(feature = "rusqlite")]
 pub use sqlite::MemoryBackingStore;
 
+pub use self::caching::ClarityExecutionCache;
 pub use self::clarity_db::{
     BurnStateDB, ClarityDatabase, HeadersDB, NULL_BURN_STATE_DB, NULL_HEADER_DB,
     STORE_CONTRACT_SRC_INTERFACE, StoreType,
@@ -29,6 +30,7 @@ pub use self::structures::{
     FungibleTokenMetadata, NonFungibleTokenMetadata, STXBalance,
 };
 
+mod caching;
 pub mod clarity_db;
 pub mod clarity_store;
 mod key_value_wrapper;

--- a/clarity/src/vm/database/structures.rs
+++ b/clarity/src/vm/database/structures.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use stacks_common::util::hash::{hex_bytes, to_hex};
 
 use crate::vm::analysis::ContractAnalysis;
-use crate::vm::contracts::Contract;
+use crate::vm::contexts::ContractContext;
 use crate::vm::database::ClarityDatabase;
 use crate::vm::errors::{RuntimeError, VmExecutionError, VmInternalError};
 use crate::vm::types::{PrincipalData, TypeSignature};
@@ -45,6 +45,29 @@ impl ClarityDeserializable<String> for String {
     }
 }
 
+/// JSON deserialization helper for non-WASM targets.
+#[cfg(not(target_family = "wasm"))]
+fn deserialize_json<T: serde::de::DeserializeOwned>(json: &str) -> Result<T, VmExecutionError> {
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+
+    // serde's default 128 depth limit can be exhausted by a 64-stack-depth AST, so
+    // disable the recursion limit and let stacker spill the deserializer to the heap
+    // instead of overflowing.
+    deserializer.disable_recursion_limit();
+    let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
+
+    T::deserialize(deserializer)
+        .map_err(|_| VmInternalError::Expect("Failed to deserialize vm.Value".into()).into())
+}
+
+/// JSON deserialization helper for WASM targets, which don't have access to
+/// `serde_stacker` and thus can't disable the recursion limit.
+#[cfg(target_family = "wasm")]
+fn deserialize_json<T: serde::de::DeserializeOwned>(json: &str) -> Result<T, VmExecutionError> {
+    serde_json::from_str(json)
+        .map_err(|_| VmInternalError::Expect("Failed to deserialize vm.Value".into()).into())
+}
+
 macro_rules! clarity_serializable {
     ($Name:ident) => {
         impl ClaritySerializable for $Name {
@@ -53,24 +76,8 @@ macro_rules! clarity_serializable {
             }
         }
         impl ClarityDeserializable<$Name> for $Name {
-            #[cfg(not(target_family = "wasm"))]
             fn deserialize(json: &str) -> Result<Self, VmExecutionError> {
-                let mut deserializer = serde_json::Deserializer::from_str(&json);
-                // serde's default 128 depth limit can be exhausted
-                //  by a 64-stack-depth AST, so disable the recursion limit
-                deserializer.disable_recursion_limit();
-                // use stacker to prevent the deserializer from overflowing.
-                //  this will instead spill to the heap
-                let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
-                Deserialize::deserialize(deserializer).map_err(|_| {
-                    VmInternalError::Expect("Failed to deserialize vm.Value".into()).into()
-                })
-            }
-            #[cfg(target_family = "wasm")]
-            fn deserialize(json: &str) -> Result<Self, VmExecutionError> {
-                serde_json::from_str(json).map_err(|_| {
-                    VmInternalError::Expect("Failed to deserialize vm.Value".into()).into()
-                })
+                deserialize_json(json)
             }
         }
     };
@@ -106,13 +113,6 @@ pub struct DataVariableMetadata {
 clarity_serializable!(DataVariableMetadata);
 
 #[derive(Serialize, Deserialize)]
-pub struct ContractMetadata {
-    pub contract: Contract,
-}
-
-clarity_serializable!(ContractMetadata);
-
-#[derive(Serialize, Deserialize)]
 pub struct SimmedBlock {
     pub block_height: u64,
     pub block_time: u64,
@@ -127,7 +127,36 @@ clarity_serializable!(PrincipalData);
 clarity_serializable!(i128);
 clarity_serializable!(u128);
 clarity_serializable!(u64);
-clarity_serializable!(Contract);
+
+/// Handle serialization of [`ContractContext`] behind a wrapper struct with a single
+/// `contract_context` field.
+///
+/// This is for compatibility with the current on-disk format, where the `ContractContext` was
+/// previously serialized via the `Contract` type. This removes/isolates that dependency and
+/// allows us to work directly with `ContractContext`s.
+mod contract_context {
+    use super::*;
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Wrapper<T> {
+        pub contract_context: T,
+    }
+
+    impl ClaritySerializable for ContractContext {
+        fn serialize(&self) -> String {
+            serde_json::to_string(&Wrapper {
+                contract_context: self,
+            })
+            .expect("Failed to serialize vm.Value")
+        }
+    }
+    impl ClarityDeserializable<ContractContext> for ContractContext {
+        fn deserialize(json: &str) -> Result<Self, VmExecutionError> {
+            deserialize_json::<Wrapper<ContractContext>>(json).map(|w| w.contract_context)
+        }
+    }
+}
+
 clarity_serializable!(ContractAnalysis);
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -156,13 +156,11 @@ pub fn special_contract_call(
                         .map_err(|_e| {
                             RuntimeCheckErrorKind::NoSuchContract(contract_identifier.to_string())
                         })?;
-                    let contract_context_to_check = contract_to_check.contract_context;
 
                     // Attempt to short circuit the dynamic dispatch checks:
                     // If the contract is explicitely implementing the trait with `impl-trait`,
                     // then we can simply rely on the analysis performed at publish time.
-                    if contract_context_to_check.is_explicitly_implementing_trait(&trait_identifier)
-                    {
+                    if contract_to_check.is_explicitly_implementing_trait(&trait_identifier) {
                         (contract_identifier.clone(), None)
                     } else {
                         let trait_name = trait_identifier.name.to_string();
@@ -177,11 +175,9 @@ pub fn special_contract_call(
                                     trait_identifier.contract_identifier.to_string(),
                                 )
                             })?;
-                        let contract_context_defining_trait =
-                            contract_defining_trait.contract_context;
 
                         // Retrieve the function that will be invoked
-                        let function_to_check = contract_context_to_check
+                        let function_to_check = contract_to_check
                             .lookup_function(function_name)
                             .ok_or(RuntimeCheckErrorKind::BadTraitImplementation(
                                 trait_name.clone(),
@@ -208,12 +204,12 @@ pub fn special_contract_call(
                         // If this check succeeds, the subsequent trait reference and method checks cannot fail
                         function_to_check.check_trait_expectations(
                             exec_state.epoch(),
-                            &contract_context_defining_trait,
+                            &contract_defining_trait,
                             &trait_identifier,
                         )?;
 
                         // Retrieve the expected method signature
-                        let constraining_trait = contract_context_defining_trait
+                        let constraining_trait = contract_defining_trait
                             .lookup_trait_definition(&trait_name)
                             .ok_or(RuntimeCheckErrorKind::Unreachable(format!(
                                 "Trait reference unknown: {trait_name}"

--- a/pox-locking/src/events.rs
+++ b/pox-locking/src/events.rs
@@ -651,7 +651,7 @@ fn inner_synthesize_pox_event_info(
         .special_cc_handler_execute_read_only(
             sender.clone(),
             None,
-            pox_contract.contract_context,
+            &pox_contract,
             |exec_state, invoke_ctx| {
                 let base_event_info = exec_state
                     .eval_read_only(invoke_ctx, contract_id, &code_snippet)

--- a/pox-locking/src/events_24.rs
+++ b/pox-locking/src/events_24.rs
@@ -383,7 +383,7 @@ pub fn synthesize_pox_2_or_3_event_info(
         .special_cc_handler_execute_read_only(
             sender.clone(),
             None,
-            pox_2_contract.contract_context,
+            &pox_2_contract,
             |exec_state, invoke_ctx| {
                 let base_event_info = exec_state
                     .eval_read_only(invoke_ctx, contract_id, &code_snippet)

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -24,8 +24,8 @@ pub use clarity::vm::clarity::{ClarityConnection, ClarityError};
 use clarity::vm::contexts::{AbortCallback, AssetMap, OwnedEnvironment};
 use clarity::vm::costs::{CostTracker, ExecutionCost, LimitedCostTracker};
 use clarity::vm::database::{
-    BurnStateDB, ClarityBackingStore, ClarityDatabase, HeadersDB, RollbackWrapper,
-    RollbackWrapperPersistedLog, STXBalance, NULL_BURN_STATE_DB, NULL_HEADER_DB,
+    BurnStateDB, ClarityBackingStore, ClarityDatabase, ClarityExecutionCache, HeadersDB,
+    RollbackWrapper, RollbackWrapperPersistedLog, STXBalance, NULL_BURN_STATE_DB, NULL_HEADER_DB,
 };
 use clarity::vm::errors::VmExecutionError;
 use clarity::vm::events::{STXEventType, STXMintEventData};
@@ -141,6 +141,9 @@ pub struct ClarityTransactionConnection<'a, 'b> {
     chain_id: u32,
     epoch: StacksEpochId,
     abort_callback: AbortCallback,
+    /// Per-tx cache container which is attached to [`ClarityDatabase`] instances handed out by this
+    /// connection.
+    cache: ClarityExecutionCache,
 }
 
 /// Unified API common to all MARF stores
@@ -272,6 +275,7 @@ impl<'a, 'b> ClarityTransactionConnection<'a, 'b> {
             chain_id,
             epoch,
             abort_callback,
+            cache: ClarityExecutionCache::default(),
         }
     }
 }
@@ -815,8 +819,11 @@ impl ClarityInstance {
         contract: &QualifiedContractIdentifier,
         program: &str,
     ) -> Result<Value, ClarityError> {
+        let mut cache = ClarityExecutionCache::default();
         let mut read_only_conn = self.datastore.begin_read_only(Some(at_block));
-        let mut clarity_db = read_only_conn.as_clarity_db(header_db, burn_state_db);
+        let mut clarity_db = read_only_conn
+            .as_clarity_db(header_db, burn_state_db)
+            .with_cache(&mut cache);
         let epoch_id = {
             clarity_db.begin();
             let result = clarity_db.get_clarity_epoch_version();
@@ -841,7 +848,9 @@ impl ClarityConnection for ClarityBlockConnection<'_, '_> {
     where
         F: FnOnce(ClarityDatabase) -> (R, ClarityDatabase),
     {
-        let mut db = ClarityDatabase::new(&mut self.datastore, self.header_db, self.burn_state_db);
+        let mut cache = ClarityExecutionCache::default();
+        let mut db = ClarityDatabase::new(&mut self.datastore, self.header_db, self.burn_state_db)
+            .with_cache(&mut cache);
         db.begin();
         let (result, mut db) = to_do(db);
         db.roll_back()
@@ -872,9 +881,12 @@ impl ClarityConnection for ClarityReadOnlyConnection<'_> {
     where
         F: FnOnce(ClarityDatabase) -> (R, ClarityDatabase),
     {
+        let mut cache = ClarityExecutionCache::default();
         let mut db = self
             .datastore
-            .as_clarity_db(self.header_db, self.burn_state_db);
+            .as_clarity_db(self.header_db, self.burn_state_db)
+            .with_cache(&mut cache);
+
         db.begin();
         let (result, mut db) = to_do(db);
         db.roll_back()
@@ -2047,7 +2059,8 @@ impl ClarityConnection for ClarityTransactionConnection<'_, '_> {
                 rollback_wrapper,
                 self.header_db,
                 self.burn_state_db,
-            );
+            )
+            .with_cache(&mut self.cache);
             db.begin();
             let (r, mut db) = to_do(db);
             db.roll_back()
@@ -2112,7 +2125,8 @@ impl TransactionConnection for ClarityTransactionConnection<'_, '_> {
                     rollback_wrapper,
                     self.header_db,
                     self.burn_state_db,
-                );
+                )
+                .with_cache(&mut self.cache);
 
                 // wrap the whole contract-call in a claritydb transaction,
                 //   so we can abort on call_back's boolean retun
@@ -2185,7 +2199,8 @@ impl ClarityTransactionConnection<'_, '_> {
                 rollback_wrapper,
                 self.header_db,
                 self.burn_state_db,
-            );
+            )
+            .with_cache(&mut self.cache);
 
             db.begin();
             let result = to_do(&mut db);
@@ -3356,5 +3371,121 @@ mod tests {
 
             conn.commit_block();
         }
+    }
+
+    /// `ClarityTransactionConnection` constructs a fresh `ContractCache` per call to
+    /// `start_transaction_processing`, so every `as_transaction` enters with an empty cache. This
+    /// test exercises a deploy + two same-tx contract-calls (miss then hit), then opens a fresh tx
+    /// and confirms counters reset.
+    #[test]
+    pub fn contract_cache_is_scoped_to_transaction() {
+        let marf = MarfedKV::temporary();
+        let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
+        let contract_identifier = QualifiedContractIdentifier::local("cache-scope").unwrap();
+        let sender: PrincipalData = StandardPrincipalData::transient().into();
+
+        clarity_instance
+            .begin_test_genesis_block(
+                &StacksBlockId::sentinel(),
+                &StacksBlockId([0; 32]),
+                &TEST_HEADER_DB,
+                &TEST_BURN_STATE_DB,
+            )
+            .commit_block();
+
+        let mut conn = clarity_instance.begin_block(
+            &StacksBlockId([0; 32]),
+            &StacksBlockId([1; 32]),
+            &TEST_HEADER_DB,
+            &TEST_BURN_STATE_DB,
+        );
+
+        let contract_src = "(define-public (noop) (ok true))";
+
+        // tx1: deploy (no contract-call path → no cache activity).
+        conn.as_transaction(|tx| {
+            let (ct_ast, ct_analysis) = tx
+                .analyze_smart_contract(
+                    &contract_identifier,
+                    ClarityVersion::Clarity1,
+                    contract_src,
+                )
+                .unwrap();
+            tx.initialize_smart_contract(
+                &contract_identifier,
+                ClarityVersion::Clarity1,
+                &ct_ast,
+                contract_src,
+                None,
+                |_, _| None,
+                None,
+            )
+            .unwrap();
+            tx.save_analysis(&contract_identifier, &ct_analysis)
+                .unwrap();
+        });
+
+        // tx2: first call misses, second call hits.
+        conn.as_transaction(|tx| {
+            assert_eq!(tx.cache.contracts.hits(), 0);
+            assert_eq!(tx.cache.contracts.misses(), 0);
+
+            tx.run_contract_call(
+                &sender,
+                None,
+                &contract_identifier,
+                "noop",
+                &[],
+                |_, _| None,
+                None,
+            )
+            .unwrap();
+
+            let misses_after_first = tx.cache.contracts.misses();
+            let hits_after_first = tx.cache.contracts.hits();
+            assert!(misses_after_first >= 1, "first call should miss");
+
+            tx.run_contract_call(
+                &sender,
+                None,
+                &contract_identifier,
+                "noop",
+                &[],
+                |_, _| None,
+                None,
+            )
+            .unwrap();
+            assert!(
+                tx.cache.contracts.hits() > hits_after_first,
+                "second call should hit the cache",
+            );
+        });
+
+        // tx3: fresh tx must see counters reset and still work.
+        conn.as_transaction(|tx| {
+            assert_eq!(tx.cache.contracts.hits(), 0, "fresh tx starts at 0 hits");
+            assert_eq!(
+                tx.cache.contracts.misses(),
+                0,
+                "fresh tx starts at 0 misses"
+            );
+
+            tx.run_contract_call(
+                &sender,
+                None,
+                &contract_identifier,
+                "noop",
+                &[],
+                |_, _| None,
+                None,
+            )
+            .unwrap();
+            assert!(
+                tx.cache.contracts.misses() >= 1,
+                "fresh tx miss on first call"
+            );
+        });
+
+        conn.commit_block();
     }
 }

--- a/stackslib/src/net/api/getconstantval.rs
+++ b/stackslib/src/net/api/getconstantval.rs
@@ -136,7 +136,6 @@ impl RPCRequestHandler for RPCGetConstantValRequestHandler {
                             let contract = clarity_db.get_contract(&contract_identifier).ok()?;
 
                             let cst = contract
-                                .contract_context
                                 .lookup_variable(constant_name.as_str())?
                                 .serialize_to_hex()
                                 .ok()?;


### PR DESCRIPTION
### Description

Implements and integrates a simple per-transaction FIFO cache for loaded Clarity contracts. Entries are weighted by the consensus `LoadContract` cost size (`contract_size + contract_data_size`) and attached to `ClarityDatabase` instances within logical transaction scopes.

No memory tracking or cost accounting changes are made in this PR; however the implementation (and tests) were written with determinism in mind. Updating cost accounting should be a followup to this.

P.S. A lot of the line count is tests.

### Applicable issues

- Resolves: https://github.com/stx-labs/core-epics/issues/126
- Alleviates: https://github.com/stx-labs/core-epics/issues/251

### Additional info (benefits, drawbacks, caveats)

- Avoids repeated contract loads (metadata reads, deserialization, and type canonicalization) when the same contract is loaded multiple times within one logical Clarity transaction.
- Cache scope is intentionally limited to a single logical transaction. Nested rollback scopes within the transaction share the cache, but new transactions, block rollbacks/reorgs, epoch transitions, and `(at-block ...)` retargeted reads do not.
- The cache is byte-weighted and bounded, rather than unbounded or count-only. This keeps adversarial transactions that touch many large contracts from retaining large amounts of parsed-contract memory.
- FIFO eviction was chosen over LRU or "first N.." to keep the implementation small/reviewable while still remaining deterministic and allowing the cache to adapt if/after the initial working set fills.
- Oversized entries whose individual `LoadContract` size exceeds the cache budget are not cached (should never happen with a ~2MiB block/transaction limit, just defensive).
- Any VM path that goes through `ClarityDatabase::get_contract()` can benefit from the cache (e.g. `contract-of`).

### Benchmark Summary

Transaction `afd5af8a29895add0c4832c20eea1023db421252098dce7add80e38e296ca7ce`, run using `--txid` transaction-isolation mode:

```sh
stacks-bench bench run \
    -s /data/chainstates/mainnet-7.9m \ # compressed chainstate
    --warmup 20 \
    --repetitions 50 \
    --no-profiler-kv \
    --txid afd5af8a29895add0c4832c20eea1023db421252098dce7add80e38e296ca7ce
```

#### `develop`:

```
◇  Benchmark Summary ─────────────────────────────╮
│                                                 │
│  Metric                    Total    Per Block   │
│  ───────────────  ──────────────  ───────────   │
│  Blocks                       50            —   │
│  Transactions                 50          1.0   │
│  Duration                372.10s        7.44s   │
│    Setup                   1.08s      21.57ms   │
│    Execution             366.04s        7.32s   │
│    Commit                  4.98s      99.70ms   │
│  Clarity Runtime  13,146,303,600  262,926,072   │
│  Write Length        206,332,500    4,126,650   │
│  Read Length       3,333,795,500   66,675,910   │
├─────────────────────────────────────────────────╯
```

#### This PR:

```
◇  Benchmark Summary ─────────────────────────────╮
│                                                 │
│  Metric                    Total    Per Block   │
│  ───────────────  ──────────────  ───────────   │
│  Blocks                       50            —   │
│  Transactions                 50          1.0   │
│  Duration                136.22s        2.72s   │
│    Setup                   1.06s      21.29ms   │
│    Execution             131.66s        2.63s   │
│    Commit                  3.49s      69.86ms   │
│  Clarity Runtime  13,146,303,600  262,926,072   │
│  Write Length        206,332,500    4,126,650   │
│  Read Length       3,333,795,500   66,675,910   │
├─────────────────────────────────────────────────╯
```

---

### Checklist

- [x] Test coverage for new or modified code paths
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
