### PR TITLE
chore: update clar2wam depedency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stx-labs/clarity-wasm.git#84f18a629f70cfa12b4a130aa7b18a8ee1a48ccb"
+source = "git+https://github.com/stx-labs/clarity-wasm.git#f346b438c43b5e0f17e522a651e4e2567f1051e5"
 dependencies = [
  "chrono",
  "clap",


### PR DESCRIPTION
Update dependency to use post sync clarity-wasm.