### PR TITLE
feat: snapshot copy of SPV headers DB

### DIFF
--- a/changelog.d/marf-snapshot-spv.added
+++ b/changelog.d/marf-snapshot-spv.added
@@ -1,0 +1,1 @@
+Add snapshot copy of Bitcoin SPV headers and complete chain-work intervals up to the squash height into squashed output.

--- a/stackslib/src/burnchains/bitcoin/spv.rs
+++ b/stackslib/src/burnchains/bitcoin/spv.rs
@@ -58,7 +58,7 @@ const BLOCK_DIFFICULTY_INTERVAL: u32 = 14 * 24 * 60 * 60; // two weeks, in secon
 /// is complete iff its last header height,
 /// `(k + 1) * BLOCK_DIFFICULTY_CHUNK_SIZE - 1`, is at or below
 /// `burn_height`.
-pub(crate) fn num_complete_chain_work_intervals(burn_height: u64) -> u64 {
+pub fn num_complete_chain_work_intervals(burn_height: u64) -> u64 {
     burn_height.saturating_add(1) / BLOCK_DIFFICULTY_CHUNK_SIZE
 }
 
@@ -751,7 +751,7 @@ impl SpvClient {
         header: BlockHeader,
         height: u64,
     ) -> Result<(), btc_error> {
-        let sql = "INSERT OR REPLACE INTO headers 
+        let sql = "INSERT OR REPLACE INTO headers
         (version, prev_blockhash, merkle_root, time, bits, nonce, height, hash)
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
         let args = params![
@@ -1018,7 +1018,7 @@ impl SpvClient {
             Some(child_header) => {
                 // contiguous?
                 if last_block_header.header.bitcoin_hash() != child_header.header.prev_blockhash {
-                    warn!("Received discontiguous headers at height {}: we have child {:?} ({}), but were given {:?} ({})", 
+                    warn!("Received discontiguous headers at height {}: we have child {:?} ({}), but were given {:?} ({})",
                           end_height, &child_header, child_header.header.bitcoin_hash(), &last_block_header, &last_block_header.header.bitcoin_hash());
                     return Err(btc_error::NoncontiguousHeader);
                 }

--- a/stackslib/src/burnchains/bitcoin/spv.rs
+++ b/stackslib/src/burnchains/bitcoin/spv.rs
@@ -54,6 +54,14 @@ pub const BITCOIN_GENESIS_BLOCK_HASH_REGTEST: &str =
 pub const BLOCK_DIFFICULTY_CHUNK_SIZE: u64 = 2016;
 const BLOCK_DIFFICULTY_INTERVAL: u32 = 14 * 24 * 60 * 60; // two weeks, in seconds
 
+/// Number of complete difficulty intervals at `burn_height`: interval `k`
+/// is complete iff its last header height,
+/// `(k + 1) * BLOCK_DIFFICULTY_CHUNK_SIZE - 1`, is at or below
+/// `burn_height`.
+pub(crate) fn num_complete_chain_work_intervals(burn_height: u64) -> u64 {
+    burn_height.saturating_add(1) / BLOCK_DIFFICULTY_CHUNK_SIZE
+}
+
 pub const SPV_DB_VERSION: &str = "3";
 
 const SPV_INITIAL_SCHEMA: &[&str] = &[
@@ -913,6 +921,22 @@ impl SpvClient {
         headers: Vec<LoneBlockHeader>,
     ) -> Result<(), btc_error> {
         self.write_block_headers(height, headers)
+    }
+
+    /// Insert a `chain_work` interval row directly (test fixtures only;
+    /// production rows go through [`SpvClient::update_chain_work`]).
+    #[cfg(test)]
+    pub fn test_insert_chain_work(
+        conn: &DBConn,
+        interval: u64,
+        work: &str,
+    ) -> Result<(), btc_error> {
+        conn.execute(
+            "INSERT INTO chain_work (interval, work) VALUES (?1, ?2)",
+            params![u64_to_sql(interval)?, work],
+        )
+        .map_err(|e| btc_error::from(db_error::SqliteError(e)))?;
+        Ok(())
     }
 
     /// Insert block headers into the headers DB.

--- a/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/mod.rs
@@ -27,8 +27,10 @@
 pub(crate) mod common;
 pub(crate) mod fork_storage;
 mod index;
+mod spv;
 
 #[cfg(test)]
 mod tests;
 
 pub use index::{copy_index_side_tables, IndexSideTableStats};
+pub use spv::{copy_spv_headers, SpvHeadersCopyStats};

--- a/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
@@ -37,28 +37,18 @@ pub struct SpvHeadersCopyStats {
 
 /// Copy canonical SPV headers up to `burn_height` into a new destination.
 ///
-/// Returns an error if the source file does not exist, or if the
-/// destination already exists.
+/// Returns [`Error::DestinationExists`] if the destination already exists.
 pub fn copy_spv_headers(
     src_path: &str,
     dst_path: &str,
-    burn_height: u32,
+    burn_height: u64,
 ) -> Result<SpvHeadersCopyStats, Error> {
-    if !Path::new(src_path).exists() {
-        return Err(Error::IOError(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("SPV headers source not found: {src_path}"),
-        )));
-    }
     if Path::new(dst_path).exists() {
-        return Err(Error::IOError(std::io::Error::new(
-            std::io::ErrorKind::AlreadyExists,
-            format!("SPV headers destination already exists: {dst_path}"),
-        )));
+        return Err(Error::DestinationExists(dst_path.to_string()));
     }
 
     if let Some(parent) = Path::new(dst_path).parent() {
-        fs::create_dir_all(parent).map_err(Error::IOError)?;
+        fs::create_dir_all(parent)?;
     }
 
     with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {
@@ -69,8 +59,8 @@ pub fn copy_spv_headers(
 /// Build the copy specs for the SPV headers DB: `db_config` verbatim,
 /// `headers` up to `burn_height`, `chain_work` for complete difficulty
 /// intervals only.
-fn spv_copy_specs(burn_height: u32) -> Vec<TableCopySpec> {
-    let complete_intervals = num_complete_chain_work_intervals(u64::from(burn_height));
+fn spv_copy_specs(burn_height: u64) -> Vec<TableCopySpec> {
+    let complete_intervals = num_complete_chain_work_intervals(burn_height);
     vec![
         TableCopySpec {
             table: "db_config",
@@ -91,14 +81,20 @@ fn spv_copy_specs(burn_height: u32) -> Vec<TableCopySpec> {
 
 fn copy_spv_headers_inner(
     conn: &Connection,
-    burn_height: u32,
+    burn_height: u64,
 ) -> Result<SpvHeadersCopyStats, Error> {
     clone_schemas_from_source(conn, REQUIRED_TABLES)?;
 
     let results = execute_copy_specs(conn, &spv_copy_specs(burn_height))?;
 
-    Ok(SpvHeadersCopyStats {
+    let stats = SpvHeadersCopyStats {
         headers_rows: copied_rows(&results, "headers"),
         chain_work_rows: copied_rows(&results, "chain_work"),
-    })
+    };
+    info!(
+        "Copied SPV headers";
+        "headers_rows" => stats.headers_rows,
+        "chain_work_rows" => stats.chain_work_rows
+    );
+    Ok(stats)
 }

--- a/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
@@ -37,7 +37,8 @@ pub struct SpvHeadersCopyStats {
 
 /// Copy canonical SPV headers up to `burn_height` into a new destination.
 ///
-/// Returns an error if the source file does not exist.
+/// Returns an error if the source file does not exist, or if the
+/// destination already exists.
 pub fn copy_spv_headers(
     src_path: &str,
     dst_path: &str,
@@ -47,6 +48,12 @@ pub fn copy_spv_headers(
         return Err(Error::IOError(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             format!("SPV headers source not found: {src_path}"),
+        )));
+    }
+    if Path::new(dst_path).exists() {
+        return Err(Error::IOError(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            format!("SPV headers destination already exists: {dst_path}"),
         )));
     }
 

--- a/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
@@ -25,7 +25,7 @@ use super::common::{
 use crate::burnchains::bitcoin::spv::num_complete_chain_work_intervals;
 use crate::chainstate::stacks::index::Error;
 
-/// Tables required in all headers.sqlite versions.
+/// Tables required for the current headers.sqlite schema.
 pub(super) const REQUIRED_TABLES: &[&str] = &["headers", "db_config", "chain_work"];
 
 /// Row-count statistics returned by [`copy_spv_headers`].

--- a/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
@@ -16,17 +16,36 @@
 use std::fs;
 use std::path::Path;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 use super::common::{
-    clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
-    TableCopySpec,
+    assert_source_schema, clone_schemas_from_source, copied_rows, execute_copy_specs,
+    with_offline_write_session, TableCopySpec,
 };
 use crate::burnchains::bitcoin::spv::num_complete_chain_work_intervals;
 use crate::chainstate::stacks::index::Error;
+use crate::util_lib::db::sqlite_open;
 
 /// Tables required for the current headers.sqlite schema.
 pub(super) const REQUIRED_TABLES: &[&str] = &["headers", "db_config", "chain_work"];
+
+/// Every table the SPV headers snapshot accounts for. headers.sqlite is not
+/// MARF-backed, so unlike the other slices there are no MARF infra tables to
+/// exempt — the content-copied [`REQUIRED_TABLES`] are the whole schema.
+fn known_spv_tables() -> Vec<&'static str> {
+    REQUIRED_TABLES.to_vec()
+}
+
+/// The spv snapshot's source-schema guard (see [`assert_source_schema`]);
+/// `test_no_unclassified_spv_tables` runs it against a fresh schema.
+pub(super) fn assert_source_tables_classified(src_conn: &Connection) -> Result<(), Error> {
+    assert_source_schema(
+        src_conn,
+        &known_spv_tables(),
+        "headers.sqlite",
+        "REQUIRED_TABLES in snapshot/spv.rs",
+    )
+}
 
 /// Row-count statistics returned by [`copy_spv_headers`].
 #[derive(Debug, Clone)]
@@ -51,6 +70,12 @@ pub fn copy_spv_headers(
         fs::create_dir_all(parent)?;
     }
 
+    // Reject an unrecognized source schema before any destination work.
+    // The copy session only ATTACHes src, so open it read-only here for the check.
+    let src_conn = sqlite_open(src_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;
+    assert_source_tables_classified(&src_conn)?;
+    drop(src_conn);
+
     with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {
         copy_spv_headers_inner(conn, burn_height)
     })
@@ -59,7 +84,7 @@ pub fn copy_spv_headers(
 /// Build the copy specs for the SPV headers DB: `db_config` verbatim,
 /// `headers` up to `burn_height`, `chain_work` for complete difficulty
 /// intervals only.
-fn spv_copy_specs(burn_height: u64) -> Vec<TableCopySpec> {
+pub(super) fn spv_copy_specs(burn_height: u64) -> Vec<TableCopySpec> {
     let complete_intervals = num_complete_chain_work_intervals(burn_height);
     vec![
         TableCopySpec {

--- a/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/spv.rs
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fs;
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use super::common::{
+    clone_schemas_from_source, copied_rows, execute_copy_specs, with_offline_write_session,
+    TableCopySpec,
+};
+use crate::burnchains::bitcoin::spv::num_complete_chain_work_intervals;
+use crate::chainstate::stacks::index::Error;
+
+/// Tables required in all headers.sqlite versions.
+pub(super) const REQUIRED_TABLES: &[&str] = &["headers", "db_config", "chain_work"];
+
+/// Row-count statistics returned by [`copy_spv_headers`].
+#[derive(Debug, Clone)]
+pub struct SpvHeadersCopyStats {
+    pub headers_rows: u64,
+    pub chain_work_rows: u64,
+}
+
+/// Copy canonical SPV headers up to `burn_height` into a new destination.
+///
+/// Returns an error if the source file does not exist.
+pub fn copy_spv_headers(
+    src_path: &str,
+    dst_path: &str,
+    burn_height: u32,
+) -> Result<SpvHeadersCopyStats, Error> {
+    if !Path::new(src_path).exists() {
+        return Err(Error::IOError(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("SPV headers source not found: {src_path}"),
+        )));
+    }
+
+    if let Some(parent) = Path::new(dst_path).parent() {
+        fs::create_dir_all(parent).map_err(Error::IOError)?;
+    }
+
+    with_offline_write_session(dst_path, &[("src", src_path)], "", |conn| {
+        copy_spv_headers_inner(conn, burn_height)
+    })
+}
+
+/// Build the copy specs for the SPV headers DB: `db_config` verbatim,
+/// `headers` up to `burn_height`, `chain_work` for complete difficulty
+/// intervals only.
+fn spv_copy_specs(burn_height: u32) -> Vec<TableCopySpec> {
+    let complete_intervals = num_complete_chain_work_intervals(u64::from(burn_height));
+    vec![
+        TableCopySpec {
+            table: "db_config",
+            source_sql: "SELECT * FROM src.db_config".into(),
+        },
+        TableCopySpec {
+            table: "headers",
+            source_sql: format!("SELECT * FROM src.headers WHERE height <= {burn_height}"),
+        },
+        TableCopySpec {
+            table: "chain_work",
+            source_sql: format!(
+                "SELECT * FROM src.chain_work WHERE interval < {complete_intervals}"
+            ),
+        },
+    ]
+}
+
+fn copy_spv_headers_inner(
+    conn: &Connection,
+    burn_height: u32,
+) -> Result<SpvHeadersCopyStats, Error> {
+    clone_schemas_from_source(conn, REQUIRED_TABLES)?;
+
+    let results = execute_copy_specs(conn, &spv_copy_specs(burn_height))?;
+
+    Ok(SpvHeadersCopyStats {
+        headers_rows: copied_rows(&results, "headers"),
+        chain_work_rows: copied_rows(&results, "chain_work"),
+    })
+}

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/mod.rs
@@ -25,6 +25,7 @@ use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::{trie_sql, ClarityMarfTrieId, Error, MARFValue};
 
 mod index;
+mod spv;
 
 /// Create a source `index.sqlite`
 fn create_source_db(path: &std::path::Path) -> Connection {

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
@@ -25,6 +25,7 @@ use tempfile::tempdir;
 use super::super::common::unclassified_tables;
 use crate::burnchains::bitcoin::spv::{SpvClient, SPV_DB_VERSION};
 use crate::burnchains::bitcoin::BitcoinNetworkType;
+use crate::chainstate::stacks::index::Error;
 
 /// Drift guard: every table the SPV migrations create must be
 /// classified, so a future migration can't silently drop one from the copy.
@@ -165,7 +166,7 @@ fn test_spv_headers_copy() {
 #[case::exactly_second_interval_end(4031, 3, 2)]
 #[case::one_past_second_interval_end(4032, 3, 2)]
 fn test_spv_headers_chain_work_boundaries(
-    #[case] burn_height: u32,
+    #[case] burn_height: u64,
     #[case] src_chain_work_intervals: u32,
     #[case] expected_chain_work_rows: u64,
 ) {
@@ -174,7 +175,7 @@ fn test_spv_headers_chain_work_boundaries(
     let dst_path = dir.path().join("dst.sqlite");
 
     let mut client = create_spv_headers_db(&src_path);
-    seed_headers(&mut client, burn_height);
+    seed_headers(&mut client, burn_height as u32);
     drop(client);
     seed_chain_work(&src_path, src_chain_work_intervals);
 
@@ -185,7 +186,7 @@ fn test_spv_headers_chain_work_boundaries(
     )
     .unwrap();
 
-    assert_eq!(stats.headers_rows, u64::from(burn_height) + 1);
+    assert_eq!(stats.headers_rows, burn_height + 1);
     assert_eq!(stats.chain_work_rows, expected_chain_work_rows);
 }
 
@@ -228,12 +229,16 @@ fn test_spv_headers_existing_destination_is_error() {
     create_spv_headers_db(&src_path);
     std::fs::write(&dst_path, b"stale data").unwrap();
 
-    let result = super::super::spv::copy_spv_headers(
+    let err = super::super::spv::copy_spv_headers(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         100,
+    )
+    .expect_err("existing destination should error");
+    assert!(
+        matches!(err, Error::DestinationExists(_)),
+        "expected DestinationExists, got {err:?}"
     );
-    assert!(result.is_err(), "existing destination should error");
     assert_eq!(
         std::fs::read(&dst_path).unwrap(),
         b"stale data",

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
@@ -168,12 +168,8 @@ fn test_spv_headers_copy() {
     // chain_work for intervals 0, 1, 2.
     seed_chain_work(&src_path, 3);
 
-    let stats = super::super::spv::copy_spv_headers(
-        src_path.to_str().unwrap(),
-        dst_path.to_str().unwrap(),
-        4500,
-    )
-    .unwrap();
+    let stats =
+        copy_spv_headers(src_path.to_str().unwrap(), dst_path.to_str().unwrap(), 4500).unwrap();
 
     // Headers 0..=4500 = 4501 rows.
     assert_eq!(stats.headers_rows, 4501);
@@ -237,7 +233,7 @@ fn test_spv_headers_copy_round_trip() {
     client.update_chain_work().unwrap();
     drop(client);
 
-    let stats = super::super::spv::copy_spv_headers(
+    let stats = copy_spv_headers(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         boundary,
@@ -318,7 +314,7 @@ fn test_spv_headers_chain_work_boundaries(
     drop(client);
     seed_chain_work(&src_path, src_chain_work_intervals);
 
-    let stats = super::super::spv::copy_spv_headers(
+    let stats = copy_spv_headers(
         src_path.to_str().unwrap(),
         dst_path.to_str().unwrap(),
         burn_height,
@@ -344,11 +340,7 @@ fn test_spv_headers_missing_source_is_error(#[case] stale_destination: bool) {
         std::fs::write(&dst_path, b"stale data").unwrap();
     }
 
-    let result = super::super::spv::copy_spv_headers(
-        src_path.to_str().unwrap(),
-        dst_path.to_str().unwrap(),
-        100,
-    );
+    let result = copy_spv_headers(src_path.to_str().unwrap(), dst_path.to_str().unwrap(), 100);
     assert!(result.is_err(), "missing source should error");
     assert!(
         !src_path.exists(),
@@ -368,12 +360,8 @@ fn test_spv_headers_existing_destination_is_error() {
     create_spv_headers_db(&src_path);
     std::fs::write(&dst_path, b"stale data").unwrap();
 
-    let err = super::super::spv::copy_spv_headers(
-        src_path.to_str().unwrap(),
-        dst_path.to_str().unwrap(),
-        100,
-    )
-    .expect_err("existing destination should error");
+    let err = copy_spv_headers(src_path.to_str().unwrap(), dst_path.to_str().unwrap(), 100)
+        .expect_err("existing destination should error");
     assert!(
         matches!(err, Error::DestinationExists(_)),
         "expected DestinationExists, got {err:?}"

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
@@ -215,3 +215,28 @@ fn test_spv_headers_missing_source_is_error(#[case] stale_destination: bool) {
         "missing source must not be created by ATTACH"
     );
 }
+
+/// The copy writes into a NEW destination only: a pre-existing
+/// destination file (e.g. left over from a prior squash run) is an
+/// error, never appended to or overwritten.
+#[test]
+fn test_spv_headers_existing_destination_is_error() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    create_spv_headers_db(&src_path);
+    std::fs::write(&dst_path, b"stale data").unwrap();
+
+    let result = super::super::spv::copy_spv_headers(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        100,
+    );
+    assert!(result.is_err(), "existing destination should error");
+    assert_eq!(
+        std::fs::read(&dst_path).unwrap(),
+        b"stale data",
+        "existing destination must be left untouched"
+    );
+}

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
@@ -23,7 +23,7 @@ use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
 use tempfile::tempdir;
 
 use super::super::common::unclassified_tables;
-use crate::burnchains::bitcoin::spv::{SpvClient, SPV_DB_VERSION};
+use crate::burnchains::bitcoin::spv::{SpvClient, BLOCK_DIFFICULTY_CHUNK_SIZE, SPV_DB_VERSION};
 use crate::burnchains::bitcoin::BitcoinNetworkType;
 use crate::chainstate::stacks::index::Error;
 
@@ -57,6 +57,19 @@ fn create_spv_headers_db(path: &std::path::Path) -> SpvClient {
         false,
     )
     .expect("SPV headers DB init failed")
+}
+
+/// Open an existing headers.sqlite read-only.
+fn open_spv_headers_db_readonly(path: &std::path::Path) -> SpvClient {
+    SpvClient::new(
+        path.to_str().unwrap(),
+        0,
+        None,
+        BitcoinNetworkType::Regtest,
+        false,
+        false,
+    )
+    .expect("opening copied headers.sqlite as SpvClient failed")
 }
 
 /// A synthetic-but-real header for height `h`, with deterministic fields.
@@ -152,6 +165,83 @@ fn test_spv_headers_copy() {
         .query_row("SELECT version FROM db_config", [], |row| row.get(0))
         .unwrap();
     assert_eq!(version, SPV_DB_VERSION);
+}
+
+/// End-to-end round trip: a copied headers.sqlite must be consumable through
+/// the production [`SpvClient`] reader - the same headers and `chain_work` as
+/// the source within the boundary, nothing beyond it.
+#[test]
+fn test_spv_headers_copy_round_trip() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    // Copy at the end of the second complete interval: the copy keeps intervals
+    // 0 and 1 plus the headers through interval 1's last block, so the aggregate
+    // path has >1 stored interval and an empty partial tail. The source extends a
+    // full interval further, so the boundary actually drops a header and an interval.
+    let boundary = 2 * BLOCK_DIFFICULTY_CHUNK_SIZE - 1; // 4031: last block of interval 1
+    let source_tip = 3 * BLOCK_DIFFICULTY_CHUNK_SIZE - 1; // 6047: source also stores interval 2
+
+    let mut client = create_spv_headers_db(&src_path);
+    seed_headers(&mut client, source_tip as u32);
+    client.update_chain_work().unwrap();
+    drop(client);
+
+    let stats = super::super::spv::copy_spv_headers(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        boundary,
+    )
+    .unwrap();
+    assert_eq!(stats.headers_rows, boundary + 1);
+    assert_eq!(stats.chain_work_rows, 2);
+
+    let src = open_spv_headers_db_readonly(&src_path);
+    let dst = open_spv_headers_db_readonly(&dst_path);
+
+    // Headers through the boundary round-trip identically through the reader,
+    // and nothing above the boundary survives in the copy.
+    assert_eq!(
+        dst.read_block_headers(0, boundary + 1).unwrap(),
+        src.read_block_headers(0, boundary + 1).unwrap()
+    );
+    assert!(
+        dst.read_block_header(boundary + 1).unwrap().is_none(),
+        "copy must not hold a header above the boundary"
+    );
+
+    // chain_work round-trips as real Uint256: both complete intervals match the
+    // source; the interval past the boundary is dropped.
+    for interval in [0, 1] {
+        let work = dst.find_interval_work(interval).unwrap();
+        assert!(work.is_some(), "interval {interval} work must be copied");
+        assert_eq!(
+            work,
+            src.find_interval_work(interval).unwrap(),
+            "interval {interval} work must round-trip through the reader"
+        );
+    }
+    assert!(
+        dst.find_interval_work(2).unwrap().is_none(),
+        "interval 2 is past the boundary and must not be copied"
+    );
+
+    // The copy is consumable by the aggregate-work path, not just per-interval
+    // reads. Its tip sits on interval 1's boundary (no partial tail), so the
+    // total equals that interval's running work.
+    assert_eq!(
+        dst.get_chain_work().unwrap(),
+        dst.find_interval_work(1)
+            .unwrap()
+            .expect("interval 1 work present"),
+        "aggregate chain work over the copy must equal interval 1's running total"
+    );
+
+    // Setup invariants: confirm the boundary actually elided data, so the
+    // truncation assertions above are not satisfied by an empty src.
+    assert!(src.read_block_header(boundary + 1).unwrap().is_some());
+    assert!(src.find_interval_work(2).unwrap().is_some());
 }
 
 /// Chain-work interval boundary cases: interval `k` is copied iff it is

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
@@ -15,6 +15,8 @@
 
 //! SPV headers DB (headers.sqlite) copy tests.
 
+use std::collections::HashSet;
+
 use rstest::rstest;
 use rusqlite::Connection;
 use stacks_common::deps_common::bitcoin::blockdata::block::{BlockHeader, LoneBlockHeader};
@@ -22,25 +24,72 @@ use stacks_common::deps_common::bitcoin::network::encodable::VarInt;
 use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
 use tempfile::tempdir;
 
-use super::super::common::unclassified_tables;
+use super::super::spv::{
+    assert_source_tables_classified, copy_spv_headers, spv_copy_specs, REQUIRED_TABLES,
+};
 use crate::burnchains::bitcoin::spv::{SpvClient, BLOCK_DIFFICULTY_CHUNK_SIZE, SPV_DB_VERSION};
 use crate::burnchains::bitcoin::BitcoinNetworkType;
 use crate::chainstate::stacks::index::Error;
 
-/// Drift guard: every table the SPV migrations create must be
-/// classified, so a future migration can't silently drop one from the copy.
+/// Drift guard: every table the SPV migrations create must be classified, so a
+/// future migration can't silently drop one from the copy. Runs the exact
+/// production guard against a freshly-migrated schema, so the test and the
+/// runtime check cannot drift apart.
 #[test]
 fn test_no_unclassified_spv_tables() {
     let dir = tempdir().unwrap();
     let src_path = dir.path().join("src.sqlite");
     let _client = create_spv_headers_db(&src_path);
     let conn = Connection::open(&src_path).unwrap();
-    // headers.sqlite is not MARF-backed, so unlike the other drift guards
-    // no MARF infra tables are exempted here.
-    let extra = unclassified_tables(&conn, super::super::spv::REQUIRED_TABLES);
+    assert_source_tables_classified(&conn)
+        .expect("fresh production SPV schema must be fully classified");
+}
+
+/// Every cloned table ([`REQUIRED_TABLES`]) must have a row-copy spec and vice versa,
+/// else it would be cloned but never populated (present-but-empty).
+#[test]
+fn test_spv_copy_specs_match_required_tables() {
+    let spec_tables: Vec<&str> = spv_copy_specs(100).iter().map(|s| s.table).collect();
+    let spec_set: HashSet<&str> = spec_tables.iter().copied().collect();
+    assert_eq!(
+        spec_tables.len(),
+        spec_set.len(),
+        "duplicate table in spv_copy_specs"
+    );
+    let required_set: HashSet<&str> = REQUIRED_TABLES.iter().copied().collect();
+    assert_eq!(
+        spec_set, required_set,
+        "every REQUIRED_TABLES entry must have exactly one copy spec (and vice versa); \
+         a cloned-but-uncopied table would be present-but-empty in the squash"
+    );
+}
+
+/// A source table the copy lists don't classify is rejected before any
+/// destination is produced — the runtime complement to the drift test.
+#[test]
+fn test_unclassified_source_table_is_rejected() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    let _client = create_spv_headers_db(&src_path);
+    let conn = Connection::open(&src_path).unwrap();
+    conn.execute_batch("CREATE TABLE surprise_table (x INTEGER)")
+        .unwrap();
+    drop(conn);
+
+    let err = copy_spv_headers(src_path.to_str().unwrap(), dst_path.to_str().unwrap(), 100)
+        .expect_err("unclassified source table must be rejected");
+    match err {
+        Error::CorruptionError(msg) => assert!(
+            msg.contains("surprise_table"),
+            "error should name the offending table, got: {msg}"
+        ),
+        other => panic!("expected CorruptionError, got {other:?}"),
+    }
     assert!(
-        extra.is_empty(),
-        "unclassified SPV table(s) {extra:?}: classify each in REQUIRED_TABLES (snapshot/spv.rs)"
+        !dst_path.exists(),
+        "no destination should be produced when the source is rejected"
     );
 }
 

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/spv.rs
@@ -1,0 +1,217 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! SPV headers DB (headers.sqlite) copy tests.
+
+use rstest::rstest;
+use rusqlite::Connection;
+use stacks_common::deps_common::bitcoin::blockdata::block::{BlockHeader, LoneBlockHeader};
+use stacks_common::deps_common::bitcoin::network::encodable::VarInt;
+use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
+use tempfile::tempdir;
+
+use super::super::common::unclassified_tables;
+use crate::burnchains::bitcoin::spv::{SpvClient, SPV_DB_VERSION};
+use crate::burnchains::bitcoin::BitcoinNetworkType;
+
+/// Drift guard: every table the SPV migrations create must be
+/// classified, so a future migration can't silently drop one from the copy.
+#[test]
+fn test_no_unclassified_spv_tables() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let _client = create_spv_headers_db(&src_path);
+    let conn = Connection::open(&src_path).unwrap();
+    // headers.sqlite is not MARF-backed, so unlike the other drift guards
+    // no MARF infra tables are exempted here.
+    let extra = unclassified_tables(&conn, super::super::spv::REQUIRED_TABLES);
+    assert!(
+        extra.is_empty(),
+        "unclassified SPV table(s) {extra:?}: classify each in REQUIRED_TABLES (snapshot/spv.rs)"
+    );
+}
+
+/// Create a source headers.sqlite. Initialization seeds the
+/// regtest genesis header at height 0, so tests seed from height 1.
+/// Returns the client so headers go through the production write path.
+fn create_spv_headers_db(path: &std::path::Path) -> SpvClient {
+    SpvClient::new(
+        path.to_str().unwrap(),
+        0,
+        None,
+        BitcoinNetworkType::Regtest,
+        true,
+        false,
+    )
+    .expect("SPV headers DB init failed")
+}
+
+/// A synthetic-but-real header for height `h`, with deterministic fields.
+fn fixture_header(h: u32) -> LoneBlockHeader {
+    LoneBlockHeader {
+        header: BlockHeader {
+            version: 1,
+            prev_blockhash: Sha256dHash::from_data(&h.wrapping_sub(1).to_le_bytes()),
+            merkle_root: Sha256dHash::from_data(&h.to_le_bytes()),
+            time: h,
+            bits: 545259519,
+            nonce: h,
+        },
+        tx_count: VarInt(0),
+    }
+}
+
+/// Seed headers at heights 1..=`count` through the SPV client's storage
+/// writer ([`SpvClient::test_write_block_headers`]; storage only, no
+/// contiguity validation).
+fn seed_headers(client: &mut SpvClient, count: u32) {
+    let headers = (1..=count).map(fixture_header).collect();
+    client.test_write_block_headers(1, headers).unwrap();
+}
+
+/// Seed `chain_work` interval rows.
+fn seed_chain_work(src_path: &std::path::Path, intervals: u32) {
+    let conn = Connection::open(src_path).unwrap();
+    for interval in 0..intervals {
+        SpvClient::test_insert_chain_work(&conn, u64::from(interval), &format!("work_{interval}"))
+            .unwrap();
+    }
+}
+
+/// Headers are copied up to the burn height and `chain_work` only for
+/// complete 2016-block intervals.
+#[test]
+fn test_spv_headers_copy() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src_headers.sqlite");
+    let dst_path = dir.path().join("dst_headers.sqlite");
+
+    let mut client = create_spv_headers_db(&src_path);
+    // Headers at heights 0 (genesis) ..=5000.
+    seed_headers(&mut client, 5000);
+    drop(client);
+    // chain_work for intervals 0, 1, 2.
+    seed_chain_work(&src_path, 3);
+
+    let stats = super::super::spv::copy_spv_headers(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        4500,
+    )
+    .unwrap();
+
+    // Headers 0..=4500 = 4501 rows.
+    assert_eq!(stats.headers_rows, 4501);
+    // Interval 0: (0+1)*2016-1=2015 <= 4500 ✓
+    // Interval 1: (1+1)*2016-1=4031 <= 4500 ✓
+    // Interval 2: (2+1)*2016-1=6047 <= 4500 ✗
+    assert_eq!(stats.chain_work_rows, 2);
+
+    // The destination holds exactly the boundary content: the last header is
+    // height 4500 with its source hash, nothing above it, the two complete
+    // chain_work intervals, and the source db_config version.
+    let src = Connection::open(&src_path).unwrap();
+    let src_tip_hash: String = src
+        .query_row("SELECT hash FROM headers WHERE height = 4500", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let dst = Connection::open(&dst_path).unwrap();
+    let (count, max_height, tip_hash): (i64, u32, String) = dst
+        .query_row(
+            "SELECT COUNT(*), MAX(height), \
+                    (SELECT hash FROM headers ORDER BY height DESC LIMIT 1) \
+             FROM headers",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!((count, max_height, tip_hash), (4501, 4500, src_tip_hash));
+    let work: Vec<(u32, String)> = dst
+        .prepare("SELECT interval, work FROM chain_work ORDER BY interval")
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(work, vec![(0, "work_0".into()), (1, "work_1".into())]);
+    let version: String = dst
+        .query_row("SELECT version FROM db_config", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, SPV_DB_VERSION);
+}
+
+/// Chain-work interval boundary cases: interval `k` is copied iff it is
+/// complete at the squash height, i.e. `(k + 1) * 2016 - 1 <= burn_height`.
+/// Headers are always copied through `burn_height` inclusive; the source
+/// holds one more `chain_work` interval than the expected copy where
+/// possible, so each case proves the cutoff.
+#[rstest]
+#[case::below_first_interval_end(0, 1, 0)]
+#[case::exactly_first_interval_end(2015, 2, 1)]
+#[case::one_past_first_interval_end(2016, 2, 1)]
+#[case::exactly_second_interval_end(4031, 3, 2)]
+#[case::one_past_second_interval_end(4032, 3, 2)]
+fn test_spv_headers_chain_work_boundaries(
+    #[case] burn_height: u32,
+    #[case] src_chain_work_intervals: u32,
+    #[case] expected_chain_work_rows: u64,
+) {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("src.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+
+    let mut client = create_spv_headers_db(&src_path);
+    seed_headers(&mut client, burn_height);
+    drop(client);
+    seed_chain_work(&src_path, src_chain_work_intervals);
+
+    let stats = super::super::spv::copy_spv_headers(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        burn_height,
+    )
+    .unwrap();
+
+    assert_eq!(stats.headers_rows, u64::from(burn_height) + 1);
+    assert_eq!(stats.chain_work_rows, expected_chain_work_rows);
+}
+
+/// A missing source headers.sqlite is an error, whether or not a stale
+/// destination file is already present (a reused output dir must not mask
+/// the missing source), and the read-only ATTACH must not create the
+/// source file as a side effect.
+#[rstest]
+#[case::fresh_destination(false)]
+#[case::stale_destination(true)]
+fn test_spv_headers_missing_source_is_error(#[case] stale_destination: bool) {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("nonexistent.sqlite");
+    let dst_path = dir.path().join("dst.sqlite");
+    if stale_destination {
+        std::fs::write(&dst_path, b"stale data").unwrap();
+    }
+
+    let result = super::super::spv::copy_spv_headers(
+        src_path.to_str().unwrap(),
+        dst_path.to_str().unwrap(),
+        100,
+    );
+    assert!(result.is_err(), "missing source should error");
+    assert!(
+        !src_path.exists(),
+        "missing source must not be created by ATTACH"
+    );
+}


### PR DESCRIPTION
### Description

Adds the snapshot copy of the Bitcoin SPV headers.sqlite: headers up to the squash burn height, db_config verbatim, and chain_work rows only for difficulty intervals that are fully determined at that height.
  
  
### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
