### PR TITLE
Fix off-by-one bug in SIP-031 stateful PBT

### DIFF
--- a/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
+++ b/contrib/core-contract-tests/tests/sip-031/sip-031.stateful.prop.test.ts
@@ -24,7 +24,7 @@ test("SIP-031 Stateful", () => {
 
   const model: Model = {
     balance: 0n,
-    blockHeight: rov(contracts.sip031.getDeployBlockHeight()),
+    blockHeight: BigInt(simnet.burnBlockHeight),
     constants: contracts.sip031.constants,
     deployBlockHeight: rov(contracts.sip031.getDeployBlockHeight()),
     initialized: false,


### PR DESCRIPTION
This PR fixes an off-by-one issue in the stateful property-based testing setup that targets the SIP-031 smart contract. The issue was caught in CI and is tracked in #7251. The SIP-031 contract was thoroughly checked and confirmed safe.

The current fix was confirmed after re-running with the same seed reported in the failed CI job, along with 10 other novel runs.

This PR replaces #7252.