### PR TITLE
feat: sortition  marf snapshot

### DIFF
--- a/changelog.d/marf-snapshot-sortition.added
+++ b/changelog.d/marf-snapshot-sortition.added
@@ -1,0 +1,1 @@
+Add snapshot copy of canonical sortition side tables into squashed output, with an optional Stacks-tip boundary rewrite for the sortition tip memo tables.

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -487,7 +487,7 @@ impl FromRow<StacksEpoch> for StacksEpoch {
 
 pub const SORTITION_DB_VERSION: u32 = 11;
 
-const SORTITION_DB_INITIAL_SCHEMA: &[&str] = &[
+pub(crate) const SORTITION_DB_INITIAL_SCHEMA: &[&str] = &[
     r#"
     PRAGMA foreign_keys = ON;
     "#,
@@ -622,7 +622,7 @@ const SORTITION_DB_INITIAL_SCHEMA: &[&str] = &[
     "CREATE TABLE db_config(version TEXT PRIMARY KEY);",
 ];
 
-const SORTITION_DB_SCHEMA_2: &[&str] = &[r#"
+pub(crate) const SORTITION_DB_SCHEMA_2: &[&str] = &[r#"
      CREATE TABLE epochs (
          start_block_height INTEGER NOT NULL,
          end_block_height INTEGER NOT NULL,
@@ -632,7 +632,7 @@ const SORTITION_DB_SCHEMA_2: &[&str] = &[r#"
          PRIMARY KEY(start_block_height,epoch_id)
      );"#];
 
-const SORTITION_DB_SCHEMA_3: &[&str] = &[r#"
+pub(crate) const SORTITION_DB_SCHEMA_3: &[&str] = &[r#"
     CREATE TABLE block_commit_parents (
         block_commit_txid TEXT NOT NULL,
         block_commit_sortition_id TEXT NOT NULL,
@@ -643,7 +643,7 @@ const SORTITION_DB_SCHEMA_3: &[&str] = &[r#"
         FOREIGN KEY(block_commit_txid,block_commit_sortition_id) REFERENCES block_commits(txid,sortition_id)
     );"#];
 
-const SORTITION_DB_SCHEMA_4: &[&str] = &[
+pub(crate) const SORTITION_DB_SCHEMA_4: &[&str] = &[
     r#"
     CREATE TABLE delegate_stx (
         txid TEXT NOT NULL,
@@ -668,16 +668,16 @@ const SORTITION_DB_SCHEMA_4: &[&str] = &[
 
 /// The changes for version five *just* replace the existing epochs table
 ///  by deleting all the current entries and inserting the new epochs definition.
-const SORTITION_DB_SCHEMA_5: &[&str] = &[r#"
+pub(crate) const SORTITION_DB_SCHEMA_5: &[&str] = &[r#"
      DELETE FROM epochs;"#];
 
-const SORTITION_DB_SCHEMA_6: &[&str] = &[r#"
+pub(crate) const SORTITION_DB_SCHEMA_6: &[&str] = &[r#"
      DELETE FROM epochs;"#];
 
-const SORTITION_DB_SCHEMA_7: &[&str] = &[r#"
+pub(crate) const SORTITION_DB_SCHEMA_7: &[&str] = &[r#"
      DELETE FROM epochs;"#];
 
-const SORTITION_DB_SCHEMA_8: &[&str] = &[
+pub(crate) const SORTITION_DB_SCHEMA_8: &[&str] = &[
     r#"DELETE FROM epochs;"#,
     r#"DROP INDEX IF EXISTS index_user_burn_support_txid;"#,
     r#"DROP INDEX IF EXISTS index_user_burn_support_sortition_id_vtxindex;"#,
@@ -722,17 +722,17 @@ const SORTITION_DB_SCHEMA_8: &[&str] = &[
     );"#,
 ];
 
-static SORTITION_DB_SCHEMA_9: &[&str] =
+pub(crate) static SORTITION_DB_SCHEMA_9: &[&str] =
     &[r#"ALTER TABLE block_commits ADD punished TEXT DEFAULT NULL;"#];
-static SORTITION_DB_SCHEMA_10: &[&str] = &[r#"DROP TABLE IF EXISTS ast_rule_heights;"#];
+pub(crate) static SORTITION_DB_SCHEMA_10: &[&str] = &[r#"DROP TABLE IF EXISTS ast_rule_heights;"#];
 
-static SORTITION_DB_SCHEMA_11: &[&str] = &[r#"
+pub(crate) static SORTITION_DB_SCHEMA_11: &[&str] = &[r#"
     -- replacement for `stacks_chain_tips`, which considers the Nakamoto block burn view.
     -- Unlike `stacks_chain_tips`, rows in this table are only inserted for Nakamoto blocks
     -- if they happen to have the same burn view as the given sortition.
     CREATE TABLE stacks_chain_tips_by_burn_view (
         sortition_id TEXT PRIMARY KEY,
-        consensus_hash TEXT NOT NULL, 
+        consensus_hash TEXT NOT NULL,
         burn_view_consensus_hash TEXT NOT NULL,
         block_hash TEXT NOT NULL,
         block_height INTEGER NOT NULL,
@@ -2706,12 +2706,12 @@ impl SortitionDB {
         self.marf.sqlite_conn()
     }
 
-    /// Open or create the sortition MARF index database with internal blobs.
+    /// Open or create the sortition MARF index database.
     ///
     /// This function opens the SQLite-based MARF index at `marf_path`.
     /// If the index database does not exist, it will be created.
-    /// This index stores all blobs internally within the SQLite database
-    /// (i.e., no separate `.blobs` file).
+    /// Archival sortition DBs store blobs internally. Squashed sortition DBs
+    /// are expected to store blobs externally in `marf.sqlite.blobs`.
     ///
     /// # Arguments
     /// * `marf_path` - Path to the MARF SQLite index database.
@@ -2719,7 +2719,7 @@ impl SortitionDB {
     ///
     /// # Behavior
     /// Given a `marf_path` such as `burnchain/sortition/marf.sqlite`,
-    /// the MARF blobs are stored internally within the SQLite database.
+    /// the MARF blobs are stored internally unless `marf.sqlite.blobs` exists.
     /// This function also enables SQLite foreign key enforcement.
     fn open_index(
         marf_path: &str,
@@ -2727,7 +2727,7 @@ impl SortitionDB {
     ) -> Result<MARF<SortitionId>, db_error> {
         test_debug!("Open MARF index at {}", marf_path);
         let mut open_opts = marf_opts.unwrap_or(MARFOpenOpts::default());
-        open_opts.external_blobs = false;
+        open_opts.external_blobs = std::path::Path::new(&format!("{marf_path}.blobs")).exists();
         test_override_marf_compression(&mut open_opts);
         let marf = MARF::from_path(marf_path, open_opts).map_err(|_e| db_error::Corruption)?;
         sql_pragma(marf.sqlite_conn(), "foreign_keys", &true)?;

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4500,9 +4500,13 @@ impl SortitionDB {
 /// The squash anchors the Stacks MARF at the boundary tenure's FIRST block,
 /// but the fully-synced source already processed the whole tenure, so its
 /// `stacks_chain_tips*` memo rows for that burn view point at the tenure's
-/// LAST block. Copied verbatim, those memos would make a booting node treat
+/// LAST block. If copied in full, those memos would make a booting node treat
 /// the dropped intra-tenure descendants as already processed; rewriting them
 /// down to the anchor makes the node re-fetch and process them from peers.
+///
+/// Rows already at or below the boundary re copied verbatim;
+/// above-boundary rows are rewritten down to the anchor only
+/// when they belong to the anchor tenure, and dropped otherwise.
 #[derive(Debug, Clone)]
 pub struct SortitionTipCopyBoundary {
     pub max_stacks_height: u64,

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4507,7 +4507,7 @@ impl SortitionDB {
 /// the dropped intra-tenure descendants as already processed; rewriting them
 /// down to the anchor makes the node re-fetch and process them from peers.
 ///
-/// Rows already at or below the boundary re copied verbatim;
+/// Rows already at or below the boundary are copied verbatim;
 /// above-boundary rows are rewritten down to the anchor only
 /// when they belong to the anchor tenure, and dropped otherwise.
 #[derive(Debug, Clone)]
@@ -4630,11 +4630,12 @@ impl SortitionDB {
             return Ok(true);
         };
         let max_height = u64_to_sql(boundary.max_stacks_height)?;
+        // Check if ANY above-boundary memo row exists.
         conn.query_row(
-            "SELECT COUNT(*) = 0 FROM ( \
-                 SELECT block_height FROM stacks_chain_tips WHERE block_height > ?1 \
+            "SELECT NOT EXISTS( \
+                 SELECT 1 FROM stacks_chain_tips WHERE block_height > ?1 \
                  UNION ALL \
-                 SELECT block_height FROM stacks_chain_tips_by_burn_view WHERE block_height > ?1 \
+                 SELECT 1 FROM stacks_chain_tips_by_burn_view WHERE block_height > ?1 \
              )",
             params![max_height],
             |row| row.get(0),

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4495,6 +4495,23 @@ impl SortitionDB {
     }
 }
 
+/// Stacks-side boundary used when copying sortition tip memo tables.
+///
+/// The squash anchors the Stacks MARF at the boundary tenure's FIRST block,
+/// but the fully-synced source already processed the whole tenure, so its
+/// `stacks_chain_tips*` memo rows for that burn view point at the tenure's
+/// LAST block. Copied verbatim, those memos would make a booting node treat
+/// the dropped intra-tenure descendants as already processed; rewriting them
+/// down to the anchor makes the node re-fetch and process them from peers.
+#[derive(Debug, Clone)]
+pub struct SortitionTipCopyBoundary {
+    pub max_stacks_height: u64,
+    pub anchor_consensus_hash: ConsensusHash,
+    pub anchor_burn_view_consensus_hash: ConsensusHash,
+    pub anchor_block_hash: BlockHeaderHash,
+    pub anchor_block_height: u64,
+}
+
 // Querying methods
 impl SortitionDB {
     /// Get the canonical burn chain tip -- the tip of the longest burn chain we know about.
@@ -4511,6 +4528,71 @@ impl SortitionDB {
         let qry =
             "SELECT * FROM snapshots ORDER BY block_height DESC, burn_header_hash ASC LIMIT 1";
         query_row(conn, qry, NO_PARAMS).map(|opt| opt.expect("CORRUPTION: No burnchain tips"))
+    }
+
+    /// Get the burn header hash of the snapshot with the given sortition
+    /// ID, or `None` if no such snapshot exists. Used by the offline
+    /// snapshot copy to derive its canonical burn-hash set. Returns the raw
+    /// stored TEXT, so the copy preserves the value byte-for-byte.
+    pub(crate) fn get_snapshot_burn_header_hash(
+        conn: &Connection,
+        sortition_id: &SortitionId,
+    ) -> Result<Option<String>, db_error> {
+        conn.prepare_cached("SELECT burn_header_hash FROM snapshots WHERE sortition_id = ?1")?
+            .query_row(params![sortition_id], |row| row.get(0))
+            .optional()
+            .map_err(db_error::from)
+    }
+
+    /// Source-projection SQL for copying a Stacks-tip memo table
+    /// (`stacks_chain_tips`, or `stacks_chain_tips_by_burn_view` with
+    /// `include_burn_view`) from the schema `from`, keeping rows whose
+    /// `sortition_id` is in `sortition_id_sql`. With a `boundary`, memo
+    /// rows above its Stacks height are rewritten down to the anchor (see
+    /// [`SortitionTipCopyBoundary`])
+    pub(crate) fn stacks_tip_memo_copy_sql(
+        table: &str,
+        from: &str,
+        sortition_id_sql: &str,
+        include_burn_view: bool,
+        boundary: Option<&SortitionTipCopyBoundary>,
+    ) -> String {
+        let Some(boundary) = boundary else {
+            return format!(
+                "SELECT * FROM {from}.{table} WHERE sortition_id IN ({sortition_id_sql})"
+            );
+        };
+        let max_height = boundary.max_stacks_height;
+        let anchor_height = boundary.anchor_block_height;
+        let anchor_ch = &boundary.anchor_consensus_hash;
+        let anchor_bhh = &boundary.anchor_block_hash;
+        let anchor_burn_view_ch = &boundary.anchor_burn_view_consensus_hash;
+        let burn_view_column = if include_burn_view {
+            format!(
+                "CASE WHEN block_height > {max_height} THEN '{anchor_burn_view_ch}' \
+                      ELSE burn_view_consensus_hash END, "
+            )
+        } else {
+            String::new()
+        };
+        let anchor_match = if include_burn_view {
+            format!(
+                "(consensus_hash = '{anchor_ch}' \
+                  AND burn_view_consensus_hash = '{anchor_burn_view_ch}')"
+            )
+        } else {
+            format!("consensus_hash = '{anchor_ch}'")
+        };
+        format!(
+            "SELECT sortition_id, \
+                    CASE WHEN block_height > {max_height} THEN '{anchor_ch}' ELSE consensus_hash END, \
+                    {burn_view_column}\
+                    CASE WHEN block_height > {max_height} THEN '{anchor_bhh}' ELSE block_hash END, \
+                    CASE WHEN block_height > {max_height} THEN {anchor_height} ELSE block_height END \
+             FROM {from}.{table} \
+             WHERE sortition_id IN ({sortition_id_sql}) \
+               AND (block_height <= {max_height} OR {anchor_match})"
+        )
     }
 
     /// Get the canonical burn chain tip -- the tip of the longest burn chain we know about.

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -2706,12 +2706,12 @@ impl SortitionDB {
         self.marf.sqlite_conn()
     }
 
-    /// Open or create the sortition MARF index database.
+    /// Open or create the sortition MARF index database with internal blobs.
     ///
     /// This function opens the SQLite-based MARF index at `marf_path`.
     /// If the index database does not exist, it will be created.
-    /// Archival sortition DBs store blobs internally. Squashed sortition DBs
-    /// are expected to store blobs externally in `marf.sqlite.blobs`.
+    /// This index stores all blobs internally within the SQLite database
+    /// (i.e., no separate `.blobs` file).
     ///
     /// # Arguments
     /// * `marf_path` - Path to the MARF SQLite index database.
@@ -2719,7 +2719,7 @@ impl SortitionDB {
     ///
     /// # Behavior
     /// Given a `marf_path` such as `burnchain/sortition/marf.sqlite`,
-    /// the MARF blobs are stored internally unless `marf.sqlite.blobs` exists.
+    /// the MARF blobs are stored internally within the SQLite database.
     /// This function also enables SQLite foreign key enforcement.
     fn open_index(
         marf_path: &str,
@@ -2727,7 +2727,7 @@ impl SortitionDB {
     ) -> Result<MARF<SortitionId>, db_error> {
         test_debug!("Open MARF index at {}", marf_path);
         let mut open_opts = marf_opts.unwrap_or(MARFOpenOpts::default());
-        open_opts.external_blobs = std::path::Path::new(&format!("{marf_path}.blobs")).exists();
+        open_opts.external_blobs = false;
         test_override_marf_compression(&mut open_opts);
         let marf = MARF::from_path(marf_path, open_opts).map_err(|_e| db_error::Corruption)?;
         sql_pragma(marf.sqlite_conn(), "foreign_keys", &true)?;

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -487,7 +487,7 @@ impl FromRow<StacksEpoch> for StacksEpoch {
 
 pub const SORTITION_DB_VERSION: u32 = 11;
 
-pub(crate) const SORTITION_DB_INITIAL_SCHEMA: &[&str] = &[
+const SORTITION_DB_INITIAL_SCHEMA: &[&str] = &[
     r#"
     PRAGMA foreign_keys = ON;
     "#,
@@ -622,7 +622,7 @@ pub(crate) const SORTITION_DB_INITIAL_SCHEMA: &[&str] = &[
     "CREATE TABLE db_config(version TEXT PRIMARY KEY);",
 ];
 
-pub(crate) const SORTITION_DB_SCHEMA_2: &[&str] = &[r#"
+const SORTITION_DB_SCHEMA_2: &[&str] = &[r#"
      CREATE TABLE epochs (
          start_block_height INTEGER NOT NULL,
          end_block_height INTEGER NOT NULL,
@@ -632,7 +632,7 @@ pub(crate) const SORTITION_DB_SCHEMA_2: &[&str] = &[r#"
          PRIMARY KEY(start_block_height,epoch_id)
      );"#];
 
-pub(crate) const SORTITION_DB_SCHEMA_3: &[&str] = &[r#"
+const SORTITION_DB_SCHEMA_3: &[&str] = &[r#"
     CREATE TABLE block_commit_parents (
         block_commit_txid TEXT NOT NULL,
         block_commit_sortition_id TEXT NOT NULL,
@@ -643,7 +643,7 @@ pub(crate) const SORTITION_DB_SCHEMA_3: &[&str] = &[r#"
         FOREIGN KEY(block_commit_txid,block_commit_sortition_id) REFERENCES block_commits(txid,sortition_id)
     );"#];
 
-pub(crate) const SORTITION_DB_SCHEMA_4: &[&str] = &[
+const SORTITION_DB_SCHEMA_4: &[&str] = &[
     r#"
     CREATE TABLE delegate_stx (
         txid TEXT NOT NULL,
@@ -668,16 +668,16 @@ pub(crate) const SORTITION_DB_SCHEMA_4: &[&str] = &[
 
 /// The changes for version five *just* replace the existing epochs table
 ///  by deleting all the current entries and inserting the new epochs definition.
-pub(crate) const SORTITION_DB_SCHEMA_5: &[&str] = &[r#"
+const SORTITION_DB_SCHEMA_5: &[&str] = &[r#"
      DELETE FROM epochs;"#];
 
-pub(crate) const SORTITION_DB_SCHEMA_6: &[&str] = &[r#"
+const SORTITION_DB_SCHEMA_6: &[&str] = &[r#"
      DELETE FROM epochs;"#];
 
-pub(crate) const SORTITION_DB_SCHEMA_7: &[&str] = &[r#"
+const SORTITION_DB_SCHEMA_7: &[&str] = &[r#"
      DELETE FROM epochs;"#];
 
-pub(crate) const SORTITION_DB_SCHEMA_8: &[&str] = &[
+const SORTITION_DB_SCHEMA_8: &[&str] = &[
     r#"DELETE FROM epochs;"#,
     r#"DROP INDEX IF EXISTS index_user_burn_support_txid;"#,
     r#"DROP INDEX IF EXISTS index_user_burn_support_sortition_id_vtxindex;"#,
@@ -722,11 +722,11 @@ pub(crate) const SORTITION_DB_SCHEMA_8: &[&str] = &[
     );"#,
 ];
 
-pub(crate) static SORTITION_DB_SCHEMA_9: &[&str] =
+static SORTITION_DB_SCHEMA_9: &[&str] =
     &[r#"ALTER TABLE block_commits ADD punished TEXT DEFAULT NULL;"#];
-pub(crate) static SORTITION_DB_SCHEMA_10: &[&str] = &[r#"DROP TABLE IF EXISTS ast_rule_heights;"#];
+static SORTITION_DB_SCHEMA_10: &[&str] = &[r#"DROP TABLE IF EXISTS ast_rule_heights;"#];
 
-pub(crate) static SORTITION_DB_SCHEMA_11: &[&str] = &[r#"
+static SORTITION_DB_SCHEMA_11: &[&str] = &[r#"
     -- replacement for `stacks_chain_tips`, which considers the Nakamoto block burn view.
     -- Unlike `stacks_chain_tips`, rows in this table are only inserted for Nakamoto blocks
     -- if they happen to have the same burn view as the given sortition.

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4512,6 +4512,23 @@ pub struct SortitionTipCopyBoundary {
     pub anchor_block_height: u64,
 }
 
+impl SortitionTipCopyBoundary {
+    /// Check the boundary's internal invariants: the anchor must not sit
+    /// above the Stacks boundary, and both heights must be
+    /// SQL-representable.
+    pub fn validate(&self) -> Result<(), db_error> {
+        if self.anchor_block_height > self.max_stacks_height {
+            return Err(db_error::Other(format!(
+                "sortition tip rewrite anchor height {} exceeds Stacks boundary {}",
+                self.anchor_block_height, self.max_stacks_height
+            )));
+        }
+        u64_to_sql(self.max_stacks_height)?;
+        u64_to_sql(self.anchor_block_height)?;
+        Ok(())
+    }
+}
+
 // Querying methods
 impl SortitionDB {
     /// Get the canonical burn chain tip -- the tip of the longest burn chain we know about.
@@ -4531,9 +4548,8 @@ impl SortitionDB {
     }
 
     /// Get the burn header hash of the snapshot with the given sortition
-    /// ID, or `None` if no such snapshot exists. Used by the offline
-    /// snapshot copy to derive its canonical burn-hash set. Returns the raw
-    /// stored TEXT, so the copy preserves the value byte-for-byte.
+    /// ID, or `None` if no such snapshot exists. Returns the raw stored
+    /// TEXT so callers can preserve the value byte-for-byte.
     pub(crate) fn get_snapshot_burn_header_hash(
         conn: &Connection,
         sortition_id: &SortitionId,
@@ -4593,6 +4609,30 @@ impl SortitionDB {
              WHERE sortition_id IN ({sortition_id_sql}) \
                AND (block_height <= {max_height} OR {anchor_match})"
         )
+    }
+
+    /// Whether every Stacks-tip memo row (in both memo tables) sits at or
+    /// below the boundary's Stacks height. A `None` boundary trivially
+    /// passes. Validation counterpart of
+    /// [`Self::stacks_tip_memo_copy_sql`]'s height rewrite.
+    pub(crate) fn stacks_tip_memos_within_boundary(
+        conn: &Connection,
+        boundary: Option<&SortitionTipCopyBoundary>,
+    ) -> Result<bool, db_error> {
+        let Some(boundary) = boundary else {
+            return Ok(true);
+        };
+        let max_height = u64_to_sql(boundary.max_stacks_height)?;
+        conn.query_row(
+            "SELECT COUNT(*) = 0 FROM ( \
+                 SELECT block_height FROM stacks_chain_tips WHERE block_height > ?1 \
+                 UNION ALL \
+                 SELECT block_height FROM stacks_chain_tips_by_burn_view WHERE block_height > ?1 \
+             )",
+            params![max_height],
+            |row| row.get(0),
+        )
+        .map_err(db_error::from)
     }
 
     /// Get the canonical burn chain tip -- the tip of the longest burn chain we know about.
@@ -7339,6 +7379,252 @@ pub mod tests {
         block_ops: &[BlockstackOperationType],
     ) -> BlockSnapshot {
         test_append_snapshot_with_winner(db, next_hash, block_ops, None, None)
+    }
+
+    // Raw-row test fixture writers. Each helper owns its table's column
+    // list so fixtures can't drift from the schema; values are raw
+    // TEXT/ints because fixtures use readable labels, not valid hashes
+    // (which the typed write paths would reject).
+
+    /// Insert a minimal `snapshots` row with the given identity columns;
+    /// every other column gets a fixed placeholder.
+    pub fn test_insert_snapshot_row(
+        conn: &Connection,
+        block_height: u32,
+        burn_header_hash: &str,
+        sortition_id: &str,
+        consensus_hash: &str,
+        index_root: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO snapshots (
+                block_height, burn_header_hash, sortition_id, parent_sortition_id,
+                burn_header_timestamp, parent_burn_header_hash, consensus_hash,
+                ops_hash, total_burn, sortition, sortition_hash,
+                winning_block_txid, winning_stacks_block_hash, index_root,
+                num_sortitions, stacks_block_accepted, stacks_block_height,
+                arrival_index, canonical_stacks_tip_height, canonical_stacks_tip_hash,
+                canonical_stacks_tip_consensus_hash, pox_valid,
+                accumulated_coinbase_ustx, pox_payouts, miner_pk_hash
+            ) VALUES (
+                ?1, ?2, ?3, 'parent_sort', 1000, 'parent_bhh', ?4,
+                'ops', '0', 1, 'shash', 'wbtxid', 'wsbh', ?5,
+                ?1, 0, 0, ?1, 0, 'csth', 'cstch', 1, '0', '[]', NULL
+            )",
+            params![
+                block_height,
+                burn_header_hash,
+                sortition_id,
+                consensus_hash,
+                index_root,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Rewrite a `snapshots` row's consensus hash (boundary-anchor fixtures).
+    pub fn test_set_snapshot_consensus_hash(
+        conn: &Connection,
+        sortition_id: &str,
+        consensus_hash: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "UPDATE snapshots SET consensus_hash = ?1 WHERE sortition_id = ?2",
+            params![consensus_hash, sortition_id],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `leader_keys` row.
+    pub fn test_insert_leader_key_row(
+        conn: &Connection,
+        txid: &str,
+        sortition_id: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO leader_keys (txid, vtxindex, block_height, burn_header_hash, \
+             sortition_id, consensus_hash, public_key, memo) \
+             VALUES (?1, 0, 1, 'bhh', ?2, 'ch', 'pk', 'memo')",
+            params![txid, sortition_id],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `block_commits` row.
+    pub fn test_insert_block_commit_row(
+        conn: &Connection,
+        txid: &str,
+        sortition_id: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO block_commits (txid, vtxindex, block_height, burn_header_hash, \
+             sortition_id, block_header_hash, new_seed, parent_block_ptr, parent_vtxindex, \
+             key_block_ptr, key_vtxindex, memo, commit_outs, burn_fee, sunset_burn, \
+             input, apparent_sender, burn_parent_modulus, punished) \
+             VALUES (?1, 0, 1, 'bhh', ?2, 'bhh', 'seed', 0, 0, 0, 0, '', '', '0', '0', \
+             'input', 'sender', 0, NULL)",
+            params![txid, sortition_id],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `block_commit_parents` row.
+    pub fn test_insert_block_commit_parent_row(
+        conn: &Connection,
+        block_commit_txid: &str,
+        block_commit_sortition_id: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO block_commit_parents (block_commit_txid, block_commit_sortition_id, \
+             parent_sortition_id) VALUES (?1, ?2, 'parent_sort')",
+            params![block_commit_txid, block_commit_sortition_id],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `stack_stx` row.
+    pub fn test_insert_stack_stx_row(
+        conn: &Connection,
+        txid: &str,
+        burn_header_hash: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO stack_stx (txid, vtxindex, block_height, burn_header_hash, \
+             sender_addr, reward_addr, stacked_ustx, num_cycles, signer_key, max_amount, auth_id) \
+             VALUES (?1, 0, 1, ?2, 'sender', 'reward', '1000', 1, NULL, NULL, NULL)",
+            params![txid, burn_header_hash],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `transfer_stx` row.
+    pub fn test_insert_transfer_stx_row(
+        conn: &Connection,
+        txid: &str,
+        burn_header_hash: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO transfer_stx (txid, vtxindex, block_height, burn_header_hash, \
+             sender_addr, recipient_addr, transfered_ustx, memo) \
+             VALUES (?1, 0, 0, ?2, 's', 'r', '100', 'x')",
+            params![txid, burn_header_hash],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `delegate_stx` row.
+    pub fn test_insert_delegate_stx_row(
+        conn: &Connection,
+        txid: &str,
+        burn_header_hash: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO delegate_stx (txid, vtxindex, block_height, burn_header_hash, \
+             sender_addr, delegate_to, reward_addr, delegated_ustx, until_burn_height) \
+             VALUES (?1, 0, 0, ?2, 's', 'd', 'r', '100', NULL)",
+            params![txid, burn_header_hash],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `vote_for_aggregate_key` row.
+    pub fn test_insert_vote_for_aggregate_key_row(
+        conn: &Connection,
+        txid: &str,
+        burn_header_hash: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO vote_for_aggregate_key (txid, vtxindex, block_height, \
+             burn_header_hash, sender_addr, aggregate_key, round, reward_cycle, \
+             signer_index, signer_key) \
+             VALUES (?1, 0, 0, ?2, 's', 'k', 0, 0, 0, 'sk')",
+            params![txid, burn_header_hash],
+        )?;
+        Ok(())
+    }
+
+    /// Insert an empty `snapshot_transition_ops` row.
+    pub fn test_insert_snapshot_transition_ops_row(
+        conn: &Connection,
+        sortition_id: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO snapshot_transition_ops (sortition_id, accepted_ops, consumed_keys) \
+             VALUES (?1, '[]', '[]')",
+            params![sortition_id],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a `stacks_chain_tips` row.
+    pub fn test_insert_stacks_chain_tip_row(
+        conn: &Connection,
+        sortition_id: &str,
+        consensus_hash: &str,
+        block_hash: &str,
+        block_height: u64,
+    ) -> Result<(), db_error> {
+        conn.execute(
+            "INSERT INTO stacks_chain_tips (sortition_id, consensus_hash, block_hash, \
+             block_height) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                sortition_id,
+                consensus_hash,
+                block_hash,
+                u64_to_sql(block_height)?,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a `stacks_chain_tips_by_burn_view` row.
+    pub fn test_insert_stacks_chain_tip_by_burn_view_row(
+        conn: &Connection,
+        sortition_id: &str,
+        consensus_hash: &str,
+        burn_view_consensus_hash: &str,
+        block_hash: &str,
+        block_height: u64,
+    ) -> Result<(), db_error> {
+        conn.execute(
+            "INSERT INTO stacks_chain_tips_by_burn_view \
+             (sortition_id, consensus_hash, burn_view_consensus_hash, block_hash, block_height) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                sortition_id,
+                consensus_hash,
+                burn_view_consensus_hash,
+                block_hash,
+                u64_to_sql(block_height)?,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `missed_commits` row.
+    pub fn test_insert_missed_commit_row(
+        conn: &Connection,
+        txid: &str,
+        intended_sortition_id: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO missed_commits (txid, input, intended_sortition_id) \
+             VALUES (?1, 'input', ?2)",
+            params![txid, intended_sortition_id],
+        )?;
+        Ok(())
+    }
+
+    /// Insert an empty `preprocessed_reward_sets` row.
+    pub fn test_insert_preprocessed_reward_set_row(
+        conn: &Connection,
+        sortition_id: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO preprocessed_reward_sets (sortition_id, reward_set) VALUES (?1, '{}')",
+            params![sortition_id],
+        )?;
+        Ok(())
     }
 
     #[test]

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -23,7 +23,7 @@ use rusqlite::{Connection, OpenFlags};
 use stacks_common::types::chainstate::StacksBlockId;
 
 use super::common::{
-    clone_schemas_from_source, unclassified_tables, with_indexes_dropped,
+    assert_source_schema, clone_schemas_from_source, with_indexes_dropped,
     with_offline_write_session, MARF_INFRA_TABLES,
 };
 use super::fork_storage::{collect_leaf_value_hashes, copy_leaf_referenced_rows};
@@ -46,22 +46,15 @@ fn known_clarity_tables() -> Vec<&'static str> {
         .collect()
 }
 
-/// Refuse to snapshot a source clarity DB with tables the hardcoded copy lists
-/// don't recognize: the snapshot would silently omit them and a node would
-/// recreate them empty. Runs on the real source DB, so unlike the compile-time
-/// `test_no_unclassified_clarity_source_tables` it also catches tables added outside
-/// the migration path (a newer node, an ad-hoc `CREATE TABLE`).
+/// The clarity snapshot's source-schema guard (see [`assert_source_schema`]);
+/// `test_no_unclassified_clarity_source_tables` runs it against a fresh schema.
 pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
-    let unknown = unclassified_tables(src_conn, &known_clarity_tables());
-    if !unknown.is_empty() {
-        return Err(Error::CorruptionError(format!(
-            "source clarity DB has unrecognized table(s) {unknown:?}: the snapshot would omit \
-             them and a node booting from it would recreate them empty. The tool may be older \
-             than the DB's schema (upgrade it to match the node); if this is a newly added \
-             table, classify each in CLARITY_SIDE_TABLES (to copy) in snapshot/clarity.rs"
-        )));
-    }
-    Ok(())
+    assert_source_schema(
+        src_conn,
+        &known_clarity_tables(),
+        "clarity DB",
+        "CLARITY_SIDE_TABLES (to copy) in snapshot/clarity.rs",
+    )
 }
 
 /// Copy Clarity side-storage tables (`data_table`, `metadata_table`) from a

--- a/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/clarity.rs
@@ -22,7 +22,10 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::{Connection, OpenFlags};
 use stacks_common::types::chainstate::StacksBlockId;
 
-use super::common::{clone_schemas_from_source, with_indexes_dropped, with_offline_write_session};
+use super::common::{
+    clone_schemas_from_source, unclassified_tables, with_indexes_dropped,
+    with_offline_write_session, MARF_INFRA_TABLES,
+};
 use super::fork_storage::{collect_leaf_value_hashes, copy_leaf_referenced_rows};
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MarfConnection as _, MARF};
 use crate::chainstate::stacks::index::storage::{TrieFileStorage, TrieHashCalculationMode};
@@ -31,6 +34,35 @@ use crate::util_lib::db::sqlite_open;
 
 /// Clarity side-storage tables copied by [`copy_clarity_side_tables`].
 pub(super) const CLARITY_SIDE_TABLES: &[&str] = &[DATA_TABLE_NAME, METADATA_TABLE_NAME];
+
+/// Every table the Clarity snapshot accounts for: side-storage copied by
+/// [`copy_clarity_side_tables`] ([`CLARITY_SIDE_TABLES`]) or owned by the MARF
+/// trie itself, recreated by [`MARF::squash_to_path`] ([`MARF_INFRA_TABLES`]).
+fn known_clarity_tables() -> Vec<&'static str> {
+    CLARITY_SIDE_TABLES
+        .iter()
+        .chain(MARF_INFRA_TABLES)
+        .copied()
+        .collect()
+}
+
+/// Refuse to snapshot a source clarity DB with tables the hardcoded copy lists
+/// don't recognize: the snapshot would silently omit them and a node would
+/// recreate them empty. Runs on the real source DB, so unlike the compile-time
+/// `test_no_unclassified_clarity_source_tables` it also catches tables added outside
+/// the migration path (a newer node, an ad-hoc `CREATE TABLE`).
+pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
+    let unknown = unclassified_tables(src_conn, &known_clarity_tables());
+    if !unknown.is_empty() {
+        return Err(Error::CorruptionError(format!(
+            "source clarity DB has unrecognized table(s) {unknown:?}: the snapshot would omit \
+             them and a node booting from it would recreate them empty. The tool may be older \
+             than the DB's schema (upgrade it to match the node); if this is a newly added \
+             table, classify each in CLARITY_SIDE_TABLES (to copy) in snapshot/clarity.rs"
+        )));
+    }
+    Ok(())
+}
 
 /// Copy Clarity side-storage tables (`data_table`, `metadata_table`) from a
 /// source MARF database to a squashed MARF database.
@@ -49,6 +81,10 @@ pub fn copy_clarity_side_tables(
 ) -> Result<ClaritySideTableStats, Error> {
     let total_start = Instant::now();
 
+    // Reject an unrecognized source schema before any destination work.
+    let src_conn = open_readonly_clarity_db(src_db_path)?;
+    assert_source_tables_classified(&src_conn)?;
+
     // Walk the squashed trie before opening dst for writes. we need
     // the readonly MARF view, and `marf_sqlite_open` would fight the
     // writer's lock on dst.
@@ -61,8 +97,6 @@ pub fn copy_clarity_side_tables(
     );
 
     let required_contract_ids = resolve_required_contracts(src_db_path, &squashed_tip)?;
-
-    let src_conn = open_readonly_clarity_db(src_db_path)?;
 
     let stats = with_offline_write_session(
         dst_db_path,

--- a/stackslib/src/chainstate/stacks/db/snapshot/common.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/common.rs
@@ -260,10 +260,10 @@ where
 }
 
 /// The user tables in `conn`'s `main` schema not in `known`. Each squash copy
-/// module lists the tables it handles and a guard test asserts this is empty, so
-/// a new migration can't silently drop a table from the copy.
-#[cfg(test)]
-pub(crate) fn unclassified_tables(conn: &Connection, known: &[&str]) -> Vec<String> {
+/// module lists the tables it handles; both the runtime source-schema check and
+/// the drift-guard tests assert this is empty, so a new migration can't silently
+/// drop a table from the copy.
+pub(super) fn unclassified_tables(conn: &Connection, known: &[&str]) -> Vec<String> {
     let known: std::collections::HashSet<&str> = known.iter().copied().collect();
     let mut stmt = conn
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
@@ -283,8 +283,7 @@ pub(crate) fn unclassified_tables(conn: &Connection, known: &[&str]) -> Vec<Stri
 /// source DB and are created by the squash engine (`MARF::squash_to_path`) or
 /// store init — not by a side-table copy — so the drift guards treat them as
 /// already handled.
-#[cfg(test)]
-pub(crate) const MARF_INFRA_TABLES: &[&str] = &[
+pub(super) const MARF_INFRA_TABLES: &[&str] = &[
     "marf_data",
     "__fork_storage",
     "marf_squash_info",

--- a/stackslib/src/chainstate/stacks/db/snapshot/common.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/common.rs
@@ -279,6 +279,30 @@ pub(super) fn unclassified_tables(conn: &Connection, known: &[&str]) -> Vec<Stri
         .collect()
 }
 
+/// Reject snapshotting a source DB whose schema has tables `known` doesn't
+/// cover: the snapshot would omit them and a node booting from it would recreate
+/// them empty. Runs on the real source DB, so it also catches tables that reached
+/// disk outside the tool's migration path (a newer node, an ad-hoc `CREATE
+/// TABLE`) that a compile-time list check would miss. `db_label` names the DB in
+/// the error; `classify_hint` says where to classify a newly added table.
+pub(super) fn assert_source_schema(
+    src_conn: &Connection,
+    known: &[&str],
+    db_label: &str,
+    classify_hint: &str,
+) -> Result<(), Error> {
+    let unknown = unclassified_tables(src_conn, known);
+    if !unknown.is_empty() {
+        return Err(Error::CorruptionError(format!(
+            "source {db_label} has unrecognized table(s) {unknown:?}: the snapshot would omit them \
+             and a node booting from it would recreate them empty. The tool may be older than the \
+             DB's schema (upgrade it to match the node); if this is a newly added table, classify \
+             each in {classify_hint}"
+        )));
+    }
+    Ok(())
+}
+
 /// MARF / Clarity-store infrastructure tables. They live in every MARF-backed
 /// source DB and are created by the squash engine (`MARF::squash_to_path`) or
 /// store init — not by a side-table copy — so the drift guards treat them as

--- a/stackslib/src/chainstate/stacks/db/snapshot/index.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/index.rs
@@ -20,7 +20,7 @@ use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use stacks_common::types::chainstate::StacksBlockId;
 
 use super::common::{
-    clone_schemas_from_source, copied_rows, execute_copy_specs, unclassified_tables,
+    assert_source_schema, clone_schemas_from_source, copied_rows, execute_copy_specs,
     with_offline_write_session, TableCopySpec, MARF_INFRA_TABLES,
 };
 use super::fork_storage::{collect_canonical_leaf_hashes, copy_canonical_fork_storage};
@@ -76,23 +76,15 @@ fn known_index_tables() -> Vec<&'static str> {
         .collect()
 }
 
-/// Refuse to snapshot a source index DB with tables the hardcoded copy lists
-/// don't recognize: the snapshot would silently omit them and a node would
-/// recreate them empty. Runs on the real source DB, so unlike the compile-time
-/// `test_no_unclassified_source_tables` it also catches tables added outside
-/// the migration path (a newer node, an ad-hoc `CREATE TABLE`).
+/// The index snapshot's source-schema guard (see [`assert_source_schema`]);
+/// `test_no_unclassified_source_tables` runs it against a fresh schema.
 pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
-    let unknown = unclassified_tables(src_conn, &known_index_tables());
-    if !unknown.is_empty() {
-        return Err(Error::CorruptionError(format!(
-            "source index DB has unrecognized table(s) {unknown:?}: the snapshot would omit them \
-             and a node booting from it would recreate them empty. The tool may be older than the \
-             DB's schema (upgrade it to match the node); if this is a newly added table, classify \
-             each in COPIED_TABLES (to copy) or SCHEMA_ONLY_TABLES (to schema-clone only) in \
-             snapshot/index.rs"
-        )));
-    }
-    Ok(())
+    assert_source_schema(
+        src_conn,
+        &known_index_tables(),
+        "index DB",
+        "COPIED_TABLES (to copy) or SCHEMA_ONLY_TABLES (to schema-clone only) in snapshot/index.rs",
+    )
 }
 
 /// Row-count statistics returned by [`copy_index_side_tables`].

--- a/stackslib/src/chainstate/stacks/db/snapshot/index.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/index.rs
@@ -16,16 +16,17 @@
 use std::collections::HashSet;
 use std::time::Instant;
 
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use stacks_common::types::chainstate::StacksBlockId;
 
 use super::common::{
-    clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
-    TableCopySpec,
+    clone_schemas_from_source, copied_rows, execute_copy_specs, unclassified_tables,
+    with_offline_write_session, TableCopySpec, MARF_INFRA_TABLES,
 };
 use super::fork_storage::{collect_canonical_leaf_hashes, copy_canonical_fork_storage};
 use crate::burnchains::PoxConstants;
 use crate::chainstate::stacks::index::{trie_sql, Error, MARFValue};
+use crate::util_lib::db::sqlite_open;
 
 /// Tables copied (with canonical-filtered content) into the squashed index DB.
 pub(crate) const COPIED_TABLES: &[&str] = &[
@@ -61,6 +62,37 @@ fn all_required_tables() -> Vec<&'static str> {
         .chain(SCHEMA_ONLY_TABLES)
         .copied()
         .collect()
+}
+
+/// Every table the index snapshot accounts for: content-copied ([`COPIED_TABLES`]),
+/// schema-cloned but unpopulated ([`SCHEMA_ONLY_TABLES`]), or owned by the MARF
+/// squash itself ([`MARF_INFRA_TABLES`]).
+fn known_index_tables() -> Vec<&'static str> {
+    COPIED_TABLES
+        .iter()
+        .chain(SCHEMA_ONLY_TABLES)
+        .chain(MARF_INFRA_TABLES)
+        .copied()
+        .collect()
+}
+
+/// Refuse to snapshot a source index DB with tables the hardcoded copy lists
+/// don't recognize: the snapshot would silently omit them and a node would
+/// recreate them empty. Runs on the real source DB, so unlike the compile-time
+/// `test_no_unclassified_source_tables` it also catches tables added outside
+/// the migration path (a newer node, an ad-hoc `CREATE TABLE`).
+pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
+    let unknown = unclassified_tables(src_conn, &known_index_tables());
+    if !unknown.is_empty() {
+        return Err(Error::CorruptionError(format!(
+            "source index DB has unrecognized table(s) {unknown:?}: the snapshot would omit them \
+             and a node booting from it would recreate them empty. The tool may be older than the \
+             DB's schema (upgrade it to match the node); if this is a newly added table, classify \
+             each in COPIED_TABLES (to copy) or SCHEMA_ONLY_TABLES (to schema-clone only) in \
+             snapshot/index.rs"
+        )));
+    }
+    Ok(())
 }
 
 /// Row-count statistics returned by [`copy_index_side_tables`].
@@ -262,6 +294,11 @@ pub fn copy_index_side_tables(
     first_burn_height: u64,
     reward_cycle_len: u64,
 ) -> Result<IndexSideTableStats, Error> {
+    // Reject an unrecognized source schema before any destination work.
+    let src_conn = sqlite_open(src_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
+    assert_source_tables_classified(&src_conn)?;
+    drop(src_conn);
+
     let leaf_hashes = collect_canonical_leaf_hashes::<StacksBlockId>(dst_path)?;
 
     with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {

--- a/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
@@ -27,8 +27,13 @@
 pub(crate) mod common;
 pub(crate) mod fork_storage;
 mod index;
+mod sortition;
 
 #[cfg(test)]
 mod tests;
 
 pub use index::{copy_index_side_tables, IndexSideTableStats};
+pub use sortition::{
+    copy_sortition_side_tables, copy_sortition_side_tables_with_boundary, SortitionSideTableStats,
+    SortitionTipCopyBoundary,
+};

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -260,6 +260,10 @@ pub fn copy_sortition_side_tables(
     copy_sortition_side_tables_with_boundary(src_path, dst_path, None)
 }
 
+/// [`copy_sortition_side_tables`] with an explicit Stacks-tip boundary: the
+/// `stacks_chain_tips*` memo rows are rewritten/dropped relative to
+/// `stacks_boundary` (see [`SortitionTipCopyBoundary`]).
+/// A `None` boundary copies all the memo rows.
 pub fn copy_sortition_side_tables_with_boundary(
     src_path: &str,
     dst_path: &str,

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -89,9 +89,7 @@ fn populate_canonical_sortitions(
     let mut burn_hashes: HashSet<String> = HashSet::new();
     let mut orphans: u64 = 0;
     for (_, sortition_id, _) in &canonical {
-        match SortitionDB::get_snapshot_burn_header_hash(src_conn, sortition_id).map_err(|e| {
-            Error::CorruptionError(format!("cannot read src snapshot {sortition_id}: {e}"))
-        })? {
+        match SortitionDB::get_snapshot_burn_header_hash(src_conn, sortition_id)? {
             Some(burn_header_hash) => {
                 burn_hashes.insert(burn_header_hash);
             }
@@ -105,48 +103,33 @@ fn populate_canonical_sortitions(
     }
 
     session_conn
-        .execute_batch("CREATE TEMP TABLE canonical_sortitions (sortition_id TEXT PRIMARY KEY)")
-        .map_err(Error::SQLError)?;
-    session_conn
-        .execute_batch(
-            "CREATE TEMP TABLE canonical_burn_hashes (burn_header_hash TEXT PRIMARY KEY)",
-        )
-        .map_err(Error::SQLError)?;
+        .execute_batch("CREATE TEMP TABLE canonical_sortitions (sortition_id TEXT PRIMARY KEY)")?;
+    session_conn.execute_batch(
+        "CREATE TEMP TABLE canonical_burn_hashes (burn_header_hash TEXT PRIMARY KEY)",
+    )?;
     // A savepoint batches the temp-table inserts whether or not the session
     // already holds an open transaction.
-    session_conn
-        .execute_batch("SAVEPOINT canonical_sortitions")
-        .map_err(Error::SQLError)?;
-    let mut insert = session_conn
-        .prepare("INSERT INTO canonical_sortitions (sortition_id) VALUES (?1)")
-        .map_err(Error::SQLError)?;
+    session_conn.execute_batch("SAVEPOINT canonical_sortitions")?;
+    let mut insert =
+        session_conn.prepare("INSERT INTO canonical_sortitions (sortition_id) VALUES (?1)")?;
     for (_, sortition_id, _) in &canonical {
-        insert
-            .execute(params![sortition_id])
-            .map_err(Error::SQLError)?;
+        insert.execute(params![sortition_id])?;
     }
     drop(insert);
-    let mut insert = session_conn
-        .prepare("INSERT INTO canonical_burn_hashes (burn_header_hash) VALUES (?1)")
-        .map_err(Error::SQLError)?;
+    let mut insert =
+        session_conn.prepare("INSERT INTO canonical_burn_hashes (burn_header_hash) VALUES (?1)")?;
     for burn_header_hash in &burn_hashes {
-        insert
-            .execute([burn_header_hash])
-            .map_err(Error::SQLError)?;
+        insert.execute([burn_header_hash])?;
     }
     drop(insert);
-    session_conn
-        .execute_batch("RELEASE canonical_sortitions")
-        .map_err(Error::SQLError)?;
+    session_conn.execute_batch("RELEASE canonical_sortitions")?;
 
     Ok(())
 }
 
 fn validate_tip_boundary(boundary: Option<&SortitionTipCopyBoundary>) -> Result<(), Error> {
     if let Some(boundary) = boundary {
-        boundary
-            .validate()
-            .map_err(|e| Error::CorruptionError(e.to_string()))?;
+        boundary.validate()?;
     }
     Ok(())
 }
@@ -253,6 +236,8 @@ fn sortition_copy_specs(boundary: Option<&SortitionTipCopyBoundary>) -> Vec<Tabl
 /// Copy required non-MARF tables from the source sortition DB into the
 /// squashed destination. Only canonical rows (determined by the squashed MARF's
 /// `marf_squashed_blocks`) are included.
+///
+/// `dst_path` is the squashed sortition DB already created by `MARF::squash_to_path`.
 pub fn copy_sortition_side_tables(
     src_path: &str,
     dst_path: &str,
@@ -274,8 +259,7 @@ pub fn copy_sortition_side_tables_with_boundary(
     let leaf_hashes = collect_canonical_leaf_hashes::<SortitionId>(dst_path)?;
     // Read-only source handle for the sortdb-owned readers; the session
     // below still attaches src for the copy specs.
-    let src_conn =
-        sqlite_open(src_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false).map_err(Error::SQLError)?;
+    let src_conn = sqlite_open(src_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
 
     with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {
         clone_schemas_from_source(conn, REQUIRED_TABLES)?;
@@ -300,22 +284,16 @@ fn copy_sortition_tables_inner(
     // Execute descriptor-driven copies.
     let specs = sortition_copy_specs(stacks_boundary);
     let results = execute_copy_specs(session_conn, &specs)?;
-    if !SortitionDB::stacks_tip_memos_within_boundary(session_conn, stacks_boundary)
-        .map_err(|e| Error::CorruptionError(format!("cannot check sortition tip boundary: {e}")))?
-    {
+    if !SortitionDB::stacks_tip_memos_within_boundary(session_conn, stacks_boundary)? {
         return Err(Error::CorruptionError(
             "copied sortition tip row points past the Stacks MARF boundary".into(),
         ));
     }
 
-    session_conn
-        .execute_batch("DROP TABLE IF EXISTS temp.canonical_sortitions")
-        .map_err(Error::SQLError)?;
-    session_conn
-        .execute_batch("DROP TABLE IF EXISTS temp.canonical_burn_hashes")
-        .map_err(Error::SQLError)?;
+    session_conn.execute_batch("DROP TABLE IF EXISTS temp.canonical_sortitions")?;
+    session_conn.execute_batch("DROP TABLE IF EXISTS temp.canonical_burn_hashes")?;
 
-    Ok(SortitionSideTableStats {
+    let stats = SortitionSideTableStats {
         snapshots_rows: copied_rows(&results, "snapshots"),
         leader_keys_rows: copied_rows(&results, "leader_keys"),
         block_commits_rows: copied_rows(&results, "block_commits"),
@@ -335,5 +313,11 @@ fn copy_sortition_tables_inner(
         epochs_rows: copied_rows(&results, "epochs"),
         db_config_rows: copied_rows(&results, "db_config"),
         fork_storage_rows,
-    })
+    };
+    info!(
+        "Copied sortition side tables";
+        "snapshots_rows" => stats.snapshots_rows,
+        "fork_storage_rows" => stats.fork_storage_rows
+    );
+    Ok(stats)
 }

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -19,8 +19,8 @@ use rusqlite::{params, Connection, OpenFlags};
 use stacks_common::types::chainstate::SortitionId;
 
 use super::common::{
-    clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
-    TableCopySpec,
+    clone_schemas_from_source, copied_rows, execute_copy_specs, unclassified_tables,
+    with_offline_write_session, TableCopySpec, MARF_INFRA_TABLES,
 };
 use super::fork_storage::{collect_canonical_leaf_hashes, copy_canonical_fork_storage};
 use crate::chainstate::burn::db::sortdb::SortitionDB;
@@ -46,6 +46,42 @@ pub(super) const REQUIRED_TABLES: &[&str] = &[
     "preprocessed_reward_sets",
     "epochs",
 ];
+
+/// Tables that may appear in a source sortition DB but are deliberately not
+/// copied. `snapshot_burn_distributions` is written only under the `testing`
+/// feature (`SortitionDBTx::store_burn_distribution`), never in production.
+pub(super) const IGNORED_TABLES: &[&str] = &["snapshot_burn_distributions"];
+
+/// Every table the sortition snapshot accounts for: content-copied
+/// ([`REQUIRED_TABLES`]), owned by the MARF squash itself
+/// ([`MARF_INFRA_TABLES`]), or deliberately skipped ([`IGNORED_TABLES`]).
+fn known_sortition_tables() -> Vec<&'static str> {
+    REQUIRED_TABLES
+        .iter()
+        .chain(MARF_INFRA_TABLES)
+        .chain(IGNORED_TABLES)
+        .copied()
+        .collect()
+}
+
+/// Refuse to snapshot a source sortition DB with tables the hardcoded copy
+/// lists don't recognize: the snapshot would silently omit them and a node
+/// would recreate them empty. Runs on the real source DB, so unlike the
+/// compile-time `test_no_unclassified_sortition_tables` it also catches tables
+/// added outside the migration path.
+pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
+    let unknown = unclassified_tables(src_conn, &known_sortition_tables());
+    if !unknown.is_empty() {
+        return Err(Error::CorruptionError(format!(
+            "source sortition DB has unrecognized table(s) {unknown:?}: the snapshot would omit \
+             them and a node booting from it would recreate them empty. The tool may be older than \
+             the DB's schema (upgrade it to match the node); if this is a newly added table, \
+             classify each in REQUIRED_TABLES (to copy) or IGNORED_TABLES (to skip) in \
+             snapshot/sortition.rs"
+        )));
+    }
+    Ok(())
+}
 
 /// Row-count statistics returned by [`copy_sortition_side_tables`].
 #[derive(Debug, Clone)]
@@ -140,7 +176,12 @@ fn validate_tip_boundary(boundary: Option<&SortitionTipCopyBoundary>) -> Result<
 /// - `sortition_id` filtered
 /// - `burn_header_hash` filtered
 /// - full-copy
-fn sortition_copy_specs(boundary: Option<&SortitionTipCopyBoundary>) -> Vec<TableCopySpec> {
+///
+/// The set of tables is independent of `boundary`; the boundary only rewrites
+/// the `stacks_chain_tips*` source SQL.
+pub(super) fn sortition_copy_specs(
+    boundary: Option<&SortitionTipCopyBoundary>,
+) -> Vec<TableCopySpec> {
     let sid = "SELECT sortition_id FROM canonical_sortitions";
     let bhh = "SELECT burn_header_hash FROM canonical_burn_hashes";
 
@@ -255,11 +296,13 @@ pub fn copy_sortition_side_tables_with_boundary(
     stacks_boundary: Option<&SortitionTipCopyBoundary>,
 ) -> Result<SortitionSideTableStats, Error> {
     validate_tip_boundary(stacks_boundary)?;
+    // Read-only source handle for the sortdb-owned readers; the session below
+    // still attaches src for the copy specs.
+    let src_conn = sqlite_open(src_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
+    // Reject an unrecognized source schema before any destination work.
+    assert_source_tables_classified(&src_conn)?;
     // Walk the squashed trie before opening dst R/W.
     let leaf_hashes = collect_canonical_leaf_hashes::<SortitionId>(dst_path)?;
-    // Read-only source handle for the sortdb-owned readers; the session
-    // below still attaches src for the copy specs.
-    let src_conn = sqlite_open(src_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
 
     with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {
         clone_schemas_from_source(conn, REQUIRED_TABLES)?;

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -19,7 +19,7 @@ use rusqlite::{params, Connection, OpenFlags};
 use stacks_common::types::chainstate::SortitionId;
 
 use super::common::{
-    clone_schemas_from_source, copied_rows, execute_copy_specs, unclassified_tables,
+    assert_source_schema, clone_schemas_from_source, copied_rows, execute_copy_specs,
     with_offline_write_session, TableCopySpec, MARF_INFRA_TABLES,
 };
 use super::fork_storage::{collect_canonical_leaf_hashes, copy_canonical_fork_storage};
@@ -64,23 +64,15 @@ fn known_sortition_tables() -> Vec<&'static str> {
         .collect()
 }
 
-/// Refuse to snapshot a source sortition DB with tables the hardcoded copy
-/// lists don't recognize: the snapshot would silently omit them and a node
-/// would recreate them empty. Runs on the real source DB, so unlike the
-/// compile-time `test_no_unclassified_sortition_tables` it also catches tables
-/// added outside the migration path.
+/// The sortition snapshot's source-schema guard (see [`assert_source_schema`]);
+/// `test_no_unclassified_sortition_tables` runs it against a fresh schema.
 pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
-    let unknown = unclassified_tables(src_conn, &known_sortition_tables());
-    if !unknown.is_empty() {
-        return Err(Error::CorruptionError(format!(
-            "source sortition DB has unrecognized table(s) {unknown:?}: the snapshot would omit \
-             them and a node booting from it would recreate them empty. The tool may be older than \
-             the DB's schema (upgrade it to match the node); if this is a newly added table, \
-             classify each in REQUIRED_TABLES (to copy) or IGNORED_TABLES (to skip) in \
-             snapshot/sortition.rs"
-        )));
-    }
-    Ok(())
+    assert_source_schema(
+        src_conn,
+        &known_sortition_tables(),
+        "sortition DB",
+        "REQUIRED_TABLES (to copy) or IGNORED_TABLES (to skip) in snapshot/sortition.rs",
+    )
 }
 
 /// Row-count statistics returned by [`copy_sortition_side_tables`].

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -305,10 +305,10 @@ fn copy_sortition_tables_inner(
     }
 
     session_conn
-        .execute_batch("DROP TABLE IF EXISTS canonical_sortitions")
+        .execute_batch("DROP TABLE IF EXISTS temp.canonical_sortitions")
         .map_err(Error::SQLError)?;
     session_conn
-        .execute_batch("DROP TABLE IF EXISTS canonical_burn_hashes")
+        .execute_batch("DROP TABLE IF EXISTS temp.canonical_burn_hashes")
         .map_err(Error::SQLError)?;
 
     Ok(SortitionSideTableStats {

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -1,0 +1,396 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use rusqlite::{params, Connection};
+use stacks_common::types::chainstate::{BlockHeaderHash, ConsensusHash, SortitionId};
+
+use super::common::{
+    clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
+    TableCopySpec,
+};
+use super::fork_storage::{collect_canonical_leaf_hashes, copy_canonical_fork_storage};
+use crate::chainstate::stacks::index::{trie_sql, Error, MARFValue};
+use crate::util_lib::db::u64_to_sql;
+
+/// Required sortition tables always present in production.
+pub(super) const REQUIRED_TABLES: &[&str] = &[
+    "db_config",
+    "snapshots",
+    "leader_keys",
+    "block_commits",
+    "block_commit_parents",
+    "snapshot_transition_ops",
+    "stacks_chain_tips",
+    "stacks_chain_tips_by_burn_view",
+    "missed_commits",
+    "stack_stx",
+    "transfer_stx",
+    "delegate_stx",
+    "vote_for_aggregate_key",
+    "preprocessed_reward_sets",
+    "epochs",
+];
+
+/// Row-count statistics returned by [`copy_sortition_side_tables`].
+#[derive(Debug, Clone)]
+pub struct SortitionSideTableStats {
+    pub snapshots_rows: u64,
+    pub leader_keys_rows: u64,
+    pub block_commits_rows: u64,
+    pub block_commit_parents_rows: u64,
+    pub snapshot_transition_ops_rows: u64,
+    pub stacks_chain_tips_rows: u64,
+    pub stacks_chain_tips_by_burn_view_rows: u64,
+    pub preprocessed_reward_sets_rows: u64,
+    pub missed_commits_rows: u64,
+    pub stack_stx_rows: u64,
+    pub transfer_stx_rows: u64,
+    pub delegate_stx_rows: u64,
+    pub vote_for_aggregate_key_rows: u64,
+    pub epochs_rows: u64,
+    pub db_config_rows: u64,
+    pub fork_storage_rows: u64,
+}
+
+/// Stacks-side boundary used when copying sortition tip memo tables.
+///
+/// A squash can anchor the sortition MARF at a burn view whose runtime source
+/// tip is later than the copied Stacks MARF. In that case, the memoized
+/// sortition tip must be rewritten to the copied Stacks anchor so a booting
+/// node still processes the intra-tenure descendants (re-fetched from peers)
+/// instead of believing they are already processed.
+#[derive(Debug, Clone)]
+pub struct SortitionTipCopyBoundary {
+    pub max_stacks_height: u64,
+    pub anchor_consensus_hash: ConsensusHash,
+    pub anchor_burn_view_consensus_hash: ConsensusHash,
+    pub anchor_block_hash: BlockHeaderHash,
+    pub anchor_block_height: u64,
+}
+
+/// Fill the (already-created) `canonical_sortitions` temp table from the
+/// squashed MARF metadata, read through the MARF-domain accessor
+/// [`trie_sql::bulk_read_squashed_blocks`] rather than a raw read of the
+/// MARF-owned `marf_squashed_blocks` table. The `SortitionId` binds as its
+/// lowercase-hex form, matching the `sortition_id` TEXT in `src.snapshots`.
+/// Returns the number of ids inserted.
+fn insert_canonical_sortition_ids(conn: &Connection) -> Result<usize, Error> {
+    let canonical = trie_sql::bulk_read_squashed_blocks::<SortitionId>(conn)?;
+    let mut insert = conn
+        .prepare("INSERT INTO canonical_sortitions (sortition_id) VALUES (?1)")
+        .map_err(Error::SQLError)?;
+    let mut inserted = 0usize;
+    for (_, sortition_id, _) in &canonical {
+        inserted += insert
+            .execute(params![sortition_id])
+            .map_err(Error::SQLError)?;
+    }
+    Ok(inserted)
+}
+
+/// Build temp tables for the canonical sortition set and canonical burn hashes.
+fn populate_canonical_sortitions(conn: &Connection) -> Result<(), Error> {
+    conn.execute_batch("CREATE TEMP TABLE canonical_sortitions (sortition_id TEXT PRIMARY KEY)")
+        .map_err(Error::SQLError)?;
+    let inserted = insert_canonical_sortition_ids(conn)?;
+    if inserted == 0 {
+        return Err(Error::CorruptionError(
+            "marf_squashed_blocks is empty; post-squash dst must have at least one canonical sortition"
+                .into(),
+        ));
+    }
+    // Source-completeness: every canonical sortition must exist in
+    // src.snapshots. A canonical sortition_id missing from src is
+    // corruption. The squash claimed a sortition that src doesn't have.
+    let orphans: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM canonical_sortitions \
+             WHERE sortition_id NOT IN (SELECT sortition_id FROM src.snapshots)",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(Error::SQLError)?;
+    if orphans > 0 {
+        return Err(Error::CorruptionError(format!(
+            "{orphans} canonical sortition(s) in marf_squashed_blocks are absent from src.snapshots"
+        )));
+    }
+
+    conn.execute_batch(
+        "CREATE TEMP TABLE canonical_burn_hashes (burn_header_hash TEXT PRIMARY KEY)",
+    )
+    .map_err(Error::SQLError)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO canonical_burn_hashes (burn_header_hash) \
+         SELECT DISTINCT s.burn_header_hash FROM src.snapshots s \
+         INNER JOIN canonical_sortitions cs ON s.sortition_id = cs.sortition_id",
+        [],
+    )
+    .map_err(Error::SQLError)?;
+
+    Ok(())
+}
+
+fn validate_tip_boundary(boundary: Option<&SortitionTipCopyBoundary>) -> Result<(), Error> {
+    if let Some(boundary) = boundary {
+        if boundary.anchor_block_height > boundary.max_stacks_height {
+            return Err(Error::CorruptionError(format!(
+                "sortition tip rewrite anchor height {} exceeds Stacks boundary {}",
+                boundary.anchor_block_height, boundary.max_stacks_height
+            )));
+        }
+        u64_to_sql(boundary.max_stacks_height)?;
+        u64_to_sql(boundary.anchor_block_height)?;
+    }
+    Ok(())
+}
+
+/// Build the copy source SQL for a sortition Stacks-tip memo table.
+///
+/// Handles both `stacks_chain_tips` and (with `include_burn_view`)
+/// `stacks_chain_tips_by_burn_view`; the latter carries an extra
+/// `burn_view_consensus_hash` column and a correspondingly stricter anchor
+/// match. With a `boundary`, rows whose `block_height` exceeds it are rewritten
+/// down to the anchor (see [`SortitionTipCopyBoundary`]).
+fn stacks_chain_tip_memo_source_sql(
+    table: &str,
+    sid: &str,
+    include_burn_view: bool,
+    boundary: Option<&SortitionTipCopyBoundary>,
+) -> String {
+    let Some(boundary) = boundary else {
+        return format!("SELECT * FROM src.{table} WHERE sortition_id IN ({sid})");
+    };
+    let max_height = boundary.max_stacks_height;
+    let anchor_height = boundary.anchor_block_height;
+    let anchor_ch = &boundary.anchor_consensus_hash;
+    let anchor_bhh = &boundary.anchor_block_hash;
+    let anchor_burn_view_ch = &boundary.anchor_burn_view_consensus_hash;
+    let burn_view_column = if include_burn_view {
+        format!(
+            "CASE WHEN block_height > {max_height} THEN '{anchor_burn_view_ch}' \
+                  ELSE burn_view_consensus_hash END, "
+        )
+    } else {
+        String::new()
+    };
+    let anchor_match = if include_burn_view {
+        format!(
+            "(consensus_hash = '{anchor_ch}' \
+              AND burn_view_consensus_hash = '{anchor_burn_view_ch}')"
+        )
+    } else {
+        format!("consensus_hash = '{anchor_ch}'")
+    };
+    format!(
+        "SELECT sortition_id, \
+                CASE WHEN block_height > {max_height} THEN '{anchor_ch}' ELSE consensus_hash END, \
+                {burn_view_column}\
+                CASE WHEN block_height > {max_height} THEN '{anchor_bhh}' ELSE block_hash END, \
+                CASE WHEN block_height > {max_height} THEN {anchor_height} ELSE block_height END \
+         FROM src.{table} \
+         WHERE sortition_id IN ({sid}) \
+           AND (block_height <= {max_height} OR {anchor_match})"
+    )
+}
+
+fn sortition_tip_heights_within_boundary(
+    conn: &Connection,
+    boundary: Option<&SortitionTipCopyBoundary>,
+) -> Result<bool, Error> {
+    let Some(boundary) = boundary else {
+        return Ok(true);
+    };
+    let max_height = u64_to_sql(boundary.max_stacks_height)?;
+    conn.query_row(
+        "SELECT COUNT(*) = 0 FROM ( \
+             SELECT block_height FROM stacks_chain_tips WHERE block_height > ?1 \
+             UNION ALL \
+             SELECT block_height FROM stacks_chain_tips_by_burn_view WHERE block_height > ?1 \
+         )",
+        params![max_height],
+        |row| row.get(0),
+    )
+    .map_err(Error::SQLError)
+}
+
+/// Build the copy specs for sortition side tables.
+///
+/// Tables are grouped by their filter key:
+/// - `sortition_id` filtered
+/// - `burn_header_hash` filtered
+/// - full-copy
+fn sortition_copy_specs(boundary: Option<&SortitionTipCopyBoundary>) -> Vec<TableCopySpec> {
+    let sid = "SELECT sortition_id FROM canonical_sortitions";
+    let bhh = "SELECT burn_header_hash FROM canonical_burn_hashes";
+
+    vec![
+        TableCopySpec {
+            table: "db_config",
+            source_sql: "SELECT * FROM src.db_config".into(),
+        },
+        // sortition_id-filtered tables
+        TableCopySpec {
+            table: "snapshots",
+            source_sql: format!("SELECT * FROM src.snapshots WHERE sortition_id IN ({sid})"),
+        },
+        TableCopySpec {
+            table: "leader_keys",
+            source_sql: format!("SELECT * FROM src.leader_keys WHERE sortition_id IN ({sid})"),
+        },
+        TableCopySpec {
+            table: "block_commits",
+            source_sql: format!("SELECT * FROM src.block_commits WHERE sortition_id IN ({sid})"),
+        },
+        TableCopySpec {
+            table: "block_commit_parents",
+            source_sql: format!(
+                "SELECT * FROM src.block_commit_parents WHERE block_commit_sortition_id IN ({sid})"
+            ),
+        },
+        TableCopySpec {
+            table: "snapshot_transition_ops",
+            source_sql: format!(
+                "SELECT * FROM src.snapshot_transition_ops WHERE sortition_id IN ({sid})"
+            ),
+        },
+        TableCopySpec {
+            table: "stacks_chain_tips",
+            source_sql: stacks_chain_tip_memo_source_sql("stacks_chain_tips", sid, false, boundary),
+        },
+        TableCopySpec {
+            table: "stacks_chain_tips_by_burn_view",
+            source_sql: stacks_chain_tip_memo_source_sql(
+                "stacks_chain_tips_by_burn_view",
+                sid,
+                true,
+                boundary,
+            ),
+        },
+        TableCopySpec {
+            table: "preprocessed_reward_sets",
+            source_sql: format!(
+                "SELECT * FROM src.preprocessed_reward_sets WHERE sortition_id IN ({sid})"
+            ),
+        },
+        TableCopySpec {
+            table: "missed_commits",
+            source_sql: format!(
+                "SELECT * FROM src.missed_commits WHERE intended_sortition_id IN ({sid})"
+            ),
+        },
+        // burn_header_hash-filtered tables
+        TableCopySpec {
+            table: "stack_stx",
+            source_sql: format!("SELECT * FROM src.stack_stx WHERE burn_header_hash IN ({bhh})"),
+        },
+        TableCopySpec {
+            table: "transfer_stx",
+            source_sql: format!("SELECT * FROM src.transfer_stx WHERE burn_header_hash IN ({bhh})"),
+        },
+        TableCopySpec {
+            table: "delegate_stx",
+            source_sql: format!("SELECT * FROM src.delegate_stx WHERE burn_header_hash IN ({bhh})"),
+        },
+        TableCopySpec {
+            table: "vote_for_aggregate_key",
+            source_sql: format!(
+                "SELECT * FROM src.vote_for_aggregate_key WHERE burn_header_hash IN ({bhh})"
+            ),
+        },
+        // Full-copy tables
+        TableCopySpec {
+            table: "epochs",
+            source_sql: "SELECT * FROM src.epochs".to_string(),
+        },
+    ]
+}
+
+/// Copy required non-MARF tables from the source sortition DB into the
+/// squashed destination. Only canonical rows (determined by the squashed MARF's
+/// `marf_squashed_blocks`) are included.
+pub fn copy_sortition_side_tables(
+    src_path: &str,
+    dst_path: &str,
+) -> Result<SortitionSideTableStats, Error> {
+    copy_sortition_side_tables_with_boundary(src_path, dst_path, None)
+}
+
+pub fn copy_sortition_side_tables_with_boundary(
+    src_path: &str,
+    dst_path: &str,
+    stacks_boundary: Option<&SortitionTipCopyBoundary>,
+) -> Result<SortitionSideTableStats, Error> {
+    validate_tip_boundary(stacks_boundary)?;
+    // Walk the squashed trie before opening dst R/W.
+    let leaf_hashes = collect_canonical_leaf_hashes::<SortitionId>(dst_path)?;
+
+    with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {
+        clone_schemas_from_source(conn, REQUIRED_TABLES)?;
+        copy_sortition_tables_inner(conn, &leaf_hashes, stacks_boundary)
+    })
+}
+
+fn copy_sortition_tables_inner(
+    conn: &Connection,
+    leaf_hashes: &HashSet<MARFValue>,
+    stacks_boundary: Option<&SortitionTipCopyBoundary>,
+) -> Result<SortitionSideTableStats, Error> {
+    // Copy only canonical __fork_storage rows. The squashed MARF trie
+    // leaves reference these by value_hash. Non-canonical fork entries
+    // are excluded.
+    let fork_storage_rows = copy_canonical_fork_storage(conn, leaf_hashes)?;
+
+    // Build canonical sortition set from squash metadata.
+    populate_canonical_sortitions(conn)?;
+
+    // Execute descriptor-driven copies.
+    let specs = sortition_copy_specs(stacks_boundary);
+    let results = execute_copy_specs(conn, &specs)?;
+    if !sortition_tip_heights_within_boundary(conn, stacks_boundary)? {
+        return Err(Error::CorruptionError(
+            "copied sortition tip row points past the Stacks MARF boundary".into(),
+        ));
+    }
+
+    conn.execute_batch("DROP TABLE IF EXISTS canonical_sortitions")
+        .map_err(Error::SQLError)?;
+    conn.execute_batch("DROP TABLE IF EXISTS canonical_burn_hashes")
+        .map_err(Error::SQLError)?;
+
+    Ok(SortitionSideTableStats {
+        snapshots_rows: copied_rows(&results, "snapshots"),
+        leader_keys_rows: copied_rows(&results, "leader_keys"),
+        block_commits_rows: copied_rows(&results, "block_commits"),
+        block_commit_parents_rows: copied_rows(&results, "block_commit_parents"),
+        snapshot_transition_ops_rows: copied_rows(&results, "snapshot_transition_ops"),
+        stacks_chain_tips_rows: copied_rows(&results, "stacks_chain_tips"),
+        stacks_chain_tips_by_burn_view_rows: copied_rows(
+            &results,
+            "stacks_chain_tips_by_burn_view",
+        ),
+        preprocessed_reward_sets_rows: copied_rows(&results, "preprocessed_reward_sets"),
+        missed_commits_rows: copied_rows(&results, "missed_commits"),
+        stack_stx_rows: copied_rows(&results, "stack_stx"),
+        transfer_stx_rows: copied_rows(&results, "transfer_stx"),
+        delegate_stx_rows: copied_rows(&results, "delegate_stx"),
+        vote_for_aggregate_key_rows: copied_rows(&results, "vote_for_aggregate_key"),
+        epochs_rows: copied_rows(&results, "epochs"),
+        db_config_rows: copied_rows(&results, "db_config"),
+        fork_storage_rows,
+    })
+}

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -26,7 +26,7 @@ use super::fork_storage::{collect_canonical_leaf_hashes, copy_canonical_fork_sto
 use crate::chainstate::burn::db::sortdb::SortitionDB;
 pub use crate::chainstate::burn::db::sortdb::SortitionTipCopyBoundary;
 use crate::chainstate::stacks::index::{trie_sql, Error, MARFValue};
-use crate::util_lib::db::{sqlite_open, u64_to_sql};
+use crate::util_lib::db::sqlite_open;
 
 /// Required sortition tables always present in production.
 pub(super) const REQUIRED_TABLES: &[&str] = &[
@@ -144,36 +144,11 @@ fn populate_canonical_sortitions(
 
 fn validate_tip_boundary(boundary: Option<&SortitionTipCopyBoundary>) -> Result<(), Error> {
     if let Some(boundary) = boundary {
-        if boundary.anchor_block_height > boundary.max_stacks_height {
-            return Err(Error::CorruptionError(format!(
-                "sortition tip rewrite anchor height {} exceeds Stacks boundary {}",
-                boundary.anchor_block_height, boundary.max_stacks_height
-            )));
-        }
-        u64_to_sql(boundary.max_stacks_height)?;
-        u64_to_sql(boundary.anchor_block_height)?;
+        boundary
+            .validate()
+            .map_err(|e| Error::CorruptionError(e.to_string()))?;
     }
     Ok(())
-}
-
-fn sortition_tip_heights_within_boundary(
-    conn: &Connection,
-    boundary: Option<&SortitionTipCopyBoundary>,
-) -> Result<bool, Error> {
-    let Some(boundary) = boundary else {
-        return Ok(true);
-    };
-    let max_height = u64_to_sql(boundary.max_stacks_height)?;
-    conn.query_row(
-        "SELECT COUNT(*) = 0 FROM ( \
-             SELECT block_height FROM stacks_chain_tips WHERE block_height > ?1 \
-             UNION ALL \
-             SELECT block_height FROM stacks_chain_tips_by_burn_view WHERE block_height > ?1 \
-         )",
-        params![max_height],
-        |row| row.get(0),
-    )
-    .map_err(Error::SQLError)
 }
 
 /// Build the copy specs for sortition side tables.
@@ -321,7 +296,9 @@ fn copy_sortition_tables_inner(
     // Execute descriptor-driven copies.
     let specs = sortition_copy_specs(stacks_boundary);
     let results = execute_copy_specs(session_conn, &specs)?;
-    if !sortition_tip_heights_within_boundary(session_conn, stacks_boundary)? {
+    if !SortitionDB::stacks_tip_memos_within_boundary(session_conn, stacks_boundary)
+        .map_err(|e| Error::CorruptionError(format!("cannot check sortition tip boundary: {e}")))?
+    {
         return Err(Error::CorruptionError(
             "copied sortition tip row points past the Stacks MARF boundary".into(),
         ));

--- a/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/sortition.rs
@@ -15,16 +15,18 @@
 
 use std::collections::HashSet;
 
-use rusqlite::{params, Connection};
-use stacks_common::types::chainstate::{BlockHeaderHash, ConsensusHash, SortitionId};
+use rusqlite::{params, Connection, OpenFlags};
+use stacks_common::types::chainstate::SortitionId;
 
 use super::common::{
     clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
     TableCopySpec,
 };
 use super::fork_storage::{collect_canonical_leaf_hashes, copy_canonical_fork_storage};
+use crate::chainstate::burn::db::sortdb::SortitionDB;
+pub use crate::chainstate::burn::db::sortdb::SortitionTipCopyBoundary;
 use crate::chainstate::stacks::index::{trie_sql, Error, MARFValue};
-use crate::util_lib::db::u64_to_sql;
+use crate::util_lib::db::{sqlite_open, u64_to_sql};
 
 /// Required sortition tables always present in production.
 pub(super) const REQUIRED_TABLES: &[&str] = &[
@@ -66,81 +68,76 @@ pub struct SortitionSideTableStats {
     pub fork_storage_rows: u64,
 }
 
-/// Stacks-side boundary used when copying sortition tip memo tables.
-///
-/// A squash can anchor the sortition MARF at a burn view whose runtime source
-/// tip is later than the copied Stacks MARF. In that case, the memoized
-/// sortition tip must be rewritten to the copied Stacks anchor so a booting
-/// node still processes the intra-tenure descendants (re-fetched from peers)
-/// instead of believing they are already processed.
-#[derive(Debug, Clone)]
-pub struct SortitionTipCopyBoundary {
-    pub max_stacks_height: u64,
-    pub anchor_consensus_hash: ConsensusHash,
-    pub anchor_burn_view_consensus_hash: ConsensusHash,
-    pub anchor_block_hash: BlockHeaderHash,
-    pub anchor_block_height: u64,
-}
-
-/// Fill the (already-created) `canonical_sortitions` temp table from the
-/// squashed MARF metadata, read through the MARF-domain accessor
-/// [`trie_sql::bulk_read_squashed_blocks`] rather than a raw read of the
-/// MARF-owned `marf_squashed_blocks` table. The `SortitionId` binds as its
-/// lowercase-hex form, matching the `sortition_id` TEXT in `src.snapshots`.
-/// Returns the number of ids inserted.
-fn insert_canonical_sortition_ids(conn: &Connection) -> Result<usize, Error> {
-    let canonical = trie_sql::bulk_read_squashed_blocks::<SortitionId>(conn)?;
-    let mut insert = conn
-        .prepare("INSERT INTO canonical_sortitions (sortition_id) VALUES (?1)")
-        .map_err(Error::SQLError)?;
-    let mut inserted = 0usize;
-    for (_, sortition_id, _) in &canonical {
-        inserted += insert
-            .execute(params![sortition_id])
-            .map_err(Error::SQLError)?;
-    }
-    Ok(inserted)
-}
-
-/// Build temp tables for the canonical sortition set and canonical burn hashes.
-fn populate_canonical_sortitions(conn: &Connection) -> Result<(), Error> {
-    conn.execute_batch("CREATE TEMP TABLE canonical_sortitions (sortition_id TEXT PRIMARY KEY)")
-        .map_err(Error::SQLError)?;
-    let inserted = insert_canonical_sortition_ids(conn)?;
-    if inserted == 0 {
+/// Build temp tables for the canonical sortition set and canonical burn
+/// hashes. Each `SortitionId` binds as its lowercase-hex form, matching the
+/// `sortition_id` TEXT in `src.snapshots`.
+fn populate_canonical_sortitions(
+    src_conn: &Connection,
+    session_conn: &Connection,
+) -> Result<(), Error> {
+    let canonical = trie_sql::bulk_read_squashed_blocks::<SortitionId>(session_conn)?;
+    if canonical.is_empty() {
         return Err(Error::CorruptionError(
             "marf_squashed_blocks is empty; post-squash dst must have at least one canonical sortition"
                 .into(),
         ));
     }
+
     // Source-completeness: every canonical sortition must exist in
     // src.snapshots. A canonical sortition_id missing from src is
     // corruption. The squash claimed a sortition that src doesn't have.
-    let orphans: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM canonical_sortitions \
-             WHERE sortition_id NOT IN (SELECT sortition_id FROM src.snapshots)",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(Error::SQLError)?;
+    let mut burn_hashes: HashSet<String> = HashSet::new();
+    let mut orphans: u64 = 0;
+    for (_, sortition_id, _) in &canonical {
+        match SortitionDB::get_snapshot_burn_header_hash(src_conn, sortition_id).map_err(|e| {
+            Error::CorruptionError(format!("cannot read src snapshot {sortition_id}: {e}"))
+        })? {
+            Some(burn_header_hash) => {
+                burn_hashes.insert(burn_header_hash);
+            }
+            None => orphans += 1,
+        }
+    }
     if orphans > 0 {
         return Err(Error::CorruptionError(format!(
             "{orphans} canonical sortition(s) in marf_squashed_blocks are absent from src.snapshots"
         )));
     }
 
-    conn.execute_batch(
-        "CREATE TEMP TABLE canonical_burn_hashes (burn_header_hash TEXT PRIMARY KEY)",
-    )
-    .map_err(Error::SQLError)?;
-    conn.execute(
-        "INSERT OR IGNORE INTO canonical_burn_hashes (burn_header_hash) \
-         SELECT DISTINCT s.burn_header_hash FROM src.snapshots s \
-         INNER JOIN canonical_sortitions cs ON s.sortition_id = cs.sortition_id",
-        [],
-    )
-    .map_err(Error::SQLError)?;
+    session_conn
+        .execute_batch("CREATE TEMP TABLE canonical_sortitions (sortition_id TEXT PRIMARY KEY)")
+        .map_err(Error::SQLError)?;
+    session_conn
+        .execute_batch(
+            "CREATE TEMP TABLE canonical_burn_hashes (burn_header_hash TEXT PRIMARY KEY)",
+        )
+        .map_err(Error::SQLError)?;
+    // A savepoint batches the temp-table inserts whether or not the session
+    // already holds an open transaction.
+    session_conn
+        .execute_batch("SAVEPOINT canonical_sortitions")
+        .map_err(Error::SQLError)?;
+    let mut insert = session_conn
+        .prepare("INSERT INTO canonical_sortitions (sortition_id) VALUES (?1)")
+        .map_err(Error::SQLError)?;
+    for (_, sortition_id, _) in &canonical {
+        insert
+            .execute(params![sortition_id])
+            .map_err(Error::SQLError)?;
+    }
+    drop(insert);
+    let mut insert = session_conn
+        .prepare("INSERT INTO canonical_burn_hashes (burn_header_hash) VALUES (?1)")
+        .map_err(Error::SQLError)?;
+    for burn_header_hash in &burn_hashes {
+        insert
+            .execute([burn_header_hash])
+            .map_err(Error::SQLError)?;
+    }
+    drop(insert);
+    session_conn
+        .execute_batch("RELEASE canonical_sortitions")
+        .map_err(Error::SQLError)?;
 
     Ok(())
 }
@@ -157,55 +154,6 @@ fn validate_tip_boundary(boundary: Option<&SortitionTipCopyBoundary>) -> Result<
         u64_to_sql(boundary.anchor_block_height)?;
     }
     Ok(())
-}
-
-/// Build the copy source SQL for a sortition Stacks-tip memo table.
-///
-/// Handles both `stacks_chain_tips` and (with `include_burn_view`)
-/// `stacks_chain_tips_by_burn_view`; the latter carries an extra
-/// `burn_view_consensus_hash` column and a correspondingly stricter anchor
-/// match. With a `boundary`, rows whose `block_height` exceeds it are rewritten
-/// down to the anchor (see [`SortitionTipCopyBoundary`]).
-fn stacks_chain_tip_memo_source_sql(
-    table: &str,
-    sid: &str,
-    include_burn_view: bool,
-    boundary: Option<&SortitionTipCopyBoundary>,
-) -> String {
-    let Some(boundary) = boundary else {
-        return format!("SELECT * FROM src.{table} WHERE sortition_id IN ({sid})");
-    };
-    let max_height = boundary.max_stacks_height;
-    let anchor_height = boundary.anchor_block_height;
-    let anchor_ch = &boundary.anchor_consensus_hash;
-    let anchor_bhh = &boundary.anchor_block_hash;
-    let anchor_burn_view_ch = &boundary.anchor_burn_view_consensus_hash;
-    let burn_view_column = if include_burn_view {
-        format!(
-            "CASE WHEN block_height > {max_height} THEN '{anchor_burn_view_ch}' \
-                  ELSE burn_view_consensus_hash END, "
-        )
-    } else {
-        String::new()
-    };
-    let anchor_match = if include_burn_view {
-        format!(
-            "(consensus_hash = '{anchor_ch}' \
-              AND burn_view_consensus_hash = '{anchor_burn_view_ch}')"
-        )
-    } else {
-        format!("consensus_hash = '{anchor_ch}'")
-    };
-    format!(
-        "SELECT sortition_id, \
-                CASE WHEN block_height > {max_height} THEN '{anchor_ch}' ELSE consensus_hash END, \
-                {burn_view_column}\
-                CASE WHEN block_height > {max_height} THEN '{anchor_bhh}' ELSE block_hash END, \
-                CASE WHEN block_height > {max_height} THEN {anchor_height} ELSE block_height END \
-         FROM src.{table} \
-         WHERE sortition_id IN ({sid}) \
-           AND (block_height <= {max_height} OR {anchor_match})"
-    )
 }
 
 fn sortition_tip_heights_within_boundary(
@@ -270,12 +218,19 @@ fn sortition_copy_specs(boundary: Option<&SortitionTipCopyBoundary>) -> Vec<Tabl
         },
         TableCopySpec {
             table: "stacks_chain_tips",
-            source_sql: stacks_chain_tip_memo_source_sql("stacks_chain_tips", sid, false, boundary),
+            source_sql: SortitionDB::stacks_tip_memo_copy_sql(
+                "stacks_chain_tips",
+                "src",
+                sid,
+                false,
+                boundary,
+            ),
         },
         TableCopySpec {
             table: "stacks_chain_tips_by_burn_view",
-            source_sql: stacks_chain_tip_memo_source_sql(
+            source_sql: SortitionDB::stacks_tip_memo_copy_sql(
                 "stacks_chain_tips_by_burn_view",
+                "src",
                 sid,
                 true,
                 boundary,
@@ -338,38 +293,45 @@ pub fn copy_sortition_side_tables_with_boundary(
     validate_tip_boundary(stacks_boundary)?;
     // Walk the squashed trie before opening dst R/W.
     let leaf_hashes = collect_canonical_leaf_hashes::<SortitionId>(dst_path)?;
+    // Read-only source handle for the sortdb-owned readers; the session
+    // below still attaches src for the copy specs.
+    let src_conn =
+        sqlite_open(src_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false).map_err(Error::SQLError)?;
 
     with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {
         clone_schemas_from_source(conn, REQUIRED_TABLES)?;
-        copy_sortition_tables_inner(conn, &leaf_hashes, stacks_boundary)
+        copy_sortition_tables_inner(&src_conn, conn, &leaf_hashes, stacks_boundary)
     })
 }
 
 fn copy_sortition_tables_inner(
-    conn: &Connection,
+    src_conn: &Connection,
+    session_conn: &Connection,
     leaf_hashes: &HashSet<MARFValue>,
     stacks_boundary: Option<&SortitionTipCopyBoundary>,
 ) -> Result<SortitionSideTableStats, Error> {
     // Copy only canonical __fork_storage rows. The squashed MARF trie
     // leaves reference these by value_hash. Non-canonical fork entries
     // are excluded.
-    let fork_storage_rows = copy_canonical_fork_storage(conn, leaf_hashes)?;
+    let fork_storage_rows = copy_canonical_fork_storage(session_conn, leaf_hashes)?;
 
     // Build canonical sortition set from squash metadata.
-    populate_canonical_sortitions(conn)?;
+    populate_canonical_sortitions(src_conn, session_conn)?;
 
     // Execute descriptor-driven copies.
     let specs = sortition_copy_specs(stacks_boundary);
-    let results = execute_copy_specs(conn, &specs)?;
-    if !sortition_tip_heights_within_boundary(conn, stacks_boundary)? {
+    let results = execute_copy_specs(session_conn, &specs)?;
+    if !sortition_tip_heights_within_boundary(session_conn, stacks_boundary)? {
         return Err(Error::CorruptionError(
             "copied sortition tip row points past the Stacks MARF boundary".into(),
         ));
     }
 
-    conn.execute_batch("DROP TABLE IF EXISTS canonical_sortitions")
+    session_conn
+        .execute_batch("DROP TABLE IF EXISTS canonical_sortitions")
         .map_err(Error::SQLError)?;
-    conn.execute_batch("DROP TABLE IF EXISTS canonical_burn_hashes")
+    session_conn
+        .execute_batch("DROP TABLE IF EXISTS canonical_burn_hashes")
         .map_err(Error::SQLError)?;
 
     Ok(SortitionSideTableStats {

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
@@ -24,12 +24,11 @@ use stacks_common::types::chainstate::{StacksBlockId, TrieHash};
 use stacks_common::util::hash::Sha512Trunc256Sum;
 use tempfile::tempdir;
 
-use super::super::clarity::CLARITY_SIDE_TABLES;
-use super::super::common::{unclassified_tables, MARF_INFRA_TABLES};
+use super::super::clarity::assert_source_tables_classified;
 use super::super::copy_clarity_side_tables;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::storage::TrieHashCalculationMode;
-use crate::chainstate::stacks::index::{ClarityMarfTrieId as _, MARFValue};
+use crate::chainstate::stacks::index::{ClarityMarfTrieId as _, Error, MARFValue};
 use crate::clarity_vm::clarity::ClarityMarfStoreTransaction as _;
 use crate::clarity_vm::database::marf::MarfedKV;
 
@@ -495,25 +494,48 @@ fn test_copy_clarity_side_tables_with_double_colon_metadata_keys() {
     }
 }
 
+/// Drift guard for the Clarity MARF DB: every table must be either copied by
+/// `copy_clarity_side_tables` (data_table, metadata_table) or owned by the MARF
+/// trie itself (recreated by `MARF::squash_to_path`). Runs the exact production
+/// guard against a freshly-built schema, so the test and the runtime check
+/// cannot drift apart.
 #[test]
 fn test_no_unclassified_clarity_source_tables() {
-    // Drift guard for the Clarity MARF DB: every table must be either copied by
-    // `copy_clarity_side_tables` (data_table, metadata_table) or owned by the
-    // MARF trie itself (copied by `MARF::squash_to_path`).
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     build_clarity_marf(&src_dir, 2, "test-contract", "");
     let conn = rusqlite::Connection::open(clarity_marf_db_path(&src_dir)).unwrap();
 
-    let known: Vec<&str> = CLARITY_SIDE_TABLES
-        .iter()
-        .copied()
-        .chain(MARF_INFRA_TABLES.iter().copied())
-        .collect();
-    let extra = unclassified_tables(&conn, &known);
+    assert_source_tables_classified(&conn)
+        .expect("fresh production Clarity schema must be fully classified");
+}
+
+/// A source table the copy lists don't classify is rejected before any
+/// destination is produced — the runtime complement to the drift test.
+#[test]
+fn test_unclassified_source_table_is_rejected() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    build_clarity_marf(&src_dir, 2, "test-contract", "");
+    let src_db = clarity_marf_db_path(&src_dir);
+
+    let conn = rusqlite::Connection::open(&src_db).unwrap();
+    conn.execute_batch("CREATE TABLE surprise_table (x INTEGER)")
+        .unwrap();
+    drop(conn);
+
+    let dst_db = dir.path().join("squashed").join("marf.sqlite");
+    let err = copy_clarity_side_tables(src_db.to_str().unwrap(), dst_db.to_str().unwrap())
+        .expect_err("unclassified source table must be rejected");
+    match err {
+        Error::CorruptionError(msg) => assert!(
+            msg.contains("surprise_table"),
+            "error should name the offending table, got: {msg}"
+        ),
+        other => panic!("expected CorruptionError, got {other:?}"),
+    }
     assert!(
-        extra.is_empty(),
-        "unclassified Clarity source table(s) {extra:?}: handle each in \
-         copy_clarity_side_tables (chainstate/stacks/db/snapshot/clarity.rs)"
+        !dst_db.exists(),
+        "no destination should be produced when the source is rejected"
     );
 }

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/index.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/index.rs
@@ -24,15 +24,16 @@ use stacks_common::types::chainstate::{
 };
 use tempfile::tempdir;
 
-use super::super::common::{unclassified_tables, MARF_INFRA_TABLES};
-use super::super::index::{copy_index_side_tables, index_copy_specs, COPIED_TABLES};
+use super::super::index::{
+    assert_source_tables_classified, copy_index_side_tables, index_copy_specs, COPIED_TABLES,
+};
 use super::{
     append_canonical_block, assert_corruption_containing, create_dest_db_with_canonical_blocks,
     create_source_db, hex_id, label_block_id, FIXTURE_LEAF,
 };
 use crate::chainstate::nakamoto::{NakamotoBlockHeader, NakamotoChainState};
 use crate::chainstate::stacks::db::{StacksHeaderInfo, CHAINSTATE_VERSION};
-use crate::chainstate::stacks::index::MARFValue;
+use crate::chainstate::stacks::index::{Error, MARFValue};
 
 /// Insert an epoch-2 `block_headers` row at the given height.
 fn insert_epoch2_block_header(conn: &Connection, height: u32, suffix: &str) {
@@ -510,20 +511,39 @@ fn test_copy_specs_match_copied_tables() {
 
 /// Drift guard: every table the chainstate migrations create must be
 /// classified, so a future migration can't silently drop one from the copy.
+/// Runs the exact production guard against a freshly-migrated schema, so the
+/// test and the runtime check cannot drift apart.
 #[test]
 fn test_no_unclassified_source_tables() {
     let dir = tempdir().unwrap();
     let conn = create_source_db(&dir.path().join("src.sqlite"));
-    let known: Vec<&str> = super::super::index::COPIED_TABLES
-        .iter()
-        .chain(super::super::index::SCHEMA_ONLY_TABLES)
-        .chain(MARF_INFRA_TABLES.iter())
-        .copied()
-        .collect();
-    let extra = unclassified_tables(&conn, &known);
+    assert_source_tables_classified(&conn)
+        .expect("fresh production index schema must be fully classified");
+}
+
+/// A source table the copy lists don't classify is rejected before any
+/// destination is produced — the runtime complement to the drift test.
+#[test]
+fn test_unclassified_source_table_is_rejected() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let conn = create_source_db(&src_path);
+    conn.execute_batch("CREATE TABLE surprise_table (x INTEGER)")
+        .unwrap();
+    drop(conn);
+
+    let dst_path = dir.path().join("dst_index.sqlite");
+    let err = copy_index_side_tables(src_path.to_str().unwrap(), dst_path.to_str().unwrap(), 0, 1)
+        .expect_err("unclassified source table must be rejected");
+    match err {
+        Error::CorruptionError(msg) => assert!(
+            msg.contains("surprise_table"),
+            "error should name the offending table, got: {msg}"
+        ),
+        other => panic!("expected CorruptionError, got {other:?}"),
+    }
     assert!(
-        extra.is_empty(),
-        "unclassified index table(s) {extra:?}: classify each in COPIED_TABLES or \
-         SCHEMA_ONLY_TABLES (snapshot/index.rs)"
+        !dst_path.exists(),
+        "no destination should be produced when the source is rejected"
     );
 }

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
@@ -25,6 +25,7 @@ use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
 
 mod index;
+mod sortition;
 
 /// Create a source `index.sqlite`
 fn create_source_db(path: &std::path::Path) -> Connection {

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
@@ -17,7 +17,8 @@
 
 use std::path::{Path, PathBuf};
 
-use rusqlite::{params, Connection};
+use rstest::rstest;
+use rusqlite::{params, Connection, OptionalExtension};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, TrieHash,
 };
@@ -441,13 +442,91 @@ fn test_sortition_stacks_chain_tips_by_burn_view_copied() {
     );
 }
 
-/// Sortition tip memo rows pointing above the Stacks boundary are
-/// rewritten down to the anchor in both memo tables.
-#[test]
-fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
+/// Expected outcome of a single Stacks-tip memo row under the boundary copy.
+enum Expect {
+    /// Copied unchanged (row at or below the boundary).
+    Verbatim,
+    /// Kept but clamped down to the anchor (above-boundary anchor row).
+    RewrittenToAnchor,
+    /// Excluded entirely (above-boundary, not the anchor).
+    Dropped,
+}
+
+/// `stacks_chain_tips` boundary handling (the relaxed-match memo table): a row
+/// at/below the boundary is copied verbatim, an above-boundary anchor row is
+/// rewritten down to the anchor, and an above-boundary non-anchor row is
+/// dropped.
+#[rstest]
+#[case::pass_through(5, false, Expect::Verbatim)]
+#[case::rewrite_anchor(20, true, Expect::RewrittenToAnchor)]
+#[case::drop_non_anchor(20, false, Expect::Dropped)]
+fn test_sortition_stacks_chain_tip_boundary(
+    #[case] input_height: u64,
+    #[case] input_is_anchor: bool,
+    #[case] expect: Expect,
+) {
     let dir = tempdir().unwrap();
     let (conn, src_path) = create_sortition_source_db(dir.path());
+    insert_snapshot(&conn, "sort_0", "bhh_0", 0);
+    insert_snapshot(&conn, "sort_1", "bhh_1", 1);
 
+    let boundary = sortition_test_tip_boundary(10);
+    let anchor_ch = boundary.anchor_consensus_hash.to_string();
+    let anchor_bhh = boundary.anchor_block_hash.to_string();
+    // stacks_chain_tips has no consensus_hash FK, so the input hash is free.
+    let input_ch = if input_is_anchor {
+        anchor_ch.clone()
+    } else {
+        "ch_other".to_string()
+    };
+    test_insert_stacks_chain_tip_row(&conn, &hex_id("sort_1"), &input_ch, "bh_in", input_height)
+        .unwrap();
+    drop(conn);
+
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    create_sortition_dest_db(&dst_path, &["sort_0", "sort_1"]);
+
+    copy_sortition_side_tables_with_boundary(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        Some(&boundary),
+    )
+    .unwrap();
+
+    let dst_conn = Connection::open(&dst_path).unwrap();
+    let row: Option<(String, String, i64)> = dst_conn
+        .query_row(
+            "SELECT consensus_hash, block_hash, block_height FROM stacks_chain_tips \
+             WHERE sortition_id = ?1",
+            params![hex_id("sort_1")],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .optional()
+        .unwrap();
+
+    let expected = match expect {
+        Expect::Verbatim => Some((input_ch, "bh_in".to_string(), input_height as i64)),
+        Expect::RewrittenToAnchor => {
+            Some((anchor_ch, anchor_bhh, boundary.anchor_block_height as i64))
+        }
+        Expect::Dropped => None,
+    };
+    assert_eq!(row, expected);
+}
+
+/// `stacks_chain_tips_by_burn_view` boundary handling (the strict-match memo
+/// table): its anchor match requires BOTH `consensus_hash` AND
+/// `burn_view_consensus_hash` to equal the anchor. An above-boundary row with
+/// the anchor consensus hash is kept+rewritten only when its burn-view hash
+/// also matches; a mismatching burn view is dropped (whereas
+/// `stacks_chain_tips` would keep it -- see
+/// [`test_sortition_stacks_chain_tip_boundary`]).
+#[rstest]
+#[case::rewrite_when_burn_view_matches(true)]
+#[case::drop_when_burn_view_differs(false)]
+fn test_sortition_by_burn_view_boundary(#[case] burn_view_is_anchor: bool) {
+    let dir = tempdir().unwrap();
+    let (conn, src_path) = create_sortition_source_db(dir.path());
     insert_snapshot(&conn, "sort_0", "bhh_0", 0);
     insert_snapshot(&conn, "sort_1", "bhh_1", 1);
 
@@ -455,17 +534,25 @@ fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
     let anchor_ch = boundary.anchor_consensus_hash.to_string();
     let anchor_burn_view_ch = boundary.anchor_burn_view_consensus_hash.to_string();
     let anchor_bhh = boundary.anchor_block_hash.to_string();
-    let source_tip_bhh = BlockHeaderHash([0x33; 32]).to_string();
 
-    test_set_snapshot_consensus_hash(&conn, &hex_id("sort_1"), &anchor_burn_view_ch).unwrap();
-    test_insert_stacks_chain_tip_row(&conn, &hex_id("sort_1"), &anchor_ch, &source_tip_bhh, 20)
-        .unwrap();
+    // Both by_burn_view columns FK to snapshots(consensus_hash): the row's
+    // consensus_hash is always the anchor; its burn_view_consensus_hash is the
+    // anchor (rewrite) or a different, snapshot-backed value (drop).
+    test_set_snapshot_consensus_hash(&conn, &hex_id("sort_0"), &anchor_ch).unwrap();
+    let burn_view_ch = if burn_view_is_anchor {
+        anchor_burn_view_ch.clone()
+    } else {
+        let wrong_ch = ConsensusHash([0x22; 20]).to_string();
+        test_set_snapshot_consensus_hash(&conn, &hex_id("sort_1"), &wrong_ch).unwrap();
+        wrong_ch
+    };
+    // Above the boundary (20 > 10) so the height branch fires.
     test_insert_stacks_chain_tip_by_burn_view_row(
         &conn,
         &hex_id("sort_1"),
         &anchor_ch,
-        &anchor_burn_view_ch,
-        &source_tip_bhh,
+        &burn_view_ch,
+        "bh_bv",
         20,
     )
     .unwrap();
@@ -482,28 +569,29 @@ fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
     .unwrap();
 
     let dst_conn = Connection::open(&dst_path).unwrap();
-    let old_tip: (String, String, i64) = dst_conn
-        .query_row(
-            "SELECT consensus_hash, block_hash, block_height FROM stacks_chain_tips \
-             WHERE sortition_id = ?1",
-            params![hex_id("sort_1")],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .unwrap();
-    assert_eq!(old_tip, (anchor_ch.clone(), anchor_bhh.clone(), 10));
-
-    let burn_view_tip: (String, String, String, i64) = dst_conn
+    let row: Option<(String, String, String, i64)> = dst_conn
         .query_row(
             "SELECT consensus_hash, burn_view_consensus_hash, block_hash, block_height \
              FROM stacks_chain_tips_by_burn_view WHERE sortition_id = ?1",
             params![hex_id("sort_1")],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
         )
+        .optional()
         .unwrap();
-    assert_eq!(
-        burn_view_tip,
-        (anchor_ch, anchor_burn_view_ch, anchor_bhh, 10)
-    );
+
+    let expected = if burn_view_is_anchor {
+        // Strict anchor match -> kept and clamped to the anchor.
+        Some((
+            anchor_ch,
+            anchor_burn_view_ch,
+            anchor_bhh,
+            boundary.anchor_block_height as i64,
+        ))
+    } else {
+        // Burn view != anchor -> dropped (stacks_chain_tips would keep it).
+        None
+    };
+    assert_eq!(row, expected);
 }
 
 /// Production-path integration. The copy keeps the canonical chain's

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
@@ -15,6 +15,7 @@
 
 //! Sortition side-table copy tests.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use rstest::rstest;
@@ -24,9 +25,9 @@ use stacks_common::types::chainstate::{
 };
 use tempfile::tempdir;
 
-use super::super::common::{unclassified_tables, MARF_INFRA_TABLES};
 use super::super::sortition::{
-    copy_sortition_side_tables, copy_sortition_side_tables_with_boundary, SortitionTipCopyBoundary,
+    assert_source_tables_classified, copy_sortition_side_tables,
+    copy_sortition_side_tables_with_boundary, sortition_copy_specs, SortitionTipCopyBoundary,
     REQUIRED_TABLES,
 };
 use super::{hex_id, label_block_id};
@@ -652,20 +653,61 @@ fn test_sortition_copy_with_production_seeded_source() {
 
 /// Drift guard: every table the sortition migrations create must be
 /// classified, so a future migration can't silently drop one from the copy.
+/// Runs the exact production guard against a freshly-migrated schema, so the
+/// test and the runtime check cannot drift apart.
 #[test]
 fn test_no_unclassified_sortition_tables() {
     let dir = tempdir().unwrap();
     let (conn, _src_path) = create_sortition_source_db(dir.path());
-    let known: Vec<&str> = REQUIRED_TABLES
-        .iter()
-        .chain(MARF_INFRA_TABLES.iter())
-        .chain(["snapshot_burn_distributions"].iter())
-        .copied()
-        .collect();
-    let extra = unclassified_tables(&conn, &known);
+    assert_source_tables_classified(&conn)
+        .expect("fresh production sortition schema must be fully classified");
+}
+
+/// Every table whose schema is cloned ([`REQUIRED_TABLES`]) must also have a
+/// row-copy spec, and vice versa. Without this, a table could pass the
+/// classification guard and be cloned into the dst yet never populated —
+/// recreated-empty inconsistency one level below the unclassified-table check.
+#[test]
+fn test_sortition_copy_specs_match_required_tables() {
+    let spec_tables: Vec<&str> = sortition_copy_specs(None).iter().map(|s| s.table).collect();
+    let spec_set: HashSet<&str> = spec_tables.iter().copied().collect();
+    assert_eq!(
+        spec_tables.len(),
+        spec_set.len(),
+        "duplicate table in sortition_copy_specs"
+    );
+    let required_set: HashSet<&str> = REQUIRED_TABLES.iter().copied().collect();
+    assert_eq!(
+        spec_set, required_set,
+        "every REQUIRED_TABLES entry must have exactly one copy spec (and vice versa); \
+         a cloned-but-uncopied table would be present-but-empty in the squash"
+    );
+}
+
+/// Runtime guard: a source DB carrying a table the copy lists don't classify
+/// is rejected up front, naming the offending table, before any destination is
+/// produced. This is the defense-in-depth complement to the compile-time
+/// `test_no_unclassified_sortition_tables` guard.
+#[test]
+fn test_unclassified_source_table_is_rejected() {
+    let dir = tempdir().unwrap();
+    let (conn, src_path) = create_sortition_source_db(dir.path());
+    conn.execute_batch("CREATE TABLE surprise_table (x INTEGER)")
+        .unwrap();
+    drop(conn);
+
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    let err = copy_sortition_side_tables(src_path.to_str().unwrap(), dst_path.to_str().unwrap())
+        .expect_err("unclassified source table must be rejected");
+    match err {
+        Error::CorruptionError(msg) => assert!(
+            msg.contains("surprise_table"),
+            "error should name the offending table, got: {msg}"
+        ),
+        other => panic!("expected CorruptionError, got {other:?}"),
+    }
     assert!(
-        extra.is_empty(),
-        "unclassified sortition table(s) {extra:?}: classify each in REQUIRED_TABLES \
-         (snapshot/sortition.rs)"
+        !dst_path.exists(),
+        "no destination should be produced when the source is rejected"
     );
 }

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
@@ -16,7 +16,9 @@
 //! Sortition side-table copy tests.
 
 use rusqlite::{params, Connection};
-use stacks_common::types::chainstate::{BlockHeaderHash, ConsensusHash, SortitionId, TrieHash};
+use stacks_common::types::chainstate::{
+    BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, TrieHash,
+};
 use tempfile::tempdir;
 
 use super::super::common::{unclassified_tables, MARF_INFRA_TABLES};
@@ -24,75 +26,34 @@ use super::super::sortition::{
     copy_sortition_side_tables, copy_sortition_side_tables_with_boundary, SortitionTipCopyBoundary,
 };
 use super::{hex_id, label_block_id};
-use crate::chainstate::burn::db::sortdb::{
-    SORTITION_DB_INITIAL_SCHEMA, SORTITION_DB_SCHEMA_10, SORTITION_DB_SCHEMA_11,
-    SORTITION_DB_SCHEMA_2, SORTITION_DB_SCHEMA_3, SORTITION_DB_SCHEMA_4, SORTITION_DB_SCHEMA_5,
-    SORTITION_DB_SCHEMA_6, SORTITION_DB_SCHEMA_7, SORTITION_DB_SCHEMA_8, SORTITION_DB_SCHEMA_9,
-    SORTITION_DB_VERSION,
-};
+use crate::burnchains::PoxConstants;
+use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
+use crate::core::{StacksEpoch, StacksEpochExtension};
 
-/// Create a sortition source DB with the real schema (all migrations
-/// through schema 11). Applies only the DDL; epoch data inserts are
-/// skipped since tests only need the table structure.
-fn create_sortition_source_db(path: &std::path::Path) -> Connection {
-    let conn = Connection::open(path).unwrap();
-    for cmd in SORTITION_DB_INITIAL_SCHEMA {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_2 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_3 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_4 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_5 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_6 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_7 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_8 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_9 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_10 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    for cmd in SORTITION_DB_SCHEMA_11 {
-        conn.execute_batch(cmd).unwrap();
-    }
-    // Sentinel: a new sortition schema bumps SORTITION_DB_VERSION; this
-    // fixture must then replay the new migration too.
-    assert_eq!(
-        SORTITION_DB_VERSION, 11,
-        "sortition schema changed: replay the new migration in this fixture"
-    );
-    conn.execute(
-        "INSERT OR REPLACE INTO db_config (version) VALUES (?1)",
-        params![SORTITION_DB_VERSION.to_string()],
+/// Create a sortition source DB via the production initializer
+/// ([`SortitionDB::connect`]), so the fixture always carries the current
+/// schema instead of replaying migrations by hand. `connect` also seeds
+/// the genesis snapshot and the epoch rows. Returns a connection to the
+/// underlying sqlite file along with its path.
+fn create_sortition_source_db(dir: &std::path::Path) -> (Connection, std::path::PathBuf) {
+    let db_dir = dir.join("src_sort");
+    let _db = SortitionDB::connect(
+        db_dir.to_str().unwrap(),
+        0,
+        &BurnchainHeaderHash([0u8; 32]),
+        0,
+        &StacksEpoch::unit_test_3_4(0),
+        PoxConstants::test_default(),
+        None,
+        true,
+        None,
     )
-    .unwrap();
-    // Same reason as `create_source_db`: satisfy the strict
-    // src-has-table check in `copy_canonical_fork_storage`.
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS __fork_storage (
-            value_hash TEXT NOT NULL,
-            value TEXT NOT NULL,
-            PRIMARY KEY(value_hash)
-        );",
-    )
-    .unwrap();
-    conn
+    .expect("sortition DB init failed");
+    let db_path = db_dir.join("marf.sqlite");
+    let conn = Connection::open(&db_path).unwrap();
+    (conn, db_path)
 }
 
 /// Insert a snapshot row for the given sortition_id and burn_header_hash labels.
@@ -188,16 +149,6 @@ fn insert_stack_stx(conn: &Connection, burn_header_hash: &str, txid: &str) {
     .unwrap();
 }
 
-/// Insert an epochs row.
-fn insert_epoch(conn: &Connection, start: u32, epoch_id: u32) {
-    conn.execute(
-        "INSERT INTO epochs (start_block_height, end_block_height, epoch_id, \
-             block_limit, network_epoch) VALUES (?1, ?2, ?3, '{}', 1)",
-        params![start, start + 100, epoch_id],
-    )
-    .unwrap();
-}
-
 /// Create a sortition dest DB simulating a squashed MARF with the given
 /// canonical sortition-ID labels.
 ///
@@ -243,8 +194,7 @@ fn sortition_test_tip_boundary(max_stacks_height: u64) -> SortitionTipCopyBounda
 #[test]
 fn test_sortition_copy_excludes_fork_data() {
     let dir = tempdir().unwrap();
-    let src_path = dir.path().join("src_sort.sqlite");
-    let conn = create_sortition_source_db(&src_path);
+    let (conn, src_path) = create_sortition_source_db(dir.path());
 
     // Canonical chain: sort_0 at height 0, sort_1 at height 1.
     insert_snapshot(&conn, "sort_0", "bhh_0", 0);
@@ -261,7 +211,6 @@ fn test_sortition_copy_excludes_fork_data() {
     insert_block_commit_parent(&conn, "sort_1_fork");
     insert_stack_stx(&conn, "bhh_1", "stx_tx_canon");
     insert_stack_stx(&conn, "bhh_1_fork", "stx_tx_fork");
-    insert_epoch(&conn, 0, 1);
 
     // Transition ops.
     conn.execute(
@@ -331,6 +280,15 @@ fn test_sortition_copy_excludes_fork_data() {
         params![MARFValue([0xee; 40]).to_hex()],
     )
     .unwrap();
+    // `connect` seeds the epochs and one db_config row per migration, so
+    // the full-copy expectations come from the source itself.
+    let (src_epochs, src_db_config): (u64, u64) = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM epochs), (SELECT COUNT(*) FROM db_config)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
     drop(conn);
 
     // Only sort_0 and sort_1 are canonical.
@@ -359,8 +317,8 @@ fn test_sortition_copy_excludes_fork_data() {
         "only sort_1 reward set"
     );
     assert_eq!(stats.stack_stx_rows, 1, "only bhh_1 stack_stx");
-    assert_eq!(stats.epochs_rows, 1, "epochs full copy");
-    assert_eq!(stats.db_config_rows, 1, "db_config full copy");
+    assert_eq!(stats.epochs_rows, src_epochs, "epochs full copy");
+    assert_eq!(stats.db_config_rows, src_db_config, "db_config full copy");
     assert_eq!(stats.fork_storage_rows, 1, "only the canonical leaf row");
 
     // Copied rows carry their source content; fork rows are absent by key.
@@ -391,8 +349,7 @@ fn test_sortition_copy_excludes_fork_data() {
 #[test]
 fn test_sortition_burn_header_hash_filtering() {
     let dir = tempdir().unwrap();
-    let src_path = dir.path().join("src_sort.sqlite");
-    let conn = create_sortition_source_db(&src_path);
+    let (conn, src_path) = create_sortition_source_db(dir.path());
 
     insert_snapshot(&conn, "sort_0", "bhh_canon", 0);
     insert_snapshot(&conn, "sort_0_fork", "bhh_fork", 0);
@@ -438,7 +395,6 @@ fn test_sortition_burn_header_hash_filtering() {
         .unwrap();
     }
 
-    insert_epoch(&conn, 0, 1);
     drop(conn);
 
     // Only sort_0 is canonical -> bhh_canon is the only canonical burn hash.
@@ -483,11 +439,9 @@ fn test_sortition_burn_header_hash_filtering() {
 #[test]
 fn test_sortition_copy_rejects_fabricated_canonical_set() {
     let dir = tempdir().unwrap();
-    let src_path = dir.path().join("src_sort.sqlite");
-    let conn = create_sortition_source_db(&src_path);
+    let (conn, src_path) = create_sortition_source_db(dir.path());
 
     insert_snapshot(&conn, "sort_0", "bhh_0", 0);
-    insert_epoch(&conn, 0, 1);
     drop(conn);
 
     // Destination claims sort_0 AND sort_fake as canonical.
@@ -510,13 +464,11 @@ fn test_sortition_copy_rejects_fabricated_canonical_set() {
 #[test]
 fn test_sortition_stacks_chain_tips_by_burn_view_copied() {
     let dir = tempdir().unwrap();
-    let src_path = dir.path().join("src_sort.sqlite");
-    let conn = create_sortition_source_db(&src_path);
+    let (conn, src_path) = create_sortition_source_db(dir.path());
 
     // Insert canonical snapshots.
     insert_snapshot(&conn, "sort_0", "bhh_0", 0);
     insert_snapshot(&conn, "sort_1", "bhh_1", 1);
-    insert_epoch(&conn, 0, 2);
 
     // Insert stacks_chain_tips_by_burn_view rows (schema 11 table).
     // consensus_hash and burn_view_consensus_hash must reference
@@ -577,12 +529,10 @@ fn test_sortition_stacks_chain_tips_by_burn_view_copied() {
 #[test]
 fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
     let dir = tempdir().unwrap();
-    let src_path = dir.path().join("src_sort.sqlite");
-    let conn = create_sortition_source_db(&src_path);
+    let (conn, src_path) = create_sortition_source_db(dir.path());
 
     insert_snapshot(&conn, "sort_0", "bhh_0", 0);
     insert_snapshot(&conn, "sort_1", "bhh_1", 1);
-    insert_epoch(&conn, 0, 2);
 
     let boundary = sortition_test_tip_boundary(10);
     let anchor_ch = boundary.anchor_consensus_hash.to_string();
@@ -656,10 +606,14 @@ fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
 #[test]
 fn test_no_unclassified_sortition_tables() {
     let dir = tempdir().unwrap();
-    let conn = create_sortition_source_db(&dir.path().join("src.sqlite"));
+    let (conn, _src_path) = create_sortition_source_db(dir.path());
+    // `snapshot_burn_distributions` only exists in test/testing builds
+    // (`store_burn_distribution` is cfg-gated); production sources never
+    // have it, so the copy rightly ignores it.
     let known: Vec<&str> = super::super::sortition::REQUIRED_TABLES
         .iter()
         .chain(MARF_INFRA_TABLES.iter())
+        .chain(["snapshot_burn_distributions"].iter())
         .copied()
         .collect();
     let extra = unclassified_tables(&conn, &known);

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
@@ -15,6 +15,8 @@
 
 //! Sortition side-table copy tests.
 
+use std::path::{Path, PathBuf};
+
 use rusqlite::{params, Connection};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, TrieHash,
@@ -24,20 +26,21 @@ use tempfile::tempdir;
 use super::super::common::{unclassified_tables, MARF_INFRA_TABLES};
 use super::super::sortition::{
     copy_sortition_side_tables, copy_sortition_side_tables_with_boundary, SortitionTipCopyBoundary,
+    REQUIRED_TABLES,
 };
 use super::{hex_id, label_block_id};
 use crate::burnchains::PoxConstants;
+use crate::chainstate::burn::db::sortdb::tests::{make_fork_run, test_append_snapshot};
 use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
 use crate::core::{StacksEpoch, StacksEpochExtension};
-
 /// Create a sortition source DB via the production initializer
 /// ([`SortitionDB::connect`]), so the fixture always carries the current
 /// schema instead of replaying migrations by hand. `connect` also seeds
 /// the genesis snapshot and the epoch rows. Returns a connection to the
 /// underlying sqlite file along with its path.
-fn create_sortition_source_db(dir: &std::path::Path) -> (Connection, std::path::PathBuf) {
+fn create_sortition_source_db(dir: &Path) -> (Connection, PathBuf) {
     let db_dir = dir.join("src_sort");
     let _db = SortitionDB::connect(
         db_dir.to_str().unwrap(),
@@ -150,15 +153,12 @@ fn insert_stack_stx(conn: &Connection, burn_header_hash: &str, txid: &str) {
 }
 
 /// Create a sortition dest DB simulating a squashed MARF with the given
-/// canonical sortition-ID labels.
-///
-/// Each label is stored as a 32-byte zero-padded id so its hex form matches
-/// the `hex_id`-encoded sortition_id that test chainstate inserts use
-/// (sortition IDs in `snapshots` are TEXT).
-fn create_sortition_dest_db(path: &std::path::Path, canonical_sortition_ids: &[&str]) {
+/// canonical sortition IDs.
+fn create_sortition_dest_db_with_ids(path: &Path, canonical_ids: &[SortitionId]) {
     // A real (tiny) MARF so the leaf walk in `collect_canonical_leaf_hashes`
     // succeeds; its single leaf is irrelevant to the sortition assertions
-    // (src `__fork_storage` is empty, so nothing matches it anyway).
+    // (src `__fork_storage` holds no matching value hash, so nothing is
+    // copied from it).
     let mut marf = MARF::<SortitionId>::from_path(path.to_str().unwrap(), MARFOpenOpts::default())
         .expect("MARF init failed");
     marf.begin(&SortitionId::sentinel(), &SortitionId([0x99; 32]))
@@ -168,15 +168,22 @@ fn create_sortition_dest_db(path: &std::path::Path, canonical_sortition_ids: &[&
     drop(marf);
 
     let conn = Connection::open(path).unwrap();
-    for (h, sid) in canonical_sortition_ids.iter().enumerate() {
-        trie_sql::test_insert_squashed_block(
-            &conn,
-            h as u32,
-            &SortitionId(label_block_id(sid).0),
-            &TrieHash([0u8; 32]),
-        )
-        .unwrap();
+    for (h, sid) in canonical_ids.iter().enumerate() {
+        trie_sql::test_insert_squashed_block(&conn, h as u32, sid, &TrieHash([0u8; 32])).unwrap();
     }
+}
+
+/// [`create_sortition_dest_db_with_ids`] for canonical sortition-ID labels.
+///
+/// Each label is stored as a 32-byte zero-padded id so its hex form matches
+/// the `hex_id`-encoded sortition_id that test chainstate inserts use
+/// (sortition IDs in `snapshots` are TEXT).
+fn create_sortition_dest_db(path: &Path, canonical_sortition_ids: &[&str]) {
+    let ids: Vec<SortitionId> = canonical_sortition_ids
+        .iter()
+        .map(|sid| SortitionId(label_block_id(sid).0))
+        .collect();
+    create_sortition_dest_db_with_ids(path, &ids);
 }
 
 fn sortition_test_tip_boundary(max_stacks_height: u64) -> SortitionTipCopyBoundary {
@@ -470,7 +477,7 @@ fn test_sortition_stacks_chain_tips_by_burn_view_copied() {
     insert_snapshot(&conn, "sort_0", "bhh_0", 0);
     insert_snapshot(&conn, "sort_1", "bhh_1", 1);
 
-    // Insert stacks_chain_tips_by_burn_view rows (schema 11 table).
+    // Insert stacks_chain_tips_by_burn_view rows.
     // consensus_hash and burn_view_consensus_hash must reference
     // existing snapshots(consensus_hash) due to FK constraints.
     conn.execute(
@@ -601,16 +608,72 @@ fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
     );
 }
 
+/// Production-path integration: the source is seeded exclusively through
+/// SortitionDB's own write paths ([`SortitionDB::connect`],
+/// [`test_append_snapshot`], [`make_fork_run`]), so the fixture cannot
+/// drift from what production actually writes. The copy keeps the
+/// canonical chain's rows and drops the fork's.
+#[test]
+fn test_sortition_copy_with_production_seeded_source() {
+    let dir = tempdir().unwrap();
+    let db_dir = dir.path().join("src_sort");
+    let mut db = SortitionDB::connect(
+        db_dir.to_str().unwrap(),
+        0,
+        &BurnchainHeaderHash([0u8; 32]),
+        0,
+        &StacksEpoch::unit_test_3_4(0),
+        PoxConstants::test_default(),
+        None,
+        true,
+        None,
+    )
+    .expect("sortition DB init failed");
+
+    let genesis = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();
+    // Canonical chain: two snapshots appended at the tip.
+    let sn1 = test_append_snapshot(&mut db, BurnchainHeaderHash([0x11; 32]), &[]);
+    let sn2 = test_append_snapshot(&mut db, BurnchainHeaderHash([0x12; 32]), &[]);
+    // A two-block fork branching off sn1.
+    let fork = make_fork_run(&mut db, &sn1, 2, 0x80);
+    assert_eq!(fork.len(), 2);
+    drop(db);
+    let src_path = db_dir.join("marf.sqlite");
+
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    create_sortition_dest_db_with_ids(
+        &dst_path,
+        &[
+            genesis.sortition_id.clone(),
+            sn1.sortition_id.clone(),
+            sn2.sortition_id.clone(),
+        ],
+    );
+
+    let stats =
+        copy_sortition_side_tables(src_path.to_str().unwrap(), dst_path.to_str().unwrap()).unwrap();
+    assert_eq!(stats.snapshots_rows, 3, "genesis + two canonical snapshots");
+
+    let dst_conn = Connection::open(&dst_path).unwrap();
+    for fork_sn in &fork {
+        let count: i64 = dst_conn
+            .query_row(
+                "SELECT COUNT(*) FROM snapshots WHERE sortition_id = ?1",
+                params![fork_sn.sortition_id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "fork snapshot must not be copied");
+    }
+}
+
 /// Drift guard: every table the sortition migrations create must be
 /// classified, so a future migration can't silently drop one from the copy.
 #[test]
 fn test_no_unclassified_sortition_tables() {
     let dir = tempdir().unwrap();
     let (conn, _src_path) = create_sortition_source_db(dir.path());
-    // `snapshot_burn_distributions` only exists in test/testing builds
-    // (`store_burn_distribution` is cfg-gated); production sources never
-    // have it, so the copy rightly ignores it.
-    let known: Vec<&str> = super::super::sortition::REQUIRED_TABLES
+    let known: Vec<&str> = REQUIRED_TABLES
         .iter()
         .chain(MARF_INFRA_TABLES.iter())
         .chain(["snapshot_burn_distributions"].iter())

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
@@ -35,11 +35,10 @@ use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
 use crate::core::{StacksEpoch, StacksEpochExtension};
-/// Create a sortition source DB via the production initializer
-/// ([`SortitionDB::connect`]), so the fixture always carries the current
-/// schema instead of replaying migrations by hand. `connect` also seeds
-/// the genesis snapshot and the epoch rows. Returns a connection to the
-/// underlying sqlite file along with its path.
+
+/// Create a sortition source DB. `connect` also seeds the genesis
+/// snapshot and the epoch rows. Returns a connection to the sqlite
+/// file along with its path.
 fn create_sortition_source_db(dir: &Path) -> (Connection, PathBuf) {
     let db_dir = dir.join("src_sort");
     let _db = SortitionDB::connect(
@@ -63,8 +62,7 @@ fn create_sortition_source_db(dir: &Path) -> (Connection, PathBuf) {
 ///
 /// `sortition_id` is stored as its [`hex_id`] form so it joins against the
 /// canonical-sortitions temp table, which `populate_canonical_sortitions`
-/// fills with the lowercase-hex ids read via
-/// `trie_sql::bulk_read_squashed_blocks`.
+/// fills with the lowercase-hex ids read via `trie_sql::bulk_read_squashed_blocks`.
 fn insert_snapshot(
     conn: &Connection,
     sortition_id_label: &str,
@@ -608,11 +606,8 @@ fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
     );
 }
 
-/// Production-path integration: the source is seeded exclusively through
-/// SortitionDB's own write paths ([`SortitionDB::connect`],
-/// [`test_append_snapshot`], [`make_fork_run`]), so the fixture cannot
-/// drift from what production actually writes. The copy keeps the
-/// canonical chain's rows and drops the fork's.
+/// Production-path integration. The copy keeps the canonical chain's
+/// rows and drops the fork's.
 #[test]
 fn test_sortition_copy_with_production_seeded_source() {
     let dir = tempdir().unwrap();

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
@@ -30,7 +30,15 @@ use super::super::sortition::{
 };
 use super::{hex_id, label_block_id};
 use crate::burnchains::PoxConstants;
-use crate::chainstate::burn::db::sortdb::tests::{make_fork_run, test_append_snapshot};
+use crate::chainstate::burn::db::sortdb::tests::{
+    make_fork_run, test_append_snapshot, test_insert_block_commit_parent_row,
+    test_insert_block_commit_row, test_insert_delegate_stx_row, test_insert_leader_key_row,
+    test_insert_missed_commit_row, test_insert_preprocessed_reward_set_row,
+    test_insert_snapshot_row, test_insert_snapshot_transition_ops_row, test_insert_stack_stx_row,
+    test_insert_stacks_chain_tip_by_burn_view_row, test_insert_stacks_chain_tip_row,
+    test_insert_transfer_stx_row, test_insert_vote_for_aggregate_key_row,
+    test_set_snapshot_consensus_hash,
+};
 use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
@@ -69,85 +77,50 @@ fn insert_snapshot(
     burn_header_hash: &str,
     block_height: u32,
 ) {
-    conn.execute(
-        "INSERT INTO snapshots (
-                block_height, burn_header_hash, sortition_id, parent_sortition_id,
-                burn_header_timestamp, parent_burn_header_hash, consensus_hash,
-                ops_hash, total_burn, sortition, sortition_hash,
-                winning_block_txid, winning_stacks_block_hash, index_root,
-                num_sortitions, stacks_block_accepted, stacks_block_height,
-                arrival_index, canonical_stacks_tip_height, canonical_stacks_tip_hash,
-                canonical_stacks_tip_consensus_hash, pox_valid,
-                accumulated_coinbase_ustx, pox_payouts, miner_pk_hash
-            ) VALUES (
-                ?1, ?2, ?3, 'parent_sort', 1000, 'parent_bhh', ?4,
-                'ops', '0', 1, 'shash', 'wbtxid', 'wsbh', ?5,
-                ?1, 0, 0, ?1, 0, 'csth', 'cstch', 1, '0', '[]', NULL
-            )",
-        params![
-            block_height,
-            burn_header_hash,
-            hex_id(sortition_id_label),
-            format!("ch_{sortition_id_label}"),
-            format!("ir_{sortition_id_label}"),
-        ],
+    test_insert_snapshot_row(
+        conn,
+        block_height,
+        burn_header_hash,
+        &hex_id(sortition_id_label),
+        &format!("ch_{sortition_id_label}"),
+        &format!("ir_{sortition_id_label}"),
     )
     .unwrap();
 }
 
 /// Insert a leader_keys row for the given sortition_id label.
 fn insert_leader_key(conn: &Connection, sortition_id_label: &str) {
-    conn.execute(
-        "INSERT INTO leader_keys (txid, vtxindex, block_height, burn_header_hash, \
-             sortition_id, consensus_hash, public_key, memo) \
-             VALUES (?1, 0, 1, 'bhh', ?2, 'ch', 'pk', 'memo')",
-        params![
-            format!("lk_tx_{sortition_id_label}"),
-            hex_id(sortition_id_label),
-        ],
+    test_insert_leader_key_row(
+        conn,
+        &format!("lk_tx_{sortition_id_label}"),
+        &hex_id(sortition_id_label),
     )
     .unwrap();
 }
 
 /// Insert a block_commits row for the given sortition_id label.
 fn insert_block_commit(conn: &Connection, sortition_id_label: &str) {
-    conn.execute(
-        "INSERT INTO block_commits (txid, vtxindex, block_height, burn_header_hash, \
-             sortition_id, block_header_hash, new_seed, parent_block_ptr, parent_vtxindex, \
-             key_block_ptr, key_vtxindex, memo, commit_outs, burn_fee, sunset_burn, \
-             input, apparent_sender, burn_parent_modulus, punished) \
-             VALUES (?1, 0, 1, 'bhh', ?2, 'bhh', 'seed', 0, 0, 0, 0, '', '', '0', '0', \
-             'input', 'sender', 0, NULL)",
-        params![
-            format!("bc_tx_{sortition_id_label}"),
-            hex_id(sortition_id_label),
-        ],
+    test_insert_block_commit_row(
+        conn,
+        &format!("bc_tx_{sortition_id_label}"),
+        &hex_id(sortition_id_label),
     )
     .unwrap();
 }
 
 /// Insert a block_commit_parents row.
 fn insert_block_commit_parent(conn: &Connection, sortition_id_label: &str) {
-    conn.execute(
-        "INSERT INTO block_commit_parents (block_commit_txid, block_commit_sortition_id, \
-             parent_sortition_id) VALUES (?1, ?2, 'parent_sort')",
-        params![
-            format!("bc_tx_{sortition_id_label}"),
-            hex_id(sortition_id_label),
-        ],
+    test_insert_block_commit_parent_row(
+        conn,
+        &format!("bc_tx_{sortition_id_label}"),
+        &hex_id(sortition_id_label),
     )
     .unwrap();
 }
 
 /// Insert a stack_stx row for the given burn_header_hash.
 fn insert_stack_stx(conn: &Connection, burn_header_hash: &str, txid: &str) {
-    conn.execute(
-        "INSERT INTO stack_stx (txid, vtxindex, block_height, burn_header_hash, \
-             sender_addr, reward_addr, stacked_ustx, num_cycles, signer_key, max_amount, auth_id) \
-             VALUES (?1, 0, 1, ?2, 'sender', 'reward', '1000', 1, NULL, NULL, NULL)",
-        params![txid, burn_header_hash],
-    )
-    .unwrap();
+    test_insert_stack_stx_row(conn, txid, burn_header_hash).unwrap();
 }
 
 /// Create a sortition dest DB simulating a squashed MARF with the given
@@ -218,60 +191,20 @@ fn test_sortition_copy_excludes_fork_data() {
     insert_stack_stx(&conn, "bhh_1_fork", "stx_tx_fork");
 
     // Transition ops.
-    conn.execute(
-        "INSERT INTO snapshot_transition_ops (sortition_id, accepted_ops, consumed_keys) \
-             VALUES (?1, '[]', '[]')",
-        params![hex_id("sort_1")],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO snapshot_transition_ops (sortition_id, accepted_ops, consumed_keys) \
-             VALUES (?1, '[]', '[]')",
-        params![hex_id("sort_1_fork")],
-    )
-    .unwrap();
+    test_insert_snapshot_transition_ops_row(&conn, &hex_id("sort_1")).unwrap();
+    test_insert_snapshot_transition_ops_row(&conn, &hex_id("sort_1_fork")).unwrap();
 
     // Stacks chain tips.
-    conn.execute(
-        "INSERT INTO stacks_chain_tips (sortition_id, consensus_hash, block_hash, block_height) \
-             VALUES (?1, 'ch', 'bh', 1)",
-        params![hex_id("sort_1")],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO stacks_chain_tips (sortition_id, consensus_hash, block_hash, block_height) \
-             VALUES (?1, 'ch2', 'bh2', 1)",
-        params![hex_id("sort_1_fork")],
-    )
-    .unwrap();
+    test_insert_stacks_chain_tip_row(&conn, &hex_id("sort_1"), "ch", "bh", 1).unwrap();
+    test_insert_stacks_chain_tip_row(&conn, &hex_id("sort_1_fork"), "ch2", "bh2", 1).unwrap();
 
     // Missed commits.
-    conn.execute(
-        "INSERT INTO missed_commits (txid, input, intended_sortition_id) \
-             VALUES ('mc_tx', 'input', ?1)",
-        params![hex_id("sort_1")],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO missed_commits (txid, input, intended_sortition_id) \
-             VALUES ('mc_tx_fork', 'input', ?1)",
-        params![hex_id("sort_1_fork")],
-    )
-    .unwrap();
+    test_insert_missed_commit_row(&conn, "mc_tx", &hex_id("sort_1")).unwrap();
+    test_insert_missed_commit_row(&conn, "mc_tx_fork", &hex_id("sort_1_fork")).unwrap();
 
     // Preprocessed reward sets.
-    conn.execute(
-        "INSERT INTO preprocessed_reward_sets (sortition_id, reward_set) \
-             VALUES (?1, '{}')",
-        params![hex_id("sort_1")],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO preprocessed_reward_sets (sortition_id, reward_set) \
-             VALUES (?1, '{}')",
-        params![hex_id("sort_1_fork")],
-    )
-    .unwrap();
+    test_insert_preprocessed_reward_set_row(&conn, &hex_id("sort_1")).unwrap();
+    test_insert_preprocessed_reward_set_row(&conn, &hex_id("sort_1_fork")).unwrap();
 
     // src __fork_storage: the dest fixture's single MARF leaf ([0xff; 40])
     // is canonical; an unreferenced entry must be dropped.
@@ -364,40 +297,15 @@ fn test_sortition_burn_header_hash_filtering() {
     insert_stack_stx(&conn, "bhh_fork", "stx_fork");
 
     // transfer_stx at canonical and fork.
-    conn.execute(
-        "INSERT INTO transfer_stx (txid, vtxindex, block_height, burn_header_hash, \
-             sender_addr, recipient_addr, transfered_ustx, memo) \
-             VALUES ('xfer_canon', 0, 0, 'bhh_canon', 's', 'r', '100', 'x')",
-        [],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO transfer_stx (txid, vtxindex, block_height, burn_header_hash, \
-             sender_addr, recipient_addr, transfered_ustx, memo) \
-             VALUES ('xfer_fork', 0, 0, 'bhh_fork', 's', 'r', '100', 'x')",
-        [],
-    )
-    .unwrap();
+    test_insert_transfer_stx_row(&conn, "xfer_canon", "bhh_canon").unwrap();
+    test_insert_transfer_stx_row(&conn, "xfer_fork", "bhh_fork").unwrap();
 
     // delegate_stx and vote_for_aggregate_key at canonical and fork.
     for (txid, bhh) in [("del_canon", "bhh_canon"), ("del_fork", "bhh_fork")] {
-        conn.execute(
-            "INSERT INTO delegate_stx (txid, vtxindex, block_height, burn_header_hash, \
-                 sender_addr, delegate_to, reward_addr, delegated_ustx, until_burn_height) \
-                 VALUES (?1, 0, 0, ?2, 's', 'd', 'r', '100', NULL)",
-            params![txid, bhh],
-        )
-        .unwrap();
+        test_insert_delegate_stx_row(&conn, txid, bhh).unwrap();
     }
     for (txid, bhh) in [("vote_canon", "bhh_canon"), ("vote_fork", "bhh_fork")] {
-        conn.execute(
-            "INSERT INTO vote_for_aggregate_key (txid, vtxindex, block_height, \
-                 burn_header_hash, sender_addr, aggregate_key, round, reward_cycle, \
-                 signer_index, signer_key) \
-                 VALUES (?1, 0, 0, ?2, 's', 'k', 0, 0, 0, 'sk')",
-            params![txid, bhh],
-        )
-        .unwrap();
+        test_insert_vote_for_aggregate_key_row(&conn, txid, bhh).unwrap();
     }
 
     drop(conn);
@@ -478,18 +386,22 @@ fn test_sortition_stacks_chain_tips_by_burn_view_copied() {
     // Insert stacks_chain_tips_by_burn_view rows.
     // consensus_hash and burn_view_consensus_hash must reference
     // existing snapshots(consensus_hash) due to FK constraints.
-    conn.execute(
-        "INSERT INTO stacks_chain_tips_by_burn_view \
-         (sortition_id, consensus_hash, burn_view_consensus_hash, block_hash, block_height) \
-         VALUES (?1, 'ch_sort_0', 'ch_sort_0', 'bh_0', 0)",
-        params![hex_id("sort_0")],
+    test_insert_stacks_chain_tip_by_burn_view_row(
+        &conn,
+        &hex_id("sort_0"),
+        "ch_sort_0",
+        "ch_sort_0",
+        "bh_0",
+        0,
     )
     .unwrap();
-    conn.execute(
-        "INSERT INTO stacks_chain_tips_by_burn_view \
-         (sortition_id, consensus_hash, burn_view_consensus_hash, block_hash, block_height) \
-         VALUES (?1, 'ch_sort_1', 'ch_sort_1', 'bh_1', 1)",
-        params![hex_id("sort_1")],
+    test_insert_stacks_chain_tip_by_burn_view_row(
+        &conn,
+        &hex_id("sort_1"),
+        "ch_sort_1",
+        "ch_sort_1",
+        "bh_1",
+        1,
     )
     .unwrap();
     drop(conn);
@@ -545,28 +457,16 @@ fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
     let anchor_bhh = boundary.anchor_block_hash.to_string();
     let source_tip_bhh = BlockHeaderHash([0x33; 32]).to_string();
 
-    conn.execute(
-        "UPDATE snapshots SET consensus_hash = ?1 WHERE sortition_id = ?2",
-        params![&anchor_burn_view_ch, hex_id("sort_1")],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO stacks_chain_tips \
-         (sortition_id, consensus_hash, block_hash, block_height) \
-         VALUES (?1, ?2, ?3, 20)",
-        params![hex_id("sort_1"), &anchor_ch, &source_tip_bhh],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO stacks_chain_tips_by_burn_view \
-         (sortition_id, consensus_hash, burn_view_consensus_hash, block_hash, block_height) \
-         VALUES (?1, ?2, ?3, ?4, 20)",
-        params![
-            hex_id("sort_1"),
-            &anchor_ch,
-            &anchor_burn_view_ch,
-            &source_tip_bhh
-        ],
+    test_set_snapshot_consensus_hash(&conn, &hex_id("sort_1"), &anchor_burn_view_ch).unwrap();
+    test_insert_stacks_chain_tip_row(&conn, &hex_id("sort_1"), &anchor_ch, &source_tip_bhh, 20)
+        .unwrap();
+    test_insert_stacks_chain_tip_by_burn_view_row(
+        &conn,
+        &hex_id("sort_1"),
+        &anchor_ch,
+        &anchor_burn_view_ch,
+        &source_tip_bhh,
+        20,
     )
     .unwrap();
     drop(conn);

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/sortition.rs
@@ -1,0 +1,671 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Sortition side-table copy tests.
+
+use rusqlite::{params, Connection};
+use stacks_common::types::chainstate::{BlockHeaderHash, ConsensusHash, SortitionId, TrieHash};
+use tempfile::tempdir;
+
+use super::super::common::{unclassified_tables, MARF_INFRA_TABLES};
+use super::super::sortition::{
+    copy_sortition_side_tables, copy_sortition_side_tables_with_boundary, SortitionTipCopyBoundary,
+};
+use super::{hex_id, label_block_id};
+use crate::chainstate::burn::db::sortdb::{
+    SORTITION_DB_INITIAL_SCHEMA, SORTITION_DB_SCHEMA_10, SORTITION_DB_SCHEMA_11,
+    SORTITION_DB_SCHEMA_2, SORTITION_DB_SCHEMA_3, SORTITION_DB_SCHEMA_4, SORTITION_DB_SCHEMA_5,
+    SORTITION_DB_SCHEMA_6, SORTITION_DB_SCHEMA_7, SORTITION_DB_SCHEMA_8, SORTITION_DB_SCHEMA_9,
+    SORTITION_DB_VERSION,
+};
+use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
+use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
+
+/// Create a sortition source DB with the real schema (all migrations
+/// through schema 11). Applies only the DDL; epoch data inserts are
+/// skipped since tests only need the table structure.
+fn create_sortition_source_db(path: &std::path::Path) -> Connection {
+    let conn = Connection::open(path).unwrap();
+    for cmd in SORTITION_DB_INITIAL_SCHEMA {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_2 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_3 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_4 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_5 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_6 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_7 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_8 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_9 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_10 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    for cmd in SORTITION_DB_SCHEMA_11 {
+        conn.execute_batch(cmd).unwrap();
+    }
+    // Sentinel: a new sortition schema bumps SORTITION_DB_VERSION; this
+    // fixture must then replay the new migration too.
+    assert_eq!(
+        SORTITION_DB_VERSION, 11,
+        "sortition schema changed: replay the new migration in this fixture"
+    );
+    conn.execute(
+        "INSERT OR REPLACE INTO db_config (version) VALUES (?1)",
+        params![SORTITION_DB_VERSION.to_string()],
+    )
+    .unwrap();
+    // Same reason as `create_source_db`: satisfy the strict
+    // src-has-table check in `copy_canonical_fork_storage`.
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS __fork_storage (
+            value_hash TEXT NOT NULL,
+            value TEXT NOT NULL,
+            PRIMARY KEY(value_hash)
+        );",
+    )
+    .unwrap();
+    conn
+}
+
+/// Insert a snapshot row for the given sortition_id and burn_header_hash labels.
+///
+/// `sortition_id` is stored as its [`hex_id`] form so it joins against the
+/// canonical-sortitions temp table, which `populate_canonical_sortitions`
+/// fills with the lowercase-hex ids read via
+/// `trie_sql::bulk_read_squashed_blocks`.
+fn insert_snapshot(
+    conn: &Connection,
+    sortition_id_label: &str,
+    burn_header_hash: &str,
+    block_height: u32,
+) {
+    conn.execute(
+        "INSERT INTO snapshots (
+                block_height, burn_header_hash, sortition_id, parent_sortition_id,
+                burn_header_timestamp, parent_burn_header_hash, consensus_hash,
+                ops_hash, total_burn, sortition, sortition_hash,
+                winning_block_txid, winning_stacks_block_hash, index_root,
+                num_sortitions, stacks_block_accepted, stacks_block_height,
+                arrival_index, canonical_stacks_tip_height, canonical_stacks_tip_hash,
+                canonical_stacks_tip_consensus_hash, pox_valid,
+                accumulated_coinbase_ustx, pox_payouts, miner_pk_hash
+            ) VALUES (
+                ?1, ?2, ?3, 'parent_sort', 1000, 'parent_bhh', ?4,
+                'ops', '0', 1, 'shash', 'wbtxid', 'wsbh', ?5,
+                ?1, 0, 0, ?1, 0, 'csth', 'cstch', 1, '0', '[]', NULL
+            )",
+        params![
+            block_height,
+            burn_header_hash,
+            hex_id(sortition_id_label),
+            format!("ch_{sortition_id_label}"),
+            format!("ir_{sortition_id_label}"),
+        ],
+    )
+    .unwrap();
+}
+
+/// Insert a leader_keys row for the given sortition_id label.
+fn insert_leader_key(conn: &Connection, sortition_id_label: &str) {
+    conn.execute(
+        "INSERT INTO leader_keys (txid, vtxindex, block_height, burn_header_hash, \
+             sortition_id, consensus_hash, public_key, memo) \
+             VALUES (?1, 0, 1, 'bhh', ?2, 'ch', 'pk', 'memo')",
+        params![
+            format!("lk_tx_{sortition_id_label}"),
+            hex_id(sortition_id_label),
+        ],
+    )
+    .unwrap();
+}
+
+/// Insert a block_commits row for the given sortition_id label.
+fn insert_block_commit(conn: &Connection, sortition_id_label: &str) {
+    conn.execute(
+        "INSERT INTO block_commits (txid, vtxindex, block_height, burn_header_hash, \
+             sortition_id, block_header_hash, new_seed, parent_block_ptr, parent_vtxindex, \
+             key_block_ptr, key_vtxindex, memo, commit_outs, burn_fee, sunset_burn, \
+             input, apparent_sender, burn_parent_modulus, punished) \
+             VALUES (?1, 0, 1, 'bhh', ?2, 'bhh', 'seed', 0, 0, 0, 0, '', '', '0', '0', \
+             'input', 'sender', 0, NULL)",
+        params![
+            format!("bc_tx_{sortition_id_label}"),
+            hex_id(sortition_id_label),
+        ],
+    )
+    .unwrap();
+}
+
+/// Insert a block_commit_parents row.
+fn insert_block_commit_parent(conn: &Connection, sortition_id_label: &str) {
+    conn.execute(
+        "INSERT INTO block_commit_parents (block_commit_txid, block_commit_sortition_id, \
+             parent_sortition_id) VALUES (?1, ?2, 'parent_sort')",
+        params![
+            format!("bc_tx_{sortition_id_label}"),
+            hex_id(sortition_id_label),
+        ],
+    )
+    .unwrap();
+}
+
+/// Insert a stack_stx row for the given burn_header_hash.
+fn insert_stack_stx(conn: &Connection, burn_header_hash: &str, txid: &str) {
+    conn.execute(
+        "INSERT INTO stack_stx (txid, vtxindex, block_height, burn_header_hash, \
+             sender_addr, reward_addr, stacked_ustx, num_cycles, signer_key, max_amount, auth_id) \
+             VALUES (?1, 0, 1, ?2, 'sender', 'reward', '1000', 1, NULL, NULL, NULL)",
+        params![txid, burn_header_hash],
+    )
+    .unwrap();
+}
+
+/// Insert an epochs row.
+fn insert_epoch(conn: &Connection, start: u32, epoch_id: u32) {
+    conn.execute(
+        "INSERT INTO epochs (start_block_height, end_block_height, epoch_id, \
+             block_limit, network_epoch) VALUES (?1, ?2, ?3, '{}', 1)",
+        params![start, start + 100, epoch_id],
+    )
+    .unwrap();
+}
+
+/// Create a sortition dest DB simulating a squashed MARF with the given
+/// canonical sortition-ID labels.
+///
+/// Each label is stored as a 32-byte zero-padded id so its hex form matches
+/// the `hex_id`-encoded sortition_id that test chainstate inserts use
+/// (sortition IDs in `snapshots` are TEXT).
+fn create_sortition_dest_db(path: &std::path::Path, canonical_sortition_ids: &[&str]) {
+    // A real (tiny) MARF so the leaf walk in `collect_canonical_leaf_hashes`
+    // succeeds; its single leaf is irrelevant to the sortition assertions
+    // (src `__fork_storage` is empty, so nothing matches it anyway).
+    let mut marf = MARF::<SortitionId>::from_path(path.to_str().unwrap(), MARFOpenOpts::default())
+        .expect("MARF init failed");
+    marf.begin(&SortitionId::sentinel(), &SortitionId([0x99; 32]))
+        .unwrap();
+    marf.insert("test::leaf", MARFValue([0xff; 40])).unwrap();
+    marf.commit().unwrap();
+    drop(marf);
+
+    let conn = Connection::open(path).unwrap();
+    for (h, sid) in canonical_sortition_ids.iter().enumerate() {
+        trie_sql::test_insert_squashed_block(
+            &conn,
+            h as u32,
+            &SortitionId(label_block_id(sid).0),
+            &TrieHash([0u8; 32]),
+        )
+        .unwrap();
+    }
+}
+
+fn sortition_test_tip_boundary(max_stacks_height: u64) -> SortitionTipCopyBoundary {
+    SortitionTipCopyBoundary {
+        max_stacks_height,
+        anchor_consensus_hash: ConsensusHash([0x11; 20]),
+        anchor_burn_view_consensus_hash: ConsensusHash([0x11; 20]),
+        anchor_block_hash: BlockHeaderHash([0x22; 32]),
+        anchor_block_height: max_stacks_height,
+    }
+}
+
+/// Canonical and fork rows across every sortition_id-filtered table:
+/// only the canonical sortitions' rows are copied.
+#[test]
+fn test_sortition_copy_excludes_fork_data() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src_sort.sqlite");
+    let conn = create_sortition_source_db(&src_path);
+
+    // Canonical chain: sort_0 at height 0, sort_1 at height 1.
+    insert_snapshot(&conn, "sort_0", "bhh_0", 0);
+    insert_snapshot(&conn, "sort_1", "bhh_1", 1);
+    // Fork at height 1: sort_1_fork with different burn hash.
+    insert_snapshot(&conn, "sort_1_fork", "bhh_1_fork", 1);
+
+    // Insert related data for canonical and fork.
+    insert_leader_key(&conn, "sort_1");
+    insert_leader_key(&conn, "sort_1_fork");
+    insert_block_commit(&conn, "sort_1");
+    insert_block_commit(&conn, "sort_1_fork");
+    insert_block_commit_parent(&conn, "sort_1");
+    insert_block_commit_parent(&conn, "sort_1_fork");
+    insert_stack_stx(&conn, "bhh_1", "stx_tx_canon");
+    insert_stack_stx(&conn, "bhh_1_fork", "stx_tx_fork");
+    insert_epoch(&conn, 0, 1);
+
+    // Transition ops.
+    conn.execute(
+        "INSERT INTO snapshot_transition_ops (sortition_id, accepted_ops, consumed_keys) \
+             VALUES (?1, '[]', '[]')",
+        params![hex_id("sort_1")],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO snapshot_transition_ops (sortition_id, accepted_ops, consumed_keys) \
+             VALUES (?1, '[]', '[]')",
+        params![hex_id("sort_1_fork")],
+    )
+    .unwrap();
+
+    // Stacks chain tips.
+    conn.execute(
+        "INSERT INTO stacks_chain_tips (sortition_id, consensus_hash, block_hash, block_height) \
+             VALUES (?1, 'ch', 'bh', 1)",
+        params![hex_id("sort_1")],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO stacks_chain_tips (sortition_id, consensus_hash, block_hash, block_height) \
+             VALUES (?1, 'ch2', 'bh2', 1)",
+        params![hex_id("sort_1_fork")],
+    )
+    .unwrap();
+
+    // Missed commits.
+    conn.execute(
+        "INSERT INTO missed_commits (txid, input, intended_sortition_id) \
+             VALUES ('mc_tx', 'input', ?1)",
+        params![hex_id("sort_1")],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO missed_commits (txid, input, intended_sortition_id) \
+             VALUES ('mc_tx_fork', 'input', ?1)",
+        params![hex_id("sort_1_fork")],
+    )
+    .unwrap();
+
+    // Preprocessed reward sets.
+    conn.execute(
+        "INSERT INTO preprocessed_reward_sets (sortition_id, reward_set) \
+             VALUES (?1, '{}')",
+        params![hex_id("sort_1")],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO preprocessed_reward_sets (sortition_id, reward_set) \
+             VALUES (?1, '{}')",
+        params![hex_id("sort_1_fork")],
+    )
+    .unwrap();
+
+    // src __fork_storage: the dest fixture's single MARF leaf ([0xff; 40])
+    // is canonical; an unreferenced entry must be dropped.
+    conn.execute(
+        "INSERT INTO __fork_storage (value_hash, value) VALUES (?1, 'canon')",
+        params![MARFValue([0xff; 40]).to_hex()],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO __fork_storage (value_hash, value) VALUES (?1, 'fork')",
+        params![MARFValue([0xee; 40]).to_hex()],
+    )
+    .unwrap();
+    drop(conn);
+
+    // Only sort_0 and sort_1 are canonical.
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    create_sortition_dest_db(&dst_path, &["sort_0", "sort_1"]);
+
+    let stats =
+        copy_sortition_side_tables(src_path.to_str().unwrap(), dst_path.to_str().unwrap()).unwrap();
+
+    // Only canonical rows should be copied.
+    assert_eq!(stats.snapshots_rows, 2, "2 canonical snapshots");
+    assert_eq!(stats.leader_keys_rows, 1, "only sort_1 leader key");
+    assert_eq!(stats.block_commits_rows, 1, "only sort_1 block commit");
+    assert_eq!(
+        stats.block_commit_parents_rows, 1,
+        "only sort_1 block commit parent"
+    );
+    assert_eq!(
+        stats.snapshot_transition_ops_rows, 1,
+        "only sort_1 transition ops"
+    );
+    assert_eq!(stats.stacks_chain_tips_rows, 1, "only sort_1 chain tip");
+    assert_eq!(stats.missed_commits_rows, 1, "only sort_1 missed commit");
+    assert_eq!(
+        stats.preprocessed_reward_sets_rows, 1,
+        "only sort_1 reward set"
+    );
+    assert_eq!(stats.stack_stx_rows, 1, "only bhh_1 stack_stx");
+    assert_eq!(stats.epochs_rows, 1, "epochs full copy");
+    assert_eq!(stats.db_config_rows, 1, "db_config full copy");
+    assert_eq!(stats.fork_storage_rows, 1, "only the canonical leaf row");
+
+    // Copied rows carry their source content; fork rows are absent by key.
+    let dst_conn = Connection::open(&dst_path).unwrap();
+    let burn_hash: String = dst_conn
+        .query_row(
+            "SELECT burn_header_hash FROM snapshots WHERE sortition_id = ?1",
+            params![hex_id("sort_1")],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(burn_hash, "bhh_1");
+    let fork_rows: i64 = dst_conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM snapshots WHERE sortition_id = ?1) \
+             + (SELECT COUNT(*) FROM leader_keys WHERE txid = 'lk_tx_sort_1_fork') \
+             + (SELECT COUNT(*) FROM stack_stx WHERE txid = 'stx_tx_fork') \
+             + (SELECT COUNT(*) FROM __fork_storage WHERE value_hash = ?2)",
+            params![hex_id("sort_1_fork"), MARFValue([0xee; 40]).to_hex()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(fork_rows, 0, "fork rows must be absent by key");
+}
+
+/// burn_header_hash-keyed tables (`stack_stx`, `transfer_stx`, ...) must
+/// exclude rows associated with non-canonical burn hashes.
+#[test]
+fn test_sortition_burn_header_hash_filtering() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src_sort.sqlite");
+    let conn = create_sortition_source_db(&src_path);
+
+    insert_snapshot(&conn, "sort_0", "bhh_canon", 0);
+    insert_snapshot(&conn, "sort_0_fork", "bhh_fork", 0);
+
+    // stack_stx at canonical and fork burn hashes.
+    insert_stack_stx(&conn, "bhh_canon", "stx_canon");
+    insert_stack_stx(&conn, "bhh_fork", "stx_fork");
+
+    // transfer_stx at canonical and fork.
+    conn.execute(
+        "INSERT INTO transfer_stx (txid, vtxindex, block_height, burn_header_hash, \
+             sender_addr, recipient_addr, transfered_ustx, memo) \
+             VALUES ('xfer_canon', 0, 0, 'bhh_canon', 's', 'r', '100', 'x')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO transfer_stx (txid, vtxindex, block_height, burn_header_hash, \
+             sender_addr, recipient_addr, transfered_ustx, memo) \
+             VALUES ('xfer_fork', 0, 0, 'bhh_fork', 's', 'r', '100', 'x')",
+        [],
+    )
+    .unwrap();
+
+    // delegate_stx and vote_for_aggregate_key at canonical and fork.
+    for (txid, bhh) in [("del_canon", "bhh_canon"), ("del_fork", "bhh_fork")] {
+        conn.execute(
+            "INSERT INTO delegate_stx (txid, vtxindex, block_height, burn_header_hash, \
+                 sender_addr, delegate_to, reward_addr, delegated_ustx, until_burn_height) \
+                 VALUES (?1, 0, 0, ?2, 's', 'd', 'r', '100', NULL)",
+            params![txid, bhh],
+        )
+        .unwrap();
+    }
+    for (txid, bhh) in [("vote_canon", "bhh_canon"), ("vote_fork", "bhh_fork")] {
+        conn.execute(
+            "INSERT INTO vote_for_aggregate_key (txid, vtxindex, block_height, \
+                 burn_header_hash, sender_addr, aggregate_key, round, reward_cycle, \
+                 signer_index, signer_key) \
+                 VALUES (?1, 0, 0, ?2, 's', 'k', 0, 0, 0, 'sk')",
+            params![txid, bhh],
+        )
+        .unwrap();
+    }
+
+    insert_epoch(&conn, 0, 1);
+    drop(conn);
+
+    // Only sort_0 is canonical -> bhh_canon is the only canonical burn hash.
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    create_sortition_dest_db(&dst_path, &["sort_0"]);
+
+    let stats =
+        copy_sortition_side_tables(src_path.to_str().unwrap(), dst_path.to_str().unwrap()).unwrap();
+
+    assert_eq!(stats.stack_stx_rows, 1, "only bhh_canon stack_stx");
+    assert_eq!(stats.transfer_stx_rows, 1, "only bhh_canon transfer_stx");
+    assert_eq!(stats.delegate_stx_rows, 1, "only bhh_canon delegate_stx");
+    assert_eq!(
+        stats.vote_for_aggregate_key_rows, 1,
+        "only bhh_canon vote_for_aggregate_key"
+    );
+
+    // The canonical row of each table survives by key; the fork row is absent.
+    let dst_conn = Connection::open(&dst_path).unwrap();
+    for (table, canon, fork) in [
+        ("stack_stx", "stx_canon", "stx_fork"),
+        ("transfer_stx", "xfer_canon", "xfer_fork"),
+        ("delegate_stx", "del_canon", "del_fork"),
+        ("vote_for_aggregate_key", "vote_canon", "vote_fork"),
+    ] {
+        let (canon_rows, fork_rows): (i64, i64) = dst_conn
+            .query_row(
+                &format!(
+                    "SELECT (SELECT COUNT(*) FROM {table} WHERE txid = ?1), \
+                            (SELECT COUNT(*) FROM {table} WHERE txid = ?2)"
+                ),
+                params![canon, fork],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((canon_rows, fork_rows), (1, 0), "{table}");
+    }
+}
+
+/// A destination claiming a canonical sortition_id absent from
+/// `src.snapshots` is corruption: the copy must abort.
+#[test]
+fn test_sortition_copy_rejects_fabricated_canonical_set() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src_sort.sqlite");
+    let conn = create_sortition_source_db(&src_path);
+
+    insert_snapshot(&conn, "sort_0", "bhh_0", 0);
+    insert_epoch(&conn, 0, 1);
+    drop(conn);
+
+    // Destination claims sort_0 AND sort_fake as canonical.
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    create_sortition_dest_db(&dst_path, &["sort_0", "sort_fake"]);
+
+    let err = copy_sortition_side_tables(src_path.to_str().unwrap(), dst_path.to_str().unwrap())
+        .expect_err("copy must reject fabricated canonical sortition");
+    match err {
+        Error::CorruptionError(msg) => assert!(
+            msg.contains("canonical sortition") && msg.contains("absent from src.snapshots"),
+            "unexpected corruption message: {msg}"
+        ),
+        other => panic!("expected CorruptionError, got {other:?}"),
+    }
+}
+
+/// `stacks_chain_tips_by_burn_view` (schema 11) rows for canonical
+/// sortitions are copied and reported in the stats.
+#[test]
+fn test_sortition_stacks_chain_tips_by_burn_view_copied() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src_sort.sqlite");
+    let conn = create_sortition_source_db(&src_path);
+
+    // Insert canonical snapshots.
+    insert_snapshot(&conn, "sort_0", "bhh_0", 0);
+    insert_snapshot(&conn, "sort_1", "bhh_1", 1);
+    insert_epoch(&conn, 0, 2);
+
+    // Insert stacks_chain_tips_by_burn_view rows (schema 11 table).
+    // consensus_hash and burn_view_consensus_hash must reference
+    // existing snapshots(consensus_hash) due to FK constraints.
+    conn.execute(
+        "INSERT INTO stacks_chain_tips_by_burn_view \
+         (sortition_id, consensus_hash, burn_view_consensus_hash, block_hash, block_height) \
+         VALUES (?1, 'ch_sort_0', 'ch_sort_0', 'bh_0', 0)",
+        params![hex_id("sort_0")],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO stacks_chain_tips_by_burn_view \
+         (sortition_id, consensus_hash, burn_view_consensus_hash, block_hash, block_height) \
+         VALUES (?1, 'ch_sort_1', 'ch_sort_1', 'bh_1', 1)",
+        params![hex_id("sort_1")],
+    )
+    .unwrap();
+    drop(conn);
+
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    create_sortition_dest_db(&dst_path, &["sort_0", "sort_1"]);
+
+    let stats =
+        copy_sortition_side_tables(src_path.to_str().unwrap(), dst_path.to_str().unwrap()).unwrap();
+
+    // The stats struct should reflect the copied rows.
+    assert_eq!(
+        stats.stacks_chain_tips_by_burn_view_rows, 2,
+        "stats should report 2 stacks_chain_tips_by_burn_view rows"
+    );
+
+    // Verify the exact rows landed in the destination.
+    let dst_conn = Connection::open(&dst_path).unwrap();
+    let rows: Vec<(String, String, String, i64)> = dst_conn
+        .prepare(
+            "SELECT consensus_hash, burn_view_consensus_hash, block_hash, block_height \
+             FROM stacks_chain_tips_by_burn_view ORDER BY block_height",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            ("ch_sort_0".into(), "ch_sort_0".into(), "bh_0".into(), 0),
+            ("ch_sort_1".into(), "ch_sort_1".into(), "bh_1".into(), 1),
+        ]
+    );
+}
+
+/// Sortition tip memo rows pointing above the Stacks boundary are
+/// rewritten down to the anchor in both memo tables.
+#[test]
+fn test_sortition_tip_copy_rewrites_rows_above_stacks_boundary() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src_sort.sqlite");
+    let conn = create_sortition_source_db(&src_path);
+
+    insert_snapshot(&conn, "sort_0", "bhh_0", 0);
+    insert_snapshot(&conn, "sort_1", "bhh_1", 1);
+    insert_epoch(&conn, 0, 2);
+
+    let boundary = sortition_test_tip_boundary(10);
+    let anchor_ch = boundary.anchor_consensus_hash.to_string();
+    let anchor_burn_view_ch = boundary.anchor_burn_view_consensus_hash.to_string();
+    let anchor_bhh = boundary.anchor_block_hash.to_string();
+    let source_tip_bhh = BlockHeaderHash([0x33; 32]).to_string();
+
+    conn.execute(
+        "UPDATE snapshots SET consensus_hash = ?1 WHERE sortition_id = ?2",
+        params![&anchor_burn_view_ch, hex_id("sort_1")],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO stacks_chain_tips \
+         (sortition_id, consensus_hash, block_hash, block_height) \
+         VALUES (?1, ?2, ?3, 20)",
+        params![hex_id("sort_1"), &anchor_ch, &source_tip_bhh],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO stacks_chain_tips_by_burn_view \
+         (sortition_id, consensus_hash, burn_view_consensus_hash, block_hash, block_height) \
+         VALUES (?1, ?2, ?3, ?4, 20)",
+        params![
+            hex_id("sort_1"),
+            &anchor_ch,
+            &anchor_burn_view_ch,
+            &source_tip_bhh
+        ],
+    )
+    .unwrap();
+    drop(conn);
+
+    let dst_path = dir.path().join("dst_sort.sqlite");
+    create_sortition_dest_db(&dst_path, &["sort_0", "sort_1"]);
+
+    copy_sortition_side_tables_with_boundary(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        Some(&boundary),
+    )
+    .unwrap();
+
+    let dst_conn = Connection::open(&dst_path).unwrap();
+    let old_tip: (String, String, i64) = dst_conn
+        .query_row(
+            "SELECT consensus_hash, block_hash, block_height FROM stacks_chain_tips \
+             WHERE sortition_id = ?1",
+            params![hex_id("sort_1")],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(old_tip, (anchor_ch.clone(), anchor_bhh.clone(), 10));
+
+    let burn_view_tip: (String, String, String, i64) = dst_conn
+        .query_row(
+            "SELECT consensus_hash, burn_view_consensus_hash, block_hash, block_height \
+             FROM stacks_chain_tips_by_burn_view WHERE sortition_id = ?1",
+            params![hex_id("sort_1")],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        burn_view_tip,
+        (anchor_ch, anchor_burn_view_ch, anchor_bhh, 10)
+    );
+}
+
+/// Drift guard: every table the sortition migrations create must be
+/// classified, so a future migration can't silently drop one from the copy.
+#[test]
+fn test_no_unclassified_sortition_tables() {
+    let dir = tempdir().unwrap();
+    let conn = create_sortition_source_db(&dir.path().join("src.sqlite"));
+    let known: Vec<&str> = super::super::sortition::REQUIRED_TABLES
+        .iter()
+        .chain(MARF_INFRA_TABLES.iter())
+        .copied()
+        .collect();
+    let extra = unclassified_tables(&conn, &known);
+    assert!(
+        extra.is_empty(),
+        "unclassified sortition table(s) {extra:?}: classify each in REQUIRED_TABLES \
+         (snapshot/sortition.rs)"
+    );
+}


### PR DESCRIPTION
### Description

Follow-up to #7254: adds the sortition DB to the offline snapshot copy. `copy_sortition_side_tables` copies the canonical rows of every sortition side table into a squashed destination, with the canonical set read from the squashed MARF's `marf_squashed_blocks` metadata (sortition_id-filtered, burn-hash-filtered, and full-copy tables). An optional Stacks-side boundary rewrites the sortition tip memo tables down to the copied Stacks anchor, so a booting node re-processes intra-tenure descendants instead of believing them already processed.
 
### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
