### PR TITLE
fix: require `revoke-signer-grant` to be called directly

### DIFF
--- a/changelog.d/revoke-signer-grant.fixed
+++ b/changelog.d/revoke-signer-grant.fixed
@@ -1,0 +1,1 @@
+Require that `revoke-signer-grant` is called directly only, not indirectly through any contract.

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -2672,7 +2672,7 @@
         ;; ensure no reentrancy through signer-manager trait calls
         (try! (validate-no-reentrancy))
 
-        ;; Validate that `tx-sender` has the same pubkey hash as `signer-key`
+        ;; Validate that `contract-caller` has the same pubkey hash as `signer-key`
         (asserts!
             (is-eq
                 (unwrap-panic (principal-construct?
@@ -2682,7 +2682,7 @@
                     )
                     (hash160 signer-key)
                 ))
-                tx-sender
+                contract-caller
             )
             ERR_UNAUTHORIZED
         )


### PR DESCRIPTION
This cannot be called indirectly, so we should use `contract-caller` instead of `tx-sender`.