### PR TITLE
feat: allow L1 script unlock height to be `>=` the minimum

### DIFF
--- a/changelog.d/pox-5-l1-unlock-height.changed
+++ b/changelog.d/pox-5-l1-unlock-height.changed
@@ -1,0 +1,1 @@
+Allow pox-5 L1 BTC lockups to use timelock unlock heights greater than or equal to the bond's minimum L1 unlock height.

--- a/contrib/core-contract-tests/package-lock.json
+++ b/contrib/core-contract-tests/package-lock.json
@@ -656,7 +656,6 @@
       "integrity": "sha512-eYaoxI/luH7xe0DeE3c1q66Cxqi0bBed3AOUbhL9wqWtW7leD9RG+wQFuL3fJAPq7wONq32C92DDGuvQo6ZNQA==",
       "deprecated": "The Clarinet SDK has been moved to @stacks/clarinet-sdk",
       "license": "GPL-3.0",
-      "peer": true,
       "dependencies": {
         "@hirosystems/clarinet-sdk-wasm": "^3.1.0",
         "@stacks/transactions": "^7.0.6",
@@ -1202,7 +1201,6 @@
       "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.20.0.tgz",
       "integrity": "sha512-pITFBfCXoiwn2XmS30nhYDPWSbXGiGgqEWYIHslH9NDYPNo1lctjydR/dUYqOOxa+49hJk4ye8R+heZyMLydrA==",
       "license": "GPL-3.0",
-      "peer": true,
       "dependencies": {
         "@stacks/clarinet-sdk-wasm": "3.20.0",
         "@stacks/transactions": "7.4.0",
@@ -1218,8 +1216,7 @@
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.20.0.tgz",
       "integrity": "sha512-UJsepeAidFpPSffF283HZMtlOk5pGPaUS7OmBQgOC8tN5jWeADqYl97m61XdXi43pI/jdaKLuLVyktJkaOfJOw==",
-      "license": "GPL-3.0",
-      "peer": true
+      "license": "GPL-3.0"
     },
     "node_modules/@stacks/clarinet-sdk/node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -1969,7 +1966,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2069,7 +2065,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.3.tgz",
       "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",
@@ -4570,7 +4565,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4663,7 +4657,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4800,7 +4793,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -7555,6 +7555,16 @@ export const contracts = {
         },
         access: 'constant',
       } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_UNLOCK_HEIGHT: {
+        name: 'ERR_INVALID_UNLOCK_HEIGHT',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
       ERR_INVALID_UNSTAKE_SBTC_AMOUNT: {
         name: 'ERR_INVALID_UNSTAKE_SBTC_AMOUNT',
         type: {
@@ -7987,6 +7997,10 @@ export const contracts = {
       ERR_INVALID_START_BURN_HEIGHT: {
         isOk: false,
         value: 24n,
+      },
+      ERR_INVALID_UNLOCK_HEIGHT: {
+        isOk: false,
+        value: 52n,
       },
       ERR_INVALID_UNSTAKE_SBTC_AMOUNT: {
         isOk: false,

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -4072,6 +4072,7 @@ export const contracts = {
                 { name: 'tx', type: { buffer: { length: 100000 } } },
                 { name: 'tx-count', type: 'uint128' },
                 { name: 'tx-index', type: 'uint128' },
+                { name: 'unlock-burn-height', type: 'uint128' },
               ],
             },
           },
@@ -4096,6 +4097,7 @@ export const contracts = {
               tx: Uint8Array;
               txCount: number | bigint;
               txIndex: number | bigint;
+              unlockBurnHeight: number | bigint;
             },
             'lockup'
           >,
@@ -4746,6 +4748,7 @@ export const contracts = {
                 { name: 'tx', type: { buffer: { length: 100000 } } },
                 { name: 'tx-count', type: 'uint128' },
                 { name: 'tx-index', type: 'uint128' },
+                { name: 'unlock-burn-height', type: 'uint128' },
               ],
             },
           },
@@ -4756,9 +4759,10 @@ export const contracts = {
                 ok: {
                   tuple: [
                     {
-                      name: 'expected-script-hash',
-                      type: { buffer: { length: 34 } },
+                      name: 'early-unlock-bytes',
+                      type: { buffer: { length: 683 } },
                     },
+                    { name: 'minimum-unlock-height', type: 'uint128' },
                     {
                       name: 'seen-outpoints',
                       type: {
@@ -4776,6 +4780,11 @@ export const contracts = {
                         },
                       },
                     },
+                    { name: 'staker', type: 'principal' },
+                    {
+                      name: 'staker-unlock-bytes',
+                      type: { buffer: { length: 683 } },
+                    },
                     { name: 'sum', type: 'uint128' },
                   ],
                 },
@@ -4790,9 +4799,10 @@ export const contracts = {
               ok: {
                 tuple: [
                   {
-                    name: 'expected-script-hash',
-                    type: { buffer: { length: 34 } },
+                    name: 'early-unlock-bytes',
+                    type: { buffer: { length: 683 } },
                   },
+                  { name: 'minimum-unlock-height', type: 'uint128' },
                   {
                     name: 'seen-outpoints',
                     type: {
@@ -4806,6 +4816,11 @@ export const contracts = {
                         length: 10,
                       },
                     },
+                  },
+                  { name: 'staker', type: 'principal' },
+                  {
+                    name: 'staker-unlock-bytes',
+                    type: { buffer: { length: 683 } },
                   },
                   { name: 'sum', type: 'uint128' },
                 ],
@@ -4826,17 +4841,21 @@ export const contracts = {
               tx: Uint8Array;
               txCount: number | bigint;
               txIndex: number | bigint;
+              unlockBurnHeight: number | bigint;
             },
             'lockup'
           >,
           accumulatorRes: TypedAbiArg<
             Response<
               {
-                expectedScriptHash: Uint8Array;
+                earlyUnlockBytes: Uint8Array;
+                minimumUnlockHeight: number | bigint;
                 seenOutpoints: {
                   outputIndex: number | bigint;
                   txid: Uint8Array;
                 }[];
+                staker: string;
+                stakerUnlockBytes: Uint8Array;
                 sum: number | bigint;
               },
               number | bigint
@@ -4846,11 +4865,14 @@ export const contracts = {
         ],
         Response<
           {
-            expectedScriptHash: Uint8Array;
+            earlyUnlockBytes: Uint8Array;
+            minimumUnlockHeight: bigint;
             seenOutpoints: {
               outputIndex: bigint;
               txid: Uint8Array;
             }[];
+            staker: string;
+            stakerUnlockBytes: Uint8Array;
             sum: bigint;
           },
           bigint
@@ -4929,6 +4951,7 @@ export const contracts = {
                           { name: 'tx', type: { buffer: { length: 100000 } } },
                           { name: 'tx-count', type: 'uint128' },
                           { name: 'tx-index', type: 'uint128' },
+                          { name: 'unlock-burn-height', type: 'uint128' },
                         ],
                       },
                       length: 10,
@@ -4959,6 +4982,7 @@ export const contracts = {
                 tx: Uint8Array;
                 txCount: number | bigint;
                 txIndex: number | bigint;
+                unlockBurnHeight: number | bigint;
               }[];
               stakerUnlockBytes: Uint8Array;
             },
@@ -5247,6 +5271,7 @@ export const contracts = {
                               },
                               { name: 'tx-count', type: 'uint128' },
                               { name: 'tx-index', type: 'uint128' },
+                              { name: 'unlock-burn-height', type: 'uint128' },
                             ],
                           },
                           length: 10,
