### PR TITLE
fix: add fixed npm version to prevent package-lock.json thrash

### DIFF
--- a/contrib/core-contract-tests/package-lock.json
+++ b/contrib/core-contract-tests/package-lock.json
@@ -656,7 +656,6 @@
       "integrity": "sha512-eYaoxI/luH7xe0DeE3c1q66Cxqi0bBed3AOUbhL9wqWtW7leD9RG+wQFuL3fJAPq7wONq32C92DDGuvQo6ZNQA==",
       "deprecated": "The Clarinet SDK has been moved to @stacks/clarinet-sdk",
       "license": "GPL-3.0",
-      "peer": true,
       "dependencies": {
         "@hirosystems/clarinet-sdk-wasm": "^3.1.0",
         "@stacks/transactions": "^7.0.6",
@@ -1202,7 +1201,6 @@
       "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.20.0.tgz",
       "integrity": "sha512-pITFBfCXoiwn2XmS30nhYDPWSbXGiGgqEWYIHslH9NDYPNo1lctjydR/dUYqOOxa+49hJk4ye8R+heZyMLydrA==",
       "license": "GPL-3.0",
-      "peer": true,
       "dependencies": {
         "@stacks/clarinet-sdk-wasm": "3.20.0",
         "@stacks/transactions": "7.4.0",
@@ -1218,8 +1216,7 @@
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.20.0.tgz",
       "integrity": "sha512-UJsepeAidFpPSffF283HZMtlOk5pGPaUS7OmBQgOC8tN5jWeADqYl97m61XdXi43pI/jdaKLuLVyktJkaOfJOw==",
-      "license": "GPL-3.0",
-      "peer": true
+      "license": "GPL-3.0"
     },
     "node_modules/@stacks/clarinet-sdk/node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -1969,7 +1966,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2069,7 +2065,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.3.tgz",
       "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",
@@ -4570,7 +4565,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4663,7 +4657,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4800,7 +4793,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/contrib/core-contract-tests/package.json
+++ b/contrib/core-contract-tests/package.json
@@ -4,11 +4,11 @@
   "description": "Run unit tests on this project.",
   "private": true,
   "type": "module",
-  "packageManager": "npm@11",
+  "packageManager": "npm@>=11.7 <12",
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": ">=11 <12",
+      "version": ">=11.7 <12",
       "onFail": "error"
     }
   },

--- a/contrib/core-contract-tests/package.json
+++ b/contrib/core-contract-tests/package.json
@@ -4,6 +4,14 @@
   "description": "Run unit tests on this project.",
   "private": true,
   "type": "module",
+  "packageManager": "npm@11",
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11 <12",
+      "onFail": "error"
+    }
+  },
   "scripts": {
     "test": "vitest run -- --coverage",
     "test:watch": "SUPPRESS_CLARINET_LOGS=1 NODE_OPTIONS=\"--import ./tests/suppress-stdout.js\" vitest",


### PR DESCRIPTION
This adds a major version requirement to `package.json`, so that `package-lock.json` doesn't get updated depending on which version of NPM you're using. I've set our version to the latest stable major version (v11)