### PR TITLE
Fix: current cycle unstaking logic

### DIFF
--- a/changelog.d/current-cycle-unstaking.fixed
+++ b/changelog.d/current-cycle-unstaking.fixed
@@ -1,0 +1,9 @@
+Fixed an issue related to how current and future cycle rewards state is managed after unstaking.
+
+Before this fix, there was an issue where the "global" bond signer membership state was used,
+even though bond participants could have a different signer in the current cycle. This led
+to various issues around reward calculations if a staker unstaked after updating their signer.
+
+This change updates the logic around unstaking to remove the staker from the current and
+future cycles. In each cycle, the signer is derived from per-cycle state instead of
+being passed explicitly.

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -4498,6 +4498,123 @@ export const contracts = {
         ],
         Response<boolean, bigint>
       >,
+      unstakeSbtcFromBondCycle: {
+        name: 'unstake-sbtc-from-bond-cycle',
+        access: 'private',
+        args: [
+          { name: 'cycle-index', type: 'uint128' },
+          {
+            name: 'accumulator-res',
+            type: {
+              response: {
+                ok: {
+                  tuple: [
+                    { name: 'amount-to-withdrawal-sats', type: 'uint128' },
+                    { name: 'bond-index', type: 'uint128' },
+                    { name: 'first-reward-cycle', type: 'uint128' },
+                    { name: 'new-amount-sats', type: 'uint128' },
+                    { name: 'staker', type: 'principal' },
+                  ],
+                },
+                error: 'uint128',
+              },
+            },
+          },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'amount-to-withdrawal-sats', type: 'uint128' },
+                  { name: 'bond-index', type: 'uint128' },
+                  { name: 'first-reward-cycle', type: 'uint128' },
+                  { name: 'new-amount-sats', type: 'uint128' },
+                  { name: 'staker', type: 'principal' },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          cycleIndex: TypedAbiArg<number | bigint, 'cycleIndex'>,
+          accumulatorRes: TypedAbiArg<
+            Response<
+              {
+                amountToWithdrawalSats: number | bigint;
+                bondIndex: number | bigint;
+                firstRewardCycle: number | bigint;
+                newAmountSats: number | bigint;
+                staker: string;
+              },
+              number | bigint
+            >,
+            'accumulatorRes'
+          >,
+        ],
+        Response<
+          {
+            amountToWithdrawalSats: bigint;
+            bondIndex: bigint;
+            firstRewardCycle: bigint;
+            newAmountSats: bigint;
+            staker: string;
+          },
+          bigint
+        >
+      >,
+      unstakeSbtcFromBondCycles: {
+        name: 'unstake-sbtc-from-bond-cycles',
+        access: 'private',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'bond-index', type: 'uint128' },
+          { name: 'first-reward-cycle', type: 'uint128' },
+          { name: 'num-cycles', type: 'uint128' },
+          { name: 'amount-to-withdrawal-sats', type: 'uint128' },
+          { name: 'new-amount-sats', type: 'uint128' },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'amount-to-withdrawal-sats', type: 'uint128' },
+                  { name: 'bond-index', type: 'uint128' },
+                  { name: 'first-reward-cycle', type: 'uint128' },
+                  { name: 'new-amount-sats', type: 'uint128' },
+                  { name: 'staker', type: 'principal' },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          bondIndex: TypedAbiArg<number | bigint, 'bondIndex'>,
+          firstRewardCycle: TypedAbiArg<number | bigint, 'firstRewardCycle'>,
+          numCycles: TypedAbiArg<number | bigint, 'numCycles'>,
+          amountToWithdrawalSats: TypedAbiArg<
+            number | bigint,
+            'amountToWithdrawalSats'
+          >,
+          newAmountSats: TypedAbiArg<number | bigint, 'newAmountSats'>,
+        ],
+        Response<
+          {
+            amountToWithdrawalSats: bigint;
+            bondIndex: bigint;
+            firstRewardCycle: bigint;
+            newAmountSats: bigint;
+            staker: string;
+          },
+          bigint
+        >
+      >,
       updateClaimableBondRewards: {
         name: 'update-claimable-bond-rewards',
         access: 'private',

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -4498,8 +4498,8 @@ export const contracts = {
         ],
         Response<boolean, bigint>
       >,
-      unstakeSbtcFromBondCycle: {
-        name: 'unstake-sbtc-from-bond-cycle',
+      unstakeSatsFromBondCycle: {
+        name: 'unstake-sats-from-bond-cycle',
         access: 'private',
         args: [
           { name: 'cycle-index', type: 'uint128' },
@@ -4565,8 +4565,8 @@ export const contracts = {
           bigint
         >
       >,
-      unstakeSbtcFromBondCycles: {
-        name: 'unstake-sbtc-from-bond-cycles',
+      unstakeSatsFromBondCycles: {
+        name: 'unstake-sats-from-bond-cycles',
         access: 'private',
         args: [
           { name: 'staker', type: 'principal' },

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -2575,6 +2575,63 @@ test('bond signer update keeps current-cycle uncrystallized rewards with old sig
   expect(rov(pox5.getEarned(signer2, 1n, 0n))).toBe(0n);
 });
 
+test('bond staker can update signer and fully unstake sbtc in the same cycle', () => {
+  const signer1 = testSigner.identifier;
+  const signer2 = deployTestSigner(
+    'bond-update-then-unstake-signer-2',
+  ).identifier;
+  const aliceSbtc = 480000n;
+
+  registerSigner();
+
+  txOk(
+    pox5.setupBond({
+      bondIndex: 0n,
+      targetRate: 1500n,
+      stxValueRatio: 10n,
+      minUstxRatio: 100n,
+      earlyUnlockBytes: new Uint8Array(),
+      allowlist: [{ maxSats: aliceSbtc, staker: alice }],
+    }),
+    deployer,
+  );
+  txOk(
+    pox5.registerForBond({
+      bondIndex: 0n,
+      signerManager: signer1,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: err(aliceSbtc),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+
+  mineUntil(rov(pox5.rewardCycleToBurnHeight(1n)) + 1n);
+  txOk(
+    pox5.updateBondRegistration({
+      signerManager: signer2,
+      oldSignerManager: signer1,
+      signerCalldata: null,
+    }),
+    alice,
+  );
+  txOk(
+    pox5.unstakeSbtc({
+      signerManager: signer2,
+      amountToWithdrawalSats: aliceSbtc,
+    }),
+    alice,
+  );
+
+  sbtcTransfer(1200n, deployer, pox5.identifier);
+  mineUntil(rov(pox5.rewardCycleToBurnHeight(1n)) + HALF_CYCLE_LENGTH);
+  txOk(pox5.calculateRewards([0n]), deployer);
+
+  expect(rov(pox5.getTotalSbtcStaked())).toBe(0n);
+  expect(rov(pox5.getEarned(signer1, 1n, 0n))).toBe(0n);
+  expect(rov(pox5.getEarned(signer2, 1n, 0n))).toBe(0n);
+});
+
 /**
  * Regression: changing signer for an active bond must not let the staker
  * double-collect already-distributed bond rewards on the new signer. Before

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -2606,6 +2606,7 @@ test('bond staker can update signer and fully unstake sbtc in the same cycle', (
     alice,
   );
 
+  sbtcTransfer(1200n, deployer, pox5.identifier);
   mineUntil(rov(pox5.rewardCycleToBurnHeight(1n)) + 1n);
   txOk(
     pox5.updateBondRegistration({
@@ -2622,8 +2623,6 @@ test('bond staker can update signer and fully unstake sbtc in the same cycle', (
     }),
     alice,
   );
-
-  sbtcTransfer(1200n, deployer, pox5.identifier);
   mineUntil(rov(pox5.rewardCycleToBurnHeight(1n)) + HALF_CYCLE_LENGTH);
   txOk(pox5.calculateRewards([0n]), deployer);
 

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -1204,13 +1204,9 @@
             ERR_L1_EARLY_EXIT_ALREADY_ANNOUNCED
         )
 
-        ;; Settle rewards before updating state
-        (settle-rewards signer current-cycle (some bond-index))
-        (settle-staker-rewards signer current-cycle (some bond-index) staker)
-
-        (try! (remove-staker-from-bond-cycles staker signer bond-index
+        (try! (unstake-sats-from-bond-cycles staker bond-index
             first-changed-reward-cycle
-            (- bond-end-cycle first-changed-reward-cycle) amount-sats
+            (- bond-end-cycle first-changed-reward-cycle) amount-sats u0
         ))
 
         (map-set protocol-bond-memberships staker
@@ -1285,7 +1281,7 @@
         ;; cycle vs future cycles (through `update-bond-registration`), we must
         ;; derive the signer from each cycle individually (instead of using
         ;; `remove-staker-from-bond-cycles`).
-        (try! (unstake-sbtc-from-bond-cycles staker bond-index
+        (try! (unstake-sats-from-bond-cycles staker bond-index
             first-changed-reward-cycle num-cycles amount-to-withdrawal-sats
             new-amount-sats
         ))
@@ -1325,7 +1321,7 @@
     )
 )
 
-(define-private (unstake-sbtc-from-bond-cycles
+(define-private (unstake-sats-from-bond-cycles
         (staker principal)
         (bond-index uint)
         (first-reward-cycle uint)
@@ -1333,7 +1329,7 @@
         (amount-to-withdrawal-sats uint)
         (new-amount-sats uint)
     )
-    (ok (try! (fold unstake-sbtc-from-bond-cycle
+    (ok (try! (fold unstake-sats-from-bond-cycle
         (unwrap-panic (slice? (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11) u0 num-cycles))
         (ok {
             staker: staker,
@@ -1345,11 +1341,11 @@
     )))
 )
 
-;; Unstake an amount of sBTC from a staker for a given cycle.
+;; Remove a staker's bond shares for a given cycle.
 ;; For the provided cycle, the signer is derived from `staker-signer-cycle-memberships`.
 ;; Rewards are settled, even if this is a future cycle.
 ;; Finally, state is mutated.
-(define-private (unstake-sbtc-from-bond-cycle
+(define-private (unstake-sats-from-bond-cycle
         (cycle-index uint)
         (accumulator-res (response {
             staker: principal,

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -1280,17 +1280,14 @@
         ;; ensure no reentrancy through signer-manager trait calls
         (try! (validate-no-reentrancy))
 
-        ;; Take a snapshot of the staker's and signer's current rewards
-        (settle-rewards signer current-cycle (some bond-index))
-        (settle-staker-rewards signer current-cycle (some bond-index) tx-sender)
-
-        ;; We need to update each affected cycle with this staker's new amount. Instead of
-        ;; mutating each cycle, we instead re-use existing "remove" and "add" helpers.
-        (try! (remove-staker-from-bond-cycles staker signer bond-index
-            first-changed-reward-cycle num-cycles current-amount-sats
-        ))
-        (try! (add-staker-to-bond-cycles staker signer bond-index
-            first-changed-reward-cycle num-cycles new-amount-sats
+        ;; Unstake this staker's sBTC from the current and future cycles.
+        ;; N.B. Because the staker might use a different signer for the current
+        ;; cycle vs future cycles (through `update-bond-registration`), we must
+        ;; derive the signer from each cycle individually (instead of using
+        ;; `remove-staker-from-bond-cycles`).
+        (try! (unstake-sbtc-from-bond-cycles staker bond-index
+            first-changed-reward-cycle num-cycles amount-to-withdrawal-sats
+            new-amount-sats
         ))
 
         (map-set protocol-bond-memberships staker
@@ -1325,6 +1322,85 @@
             (print (merge { topic: "unstake-sbtc" } result))
             (ok result)
         )
+    )
+)
+
+(define-private (unstake-sbtc-from-bond-cycles
+        (staker principal)
+        (bond-index uint)
+        (first-reward-cycle uint)
+        (num-cycles uint)
+        (amount-to-withdrawal-sats uint)
+        (new-amount-sats uint)
+    )
+    (ok (try! (fold unstake-sbtc-from-bond-cycle
+        (unwrap-panic (slice? (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11) u0 num-cycles))
+        (ok {
+            staker: staker,
+            bond-index: bond-index,
+            first-reward-cycle: first-reward-cycle,
+            amount-to-withdrawal-sats: amount-to-withdrawal-sats,
+            new-amount-sats: new-amount-sats,
+        })
+    )))
+)
+
+;; Unstake an amount of sBTC from a staker for a given cycle.
+;; For the provided cycle, the signer is derived from `staker-signer-cycle-memberships`.
+;; Rewards are settled, even if this is a future cycle.
+;; Finally, state is mutated.
+(define-private (unstake-sbtc-from-bond-cycle
+        (cycle-index uint)
+        (accumulator-res (response {
+            staker: principal,
+            bond-index: uint,
+            first-reward-cycle: uint,
+            amount-to-withdrawal-sats: uint,
+            new-amount-sats: uint,
+        }
+            uint
+        ))
+    )
+    (let (
+            (accumulator (try! accumulator-res))
+            (reward-cycle (+ cycle-index (get first-reward-cycle accumulator)))
+            (staker (get staker accumulator))
+            (bond-index (get bond-index accumulator))
+            (amount-to-withdrawal-sats (get amount-to-withdrawal-sats accumulator))
+            (new-amount-sats (get new-amount-sats accumulator))
+            (signer (get signer
+                (unwrap! (get-signer-cycle-membership staker reward-cycle)
+                    ERR_NOT_STAKING
+                )))
+            (current-total-staked (get-total-shares-staked-for-cycle reward-cycle (some bond-index)))
+            (current-signer-staked (get-signer-shares-staked-for-cycle signer reward-cycle
+                (some bond-index)
+            ))
+        )
+        (settle-rewards signer reward-cycle (some bond-index))
+        (settle-staker-rewards signer reward-cycle (some bond-index) staker)
+        (map-set total-shares-staked-for-cycle {
+            reward-cycle: reward-cycle,
+            bond-index: (some bond-index),
+        }
+            (- current-total-staked amount-to-withdrawal-sats)
+        )
+        (map-set signer-shares-staked-for-cycle {
+            reward-cycle: reward-cycle,
+            bond-index: (some bond-index),
+            signer: signer,
+        }
+            (- current-signer-staked amount-to-withdrawal-sats)
+        )
+        (map-set staker-shares-staked-for-cycle {
+            reward-cycle: reward-cycle,
+            bond-index: (some bond-index),
+            signer: signer,
+            staker: staker,
+        }
+            new-amount-sats
+        )
+        (ok accumulator)
     )
 )
 

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -1341,10 +1341,10 @@
     )))
 )
 
-;; Remove a staker's bond shares for a given cycle.
+;; Reduce (or remove) a staker's bond shares for a given cycle.
 ;; For the provided cycle, the signer is derived from `staker-signer-cycle-memberships`.
-;; Rewards are settled, even if this is a future cycle.
-;; Finally, state is mutated.
+;; Rewards are settled for this cycle before mutating state.
+;; Finally, cycle stake state is updated.
 (define-private (unstake-sats-from-bond-cycle
         (cycle-index uint)
         (accumulator-res (response {


### PR DESCRIPTION
This PR fixes bond unstaking accounting to ensure that stakers don't receive further rewards for the current cycle after unstaking, either through `unstake-sbtc` or `announce-early-l1-exit`.

It also fixes an issue with `unstake-sbtc` where the staker could have a different signer in the current cycle vs future cycles, because they had called `update-bond-registration` previously.