### PR TITLE
Feat/reduce tenure extend timings

### DIFF
--- a/changelog.d/reduce_tenure_extend_timings.added
+++ b/changelog.d/reduce_tenure_extend_timings.added
@@ -1,0 +1,1 @@
+Reduced tenure extend timings

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -71,7 +71,7 @@ Key interactions:
   The signer waits `block_proposal_timeout_ms` before marking an unresponsive miner as inactive.
   If the miner extends before the signer invalidates the new winner, the extend is rejected.
 
-- **`tenure_timeout_secs`** (miner) should be > signer's **`tenure_idle_timeout_secs + tenure_idle_timeout_buffer_secs`** (default 62s).
+- **`tenure_timeout_secs`** (miner) should be > signer's **`tenure_idle_timeout_secs + tenure_idle_timeout_buffer_secs`** (default 32s).
   The signer computes an extend timestamp from the last block time + idle timeout + buffer.
   The miner must wait at least this long before time-based extends.
 

--- a/sample/conf/mainnet-miner-conf.toml
+++ b/sample/conf/mainnet-miner-conf.toml
@@ -223,7 +223,7 @@ max_rbf = 150
 #   Signer times out new winner first, then accepts the extend -> OK
 #
 # Additionally, the signer requires `tenure_idle_timeout_secs + tenure_idle_timeout_buffer_secs`
-# (default 62s) to have passed since the last block before accepting any extend.
+# (default 32s) to have passed since the last block before accepting any extend.
 # Both conditions must be met on the signer side.
 #
 # Default: 120_000
@@ -239,7 +239,7 @@ max_rbf = 150
 # timestamp allows it.
 #
 # WARNING: Should be greater than `tenure_extend_wait_timeout_ms` and
-# greater than signer's `tenure_idle_timeout_secs + tenure_idle_timeout_buffer_secs` (default 62s).
+# greater than signer's `tenure_idle_timeout_secs + tenure_idle_timeout_buffer_secs` (default 32s).
 #
 # Default: 180
 # Units: seconds

--- a/sample/conf/signer/mainnet-signer-conf.toml
+++ b/sample/conf/signer/mainnet-signer-conf.toml
@@ -114,9 +114,9 @@ db_path = "/var/lib/stacks-signer/signerdb.sqlite"
 #   - Miner `tenure_extend_wait_timeout_ms` (default 120_000ms): should
 #     be >= this + buffer so the miner doesn't extend too early
 #
-# Default: 60
+# Default: 30
 # Units: seconds
-# tenure_idle_timeout_secs = 60
+# tenure_idle_timeout_secs = 30
 
 # Buffer added to the tenure idle timeout to account for clock skew
 # between signer and miner nodes. The effective idle timeout sent to
@@ -128,9 +128,9 @@ db_path = "/var/lib/stacks-signer/signerdb.sqlite"
 
 # How much idle time must pass before allowing a read-count tenure extend.
 # Triggered when the read-count budget is nearly exhausted.
-# Default: 20
+# Default: 15
 # Units: seconds
-# read_count_idle_timeout_secs = 20
+# read_count_idle_timeout_secs = 15
 
 # Time to wait for the last block of a tenure to be globally accepted
 # or rejected before considering a new miner's block at the same height

--- a/sample/conf/testnet-miner-conf.toml
+++ b/sample/conf/testnet-miner-conf.toml
@@ -55,7 +55,7 @@ max_rbf = 150
 # tenure_extend_wait_timeout_ms = 120000
 
 # WARNING: Should be > tenure_extend_wait_timeout_ms and > signer's
-# tenure_idle_timeout_secs + tenure_idle_timeout_buffer_secs (default 62s).
+# tenure_idle_timeout_secs + tenure_idle_timeout_buffer_secs (default 32s).
 # Default: 180 seconds
 # tenure_timeout_secs = 180
 

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -44,8 +44,8 @@ const DEFAULT_TENURE_LAST_BLOCK_PROPOSAL_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_DRY_RUN: bool = false;
 /// Default number of idle seconds before the signer will accept a
 ///  tenure extend from the miner
-const TENURE_IDLE_TIMEOUT_SECS: u64 = 60;
-const READ_COUNT_IDLE_TIMEOUT_SECS: u64 = 20;
+const TENURE_IDLE_TIMEOUT_SECS: u64 = 30;
+const READ_COUNT_IDLE_TIMEOUT_SECS: u64 = 15;
 const DEFAULT_REORG_ATTEMPTS_ACTIVITY_TIMEOUT_MS: u64 = 200_000;
 /// Default number of seconds to add to the tenure extend time, after computing the idle timeout,
 /// to allow for clock skew between the signer and the miner
@@ -393,7 +393,7 @@ struct RawConfigFile {
     /// This is one of two gates for tenure extends (the other is
     /// `block_proposal_timeout` for new-winner invalidation).
     /// ---
-    /// @default: `60`
+    /// @default: `30`
     /// @units: seconds
     /// @notes:
     ///   - WARNING: Must coordinate with miner's `tenure_timeout` (default 180s,
@@ -404,7 +404,7 @@ struct RawConfigFile {
     /// A read-count tenure extend is triggered when the read count budget is nearly
     /// exhausted.
     /// ---
-    /// @default: `20`
+    /// @default: `15`
     /// @units: seconds
     pub read_count_idle_timeout_secs: Option<u64>,
     /// Buffer time added to the tenure extend time sent to miners to account for


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This patch reduces the renure extend timings from 60/20 to 30/15

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
