### PR TITLE
feat: snapshot copy of canonical burnchain DB

### DIFF
--- a/changelog.d/marf-snapshot-burnchain.added
+++ b/changelog.d/marf-snapshot-burnchain.added
@@ -1,0 +1,1 @@
+Add snapshot copy of canonical burnchain.sqlite tables into squashed output, using the squashed sortition DB as the canonical set.

--- a/stackslib/src/burnchains/db.rs
+++ b/stackslib/src/burnchains/db.rs
@@ -965,14 +965,15 @@ impl BurnchainDB {
         )
         .map_err(DBError::from)
     }
+}
 
-    // Raw-row test fixture writers. Each helper owns its table's column
-    // list so fixtures can't drift from the schema; values are raw
-    // TEXT/ints because fixtures use readable labels, not valid hashes
-    // (which the typed write paths would reject).
-
+// Raw-row test fixture writers. Each helper owns its table's column
+// list so fixtures can't drift from the schema; values are raw
+// TEXT/ints because fixtures use readable labels, not valid hashes
+// (which the typed write paths would reject).
+#[cfg(test)]
+impl BurnchainDB {
     /// Insert a `burnchain_db_block_headers` row with no transactions.
-    #[cfg(test)]
     pub fn test_insert_block_header_row(
         conn: &Connection,
         block_height: u64,
@@ -989,7 +990,6 @@ impl BurnchainDB {
     }
 
     /// Insert a `burnchain_db_block_ops` row with an opaque op payload.
-    #[cfg(test)]
     pub fn test_insert_block_ops_row(
         conn: &Connection,
         block_hash: &str,
@@ -1004,7 +1004,6 @@ impl BurnchainDB {
     }
 
     /// Insert a minimal `block_commit_metadata` row.
-    #[cfg(test)]
     pub fn test_insert_block_commit_metadata_row(
         conn: &Connection,
         burn_block_hash: &str,
@@ -1028,7 +1027,6 @@ impl BurnchainDB {
     }
 
     /// Insert an `anchor_blocks` row.
-    #[cfg(test)]
     pub fn test_insert_anchor_block_row(
         conn: &Connection,
         reward_cycle: u64,
@@ -1041,7 +1039,6 @@ impl BurnchainDB {
     }
 
     /// Insert an `overrides` row.
-    #[cfg(test)]
     pub fn test_insert_override_row(
         conn: &Connection,
         reward_cycle: u64,
@@ -1053,7 +1050,9 @@ impl BurnchainDB {
         )?;
         Ok(())
     }
+}
 
+impl BurnchainDB {
     // do NOT call directly; only call directly in tests.
     // This is only `pub` because the tests for it live in a different file.
     pub fn store_new_burnchain_block_ops_unchecked(

--- a/stackslib/src/burnchains/db.rs
+++ b/stackslib/src/burnchains/db.rs
@@ -945,6 +945,115 @@ impl BurnchainDB {
         }
     }
 
+    /// Count the burn header hashes yielded by `canonical_sql` (a SELECT
+    /// producing one TEXT column) that have no `burnchain_db_block_headers`
+    /// row in `headers_schema`. Both arguments are interpolated into SQL;
+    /// pass only trusted fixed fragments.
+    pub(crate) fn count_canonical_burn_hashes_missing_from(
+        conn: &Connection,
+        headers_schema: &str,
+        canonical_sql: &str,
+    ) -> Result<u64, DBError> {
+        conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM ({canonical_sql}) \
+                 WHERE burn_header_hash NOT IN \
+                     (SELECT block_hash FROM {headers_schema}.burnchain_db_block_headers)"
+            ),
+            NO_PARAMS,
+            |row| row.get(0),
+        )
+        .map_err(DBError::from)
+    }
+
+    // Raw-row test fixture writers. Each helper owns its table's column
+    // list so fixtures can't drift from the schema; values are raw
+    // TEXT/ints because fixtures use readable labels, not valid hashes
+    // (which the typed write paths would reject).
+
+    /// Insert a `burnchain_db_block_headers` row with no transactions.
+    #[cfg(test)]
+    pub fn test_insert_block_header_row(
+        conn: &Connection,
+        block_height: u64,
+        block_hash: &str,
+        parent_block_hash: &str,
+    ) -> Result<(), DBError> {
+        conn.execute(
+            "INSERT INTO burnchain_db_block_headers \
+             (block_height, block_hash, parent_block_hash, num_txs, timestamp) \
+             VALUES (?1, ?2, ?3, 0, 0)",
+            params![u64_to_sql(block_height)?, block_hash, parent_block_hash],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a `burnchain_db_block_ops` row with an opaque op payload.
+    #[cfg(test)]
+    pub fn test_insert_block_ops_row(
+        conn: &Connection,
+        block_hash: &str,
+        op: &str,
+        txid: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO burnchain_db_block_ops (block_hash, op, txid) VALUES (?1, ?2, ?3)",
+            params![block_hash, op, txid],
+        )?;
+        Ok(())
+    }
+
+    /// Insert a minimal `block_commit_metadata` row.
+    #[cfg(test)]
+    pub fn test_insert_block_commit_metadata_row(
+        conn: &Connection,
+        burn_block_hash: &str,
+        txid: &str,
+        block_height: u64,
+        anchor_block: Option<u64>,
+    ) -> Result<(), DBError> {
+        conn.execute(
+            "INSERT INTO block_commit_metadata \
+             (burn_block_hash, txid, block_height, vtxindex, anchor_block, \
+              anchor_block_descendant) \
+             VALUES (?1, ?2, ?3, 0, ?4, NULL)",
+            params![
+                burn_block_hash,
+                txid,
+                u64_to_sql(block_height)?,
+                opt_u64_to_sql(anchor_block)?,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Insert an `anchor_blocks` row.
+    #[cfg(test)]
+    pub fn test_insert_anchor_block_row(
+        conn: &Connection,
+        reward_cycle: u64,
+    ) -> Result<(), DBError> {
+        conn.execute(
+            "INSERT INTO anchor_blocks (reward_cycle) VALUES (?1)",
+            params![u64_to_sql(reward_cycle)?],
+        )?;
+        Ok(())
+    }
+
+    /// Insert an `overrides` row.
+    #[cfg(test)]
+    pub fn test_insert_override_row(
+        conn: &Connection,
+        reward_cycle: u64,
+        affirmation_map: &str,
+    ) -> Result<(), DBError> {
+        conn.execute(
+            "INSERT INTO overrides (reward_cycle, affirmation_map) VALUES (?1, ?2)",
+            params![u64_to_sql(reward_cycle)?, affirmation_map],
+        )?;
+        Ok(())
+    }
+
     // do NOT call directly; only call directly in tests.
     // This is only `pub` because the tests for it live in a different file.
     pub fn store_new_burnchain_block_ops_unchecked(

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4557,7 +4557,7 @@ impl SortitionDB {
     /// Get the distinct burn header hashes of all snapshots, forks included.
     /// Only on a squashed sortition DB is this exactly the canonical
     /// burnchain.
-    pub(crate) fn get_all_snapshot_burn_header_hashes(
+    pub fn get_all_snapshot_burn_header_hashes(
         conn: &Connection,
     ) -> Result<Vec<BurnchainHeaderHash>, db_error> {
         let mut stmt = conn.prepare("SELECT DISTINCT burn_header_hash FROM snapshots")?;
@@ -4568,7 +4568,7 @@ impl SortitionDB {
     /// Get the burn header hash of the snapshot with the given sortition
     /// ID, or `None` if no such snapshot exists. Returns the raw stored
     /// TEXT so callers can preserve the value byte-for-byte.
-    pub(crate) fn get_snapshot_burn_header_hash(
+    pub fn get_snapshot_burn_header_hash(
         conn: &Connection,
         sortition_id: &SortitionId,
     ) -> Result<Option<String>, db_error> {

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -4513,6 +4513,17 @@ impl SortitionDB {
         query_row(conn, qry, NO_PARAMS).map(|opt| opt.expect("CORRUPTION: No burnchain tips"))
     }
 
+    /// Get the distinct burn header hashes of all snapshots, forks included.
+    /// Only on a squashed sortition DB is this exactly the canonical
+    /// burnchain.
+    pub(crate) fn get_all_snapshot_burn_header_hashes(
+        conn: &Connection,
+    ) -> Result<Vec<BurnchainHeaderHash>, db_error> {
+        let mut stmt = conn.prepare("SELECT DISTINCT burn_header_hash FROM snapshots")?;
+        let rows = stmt.query_map(NO_PARAMS, |row| row.get(0))?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(db_error::from)
+    }
+
     /// Get the canonical burn chain tip -- the tip of the longest burn chain we know about.
     /// Break ties deterministically by ordering on burnchain block hash.
     pub fn get_canonical_chain_tip_bhh(conn: &Connection) -> Result<BurnchainHeaderHash, db_error> {

--- a/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
@@ -52,19 +52,12 @@ fn all_required_tables() -> Vec<&'static str> {
         .collect()
 }
 
-/// Every table the snapshot recognizes in a source `burnchain.sqlite`: the
-/// row-copied tables plus the schema-only ones. burnchain.sqlite is not
-/// MARF-backed, so there are no MARF infra tables to exempt.
-fn known_burnchain_tables() -> Vec<&'static str> {
-    all_required_tables()
-}
-
 /// The burnchain snapshot's source-schema guard (see [`assert_source_schema`]);
 /// `test_no_unclassified_burnchain_tables` runs it against a fresh schema.
 pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
     assert_source_schema(
         src_conn,
-        &known_burnchain_tables(),
+        &all_required_tables(),
         "burnchain DB",
         "COPIED_TABLES (to copy) or SCHEMA_ONLY_TABLES (to skip) in snapshot/burnchain.rs",
     )

--- a/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
@@ -140,7 +140,6 @@ fn populate_canonical_burn_hashes(
 /// 1. Canonical headers and ops (burn_header_hash filtered)
 /// 2. Canonical block_commit_metadata
 /// 3. anchor_blocks derived from copied commit metadata
-/// 4. overrides derived from copied anchor blocks
 pub fn copy_burnchain_db(
     src_burnchain_db_path: &str,
     dst_burnchain_db_path: &str,
@@ -180,9 +179,8 @@ pub fn copy_burnchain_db(
 }
 
 /// Build the copy specs for the burnchain DB, in dependency order:
-/// canonical headers and ops (burn-hash filtered), commit metadata,
-/// `anchor_blocks` derived from the copied commit metadata, and `overrides`
-/// derived from the copied anchor blocks.
+/// canonical headers and ops (burn-hash filtered), commit metadata, and
+/// `anchor_blocks` derived from the copied commit metadata.
 pub(super) fn burnchain_copy_specs() -> Vec<TableCopySpec> {
     let bhh = CANONICAL_BURN_HASHES_SQL;
     vec![

--- a/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
@@ -43,6 +43,10 @@ pub(super) const COPIED_TABLES: &[&str] = &[
 /// keeps the dst complete and drift-guarded without copying rows.
 pub(super) const SCHEMA_ONLY_TABLES: &[&str] = &["overrides"];
 
+/// The canonical burn-hash set staged by [`populate_canonical_burn_hashes`],
+/// as a SELECT fragment.
+const CANONICAL_BURN_HASHES_SQL: &str = "SELECT burn_header_hash FROM canonical_burn_hashes";
+
 /// Every table whose schema must exist in the squashed dst (copied + schema-only).
 fn all_required_tables() -> Vec<&'static str> {
     COPIED_TABLES
@@ -62,10 +66,6 @@ pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(
         "COPIED_TABLES (to copy) or SCHEMA_ONLY_TABLES (to skip) in snapshot/burnchain.rs",
     )
 }
-
-/// The canonical burn-hash set staged by [`populate_canonical_burn_hashes`],
-/// as a SELECT fragment.
-const CANONICAL_BURN_HASHES_SQL: &str = "SELECT burn_header_hash FROM canonical_burn_hashes";
 
 /// Row-count statistics returned by [`copy_burnchain_db`].
 #[derive(Debug, Clone)]

--- a/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
@@ -20,8 +20,8 @@ use rusqlite::{Connection, OpenFlags};
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 
 use super::common::{
-    clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
-    TableCopySpec,
+    assert_source_schema, clone_schemas_from_source, copied_rows, execute_copy_specs,
+    with_offline_write_session, TableCopySpec,
 };
 use crate::burnchains::db::BurnchainDB;
 use crate::chainstate::burn::db::sortdb::SortitionDB;
@@ -50,6 +50,24 @@ fn all_required_tables() -> Vec<&'static str> {
         .chain(SCHEMA_ONLY_TABLES)
         .copied()
         .collect()
+}
+
+/// Every table the snapshot recognizes in a source `burnchain.sqlite`: the
+/// row-copied tables plus the schema-only ones. burnchain.sqlite is not
+/// MARF-backed, so there are no MARF infra tables to exempt.
+fn known_burnchain_tables() -> Vec<&'static str> {
+    all_required_tables()
+}
+
+/// The burnchain snapshot's source-schema guard (see [`assert_source_schema`]);
+/// `test_no_unclassified_burnchain_tables` runs it against a fresh schema.
+pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
+    assert_source_schema(
+        src_conn,
+        &known_burnchain_tables(),
+        "burnchain DB",
+        "COPIED_TABLES (to copy) or SCHEMA_ONLY_TABLES (to skip) in snapshot/burnchain.rs",
+    )
 }
 
 /// The canonical burn-hash set staged by [`populate_canonical_burn_hashes`],
@@ -140,6 +158,15 @@ pub fn copy_burnchain_db(
         return Err(Error::DestinationExists(dst_burnchain_db_path.to_string()));
     }
 
+    // Reject an unrecognized source schema before any destination work.
+    let src_conn = sqlite_open(
+        src_burnchain_db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+        false,
+    )?;
+    assert_source_tables_classified(&src_conn)?;
+    drop(src_conn);
+
     if let Some(parent) = Path::new(dst_burnchain_db_path).parent() {
         fs::create_dir_all(parent)?;
     }
@@ -163,7 +190,7 @@ pub fn copy_burnchain_db(
 /// canonical headers and ops (burn-hash filtered), commit metadata,
 /// `anchor_blocks` derived from the copied commit metadata, and `overrides`
 /// derived from the copied anchor blocks.
-fn burnchain_copy_specs() -> Vec<TableCopySpec> {
+pub(super) fn burnchain_copy_specs() -> Vec<TableCopySpec> {
     let bhh = CANONICAL_BURN_HASHES_SQL;
     vec![
         TableCopySpec {

--- a/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
@@ -91,27 +91,26 @@ fn populate_canonical_burn_hashes(
 ) -> Result<(), Error> {
     conn.execute_batch(
         "CREATE TEMP TABLE canonical_burn_hashes (burn_header_hash TEXT PRIMARY KEY)",
-    )
-    .map_err(Error::SQLError)?;
+    )?;
     // A savepoint batches the inserts whether or not the session already
     // holds an open transaction (the copy session does, and
     // autocommit-per-row would be slow).
-    conn.execute_batch("SAVEPOINT canonical_burn_hashes")
-        .map_err(Error::SQLError)?;
-    let mut stmt = conn
-        .prepare("INSERT INTO canonical_burn_hashes (burn_header_hash) VALUES (?1)")
-        .map_err(Error::SQLError)?;
+    conn.execute_batch("SAVEPOINT canonical_burn_hashes")?;
+    let mut stmt =
+        conn.prepare("INSERT INTO canonical_burn_hashes (burn_header_hash) VALUES (?1)")?;
     for hash in canonical_hashes {
-        stmt.execute([hash.to_string()]).map_err(Error::SQLError)?;
+        stmt.execute([hash.to_string()])?;
     }
     drop(stmt);
-    conn.execute_batch("RELEASE canonical_burn_hashes")
-        .map_err(Error::SQLError)?;
+    conn.execute_batch("RELEASE canonical_burn_hashes")?;
     Ok(())
 }
 
 /// Copy canonical rows from source `burnchain.sqlite` into a new destination,
 /// using the squashed sortition DB as the authoritative canonical set.
+///
+/// Returns an error if a required source is missing or if the destination
+/// already exists.
 ///
 /// Preserves dependency-ordered copy:
 /// 1. Canonical headers and ops (burn_header_hash filtered)
@@ -122,21 +121,14 @@ pub fn copy_burnchain_db(
     src_burnchain_db_path: &str,
     dst_burnchain_db_path: &str,
     squashed_sortition_path: &str,
-    expected_burn_height: u32,
+    expected_burn_height: u64,
 ) -> Result<BurnchainDbCopyStats, Error> {
-    if !Path::new(src_burnchain_db_path).exists() {
-        return Err(Error::CorruptionError(format!(
-            "Source burnchain DB not found: {src_burnchain_db_path}"
-        )));
-    }
-    if !Path::new(squashed_sortition_path).exists() {
-        return Err(Error::CorruptionError(format!(
-            "Squashed sortition DB not found: {squashed_sortition_path}"
-        )));
+    if Path::new(dst_burnchain_db_path).exists() {
+        return Err(Error::DestinationExists(dst_burnchain_db_path.to_string()));
     }
 
     if let Some(parent) = Path::new(dst_burnchain_db_path).parent() {
-        fs::create_dir_all(parent).map_err(Error::IOError)?;
+        fs::create_dir_all(parent)?;
     }
 
     let sort_conn = open_squashed_sortition_db(squashed_sortition_path)?;
@@ -205,9 +197,9 @@ fn burnchain_copy_specs() -> Vec<TableCopySpec> {
 /// caller's expected burn height.
 fn assert_sortition_tip_height(
     sortition_tip_height: u64,
-    expected_burn_height: u32,
+    expected_burn_height: u64,
 ) -> Result<(), Error> {
-    if sortition_tip_height != u64::from(expected_burn_height) {
+    if sortition_tip_height != expected_burn_height {
         return Err(Error::CorruptionError(format!(
             "Sortition tip height mismatch: expected {expected_burn_height}, got {sortition_tip_height}"
         )));
@@ -238,11 +230,20 @@ fn copy_burnchain_db_inner(
 
     let results = execute_copy_specs(conn, &burnchain_copy_specs())?;
 
-    Ok(BurnchainDbCopyStats {
+    let stats = BurnchainDbCopyStats {
         block_headers_rows: copied_rows(&results, "burnchain_db_block_headers"),
         block_ops_rows: copied_rows(&results, "burnchain_db_block_ops"),
         block_commit_metadata_rows: copied_rows(&results, "block_commit_metadata"),
         anchor_blocks_rows: copied_rows(&results, "anchor_blocks"),
         overrides_rows: copied_rows(&results, "overrides"),
-    })
+    };
+    info!(
+        "Copied burnchain DB";
+        "block_headers_rows" => stats.block_headers_rows,
+        "block_ops_rows" => stats.block_ops_rows,
+        "block_commit_metadata_rows" => stats.block_commit_metadata_rows,
+        "anchor_blocks_rows" => stats.anchor_blocks_rows,
+        "overrides_rows" => stats.overrides_rows
+    );
+    Ok(stats)
 }

--- a/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
@@ -28,15 +28,29 @@ use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::stacks::index::Error;
 use crate::util_lib::db::sqlite_open;
 
-/// Tables required in all burnchain.sqlite versions.
-pub(super) const REQUIRED_TABLES: &[&str] = &[
+/// Tables copied (with canonical-filtered content) into the squashed burnchain DB.
+pub(super) const COPIED_TABLES: &[&str] = &[
     "burnchain_db_block_headers",
     "burnchain_db_block_ops",
     "block_commit_metadata",
     "anchor_blocks",
-    "overrides",
     "db_config",
 ];
+
+/// Tables the burnchain copy clones for schema fidelity but does not populate.
+/// `overrides` (reward-cycle affirmation-map overrides) is never read or written
+/// by any production path, so it is intentionally schema-only: cloning its schema
+/// keeps the dst complete and drift-guarded without copying rows.
+pub(super) const SCHEMA_ONLY_TABLES: &[&str] = &["overrides"];
+
+/// Every table whose schema must exist in the squashed dst (copied + schema-only).
+fn all_required_tables() -> Vec<&'static str> {
+    COPIED_TABLES
+        .iter()
+        .chain(SCHEMA_ONLY_TABLES)
+        .copied()
+        .collect()
+}
 
 /// The canonical burn-hash set staged by [`populate_canonical_burn_hashes`],
 /// as a SELECT fragment.
@@ -49,7 +63,6 @@ pub struct BurnchainDbCopyStats {
     pub block_ops_rows: u64,
     pub block_commit_metadata_rows: u64,
     pub anchor_blocks_rows: u64,
-    pub overrides_rows: u64,
 }
 
 /// Open a read-only connection to the squashed sortition DB.
@@ -184,12 +197,6 @@ fn burnchain_copy_specs() -> Vec<TableCopySpec> {
                  )"
             .into(),
         },
-        TableCopySpec {
-            table: "overrides",
-            source_sql: "SELECT * FROM src.overrides \
-                 WHERE reward_cycle IN (SELECT reward_cycle FROM anchor_blocks)"
-                .into(),
-        },
     ]
 }
 
@@ -211,7 +218,7 @@ fn copy_burnchain_db_inner(
     conn: &Connection,
     canonical_hashes: &[BurnchainHeaderHash],
 ) -> Result<BurnchainDbCopyStats, Error> {
-    clone_schemas_from_source(conn, REQUIRED_TABLES)?;
+    clone_schemas_from_source(conn, &all_required_tables())?;
 
     populate_canonical_burn_hashes(conn, canonical_hashes)?;
 
@@ -235,15 +242,13 @@ fn copy_burnchain_db_inner(
         block_ops_rows: copied_rows(&results, "burnchain_db_block_ops"),
         block_commit_metadata_rows: copied_rows(&results, "block_commit_metadata"),
         anchor_blocks_rows: copied_rows(&results, "anchor_blocks"),
-        overrides_rows: copied_rows(&results, "overrides"),
     };
     info!(
         "Copied burnchain DB";
         "block_headers_rows" => stats.block_headers_rows,
         "block_ops_rows" => stats.block_ops_rows,
         "block_commit_metadata_rows" => stats.block_commit_metadata_rows,
-        "anchor_blocks_rows" => stats.anchor_blocks_rows,
-        "overrides_rows" => stats.overrides_rows
+        "anchor_blocks_rows" => stats.anchor_blocks_rows
     );
     Ok(stats)
 }

--- a/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/burnchain.rs
@@ -1,0 +1,248 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fs;
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags};
+use stacks_common::types::chainstate::BurnchainHeaderHash;
+
+use super::common::{
+    clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
+    TableCopySpec,
+};
+use crate::burnchains::db::BurnchainDB;
+use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::stacks::index::Error;
+use crate::util_lib::db::sqlite_open;
+
+/// Tables required in all burnchain.sqlite versions.
+pub(super) const REQUIRED_TABLES: &[&str] = &[
+    "burnchain_db_block_headers",
+    "burnchain_db_block_ops",
+    "block_commit_metadata",
+    "anchor_blocks",
+    "overrides",
+    "db_config",
+];
+
+/// The canonical burn-hash set staged by [`populate_canonical_burn_hashes`],
+/// as a SELECT fragment.
+const CANONICAL_BURN_HASHES_SQL: &str = "SELECT burn_header_hash FROM canonical_burn_hashes";
+
+/// Row-count statistics returned by [`copy_burnchain_db`].
+#[derive(Debug, Clone)]
+pub struct BurnchainDbCopyStats {
+    pub block_headers_rows: u64,
+    pub block_ops_rows: u64,
+    pub block_commit_metadata_rows: u64,
+    pub anchor_blocks_rows: u64,
+    pub overrides_rows: u64,
+}
+
+/// Open a read-only connection to the squashed sortition DB.
+fn open_squashed_sortition_db(squashed_sortition_path: &str) -> Result<Connection, Error> {
+    sqlite_open(
+        squashed_sortition_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+        false,
+    )
+    .map_err(|e| {
+        Error::CorruptionError(format!(
+            "cannot open squashed sortition DB {squashed_sortition_path}: {e}"
+        ))
+    })
+}
+
+/// Read the canonical burn set (tip height plus all burn header hashes)
+/// from a squashed sortition DB connection via [`SortitionDB`] readers, so
+/// this module never queries sortition-owned tables directly.
+fn read_squashed_sortition_canonical_set(
+    conn: &Connection,
+) -> Result<(u64, Vec<BurnchainHeaderHash>), Error> {
+    // Panics if `snapshots` is empty; a squashed sortition DB always holds
+    // at least the genesis snapshot.
+    let tip_height = SortitionDB::get_highest_known_burn_chain_tip(conn)
+        .map_err(|e| Error::CorruptionError(format!("cannot read squashed sortition tip: {e}")))?
+        .block_height;
+    let hashes = SortitionDB::get_all_snapshot_burn_header_hashes(conn).map_err(|e| {
+        Error::CorruptionError(format!("cannot read squashed sortition snapshots: {e}"))
+    })?;
+    Ok((tip_height, hashes))
+}
+
+/// Build a temp table of the canonical burn header hashes read from the
+/// squashed sortition DB.
+fn populate_canonical_burn_hashes(
+    conn: &Connection,
+    canonical_hashes: &[BurnchainHeaderHash],
+) -> Result<(), Error> {
+    conn.execute_batch(
+        "CREATE TEMP TABLE canonical_burn_hashes (burn_header_hash TEXT PRIMARY KEY)",
+    )
+    .map_err(Error::SQLError)?;
+    // A savepoint batches the inserts whether or not the session already
+    // holds an open transaction (the copy session does, and
+    // autocommit-per-row would be slow).
+    conn.execute_batch("SAVEPOINT canonical_burn_hashes")
+        .map_err(Error::SQLError)?;
+    let mut stmt = conn
+        .prepare("INSERT INTO canonical_burn_hashes (burn_header_hash) VALUES (?1)")
+        .map_err(Error::SQLError)?;
+    for hash in canonical_hashes {
+        stmt.execute([hash.to_string()]).map_err(Error::SQLError)?;
+    }
+    drop(stmt);
+    conn.execute_batch("RELEASE canonical_burn_hashes")
+        .map_err(Error::SQLError)?;
+    Ok(())
+}
+
+/// Copy canonical rows from source `burnchain.sqlite` into a new destination,
+/// using the squashed sortition DB as the authoritative canonical set.
+///
+/// Preserves dependency-ordered copy:
+/// 1. Canonical headers and ops (burn_header_hash filtered)
+/// 2. Canonical block_commit_metadata
+/// 3. anchor_blocks derived from copied commit metadata
+/// 4. overrides derived from copied anchor blocks
+pub fn copy_burnchain_db(
+    src_burnchain_db_path: &str,
+    dst_burnchain_db_path: &str,
+    squashed_sortition_path: &str,
+    expected_burn_height: u32,
+) -> Result<BurnchainDbCopyStats, Error> {
+    if !Path::new(src_burnchain_db_path).exists() {
+        return Err(Error::CorruptionError(format!(
+            "Source burnchain DB not found: {src_burnchain_db_path}"
+        )));
+    }
+    if !Path::new(squashed_sortition_path).exists() {
+        return Err(Error::CorruptionError(format!(
+            "Squashed sortition DB not found: {squashed_sortition_path}"
+        )));
+    }
+
+    if let Some(parent) = Path::new(dst_burnchain_db_path).parent() {
+        fs::create_dir_all(parent).map_err(Error::IOError)?;
+    }
+
+    let sort_conn = open_squashed_sortition_db(squashed_sortition_path)?;
+    let (sortition_tip_height, canonical_hashes) =
+        read_squashed_sortition_canonical_set(&sort_conn)?;
+    drop(sort_conn);
+    assert_sortition_tip_height(sortition_tip_height, expected_burn_height)?;
+
+    with_offline_write_session(
+        dst_burnchain_db_path,
+        &[("src", src_burnchain_db_path)],
+        // FK off must run before BEGIN IMMEDIATE; per-connection only.
+        "PRAGMA foreign_keys = OFF;",
+        |conn| copy_burnchain_db_inner(conn, &canonical_hashes),
+    )
+}
+
+/// Build the copy specs for the burnchain DB, in dependency order:
+/// canonical headers and ops (burn-hash filtered), commit metadata,
+/// `anchor_blocks` derived from the copied commit metadata, and `overrides`
+/// derived from the copied anchor blocks.
+fn burnchain_copy_specs() -> Vec<TableCopySpec> {
+    let bhh = CANONICAL_BURN_HASHES_SQL;
+    vec![
+        TableCopySpec {
+            table: "db_config",
+            source_sql: "SELECT * FROM src.db_config".into(),
+        },
+        TableCopySpec {
+            table: "burnchain_db_block_headers",
+            source_sql: format!(
+                "SELECT * FROM src.burnchain_db_block_headers WHERE block_hash IN ({bhh})"
+            ),
+        },
+        TableCopySpec {
+            table: "burnchain_db_block_ops",
+            source_sql: format!(
+                "SELECT * FROM src.burnchain_db_block_ops WHERE block_hash IN ({bhh})"
+            ),
+        },
+        TableCopySpec {
+            table: "block_commit_metadata",
+            source_sql: format!(
+                "SELECT * FROM src.block_commit_metadata WHERE burn_block_hash IN ({bhh})"
+            ),
+        },
+        TableCopySpec {
+            table: "anchor_blocks",
+            source_sql: "SELECT * FROM src.anchor_blocks \
+                 WHERE reward_cycle IN ( \
+                     SELECT DISTINCT anchor_block FROM block_commit_metadata \
+                     WHERE anchor_block IS NOT NULL \
+                 )"
+            .into(),
+        },
+        TableCopySpec {
+            table: "overrides",
+            source_sql: "SELECT * FROM src.overrides \
+                 WHERE reward_cycle IN (SELECT reward_cycle FROM anchor_blocks)"
+                .into(),
+        },
+    ]
+}
+
+/// Consistency assertion: the squashed sortition DB's tip must match the
+/// caller's expected burn height.
+fn assert_sortition_tip_height(
+    sortition_tip_height: u64,
+    expected_burn_height: u32,
+) -> Result<(), Error> {
+    if sortition_tip_height != u64::from(expected_burn_height) {
+        return Err(Error::CorruptionError(format!(
+            "Sortition tip height mismatch: expected {expected_burn_height}, got {sortition_tip_height}"
+        )));
+    }
+    Ok(())
+}
+
+fn copy_burnchain_db_inner(
+    conn: &Connection,
+    canonical_hashes: &[BurnchainHeaderHash],
+) -> Result<BurnchainDbCopyStats, Error> {
+    clone_schemas_from_source(conn, REQUIRED_TABLES)?;
+
+    populate_canonical_burn_hashes(conn, canonical_hashes)?;
+
+    // Completeness assertion: every canonical burn hash must exist in source.
+    let missing_count = BurnchainDB::count_canonical_burn_hashes_missing_from(
+        conn,
+        "src",
+        CANONICAL_BURN_HASHES_SQL,
+    )
+    .map_err(|e| Error::CorruptionError(format!("cannot check canonical burn hashes: {e}")))?;
+    if missing_count > 0 {
+        return Err(Error::CorruptionError(format!(
+            "{missing_count} canonical burn hashes missing from source burnchain DB"
+        )));
+    }
+
+    let results = execute_copy_specs(conn, &burnchain_copy_specs())?;
+
+    Ok(BurnchainDbCopyStats {
+        block_headers_rows: copied_rows(&results, "burnchain_db_block_headers"),
+        block_ops_rows: copied_rows(&results, "burnchain_db_block_ops"),
+        block_commit_metadata_rows: copied_rows(&results, "block_commit_metadata"),
+        anchor_blocks_rows: copied_rows(&results, "anchor_blocks"),
+        overrides_rows: copied_rows(&results, "overrides"),
+    })
+}

--- a/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
@@ -24,6 +24,7 @@
 //!
 //! Detectable violations surface as `CorruptionError`s.
 
+mod burnchain;
 pub(crate) mod common;
 pub(crate) mod fork_storage;
 mod index;
@@ -31,4 +32,5 @@ mod index;
 #[cfg(test)]
 mod tests;
 
+pub use burnchain::{copy_burnchain_db, BurnchainDbCopyStats};
 pub use index::{copy_index_side_tables, IndexSideTableStats};

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
@@ -15,14 +15,16 @@
 
 //! Burnchain DB (burnchain.sqlite) copy tests.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use rusqlite::{params, Connection};
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use tempfile::tempdir;
 
-use super::super::burnchain::{copy_burnchain_db, COPIED_TABLES, SCHEMA_ONLY_TABLES};
-use super::super::common::unclassified_tables;
+use super::super::burnchain::{
+    assert_source_tables_classified, burnchain_copy_specs, copy_burnchain_db, COPIED_TABLES,
+};
 use crate::burnchains::db::BurnchainDB;
 use crate::burnchains::{Burnchain, PoxConstants};
 use crate::chainstate::burn::db::sortdb::tests::test_append_snapshot;
@@ -30,25 +32,61 @@ use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::stacks::index::Error;
 use crate::core::{StacksEpoch, StacksEpochExtension};
 
-/// Drift guard: every table the burnchain migrations create must be
-/// classified, so a future migration can't silently drop one from the copy.
+/// Drift guard: a freshly built production burnchain schema must be fully
+/// classified, so a future migration can't silently drop a table from the copy.
 #[test]
 fn test_no_unclassified_burnchain_tables() {
     let dir = tempdir().unwrap();
     let conn = create_burnchain_db(&dir.path().join("src.sqlite"));
-    // burnchain.sqlite is not MARF-backed, so unlike the other drift guards
-    // no MARF infra tables are exempted here.
-    let known: Vec<&str> = COPIED_TABLES
-        .iter()
-        .chain(SCHEMA_ONLY_TABLES)
-        .copied()
-        .collect();
-    let extra = unclassified_tables(&conn, &known);
+    assert_source_tables_classified(&conn)
+        .expect("fresh production burnchain schema must be fully classified");
+}
+
+/// A source table the copy lists don't classify is rejected before any
+/// destination is produced — the runtime complement to the drift test.
+#[test]
+fn test_unclassified_source_table_is_rejected() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    let sort_path = create_squashed_sortition(dir.path(), &[]);
+
+    let src = create_burnchain_db(&src_path);
+    src.execute_batch("CREATE TABLE surprise_table (x INTEGER)")
+        .unwrap();
+    drop(src);
+
+    let err = copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        0,
+    )
+    .expect_err("unclassified source table should error");
+    match err {
+        Error::CorruptionError(msg) => assert!(
+            msg.contains("surprise_table"),
+            "error should name the unknown table, got: {msg}"
+        ),
+        other => panic!("expected CorruptionError, got {other:?}"),
+    }
     assert!(
-        extra.is_empty(),
-        "unclassified burnchain table(s) {extra:?}: classify each in COPIED_TABLES or \
-         SCHEMA_ONLY_TABLES (snapshot/burnchain.rs)"
+        !dst_path.exists(),
+        "destination must not be produced when the source schema is rejected"
     );
+}
+
+/// Every cloned table (`COPIED_TABLES`) must have a row-copy spec and vice versa,
+/// else it would be cloned but never populated (present-but-empty).
+#[test]
+fn test_copy_specs_match_copied_tables() {
+    let copied: HashSet<&str> = COPIED_TABLES.iter().copied().collect();
+
+    let specs: Vec<&str> = burnchain_copy_specs().iter().map(|s| s.table).collect();
+    let spec_set: HashSet<&str> = specs.iter().copied().collect();
+    assert_eq!(specs.len(), spec_set.len(), "duplicate spec tables");
+    assert_eq!(spec_set, copied);
 }
 
 /// Create a burnchain.sqlite source via the production initializer

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
@@ -24,6 +24,7 @@ use crate::burnchains::db::BurnchainDB;
 use crate::burnchains::{Burnchain, PoxConstants};
 use crate::chainstate::burn::db::sortdb::tests::test_append_snapshot;
 use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::stacks::index::Error;
 use crate::core::{StacksEpoch, StacksEpochExtension};
 
 /// Drift guard: every table the burnchain migrations create must be
@@ -183,7 +184,11 @@ fn test_burnchain_db_copy() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(version, 3, "db_config copied verbatim");
+    assert_eq!(
+        version,
+        u64::from(BurnchainDB::SCHEMA_VERSION),
+        "db_config copied verbatim"
+    );
     let fork_rows: i64 = dst
         .query_row(
             "SELECT (SELECT COUNT(*) FROM burnchain_db_block_headers WHERE block_hash = 'fork_hash_1') \
@@ -194,6 +199,40 @@ fn test_burnchain_db_copy() {
         )
         .unwrap();
     assert_eq!(fork_rows, 0, "fork rows must be absent by key");
+}
+
+/// The copy writes into a NEW destination only: a pre-existing
+/// `burnchain.sqlite` (e.g. left over from a prior failed squash) is an
+/// error, never appended to or overwritten.
+#[test]
+fn test_burnchain_db_existing_destination_is_error() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    let sort_path = create_squashed_sortition(dir.path(), &[fixture_bhh(1)]);
+    let src = create_burnchain_db(&src_path);
+    drop(src);
+
+    // A stale destination left over from a prior run must not be touched.
+    std::fs::write(&dst_path, b"stale data").unwrap();
+
+    let err = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        1,
+    )
+    .expect_err("existing destination should error");
+    assert!(
+        matches!(err, Error::DestinationExists(_)),
+        "expected DestinationExists, got {err:?}"
+    );
+    assert_eq!(
+        std::fs::read(&dst_path).unwrap(),
+        b"stale data",
+        "existing destination must be left untouched"
+    );
 }
 
 /// Two headers at the same height: only the one whose hash is in the

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
@@ -15,10 +15,13 @@
 
 //! Burnchain DB (burnchain.sqlite) copy tests.
 
+use std::path::Path;
+
 use rusqlite::{params, Connection};
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use tempfile::tempdir;
 
+use super::super::burnchain::{copy_burnchain_db, COPIED_TABLES, SCHEMA_ONLY_TABLES};
 use super::super::common::unclassified_tables;
 use crate::burnchains::db::BurnchainDB;
 use crate::burnchains::{Burnchain, PoxConstants};
@@ -35,11 +38,16 @@ fn test_no_unclassified_burnchain_tables() {
     let conn = create_burnchain_db(&dir.path().join("src.sqlite"));
     // burnchain.sqlite is not MARF-backed, so unlike the other drift guards
     // no MARF infra tables are exempted here.
-    let extra = unclassified_tables(&conn, super::super::burnchain::REQUIRED_TABLES);
+    let known: Vec<&str> = COPIED_TABLES
+        .iter()
+        .chain(SCHEMA_ONLY_TABLES)
+        .copied()
+        .collect();
+    let extra = unclassified_tables(&conn, &known);
     assert!(
         extra.is_empty(),
-        "unclassified burnchain table(s) {extra:?}: classify each in REQUIRED_TABLES \
-         (snapshot/burnchain.rs)"
+        "unclassified burnchain table(s) {extra:?}: classify each in COPIED_TABLES or \
+         SCHEMA_ONLY_TABLES (snapshot/burnchain.rs)"
     );
 }
 
@@ -47,7 +55,7 @@ fn test_no_unclassified_burnchain_tables() {
 /// ([`BurnchainDB::connect`]), so the fixture always carries the current
 /// schema instead of replaying migrations by hand. `connect` also seeds
 /// the regtest first-block header.
-fn create_burnchain_db(path: &std::path::Path) -> Connection {
+fn create_burnchain_db(path: &Path) -> Connection {
     let burnchain = Burnchain::regtest(":memory:");
     let _db = BurnchainDB::connect(path.to_str().unwrap(), &burnchain, true)
         .expect("burnchain DB init failed");
@@ -67,10 +75,7 @@ fn fixture_bhh(i: u8) -> BurnchainHeaderHash {
 /// cannot drift from what production actually writes: a real sortition DB
 /// whose canonical chain is the genesis snapshot ([`GENESIS_BHH`] at height
 /// 0) followed by `hashes` at heights 1... Returns its sqlite path.
-fn create_squashed_sortition(
-    dir: &std::path::Path,
-    hashes: &[BurnchainHeaderHash],
-) -> std::path::PathBuf {
+fn create_squashed_sortition(dir: &Path, hashes: &[BurnchainHeaderHash]) -> std::path::PathBuf {
     let db_dir = dir.join("sortition");
     let mut db = SortitionDB::connect(
         db_dir.to_str().unwrap(),
@@ -126,7 +131,7 @@ fn test_burnchain_db_copy() {
         .unwrap();
     drop(src);
 
-    let stats = super::super::burnchain::copy_burnchain_db(
+    let stats = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -217,7 +222,7 @@ fn test_burnchain_db_existing_destination_is_error() {
     // A stale destination left over from a prior run must not be touched.
     std::fs::write(&dst_path, b"stale data").unwrap();
 
-    let err = super::super::burnchain::copy_burnchain_db(
+    let err = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -259,7 +264,7 @@ fn test_burnchain_db_excludes_non_canonical_fork() {
     BurnchainDB::test_insert_block_header_row(&src, 1, "hash_b", "parent_b").unwrap();
     drop(src);
 
-    let stats = super::super::burnchain::copy_burnchain_db(
+    let stats = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -299,7 +304,7 @@ fn test_burnchain_db_block_ops_follow_canonical_headers() {
     BurnchainDB::test_insert_block_ops_row(&src, "fork", "op_f", "tx_f").unwrap();
     drop(src);
 
-    let stats = super::super::burnchain::copy_burnchain_db(
+    let stats = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -343,7 +348,7 @@ fn test_burnchain_db_anchor_blocks_filtered() {
     BurnchainDB::test_insert_override_row(&src, 99, "map_99").unwrap();
     drop(src);
 
-    let stats = super::super::burnchain::copy_burnchain_db(
+    let stats = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -352,26 +357,26 @@ fn test_burnchain_db_anchor_blocks_filtered() {
     .unwrap();
 
     assert_eq!(stats.anchor_blocks_rows, 1);
-    assert_eq!(stats.overrides_rows, 1);
 
     let dst = Connection::open(&dst_path).unwrap();
     let cycle: i64 = dst
         .query_row("SELECT reward_cycle FROM anchor_blocks", [], |r| r.get(0))
         .unwrap();
     assert_eq!(cycle, 1);
-    let override_map: String = dst
-        .query_row("SELECT affirmation_map FROM overrides", [], |r| r.get(0))
+    // `overrides` is schema-only: the table exists in the dst, but no rows are
+    // copied -- not even for a canonical reward cycle.
+    let override_rows: i64 = dst
+        .query_row("SELECT COUNT(*) FROM overrides", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(override_map, "map_1");
-    let cycle99: i64 = dst
+    assert_eq!(override_rows, 0, "overrides must not be row-copied");
+    let anchor99: i64 = dst
         .query_row(
-            "SELECT (SELECT COUNT(*) FROM anchor_blocks WHERE reward_cycle = 99) \
-             + (SELECT COUNT(*) FROM overrides WHERE reward_cycle = 99)",
+            "SELECT COUNT(*) FROM anchor_blocks WHERE reward_cycle = 99",
             [],
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(cycle99, 0, "unreferenced cycle must not be copied");
+    assert_eq!(anchor99, 0, "unreferenced anchor block must not be copied");
 }
 
 /// A missing source burnchain.sqlite is an error, and the read-only
@@ -384,7 +389,7 @@ fn test_burnchain_db_missing_source_is_error() {
 
     let sort_path = create_squashed_sortition(dir.path(), &[]);
 
-    let result = super::super::burnchain::copy_burnchain_db(
+    let result = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -414,7 +419,7 @@ fn test_burnchain_db_sortition_tip_mismatch_is_error() {
     drop(src);
 
     // Pass expected_burn_height=10, but sortition tip is 5.
-    let result = super::super::burnchain::copy_burnchain_db(
+    let result = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -441,7 +446,7 @@ fn test_burnchain_db_fresh_output_dir() {
     BurnchainDB::test_insert_block_header_row(&src, 0, &GENESIS_BHH.to_string(), "none").unwrap();
     drop(src);
 
-    let stats = super::super::burnchain::copy_burnchain_db(
+    let stats = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),
@@ -476,7 +481,7 @@ fn test_burnchain_db_copy_fails_when_source_missing_canonical_hash() {
     .unwrap();
     drop(src);
 
-    let result = super::super::burnchain::copy_burnchain_db(
+    let result = copy_burnchain_db(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         sort_path.to_str().unwrap(),

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/burnchain.rs
@@ -1,0 +1,450 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Burnchain DB (burnchain.sqlite) copy tests.
+
+use rusqlite::{params, Connection};
+use stacks_common::types::chainstate::BurnchainHeaderHash;
+use tempfile::tempdir;
+
+use super::super::common::unclassified_tables;
+use crate::burnchains::db::BurnchainDB;
+use crate::burnchains::{Burnchain, PoxConstants};
+use crate::chainstate::burn::db::sortdb::tests::test_append_snapshot;
+use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::core::{StacksEpoch, StacksEpochExtension};
+
+/// Drift guard: every table the burnchain migrations create must be
+/// classified, so a future migration can't silently drop one from the copy.
+#[test]
+fn test_no_unclassified_burnchain_tables() {
+    let dir = tempdir().unwrap();
+    let conn = create_burnchain_db(&dir.path().join("src.sqlite"));
+    // burnchain.sqlite is not MARF-backed, so unlike the other drift guards
+    // no MARF infra tables are exempted here.
+    let extra = unclassified_tables(&conn, super::super::burnchain::REQUIRED_TABLES);
+    assert!(
+        extra.is_empty(),
+        "unclassified burnchain table(s) {extra:?}: classify each in REQUIRED_TABLES \
+         (snapshot/burnchain.rs)"
+    );
+}
+
+/// Create a burnchain.sqlite source via the production initializer
+/// ([`BurnchainDB::connect`]), so the fixture always carries the current
+/// schema instead of replaying migrations by hand. `connect` also seeds
+/// the regtest first-block header.
+fn create_burnchain_db(path: &std::path::Path) -> Connection {
+    let burnchain = Burnchain::regtest(":memory:");
+    let _db = BurnchainDB::connect(path.to_str().unwrap(), &burnchain, true)
+        .expect("burnchain DB init failed");
+    Connection::open(path).unwrap()
+}
+
+/// Burn header hash of the squashed-sortition fixture's genesis snapshot.
+const GENESIS_BHH: BurnchainHeaderHash = BurnchainHeaderHash([0u8; 32]);
+
+/// A distinct burn header hash for fixture block `i`.
+fn fixture_bhh(i: u8) -> BurnchainHeaderHash {
+    BurnchainHeaderHash([i; 32])
+}
+
+/// Create a squashed-sortition stand-in through production write paths
+/// ([`SortitionDB::connect`] + [`test_append_snapshot`]), so the fixture
+/// cannot drift from what production actually writes: a real sortition DB
+/// whose canonical chain is the genesis snapshot ([`GENESIS_BHH`] at height
+/// 0) followed by `hashes` at heights 1... Returns its sqlite path.
+fn create_squashed_sortition(
+    dir: &std::path::Path,
+    hashes: &[BurnchainHeaderHash],
+) -> std::path::PathBuf {
+    let db_dir = dir.join("sortition");
+    let mut db = SortitionDB::connect(
+        db_dir.to_str().unwrap(),
+        0,
+        &GENESIS_BHH,
+        0,
+        &StacksEpoch::unit_test_3_4(0),
+        PoxConstants::test_default(),
+        None,
+        true,
+        None,
+    )
+    .expect("sortition DB init failed");
+    for hash in hashes {
+        test_append_snapshot(&mut db, hash.clone(), &[]);
+    }
+    db_dir.join("marf.sqlite")
+}
+
+/// End-to-end burnchain copy: canonical headers, ops, and commit
+/// metadata are copied verbatim; fork rows are dropped.
+#[test]
+fn test_burnchain_db_copy() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src_burnchain.sqlite");
+    let dst_path = dir.path().join("dst_burnchain.sqlite");
+
+    // Canonical hashes at heights 0, 1, 2.
+    let canonical = [GENESIS_BHH, fixture_bhh(1), fixture_bhh(2)];
+    let sort_path = create_squashed_sortition(dir.path(), &canonical[1..]);
+    let hash_1 = fixture_bhh(1).to_string();
+
+    let src = create_burnchain_db(&src_path);
+    // Insert canonical block headers.
+    for (h, hash) in canonical.iter().enumerate() {
+        BurnchainDB::test_insert_block_header_row(
+            &src,
+            h as u64,
+            &hash.to_string(),
+            &format!("parent_{hash}"),
+        )
+        .unwrap();
+    }
+    // Insert a non-canonical block at height 1.
+    BurnchainDB::test_insert_block_header_row(&src, 1, "fork_hash_1", "parent_fork").unwrap();
+    // Ops for canonical and non-canonical.
+    BurnchainDB::test_insert_block_ops_row(&src, &hash_1, "op1", "tx1").unwrap();
+    BurnchainDB::test_insert_block_ops_row(&src, "fork_hash_1", "op_fork", "tx_fork").unwrap();
+    // block_commit_metadata for canonical.
+    BurnchainDB::test_insert_block_commit_metadata_row(&src, &hash_1, "tx1", 1, None).unwrap();
+    // block_commit_metadata for non-canonical.
+    BurnchainDB::test_insert_block_commit_metadata_row(&src, "fork_hash_1", "tx_fork", 1, None)
+        .unwrap();
+    drop(src);
+
+    let stats = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        2,
+    )
+    .unwrap();
+
+    assert_eq!(stats.block_headers_rows, 3); // 3 canonical
+    assert_eq!(stats.block_ops_rows, 1); // only fixture_bhh(1)'s op
+    assert_eq!(stats.block_commit_metadata_rows, 1); // only canonical
+
+    // Copied rows carry their full source content, and the fork rows are
+    // absent by key.
+    let dst = Connection::open(&dst_path).unwrap();
+    let header: (u64, String, String, u64, u64) = dst
+        .query_row(
+            "SELECT block_height, block_hash, parent_block_hash, num_txs, timestamp \
+             FROM burnchain_db_block_headers WHERE block_hash = ?1",
+            params![hash_1],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        header,
+        (1, hash_1.clone(), format!("parent_{hash_1}"), 0, 0)
+    );
+    let op: (String, String, String) = dst
+        .query_row(
+            "SELECT block_hash, op, txid FROM burnchain_db_block_ops",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(op, (hash_1.clone(), "op1".into(), "tx1".into()));
+    let commit: (String, String, u64, u64) = dst
+        .query_row(
+            "SELECT burn_block_hash, txid, block_height, vtxindex FROM block_commit_metadata",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(commit, (hash_1.clone(), "tx1".into(), 1, 0));
+    let version: u64 = dst
+        .query_row(
+            "SELECT MAX(CAST(version AS INTEGER)) FROM db_config",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(version, 3, "db_config copied verbatim");
+    let fork_rows: i64 = dst
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM burnchain_db_block_headers WHERE block_hash = 'fork_hash_1') \
+             + (SELECT COUNT(*) FROM burnchain_db_block_ops WHERE block_hash = 'fork_hash_1') \
+             + (SELECT COUNT(*) FROM block_commit_metadata WHERE burn_block_hash = 'fork_hash_1')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(fork_rows, 0, "fork rows must be absent by key");
+}
+
+/// Two headers at the same height: only the one whose hash is in the
+/// squashed sortition snapshots is copied.
+#[test]
+fn test_burnchain_db_excludes_non_canonical_fork() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    // Only fixture_bhh(0xa1) is canonical at height 1.
+    let hash_a = fixture_bhh(0xa1);
+    let sort_path = create_squashed_sortition(dir.path(), &[hash_a.clone()]);
+
+    let src = create_burnchain_db(&src_path);
+    BurnchainDB::test_insert_block_header_row(&src, 0, &GENESIS_BHH.to_string(), "none").unwrap();
+    BurnchainDB::test_insert_block_header_row(
+        &src,
+        1,
+        &hash_a.to_string(),
+        &GENESIS_BHH.to_string(),
+    )
+    .unwrap();
+    BurnchainDB::test_insert_block_header_row(&src, 1, "hash_b", "parent_b").unwrap();
+    drop(src);
+
+    let stats = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(stats.block_headers_rows, 2); // genesis + hash_a, not hash_b
+
+    // Verify hash_b is not in destination.
+    let dst = Connection::open(&dst_path).unwrap();
+    let count: i64 = dst
+        .query_row(
+            "SELECT COUNT(*) FROM burnchain_db_block_headers WHERE block_hash = 'hash_b'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
+/// Block ops follow their header's canonicality: ops of a fork header
+/// are dropped.
+#[test]
+fn test_burnchain_db_block_ops_follow_canonical_headers() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    // Only the genesis snapshot is canonical.
+    let sort_path = create_squashed_sortition(dir.path(), &[]);
+
+    let src = create_burnchain_db(&src_path);
+    BurnchainDB::test_insert_block_header_row(&src, 0, &GENESIS_BHH.to_string(), "none").unwrap();
+    BurnchainDB::test_insert_block_header_row(&src, 0, "fork", "none").unwrap();
+    BurnchainDB::test_insert_block_ops_row(&src, &GENESIS_BHH.to_string(), "op_c", "tx_c").unwrap();
+    BurnchainDB::test_insert_block_ops_row(&src, "fork", "op_f", "tx_f").unwrap();
+    drop(src);
+
+    let stats = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(stats.block_ops_rows, 1);
+
+    let dst = Connection::open(&dst_path).unwrap();
+    let op: String = dst
+        .query_row("SELECT op FROM burnchain_db_block_ops", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(op, "op_c");
+}
+
+/// `anchor_blocks` and `overrides` are restricted to reward cycles
+/// referenced by the copied commit metadata.
+#[test]
+fn test_burnchain_db_anchor_blocks_filtered() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    let h1 = fixture_bhh(1);
+    let sort_path = create_squashed_sortition(dir.path(), &[h1.clone()]);
+
+    let src = create_burnchain_db(&src_path);
+    BurnchainDB::test_insert_block_header_row(&src, 0, &GENESIS_BHH.to_string(), "none").unwrap();
+    BurnchainDB::test_insert_block_header_row(&src, 1, &h1.to_string(), &GENESIS_BHH.to_string())
+        .unwrap();
+    // Anchor block for cycle 1 (referenced by canonical commit).
+    BurnchainDB::test_insert_anchor_block_row(&src, 1).unwrap();
+    // Anchor block for cycle 99 (not referenced by any canonical commit).
+    BurnchainDB::test_insert_anchor_block_row(&src, 99).unwrap();
+    // Canonical commit referencing anchor block cycle 1.
+    BurnchainDB::test_insert_block_commit_metadata_row(&src, &h1.to_string(), "tx_a", 1, Some(1))
+        .unwrap();
+    // Override for cycle 1 (should be copied) and cycle 99 (should not).
+    BurnchainDB::test_insert_override_row(&src, 1, "map_1").unwrap();
+    BurnchainDB::test_insert_override_row(&src, 99, "map_99").unwrap();
+    drop(src);
+
+    let stats = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(stats.anchor_blocks_rows, 1);
+    assert_eq!(stats.overrides_rows, 1);
+
+    let dst = Connection::open(&dst_path).unwrap();
+    let cycle: i64 = dst
+        .query_row("SELECT reward_cycle FROM anchor_blocks", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(cycle, 1);
+    let override_map: String = dst
+        .query_row("SELECT affirmation_map FROM overrides", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(override_map, "map_1");
+    let cycle99: i64 = dst
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM anchor_blocks WHERE reward_cycle = 99) \
+             + (SELECT COUNT(*) FROM overrides WHERE reward_cycle = 99)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(cycle99, 0, "unreferenced cycle must not be copied");
+}
+
+/// A missing source burnchain.sqlite is an error, and the read-only
+/// ATTACH must not create the source file as a side effect.
+#[test]
+fn test_burnchain_db_missing_source_is_error() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("nonexistent.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    let sort_path = create_squashed_sortition(dir.path(), &[]);
+
+    let result = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        0,
+    );
+    assert!(result.is_err(), "missing source should error");
+    assert!(
+        !src_path.exists(),
+        "missing source must not be created by ATTACH"
+    );
+}
+
+/// A sortition tip height that disagrees with the caller's expected burn
+/// height is corruption: the copy must abort.
+#[test]
+fn test_burnchain_db_sortition_tip_mismatch_is_error() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    // Sortition tip is at height 5.
+    let hashes: Vec<_> = (1..=5).map(fixture_bhh).collect();
+    let sort_path = create_squashed_sortition(dir.path(), &hashes);
+
+    let src = create_burnchain_db(&src_path);
+    BurnchainDB::test_insert_block_header_row(&src, 0, &GENESIS_BHH.to_string(), "none").unwrap();
+    drop(src);
+
+    // Pass expected_burn_height=10, but sortition tip is 5.
+    let result = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        10,
+    );
+    assert!(result.is_err(), "should fail on sortition tip mismatch");
+}
+
+/// The copy creates missing parent directories for the destination path.
+#[test]
+fn test_burnchain_db_fresh_output_dir() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    // Nested non-existent directory.
+    let dst_path = dir
+        .path()
+        .join("deep")
+        .join("nested")
+        .join("burnchain.sqlite");
+
+    let sort_path = create_squashed_sortition(dir.path(), &[]);
+
+    let src = create_burnchain_db(&src_path);
+    BurnchainDB::test_insert_block_header_row(&src, 0, &GENESIS_BHH.to_string(), "none").unwrap();
+    drop(src);
+
+    let stats = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(stats.block_headers_rows, 1);
+    assert!(dst_path.exists());
+}
+
+/// A canonical burn hash absent from the source headers is corruption:
+/// the copy must abort.
+#[test]
+fn test_burnchain_db_copy_fails_when_source_missing_canonical_hash() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    // Sortition says heights 0, 1, 2 are canonical.
+    let sort_path = create_squashed_sortition(dir.path(), &[fixture_bhh(1), fixture_bhh(2)]);
+
+    // But source burnchain.sqlite only has heights 0 and 1 - 2 is missing.
+    let src = create_burnchain_db(&src_path);
+    BurnchainDB::test_insert_block_header_row(&src, 0, &GENESIS_BHH.to_string(), "none").unwrap();
+    BurnchainDB::test_insert_block_header_row(
+        &src,
+        1,
+        &fixture_bhh(1).to_string(),
+        &GENESIS_BHH.to_string(),
+    )
+    .unwrap();
+    drop(src);
+
+    let result = super::super::burnchain::copy_burnchain_db(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        sort_path.to_str().unwrap(),
+        2,
+    );
+    assert!(
+        result.is_err(),
+        "should fail when source is missing a canonical burn hash"
+    );
+}

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/index.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/index.rs
@@ -28,8 +28,7 @@ use super::{
     create_source_db, hex_id, insert_epoch2_block_header, insert_nakamoto_header, label_block_id,
     FIXTURE_LEAF,
 };
-use crate::chainstate::nakamoto::{NakamotoBlockHeader, NakamotoChainState};
-use crate::chainstate::stacks::db::{StacksHeaderInfo, CHAINSTATE_VERSION};
+use crate::chainstate::stacks::db::CHAINSTATE_VERSION;
 use crate::chainstate::stacks::index::{Error, MARFValue};
 
 /// Insert a payment row at the given height.

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
@@ -16,7 +16,7 @@
 use std::collections::HashSet;
 
 // `::clarity` disambiguates the crate from a sibling `clarity` test module.
-use clarity::vm::costs::ExecutionCost;
+use ::clarity::vm::costs::ExecutionCost;
 use rstest::rstest;
 use rusqlite::{params, Connection};
 use stacks_common::types::chainstate::{

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
@@ -24,6 +24,7 @@ use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
 
+mod burnchain;
 mod index;
 
 /// Create a source `index.sqlite`


### PR DESCRIPTION
### Description

Adds the snapshot copy of burnchain.sqlite: only rows belonging to the canonical burn chain are copied into the squashed artifact.

The canonical set is read from the already-squashed sortition DB through SortitionDB-owned readers (tip height + all snapshot burn hashes), so this phase runs after the sortition copy in the squash pipeline. Tables are copied in dependency order. headers and ops (hash filtered), block_commit_metadata, then anchor_blocks/overrides restricted to reward cycles referenced by the copied commits. 

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
