### PR TITLE
fix: verify pox-addr in signer manager callback

### DIFF
--- a/changelog.d/check-pox-addr.fixed
+++ b/changelog.d/check-pox-addr.fixed
@@ -1,0 +1,1 @@
+In `signer-manager.clar`, the function `check-pox-addr` wasn't used. Now, it is used to check when a staker has passed a `pox-addr` as part of their calldata.

--- a/contrib/core-contract-tests/contracts/signer-manager.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager.clar
@@ -143,6 +143,7 @@
                     )
                     ERR_INVALID_CALLDATA
                 )))
+                (try! (check-pox-addr (get pox-addr pox-addr)))
                 (map-set pox-addrs staker pox-addr)
                 true
             )

--- a/contrib/core-contract-tests/package-lock.json
+++ b/contrib/core-contract-tests/package-lock.json
@@ -656,7 +656,6 @@
       "integrity": "sha512-eYaoxI/luH7xe0DeE3c1q66Cxqi0bBed3AOUbhL9wqWtW7leD9RG+wQFuL3fJAPq7wONq32C92DDGuvQo6ZNQA==",
       "deprecated": "The Clarinet SDK has been moved to @stacks/clarinet-sdk",
       "license": "GPL-3.0",
-      "peer": true,
       "dependencies": {
         "@hirosystems/clarinet-sdk-wasm": "^3.1.0",
         "@stacks/transactions": "^7.0.6",
@@ -1202,7 +1201,6 @@
       "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.20.0.tgz",
       "integrity": "sha512-pITFBfCXoiwn2XmS30nhYDPWSbXGiGgqEWYIHslH9NDYPNo1lctjydR/dUYqOOxa+49hJk4ye8R+heZyMLydrA==",
       "license": "GPL-3.0",
-      "peer": true,
       "dependencies": {
         "@stacks/clarinet-sdk-wasm": "3.20.0",
         "@stacks/transactions": "7.4.0",
@@ -1218,8 +1216,7 @@
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.20.0.tgz",
       "integrity": "sha512-UJsepeAidFpPSffF283HZMtlOk5pGPaUS7OmBQgOC8tN5jWeADqYl97m61XdXi43pI/jdaKLuLVyktJkaOfJOw==",
-      "license": "GPL-3.0",
-      "peer": true
+      "license": "GPL-3.0"
     },
     "node_modules/@stacks/clarinet-sdk/node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -1969,7 +1966,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2069,7 +2065,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.3.tgz",
       "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",
@@ -4570,7 +4565,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4663,7 +4657,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4800,7 +4793,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
@@ -166,6 +166,34 @@ test('signers have pox-addr saved from calldata when provided', () => {
   expect(rov(signerManager.getPoxAddr(alice))?.maxFee).toEqual(maxFee);
 });
 
+test('staking rejects malformed pox-addr calldata', () => {
+  const calldata = hex.decode(
+    serializeCV(
+      Cl.tuple({
+        'pox-addr': Cl.tuple({
+          version: Cl.buffer(new Uint8Array([0])),
+          hashbytes: Cl.buffer(new Uint8Array(32)),
+        }),
+        'max-fee': Cl.uint(100n),
+      }),
+    ),
+  );
+
+  expect(
+    txErr(
+      pox5.stake({
+        signerManager: signerManager.identifier,
+        amountUstx: 100000000n,
+        numCycles: 1n,
+        startBurnHt: simnet.burnBlockHeight,
+        signerCalldata: calldata,
+      }),
+      alice,
+    ).value,
+  ).toBe(signerManagerErrors.ERR_INVALID_POX_ADDR);
+  expect(rov(signerManager.getPoxAddr(alice))).toBeNull();
+});
+
 test('only admins can update fees and fees cannot exceed max bips', () => {
   expect(txErr(signerManager.updateFees(1000n), alice).value).toBe(
     signerManagerErrors.ERR_UNAUTHORIZED_ADMIN,


### PR DESCRIPTION
The `signer-manager.clar` callback accepts a `pox-addr`, but `check-pox-addr` was never actually called.