### PR TITLE
feat: gate signer-manager callbacks on contract-caller

### DIFF
--- a/changelog.d/signer-manager-callbacks.fixed
+++ b/changelog.d/signer-manager-callbacks.fixed
@@ -1,0 +1,1 @@
+Gate the pox-5 callback functions in the sample signer-manager contract so that they can only be called directly by pox-5.

--- a/contrib/core-contract-tests/contracts/signer-manager.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager.clar
@@ -10,8 +10,8 @@
 ;; rate is set, the next time that staker claims rewards will have fees taken
 ;; from reward _even before_ the fee was set.
 
-(impl-trait .pox-5.signer-manager-trait)
-(use-trait signer-manager-trait .pox-5.signer-manager-trait)
+(impl-trait 'ST000000000000000000002AMW42H.pox-5.signer-manager-trait)
+(use-trait signer-manager-trait 'ST000000000000000000002AMW42H.pox-5.signer-manager-trait)
 
 ;; A staker tried to claim rewards, but they had none available
 (define-constant ERR_NO_CLAIMABLE_REWARDS (err u1001))
@@ -244,7 +244,9 @@
         (reward-cycle uint)
     )
     (let ((new-rewards-info (try! (as-contract? ()
-            (try! (contract-call? .pox-5 claim-rewards bond-periods reward-cycle))
+            (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 claim-rewards
+                bond-periods reward-cycle
+            ))
         ))))
         (update-rewards-info
             (get rewards-per-token (get stx-rewards new-rewards-info)) false
@@ -270,8 +272,9 @@
         (index uint)
     )
     (let (
-            (shares (contract-call? .pox-5 get-staker-shares-staked-for-cycle staker
-                is-bond index current-contract
+            (shares (contract-call? 'ST000000000000000000002AMW42H.pox-5
+                get-staker-shares-staked-for-cycle staker is-bond index
+                current-contract
             ))
             (rpt-current (get-rewards-per-token-for-cycle is-bond index))
             (rpt-paid (get-staker-rewards-per-token-paid-for-cycle staker is-bond index))
@@ -406,10 +409,12 @@
     (begin
         (try! (authorize-admin))
         (as-contract? ()
-            (try! (contract-call? .pox-5 grant-signer-key signer-key current-contract
-                auth-id signer-sig
+            (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 grant-signer-key
+                signer-key current-contract auth-id signer-sig
             ))
-            (try! (contract-call? .pox-5 register-signer signer-manager signer-key))
+            (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 register-signer
+                signer-manager signer-key
+            ))
         )
     )
 )
@@ -425,7 +430,9 @@
 ;; `staker` argument; they must only ever be driven by pox-5, never invoked
 ;; directly by an external principal.
 (define-private (authorize-pox-5)
-    (ok (asserts! (is-eq contract-caller .pox-5) ERR_UNAUTHORIZED_CALLER))
+    (ok (asserts! (is-eq contract-caller 'ST000000000000000000002AMW42H.pox-5)
+        ERR_UNAUTHORIZED_CALLER
+    ))
 )
 
 (define-read-only (is-admin (caller principal))

--- a/contrib/core-contract-tests/contracts/signer-manager.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager.clar
@@ -23,6 +23,9 @@
 (define-constant ERR_INVALID_POX_ADDR (err u1004))
 ;; The fees provided when updating fees is invalid
 (define-constant ERR_INVALID_FEES_BIPS (err u1005))
+;; A pox-5 callback (validate-stake!, checkpoint-staker) was invoked by a
+;; principal other than the pox-5 contract.
+(define-constant ERR_UNAUTHORIZED_CALLER (err u1006))
 
 ;; Used to prevent fractional multiplication errors
 ;; during reward calculations
@@ -117,27 +120,30 @@
         (is-bond bool)
         (signer-calldata (optional (buff 500)))
     )
-    (ok (match signer-calldata
-        calldata
-        (let ((pox-addr (unwrap!
-                (from-consensus-buff? {
-                    pox-addr: {
-                        version: (buff 1),
-                        hashbytes: (buff 32),
-                    },
-                    max-fee: uint,
-                }
-                    calldata
-                )
-                ERR_INVALID_CALLDATA
-            )))
-            (map-set pox-addrs staker pox-addr)
-            true
-        )
-        ;; If `signer-calldata` is not provided, delete (if present)
-        ;; their entry from `pox-addrs`.
-        (map-delete pox-addrs staker)
-    ))
+    (begin
+        (try! (authorize-pox-5))
+        (ok (match signer-calldata
+            calldata
+            (let ((pox-addr (unwrap!
+                    (from-consensus-buff? {
+                        pox-addr: {
+                            version: (buff 1),
+                            hashbytes: (buff 32),
+                        },
+                        max-fee: uint,
+                    }
+                        calldata
+                    )
+                    ERR_INVALID_CALLDATA
+                )))
+                (map-set pox-addrs staker pox-addr)
+                true
+            )
+            ;; If `signer-calldata` is not provided, delete (if present)
+            ;; their entry from `pox-addrs`.
+            (map-delete pox-addrs staker)
+        ))
+    )
 )
 
 ;; Handling rewards checkpointing for a staker
@@ -148,6 +154,7 @@
         (is-bond bool)
     )
     (begin
+        (try! (authorize-pox-5))
         (try! (fold checkpoint-staker-for-index
             (unwrap-panic (slice?
                 (list
@@ -411,6 +418,14 @@
     (ok (asserts! (and (is-eq contract-caller tx-sender) (is-admin tx-sender))
         ERR_UNAUTHORIZED_ADMIN
     ))
+)
+
+;; Ensure that the immediate caller is the pox-5 contract. The trait callbacks
+;; (validate-stake!, checkpoint-staker) write per-staker state keyed by the
+;; `staker` argument; they must only ever be driven by pox-5, never invoked
+;; directly by an external principal.
+(define-private (authorize-pox-5)
+    (ok (asserts! (is-eq contract-caller .pox-5) ERR_UNAUTHORIZED_CALLER))
 )
 
 (define-read-only (is-admin (caller principal))

--- a/contrib/core-contract-tests/package-lock.json
+++ b/contrib/core-contract-tests/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@clarigen/cli": "4.1.5",
-        "@clarigen/core": "4.1.5",
-        "@clarigen/test": "4.1.5",
+        "@clarigen/cli": "4.1.6",
+        "@clarigen/core": "4.1.6",
+        "@clarigen/test": "4.1.6",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@scure/base": "^2.0.0",
@@ -67,14 +67,14 @@
       "license": "MIT"
     },
     "node_modules/@clarigen/cli": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@clarigen/cli/-/cli-4.1.5.tgz",
-      "integrity": "sha512-4cJKajk0B+Y7hHzg4zOUQKGbS52kFhhejGB/NeBwxFjk2j1wrwSXQgG9i7qn7jIy9cLKlnARFPy1RXgkr+AYSw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@clarigen/cli/-/cli-4.1.6.tgz",
+      "integrity": "sha512-aTwuyoRiP2wL7Xjz+VQxMOP4eY30pYGoQnUTVJil/kisM52ZalpWq1xP82De3Wxr6NNS2ExHFrX91dzHrOaWFA==",
       "license": "MIT",
       "dependencies": {
         "@antfu/ni": "^0.21.12",
-        "@clarigen/core": "4.1.5",
-        "@clarigen/docs": "4.1.5",
+        "@clarigen/core": "4.1.6",
+        "@clarigen/docs": "4.1.6",
         "@iarna/toml": "^2.2.5",
         "@stacks/transactions": "7.1.0",
         "arktype": "^2.1.25",
@@ -125,15 +125,15 @@
       }
     },
     "node_modules/@clarigen/core": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@clarigen/core/-/core-4.1.5.tgz",
-      "integrity": "sha512-bQr3OMiYwc2QOhH8IaYLOVTHDxgH3x0XlgzQxLwhXDuXS3tdhQ899gHI66Mu30kSIvSsBddVmz0XpZyRl/Glig==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@clarigen/core/-/core-4.1.6.tgz",
+      "integrity": "sha512-kLiyvnMA/SGrAMzeWIJCI1wa5+sVy8JAbvWFf6EBAxnm36yccugstg6Ja9iQQlZr8xS97cJgpy1ZfOI3Aalr2Q==",
       "license": "MIT",
       "dependencies": {
-        "@scure/base": "^1.1.6",
+        "@scure/base": "^1.2.6",
         "@stacks/blockchain-api-client": "7.10.0",
-        "@stacks/common": "^7.0.2",
-        "@stacks/network": "^7.0.2",
+        "@stacks/common": "^7.3.1",
+        "@stacks/network": "^7.3.1",
         "@stacks/stacks-blockchain-api-types": "7.10.0",
         "@stacks/transactions": "7.1.0"
       },
@@ -183,20 +183,20 @@
       }
     },
     "node_modules/@clarigen/docs": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@clarigen/docs/-/docs-4.1.5.tgz",
-      "integrity": "sha512-vbbWPen2vCSrTbL6HLB/GJ1z7VGEMCf4X/rbzkUTI/ptOYgXYf2Stu8PQi6KqRBKUncJmVBxz3x4KDjg1O3/Xg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@clarigen/docs/-/docs-4.1.6.tgz",
+      "integrity": "sha512-6RP0vQXU4fAheLqs5ZjWC/vFQnUIkTKHspfSNyzoB+W3UlP7zzP2NguMApJMbTroAa7AxuF+FJTk7n6k3DfP5g==",
       "dependencies": {
-        "@clarigen/core": "4.1.5"
+        "@clarigen/core": "4.1.6"
       }
     },
     "node_modules/@clarigen/test": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@clarigen/test/-/test-4.1.5.tgz",
-      "integrity": "sha512-tvReWvkSVzDuROiyWf/hSU3AV8mjnobBwiVbZZPjUeUyCq0K+30hQgEfmiFDPpozUfsFCD9gcBlNd4iiJZME0A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@clarigen/test/-/test-4.1.6.tgz",
+      "integrity": "sha512-rNp/Pt7GwMYiz7TOCmlJ23RP/HHpKSWiWwP6ZTXdSvXmGzMuRJVwP2iB6kahePTr9/AOm22Bf0nfEC5LtsBL5A==",
       "license": "MIT",
       "dependencies": {
-        "@clarigen/core": "4.1.5",
+        "@clarigen/core": "4.1.6",
         "@stacks/transactions": "7.2.0",
         "yaml": "^2.4.1"
       },

--- a/contrib/core-contract-tests/package.json
+++ b/contrib/core-contract-tests/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@clarigen/cli": "4.1.5",
-    "@clarigen/core": "4.1.5",
-    "@clarigen/test": "4.1.5",
+    "@clarigen/cli": "4.1.6",
+    "@clarigen/core": "4.1.6",
+    "@clarigen/test": "4.1.6",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@scure/base": "^2.0.0",

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -3933,45 +3933,6 @@ export const contracts = {
           bigint
         >
       >,
-      getBitcoinTxOutput_q: {
-        name: 'get-bitcoin-tx-output?',
-        access: 'private',
-        args: [
-          { name: 'tx-bytes', type: { buffer: { length: 100000 } } },
-          { name: 'output-index', type: 'uint128' },
-          { name: 'amount', type: 'uint128' },
-          { name: 'script', type: { buffer: { length: 34 } } },
-        ],
-        outputs: {
-          type: {
-            response: {
-              ok: {
-                tuple: [
-                  { name: 'amount', type: 'uint128' },
-                  { name: 'script', type: { buffer: { length: 34 } } },
-                  { name: 'txid', type: { buffer: { length: 32 } } },
-                ],
-              },
-              error: 'uint128',
-            },
-          },
-        },
-      } as TypedAbiFunction<
-        [
-          txBytes: TypedAbiArg<Uint8Array, 'txBytes'>,
-          outputIndex: TypedAbiArg<number | bigint, 'outputIndex'>,
-          amount: TypedAbiArg<number | bigint, 'amount'>,
-          script: TypedAbiArg<Uint8Array, 'script'>,
-        ],
-        Response<
-          {
-            amount: bigint;
-            script: Uint8Array;
-            txid: Uint8Array;
-          },
-          bigint
-        >
-      >,
       lockSbtc: {
         name: 'lock-sbtc',
         access: 'private',
@@ -4433,30 +4394,6 @@ export const contracts = {
           >,
         ],
         Response<bigint, bigint>
-      >,
-      verifyMerkleProof: {
-        name: 'verify-merkle-proof',
-        access: 'private',
-        args: [
-          { name: 'leaf-hash', type: { buffer: { length: 32 } } },
-          { name: 'root-hash', type: { buffer: { length: 32 } } },
-          { name: 'tx-index', type: 'uint128' },
-          { name: 'tx-count', type: 'uint128' },
-          {
-            name: 'leaf-hashes',
-            type: { list: { type: { buffer: { length: 32 } }, length: 14 } },
-          },
-        ],
-        outputs: { type: 'bool' },
-      } as TypedAbiFunction<
-        [
-          leafHash: TypedAbiArg<Uint8Array, 'leafHash'>,
-          rootHash: TypedAbiArg<Uint8Array, 'rootHash'>,
-          txIndex: TypedAbiArg<number | bigint, 'txIndex'>,
-          txCount: TypedAbiArg<number | bigint, 'txCount'>,
-          leafHashes: TypedAbiArg<Uint8Array[], 'leafHashes'>,
-        ],
-        boolean
       >,
       allowContractCaller: {
         name: 'allow-contract-caller',
@@ -5162,7 +5099,7 @@ export const contracts = {
           { name: 'unlock-bytes', type: { buffer: { length: 683 } } },
           { name: 'early-unlock-bytes', type: { buffer: { length: 683 } } },
         ],
-        outputs: { type: { buffer: { length: 5141 } } },
+        outputs: { type: { buffer: { length: 4109 } } },
       } as TypedAbiFunction<
         [
           staker: TypedAbiArg<string, 'staker'>,
@@ -6482,6 +6419,16 @@ export const contracts = {
         },
         access: 'constant',
       } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_LOCKUP_AMOUNT: {
+        name: 'ERR_INVALID_LOCKUP_AMOUNT',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
       ERR_INVALID_LOCKUP_SCRIPT: {
         name: 'ERR_INVALID_LOCKUP_SCRIPT',
         type: {
@@ -6910,6 +6857,10 @@ export const contracts = {
         isOk: false,
         value: 40n,
       },
+      ERR_INVALID_LOCKUP_AMOUNT: {
+        isOk: false,
+        value: 45n,
+      },
       ERR_INVALID_LOCKUP_SCRIPT: {
         isOk: false,
         value: 42n,
@@ -7028,8 +6979,8 @@ export const contracts = {
     },
     non_fungible_tokens: [],
     fungible_tokens: [],
-    epoch: 'Epoch33',
-    clarity_version: 'Clarity4',
+    epoch: 'Epoch40',
+    clarity_version: 'Clarity6',
     contractName: 'pox-5',
   },
   pox_4_test: {
@@ -8827,6 +8778,12 @@ export const contracts = {
         args: [],
         outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
       } as TypedAbiFunction<[], Response<boolean, bigint>>,
+      authorizePox5: {
+        name: 'authorize-pox-5',
+        access: 'private',
+        args: [],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<[], Response<boolean, bigint>>,
       checkpointStakerForIndex: {
         name: 'checkpoint-staker-for-index',
         access: 'private',
@@ -9450,6 +9407,16 @@ export const contracts = {
         },
         access: 'constant',
       } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_UNAUTHORIZED_CALLER: {
+        name: 'ERR_UNAUTHORIZED_CALLER',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
       MAX_ADDRESS_VERSION: {
         name: 'MAX_ADDRESS_VERSION',
         type: 'uint128',
@@ -9502,6 +9469,10 @@ export const contracts = {
         isOk: false,
         value: 1_002n,
       },
+      ERR_UNAUTHORIZED_CALLER: {
+        isOk: false,
+        value: 1_006n,
+      },
       MAX_ADDRESS_VERSION: 6n,
       mAX_ADDRESS_VERSION_BUFF_20: 4n,
       MAX_BIPS: 10_000n,
@@ -9511,8 +9482,8 @@ export const contracts = {
     },
     non_fungible_tokens: [],
     fungible_tokens: [],
-    epoch: 'Epoch33',
-    clarity_version: 'Clarity4',
+    epoch: 'Epoch40',
+    clarity_version: 'Clarity6',
     contractName: 'signer-manager',
   },
   signers: {
@@ -10961,8 +10932,8 @@ export const contracts = {
     },
     non_fungible_tokens: [],
     fungible_tokens: [],
-    epoch: 'Epoch33',
-    clarity_version: 'Clarity4',
+    epoch: 'Epoch40',
+    clarity_version: 'Clarity6',
     contractName: 'test-pox-5-signer',
   },
 } as const;

--- a/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
@@ -115,6 +115,70 @@ function makePoxAddrCalldata(
   };
 }
 
+test('validate-stake! errors when not called by the pox-5 contract', () => {
+  // Calling the callback directly (contract-caller is a standard principal,
+  // not .pox-5) must be rejected.
+  const { calldata } = makePoxAddrCalldata();
+  expect(
+    txErr(
+      signerManager.validateStake_x({
+        staker: alice,
+        firstIndex: 0n,
+        numIndexes: 1n,
+        amountUstx: stxToUStx(50_000),
+        amountSats: 0n,
+        isBond: false,
+        signerCalldata: calldata,
+      }),
+      alice,
+    ).value,
+  ).toBe(signerManagerErrors.ERR_UNAUTHORIZED_CALLER);
+
+  // The rejected call must not have written a pox-addr for the staker.
+  expect(rov(signerManager.getPoxAddr(alice))).toBeNull();
+});
+
+test('a third party cannot hijack a staker pox-addr via a direct validate-stake! call', () => {
+  // Alice legitimately stakes through pox-5 with no L1 pox-addr.
+  setupStaker(alice);
+  expect(rov(signerManager.getPoxAddr(alice))).toBeNull();
+
+  // Bob attempts to register his own pox-addr against Alice's principal by
+  // invoking the callback directly. This would redirect Alice's L1 rewards
+  // to Bob's BTC address if the guard were missing.
+  const { calldata } = makePoxAddrCalldata();
+  expect(
+    txErr(
+      signerManager.validateStake_x({
+        staker: alice,
+        firstIndex: 0n,
+        numIndexes: 1n,
+        amountUstx: stxToUStx(50_000),
+        amountSats: 0n,
+        isBond: false,
+        signerCalldata: calldata,
+      }),
+      bob,
+    ).value,
+  ).toBe(signerManagerErrors.ERR_UNAUTHORIZED_CALLER);
+  expect(rov(signerManager.getPoxAddr(alice))).toBeNull();
+});
+
+test('checkpoint-staker reverts when not called by the pox-5 contract', () => {
+  setupTwoStakers();
+  expect(
+    txErr(
+      signerManager.checkpointStaker({
+        staker: alice,
+        firstIndex: 1n,
+        numIndexes: 1n,
+        isBond: false,
+      }),
+      alice,
+    ).value,
+  ).toBe(signerManagerErrors.ERR_UNAUTHORIZED_CALLER);
+});
+
 test('signers have pox-addr saved from calldata when provided', () => {
   const { poxAddr, calldata, maxFee } = makePoxAddrCalldata();
   txOk(


### PR DESCRIPTION
Those callback functions, `validate-stake!` and `checkpoint-staker` can only be called directly by the pox-5 contract.