### PR TITLE
adjust PR nag CRON GH action to only run within stacks-network/stacks-core repo

### DIFF
--- a/.github/workflows/_slack-pr-nag.yml
+++ b/.github/workflows/_slack-pr-nag.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   nag-slack:
     runs-on: ubuntu-latest
+    # Only execute if running in our core repo
+    if: github.repository == 'stacks-network/stacks-core'
     steps:
       - name: Fetch PRs and Post Nags to Slack
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
### Description

adjust PR nag CRON GH action to only run within stacks-network/stacks-core repo

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

adjust PR nag CRON GH action to only run within stacks-network/stacks-core repo

### Checklist

N/A