### PR TITLE
Fix: reject transactions which would contain PoX assetmap overwrites

### DIFF
--- a/changelog.d/reject-pox-assetmap-overwrite.fixed
+++ b/changelog.d/reject-pox-assetmap-overwrite.fixed
@@ -1,0 +1,1 @@
+Reject blocks which contain transactions with PoX assetmap overwrites

--- a/clarity/src/vm/analysis/errors.rs
+++ b/clarity/src/vm/analysis/errors.rs
@@ -570,6 +570,10 @@ pub enum RuntimeCheckErrorKind {
     ///  miner block assembly)
     AbortedByExecutionHook(String),
 
+    /// Block rejection: a `pox-4` call would overwrite
+    /// an existing asset-map stacking entry for its sender.
+    PoxStxAssetMapOverwrite,
+
     // List typing errors
     /// List elements have mismatched types, violating type consistency.
     ListTypesMustMatch,
@@ -677,6 +681,7 @@ impl RuntimeCheckErrorKind {
             RuntimeCheckErrorKind::Unreachable(_)
                 | RuntimeCheckErrorKind::RestrictAssetsMemoryExceeded(_, _)
                 | RuntimeCheckErrorKind::AbortedByExecutionHook(_)
+                | RuntimeCheckErrorKind::PoxStxAssetMapOverwrite
         )
     }
 

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -559,6 +559,16 @@ impl AssetMap {
             stx_burn_to_add.push((principal.clone(), next_amount));
         }
 
+        // Reject any transaction that would overwrite an
+        // existing asset-map stacking entry for `sender`.
+        for principal in other.stacking_map.keys() {
+            if self.stacking_map.contains_key(principal) {
+                return Err(VmExecutionError::from(
+                    RuntimeCheckErrorKind::PoxStxAssetMapOverwrite,
+                ));
+            }
+        }
+
         // After this point, this function will not fail.
         for (principal, mut principal_map) in other.asset_map.drain() {
             for (asset, mut transfers) in principal_map.drain() {

--- a/pox-locking/src/pox_4.rs
+++ b/pox-locking/src/pox_4.rs
@@ -19,7 +19,7 @@ use clarity::vm::contexts::{ExecutionState, GlobalContext};
 use clarity::vm::costs::cost_functions::ClarityCostFunction;
 use clarity::vm::costs::runtime_cost;
 use clarity::vm::database::{ClarityDatabase, STXBalance};
-use clarity::vm::errors::{RuntimeError, VmExecutionError, VmInternalError};
+use clarity::vm::errors::{RuntimeCheckErrorKind, RuntimeError, VmExecutionError, VmInternalError};
 use clarity::vm::events::{STXEventType, STXLockEventData, StacksTransactionEvent};
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use clarity::vm::Value;
@@ -400,6 +400,17 @@ pub fn handle_contract_call(
         // Update the asset map to reflect the delegation
         match (sender_opt, args.first()) {
             (Some(sender), Some(Value::UInt(amount))) => {
+                // Reject any transaction that would overwrite an
+                // existing asset-map stacking entry for `sender`.
+                if global_context
+                    .get_readonly_asset_map()?
+                    .get_stacking(sender)
+                    .is_some()
+                {
+                    return Err(VmExecutionError::from(
+                        RuntimeCheckErrorKind::PoxStxAssetMapOverwrite,
+                    ));
+                }
                 global_context.log_stacking(sender, *amount)?;
             }
             _ => {

--- a/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/runtime_analysis_tests.rs
@@ -143,6 +143,7 @@ fn variant_coverage_report(variant: RuntimeCheckErrorKind) {
         InvalidUTF8Encoding => {
             Ignored("Only reachable via legacy v1 parsing paths")
         },
+        PoxStxAssetMapOverwrite => todo!(),
     };
 }
 


### PR DESCRIPTION
This fixes a tracking issue in PoX assetmaps by rejecting transactions which would overwrite.