### PR TITLE
fix: reset in between prop tests to fix flakiness

### DIFF
--- a/contrib/core-contract-tests/tests/sip-031/commands/utils.ts
+++ b/contrib/core-contract-tests/tests/sip-031/commands/utils.ts
@@ -52,9 +52,9 @@ export function trackCommandRun(model: Model, commandName: string) {
   model.statistics.set(commandName, count + 1);
 }
 
-export function reportCommandRuns(model: Model) {
+export function reportCommandRuns(statistics: Model["statistics"]) {
   console.log("\nCommand execution counts:");
-  const orderedStatistics = Array.from(model.statistics.entries()).sort(
+  const orderedStatistics = Array.from(statistics.entries()).sort(
     ([keyA], [keyB]) => {
       return keyA.localeCompare(keyB);
     },

--- a/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
+++ b/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
@@ -40,7 +40,7 @@ test('SIP-031 Stateful', async () => {
       // Reset simnet so each property iteration (and each shrinking
       // attempt) runs against a fresh chain. Without this, model and
       // simnet can accumulate divergent state across runs.
-      await simnet.initSession(process.cwd(), './Clarinet.toml', null);
+      await simnet.initSession(process.cwd(), global.options.clarinet.manifestPath);
 
       const model: Model = {
         balance: 0n,

--- a/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
+++ b/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
@@ -1,37 +1,29 @@
-import fc from "fast-check";
-import { accounts, project } from "../clarigen-types";
-import { projectFactory } from "@clarigen/core";
-import { rov } from "@clarigen/test";
-import { test } from "vitest";
+import fc from 'fast-check';
+import { accounts, project } from '../clarigen-types';
+import { projectFactory } from '@clarigen/core';
+import { rov } from '@clarigen/test';
+import { test } from 'vitest';
 
-import { Claim } from "./commands/Claim";
-import { ClaimErr } from "./commands/ClaimErr";
-import { MineBlocks } from "./commands/MineBlocks";
-import { Mint } from "./commands/Mint";
-import { MintInitial } from "./commands/MintInitial";
-import { Model, Real } from "./commands/types";
-import { UpdateRecipient } from "./commands/UpdateRecipient";
-import { UpdateRecipientErr } from "./commands/UpdateRecipientErr";
-import { reportCommandRuns } from "./commands/utils";
+import { Claim } from './commands/Claim';
+import { ClaimErr } from './commands/ClaimErr';
+import { MineBlocks } from './commands/MineBlocks';
+import { Mint } from './commands/Mint';
+import { MintInitial } from './commands/MintInitial';
+import { Model, Real } from './commands/types';
+import { UpdateRecipient } from './commands/UpdateRecipient';
+import { UpdateRecipientErr } from './commands/UpdateRecipientErr';
+import { reportCommandRuns } from './commands/utils';
 
-const contracts = projectFactory(project, "simnet");
+const contracts = projectFactory(project, 'simnet');
 
-test("SIP-031 Stateful", () => {
+test('SIP-031 Stateful', async () => {
   const real: Real = {
     accounts,
     contracts,
   };
 
-  const model: Model = {
-    balance: 0n,
-    blockHeight: rov(contracts.sip031.getDeployBlockHeight()),
-    constants: contracts.sip031.constants,
-    deployBlockHeight: rov(contracts.sip031.getDeployBlockHeight()),
-    initialized: false,
-    recipient: accounts.deployer.address,
-    statistics: new Map(),
-    totalClaimed: 0n,
-  };
+  // Shared across iterations so the final report reflects every run.
+  const statistics = new Map<string, number>();
 
   const invariants = [
     Claim(accounts),
@@ -43,16 +35,28 @@ test("SIP-031 Stateful", () => {
     UpdateRecipientErr(accounts),
   ];
 
-  fc.assert(
-    fc.property(
-      fc.commands(invariants, { size: "+1" }),
-      (cmds) => {
-        const state = () => ({ model: model, real: real });
-        fc.modelRun(state, cmds);
-      },
-    ),
+  await fc.assert(
+    fc.asyncProperty(fc.commands(invariants, { size: '+1' }), async (cmds) => {
+      // Reset simnet so each property iteration (and each shrinking
+      // attempt) runs against a fresh chain. Without this, model and
+      // simnet can accumulate divergent state across runs.
+      await simnet.initSession(process.cwd(), './Clarinet.toml', null);
+
+      const model: Model = {
+        balance: 0n,
+        blockHeight: rov(contracts.sip031.getDeployBlockHeight()),
+        constants: contracts.sip031.constants,
+        deployBlockHeight: rov(contracts.sip031.getDeployBlockHeight()),
+        initialized: false,
+        recipient: accounts.deployer.address,
+        statistics,
+        totalClaimed: 0n,
+      };
+
+      fc.modelRun(() => ({ model, real }), cmds);
+    }),
     { numRuns: 100, verbose: 2 },
   );
 
-  reportCommandRuns(model);
+  reportCommandRuns(statistics);
 });


### PR DESCRIPTION
Otherwise, it was possible for the simnet and the model to get out of sync, causing flakiness in the tests.

<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
