### PR TITLE
feat: add sBTC contracts to /v2/pox

### DIFF
--- a/changelog.d/pox-info-sbtc-contracts.added
+++ b/changelog.d/pox-info-sbtc-contracts.added
@@ -1,0 +1,1 @@
+The `/v2/pox` RPC response now includes `pox_5_sbtc_contract` and `pox_5_sbtc_registry_contract`, the sBTC token and registry contract identifiers that this node's PoX-5 references. On mainnet these are the canonical sBTC contracts; on non-mainnet they reflect the node's configuration.

--- a/docs/rpc/components/examples/pox-info.example.json
+++ b/docs/rpc/components/examples/pox-info.example.json
@@ -73,6 +73,8 @@
                 },
                 "network_epoch": 1
             }
-        ]
+        ],
+        "pox_5_sbtc_contract": "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token",
+        "pox_5_sbtc_registry_contract": "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry"
     }
 }

--- a/docs/rpc/components/schemas/pox-info.schema.yaml
+++ b/docs/rpc/components/schemas/pox-info.schema.yaml
@@ -16,6 +16,8 @@ required:
   - contract_versions
   - epochs
   - current_epoch
+  - pox_5_sbtc_contract
+  - pox_5_sbtc_registry_contract
 properties:
   contract_id:
     type: string
@@ -35,13 +37,13 @@ properties:
   pox_activation_threshold_ustx:
     type: integer
     description:
-      The threshold of stacking participation that must be reached for
-      PoX to activate in any cycle
+      The threshold of stacking participation that must be reached for PoX to
+      activate in any cycle
   rejection_fraction:
     type: [integer, "null"]
     description:
-      The fraction of liquid STX that must vote to reject PoX in order
-      to prevent the next reward cycle from activating.
+      The fraction of liquid STX that must vote to reject PoX in order to
+      prevent the next reward cycle from activating.
   reward_phase_block_length:
     type: integer
     minimum: 0
@@ -62,8 +64,8 @@ properties:
     type: integer
     minimum: 0
     description:
-      The length in burn blocks of a whole PoX cycle (reward phase and
-      prepare phase)
+      The length in burn blocks of a whole PoX cycle (reward phase and prepare
+      phase)
   current_cycle:
     type: object
     additionalProperties: false
@@ -80,11 +82,13 @@ properties:
       min_threshold_ustx:
         type: integer
         minimum: 0
-        description: The threshold amount for obtaining a slot in this reward cycle.
+        description:
+          The threshold amount for obtaining a slot in this reward cycle.
       stacked_ustx:
         type: integer
         minimum: 0
-        description: The total amount of stacked microstacks in this reward cycle.
+        description:
+          The total amount of stacked microstacks in this reward cycle.
       is_pox_active:
         type: boolean
         description: Whether or not PoX is active during this reward cycle.
@@ -108,15 +112,18 @@ properties:
       min_threshold_ustx:
         type: integer
         minimum: 0
-        description: The threshold amount for obtaining a slot in this reward cycle.
+        description:
+          The threshold amount for obtaining a slot in this reward cycle.
       stacked_ustx:
         type: integer
         minimum: 0
-        description: The total amount of stacked microstacks in this reward cycle.
+        description:
+          The total amount of stacked microstacks in this reward cycle.
       min_increment_ustx:
         type: integer
         minimum: 0
-        description: The minimum amount that can be used to submit a `stack-stx` call.
+        description:
+          The minimum amount that can be used to submit a `stack-stx` call.
       prepare_phase_start_block_height:
         type: integer
         minimum: 0
@@ -127,14 +134,14 @@ properties:
         type: integer
         description:
           The number of burn blocks until the prepare phase for this cycle
-          starts. If the prepare phase for this cycle already started, this value
-          will be a negative number.
+          starts. If the prepare phase for this cycle already started, this
+          value will be a negative number.
       reward_phase_start_block_height:
         type: integer
         minimum: 0
         description:
-          The burn block height when the reward phase for this cycle begins.
-          Any eligible stacks must be stacked before this block.
+          The burn block height when the reward phase for this cycle begins. Any
+          eligible stacks must be stacked before this block.
       blocks_until_reward_phase:
         type: integer
         minimum: 0
@@ -143,8 +150,8 @@ properties:
         type: [integer, "null"]
         minimum: 0
         description:
-          The remaining amount of liquid STX that must vote to reject the
-          next reward cycle to prevent the next reward cycle from activating.
+          The remaining amount of liquid STX that must vote to reject the next
+          reward cycle to prevent the next reward cycle from activating.
   reward_cycle_id:
     type: integer
     minimum: 0
@@ -183,11 +190,26 @@ properties:
         activation_burnchain_block_height:
           type: integer
           minimum: 0
-          description: The burn block height at which this version of PoX is activated
+          description:
+            The burn block height at which this version of PoX is activated
         first_reward_cycle_id:
           type: integer
           minimum: 0
