### PR TITLE
fix: handle cycle with no STX-only stakers

### DIFF
--- a/changelog.d/no-stx-stakers.fixed
+++ b/changelog.d/no-stx-stakers.fixed
@@ -1,0 +1,1 @@
+Handle reward cycle with no STX-only stakers (all excess rewards go to the reserve).

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -765,9 +765,10 @@ test('bond rewards split across signers by staked sats', () => {
       totalShares: aliceSbtc + bobSbtc,
     }),
   );
-  expect(rov(pox5.getReserveBalance())).toBe(
-    reserveRewards(1000n - totalBondRewards),
-  );
+  // When no STX-only stake exists, the staker cut is
+  // rerouted to reserve rather than stranded, so reserve receives the
+  // full `remaining-rewards` (1000 - 960 = 40), not just 15% of it.
+  expect(rov(pox5.getReserveBalance())).toBe(1000n - totalBondRewards);
 });
 
 /**

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -1573,12 +1573,15 @@
                 (cycle-staked-ustx (get-total-shares-staked-for-cycle false stx-cycle))
                 (current-rewards-per-ustx (get-rewards-per-token-for-cycle false stx-cycle))
                 (prev-accounted-rewards (var-get last-accounted-rewards-only))
-                (new-rewards-per-ustx (if (is-eq cycle-staked-ustx u0)
-                    ;; if there are no stx staked, we have a problem
+                ;; If no STX is staked this cycle, the staker cut will be applied to the reserve.
+                (no-stx-stakers (is-eq cycle-staked-ustx u0))
+                (new-rewards-per-ustx (if no-stx-stakers
                     u0
                     (/ (* stx-staker-rewards PRECISION) cycle-staked-ustx)
                 ))
                 (next-rewards-per-ustx (+ current-rewards-per-ustx new-rewards-per-ustx))
+                ;; When no STX is staked, fold the staker cut into the reserve, otherwise zero.
+                (stranded-staker-cut (if no-stx-stakers stx-staker-rewards u0))
             )
             (print {
                 topic: "calculate-rewards",
@@ -1590,8 +1593,11 @@
                 stx-cycle: stx-cycle,
                 cycle-staked-ustx: cycle-staked-ustx,
                 next-rewards-per-ustx: next-rewards-per-ustx,
+                stranded-staker-cut: stranded-staker-cut,
             })
-            (var-set reserve-balance (+ cur-reserve new-reserve))
+            (var-set reserve-balance
+                (+ cur-reserve new-reserve stranded-staker-cut)
+            )
             (var-set last-reward-compute-height calculation-height)
             (var-set last-accounted-rewards-only
                 (+ prev-accounted-rewards (- accrued-rewards new-reserve))


### PR DESCRIPTION
In this scenario, instead of the reserve getting 15% of the leftover rewards, it gets all of the leftovers, since there are no STX-only stakers to pay.