### PR TITLE
fix: remove unnecessary guard in `add-signer-to-set-for-cycle`

### DIFF
--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -942,7 +942,9 @@
         (try! (verify-signer-key-grant signer signer-key))
 
         ;; Only the signer contract itself can register itself
-        (asserts! (is-eq contract-caller signer) ERR_UNAUTHORIZED_SIGNER_REGISTRATION)
+        (asserts! (is-eq contract-caller signer)
+            ERR_UNAUTHORIZED_SIGNER_REGISTRATION
+        )
 
         (map-set signers signer signer-key)
         (let ((result {
@@ -1596,7 +1598,7 @@
                 (if (< cur-delegated-for-signer SIGNER_SET_MIN_USTX)
                     ;; They just crossed the threshold - add to signer set and add to reward calculations
                     (begin
-                        (try! (add-signer-to-set-for-cycle signer cycle))
+                        (add-signer-to-set-for-cycle signer cycle)
                         (map-set total-shares-staked-for-cycle {
                             index: cycle,
                             is-bond: false,
@@ -2369,7 +2371,9 @@
         (try! (validate-no-reentrancy))
 
         ;; Only the signer contract itself can call this function to grant a signer key
-        (asserts! (is-eq contract-caller signer-manager) ERR_UNAUTHORIZED_SIGNER_REGISTRATION)
+        (asserts! (is-eq contract-caller signer-manager)
+            ERR_UNAUTHORIZED_SIGNER_REGISTRATION
+        )
         (asserts!
             (is-none (map-get? used-signer-key-grants {
                 signer-key: signer-key,
@@ -3080,15 +3084,6 @@
         (cycle uint)
     )
     (let ((last-item (map-get? signer-set-ll-last-for-cycle cycle)))
-        ;; Todo: remove this and guard in a higher-level fn
-        (asserts!
-            (not (is-some (map-get? signer-set-ll-for-cycle {
-                cycle: cycle,
-                signer: signer,
-            })))
-            ERR_ALREADY_STAKED
-        )
-
         (match last-item
             last-signer (let ((last-node (unwrap-panic (map-get? signer-set-ll-for-cycle {
                     cycle: cycle,
@@ -3123,7 +3118,6 @@
         )
 
         (map-set signer-set-ll-last-for-cycle cycle signer)
-        (ok true)
     )
 )
 


### PR DESCRIPTION
There was a TODO to guard this in a higher-level function, which we do. I've removed that guard, which also means the function doesn't need to return a `response`