### PR TITLE
chore: log received non-duplicate blocks only 

### DIFF
--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -898,13 +898,6 @@ impl Relayer {
         obtained_method: NakamotoBlockObtainMethod,
         force_broadcast: bool,
     ) -> Result<BlockAcceptResponse, chainstate_error> {
-        info!(
-            "Handle incoming Nakamoto block {}/{} obtained via {}",
-            &block.header.consensus_hash,
-            &block.header.block_hash(),
-            &obtained_method;
-            "block_id" => %block.header.block_id(),
-        );
         if block.is_shadow_block() {
             // drop, since we can get these from ourselves when downloading a tenure that ends in
             // a shadow block.
@@ -942,6 +935,13 @@ impl Relayer {
                 return Ok(BlockAcceptResponse::AlreadyStored);
             }
         }
+
+        info!(
+            "Handle incoming Nakamoto block {}/{} obtained via {obtained_method}",
+            &block.header.consensus_hash,
+            &block.header.block_hash();
+            "block_id" => %block.header.block_id(),
+        );
 
         let block_sn =
             SortitionDB::get_block_snapshot_consensus(sort_handle, &block.header.consensus_hash)?


### PR DESCRIPTION
### Description

while debugging a synching pruned node, I noticed that this line was being logged ~210 times/sec for duplicate blocks that the nodes already had stored while synching. I moved it a bit down where it only logs new blocks.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
