### PR TITLE
fix: require previous bond to be unstaked before re-registering

### DIFF
--- a/changelog.d/withdraw-before-restake.fixed
+++ b/changelog.d/withdraw-before-restake.fixed
@@ -1,0 +1,1 @@
+Require previous bond to be unstaked before registering for a new bond, keeping the accounting simple and preventing the new bond from overwriting the old bond before its sBTC has been returned.

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -6958,6 +6958,10 @@ export const contracts = {
         isOk: false,
         value: 32n,
       },
+      ERR_PRIOR_SBTC_NOT_WITHDRAWN: {
+        isOk: false,
+        value: 48n,
+      },
       ERR_READ_TX_OUT_OF_BOUNDS: {
         isOk: false,
         value: 39n,

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -2884,3 +2884,101 @@ test('sbtc bond participant can recover sbtc after bond ends', () => {
   );
   expect(sbtcBalance(alice)).toBe(aliceBalance + aliceSbtc);
 });
+
+/**
+ * Ensure that a bond participant cannot participate in a new bond while they
+ * have active shares from a previous bond that haven't been withdrawn yet.
+ * This keeps the accounting simple, and prevents new bond registrations from
+ * interfering with existing commitments.
+ */
+test('register-for-bond rejected while prior sBTC shares remain', () => {
+  const signer = testSigner.identifier;
+  const aliceSbtc = 100000n;
+
+  registerSigner();
+
+  // Set up the immediate bond; Alice joins it with sBTC.
+  txOk(
+    pox5.setupBond({
+      bondIndex: 0n,
+      targetRate: 1200n,
+      stxValueRatio: 10n,
+      minUstxRatio: 100n,
+      earlyUnlockSigners: new Uint8Array(),
+      earlyUnlockAdmin: deployer,
+      allowlist: [{ maxSats: aliceSbtc, staker: alice }],
+    }),
+    deployer,
+  );
+  txOk(
+    pox5.registerForBond({
+      bondIndex: 0n,
+      signerManager: signer,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: err(aliceSbtc),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+
+  // Mine past bond 0's end.
+  const bond0End =
+    rov(pox5.bondPeriodToBurnHeight(0n)) +
+    pox5.constants.BOND_LENGTH_CYCLES * REWARD_CYCLE_LENGTH;
+  mineUntil(bond0End + 1n);
+  // `get-bond-membership` is intentionally filtering expired memberships, so
+  // it returns null even though the raw map entry and Alice's sBTC shares
+  // still exist.
+  expect(rov(pox5.getBondMembership(alice))).toBeNull();
+  expect(rov(pox5.getStakerSharesStakedForCycle(alice, true, 0n, signer))).toBe(
+    aliceSbtc,
+  );
+
+  // Bond 7 starts the cycle after bond 0 ends (one bond-period gap
+  // beyond bond 0's tail), so we are inside its valid setup window.
+  txOk(
+    pox5.setupBond({
+      bondIndex: 7n,
+      targetRate: 1200n,
+      stxValueRatio: 10n,
+      minUstxRatio: 100n,
+      earlyUnlockSigners: new Uint8Array(),
+      earlyUnlockAdmin: deployer,
+      allowlist: [{ maxSats: aliceSbtc, staker: alice }],
+    }),
+    deployer,
+  );
+
+  // Without withdrawing the old sBTC, re-registration for bond 7 must
+  // fail with ERR_PRIOR_SBTC_NOT_WITHDRAWN (u48).
+  const stale = txErr(
+    pox5.registerForBond({
+      bondIndex: 7n,
+      signerManager: signer,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: err(aliceSbtc),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+  expect(stale.value).toBe(pox5Errors.ERR_PRIOR_SBTC_NOT_WITHDRAWN);
+
+  // After unstaking the prior sBTC, re-registration succeeds.
+  txOk(
+    pox5.unstakeSbtc({
+      signerManager: signer,
+      amountToWithdrawalSats: aliceSbtc,
+    }),
+    alice,
+  );
+  txOk(
+    pox5.registerForBond({
+      bondIndex: 7n,
+      signerManager: signer,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: err(aliceSbtc),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+});

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -52,6 +52,8 @@
 (define-constant ERR_UPDATE_BOND_SAME_SIGNER (err u44))
 ;; The lockup amount does not match the specified amount of sats
 (define-constant ERR_INVALID_LOCKUP_AMOUNT (err u45))
+;; sBTC from a prior bond has not yet been withdrawn
+(define-constant ERR_PRIOR_SBTC_NOT_WITHDRAWN (err u48))
 
 ;; The length, in terms of staking cycles, of a given
 ;; bond period
@@ -571,6 +573,23 @@
 
         (asserts! (is-none (get-bond-membership tx-sender))
             ERR_ALREADY_REGISTERED
+        )
+
+        ;; Ensure that a staker can't register for a bond if they have an
+        ;; active bond membership from a previous bond period, and there are
+        ;; sBTC shares from the prior bond period still outstanding.
+        (match (map-get? protocol-bond-memberships tx-sender)
+            prev-membership (asserts!
+                (is-eq
+                    (get-staker-shares-staked-for-cycle tx-sender true
+                        (get bond-index prev-membership)
+                        (get signer prev-membership)
+                    )
+                    u0
+                )
+                ERR_PRIOR_SBTC_NOT_WITHDRAWN
+            )
+            true
         )
 
         (map-set protocol-bond-memberships tx-sender {


### PR DESCRIPTION
This helps to keep the accounting simple and prevents the new bond from overwriting the record of the previously staked, but not yet returned sBTC.