### PR TITLE
fix: bump clarigen to fix clarigen-types issue

### DIFF
--- a/contrib/core-contract-tests/contracts/signer-manager.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager.clar
@@ -163,7 +163,9 @@
         (bond-periods (list 6 uint))
         (reward-cycle uint)
     )
-    (let ((result (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 claim-rewards bond-periods reward-cycle))))
+    (let ((result (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 claim-rewards
+            bond-periods reward-cycle
+        ))))
         ;; The sBTC just pulled in is owed to this signer's stakers until each
         ;; claims via `claim-staker-rewards`; reserve it so it is not sweepable.
         (var-set unclaimed-staker-rewards
@@ -192,8 +194,9 @@
         (bond-index (optional uint))
     )
     (let (
-            (earned-before-fees (contract-call? 'ST000000000000000000002AMW42H.pox-5 get-earned-staker-rewards current-contract
-                reward-cycle bond-index staker
+            (earned-before-fees (contract-call? 'ST000000000000000000002AMW42H.pox-5
+                get-earned-staker-rewards current-contract reward-cycle
+                bond-index staker
             ))
             (fees (/
                 (* earned-before-fees
@@ -223,8 +226,9 @@
     )
     (let (
             ;; `unwrap-panic` is ok here: there is no `err` type returnable
-            (rewards-info (unwrap-panic (contract-call? 'ST000000000000000000002AMW42H.pox-5 claim-staker-rewards-for-signer staker
-                reward-cycle bond-index
+            (rewards-info (unwrap-panic (contract-call? 'ST000000000000000000002AMW42H.pox-5
+                claim-staker-rewards-for-signer staker reward-cycle
+                bond-index
             )))
             (prev-fees (var-get earned-fees))
             (gross (get earned rewards-info))
@@ -531,10 +535,12 @@
     )
     (begin
         (try! (authorize-admin))
-        (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 grant-signer-key signer-key current-contract
-            auth-id signer-sig
+        (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 grant-signer-key
+            signer-key current-contract auth-id signer-sig
         ))
-        (contract-call? 'ST000000000000000000002AMW42H.pox-5 register-signer signer-manager signer-key)
+        (contract-call? 'ST000000000000000000002AMW42H.pox-5 register-signer
+            signer-manager signer-key
+        )
     )
 )
 
@@ -549,7 +555,9 @@
 ;; `staker` argument; they must only ever be driven by pox-5, never invoked
 ;; directly by an external principal.
 (define-private (authorize-pox-5)
-    (ok (asserts! (is-eq contract-caller 'ST000000000000000000002AMW42H.pox-5) ERR_UNAUTHORIZED_CALLER))
+    (ok (asserts! (is-eq contract-caller 'ST000000000000000000002AMW42H.pox-5)
+        ERR_UNAUTHORIZED_CALLER
+    ))
 )
 
 (define-read-only (is-admin (caller principal))

--- a/contrib/core-contract-tests/package-lock.json
+++ b/contrib/core-contract-tests/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@clarigen/cli": "4.1.6",
-        "@clarigen/core": "4.1.6",
-        "@clarigen/test": "4.1.6",
+        "@clarigen/cli": "4.1.7",
+        "@clarigen/core": "4.1.7",
+        "@clarigen/test": "4.1.7",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@scure/base": "^2.0.0",
@@ -67,14 +67,14 @@
       "license": "MIT"
     },
     "node_modules/@clarigen/cli": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@clarigen/cli/-/cli-4.1.6.tgz",
-      "integrity": "sha512-aTwuyoRiP2wL7Xjz+VQxMOP4eY30pYGoQnUTVJil/kisM52ZalpWq1xP82De3Wxr6NNS2ExHFrX91dzHrOaWFA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@clarigen/cli/-/cli-4.1.7.tgz",
+      "integrity": "sha512-0K4U2j4Q5v2Wh3g7a8AvEU5C47XXt3VTIIfseYhR8Jewx9XLF36et0mis+tJnJX1FqrYpiAvbBIC+BsS9l7GWA==",
       "license": "MIT",
       "dependencies": {
         "@antfu/ni": "^0.21.12",
-        "@clarigen/core": "4.1.6",
-        "@clarigen/docs": "4.1.6",
+        "@clarigen/core": "4.1.7",
+        "@clarigen/docs": "4.1.7",
         "@iarna/toml": "^2.2.5",
         "@stacks/transactions": "7.1.0",
         "arktype": "^2.1.25",
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@clarigen/core": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@clarigen/core/-/core-4.1.6.tgz",
-      "integrity": "sha512-kLiyvnMA/SGrAMzeWIJCI1wa5+sVy8JAbvWFf6EBAxnm36yccugstg6Ja9iQQlZr8xS97cJgpy1ZfOI3Aalr2Q==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@clarigen/core/-/core-4.1.7.tgz",
+      "integrity": "sha512-51o8E9Po3JTFqXirXBz/CjgsXlNRkAqByjTIzU0pHD14uZv8maW3p0ml2qE/r6Nu2zCXo+J36XvOByvvU8sYBQ==",
       "license": "MIT",
       "dependencies": {
         "@scure/base": "^1.2.6",
@@ -183,20 +183,20 @@
       }
     },
     "node_modules/@clarigen/docs": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@clarigen/docs/-/docs-4.1.6.tgz",
-      "integrity": "sha512-6RP0vQXU4fAheLqs5ZjWC/vFQnUIkTKHspfSNyzoB+W3UlP7zzP2NguMApJMbTroAa7AxuF+FJTk7n6k3DfP5g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@clarigen/docs/-/docs-4.1.7.tgz",
+      "integrity": "sha512-GfZtpUsp2TV230WepAVDzLWLypXRxuLCvkYWzlWnmmMEOL42DnX3537idTewL+PQPkBU3eDIdposzOQazRfZ5A==",
       "dependencies": {
-        "@clarigen/core": "4.1.6"
+        "@clarigen/core": "4.1.7"
       }
     },
     "node_modules/@clarigen/test": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@clarigen/test/-/test-4.1.6.tgz",
-      "integrity": "sha512-rNp/Pt7GwMYiz7TOCmlJ23RP/HHpKSWiWwP6ZTXdSvXmGzMuRJVwP2iB6kahePTr9/AOm22Bf0nfEC5LtsBL5A==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@clarigen/test/-/test-4.1.7.tgz",
+      "integrity": "sha512-KXHoMA1AcTXgxl8vCccq6R26ErL1ETNbOadtKQRaHiJDj+7927lfLKzEDYMPn94lKqpuusg+RqX2cnUebe3SOg==",
       "license": "MIT",
       "dependencies": {
-        "@clarigen/core": "4.1.6",
+        "@clarigen/core": "4.1.7",
         "@stacks/transactions": "7.2.0",
         "yaml": "^2.4.1"
       },

--- a/contrib/core-contract-tests/package.json
+++ b/contrib/core-contract-tests/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@clarigen/cli": "4.1.6",
-    "@clarigen/core": "4.1.6",
-    "@clarigen/test": "4.1.6",
+    "@clarigen/cli": "4.1.7",
+    "@clarigen/core": "4.1.7",
+    "@clarigen/test": "4.1.7",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@scure/base": "^2.0.0",


### PR DESCRIPTION
In the current `pox-wf-integration` branch, if you run `npx clarigen`, it causes an issue with the auto-generated `clarigen-types.ts` file. This has occurred since https://github.com/stacks-network/stacks-core/pull/7306, and is the result of https://github.com/stx-labs/clarinet/issues/2438

I've fixed this in Clarigen 4.1.7. You can verify this by running `npx clarigen` in this branch, and you should see no change to `clarigen-types.ts`, whereas you'd see an invalid file if you run that on the base branch.