### PR TITLE
chore: document and verify the rollover behavior

### DIFF
--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -4123,6 +4123,114 @@ test("stake rejects a bond rollover attempt before the bond's L1 unlock window",
 });
 
 /**
+ * Rollover intentionally keeps the old bond's final-cycle shares (L1 parity).
+ *
+ * A bond → STX-only `stake` rollover only opens in the bond's *final* active
+ * cycle: `verify-bond-rollover-window` gates it behind
+ * `get-bond-l1-unlock-height` (the midpoint of the bond's last cycle) and
+ * `bond-overlaps-new-position?` forces the new stake to start the next cycle.
+ * By design the rollover does NOT tear down the old bond's per-cycle shares or
+ * signer delegation (unlike `unstake-sbtc` / `update-bond-registration`). The
+ * old bond keeps earning its final-cycle reward and the new position starts
+ * the following cycle. The collateral, meanwhile, is released at this same
+ * height (sBTC is refunded here, native STX drops to the new lock amount).
+ */
+test('stake rollover intentionally preserves the old bond final-cycle shares (L1 parity)', () => {
+  const signer = testSigner.identifier;
+  const stxValueRatio = 10000000n;
+  const minUstxRatio = 1000n;
+  const sbtcAmount = 5000000n;
+  // With these ratios the bond's *minimum* STX is 50k, but the bond is
+  // registered with 80k (over-collateralized is allowed: amount-ustx >= min).
+  const bondAmount = stxToUStx(80_000);
+  const stakeAmount = stxToUStx(50_000);
+  expect(
+    rov(pox5.minUstxForSatsAmount(sbtcAmount, stxValueRatio, minUstxRatio)),
+  ).toBe(stxToUStx(50_000));
+  registerSigner({ caller: deployer });
+
+  txOk(
+    pox5.setupBond({
+      bondIndex: 0n,
+      targetRate: 300n,
+      stxValueRatio,
+      minUstxRatio,
+      earlyUnlockBytes: new Uint8Array(),
+      allowlist: [{ maxSats: sbtcAmount, staker: alice }],
+    }),
+    deployer,
+  );
+  // Register directly so we can lock 80k STX (more than the 50k minimum).
+  txOk(
+    pox5.registerForBond({
+      bondIndex: 0n,
+      signerManager: signer,
+      amountUstx: bondAmount,
+      btcLockup: err(sbtcAmount),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+
+  // Bond 0 runs cycles [1, 13); its last active cycle is 12. The L1 unlock
+  // height is the midpoint of cycle 12, so the rollover opens while cycle 12
+  // is still active. The bond delegates the full 80k and stakes 5M sats there.
+  const lastBondCycle = 12n;
+  mineUntil(rov(pox5.getBondL1UnlockHeight(0n)));
+  expect(rov(pox5.currentPoxRewardCycle())).toBe(lastBondCycle);
+  expect(rov(pox5.getBondMembership(alice))).not.toBeNull();
+  expect(rov(pox5.getAmountDelegatedForSigner(signer, lastBondCycle))).toBe(
+    bondAmount,
+  );
+  expect(rov(pox5.getTotalSharesStakedForCycle(lastBondCycle, 0n))).toBe(
+    sbtcAmount,
+  );
+  expect(rov(pox5.getTotalSbtcStaked())).toBe(sbtcAmount);
+
+  // Roll the bond into a 50k STX-only stake -- accepted.
+  const stakeResult = txOk(
+    pox5.stake({
+      signerManager: signer,
+      amountUstx: stakeAmount,
+      numCycles: 4n,
+      startBurnHt: simnet.burnBlockHeight,
+      signerCalldata: null,
+    }),
+    alice,
+  );
+  expect(stakeResult.value).toMatchObject({
+    staker: alice,
+    amountUstx: stakeAmount,
+    firstRewardCycle: lastBondCycle + 1n,
+  });
+
+  // The bond's sBTC custody is fully refunded (the contract no longer holds
+  // any of Alice's collateral) and the new stake records only 50k.
+  expect(rov(pox5.getTotalSbtcStaked())).toBe(0n);
+  expect(rov(pox5.getBondMembership(alice))).toBeNull();
+  expect(rov(pox5.getStakerInfo(alice))!.amountUstx).toBe(stakeAmount);
+
+  // The old bond's final cycle (12) intentionally keeps its full
+  // delegation (80k) and reward shares (5M sats), exactly as an L1 bond would
+  // after its timelock expires at this same height.
+  expect(rov(pox5.getAmountDelegatedForSigner(signer, lastBondCycle))).toBe(
+    bondAmount,
+  );
+  expect(rov(pox5.getTotalSharesStakedForCycle(lastBondCycle, 0n))).toBe(
+    sbtcAmount,
+  );
+
+  // The new stake's own cycle (13) delegates the lower 50k and carries no bond
+  // shares -- the positions don't overlap, so there's no double-counting.
+  expect(
+    rov(pox5.getAmountDelegatedForSigner(signer, lastBondCycle + 1n)),
+  ).toBe(stakeAmount);
+  expect(rov(pox5.getTotalSharesStakedForCycle(lastBondCycle + 1n, 0n))).toBe(
+    0n,
+  );
+});
+
+/**
  * Anti-stuck-collateral analog of the `register-for-bond after old bond
  * expires nets sBTC forward` regression, but via `stake`: after a bond
  * expires naturally, calling `stake` rolls the staker out of the bond,

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -763,6 +763,9 @@
         (map-set protocol-bonds-total-staked bond-index
             (+ current-total-staked sats-total)
         )
+        ;; A roll-over from an ending bond ADDS the new bond's shares but does
+        ;; NOT tear down the old bond's per-cycle shares/delegation (unlike
+        ;; `update-bond-registration`, which removes then re-adds).
         (try! (add-staker-to-bond-cycles tx-sender signer bond-index first-reward-cycle
             BOND_LENGTH_CYCLES sats-total
         ))
@@ -1037,8 +1040,8 @@
 
         ;; If this was a roll-over from a bond, clear the bond membership so
         ;; `unstake-sbtc` / `update-bond-registration` can no longer reach
-        ;; the old bond. The old bond's reward shares stay through its term;
-        ;; only the management pointer is gone.
+        ;; the old bond. The old bond's reward shares and signer delegation
+        ;; stay through its term; only the management pointer is gone.
         (map-delete protocol-bond-memberships tx-sender)
 
         (let ((result {


### PR DESCRIPTION
This behavior at rollover time has been flagged multiple times by reviewers, so this PR just adds some comments to clarify the intention and another test to verify the behavior. The issue is that when rolling over (bond->bond or stx-only->bond or bond->stx-only), the action is allowed during the last half of the last cycle (the same timing as the L1 unlock), but the rewards for that last cycle are unaffected.