### PR TITLE
fix: only allow fees up to 99.99%

### DIFF
--- a/changelog.d/signer-max-fee.fixed
+++ b/changelog.d/signer-max-fee.fixed
@@ -1,0 +1,1 @@
+Updates the max-fee settable by the signer to be 99.99%, to prevent accounting issues.

--- a/contrib/core-contract-tests/contracts/signer-manager.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager.clar
@@ -438,7 +438,7 @@
 (define-public (update-fees (new-fees uint))
     (begin
         (try! (authorize-admin))
-        (asserts! (<= new-fees MAX_BIPS) ERR_INVALID_FEES_BIPS)
+        (asserts! (< new-fees MAX_BIPS) ERR_INVALID_FEES_BIPS)
         (print {
             topic: "update-fees",
             old-fees: (var-get fees-bips),

--- a/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
@@ -166,14 +166,17 @@ test('signers have pox-addr saved from calldata when provided', () => {
   expect(rov(signerManager.getPoxAddr(alice))?.maxFee).toEqual(maxFee);
 });
 
-test('only admins can update fees and fees cannot exceed max bips', () => {
+test('only admins can update fees and fees must be less than max bips', () => {
   expect(txErr(signerManager.updateFees(1000n), alice).value).toBe(
     signerManagerErrors.ERR_UNAUTHORIZED_ADMIN,
+  );
+  expect(txErr(signerManager.updateFees(10000n), deployer).value).toBe(
+    signerManagerErrors.ERR_INVALID_FEES_BIPS,
   );
   expect(txErr(signerManager.updateFees(10001n), deployer).value).toBe(
     signerManagerErrors.ERR_INVALID_FEES_BIPS,
   );
-  txOk(signerManager.updateFees(10000n), deployer);
+  txOk(signerManager.updateFees(9999n), deployer);
 });
 
 test('fees are deducted from newly earned staker rewards', () => {


### PR DESCRIPTION
This changes the logic in `signer-manager.clar` to only allow fees up to 99.99%, instead of 100%. This is because using 100% could cause an issue where state snapshotting wouldn't occur, due to no new rewards being earned. Even though this is an unlikely scenario, it's a small change that seems worth doing.