-          description: The first reward cycle number that uses this version of PoX
+          description:
+            The first reward cycle number that uses this version of PoX
+  pox_5_sbtc_contract:
+    type: string
+    description:
+      The sBTC token contract used for PoX payments in epoch 4+. On mainnet this
+      is the canonical sBTC token; on non-mainnet it reflects this node's
+      configuration.
+  pox_5_sbtc_registry_contract:
+    type: string
+    description:
+      The sBTC registry contract from which the node derives the per-cycle sBTC
+      waterfall recipient (epoch 4+) via a call to
+      `get-current-aggregate-pubkey`. On mainnet this is the canonical sBTC
+      registry; on non-mainnet it reflects this node's configuration.
   epochs:
     type: array
     description: Epochs

--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -351,6 +351,8 @@ pub(crate) mod tests {
             rejection_votes_left_required: None,
             next_reward_cycle_in: thread_rng().next_u64(),
             contract_versions: vec![],
+            pox_5_sbtc_contract: "ST000000000000000000002AMW42H.sbtc-token".to_string(),
+            pox_5_sbtc_registry_contract: "ST000000000000000000002AMW42H.sbtc-registry".to_string(),
         };
         let pox_info_json = serde_json::to_string(&pox_info).expect("Failed to serialize pox info");
         (format!("HTTP/1.1 200 Ok\n\n{pox_info_json}"), pox_info)

--- a/stackslib/src/net/api/getpoxinfo.rs
+++ b/stackslib/src/net/api/getpoxinfo.rs
@@ -28,6 +28,7 @@ use stacks_common::types::StacksEpochId;
 use crate::burnchains::Burnchain;
 use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::coordinator::OnChainRewardSetProvider;
+use crate::chainstate::nakamoto::signer_set::{pox_5_sbtc_contract, pox_5_sbtc_registry_contract};
 use crate::chainstate::stacks::boot::{
     POX_1_NAME, POX_2_NAME, POX_3_NAME, POX_4_NAME, POX_5_NAME, POX_5_SIGNER_SET_MIN_USTX,
 };
@@ -130,6 +131,19 @@ pub struct RPCPoxInfoData {
 
     // Information specific to each PoX contract version
     pub contract_versions: Vec<RPCPoxContractVersion>,
+
+    // Epoch 4.0 / PoX-5 scaffolding: the sBTC token contract used for PoX
+    // payments in epoch 4+. On mainnet this is the canonical sBTC token; on
+    // non-mainnet it reflects this node's configuration (operators configuring
+    // different contracts will fork the chain), so it is exposed here for
+    // diagnostics.
+    pub pox_5_sbtc_contract: String,
+
+    // Epoch 4.0 / PoX-5 scaffolding: the sBTC registry contract from which the
+    // node derives the per-cycle sBTC waterfall recipient (epoch 4+) via a
+    // call to `get-current-aggregate-pubkey`. Same mainnet-fixed /
+    // non-mainnet-configurable semantics as `pox_5_sbtc_contract`.
+    pub pox_5_sbtc_registry_contract: String,
 }
 
 impl RPCPoxInfoData {
@@ -504,6 +518,8 @@ impl RPCPoxInfoData {
                     first_reward_cycle_id: pox_5_first_cycle,
                 },
             ],
+            pox_5_sbtc_contract: pox_5_sbtc_contract(mainnet).to_string(),
+            pox_5_sbtc_registry_contract: pox_5_sbtc_registry_contract(mainnet).to_string(),
         })
     }
 

--- a/stackslib/src/net/api/tests/getpoxinfo.rs
+++ b/stackslib/src/net/api/tests/getpoxinfo.rs
@@ -138,6 +138,29 @@ fn test_getpoxinfo_reports_newest_pox_contract() {
     );
 }
 
+/// Guard test that `/v2/pox` surfaces the sBTC token and registry contracts
+/// that PoX-5 references.
+#[test]
+fn test_getpoxinfo_reports_sbtc_contracts() {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
+    let request = StacksHttpRequest::new_getpoxinfo(addr.into(), TipRequest::UseLatestAnchoredTip);
+
+    let rpc = TestRPC::setup(function_name!());
+    let mut responses = rpc.run(vec![request]);
+    let info = decode_pox_info(responses.remove(0));
+
+    assert_eq!(
+        info.pox_5_sbtc_contract, "ST000000000000000000002AMW42H.sbtc-token",
+        "unexpected pox_5_sbtc_contract on /v2/pox: {}",
+        info.pox_5_sbtc_contract
+    );
+    assert_eq!(
+        info.pox_5_sbtc_registry_contract, "ST000000000000000000002AMW42H.sbtc-registry",
+        "unexpected pox_5_sbtc_registry_contract on /v2/pox: {}",
+        info.pox_5_sbtc_registry_contract
+    );
+}
+
 fn make_transfer_tx(
     key: &StacksPrivateKey,
     nonce: u64,

--- a/stackslib/src/net/api/tests/postblock_v3.rs
+++ b/stackslib/src/net/api/tests/postblock_v3.rs
@@ -15,7 +15,6 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use clarity::util::hash::{MerkleTree, Sha512Trunc256Sum};
 use stacks_common::types::chainstate::StacksPrivateKey;
 use stacks_common::types::StacksEpochId;
 


### PR DESCRIPTION
The `/v2/pox` RPC response now includes `pox_5_sbtc_contract` and `pox_5_sbtc_registry_contract`, the sBTC token and registry contract identifiers that this node's PoX-5 references. On mainnet these are the canonical sBTC contracts; on non-mainnet they reflect the node's configuration.

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [x] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
