### PR TITLE
fix: return error when no claimable staker rewards are available

### DIFF
--- a/changelog.d/error-no-claimable-rewards.fixed
+++ b/changelog.d/error-no-claimable-rewards.fixed
@@ -1,0 +1,1 @@
+Fixed an error where there could be an arithmetic underflow if a staker claimed rewards before the signer claimed their own first. Instead, we now explicitly return an error.

--- a/contrib/core-contract-tests/contracts/signer-manager.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager.clar
@@ -236,8 +236,10 @@
                 MAX_BIPS
             ))
             (earned (- gross fees))
+            (unclaimed-rewards (var-get unclaimed-staker-rewards))
         )
         (asserts! (> earned u0) ERR_NO_CLAIMABLE_REWARDS)
+        (asserts! (>= unclaimed-rewards gross) ERR_NO_CLAIMABLE_REWARDS)
         (asserts!
             (>
                 (unwrap-panic (contract-call?
@@ -252,7 +254,7 @@
         ;; This staker's share is being distributed now so release it from
         ;; the unclaimed count recorded when `claim-rewards` pulled it in.
         (var-set unclaimed-staker-rewards
-            (- (var-get unclaimed-staker-rewards) gross)
+            (- unclaimed-rewards gross)
         )
         (try! (as-contract?
             ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token

--- a/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/signer-manager.test.ts
@@ -390,6 +390,69 @@ test('bond rewards remain claimable from old signer after staker changes signers
   });
 });
 
+test('staker reward claim before signer reward pull returns no claimable rewards', () => {
+  const bondIndex = 0n;
+  const aliceSats = 480000n;
+  const rewards = 1200n;
+
+  txOk(
+    pox5.setupBond({
+      bondIndex,
+      targetRate: 1500n,
+      stxValueRatio: 10n,
+      minUstxRatio: 100n,
+      earlyUnlockBytes: new Uint8Array(),
+      allowlist: [{ maxSats: aliceSats, staker: alice }],
+    }),
+    deployer,
+  );
+  txOk(
+    pox5.registerForBond({
+      bondIndex,
+      signerManager: signerManager.identifier,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: err(aliceSats),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+  txOk(
+    sbtc.transfer({
+      recipient: pox5.identifier,
+      amount: rewards,
+      sender: deployer,
+      memo: null,
+    }),
+    deployer,
+  );
+
+  mineUntil(rov(pox5.rewardCycleToBurnHeight(1n)) + HALF_CYCLE_LENGTH);
+  txOk(pox5.calculateRewards([bondIndex]), deployer);
+  txOk(
+    pox5.unstakeSbtc({
+      signerManager: signerManager.identifier,
+      amountToWithdrawalSats: aliceSats,
+    }),
+    alice,
+  );
+  txOk(
+    sbtc.transfer({
+      recipient: signerManager.identifier,
+      amount: 1n,
+      sender: deployer,
+      memo: null,
+    }),
+    deployer,
+  );
+
+  expect(
+    txErr(signerManager.claimStakerRewards(alice, 1n, bondIndex), bob).value,
+  ).toBe(signerManagerErrors.ERR_NO_CLAIMABLE_REWARDS);
+
+  txOk(signerManager.claimRewards([bondIndex], 1n), deployer);
+  txOk(signerManager.claimStakerRewards(alice, 1n, bondIndex), bob);
+});
+
 test('claiming staker rewards with pox-addr initiates a withdrawal request', () => {
   const rewards = 2000n;
   const grossPerStaker = stxRewards(rewards) / 2n;


### PR DESCRIPTION
If a staker calls `claim-staker-rewards` before `claim-rewards` has been called for that signer, it could cause an arithmetic underflow. This PR updates that behavior to more cleanly return `ERR_NO_CLAIMABLE_REWARDS` instead of panicking.