### PR TITLE
fix: pin nightly+ in cargo hack checks

### DIFF
--- a/.github/workflows/check-cargo-hack.yml
+++ b/.github/workflows/check-cargo-hack.yml
@@ -119,16 +119,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      # Setup the rust toolchain for specified target
+      # Setup the rust toolchain for specified target.
+      # Pin to a specific nightly: an unpinned `nightly` tracks the latest build
+      # and breaks the job whenever rustc tightens lints (e.g. unused imports).
       - name: Setup Rust Toolchain
         uses: ./.github/actions/setup-rust-toolchain
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-06-07
 
       # Fuzz check clarity targets
       - name: Check fuzz targets (clarity)
         run: |
-          cargo +nightly check \
+          cargo +nightly-2026-06-07 check \
             --manifest-path clarity/fuzz/Cargo.toml \
             --bins \
             --locked
@@ -136,7 +138,7 @@ jobs:
       # Fuzz check stackslib targets
       - name: Check fuzz targets (stackslib)
         run: |
-          cargo +nightly check \
+          cargo +nightly-2026-06-07 check \
             --manifest-path stackslib/fuzz/Cargo.toml \
             --bins \
             --locked


### PR DESCRIPTION
### Description

In PRs CI and merge queue the `check-cargo-hack.yml` start failing due to rust toolchain nightly updates.

Example:
https://github.com/stacks-network/stacks-core/actions/runs/27200799232/job/80304117474?pr=7254

This patch as quick fix pins nightly at the day before we start having issues (1.98.0-nightly was issued at June 8th)

NOTE: To be investigated if we really need nightly here. At a first glance, it should be needed just for running `cargo fuzz run` but we are not using nightly feature at compilations.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

Added follow-up task for possible improvements: https://github.com/stx-labs/core-epics/issues/330

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
