### PR TITLE
feat: snapshot copy of clarity side tables

### DIFF
--- a/changelog.d/marf-snapshot-clarity.added
+++ b/changelog.d/marf-snapshot-clarity.added
@@ -1,0 +1,1 @@
+Add snapshot copy of Clarity side-storage tables (data_table, metadata_table) into a squashed Clarity MARF.

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -24,7 +24,7 @@ pub use self::clarity_db::{
 pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
 pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 #[cfg(feature = "rusqlite")]
-pub use self::sqlite::{DATA_TABLE_NAME, METADATA_TABLE_NAME, SqliteConnection};
+pub use self::sqlite::{DATA_TABLE_NAME, METADATA_TABLE_NAME, MetadataRow, SqliteConnection};
 pub use self::structures::{
     ClarityDeserializable, ClaritySerializable, DataMapMetadata, DataVariableMetadata,
     FungibleTokenMetadata, NonFungibleTokenMetadata, STXBalance,

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -24,7 +24,7 @@ pub use self::clarity_db::{
 pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
 pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 #[cfg(feature = "rusqlite")]
-pub use self::sqlite::SqliteConnection;
+pub use self::sqlite::{DATA_TABLE_NAME, METADATA_TABLE_NAME, SqliteConnection};
 pub use self::structures::{
     ClarityDeserializable, ClaritySerializable, DataMapMetadata, DataVariableMetadata,
     FungibleTokenMetadata, NonFungibleTokenMetadata, STXBalance,

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -155,11 +155,11 @@ impl SqliteConnection {
     pub fn insert_metadata(
         conn: &Connection,
         bhh: &StacksBlockId,
-        contract_hash: &str,
+        contract_id: &str,
         key: &str,
         value: &str,
     ) -> Result<(), VmExecutionError> {
-        let key = Self::make_metadata_key(contract_hash, key);
+        let key = Self::make_metadata_key(contract_id, key);
         let params = params![bhh, key, value];
 
         if let Err(e) = conn.execute(
@@ -268,10 +268,10 @@ impl SqliteConnection {
     pub fn get_metadata(
         conn: &Connection,
         bhh: &StacksBlockId,
-        contract_hash: &str,
+        contract_id: &str,
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
-        let key = Self::make_metadata_key(contract_hash, key);
+        let key = Self::make_metadata_key(contract_id, key);
         let params = params![bhh, key];
 
         match conn

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -36,6 +36,18 @@ const SQL_FAIL_MESSAGE: &str = "PANIC: SQL Failure in Smart Contract VM.";
 pub const DATA_TABLE_NAME: &str = "data_table";
 pub const METADATA_TABLE_NAME: &str = "metadata_table";
 
+/// A borrowed `metadata_table` row, yielded by
+/// [`SqliteConnection::visit_metadata_rows`] and accepted by
+/// [`SqliteConnection::insert_metadata_row`].
+pub struct MetadataRow<'a> {
+    /// Full `clr-meta::<contract id>::<key>` key.
+    pub key: &'a str,
+    /// The `blockhash` column: a hex-encoded [`StacksBlockId`].
+    pub block_id: &'a str,
+    /// The stored metadata value.
+    pub value: &'a str,
+}
+
 pub struct SqliteConnection {
     conn: Connection,
 }
@@ -176,46 +188,52 @@ impl SqliteConnection {
         Ok(())
     }
 
-    /// Insert a `metadata_table` row verbatim: `key` is already in the
-    /// [`Self::make_metadata_key`] format.
+    /// Insert a `metadata_table` row verbatim. [`MetadataRow::key`] is assumed
+    /// to already be in the [`Self::make_metadata_key`] (`clr-meta::`) format.
     pub fn insert_metadata_row(
         conn: &Connection,
-        key: &str,
-        blockhash: &str,
-        value: &str,
+        row: &MetadataRow,
     ) -> Result<(), rusqlite::Error> {
         conn.prepare_cached("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)")?
-            .execute(params![blockhash, key, value])?;
+            .execute(params![row.block_id, row.key, row.value])?;
         Ok(())
     }
 
-    /// Visit every `metadata_table` row on `conn` as `(key, blockhash, value)`.
-    pub fn visit_metadata_rows<F>(conn: &Connection, mut visit: F) -> Result<(), rusqlite::Error>
+    /// Visit every `metadata_table` row on `conn` as a [`MetadataRow`].
+    pub fn visit_metadata_rows<E, F>(conn: &Connection, mut visit: F) -> Result<(), E>
     where
-        F: FnMut(&str, &str, &str) -> Result<(), rusqlite::Error>,
+        E: From<rusqlite::Error>,
+        F: FnMut(&MetadataRow) -> Result<(), E>,
     {
         let mut stmt = conn.prepare("SELECT key, blockhash, value FROM metadata_table")?;
         let mut rows = stmt.query(NO_PARAMS)?;
         while let Some(row) = rows.next()? {
-            let key: String = row.get(0)?;
-            let blockhash: String = row.get(1)?;
-            let value: String = row.get(2)?;
-            visit(&key, &blockhash, &value)?;
+            let key = row.get_ref(0)?.as_str().map_err(rusqlite::Error::from)?;
+            let block_id = row.get_ref(1)?.as_str().map_err(rusqlite::Error::from)?;
+            let value = row.get_ref(2)?.as_str().map_err(rusqlite::Error::from)?;
+            visit(&MetadataRow {
+                key,
+                block_id,
+                value,
+            })?;
         }
         Ok(())
     }
 
-    /// Visit every `metadata_table` key on `conn` in ascending key order
-    /// (deterministic for scans that aggregate by contract).
-    pub fn visit_metadata_keys<F>(conn: &Connection, mut visit: F) -> Result<(), rusqlite::Error>
+    /// Visit every `metadata_table` key on `conn` in ascending key order.
+    ///
+    /// The ascending order is a guaranteed part of this method's contract
+    /// (`ORDER BY key`); callers such as the snapshot copier rely on it for
+    /// deterministic, reproducible scans (locked by `metadata_keys_visited_in_order`).
+    pub fn visit_metadata_keys<E, F>(conn: &Connection, mut visit: F) -> Result<(), E>
     where
-        F: FnMut(&str) -> Result<(), rusqlite::Error>,
+        E: From<rusqlite::Error>,
+        F: FnMut(&str) -> Result<(), E>,
     {
         let mut stmt = conn.prepare("SELECT key FROM metadata_table ORDER BY key")?;
         let mut rows = stmt.query(NO_PARAMS)?;
         while let Some(row) = rows.next()? {
-            let key: String = row.get(0)?;
-            visit(&key)?;
+            visit(row.get_ref(0)?.as_str().map_err(rusqlite::Error::from)?)?;
         }
         Ok(())
     }

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -491,23 +491,121 @@ impl ClarityBackingStore for MemoryBackingStore {
     }
 }
 
-#[test]
-fn trigger_bad_block_height() {
-    let mut store = MemoryBackingStore::default();
-    let contract_id = QualifiedContractIdentifier::transient();
-    // Use a block height that does NOT exist in MemoryBackingStore
-    // MemoryBackingStore::get_block_at_height returns None for any height != 0
-    let nonexistent_height = 42;
-    let key = "some-metadata-key";
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let err =
-        sqlite_get_metadata_manual(&mut store, nonexistent_height, &contract_id, key).unwrap_err();
+    #[test]
+    fn trigger_bad_block_height() {
+        let mut store = MemoryBackingStore::default();
+        let contract_id = QualifiedContractIdentifier::transient();
+        // Use a block height that does NOT exist in MemoryBackingStore
+        // MemoryBackingStore::get_block_at_height returns None for any height != 0
+        let nonexistent_height = 42;
+        let key = "some-metadata-key";
 
-    assert!(
-        matches!(
-            err,
-            VmExecutionError::Runtime(RuntimeError::BadBlockHeight(_), _)
-        ),
-        "Expected BadBlockHeight. Got {err}"
-    );
+        let err = sqlite_get_metadata_manual(&mut store, nonexistent_height, &contract_id, key)
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                VmExecutionError::Runtime(RuntimeError::BadBlockHeight(_), _)
+            ),
+            "Expected BadBlockHeight. Got {err}"
+        );
+    }
+
+    #[test]
+    fn metadata_keys_visited_in_order() {
+        let conn = SqliteConnection::memory().unwrap();
+        let block_id = StacksBlockId([0x11; 32]).to_hex();
+
+        // Insert keys out of order; visit_metadata_keys must yield them sorted.
+        for key in [
+            "clr-meta::contract-z::source",
+            "clr-meta::contract-a::source",
+            "clr-meta::contract-m::source",
+            "clr-meta::contract-a::other",
+        ] {
+            SqliteConnection::insert_metadata_row(
+                &conn,
+                &MetadataRow {
+                    key,
+                    block_id: &block_id,
+                    value: "v",
+                },
+            )
+            .unwrap();
+        }
+
+        let mut visited: Vec<String> = Vec::new();
+        SqliteConnection::visit_metadata_keys(&conn, |key| -> Result<(), rusqlite::Error> {
+            visited.push(key.to_string());
+            Ok(())
+        })
+        .unwrap();
+
+        let mut sorted = visited.clone();
+        sorted.sort();
+        assert_eq!(
+            visited, sorted,
+            "visit_metadata_keys must yield keys in ascending order"
+        );
+        assert_eq!(visited.len(), 4, "all rows must be visited");
+    }
+
+    #[test]
+    fn metadata_key_make_and_parse() {
+        // Round-trips through the `clr-meta::<contract id>::<key>` format.
+        let key = SqliteConnection::make_metadata_key("ST000.contract", "var");
+        assert_eq!(key, "clr-meta::ST000.contract::var");
+        assert_eq!(
+            SqliteConnection::parse_metadata_key(&key),
+            Some(("ST000.contract", "var"))
+        );
+
+        // The metadata key may itself contain "::"; only the first separator
+        // after the prefix is the boundary (contract ids never contain "::").
+        let key = SqliteConnection::make_metadata_key("ST000.contract", "vm-metadata::9::sub");
+        assert_eq!(
+            SqliteConnection::parse_metadata_key(&key),
+            Some(("ST000.contract", "vm-metadata::9::sub"))
+        );
+
+        // An empty metadata key is still well-formed.
+        let key = SqliteConnection::make_metadata_key("ST000.contract", "");
+        assert_eq!(
+            SqliteConnection::parse_metadata_key(&key),
+            Some(("ST000.contract", ""))
+        );
+
+        // A realistic mainnet contract id round-trips.
+        let key =
+            SqliteConnection::make_metadata_key("SP000000000000000000002Q6VF78.pox-4", "vars");
+        assert_eq!(
+            SqliteConnection::parse_metadata_key(&key),
+            Some(("SP000000000000000000002Q6VF78.pox-4", "vars"))
+        );
+
+        // The parser only checks shape, not identifiers: a key with an empty
+        // contract id parses here (it's rejected later by contract-id parsing).
+        assert_eq!(
+            SqliteConnection::parse_metadata_key("clr-meta::::var"),
+            Some(("", "var"))
+        );
+
+        // Keys outside the format (or with the prefix but no second separator)
+        // do not parse.
+        assert_eq!(
+            SqliteConnection::parse_metadata_key("not-a-metadata-key"),
+            None
+        );
+        assert_eq!(
+            SqliteConnection::parse_metadata_key("clr-meta::no-second-separator"),
+            None
+        );
+        assert_eq!(SqliteConnection::parse_metadata_key("clr-meta::"), None);
+        assert_eq!(SqliteConnection::parse_metadata_key(""), None);
+    }
 }

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -220,21 +220,6 @@ impl SqliteConnection {
         Ok(())
     }
 
-    /// Visit every `data_table` row on `conn` as `(key, value)`.
-    pub fn visit_data_rows<F>(conn: &Connection, mut visit: F) -> Result<(), rusqlite::Error>
-    where
-        F: FnMut(&str, &str) -> Result<(), rusqlite::Error>,
-    {
-        let mut stmt = conn.prepare("SELECT key, value FROM data_table")?;
-        let mut rows = stmt.query(NO_PARAMS)?;
-        while let Some(row) = rows.next()? {
-            let key: String = row.get(0)?;
-            let value: String = row.get(1)?;
-            visit(&key, &value)?;
-        }
-        Ok(())
-    }
-
     /// Number of rows in `data_table`.
     pub fn count_data_rows(conn: &Connection) -> Result<u64, rusqlite::Error> {
         conn.query_row("SELECT COUNT(*) FROM data_table", NO_PARAMS, |row| {

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -32,6 +32,10 @@ use crate::vm::types::QualifiedContractIdentifier;
 
 const SQL_FAIL_MESSAGE: &str = "PANIC: SQL Failure in Smart Contract VM.";
 
+/// Clarity side-storage table names.
+pub const DATA_TABLE_NAME: &str = "data_table";
+pub const METADATA_TABLE_NAME: &str = "metadata_table";
+
 pub struct SqliteConnection {
     conn: Connection,
 }

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -188,10 +188,9 @@ impl SqliteConnection {
 
     /// Visit every `metadata_table` row on `conn` as `(key, blockhash, value)`.
     /// Used by the snapshot copy.
-    pub fn visit_metadata_rows<E, F>(conn: &Connection, mut visit: F) -> Result<(), E>
+    pub fn visit_metadata_rows<F>(conn: &Connection, mut visit: F) -> Result<(), rusqlite::Error>
     where
-        E: From<rusqlite::Error>,
-        F: FnMut(&str, &str, &str) -> Result<(), E>,
+        F: FnMut(&str, &str, &str) -> Result<(), rusqlite::Error>,
     {
         let mut stmt = conn.prepare("SELECT key, blockhash, value FROM metadata_table")?;
         let mut rows = stmt.query(NO_PARAMS)?;
@@ -206,10 +205,9 @@ impl SqliteConnection {
 
     /// Visit every `metadata_table` key on `conn` in ascending key order
     /// (deterministic for scans that aggregate by contract).
-    pub fn visit_metadata_keys<E, F>(conn: &Connection, mut visit: F) -> Result<(), E>
+    pub fn visit_metadata_keys<F>(conn: &Connection, mut visit: F) -> Result<(), rusqlite::Error>
     where
-        E: From<rusqlite::Error>,
-        F: FnMut(&str) -> Result<(), E>,
+        F: FnMut(&str) -> Result<(), rusqlite::Error>,
     {
         let mut stmt = conn.prepare("SELECT key FROM metadata_table ORDER BY key")?;
         let mut rows = stmt.query(NO_PARAMS)?;

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -73,6 +73,12 @@ fn sqlite_has_entry(conn: &Connection, key: &str) -> Result<bool, VmExecutionErr
     Ok(sqlite_get(conn, key)?.is_some())
 }
 
+/// Log `e` and wrap it in the VM's generic SQL failure error.
+fn sqlite_fail(e: rusqlite::Error) -> VmExecutionError {
+    error!("SQL failure in Clarity side storage: {e:?}");
+    VmInternalError::DBError(SQL_FAIL_MESSAGE.into()).into()
+}
+
 pub fn sqlite_get_contract_hash(
     store: &mut dyn ClarityBackingStore,
     contract: &QualifiedContractIdentifier,
@@ -170,6 +176,66 @@ impl SqliteConnection {
             return Err(VmInternalError::DBError(SQL_FAIL_MESSAGE.into()).into());
         }
         Ok(())
+    }
+
+    /// Insert a `metadata_table` row verbatim: `key` is already in the
+    /// [`Self::make_metadata_key`] format. Used by the snapshot copy to
+    /// preserve source rows byte-for-byte.
+    pub fn insert_metadata_row(
+        conn: &Connection,
+        key: &str,
+        blockhash: &str,
+        value: &str,
+    ) -> Result<(), VmExecutionError> {
+        conn.prepare_cached("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)")
+            .map_err(sqlite_fail)?
+            .execute(params![blockhash, key, value])
+            .map_err(sqlite_fail)?;
+        Ok(())
+    }
+
+    /// Visit every `metadata_table` row on `conn` as `(key, blockhash, value)`.
+    /// Used by the snapshot copy.
+    pub fn visit_metadata_rows<F>(conn: &Connection, mut visit: F) -> Result<(), VmExecutionError>
+    where
+        F: FnMut(&str, &str, &str) -> Result<(), VmExecutionError>,
+    {
+        let mut stmt = conn
+            .prepare("SELECT key, blockhash, value FROM metadata_table")
+            .map_err(sqlite_fail)?;
+        let mut rows = stmt.query(NO_PARAMS).map_err(sqlite_fail)?;
+        while let Some(row) = rows.next().map_err(sqlite_fail)? {
+            let key: String = row.get(0).map_err(sqlite_fail)?;
+            let blockhash: String = row.get(1).map_err(sqlite_fail)?;
+            let value: String = row.get(2).map_err(sqlite_fail)?;
+            visit(&key, &blockhash, &value)?;
+        }
+        Ok(())
+    }
+
+    /// Visit every `metadata_table` key on `conn` in ascending key order
+    /// (deterministic for scans that aggregate by contract).
+    pub fn visit_metadata_keys<F>(conn: &Connection, mut visit: F) -> Result<(), VmExecutionError>
+    where
+        F: FnMut(&str) -> Result<(), VmExecutionError>,
+    {
+        let mut stmt = conn
+            .prepare("SELECT key FROM metadata_table ORDER BY key")
+            .map_err(sqlite_fail)?;
+        let mut rows = stmt.query(NO_PARAMS).map_err(sqlite_fail)?;
+        while let Some(row) = rows.next().map_err(sqlite_fail)? {
+            let key: String = row.get(0).map_err(sqlite_fail)?;
+            visit(&key)?;
+        }
+        Ok(())
+    }
+
+    /// Number of rows in `data_table`.
+    pub fn count_data_rows(conn: &Connection) -> Result<u64, VmExecutionError> {
+        conn.query_row("SELECT COUNT(*) FROM data_table", NO_PARAMS, |row| {
+            row.get(0)
+        })
+        .map_err(sqlite_fail)
     }
 
     pub fn commit_metadata_to(

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -73,12 +73,6 @@ fn sqlite_has_entry(conn: &Connection, key: &str) -> Result<bool, VmExecutionErr
     Ok(sqlite_get(conn, key)?.is_some())
 }
 
-/// Log `e` and wrap it in the VM's generic SQL failure error.
-fn sqlite_fail(e: rusqlite::Error) -> VmExecutionError {
-    error!("SQL failure in Clarity side storage: {e:?}");
-    VmInternalError::DBError(SQL_FAIL_MESSAGE.into()).into()
-}
-
 pub fn sqlite_get_contract_hash(
     store: &mut dyn ClarityBackingStore,
     contract: &QualifiedContractIdentifier,
@@ -186,28 +180,25 @@ impl SqliteConnection {
         key: &str,
         blockhash: &str,
         value: &str,
-    ) -> Result<(), VmExecutionError> {
-        conn.prepare_cached("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)")
-            .map_err(sqlite_fail)?
-            .execute(params![blockhash, key, value])
-            .map_err(sqlite_fail)?;
+    ) -> Result<(), rusqlite::Error> {
+        conn.prepare_cached("INSERT INTO metadata_table (blockhash, key, value) VALUES (?, ?, ?)")?
+            .execute(params![blockhash, key, value])?;
         Ok(())
     }
 
     /// Visit every `metadata_table` row on `conn` as `(key, blockhash, value)`.
     /// Used by the snapshot copy.
-    pub fn visit_metadata_rows<F>(conn: &Connection, mut visit: F) -> Result<(), VmExecutionError>
+    pub fn visit_metadata_rows<E, F>(conn: &Connection, mut visit: F) -> Result<(), E>
     where
-        F: FnMut(&str, &str, &str) -> Result<(), VmExecutionError>,
+        E: From<rusqlite::Error>,
+        F: FnMut(&str, &str, &str) -> Result<(), E>,
     {
-        let mut stmt = conn
-            .prepare("SELECT key, blockhash, value FROM metadata_table")
-            .map_err(sqlite_fail)?;
-        let mut rows = stmt.query(NO_PARAMS).map_err(sqlite_fail)?;
-        while let Some(row) = rows.next().map_err(sqlite_fail)? {
-            let key: String = row.get(0).map_err(sqlite_fail)?;
-            let blockhash: String = row.get(1).map_err(sqlite_fail)?;
-            let value: String = row.get(2).map_err(sqlite_fail)?;
+        let mut stmt = conn.prepare("SELECT key, blockhash, value FROM metadata_table")?;
+        let mut rows = stmt.query(NO_PARAMS)?;
+        while let Some(row) = rows.next()? {
+            let key: String = row.get(0)?;
+            let blockhash: String = row.get(1)?;
+            let value: String = row.get(2)?;
             visit(&key, &blockhash, &value)?;
         }
         Ok(())
@@ -215,27 +206,25 @@ impl SqliteConnection {
 
     /// Visit every `metadata_table` key on `conn` in ascending key order
     /// (deterministic for scans that aggregate by contract).
-    pub fn visit_metadata_keys<F>(conn: &Connection, mut visit: F) -> Result<(), VmExecutionError>
+    pub fn visit_metadata_keys<E, F>(conn: &Connection, mut visit: F) -> Result<(), E>
     where
-        F: FnMut(&str) -> Result<(), VmExecutionError>,
+        E: From<rusqlite::Error>,
+        F: FnMut(&str) -> Result<(), E>,
     {
-        let mut stmt = conn
-            .prepare("SELECT key FROM metadata_table ORDER BY key")
-            .map_err(sqlite_fail)?;
-        let mut rows = stmt.query(NO_PARAMS).map_err(sqlite_fail)?;
-        while let Some(row) = rows.next().map_err(sqlite_fail)? {
-            let key: String = row.get(0).map_err(sqlite_fail)?;
+        let mut stmt = conn.prepare("SELECT key FROM metadata_table ORDER BY key")?;
+        let mut rows = stmt.query(NO_PARAMS)?;
+        while let Some(row) = rows.next()? {
+            let key: String = row.get(0)?;
             visit(&key)?;
         }
         Ok(())
     }
 
     /// Number of rows in `data_table`.
-    pub fn count_data_rows(conn: &Connection) -> Result<u64, VmExecutionError> {
+    pub fn count_data_rows(conn: &Connection) -> Result<u64, rusqlite::Error> {
         conn.query_row("SELECT COUNT(*) FROM data_table", NO_PARAMS, |row| {
             row.get(0)
         })
-        .map_err(sqlite_fail)
     }
 
     pub fn commit_metadata_to(

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -173,8 +173,7 @@ impl SqliteConnection {
     }
 
     /// Insert a `metadata_table` row verbatim: `key` is already in the
-    /// [`Self::make_metadata_key`] format. Used by the snapshot copy to
-    /// preserve source rows byte-for-byte.
+    /// [`Self::make_metadata_key`] format.
     pub fn insert_metadata_row(
         conn: &Connection,
         key: &str,
@@ -187,7 +186,6 @@ impl SqliteConnection {
     }
 
     /// Visit every `metadata_table` row on `conn` as `(key, blockhash, value)`.
-    /// Used by the snapshot copy.
     pub fn visit_metadata_rows<F>(conn: &Connection, mut visit: F) -> Result<(), rusqlite::Error>
     where
         F: FnMut(&str, &str, &str) -> Result<(), rusqlite::Error>,
@@ -214,6 +212,21 @@ impl SqliteConnection {
         while let Some(row) = rows.next()? {
             let key: String = row.get(0)?;
             visit(&key)?;
+        }
+        Ok(())
+    }
+
+    /// Visit every `data_table` row on `conn` as `(key, value)`.
+    pub fn visit_data_rows<F>(conn: &Connection, mut visit: F) -> Result<(), rusqlite::Error>
+    where
+        F: FnMut(&str, &str) -> Result<(), rusqlite::Error>,
+    {
+        let mut stmt = conn.prepare("SELECT key, value FROM data_table")?;
+        let mut rows = stmt.query(NO_PARAMS)?;
+        while let Some(row) = rows.next()? {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            visit(&key, &value)?;
         }
         Ok(())
     }

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -130,6 +130,20 @@ pub fn sqlite_get_metadata_manual(
 }
 
 impl SqliteConnection {
+    /// Build a `metadata_table` key: `clr-meta::<contract id>::<metadata key>`.
+    fn make_metadata_key(contract_id: &str, key: &str) -> String {
+        format!("clr-meta::{contract_id}::{key}")
+    }
+
+    /// Split a `metadata_table` key produced by [`Self::make_metadata_key`]
+    /// back into `(contract id, metadata key)`. Returns `None` if `key` is
+    /// not in that format. The contract id never contains `::`, so the first
+    /// separator after the prefix is the boundary (the metadata key may
+    /// itself contain `::`).
+    pub fn parse_metadata_key(key: &str) -> Option<(&str, &str)> {
+        key.strip_prefix("clr-meta::")?.split_once("::")
+    }
+
     pub fn put(conn: &Connection, key: &str, value: &str) -> Result<(), VmExecutionError> {
         sqlite_put(conn, key, value)
     }
@@ -145,7 +159,7 @@ impl SqliteConnection {
         key: &str,
         value: &str,
     ) -> Result<(), VmExecutionError> {
-        let key = format!("clr-meta::{contract_hash}::{key}");
+        let key = Self::make_metadata_key(contract_hash, key);
         let params = params![bhh, key, value];
 
         if let Err(e) = conn.execute(
@@ -191,7 +205,7 @@ impl SqliteConnection {
         contract_hash: &str,
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
-        let key = format!("clr-meta::{contract_hash}::{key}");
+        let key = Self::make_metadata_key(contract_hash, key);
         let params = params![bhh, key];
 
         match conn

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -115,6 +115,7 @@ fn open_readonly_clarity_db(path: &str) -> Result<Connection, Error> {
 /// Open the MARF at `db_path` strictly read-only: contract probes must
 /// never take a write lock (the source may be a live node's file).
 fn open_readonly_marf(db_path: &str) -> Result<MARF<StacksBlockId>, Error> {
+    // Clarity MARF always stores external blobs, whether archival or squashed.
     let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
     let storage = TrieFileStorage::open_readonly(db_path, open_opts)?;
     Ok(MARF::from_storage(storage))

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 use std::time::Instant;
 
 use clarity::vm::database::clarity_store::make_contract_hash_key;
-use clarity::vm::database::SqliteConnection;
+use clarity::vm::database::{SqliteConnection, DATA_TABLE_NAME, METADATA_TABLE_NAME};
 use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::{Connection, OpenFlags};
 use stacks_common::types::chainstate::StacksBlockId;
@@ -30,7 +30,7 @@ use crate::chainstate::stacks::index::Error;
 use crate::util_lib::db::sqlite_open;
 
 /// Clarity side-storage tables copied by [`copy_clarity_side_tables`].
-pub(super) const CLARITY_SIDE_TABLES: &[&str] = &["data_table", "metadata_table"];
+pub(super) const CLARITY_SIDE_TABLES: &[&str] = &[DATA_TABLE_NAME, METADATA_TABLE_NAME];
 
 /// Copy Clarity side-storage tables (`data_table`, `metadata_table`) from a
 /// source MARF database to a squashed MARF database.
@@ -83,11 +83,11 @@ pub fn copy_clarity_side_tables(
 
             // data_table is content-addressed (key = hex MARFValue), like
             // the index `__fork_storage`, so it shares the same stream-filter.
-            let data_rows = copy_leaf_referenced_rows(conn, "data_table", "key", &needed_keys)?;
+            let data_rows = copy_leaf_referenced_rows(conn, DATA_TABLE_NAME, "key", &needed_keys)?;
 
             let t = Instant::now();
             let (metadata_scanned, metadata_rows) =
-                with_indexes_dropped(conn, "metadata_table", |conn| {
+                with_indexes_dropped(conn, METADATA_TABLE_NAME, |conn| {
                     copy_required_metadata_rows(&src_conn, conn, &required_contract_ids)
                 })?;
             info!(

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -121,10 +121,10 @@ fn open_readonly_marf(db_path: &str) -> Result<MARF<StacksBlockId>, Error> {
     Ok(MARF::from_storage(storage))
 }
 
-/// Stream the source `metadata_table` into the destination, keeping only
-/// rows whose contract id is in `required`. Rows whose key is not in the
-/// [`SqliteConnection`] metadata format are skipped.
-/// Returns `(scanned, copied)` row counts.
+/// Stream the source `metadata_table` into the destination, keeping only rows
+/// whose contract id is in `required`. Every key must be in the `clr-meta::`
+/// format (the only format any writer produces); a key that doesn't parse is
+/// treated as corruption. Returns `(scanned, copied)` row counts.
 fn copy_required_metadata_rows(
     src_conn: &Connection,
     dst_conn: &Connection,
@@ -132,31 +132,38 @@ fn copy_required_metadata_rows(
 ) -> Result<(u64, u64), Error> {
     let mut scanned: u64 = 0;
     let mut copied: u64 = 0;
-    SqliteConnection::visit_metadata_rows(src_conn, |key, blockhash, value| {
+    SqliteConnection::visit_metadata_rows(src_conn, |row| {
         scanned += 1;
-        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) else {
-            return Ok(());
+        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(row.key) else {
+            return Err(Error::CorruptionError(format!(
+                "metadata_table key is not in clr-meta:: format: {}",
+                row.key
+            )));
         };
         if !required.contains(contract_id) {
             return Ok(());
         }
-        SqliteConnection::insert_metadata_row(dst_conn, key, blockhash, value)?;
+        SqliteConnection::insert_metadata_row(dst_conn, row)?;
         copied += 1;
         Ok(())
     })?;
     Ok((scanned, copied))
 }
 
-/// The distinct contract ids appearing in `metadata_table` keys on `conn`.
-/// Scanned in key order so the result is deterministic across runs.
+/// The distinct contract ids appearing in `metadata_table` keys on `conn`,
+/// in the visitor's ascending key order. Every key must be in the
+/// `clr-meta::` format; a key that doesn't parse is corruption.
 fn scan_metadata_contract_ids(conn: &Connection) -> Result<Vec<String>, Error> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut ordered: Vec<String> = Vec::new();
     SqliteConnection::visit_metadata_keys(conn, |key| {
-        if let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) {
-            if seen.insert(contract_id.to_string()) {
-                ordered.push(contract_id.to_string());
-            }
+        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) else {
+            return Err(Error::CorruptionError(format!(
+                "metadata_table key is not in clr-meta:: format: {key}"
+            )));
+        };
+        if seen.insert(contract_id.to_string()) {
+            ordered.push(contract_id.to_string());
         }
         Ok(())
     })?;

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -18,8 +18,9 @@ use std::time::Instant;
 
 use clarity::vm::database::clarity_store::make_contract_hash_key;
 use clarity::vm::database::SqliteConnection;
+use clarity::vm::errors::VmExecutionError;
 use clarity::vm::types::QualifiedContractIdentifier;
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use stacks_common::types::chainstate::StacksBlockId;
 
 use super::common::{clone_schemas_from_source, with_indexes_dropped, with_offline_write_session};
@@ -27,6 +28,7 @@ use super::fork_storage::{collect_leaf_value_hashes, copy_leaf_referenced_rows};
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MarfConnection as _, MARF};
 use crate::chainstate::stacks::index::storage::TrieHashCalculationMode;
 use crate::chainstate::stacks::index::Error;
+use crate::util_lib::db::sqlite_open;
 
 /// Clarity side-storage tables copied by [`copy_clarity_side_tables`].
 pub(super) const CLARITY_SIDE_TABLES: &[&str] = &["data_table", "metadata_table"];
@@ -61,6 +63,8 @@ pub fn copy_clarity_side_tables(
 
     let required_contract_ids = resolve_required_contracts(src_db_path, &squashed_tip)?;
 
+    let src_conn = open_readonly_clarity_db(src_db_path)?;
+
     let stats = with_offline_write_session(
         dst_db_path,
         &[("src", src_db_path)],
@@ -69,9 +73,8 @@ pub fn copy_clarity_side_tables(
             clone_schemas_from_source(conn, CLARITY_SIDE_TABLES)?;
 
             let t = Instant::now();
-            let src_data_count: u64 = conn
-                .query_row("SELECT COUNT(*) FROM src.data_table", [], |row| row.get(0))
-                .map_err(Error::SQLError)?;
+            let src_data_count =
+                SqliteConnection::count_data_rows(&src_conn).map_err(clarity_db_error)?;
             let needed_count = needed_keys.len() as u64;
             let pruned_count = src_data_count.saturating_sub(needed_count);
             info!(
@@ -87,7 +90,7 @@ pub fn copy_clarity_side_tables(
             let t = Instant::now();
             let (metadata_scanned, metadata_rows) =
                 with_indexes_dropped(conn, "metadata_table", |conn| {
-                    copy_required_metadata_rows(conn, &required_contract_ids)
+                    copy_required_metadata_rows(&src_conn, conn, &required_contract_ids)
                 })?;
             info!(
                 "[clarity] metadata_table scan+filter: scanned {metadata_scanned}, \
@@ -106,48 +109,40 @@ pub fn copy_clarity_side_tables(
     Ok(stats)
 }
 
-/// Stream `src.metadata_table` into the destination `metadata_table`,
-/// keeping only rows whose contract id is in `required`. Rows whose key is
-/// not in the [`SqliteConnection`] metadata format are skipped.
+/// Open a read-only connection to the Clarity side-storage DB at `path`.
+fn open_readonly_clarity_db(path: &str) -> Result<Connection, Error> {
+    sqlite_open(path, OpenFlags::SQLITE_OPEN_READ_ONLY, false).map_err(Error::SQLError)
+}
+
+/// Map a Clarity side-storage error into the snapshot error domain.
+fn clarity_db_error(e: VmExecutionError) -> Error {
+    Error::CorruptionError(format!("Clarity side-table access failed: {e:?}"))
+}
+
+/// Stream the source `metadata_table` into the destination, keeping only
+/// rows whose contract id is in `required`. Rows whose key is not in the
+/// [`SqliteConnection`] metadata format are skipped.
 /// Returns `(scanned, copied)` row counts.
 fn copy_required_metadata_rows(
-    conn: &Connection,
+    src_conn: &Connection,
+    dst_conn: &Connection,
     required: &HashSet<String>,
 ) -> Result<(u64, u64), Error> {
-    let mut stmt = conn
-        .prepare("SELECT key, blockhash, value FROM src.metadata_table")
-        .map_err(Error::SQLError)?;
-    let rows = stmt
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-            ))
-        })
-        .map_err(Error::SQLError)?;
-    let mut insert = conn
-        .prepare(
-            "INSERT INTO metadata_table (key, blockhash, value) \
-             VALUES (?1, ?2, ?3)",
-        )
-        .map_err(Error::SQLError)?;
     let mut scanned: u64 = 0;
     let mut copied: u64 = 0;
-    for row in rows {
+    SqliteConnection::visit_metadata_rows(src_conn, |key, blockhash, value| {
         scanned += 1;
-        let (key, blockhash, value) = row.map_err(Error::SQLError)?;
-        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(&key) else {
-            continue;
+        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) else {
+            return Ok(());
         };
         if !required.contains(contract_id) {
-            continue;
+            return Ok(());
         }
-        insert
-            .execute([key, blockhash, value])
-            .map_err(Error::SQLError)?;
+        SqliteConnection::insert_metadata_row(dst_conn, key, blockhash, value)?;
         copied += 1;
-    }
+        Ok(())
+    })
+    .map_err(clarity_db_error)?;
     Ok((scanned, copied))
 }
 
@@ -156,20 +151,15 @@ fn copy_required_metadata_rows(
 fn scan_metadata_contract_ids(conn: &Connection) -> Result<Vec<String>, Error> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut ordered: Vec<String> = Vec::new();
-    let mut stmt = conn
-        .prepare("SELECT key FROM metadata_table ORDER BY key")
-        .map_err(Error::SQLError)?;
-    let rows = stmt
-        .query_map([], |row| row.get::<_, String>(0))
-        .map_err(Error::SQLError)?;
-    for row in rows {
-        let key = row.map_err(Error::SQLError)?;
-        if let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(&key) {
+    SqliteConnection::visit_metadata_keys(conn, |key| {
+        if let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) {
             if seen.insert(contract_id.to_string()) {
                 ordered.push(contract_id.to_string());
             }
         }
-    }
+        Ok(())
+    })
+    .map_err(clarity_db_error)?;
     Ok(ordered)
 }
 
@@ -205,11 +195,7 @@ fn resolve_required_contracts(
     squashed_tip: &StacksBlockId,
 ) -> Result<HashSet<String>, Error> {
     let t = Instant::now();
-    let src_conn = Connection::open_with_flags(
-        src_db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .map_err(Error::SQLError)?;
+    let src_conn = open_readonly_clarity_db(src_db_path)?;
     let contract_ids = scan_metadata_contract_ids(&src_conn)?;
     info!(
         "[clarity] contract ids in src.metadata_table: {} unique in {:?}",

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -1,0 +1,240 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+use std::time::Instant;
+
+use clarity::vm::database::clarity_store::make_contract_hash_key;
+use clarity::vm::database::SqliteConnection;
+use clarity::vm::types::QualifiedContractIdentifier;
+use rusqlite::Connection;
+use stacks_common::types::chainstate::StacksBlockId;
+
+use super::common::{clone_schemas_from_source, with_indexes_dropped, with_offline_write_session};
+use super::fork_storage::{collect_leaf_value_hashes, copy_leaf_referenced_rows};
+use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MarfConnection as _, MARF};
+use crate::chainstate::stacks::index::storage::TrieHashCalculationMode;
+use crate::chainstate::stacks::index::Error;
+
+/// Clarity side-storage tables copied by [`copy_clarity_side_tables`].
+pub(super) const CLARITY_SIDE_TABLES: &[&str] = &["data_table", "metadata_table"];
+
+/// Copy Clarity side-storage tables (`data_table`, `metadata_table`) from a
+/// source MARF database to a squashed MARF database.
+///
+/// **Must be called after [`MARF::squash_to_path`]** has created the squashed
+/// trie in `dst_db_path`.
+///
+/// This function:
+/// 1. Reads the squashed trie to determine which side-storage rows are still reachable.
+/// 2. Attaches the source database.
+/// 3. Clones the side-table schemas from the source and copies only the
+///    required rows.
+pub fn copy_clarity_side_tables(
+    src_db_path: &str,
+    dst_db_path: &str,
+) -> Result<ClaritySideTableStats, Error> {
+    let total_start = Instant::now();
+
+    // Walk the squashed trie before opening dst for writes. we need
+    // the readonly MARF view, and `marf_sqlite_open` would fight the
+    // writer's lock on dst.
+    let t = Instant::now();
+    let (squashed_tip, needed_keys) = collect_leaf_value_hashes::<StacksBlockId>(dst_db_path)?;
+    info!(
+        "[clarity] collect_leaf_value_hashes: {} keys in {:?}",
+        needed_keys.len(),
+        t.elapsed()
+    );
+
+    let required_contract_ids = resolve_required_contracts(src_db_path, &squashed_tip)?;
+
+    let stats = with_offline_write_session(
+        dst_db_path,
+        &[("src", src_db_path)],
+        "",
+        |conn| -> Result<ClaritySideTableStats, Error> {
+            clone_schemas_from_source(conn, CLARITY_SIDE_TABLES)?;
+
+            let t = Instant::now();
+            let src_data_count: u64 = conn
+                .query_row("SELECT COUNT(*) FROM src.data_table", [], |row| row.get(0))
+                .map_err(Error::SQLError)?;
+            let needed_count = needed_keys.len() as u64;
+            let pruned_count = src_data_count.saturating_sub(needed_count);
+            info!(
+                "[clarity] src.data_table = {src_data_count}, pruning {pruned_count} \
+                 (keep {needed_count}) in {:?}",
+                t.elapsed()
+            );
+
+            // data_table is content-addressed (key = hex MARFValue), like
+            // the index `__fork_storage`, so it shares the same stream-filter.
+            let data_rows = copy_leaf_referenced_rows(conn, "data_table", "key", &needed_keys)?;
+
+            let t = Instant::now();
+            let (metadata_scanned, metadata_rows) =
+                with_indexes_dropped(conn, "metadata_table", |conn| {
+                    copy_required_metadata_rows(conn, &required_contract_ids)
+                })?;
+            info!(
+                "[clarity] metadata_table scan+filter: scanned {metadata_scanned}, \
+                 inserted {metadata_rows} in {:?}",
+                t.elapsed()
+            );
+
+            Ok(ClaritySideTableStats {
+                data_table_rows: data_rows,
+                metadata_table_rows: metadata_rows,
+            })
+        },
+    )?;
+
+    info!("[clarity] total {:?}", total_start.elapsed());
+    Ok(stats)
+}
+
+/// Stream `src.metadata_table` into the destination `metadata_table`,
+/// keeping only rows whose contract id is in `required`. Rows whose key is
+/// not in the [`SqliteConnection`] metadata format are skipped.
+/// Returns `(scanned, copied)` row counts.
+fn copy_required_metadata_rows(
+    conn: &Connection,
+    required: &HashSet<String>,
+) -> Result<(u64, u64), Error> {
+    let mut stmt = conn
+        .prepare("SELECT key, blockhash, value FROM src.metadata_table")
+        .map_err(Error::SQLError)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(Error::SQLError)?;
+    let mut insert = conn
+        .prepare(
+            "INSERT INTO metadata_table (key, blockhash, value) \
+             VALUES (?1, ?2, ?3)",
+        )
+        .map_err(Error::SQLError)?;
+    let mut scanned: u64 = 0;
+    let mut copied: u64 = 0;
+    for row in rows {
+        scanned += 1;
+        let (key, blockhash, value) = row.map_err(Error::SQLError)?;
+        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(&key) else {
+            continue;
+        };
+        if !required.contains(contract_id) {
+            continue;
+        }
+        insert
+            .execute([key, blockhash, value])
+            .map_err(Error::SQLError)?;
+        copied += 1;
+    }
+    Ok((scanned, copied))
+}
+
+/// The distinct contract ids appearing in `metadata_table` keys on `conn`.
+/// Scanned in key order so the result is deterministic across runs.
+fn scan_metadata_contract_ids(conn: &Connection) -> Result<Vec<String>, Error> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut ordered: Vec<String> = Vec::new();
+    let mut stmt = conn
+        .prepare("SELECT key FROM metadata_table ORDER BY key")
+        .map_err(Error::SQLError)?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(Error::SQLError)?;
+    for row in rows {
+        let key = row.map_err(Error::SQLError)?;
+        if let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(&key) {
+            if seen.insert(contract_id.to_string()) {
+                ordered.push(contract_id.to_string());
+            }
+        }
+    }
+    Ok(ordered)
+}
+
+/// Probe the MARF at `db_path` for each contract's hash key at `tip`; the
+/// contracts still present in the trie are the ones whose metadata rows
+/// must be retained.
+fn filter_required_contracts(
+    db_path: &str,
+    tip: &StacksBlockId,
+    contract_ids: &[String],
+) -> Result<HashSet<String>, Error> {
+    let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
+    let mut marf = MARF::<StacksBlockId>::from_path(db_path, open_opts)?;
+    let mut required: HashSet<String> = HashSet::new();
+    for contract_id in contract_ids {
+        let contract = QualifiedContractIdentifier::parse(contract_id).map_err(|e| {
+            Error::CorruptionError(format!(
+                "Failed to parse contract identifier '{contract_id}': {e:?}"
+            ))
+        })?;
+        let key = make_contract_hash_key(&contract);
+        if marf.get(tip, &key)?.is_some() {
+            required.insert(contract_id.clone());
+        }
+    }
+    Ok(required)
+}
+
+/// Scan `src.metadata_table` for the set of contract ids that appear,
+/// then probe the squashed trie to find which are still required.
+fn resolve_required_contracts(
+    src_db_path: &str,
+    squashed_tip: &StacksBlockId,
+) -> Result<HashSet<String>, Error> {
+    let t = Instant::now();
+    let src_conn = Connection::open_with_flags(
+        src_db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(Error::SQLError)?;
+    let contract_ids = scan_metadata_contract_ids(&src_conn)?;
+    info!(
+        "[clarity] contract ids in src.metadata_table: {} unique in {:?}",
+        contract_ids.len(),
+        t.elapsed()
+    );
+
+    let t = Instant::now();
+    let required_contract_ids =
+        filter_required_contracts(src_db_path, squashed_tip, &contract_ids)?;
+    info!(
+        "[clarity] MARF.get per contract: {} required of {} in {:?}",
+        required_contract_ids.len(),
+        contract_ids.len(),
+        t.elapsed()
+    );
+
+    Ok(required_contract_ids)
+}
+
+/// Row-count statistics returned by [`copy_clarity_side_tables`].
+#[derive(Debug, Clone)]
+pub struct ClaritySideTableStats {
+    /// Number of rows copied into `data_table`.
+    pub data_table_rows: u64,
+    /// Number of rows copied into `metadata_table`.
+    pub metadata_table_rows: u64,
+}

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -18,7 +18,6 @@ use std::time::Instant;
 
 use clarity::vm::database::clarity_store::make_contract_hash_key;
 use clarity::vm::database::SqliteConnection;
-use clarity::vm::errors::VmExecutionError;
 use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::{Connection, OpenFlags};
 use stacks_common::types::chainstate::StacksBlockId;
@@ -74,7 +73,7 @@ pub fn copy_clarity_side_tables(
 
             let t = Instant::now();
             let src_data_count =
-                SqliteConnection::count_data_rows(&src_conn).map_err(clarity_db_error)?;
+                SqliteConnection::count_data_rows(&src_conn).map_err(Error::SQLError)?;
             let needed_count = needed_keys.len() as u64;
             let pruned_count = src_data_count.saturating_sub(needed_count);
             info!(
@@ -114,11 +113,6 @@ fn open_readonly_clarity_db(path: &str) -> Result<Connection, Error> {
     sqlite_open(path, OpenFlags::SQLITE_OPEN_READ_ONLY, false).map_err(Error::SQLError)
 }
 
-/// Map a Clarity side-storage error into the snapshot error domain.
-fn clarity_db_error(e: VmExecutionError) -> Error {
-    Error::CorruptionError(format!("Clarity side-table access failed: {e:?}"))
-}
-
 /// Stream the source `metadata_table` into the destination, keeping only
 /// rows whose contract id is in `required`. Rows whose key is not in the
 /// [`SqliteConnection`] metadata format are skipped.
@@ -130,19 +124,21 @@ fn copy_required_metadata_rows(
 ) -> Result<(u64, u64), Error> {
     let mut scanned: u64 = 0;
     let mut copied: u64 = 0;
-    SqliteConnection::visit_metadata_rows(src_conn, |key, blockhash, value| {
-        scanned += 1;
-        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) else {
-            return Ok(());
-        };
-        if !required.contains(contract_id) {
-            return Ok(());
-        }
-        SqliteConnection::insert_metadata_row(dst_conn, key, blockhash, value)?;
-        copied += 1;
-        Ok(())
-    })
-    .map_err(clarity_db_error)?;
+    SqliteConnection::visit_metadata_rows(
+        src_conn,
+        |key, blockhash, value| -> Result<(), Error> {
+            scanned += 1;
+            let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) else {
+                return Ok(());
+            };
+            if !required.contains(contract_id) {
+                return Ok(());
+            }
+            SqliteConnection::insert_metadata_row(dst_conn, key, blockhash, value)?;
+            copied += 1;
+            Ok(())
+        },
+    )?;
     Ok((scanned, copied))
 }
 
@@ -151,15 +147,14 @@ fn copy_required_metadata_rows(
 fn scan_metadata_contract_ids(conn: &Connection) -> Result<Vec<String>, Error> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut ordered: Vec<String> = Vec::new();
-    SqliteConnection::visit_metadata_keys(conn, |key| {
+    SqliteConnection::visit_metadata_keys(conn, |key| -> Result<(), Error> {
         if let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) {
             if seen.insert(contract_id.to_string()) {
                 ordered.push(contract_id.to_string());
             }
         }
         Ok(())
-    })
-    .map_err(clarity_db_error)?;
+    })?;
     Ok(ordered)
 }
 

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -72,8 +72,7 @@ pub fn copy_clarity_side_tables(
             clone_schemas_from_source(conn, CLARITY_SIDE_TABLES)?;
 
             let t = Instant::now();
-            let src_data_count =
-                SqliteConnection::count_data_rows(&src_conn).map_err(Error::SQLError)?;
+            let src_data_count = SqliteConnection::count_data_rows(&src_conn)?;
             let needed_count = needed_keys.len() as u64;
             let pruned_count = src_data_count.saturating_sub(needed_count);
             info!(
@@ -124,21 +123,18 @@ fn copy_required_metadata_rows(
 ) -> Result<(u64, u64), Error> {
     let mut scanned: u64 = 0;
     let mut copied: u64 = 0;
-    SqliteConnection::visit_metadata_rows(
-        src_conn,
-        |key, blockhash, value| -> Result<(), Error> {
-            scanned += 1;
-            let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) else {
-                return Ok(());
-            };
-            if !required.contains(contract_id) {
-                return Ok(());
-            }
-            SqliteConnection::insert_metadata_row(dst_conn, key, blockhash, value)?;
-            copied += 1;
-            Ok(())
-        },
-    )?;
+    SqliteConnection::visit_metadata_rows(src_conn, |key, blockhash, value| {
+        scanned += 1;
+        let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) else {
+            return Ok(());
+        };
+        if !required.contains(contract_id) {
+            return Ok(());
+        }
+        SqliteConnection::insert_metadata_row(dst_conn, key, blockhash, value)?;
+        copied += 1;
+        Ok(())
+    })?;
     Ok((scanned, copied))
 }
 
@@ -147,7 +143,7 @@ fn copy_required_metadata_rows(
 fn scan_metadata_contract_ids(conn: &Connection) -> Result<Vec<String>, Error> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut ordered: Vec<String> = Vec::new();
-    SqliteConnection::visit_metadata_keys(conn, |key| -> Result<(), Error> {
+    SqliteConnection::visit_metadata_keys(conn, |key| {
         if let Some((contract_id, _meta_key)) = SqliteConnection::parse_metadata_key(key) {
             if seen.insert(contract_id.to_string()) {
                 ordered.push(contract_id.to_string());

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -25,7 +25,7 @@ use stacks_common::types::chainstate::StacksBlockId;
 use super::common::{clone_schemas_from_source, with_indexes_dropped, with_offline_write_session};
 use super::fork_storage::{collect_leaf_value_hashes, copy_leaf_referenced_rows};
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MarfConnection as _, MARF};
-use crate::chainstate::stacks::index::storage::TrieHashCalculationMode;
+use crate::chainstate::stacks::index::storage::{TrieFileStorage, TrieHashCalculationMode};
 use crate::chainstate::stacks::index::Error;
 use crate::util_lib::db::sqlite_open;
 
@@ -112,6 +112,14 @@ fn open_readonly_clarity_db(path: &str) -> Result<Connection, Error> {
     sqlite_open(path, OpenFlags::SQLITE_OPEN_READ_ONLY, false).map_err(Error::SQLError)
 }
 
+/// Open the MARF at `db_path` strictly read-only: contract probes must
+/// never take a write lock (the source may be a live node's file).
+fn open_readonly_marf(db_path: &str) -> Result<MARF<StacksBlockId>, Error> {
+    let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
+    let storage = TrieFileStorage::open_readonly(db_path, open_opts)?;
+    Ok(MARF::from_storage(storage))
+}
+
 /// Stream the source `metadata_table` into the destination, keeping only
 /// rows whose contract id is in `required`. Rows whose key is not in the
 /// [`SqliteConnection`] metadata format are skipped.
@@ -162,8 +170,7 @@ fn filter_required_contracts(
     tip: &StacksBlockId,
     contract_ids: &[String],
 ) -> Result<HashSet<String>, Error> {
-    let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
-    let mut marf = MARF::<StacksBlockId>::from_path(db_path, open_opts)?;
+    let mut marf = open_readonly_marf(db_path)?;
     let mut required: HashSet<String> = HashSet::new();
     for contract_id in contract_ids {
         let contract = QualifiedContractIdentifier::parse(contract_id).map_err(|e| {

--- a/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
@@ -24,6 +24,7 @@
 //!
 //! Detectable violations surface as `CorruptionError`s.
 
+mod clarity;
 pub(crate) mod common;
 pub(crate) mod fork_storage;
 mod index;
@@ -31,4 +32,5 @@ mod index;
 #[cfg(test)]
 mod tests;
 
+pub use clarity::{copy_clarity_side_tables, ClaritySideTableStats};
 pub use index::{copy_index_side_tables, IndexSideTableStats};

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
@@ -19,7 +19,7 @@
 use std::path::PathBuf;
 
 use clarity::vm::database::clarity_store::make_contract_hash_key;
-use clarity::vm::database::{ClarityBackingStore, SqliteConnection};
+use clarity::vm::database::{ClarityBackingStore, MetadataRow, SqliteConnection};
 use stacks_common::types::chainstate::{StacksBlockId, TrieHash};
 use stacks_common::util::hash::Sha512Trunc256Sum;
 use tempfile::tempdir;
@@ -265,29 +265,23 @@ fn test_squashed_clarity_marf_metadata_reads_work() {
     }
 }
 
-/// Metadata rows for a contract absent from the squashed trie, and rows
-/// whose key is not in the metadata format, are not copied.
+/// Metadata rows for a (well-formed) contract absent from the squashed trie
+/// are not copied.
 #[test]
 fn test_metadata_exclusions() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     let blocks = build_clarity_marf(&src_dir, 4, "test-contract", "");
 
-    // Rogue rows in src: a contract with no trie commitment and a key
-    // outside the metadata format.
+    // A rogue but well-formed row in src: a contract with no trie commitment.
     let src_conn = rusqlite::Connection::open(clarity_marf_db_path(&src_dir)).unwrap();
     SqliteConnection::insert_metadata_row(
         &src_conn,
-        "clr-meta::ST000000000000000000002AMW42H.ghost::source",
-        &blocks[0].to_hex(),
-        "ghost",
-    )
-    .unwrap();
-    SqliteConnection::insert_metadata_row(
-        &src_conn,
-        "not-a-metadata-key",
-        &blocks[0].to_hex(),
-        "junk",
+        &MetadataRow {
+            key: "clr-meta::ST000000000000000000002AMW42H.ghost::source",
+            block_id: &blocks[0].to_hex(),
+            value: "ghost",
+        },
     )
     .unwrap();
     drop(src_conn);
@@ -301,14 +295,61 @@ fn test_metadata_exclusions() {
 
     let conn = rusqlite::Connection::open(&squashed_db).unwrap();
     let mut rogue = 0;
-    SqliteConnection::visit_metadata_keys(&conn, |key| {
-        if key.contains("ghost") || key == "not-a-metadata-key" {
+    SqliteConnection::visit_metadata_keys(&conn, |key| -> Result<(), rusqlite::Error> {
+        if key.contains("ghost") {
             rogue += 1;
         }
         Ok(())
     })
     .unwrap();
-    assert_eq!(rogue, 0, "unrequired/malformed metadata must not be copied");
+    assert_eq!(rogue, 0, "unrequired metadata must not be copied");
+}
+
+/// A `metadata_table` row whose key is not in the `clr-meta::` format is a
+/// corruption signal: the copy must fail loudly rather than silently drop it.
+#[test]
+fn test_malformed_metadata_key_is_corruption() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let blocks = build_clarity_marf(&src_dir, 4, "test-contract", "");
+
+    let src_conn = rusqlite::Connection::open(clarity_marf_db_path(&src_dir)).unwrap();
+    SqliteConnection::insert_metadata_row(
+        &src_conn,
+        &MetadataRow {
+            key: "not-a-metadata-key",
+            block_id: &blocks[0].to_hex(),
+            value: "junk",
+        },
+    )
+    .unwrap();
+    drop(src_conn);
+
+    // Squash, then attempt the side-table copy directly so we can assert it errors
+    // (the squash_clarity_marf helper unwraps the copy).
+    let squashed_dir = dir.path().join("squashed");
+    std::fs::create_dir_all(&squashed_dir).unwrap();
+    let src_db = clarity_marf_db_path(&src_dir);
+    let dst_db = squashed_dir.join("marf.sqlite");
+
+    let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
+    MARF::<StacksBlockId>::squash_to_path(
+        src_db.to_str().unwrap(),
+        dst_db.to_str().unwrap(),
+        open_opts,
+        blocks.last().unwrap(),
+        3,
+        "test",
+    )
+    .unwrap();
+
+    let err = copy_clarity_side_tables(src_db.to_str().unwrap(), dst_db.to_str().unwrap())
+        .expect_err("malformed metadata key must fail the copy");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("clr-meta"),
+        "expected a clr-meta format corruption error, got: {msg}"
+    );
 }
 
 /// Extending the squashed MARF and the archival MARF from the squash

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
@@ -221,14 +221,14 @@ fn test_squashed_clarity_marf_data_reads_work() {
     // Stale overwritten values are pruned from the content-addressed
     // data_table: only the tip value of clarity_key_1 survives.
     let conn = rusqlite::Connection::open(&squashed_db).unwrap();
-    let mut stale = 0;
-    SqliteConnection::visit_data_rows(&conn, |_key, value| {
-        if value.starts_with("clarity_val_1") && value != "clarity_val_1_at_3" {
-            stale += 1;
-        }
-        Ok(())
-    })
-    .unwrap();
+    let stale: u64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM data_table \
+             WHERE value LIKE 'clarity_val_1%' AND value != 'clarity_val_1_at_3'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
     assert_eq!(stale, 0, "overwritten values must be pruned");
 }
 

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
@@ -220,15 +220,15 @@ fn test_squashed_clarity_marf_data_reads_work() {
 
     // Stale overwritten values are pruned from the content-addressed
     // data_table: only the tip value of clarity_key_1 survives.
-    let stale: i64 = rusqlite::Connection::open(&squashed_db)
-        .unwrap()
-        .query_row(
-            "SELECT COUNT(*) FROM data_table \
-             WHERE value LIKE 'clarity_val_1%' AND value != 'clarity_val_1_at_3'",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap();
+    let conn = rusqlite::Connection::open(&squashed_db).unwrap();
+    let mut stale = 0;
+    SqliteConnection::visit_data_rows(&conn, |_key, value| {
+        if value.starts_with("clarity_val_1") && value != "clarity_val_1_at_3" {
+            stale += 1;
+        }
+        Ok(())
+    })
+    .unwrap();
     assert_eq!(stale, 0, "overwritten values must be pruned");
 }
 
@@ -276,14 +276,20 @@ fn test_metadata_exclusions() {
     // Rogue rows in src: a contract with no trie commitment and a key
     // outside the metadata format.
     let src_conn = rusqlite::Connection::open(clarity_marf_db_path(&src_dir)).unwrap();
-    src_conn
-        .execute(
-            "INSERT INTO metadata_table (key, blockhash, value) VALUES \
-             ('clr-meta::ST000000000000000000002AMW42H.ghost::source', ?1, 'ghost'), \
-             ('not-a-metadata-key', ?1, 'junk')",
-            rusqlite::params![blocks[0]],
-        )
-        .unwrap();
+    SqliteConnection::insert_metadata_row(
+        &src_conn,
+        "clr-meta::ST000000000000000000002AMW42H.ghost::source",
+        &blocks[0].to_hex(),
+        "ghost",
+    )
+    .unwrap();
+    SqliteConnection::insert_metadata_row(
+        &src_conn,
+        "not-a-metadata-key",
+        &blocks[0].to_hex(),
+        "junk",
+    )
+    .unwrap();
     drop(src_conn);
 
     let squashed_db = squash_clarity_marf(
@@ -293,15 +299,15 @@ fn test_metadata_exclusions() {
         3,
     );
 
-    let rogue: i64 = rusqlite::Connection::open(&squashed_db)
-        .unwrap()
-        .query_row(
-            "SELECT COUNT(*) FROM metadata_table \
-             WHERE key LIKE '%ghost%' OR key = 'not-a-metadata-key'",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap();
+    let conn = rusqlite::Connection::open(&squashed_db).unwrap();
+    let mut rogue = 0;
+    SqliteConnection::visit_metadata_keys(&conn, |key| {
+        if key.contains("ghost") || key == "not-a-metadata-key" {
+            rogue += 1;
+        }
+        Ok(())
+    })
+    .unwrap();
     assert_eq!(rogue, 0, "unrequired/malformed metadata must not be copied");
 }
 

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
@@ -1,0 +1,472 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Clarity MARF squash + side-table (`data_table`, `metadata_table`)
+//! copy tests.
+
+use std::path::PathBuf;
+
+use clarity::vm::database::clarity_store::make_contract_hash_key;
+use clarity::vm::database::{ClarityBackingStore, SqliteConnection};
+use stacks_common::types::chainstate::{StacksBlockId, TrieHash};
+use stacks_common::util::hash::Sha512Trunc256Sum;
+use tempfile::tempdir;
+
+use super::super::clarity::CLARITY_SIDE_TABLES;
+use super::super::common::{unclassified_tables, MARF_INFRA_TABLES};
+use super::super::copy_clarity_side_tables;
+use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
+use crate::chainstate::stacks::index::storage::TrieHashCalculationMode;
+use crate::chainstate::stacks::index::{ClarityMarfTrieId as _, MARFValue};
+use crate::clarity_vm::clarity::ClarityMarfStoreTransaction as _;
+use crate::clarity_vm::database::marf::MarfedKV;
+
+/// Build a Clarity MARF with N blocks of data and a single contract.
+/// Returns the block hashes for each height.
+fn build_clarity_marf(
+    dir: &std::path::Path,
+    num_blocks: u8,
+    contract_name: &str,
+    value_suffix: &str,
+) -> Vec<StacksBlockId> {
+    let mut kv = MarfedKV::open(dir.to_str().unwrap(), None, None).unwrap();
+
+    let blocks: Vec<StacksBlockId> = (1..=num_blocks)
+        .map(|i| StacksBlockId::from_bytes(&[i; 32]).unwrap())
+        .collect();
+
+    // Height 0
+    {
+        let mut store = kv.begin(&StacksBlockId::sentinel(), &blocks[0]);
+
+        // data_table entries (via put_all_data)
+        let contract_id =
+            clarity::vm::types::QualifiedContractIdentifier::local(contract_name).unwrap();
+        let contract_key = make_contract_hash_key(&contract_id);
+        let contract_hash =
+            Sha512Trunc256Sum::from_data(format!("{contract_name}{value_suffix}").as_bytes());
+        let contract_commitment = store.make_contract_commitment(contract_hash);
+
+        store
+            .put_all_data(vec![
+                (
+                    "clarity_key_1".into(),
+                    format!("clarity_val_1{value_suffix}"),
+                ),
+                (
+                    "clarity_key_2".into(),
+                    format!("clarity_val_2{value_suffix}"),
+                ),
+                (contract_key, contract_commitment),
+            ])
+            .unwrap();
+
+        // metadata_table entries (via insert_metadata)
+        store
+            .insert_metadata(&contract_id, "source", "contract source code v0")
+            .unwrap();
+
+        // Insert metadata with keys that contain "::" (similar to
+        // `vm-metadata::N::VAR` keys produced by ClarityDB::make_metadata_key).
+        store
+            .insert_metadata(&contract_id, "vm-metadata::9", "meta_value_9")
+            .unwrap();
+        store
+            .insert_metadata(&contract_id, "vm-metadata::10::sub", "meta_value_10_sub")
+            .unwrap();
+
+        store.commit_to_processed_block(&blocks[0]).unwrap();
+    }
+
+    // Heights 1..N-1
+    for i in 1..blocks.len() {
+        let mut store = kv.begin(&blocks[i - 1], &blocks[i]);
+
+        let key = format!("clarity_key_{}", i + 2);
+        let val = format!("clarity_val_{}{value_suffix}", i + 2);
+        store.put_all_data(vec![(key, val)]).unwrap();
+
+        // Update an existing key to exercise overwrites.
+        store
+            .put_all_data(vec![(
+                "clarity_key_1".into(),
+                format!("clarity_val_1_at_{i}{value_suffix}"),
+            )])
+            .unwrap();
+
+        store.commit_to_processed_block(&blocks[i]).unwrap();
+    }
+
+    drop(kv);
+    blocks
+}
+
+fn clarity_marf_db_path(dir: &std::path::Path) -> PathBuf {
+    dir.join("marf.sqlite")
+}
+
+/// Squash a Clarity MARF and copy side tables.  Returns the squashed db path.
+fn squash_clarity_marf(
+    src_dir: &std::path::Path,
+    dst_dir: &std::path::Path,
+    tip: &StacksBlockId,
+    height: u32,
+) -> PathBuf {
+    std::fs::create_dir_all(dst_dir).unwrap();
+    let src_db = clarity_marf_db_path(src_dir);
+    let dst_db = dst_dir.join("marf.sqlite");
+
+    let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
+    MARF::<StacksBlockId>::squash_to_path(
+        src_db.to_str().unwrap(),
+        dst_db.to_str().unwrap(),
+        open_opts,
+        tip,
+        height,
+        "test",
+    )
+    .unwrap();
+
+    // Copy Clarity side tables.
+    let stats =
+        copy_clarity_side_tables(src_db.to_str().unwrap(), dst_db.to_str().unwrap()).unwrap();
+    assert!(stats.data_table_rows > 0, "Expected data_table rows > 0");
+
+    // The destination holds exactly the copied row counts.
+    let dst_conn = rusqlite::Connection::open(&dst_db).unwrap();
+    let (data_rows, meta_rows): (u64, u64) = dst_conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM data_table), (SELECT COUNT(*) FROM metadata_table)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (data_rows, meta_rows),
+        (stats.data_table_rows, stats.metadata_table_rows)
+    );
+
+    dst_db
+}
+
+/// `SqliteConnection::check_schema` accepts the squashed Clarity DB
+/// (tables and index recreated by the copy).
+#[test]
+fn test_squashed_clarity_marf_check_schema_passes() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let blocks = build_clarity_marf(&src_dir, 3, "test-contract", "");
+
+    let squashed_db = squash_clarity_marf(
+        &src_dir,
+        &dir.path().join("squashed"),
+        blocks.last().unwrap(),
+        2,
+    );
+
+    // check_schema must pass on the squashed DB.
+    let conn = rusqlite::Connection::open(&squashed_db).unwrap();
+    SqliteConnection::check_schema(&conn)
+        .expect("check_schema should pass on squashed Clarity MARF");
+}
+
+/// Clarity data reads through `MarfedKV` work on the squashed MARF,
+/// including a key overwritten at the squash height and one written only
+/// at height 0.
+#[test]
+fn test_squashed_clarity_marf_data_reads_work() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let blocks = build_clarity_marf(&src_dir, 4, "test-contract", "");
+
+    let squashed_db = squash_clarity_marf(
+        &src_dir,
+        &dir.path().join("squashed"),
+        blocks.last().unwrap(),
+        3,
+    );
+
+    // Open the squashed MARF via MarfedKV.
+    let squashed_dir = dir.path().join("squashed");
+    let mut kv = MarfedKV::open(squashed_dir.to_str().unwrap(), Some(&blocks[3]), None).unwrap();
+
+    // Verify trie reads + data_table lookups work.
+    {
+        let mut store = kv.begin_read_only(Some(&blocks[3]));
+
+        // The latest value for clarity_key_1 should be the overwrite
+        // from the last block.
+        let val = store.get_data("clarity_key_1").unwrap();
+        assert!(val.is_some(), "clarity_key_1 should be readable");
+        assert_eq!(val.unwrap(), "clarity_val_1_at_3");
+
+        // clarity_key_2 was written at height 0 and never overwritten.
+        let val2 = store.get_data("clarity_key_2").unwrap();
+        assert!(val2.is_some(), "clarity_key_2 should be readable");
+        assert_eq!(val2.unwrap(), "clarity_val_2");
+    }
+
+    // Stale overwritten values are pruned from the content-addressed
+    // data_table: only the tip value of clarity_key_1 survives.
+    let stale: i64 = rusqlite::Connection::open(&squashed_db)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM data_table \
+             WHERE value LIKE 'clarity_val_1%' AND value != 'clarity_val_1_at_3'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stale, 0, "overwritten values must be pruned");
+}
+
+/// Contract metadata reads through `MarfedKV` work on the squashed MARF
+/// (the lookup resolves the deployment block via the copied trie).
+#[test]
+fn test_squashed_clarity_marf_metadata_reads_work() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let blocks = build_clarity_marf(&src_dir, 4, "test-contract", "");
+
+    squash_clarity_marf(
+        &src_dir,
+        &dir.path().join("squashed"),
+        blocks.last().unwrap(),
+        3,
+    );
+
+    // Open the squashed MARF via MarfedKV.
+    let squashed_dir = dir.path().join("squashed");
+    let mut kv = MarfedKV::open(squashed_dir.to_str().unwrap(), Some(&blocks[3]), None).unwrap();
+
+    // Verify sqlite_get_metadata path works. Metadata was inserted at
+    // height 0 with blockhash = blocks[0]. The lookup resolves the
+    // deployment block via get_contract_hash -> get_block_at_height.
+    {
+        let mut store = kv.begin_read_only(Some(&blocks[3]));
+        let contract_id =
+            clarity::vm::types::QualifiedContractIdentifier::local("test-contract").unwrap();
+
+        let md = store.get_metadata(&contract_id, "source").unwrap();
+        assert!(md.is_some(), "metadata should be present");
+        assert_eq!(md.unwrap(), "contract source code v0");
+    }
+}
+
+/// Metadata rows for a contract absent from the squashed trie, and rows
+/// whose key is not in the metadata format, are not copied.
+#[test]
+fn test_metadata_exclusions() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let blocks = build_clarity_marf(&src_dir, 4, "test-contract", "");
+
+    // Rogue rows in src: a contract with no trie commitment and a key
+    // outside the metadata format.
+    let src_conn = rusqlite::Connection::open(clarity_marf_db_path(&src_dir)).unwrap();
+    src_conn
+        .execute(
+            "INSERT INTO metadata_table (key, blockhash, value) VALUES \
+             ('clr-meta::ST000000000000000000002AMW42H.ghost::source', ?1, 'ghost'), \
+             ('not-a-metadata-key', ?1, 'junk')",
+            rusqlite::params![blocks[0]],
+        )
+        .unwrap();
+    drop(src_conn);
+
+    let squashed_db = squash_clarity_marf(
+        &src_dir,
+        &dir.path().join("squashed"),
+        blocks.last().unwrap(),
+        3,
+    );
+
+    let rogue: i64 = rusqlite::Connection::open(&squashed_db)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM metadata_table \
+             WHERE key LIKE '%ghost%' OR key = 'not-a-metadata-key'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(rogue, 0, "unrequired/malformed metadata must not be copied");
+}
+
+/// Extending the squashed MARF and the archival MARF from the squash
+/// height with the same block yields identical root hashes.
+#[test]
+fn test_squashed_clarity_marf_extend_hash_equality() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let blocks = build_clarity_marf(&src_dir, 5, "test-contract", "");
+
+    // Squash at height 3, copy side tables.
+    let squashed_db = squash_clarity_marf(
+        &src_dir,
+        &dir.path().join("squashed"),
+        blocks.last().unwrap(),
+        3,
+    );
+
+    // Open both MARFs at the raw MARF level for hash comparison.
+    let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
+    let src_db = clarity_marf_db_path(&src_dir);
+    let mut archival =
+        MARF::<StacksBlockId>::from_path(src_db.to_str().unwrap(), open_opts.clone()).unwrap();
+    let mut squashed =
+        MARF::<StacksBlockId>::from_path(squashed_db.to_str().unwrap(), open_opts).unwrap();
+
+    // Extend both from blocks[3] with the same new block.
+    let b_ext = StacksBlockId::from_bytes(&[201u8; 32]).unwrap();
+
+    archival.begin(&blocks[3], &b_ext).unwrap();
+    archival
+        .insert("ext_key", MARFValue::from_value("ext_val"))
+        .unwrap();
+    archival.commit().unwrap();
+
+    squashed.begin(&blocks[3], &b_ext).unwrap();
+    squashed
+        .insert("ext_key", MARFValue::from_value("ext_val"))
+        .unwrap();
+    squashed.commit().unwrap();
+
+    let arch_root = archival.get_root_hash_at(&b_ext).unwrap();
+    let sq_root = squashed.get_root_hash_at(&b_ext).unwrap();
+    assert_eq!(
+        arch_root, sq_root,
+        "Root hash mismatch after extending squashed Clarity MARF"
+    );
+    assert_ne!(
+        arch_root,
+        TrieHash([0u8; 32]),
+        "root hash should be non-zero"
+    );
+}
+
+/// Side tables copied from the wrong source MARF leave trie value hashes
+/// dangling: data and metadata reads must fail, not return wrong data.
+#[test]
+fn test_mismatched_clarity_db_causes_data_read_failure() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let other_dir = dir.path().join("other");
+
+    let blocks = build_clarity_marf(&src_dir, 4, "test-contract", "");
+    let _other_blocks = build_clarity_marf(&other_dir, 4, "other-contract", "_other");
+
+    // Squash the source MARF, but copy side tables from the OTHER MARF.
+    let squashed_dir = dir.path().join("squashed");
+    std::fs::create_dir_all(&squashed_dir).unwrap();
+    let src_db = clarity_marf_db_path(&src_dir);
+    let dst_db = squashed_dir.join("marf.sqlite");
+
+    let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, "noop", true);
+    MARF::<StacksBlockId>::squash_to_path(
+        src_db.to_str().unwrap(),
+        dst_db.to_str().unwrap(),
+        open_opts,
+        blocks.last().unwrap(),
+        3,
+        "test",
+    )
+    .unwrap();
+
+    let other_db = clarity_marf_db_path(&other_dir);
+    copy_clarity_side_tables(other_db.to_str().unwrap(), dst_db.to_str().unwrap()).unwrap();
+
+    // Open and attempt to read data via Clarity store.
+    let mut kv = MarfedKV::open(squashed_dir.to_str().unwrap(), Some(&blocks[3]), None).unwrap();
+    let mut store = kv.begin_read_only(Some(&blocks[3]));
+
+    // Data lookup should error because the value hash isn't in the copied data_table.
+    let result = store.get_data("clarity_key_1");
+    assert!(
+        result.is_err(),
+        "expected get_data to fail with mismatched side tables"
+    );
+
+    // Metadata lookup should fail because the contract commitment hash
+    // is missing from the copied data_table.
+    let contract_id =
+        clarity::vm::types::QualifiedContractIdentifier::local("test-contract").unwrap();
+    let md = store.get_metadata(&contract_id, "source");
+    assert!(
+        md.is_err(),
+        "expected get_metadata to fail with mismatched side tables"
+    );
+}
+
+/// Metadata keys containing `::` split on the first separator only: the
+/// copy keeps them, and they remain readable after the squash.
+#[test]
+fn test_copy_clarity_side_tables_with_double_colon_metadata_keys() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    // build_clarity_marf now inserts metadata keys with "::" in them
+    // (e.g. "vm-metadata::9", "vm-metadata::10::sub").
+    let blocks = build_clarity_marf(&src_dir, 4, "test-contract", "");
+    assert!(!blocks.is_empty());
+
+    squash_clarity_marf(
+        &src_dir,
+        &dir.path().join("squashed"),
+        blocks.last().unwrap(),
+        3,
+    );
+
+    // Verify the metadata with "::" keys is readable.
+    let squashed_dir = dir.path().join("squashed");
+    let mut kv = MarfedKV::open(squashed_dir.to_str().unwrap(), Some(&blocks[3]), None).unwrap();
+    {
+        let mut store = kv.begin_read_only(Some(&blocks[3]));
+        let contract_id =
+            clarity::vm::types::QualifiedContractIdentifier::local("test-contract").unwrap();
+
+        let md = store.get_metadata(&contract_id, "vm-metadata::9").unwrap();
+        assert!(md.is_some(), "vm-metadata::9 should be present");
+        assert_eq!(md.unwrap(), "meta_value_9");
+
+        let md2 = store
+            .get_metadata(&contract_id, "vm-metadata::10::sub")
+            .unwrap();
+        assert!(md2.is_some(), "vm-metadata::10::sub should be present");
+        assert_eq!(md2.unwrap(), "meta_value_10_sub");
+    }
+}
+
+#[test]
+fn test_no_unclassified_clarity_source_tables() {
+    // Drift guard for the Clarity MARF DB: every table must be either copied by
+    // `copy_clarity_side_tables` (data_table, metadata_table) or owned by the
+    // MARF trie itself (copied by `MARF::squash_to_path`).
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    build_clarity_marf(&src_dir, 2, "test-contract", "");
+    let conn = rusqlite::Connection::open(clarity_marf_db_path(&src_dir)).unwrap();
+
+    let known: Vec<&str> = CLARITY_SIDE_TABLES
+        .iter()
+        .copied()
+        .chain(MARF_INFRA_TABLES.iter().copied())
+        .collect();
+    let extra = unclassified_tables(&conn, &known);
+    assert!(
+        extra.is_empty(),
+        "unclassified Clarity source table(s) {extra:?}: handle each in \
+         copy_clarity_side_tables (chainstate/stacks/db/snapshot/clarity.rs)"
+    );
+}

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
@@ -24,6 +24,7 @@ use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
 
+mod clarity;
 mod index;
 
 /// Create a source `index.sqlite`

--- a/stackslib/src/clarity_vm/database/marf.rs
+++ b/stackslib/src/clarity_vm/database/marf.rs
@@ -26,7 +26,7 @@ use clarity::vm::database::sqlite::{
 use clarity::vm::database::{ClarityBackingStore, SpecialCaseHandler, SqliteConnection};
 use clarity::vm::errors::{IncomparableError, RuntimeError, VmExecutionError, VmInternalError};
 use clarity::vm::types::QualifiedContractIdentifier;
-use rusqlite::{self, Connection};
+use rusqlite::Connection;
 use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId, TrieHash};
 


### PR DESCRIPTION
### Description

Follow-up to #7254: adds the Clarity MARF's side storage to the offline snapshot copy. `copy_clarity_side_tables` clones the `data_table`/`metadata_table` schemas from the source and copies only what the squashed trie still references: `data_table` rows by leaf value hash, `metadata_table` rows by contracts still committed in the trie. Metadata key parsing moves behind new `SqliteConnection::{make_metadata_key, parse_metadata_key}` helpers so the clr-meta:: format stays owned by the Clarity store.

 
Tests read the copied data back through MarfedKV (real runtime path), cover stale-value pruning, ::-containing metadata keys, exclusion of uncommitted contracts, and a schema drift guard.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
