### PR TITLE
chore: fix clippy issues

### DIFF
--- a/.github/workflows/_check-clippy.yml
+++ b/.github/workflows/_check-clippy.yml
@@ -6,7 +6,7 @@ name: "Checks: Clippy"
 run-name: "Checks: Clippy [${{ github.ref_name }}]"
 
 # Only run when:
-#   - PRs are (re)opened against develop branch
+#   - PRs are (re)opened (any target branch)
 #   - commit is pushed to PR
 #   - PR is added to merge queue
 on:
@@ -15,8 +15,6 @@ on:
     types:
       - checks_requested
   pull_request:
-    branches:
-      - develop
     types:
       - opened
       - reopened

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
@@ -786,9 +786,9 @@ fn check_ed25519_verify(
     let [message, signature, public_key] = get_arguments_exact::<_, 3>(args)?;
 
     check_argument_count(3, args)?;
-    checker.type_check_expects(&message, context, &TypeSignature::BUFFER_MAX)?;
-    checker.type_check_expects(&signature, context, &TypeSignature::BUFFER_64)?;
-    checker.type_check_expects(&public_key, context, &TypeSignature::BUFFER_32)?;
+    checker.type_check_expects(message, context, &TypeSignature::BUFFER_MAX)?;
+    checker.type_check_expects(signature, context, &TypeSignature::BUFFER_64)?;
+    checker.type_check_expects(public_key, context, &TypeSignature::BUFFER_32)?;
     Ok(TypeSignature::BoolType)
 }
 

--- a/stacks-common/src/util/ed25519.rs
+++ b/stacks-common/src/util/ed25519.rs
@@ -219,7 +219,6 @@ impl Ed25519PrivateKey {
 
 /// Verify a ed25519 signature against the message
 /// The signature must be a 64-byte signature
-
 pub fn ed25519_verify(
     message_arr: &[u8],
     signature_arr: &[u8],


### PR DESCRIPTION
It seems the Clippy check only runs when targeting `develop`.