### PR TITLE
fix: issues when serializing larger cscriptnums in Clarity

### DIFF
--- a/changelog.d/pox-5-cscriptnum-unlock-height.fixed
+++ b/changelog.d/pox-5-cscriptnum-unlock-height.fixed
@@ -1,0 +1,1 @@
+Fixed PoX-5 L1 lockup CLTV height serialization so large unlock heights cannot truncate to lower Bitcoin script numbers.

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -5972,7 +5972,11 @@ export const contracts = {
           { name: 'staker-unlock-bytes', type: { buffer: { length: 683 } } },
           { name: 'early-unlock-bytes', type: { buffer: { length: 683 } } },
         ],
-        outputs: { type: { buffer: { length: 34 } } },
+        outputs: {
+          type: {
+            response: { ok: { buffer: { length: 34 } }, error: 'uint128' },
+          },
+        },
       } as TypedAbiFunction<
         [
           staker: TypedAbiArg<string, 'staker'>,
@@ -5980,7 +5984,7 @@ export const contracts = {
           stakerUnlockBytes: TypedAbiArg<Uint8Array, 'stakerUnlockBytes'>,
           earlyUnlockBytes: TypedAbiArg<Uint8Array, 'earlyUnlockBytes'>,
         ],
-        Uint8Array
+        Response<Uint8Array, bigint>
       >,
       constructLockupScript: {
         name: 'construct-lockup-script',
@@ -5991,7 +5995,11 @@ export const contracts = {
           { name: 'staker-unlock-bytes', type: { buffer: { length: 683 } } },
           { name: 'early-unlock-bytes', type: { buffer: { length: 683 } } },
         ],
-        outputs: { type: { buffer: { length: 2437 } } },
+        outputs: {
+          type: {
+            response: { ok: { buffer: { length: 2437 } }, error: 'uint128' },
+          },
+        },
       } as TypedAbiFunction<
         [
           staker: TypedAbiArg<string, 'staker'>,
@@ -5999,7 +6007,7 @@ export const contracts = {
           stakerUnlockBytes: TypedAbiArg<Uint8Array, 'stakerUnlockBytes'>,
           earlyUnlockBytes: TypedAbiArg<Uint8Array, 'earlyUnlockBytes'>,
         ],
-        Uint8Array
+        Response<Uint8Array, bigint>
       >,
       currentDistributionCycle: {
         name: 'current-distribution-cycle',
@@ -6693,8 +6701,15 @@ export const contracts = {
         name: 'push-c-script-num',
         access: 'read_only',
         args: [{ name: 'n', type: 'uint128' }],
-        outputs: { type: { buffer: { length: 1027 } } },
-      } as TypedAbiFunction<[n: TypedAbiArg<number | bigint, 'n'>], Uint8Array>,
+        outputs: {
+          type: {
+            response: { ok: { buffer: { length: 1027 } }, error: 'uint128' },
+          },
+        },
+      } as TypedAbiFunction<
+        [n: TypedAbiArg<number | bigint, 'n'>],
+        Response<Uint8Array, bigint>
+      >,
       pushScriptBytes: {
         name: 'push-script-bytes',
         access: 'read_only',
@@ -6838,8 +6853,15 @@ export const contracts = {
         name: 'serialize-c-script-num',
         access: 'read_only',
         args: [{ name: 'n', type: 'uint128' }],
-        outputs: { type: { buffer: { length: 5 } } },
-      } as TypedAbiFunction<[n: TypedAbiArg<number | bigint, 'n'>], Uint8Array>,
+        outputs: {
+          type: {
+            response: { ok: { buffer: { length: 5 } }, error: 'uint128' },
+          },
+        },
+      } as TypedAbiFunction<
+        [n: TypedAbiArg<number | bigint, 'n'>],
+        Response<Uint8Array, bigint>
+      >,
       signerSetContainsForCycle: {
         name: 'signer-set-contains-for-cycle',
         access: 'read_only',

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.prop.test.ts
@@ -6,6 +6,38 @@ import * as BTC from '@scure/btc-signer';
 import { hex } from '@scure/base';
 import { randomPrincipalGen } from '../test-helpers';
 
+const maxCScriptNum = 549755813887n;
+
+const cScriptNumBoundaryCases = [
+  [0n, ''],
+  [1n, '01'],
+  [16n, '10'],
+  [17n, '11'],
+  [127n, '7f'],
+  [128n, '8000'],
+  [255n, 'ff00'],
+  [256n, '0001'],
+  [32767n, 'ff7f'],
+  [32768n, '008000'],
+  [65535n, 'ffff00'],
+  [65536n, '000001'],
+  [8388607n, 'ffff7f'],
+  [8388608n, '00008000'],
+  [16777215n, 'ffffff00'],
+  [16777216n, '00000001'],
+  [2147483647n, 'ffffff7f'],
+  [2147483648n, '0000008000'],
+  [4294967295n, 'ffffffff00'],
+  [4294967296n, '0000000001'],
+  [maxCScriptNum, 'ffffffff7f'],
+] as const;
+
+function btcScriptNumber(n: bigint) {
+  const script = BTC.Script.encode([Number(n)]);
+  const byteLength = script[0];
+  return script.slice(1, byteLength + 1);
+}
+
 it('uint-to-buff-le matches little-endian encoding for all n < 65536', () => {
   fc.assert(
     fc.property(fc.integer({ min: 0, max: 0xffff }), (n) => {
@@ -15,6 +47,42 @@ it('uint-to-buff-le matches little-endian encoding for all n < 65536', () => {
           ? new Uint8Array([n])
           : new Uint8Array([n & 0xff, (n >> 8) & 0xff]);
       expect(hex.encode(actual)).toEqual(hex.encode(expected));
+    }),
+  );
+});
+
+it('cscriptnum helpers match expected boundary vectors and scure encodings', () => {
+  for (const [n, expected] of cScriptNumBoundaryCases) {
+    expect(hex.encode(rovOk(pox5.serializeCScriptNum(n)))).toEqual(expected);
+    if (n > 16n) {
+      expect(hex.encode(rovOk(pox5.serializeCScriptNum(n)))).toEqual(
+        hex.encode(btcScriptNumber(n)),
+      );
+    }
+    const expectedPush = BTC.Script.encode([Number(n)]);
+    expect(hex.encode(rovOk(pox5.pushCScriptNum(n)))).toEqual(
+      hex.encode(expectedPush),
+    );
+  }
+});
+
+it('serialize-c-script-num matches scure script-number payloads for all valid large values', () => {
+  fc.assert(
+    fc.property(fc.bigInt({ min: 17n, max: maxCScriptNum }), (n) => {
+      expect(hex.encode(rovOk(pox5.serializeCScriptNum(n)))).toEqual(
+        hex.encode(btcScriptNumber(n)),
+      );
+    }),
+  );
+});
+
+it('push-c-script-num matches scure script-number pushes for all valid values', () => {
+  fc.assert(
+    fc.property(fc.bigInt({ min: 0n, max: maxCScriptNum }), (n) => {
+      const expected = BTC.Script.encode([Number(n)]);
+      expect(hex.encode(rovOk(pox5.pushCScriptNum(n)))).toEqual(
+        hex.encode(expected),
+      );
     }),
   );
 });
@@ -41,14 +109,14 @@ it('should construct the unlock script', () => {
   fc.assert(
     fc.property(
       randomPrincipalGen,
-      fc.integer({
-        min: 0,
-        max: 0x7fffff - Number(minimumUnlockHeight),
+      fc.bigInt({
+        min: 0n,
+        max: maxCScriptNum - minimumUnlockHeight,
       }),
       fc.uint8Array({ minLength: 1, maxLength: 255 }),
       fc.uint8Array({ minLength: 1, maxLength: 255 }),
       (stacker, offset, stakerUnlockBytes, earlyUnlockBytes) => {
-        const unlockBurnHeight = minimumUnlockHeight + BigInt(offset);
+        const unlockBurnHeight = minimumUnlockHeight + offset;
         const expected = serializeLockupScript({
           stacker,
           unlockBurnHeight,

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.prop.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.prop.test.ts
@@ -1,7 +1,7 @@
 import fc from 'fast-check';
 import { expect, it } from 'vitest';
 import { pox5, serializeLockupScript } from './pox-5-helpers';
-import { rov } from '@clarigen/test';
+import { rov, rovOk } from '@clarigen/test';
 import * as BTC from '@scure/btc-signer';
 import { hex } from '@scure/base';
 import { randomPrincipalGen } from '../test-helpers';
@@ -55,7 +55,7 @@ it('should construct the unlock script', () => {
           stakerUnlockBytes,
           earlyUnlockBytes,
         });
-        const actual = rov(
+        const actual = rovOk(
           pox5.constructLockupScript(
             stacker,
             unlockBurnHeight,

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -165,6 +165,18 @@ test('uint-to-buff-le panics on values >= 65536', () => {
   expect(() => rov(pox5.uintToBuffLe(2n ** 64n))).toThrow();
 });
 
+test('serialize-c-script-num includes bytes above 24 bits', () => {
+  expect(hex.encode(rovOk(pox5.serializeCScriptNum(16877216n)))).toBe(
+    'a0860101',
+  );
+});
+
+test('serialize-c-script-num rejects values above the 5-byte scriptnum range', () => {
+  expect(rovErr(pox5.serializeCScriptNum(549755813888n))).toBe(
+    errorCodes.ERR_INVALID_UNLOCK_HEIGHT,
+  );
+});
+
 /**
  * Helper-only test for printing the Clarity list literal used by cycle folds.
  */
@@ -1619,6 +1631,41 @@ test('l1 lockup accepts an unlock height above the bond minimum', () => {
   );
 
   expect(result.value).toBe(errorCodes.ERR_INVALID_BTC_HEADER);
+});
+
+test('l1 lockup rejects truncated cscriptnum unlock height collision', () => {
+  const signer = testSigner.identifier;
+  const aliceSats = 480000n;
+  const effectiveUnlockHeight = 100000n;
+  const claimedUnlockHeight = effectiveUnlockHeight + 16777216n;
+
+  registerSigner();
+  setupBondForAllowlist([{ maxSats: aliceSats, staker: alice }]);
+
+  const result = txErr(
+    pox5.registerForBond({
+      bondIndex: 0n,
+      signerManager: signer,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: ok({
+        outputs: [
+          {
+            ...buildL1Lockup({
+              staker: alice,
+              sats: aliceSats,
+              unlockBurnHeight: effectiveUnlockHeight,
+            }),
+            unlockBurnHeight: claimedUnlockHeight,
+          },
+        ],
+        stakerUnlockBytes: new Uint8Array(),
+      }),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+
+  expect(result.value).toBe(errorCodes.ERR_INVALID_LOCKUP_SCRIPT);
 });
 
 // Skipped: Simnet's burn header hashes aren't real, so most of the L1 paths

--- a/stacks-node/src/tests/pox_5_integrations.rs
+++ b/stacks-node/src/tests/pox_5_integrations.rs
@@ -1697,10 +1697,10 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
     lockup_unlock_bytes.push(0xac); // OP_CHECKSIG
 
     // (a) Compute the expected P2WSH script-pubkey by calling pox-5's own
-    //     read-only `construct-lockup-output-script` — this returns the
-    //     34-byte `0x0020 || sha256(timelock_script)` that the burn-chain
-    //     output must pay to. We hand the same arguments the contract will
-    //     reconstruct internally during `verify-l1-lockups`.
+    //     read-only `construct-lockup-output-script` — this returns `(ok ...)`
+    //     with the 34-byte `0x0020 || sha256(timelock_script)` that the
+    //     burn-chain output must pay to. We hand the same arguments the
+    //     contract will reconstruct internally during `verify-l1-lockups`.
     let bond_index = 0u128;
     let minimum_unlock_burn_height = call_read_only(
         &naka_conf,
@@ -1728,6 +1728,8 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
     )
     .result()
     .expect("construct-lockup-output-script failed")
+    .expect_result_ok()
+    .expect("construct-lockup-output-script should return (ok ...)")
     .expect_buff(34)
     .expect("construct-lockup-output-script should return (buff 34)");
     assert_eq!(
@@ -2181,6 +2183,8 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
     )
     .result()
     .expect("construct-lockup-script failed")
+    .expect_result_ok()
+    .expect("construct-lockup-script should return (ok ...)")
     .expect_buff(usize::MAX)
     .expect("construct-lockup-script should return a buff");
 
@@ -2737,6 +2741,8 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
     )
     .result()
     .expect("construct-lockup-output-script failed")
+    .expect_result_ok()
+    .expect("construct-lockup-output-script should return (ok ...)")
     .expect_buff(34)
     .expect("construct-lockup-output-script should return (buff 34)");
     assert_eq!(
@@ -3039,6 +3045,8 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
     )
     .result()
     .expect("construct-lockup-script failed")
+    .expect_result_ok()
+    .expect("construct-lockup-script should return (ok ...)")
     .expect_buff(usize::MAX)
     .expect("construct-lockup-script should return a buff");
 

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -2009,10 +2009,10 @@
             (accumulator (try! accumulator-res))
             (block (try! (parse-block-header (get header lockup))))
             (unlock-burn-height (get unlock-burn-height lockup))
-            (expected-script-hash (construct-lockup-output-script (get staker accumulator)
+            (expected-script-hash (try! (construct-lockup-output-script (get staker accumulator)
                 unlock-burn-height (get staker-unlock-bytes accumulator)
                 (get early-unlock-bytes accumulator)
-            ))
+            )))
             (output (try! (get-bitcoin-tx-output? (get tx lockup) (get output-index lockup))))
             (reversed-txid (get txid output))
             (txid (reverse-buff32 reversed-txid))
@@ -3635,16 +3635,18 @@
         (early-unlock-bytes (buff 683))
     )
     ;; @format-ignore
-    (concat
-        0x63           ;; OP_IF
-        (push-c-script-num unlock-burn-height)
-        0xb167         ;; OP_CHECKLOCKTIMEVERIFY, OP_ELSE
-        0x82012088a820 ;; OP_SIZE, <32>, OP_EQUALVERIFY, OP_SHA256, OP_PUSHBYTES_32
-        (sha256 (sha256 (unwrap-panic (to-consensus-buff? staker))))
-        0x88           ;; OP_EQUALVERIFY
-        early-unlock-bytes
-        0x6869         ;; OP_ENDIF, OP_VERIFY
-        staker-unlock-bytes
+    (ok
+        (concat
+            0x63           ;; OP_IF
+            (try! (push-c-script-num unlock-burn-height))
+            0xb167         ;; OP_CHECKLOCKTIMEVERIFY, OP_ELSE
+            0x82012088a820 ;; OP_SIZE, <32>, OP_EQUALVERIFY, OP_SHA256, OP_PUSHBYTES_32
+            (sha256 (sha256 (unwrap-panic (to-consensus-buff? staker))))
+            0x88           ;; OP_EQUALVERIFY
+            early-unlock-bytes
+            0x6869         ;; OP_ENDIF, OP_VERIFY
+            staker-unlock-bytes
+        )
     )
 )
 
@@ -3655,11 +3657,11 @@
         (staker-unlock-bytes (buff 683))
         (early-unlock-bytes (buff 683))
     )
-    (concat 0x0020
-        (sha256 (construct-lockup-script staker unlock-burn-height staker-unlock-bytes
+    (ok (concat 0x0020
+        (sha256 (try! (construct-lockup-script staker unlock-burn-height staker-unlock-bytes
             early-unlock-bytes
-        ))
-    )
+        )))
+    ))
 )
 
 ;; Convert a u8 or u16 to a little-endian byte buffer,
@@ -3704,43 +3706,60 @@
 )
 
 (define-read-only (serialize-c-script-num (n uint))
-    (unwrap-panic (as-max-len?
-        (if (is-eq n u0)
-            0x
-            (let (
-                    (bytes (unwrap-panic (to-consensus-buff? n)))
-                    (b0 (unwrap-panic (slice? bytes u16 u17)))
-                    (b1 (unwrap-panic (slice? bytes u15 u16)))
-                    (b2 (unwrap-panic (slice? bytes u14 u15)))
-                )
+    (if (>= n u549755813888)
+        ERR_INVALID_UNLOCK_HEIGHT
+        (let (
+                (bytes (unwrap-panic (to-consensus-buff? n)))
+                (b0 (unwrap-panic (slice? bytes u16 u17)))
+                (b1 (unwrap-panic (slice? bytes u15 u16)))
+                (b2 (unwrap-panic (slice? bytes u14 u15)))
+                (b3 (unwrap-panic (slice? bytes u13 u14)))
+                (b4 (unwrap-panic (slice? bytes u12 u13)))
+            )
+            (ok (unwrap-panic (as-max-len?
                 (if (< n u128)
-                    b0
+                    (if (is-eq n u0)
+                        0x
+                        b0
+                    )
                     (if (< n u256)
                         (concat b0 0x00)
                         (if (< n u32768)
                             (concat b0 b1)
                             (if (< n u65536)
                                 (concat b0 b1 0x00)
-                                (concat b0 b1 b2)
+                                (if (< n u8388608)
+                                    (concat b0 b1 b2)
+                                    (if (< n u16777216)
+                                        (concat b0 b1 b2 0x00)
+                                        (if (< n u2147483648)
+                                            (concat b0 b1 b2 b3)
+                                            (if (< n u4294967296)
+                                                (concat b0 b1 b2 b3 0x00)
+                                                (concat b0 b1 b2 b3 b4)
+                                            )
+                                        )
+                                    )
+                                )
                             )
                         )
                     )
                 )
-            )
+                u5
+            )))
         )
-        u5
-    ))
+    )
 )
 
 (define-read-only (push-c-script-num (n uint))
     (if (is-eq n u0)
-        0x00
+        (ok 0x00)
         (if (<= n u16)
-            (unwrap-panic (as-max-len?
+            (ok (unwrap-panic (as-max-len?
                 (unwrap-panic (slice? (unwrap-panic (to-consensus-buff? (+ u80 n))) u16 u17))
                 u1
-            ))
-            (push-script-bytes (serialize-c-script-num n))
+            )))
+            (ok (push-script-bytes (try! (serialize-c-script-num n))))
         )
     )
 )


### PR DESCRIPTION
Previously, the CScriptNum serializer written in Clarity would only emit up to 3 bytes for the `OP_CHECKLOCKTIMEVERIFY` number. This could cause an issue where a specific number would serialize to something that Clarity thought was valid, but actually wasn't. The fix is to actually serialize 4 and 5 byte numbers (to handle much larger numbers), and also to properly throw errors in the case where numbers provided are outside of this range. This replaces a few uses of `unwrap-panic` that could have been actually hit, which we generally do not want.