### PR TITLE
feat: update print info in register-for-bond

### DIFF
--- a/changelog.d/update-l1-bond-registration-print.added
+++ b/changelog.d/update-l1-bond-registration-print.added
@@ -1,0 +1,23 @@
+Updated the print event inside `register-for-bond` to include the transaction info for L1 lockups.
+
+For an L1 lockup, you'll see:
+
+```clar
+{
+  btc-lockup: {
+    type: "l1",
+    txs: (some { txid: (buff 32), output-index: uint })
+  }
+}
+```
+
+For an L2 lockup, you'll see:
+
+```clar
+{
+  btc-lockup: {
+    type: "l2",
+    txs: none,
+  }
+}
+```

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -3608,13 +3608,13 @@ export const contracts = {
           { name: 'signer', type: 'principal' },
           { name: 'cycle', type: 'uint128' },
         ],
-        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+        outputs: { type: 'bool' },
       } as TypedAbiFunction<
         [
           signer: TypedAbiArg<string, 'signer'>,
           cycle: TypedAbiArg<number | bigint, 'cycle'>,
         ],
-        Response<boolean, bigint>
+        boolean
       >,
       addStakerToBond: {
         name: 'add-staker-to-bond',
@@ -4050,6 +4050,60 @@ export const contracts = {
           },
           bigint
         >
+      >,
+      getL1LockupSummary: {
+        name: 'get-l1-lockup-summary',
+        access: 'private',
+        args: [
+          {
+            name: 'lockup',
+            type: {
+              tuple: [
+                { name: 'amount', type: 'uint128' },
+                { name: 'header', type: { buffer: { length: 80 } } },
+                { name: 'height', type: 'uint128' },
+                {
+                  name: 'leaf-hashes',
+                  type: {
+                    list: { type: { buffer: { length: 32 } }, length: 14 },
+                  },
+                },
+                { name: 'output-index', type: 'uint128' },
+                { name: 'tx', type: { buffer: { length: 100000 } } },
+                { name: 'tx-count', type: 'uint128' },
+                { name: 'tx-index', type: 'uint128' },
+              ],
+            },
+          },
+        ],
+        outputs: {
+          type: {
+            tuple: [
+              { name: 'output-index', type: 'uint128' },
+              { name: 'txid', type: { buffer: { length: 32 } } },
+            ],
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          lockup: TypedAbiArg<
+            {
+              amount: number | bigint;
+              header: Uint8Array;
+              height: number | bigint;
+              leafHashes: Uint8Array[];
+              outputIndex: number | bigint;
+              tx: Uint8Array;
+              txCount: number | bigint;
+              txIndex: number | bigint;
+            },
+            'lockup'
+          >,
+        ],
+        {
+          outputIndex: bigint;
+          txid: Uint8Array;
+        }
       >,
       matchUintInList: {
         name: 'match-uint-in-list',
@@ -5128,6 +5182,36 @@ export const contracts = {
                 tuple: [
                   { name: 'amount-ustx', type: 'uint128' },
                   { name: 'bond-index', type: 'uint128' },
+                  {
+                    name: 'btc-lockup',
+                    type: {
+                      tuple: [
+                        {
+                          name: 'txs',
+                          type: {
+                            optional: {
+                              list: {
+                                type: {
+                                  tuple: [
+                                    { name: 'output-index', type: 'uint128' },
+                                    {
+                                      name: 'txid',
+                                      type: { buffer: { length: 32 } },
+                                    },
+                                  ],
+                                },
+                                length: 10,
+                              },
+                            },
+                          },
+                        },
+                        {
+                          name: 'type',
+                          type: { 'string-ascii': { length: 2 } },
+                        },
+                      ],
+                    },
+                  },
                   { name: 'first-reward-cycle', type: 'uint128' },
                   { name: 'is-l1-lock', type: 'bool' },
                   { name: 'sats-total', type: 'uint128' },
@@ -5171,6 +5255,15 @@ export const contracts = {
           {
             amountUstx: bigint;
             bondIndex: bigint;
+            btcLockup: {
+              txs:
+                | {
+                    outputIndex: bigint;
+                    txid: Uint8Array;
+                  }[]
+                | null;
+              type: string;
+            };
             firstRewardCycle: bigint;
             isL1Lock: boolean;
             satsTotal: bigint;

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -791,6 +791,16 @@
                 unlock-burn-height: (reward-cycle-to-burn-height unlock-cycle),
                 unlock-cycle: unlock-cycle,
                 is-l1-lock: (is-ok btc-lockup),
+                btc-lockup: (match btc-lockup
+                    l1-info {
+                        type: "l1",
+                        txs: (some (map get-l1-lockup-summary (get outputs l1-info))),
+                    }
+                    sbtc-amount {
+                        type: "l2",
+                        txs: none,
+                    }
+                ),
             }))
             (print (merge { topic: "register-for-bond" } result))
             (ok result)
@@ -1184,8 +1194,7 @@
         )
         (asserts! (get is-l1-lock membership) ERR_CANNOT_ANNOUNCE_L1_EARLY_UNLOCK)
         (asserts! (is-eq old-signer signer) ERR_INVALID_OLD_SIGNER_MANAGER)
-        (asserts!
-            (not (has-announced-l1-early-exit bond-index staker))
+        (asserts! (not (has-announced-l1-early-exit bond-index staker))
             ERR_L1_EARLY_EXIT_ALREADY_ANNOUNCED
         )
 
@@ -1974,6 +1983,22 @@
             seen-outpoints: (unwrap-panic (as-max-len? (append seen-outpoints outpoint) u10)),
         })
     )
+)
+
+(define-private (get-l1-lockup-summary (lockup {
+    height: uint,
+    tx: (buff 100000),
+    output-index: uint,
+    header: (buff 80),
+    leaf-hashes: (list 14 (buff 32)),
+    tx-count: uint,
+    tx-index: uint,
+    amount: uint,
+}))
+    {
+        txid: (get-reversed-txid (get tx lockup)),
+        output-index: (get output-index lockup),
+    }
 )
 
 ;;; Reward calculation

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -1175,7 +1175,6 @@
             (membership (unwrap! (get-bond-membership staker) ERR_NOT_BOND_PARTICIPANT))
             (bond-index (get bond-index membership))
             (signer (get signer membership))
-            (bond (unwrap-panic (get-protocol-bond bond-index)))
             (current-cycle (current-pox-reward-cycle))
             (bond-start-cycle (bond-period-to-reward-cycle bond-index))
             (bond-end-cycle (bond-period-to-reward-cycle (+ bond-index u6)))


### PR DESCRIPTION
Updated the print event inside `register-for-bond` to include the transaction info for L1 lockups.

For an L1 lockup, you'll see:

```clar
{
  btc-lockup: {
    type: "l1",
    txs: (some { txid: (buff 32), output-index: uint })
  }
}
```

For an L2 lockup, you'll see:

```clar
{
  btc-lockup: {
    type: "l2",
    txs: none,
  }
}
```
