### PR TITLE
test: fix flakiness in `idle_tenure_extend_active_mining`

### DIFF
--- a/stacks-node/src/tests/signer/v0/tenure_extend.rs
+++ b/stacks-node/src/tests/signer/v0/tenure_extend.rs
@@ -847,10 +847,13 @@ fn idle_tenure_extend_active_mining() {
             );
             // Tenure-change blocks (BlockFound/Extended) roll the timestamp over to
             // `now + idle_timeout`, while regular blocks derive it from tenure start plus
-            // accumulated processing time. With second-level granularity these two formulas
-            // can produce equal timestamps, so only assert strict advancement between
-            // consecutive regular blocks (where the injected validation delay guarantees
-            // it advances). Skip the first block of each tenure and any tenure-change block.
+            // accumulated processing time (see `SignerDb::calculate_full_extend_timestamp`).
+            // With second-level granularity these two formulas can produce equal timestamps,
+            // so only assert strict advancement between consecutive regular blocks (where the
+            // injected validation delay guarantees it advances). Skip the first block of each
+            // tenure and any tenure-change block. In this scenario tenures advance via idle
+            // timeout, so only `Extended` blocks are expected here; the `BlockFound` check is
+            // defensive against unexpected tenure-change blocks (e.g. from CI timing).
             let latest_block_is_tenure_change =
                 last_block_contains_tenure_change_tx(TenureChangeCause::Extended)
                     || last_block_contains_tenure_change_tx(TenureChangeCause::BlockFound);

--- a/stacks-node/src/tests/signer/v0/tenure_extend.rs
+++ b/stacks-node/src/tests/signer/v0/tenure_extend.rs
@@ -845,11 +845,22 @@ fn idle_tenure_extend_active_mining() {
                 &get_last_block_hash(),
                 "Expected the latest block response to be for the latest block"
             );
-            assert_ne!(
-                last_response.get_tenure_extend_timestamp(),
-                latest_response.get_tenure_extend_timestamp(),
-                "Tenure extend timestamp should change with each block"
-            );
+            // Tenure-change blocks (BlockFound/Extended) roll the timestamp over to
+            // `now + idle_timeout`, while regular blocks derive it from tenure start plus
+            // accumulated processing time. With second-level granularity these two formulas
+            // can produce equal timestamps, so only assert strict advancement between
+            // consecutive regular blocks (where the injected validation delay guarantees
+            // it advances). Skip the first block of each tenure and any tenure-change block.
+            let latest_block_is_tenure_change =
+                last_block_contains_tenure_change_tx(TenureChangeCause::Extended)
+                    || last_block_contains_tenure_change_tx(TenureChangeCause::BlockFound);
+            if i != 1 && !latest_block_is_tenure_change {
+                assert_ne!(
+                    last_response.get_tenure_extend_timestamp(),
+                    latest_response.get_tenure_extend_timestamp(),
+                    "Tenure extend timestamp should change with each block"
+                );
+            }
             last_response = latest_response;
         }
 


### PR DESCRIPTION
Tenure-change blocks (BlockFound/Extended) roll the timestamp over to `now + idle_timeout`, while regular blocks derive it from tenure start plus accumulated processing time. With second-level granularity these two formulas can produce equal timestamps, so only assert strict advancement between consecutive regular blocks (where the injected validation delay guarantees it advances). Skip the first block of each tenure and any tenure-change block.