@@ -5335,6 +5360,7 @@ export const contracts = {
                   tx: Uint8Array;
                   txCount: number | bigint;
                   txIndex: number | bigint;
+                  unlockBurnHeight: number | bigint;
                 }[];
                 stakerUnlockBytes: Uint8Array;
               },

--- a/contrib/core-contract-tests/tests/pox-5/pox-5-helpers.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5-helpers.ts
@@ -105,17 +105,16 @@ export function serializeLockupScript({
 export function buildL1Lockup({
   staker,
   sats,
-  bondIndex,
+  unlockBurnHeight,
   stakerUnlockBytes = new Uint8Array(),
   earlyUnlockBytes = new Uint8Array(),
 }: {
   staker: string;
   sats: bigint;
-  bondIndex: bigint;
+  unlockBurnHeight: bigint;
   stakerUnlockBytes?: Uint8Array;
   earlyUnlockBytes?: Uint8Array;
 }) {
-  const unlockBurnHeight = rov(pox5.getBondL1UnlockHeight(bondIndex));
   const lockupScript = serializeLockupScript({
     stacker: staker,
     unlockBurnHeight,
@@ -156,6 +155,7 @@ export function buildL1Lockup({
     txIndex: 0n,
     height: 0n,
     tx: txBytes,
+    unlockBurnHeight,
   };
 }
 

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.prop.test.ts
@@ -36,16 +36,22 @@ it('should correctly prefix a script based on length', () => {
 });
 
 it('should construct the unlock script', () => {
+  const minimumUnlockHeight = rov(pox5.getBondL1UnlockHeight(0n));
+
   fc.assert(
     fc.property(
       randomPrincipalGen,
-      fc.integer({ min: 1, max: 0x7fffff }),
+      fc.integer({
+        min: 0,
+        max: 0x7fffff - Number(minimumUnlockHeight),
+      }),
       fc.uint8Array({ minLength: 1, maxLength: 255 }),
       fc.uint8Array({ minLength: 1, maxLength: 255 }),
-      (stacker, unlockBurnHeight, stakerUnlockBytes, earlyUnlockBytes) => {
+      (stacker, offset, stakerUnlockBytes, earlyUnlockBytes) => {
+        const unlockBurnHeight = minimumUnlockHeight + BigInt(offset);
         const expected = serializeLockupScript({
           stacker,
-          unlockBurnHeight: BigInt(unlockBurnHeight),
+          unlockBurnHeight,
           stakerUnlockBytes,
           earlyUnlockBytes,
         });

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -1586,7 +1586,11 @@ test.skip('l1 early exit prevents future bond rewards but leaves stx delegated',
       amountUstx: aliceUstx,
       btcLockup: ok({
         outputs: [
-          buildL1Lockup({ staker: alice, sats: aliceSats, bondIndex: 0n }),
+          buildL1Lockup({
+            staker: alice,
+            sats: aliceSats,
+            unlockBurnHeight: rov(pox5.getBondL1UnlockHeight(0n)),
+          }),
         ],
         stakerUnlockBytes: new Uint8Array(),
       }),
@@ -1644,7 +1648,11 @@ test.skip('l1 early exit does not erase already accrued bond rewards', () => {
       amountUstx: stxToUStx(50_000),
       btcLockup: ok({
         outputs: [
-          buildL1Lockup({ staker: alice, sats: aliceSats, bondIndex: 0n }),
+          buildL1Lockup({
+            staker: alice,
+            sats: aliceSats,
+            unlockBurnHeight: rov(pox5.getBondL1UnlockHeight(0n)),
+          }),
         ],
         stakerUnlockBytes: new Uint8Array(),
       }),
@@ -1701,7 +1709,11 @@ test.skip('l1 early exit does not erase already accrued staker rewards', () => {
       amountUstx: stxToUStx(50_000),
       btcLockup: ok({
         outputs: [
-          buildL1Lockup({ staker: alice, sats: aliceSats, bondIndex: 0n }),
+          buildL1Lockup({
+            staker: alice,
+            sats: aliceSats,
+            unlockBurnHeight: rov(pox5.getBondL1UnlockHeight(0n)),
+          }),
         ],
         stakerUnlockBytes: new Uint8Array(),
       }),

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -1587,7 +1587,38 @@ test('l1 lockup rejects an unlock height below the bond minimum', () => {
     alice,
   );
 
-  expect(result.value).toBe(errorCodes.ERR_INVALID_LOCKUP_SCRIPT);
+  expect(result.value).toBe(errorCodes.ERR_INVALID_UNLOCK_HEIGHT);
+});
+
+test('l1 lockup accepts an unlock height above the bond minimum', () => {
+  const signer = testSigner.identifier;
+  const aliceSats = 480000n;
+  const minimumUnlockHeight = rov(pox5.getBondL1UnlockHeight(0n));
+
+  registerSigner();
+  setupBondForAllowlist([{ maxSats: aliceSats, staker: alice }]);
+
+  const result = txErr(
+    pox5.registerForBond({
+      bondIndex: 0n,
+      signerManager: signer,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: ok({
+        outputs: [
+          buildL1Lockup({
+            staker: alice,
+            sats: aliceSats,
+            unlockBurnHeight: minimumUnlockHeight + 1n,
+          }),
+        ],
+        stakerUnlockBytes: new Uint8Array(),
+      }),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+
+  expect(result.value).toBe(errorCodes.ERR_INVALID_BTC_HEADER);
 });
 
 // Skipped: Simnet's burn header hashes aren't real, so most of the L1 paths

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -1559,6 +1559,37 @@ test('update-bond-registration in the final bond cycle leaves no future shares',
   expect(rov(pox5.getSignerSharesStakedForCycle(signer2, 13n, 0n))).toBe(0n);
 });
 
+test('l1 lockup rejects an unlock height below the bond minimum', () => {
+  const signer = testSigner.identifier;
+  const aliceSats = 480000n;
+  const minimumUnlockHeight = rov(pox5.getBondL1UnlockHeight(0n));
+
+  registerSigner();
+  setupBondForAllowlist([{ maxSats: aliceSats, staker: alice }]);
+
+  const result = txErr(
+    pox5.registerForBond({
+      bondIndex: 0n,
+      signerManager: signer,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: ok({
+        outputs: [
+          buildL1Lockup({
+            staker: alice,
+            sats: aliceSats,
+            unlockBurnHeight: minimumUnlockHeight - 1n,
+          }),
+        ],
+        stakerUnlockBytes: new Uint8Array(),
+      }),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+
+  expect(result.value).toBe(errorCodes.ERR_INVALID_LOCKUP_SCRIPT);
+});
+
 // Skipped: Simnet's burn header hashes aren't real, so most of the L1 paths
 // can't be covered in unit tests. These will be tested in integration tests.
 test.skip('l1 early exit prevents future bond rewards but leaves stx delegated', () => {

--- a/stacks-node/src/tests/pox_5_integrations.rs
+++ b/stacks-node/src/tests/pox_5_integrations.rs
@@ -31,30 +31,30 @@ use stacks::chainstate::stacks::{
     FungibleConditionCode, PostConditionPrincipal, PoxConditionCode, TransactionPostCondition,
     TransactionPostConditionMode,
 };
-use stacks::core::test_util::{make_contract_call, make_contract_call_with_post_conditions};
 use stacks::core::StacksEpochId;
+use stacks::core::test_util::{make_contract_call, make_contract_call_with_post_conditions};
 use stacks::util::hash::hex_bytes;
 use stacks::util_lib::boot::boot_code_id;
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::chainstate::{StacksAddress, StacksPublicKey};
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 
-use crate::burnchains::bitcoin::core_controller::BitcoinCoreController;
 use crate::burnchains::BurnchainController;
+use crate::burnchains::bitcoin::core_controller::BitcoinCoreController;
 use crate::neon::Counters;
 use crate::operations::BurnchainOpSigner;
 use crate::run_loop::boot_nakamoto;
 use crate::tests::nakamoto_integrations::{
-    boot_to_epoch_4_0, enable_epoch_4_0, get_tx_result_by_id, get_tx_status_by_id,
-    naka_neon_integration_conf, next_block_and_mine_commit,
-    next_block_and_process_new_stacks_block, setup_stacker, wait_for, POX_DEFAULT_STACKER_STX_AMT,
+    POX_DEFAULT_STACKER_STX_AMT, boot_to_epoch_4_0, enable_epoch_4_0, get_tx_result_by_id,
+    get_tx_status_by_id, naka_neon_integration_conf, next_block_and_mine_commit,
+    next_block_and_process_new_stacks_block, setup_stacker, wait_for,
 };
 use crate::tests::neon_integrations::{
     call_read_only, get_account, get_chain_info_result, submit_tx, test_observer, wait_for_runloop,
 };
 use crate::tests::signer::v0::pox5_signer_manager_source;
 use crate::tests::{make_contract_publish, to_addr};
-use crate::{tests, BitcoinRegtestController, Config, Keychain};
+use crate::{BitcoinRegtestController, Config, Keychain, tests};
 
 #[test]
 #[ignore]
@@ -1702,7 +1702,7 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
     //     output must pay to. We hand the same arguments the contract will
     //     reconstruct internally during `verify-l1-lockups`.
     let bond_index = 0u128;
-    let unlock_burn_height = call_read_only(
+    let minimum_unlock_burn_height = call_read_only(
         &naka_conf,
         &pox_5_addr,
         "pox-5",
@@ -1713,6 +1713,7 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
     .expect("get-bond-l1-unlock-height failed")
     .expect_u128()
     .expect("get-bond-l1-unlock-height should return a uint");
+    let unlock_burn_height = minimum_unlock_burn_height + 1;
     let expected_script_buff = call_read_only(
         &naka_conf,
         &pox_5_addr,
@@ -1871,10 +1872,9 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
             ),
             (
                 ClarityName::try_from("leaf-hashes").unwrap(),
-                Value::cons_list_unsanitized(vec![Value::buff_from(
-                    coinbase_txid_internal.to_vec(),
-                )
-                .unwrap()])
+                Value::cons_list_unsanitized(vec![
+                    Value::buff_from(coinbase_txid_internal.to_vec()).unwrap(),
+                ])
                 .unwrap(),
             ),
             (ClarityName::try_from("tx-count").unwrap(), Value::UInt(2)),
@@ -1882,6 +1882,10 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
             (
                 ClarityName::try_from("amount").unwrap(),
                 Value::UInt(u128::from(lockup_output_amount)),
+            ),
+            (
+                ClarityName::try_from("unlock-burn-height").unwrap(),
+                Value::UInt(unlock_burn_height),
             ),
         ])
         .unwrap(),
@@ -1901,7 +1905,7 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
     );
     let l1_lockup_arg = Value::okay(lockup_tuple).expect("failed to wrap lockup tuple in (ok ...)");
 
-    let register_fee = 2000u64;
+    let register_fee = 3000u64;
     let bond_amount = POX_DEFAULT_STACKER_STX_AMT;
     let staker_balance_before = get_account(&http_origin, &staker_addr).balance;
     // 3 register attempts: dup-outpoint rejection, happy path, ERR_ALREADY_REGISTERED.
@@ -2854,10 +2858,9 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
             ),
             (
                 ClarityName::try_from("leaf-hashes").unwrap(),
-                Value::cons_list_unsanitized(vec![Value::buff_from(
-                    coinbase_txid_internal.to_vec(),
-                )
-                .unwrap()])
+                Value::cons_list_unsanitized(vec![
+                    Value::buff_from(coinbase_txid_internal.to_vec()).unwrap(),
+                ])
                 .unwrap(),
             ),
             (ClarityName::try_from("tx-count").unwrap(), Value::UInt(2)),
@@ -2865,6 +2868,10 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
             (
                 ClarityName::try_from("amount").unwrap(),
                 Value::UInt(u128::from(lockup_output_amount)),
+            ),
+            (
+                ClarityName::try_from("unlock-burn-height").unwrap(),
+                Value::UInt(unlock_burn_height),
             ),
         ])
         .unwrap(),
@@ -2888,7 +2895,7 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
     // required for the Bitcoin-script assertions below — the early-exit
     // branch is a property of the witness script alone — but it
     // documents the realistic end-to-end flow.
-    let register_fee = 2000u64;
+    let register_fee = 3000u64;
     let bond_amount = POX_DEFAULT_STACKER_STX_AMT;
     let register_tx = make_contract_call(
         &staker_sk,

--- a/stacks-node/src/tests/pox_5_integrations.rs
+++ b/stacks-node/src/tests/pox_5_integrations.rs
@@ -31,30 +31,30 @@ use stacks::chainstate::stacks::{
     FungibleConditionCode, PostConditionPrincipal, PoxConditionCode, TransactionPostCondition,
     TransactionPostConditionMode,
 };
-use stacks::core::StacksEpochId;
 use stacks::core::test_util::{make_contract_call, make_contract_call_with_post_conditions};
+use stacks::core::StacksEpochId;
 use stacks::util::hash::hex_bytes;
 use stacks::util_lib::boot::boot_code_id;
 use stacks_common::consts::CHAIN_ID_TESTNET;
 use stacks_common::types::chainstate::{StacksAddress, StacksPublicKey};
 use stacks_common::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 
-use crate::burnchains::BurnchainController;
 use crate::burnchains::bitcoin::core_controller::BitcoinCoreController;
+use crate::burnchains::BurnchainController;
 use crate::neon::Counters;
 use crate::operations::BurnchainOpSigner;
 use crate::run_loop::boot_nakamoto;
 use crate::tests::nakamoto_integrations::{
-    POX_DEFAULT_STACKER_STX_AMT, boot_to_epoch_4_0, enable_epoch_4_0, get_tx_result_by_id,
-    get_tx_status_by_id, naka_neon_integration_conf, next_block_and_mine_commit,
-    next_block_and_process_new_stacks_block, setup_stacker, wait_for,
+    boot_to_epoch_4_0, enable_epoch_4_0, get_tx_result_by_id, get_tx_status_by_id,
+    naka_neon_integration_conf, next_block_and_mine_commit,
+    next_block_and_process_new_stacks_block, setup_stacker, wait_for, POX_DEFAULT_STACKER_STX_AMT,
 };
 use crate::tests::neon_integrations::{
     call_read_only, get_account, get_chain_info_result, submit_tx, test_observer, wait_for_runloop,
 };
 use crate::tests::signer::v0::pox5_signer_manager_source;
 use crate::tests::{make_contract_publish, to_addr};
-use crate::{BitcoinRegtestController, Config, Keychain, tests};
+use crate::{tests, BitcoinRegtestController, Config, Keychain};
 
 #[test]
 #[ignore]
@@ -1872,9 +1872,10 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
             ),
             (
                 ClarityName::try_from("leaf-hashes").unwrap(),
-                Value::cons_list_unsanitized(vec![
-                    Value::buff_from(coinbase_txid_internal.to_vec()).unwrap(),
-                ])
+                Value::cons_list_unsanitized(vec![Value::buff_from(
+                    coinbase_txid_internal.to_vec(),
+                )
+                .unwrap()])
                 .unwrap(),
             ),
             (ClarityName::try_from("tx-count").unwrap(), Value::UInt(2)),
@@ -2858,9 +2859,10 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
             ),
             (
                 ClarityName::try_from("leaf-hashes").unwrap(),
-                Value::cons_list_unsanitized(vec![
-                    Value::buff_from(coinbase_txid_internal.to_vec()).unwrap(),
-                ])
+                Value::cons_list_unsanitized(vec![Value::buff_from(
+                    coinbase_txid_internal.to_vec(),
+                )
+                .unwrap()])
                 .unwrap(),
             ),
             (ClarityName::try_from("tx-count").unwrap(), Value::UInt(2)),

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -2003,10 +2003,8 @@
             (accumulator (try! accumulator-res))
             (block (try! (parse-block-header (get header lockup))))
             (unlock-burn-height (get unlock-burn-height lockup))
-            (expected-script-hash (construct-lockup-output-script
-                (get staker accumulator)
-                unlock-burn-height
-                (get staker-unlock-bytes accumulator)
+            (expected-script-hash (construct-lockup-output-script (get staker accumulator)
+                unlock-burn-height (get staker-unlock-bytes accumulator)
                 (get early-unlock-bytes accumulator)
             ))
             (output (try! (get-bitcoin-tx-output? (get tx lockup) (get output-index lockup))))
@@ -2017,9 +2015,6 @@
                 output-index: (get output-index lockup),
             })
             (seen-outpoints (get seen-outpoints accumulator))
-        )
-        (asserts! (verify-block-header (get header lockup) (get height lockup))
-            ERR_INVALID_BTC_HEADER
         )
         (asserts! (>= unlock-burn-height (get minimum-unlock-height accumulator))
             ERR_INVALID_LOCKUP_SCRIPT
@@ -2032,6 +2027,9 @@
         )
         (asserts! (is-none (index-of? seen-outpoints outpoint))
             ERR_DUPLICATE_LOCKUP_OUTPOINT
+        )
+        (asserts! (verify-block-header (get header lockup) (get height lockup))
+            ERR_INVALID_BTC_HEADER
         )
         ;; verify merkle proof
         (asserts!

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -65,6 +65,8 @@
 (define-constant ERR_L1_EARLY_EXIT_ALREADY_ANNOUNCED (err u50))
 ;; A reserve withdrawal was attempted with insufficient reserve balance
 (define-constant ERR_INSUFFICIENT_RESERVE_BALANCE (err u51))
+;; The L1 lockup unlock height is lower than this bond's minimum unlock height
+(define-constant ERR_INVALID_UNLOCK_HEIGHT (err u52))
 
 ;; The length, in terms of staking cycles, of a given
 ;; bond period
@@ -1969,6 +1971,10 @@
 
 ;; Fold function for validating l1 lockup info
 ;;
+;; - `staker` is the lockup owner committed to the timelock script.
+;; - `minimum-unlock-height` is the earliest allowed L1 unlock height.
+;; - `staker-unlock-bytes` is the subscript that must unlock every output.
+;; - `early-unlock-bytes` is the bond's early-exit subscript.
 ;; - `sum` is the running total of sats from all valid lockups processed so far.
 ;; - `seen-outpoints` tracks every (txid, output-index) pair already credited
 ;;   in this call. Duplicate entries is rejected via
@@ -2017,7 +2023,7 @@
             (seen-outpoints (get seen-outpoints accumulator))
         )
         (asserts! (>= unlock-burn-height (get minimum-unlock-height accumulator))
-            ERR_INVALID_LOCKUP_SCRIPT
+            ERR_INVALID_UNLOCK_HEIGHT
         )
         (asserts! (is-eq (get script output) expected-script-hash)
             ERR_INVALID_LOCKUP_SCRIPT

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -616,6 +616,7 @@
                     tx-count: uint,
                     tx-index: uint,
                     amount: uint,
+                    unlock-burn-height: uint,
                 }
             ),
             staker-unlock-bytes: (buff 683),
@@ -1943,6 +1944,7 @@
                     tx-count: uint,
                     tx-index: uint,
                     amount: uint,
+                    unlock-burn-height: uint,
                 }
             ),
             staker-unlock-bytes: (buff 683),
@@ -1950,15 +1952,13 @@
     )
     (let (
             (bond (unwrap! (get-protocol-bond bond-index) ERR_BOND_NOT_FOUND))
-            (expected-timelock-output (construct-lockup-output-script staker
-                (get-bond-l1-unlock-height bond-index)
-                (get staker-unlock-bytes lockups)
-                (get early-unlock-bytes bond)
-            ))
             (accumulation (try! (fold validate-l1-lockup (get outputs lockups)
                 (ok {
                     sum: u0,
-                    expected-script-hash: expected-timelock-output,
+                    staker: staker,
+                    minimum-unlock-height: (get-bond-l1-unlock-height bond-index),
+                    staker-unlock-bytes: (get staker-unlock-bytes lockups),
+                    early-unlock-bytes: (get early-unlock-bytes bond),
                     seen-outpoints: (list),
                 })
             )))
@@ -1969,7 +1969,6 @@
 
 ;; Fold function for validating l1 lockup info
 ;;
-;; - `expected-script-hash` is the timelock script that the lockup must match
 ;; - `sum` is the running total of sats from all valid lockups processed so far.
 ;; - `seen-outpoints` tracks every (txid, output-index) pair already credited
 ;;   in this call. Duplicate entries is rejected via
@@ -1984,9 +1983,13 @@
             tx-count: uint,
             tx-index: uint,
             amount: uint,
+            unlock-burn-height: uint,
         })
         (accumulator-res (response {
-            expected-script-hash: (buff 34),
+            staker: principal,
+            minimum-unlock-height: uint,
+            staker-unlock-bytes: (buff 683),
+            early-unlock-bytes: (buff 683),
             sum: uint,
             seen-outpoints: (list 10 {
                 txid: (buff 32),
@@ -1999,7 +2002,13 @@
     (let (
             (accumulator (try! accumulator-res))
             (block (try! (parse-block-header (get header lockup))))
-            (expected-script-hash (get expected-script-hash accumulator))
+            (unlock-burn-height (get unlock-burn-height lockup))
+            (expected-script-hash (construct-lockup-output-script
+                (get staker accumulator)
+                unlock-burn-height
+                (get staker-unlock-bytes accumulator)
+                (get early-unlock-bytes accumulator)
+            ))
             (output (try! (get-bitcoin-tx-output? (get tx lockup) (get output-index lockup))))
             (reversed-txid (get txid output))
             (txid (reverse-buff32 reversed-txid))
@@ -2011,6 +2020,9 @@
         )
         (asserts! (verify-block-header (get header lockup) (get height lockup))
             ERR_INVALID_BTC_HEADER
+        )
+        (asserts! (>= unlock-burn-height (get minimum-unlock-height accumulator))
+            ERR_INVALID_LOCKUP_SCRIPT
         )
         (asserts! (is-eq (get script output) expected-script-hash)
             ERR_INVALID_LOCKUP_SCRIPT
@@ -2034,7 +2046,10 @@
             ERR_INVALID_MERKLE_PROOF
         )
         (ok {
-            expected-script-hash: (get expected-script-hash accumulator),
+            staker: (get staker accumulator),
+            minimum-unlock-height: (get minimum-unlock-height accumulator),
+            staker-unlock-bytes: (get staker-unlock-bytes accumulator),
+            early-unlock-bytes: (get early-unlock-bytes accumulator),
             sum: (+ (get sum accumulator) (get amount output)),
             seen-outpoints: (unwrap-panic (as-max-len? (append seen-outpoints outpoint) u10)),
         })
@@ -2050,6 +2065,7 @@
     tx-count: uint,
     tx-index: uint,
     amount: uint,
+    unlock-burn-height: uint,
 }))
     {
         txid: (get-reversed-txid (get tx lockup)),


### PR DESCRIPTION
Previously, we required that an L1 timelock script had an exact match for the `CHECKSEQUENCEVERIFY` block height. We've decided to extend this to allow heights _larger_ than the minimum value. For one, this might help recover in scenarios where the user accidentally uses too high of a number. Secondly, it allows for re-using the same locked BTC in subsequent (not overlapping) bonds, without needing to re-lock the BTC.