### PR TITLE
Release 3.4.0.0.3 cleanup

### DIFF
--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -897,15 +897,16 @@ fn special_contract_of(
 
     let contract_identifier = match context.lookup_callable_contract(contract_ref) {
         Some(trait_data) => {
-            exec_state
+            if !exec_state
                 .global_context
                 .database
-                .get_contract(&trait_data.contract_identifier)
-                .map_err(|_e| {
-                    RuntimeCheckErrorKind::NoSuchContract(
-                        trait_data.contract_identifier.to_string(),
-                    )
-                })?;
+                .has_contract(&trait_data.contract_identifier)
+            {
+                return Err(RuntimeCheckErrorKind::NoSuchContract(
+                    trait_data.contract_identifier.to_string(),
+                )
+                .into());
+            }
 
             &trait_data.contract_identifier
         }

--- a/stackslib/src/chainstate/burn/operations/delegate_stx.rs
+++ b/stackslib/src/chainstate/burn/operations/delegate_stx.rs
@@ -210,6 +210,17 @@ impl DelegateStxOp {
             return Err(op_error::DelegateStxMustBePositive);
         }
 
+        if let Some(height) = self.until_burn_height {
+            if height > i64::MAX as u64 {
+                warn!(
+                    "Invalid DelegateStxOp: until_burn_height exceeds i64::MAX";
+                    "until_burn_height" => height,
+                    "txid" => %self.txid,
+                );
+                return Err(op_error::InvalidInput);
+            }
+        }
+
         Ok(())
     }
 }

--- a/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/stackslib/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1024,6 +1024,17 @@ impl LeaderBlockCommitOp {
                 );
                 return Err(op_error::BlockCommitNoParent);
             }
+            if !has_parent
+                && maybe_shadow_block
+                && tx
+                    .get_block_snapshot_by_height(parent_block_height)?
+                    .is_none()
+            {
+                warn!("Invalid block commit: no shadow parent block in this fork";
+                      "apparent_sender" => %apparent_sender_repr
+                );
+                return Err(op_error::BlockCommitNoParent);
+            }
         }
 
         /////////////////////////////////////////////////////////////////////////////////////

--- a/stackslib/src/chainstate/burn/operations/vote_for_aggregate_key.rs
+++ b/stackslib/src/chainstate/burn/operations/vote_for_aggregate_key.rs
@@ -185,6 +185,15 @@ impl VoteForAggregateKeyOp {
         Secp256k1PublicKey::from_slice(signer_key_bytes)
             .map_err(|_| op_error::VoteForAggregateKeyInvalidKey)?;
 
+        if self.reward_cycle > i64::MAX as u64 {
+            warn!(
+                "Invalid vote-for-aggregate-key: reward_cycle exceeds i64::MAX";
+                "reward_cycle" => self.reward_cycle,
+                "txid" => %self.txid,
+            );
+            return Err(op_error::InvalidInput);
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
This final 3.4.0.0.3 cleanup work adds checks to improve burn op filters and improve the performance of trait lookup checks.