### PR TITLE
PoX-5: document the mod-0 block windowing behavior in burnchain.rs

### DIFF
--- a/stackslib/src/burnchains/burnchain.rs
+++ b/stackslib/src/burnchains/burnchain.rs
@@ -230,6 +230,11 @@ impl BurnchainStateTransition {
         })
         .epoch_id;
 
+        // NOTE: deliberately uses the classic prepare-phase predicate, which includes the mod 0
+        // block. Under PoX-5 the mod 0 block is the first reward-paying block of the cycle, so
+        // the cycle-start sortition runs with a 1-block window (as it always has). This is a
+        // known, intentional asymmetry: the mod 0 sortition confers no privileged power, and
+        // widening its window would be a consensus change at every cycle boundary.
         if !burnchain.is_in_prepare_phase(parent_snapshot.block_height + 1)
             && !burnchain
                 .pox_constants


### PR DESCRIPTION
This is just a comment PR that documents that the windowing behavior in burnchain.rs remains the same after the PoX-5 activation.