### PR TITLE
Epoch-4.0: Sum stacking assetmap entries rather than error-on-replace

### DIFF
--- a/changelog.d/pox-5-assetmap-sum-committed.fixed
+++ b/changelog.d/pox-5-assetmap-sum-committed.fixed
@@ -1,0 +1,1 @@
+In Epoch 4.0 (PoX-5), the Clarity asset map now sums concurrent stacking entries for the same principal within a transaction (both within a frame and when merging frames) instead of rejecting the block. The pre-Epoch-4.0 soft-fork behavior (rejecting PoX assetmap overwrites) is unchanged.

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::mem::replace;
@@ -166,7 +167,7 @@ pub struct AssetMap {
     stacking_map: HashMap<PrincipalData, u128>,
     /// Principals that attempted a position-altering PoX action (`unstake`,
     /// `unstake-sbtc`, `update-bond-registration`, `announce-l1-early-exit`)
-    /// during the transaction — recorded whether or not the call succeeded, so
+    /// during the transaction -- recorded whether or not the call succeeded, so
     /// a `Pox` post-condition / `with-pox` allowance can gate even a failed
     /// attempt.
     pox_action_set: HashSet<PrincipalData>,
@@ -470,6 +471,23 @@ impl AssetMap {
             .ok_or(RuntimeError::ArithmeticOverflow.into())
     }
 
+    /// This will get the next amount for a (principal, stx) entry in the
+    /// stacking table. Used in Epoch 4.0+ (PoX-5), where multiple stacking
+    /// entries for the same principal in one transaction are summed rather
+    /// than rejected. Overflow returns `ArithmeticOverflow`; it is unreachable
+    /// in normal execution because every stacked amount is bounded by the
+    /// principal's balance, which is a subset of `stx-liquid-supply`.
+    fn get_next_stacking_amount(
+        &self,
+        principal: &PrincipalData,
+        amount: u128,
+    ) -> Result<u128, VmExecutionError> {
+        let current_amount = self.stacking_map.get(principal).unwrap_or(&0);
+        current_amount
+            .checked_add(amount)
+            .ok_or(RuntimeError::ArithmeticOverflow.into())
+    }
+
     /// This will get the next amount for a (principal, asset) entry in the asset table.
     fn get_next_amount(
         &self,
@@ -542,11 +560,32 @@ impl AssetMap {
         Ok(())
     }
 
-    /// Log an amount of STX to be stacked or delegated for stacking by a
-    /// principal. Since any given principal can only stack once, this will
-    /// overwrite any previous amount for the principal.
-    pub fn add_stacking(&mut self, principal: &PrincipalData, amount: u128) {
-        self.stacking_map.insert(principal.clone(), amount);
+    /// Add stacking entry for `principal` of `amount`.  The EpochId
+    /// controls whether or not an existing entry is replaced or
+    /// accumulated.
+    pub fn add_stacking(
+        &mut self,
+        principal: &PrincipalData,
+        amount: u128,
+        epoch_id: StacksEpochId,
+    ) -> Result<(), VmExecutionError> {
+        match self.stacking_map.entry(principal.clone()) {
+            Entry::Occupied(mut occupied_entry) => {
+                let next_amt = if epoch_id.sums_stacking_assetmap() {
+                    occupied_entry
+                        .get()
+                        .checked_add(amount)
+                        .ok_or(RuntimeError::ArithmeticOverflow)?
+                } else {
+                    amount
+                };
+                occupied_entry.insert(next_amt);
+            }
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(amount);
+            }
+        };
+        Ok(())
     }
 
     /// Record that a principal attempted a position-altering PoX action
@@ -559,10 +598,20 @@ impl AssetMap {
 
     // This will add any asset transfer data from other to self,
     //   aborting _all_ changes in the event of an error, leaving self unchanged
-    pub fn commit_other(&mut self, mut other: AssetMap) -> Result<(), VmExecutionError> {
+    //
+    // `epoch_id` selects how concurrent stacking entries for the same principal
+    // are handled (see the stacking-merge block below): pre-Epoch-4.0, a second
+    // entry is rejected (`PoxStxAssetMapOverwrite`, a soft-fork safety net);
+    // Epoch-4.0+ (PoX-5) sums the amounts.
+    pub fn commit_other(
+        &mut self,
+        mut other: AssetMap,
+        epoch_id: StacksEpochId,
+    ) -> Result<(), VmExecutionError> {
         let mut to_add = Vec::new();
         let mut stx_to_add = Vec::with_capacity(other.stx_map.len());
         let mut stx_burn_to_add = Vec::with_capacity(other.burn_map.len());
+        let mut stacking_to_add = Vec::with_capacity(other.stacking_map.len());
 
         for (principal, mut principal_map) in other.token_map.drain() {
             for (asset, amount) in principal_map.drain() {
@@ -581,13 +630,27 @@ impl AssetMap {
             stx_burn_to_add.push((principal.clone(), next_amount));
         }
 
-        // Reject any transaction that would overwrite an
-        // existing asset-map stacking entry for `sender`.
-        for principal in other.stacking_map.keys() {
-            if self.stacking_map.contains_key(principal) {
-                return Err(VmExecutionError::from(
-                    RuntimeCheckErrorKind::PoxStxAssetMapOverwrite,
-                ));
+        if epoch_id.sums_stacking_assetmap() {
+            // Epoch 4.0+ (PoX-5): sum a principal's stacking entries, mirroring
+            // how STX transfers/burns accumulate. Computed before any mutation
+            // so an overflow aborts the whole merge with `self` unchanged.
+            for (principal, stacking_amount) in other.stacking_map.drain() {
+                let next_amount = self.get_next_stacking_amount(&principal, stacking_amount)?;
+                stacking_to_add.push((principal, next_amount));
+            }
+        } else {
+            // Pre-Epoch-4.0 soft-fork behavior: reject any transaction that
+            // would overwrite an existing asset-map stacking entry.
+            for principal in other.stacking_map.keys() {
+                if self.stacking_map.contains_key(principal) {
+                    return Err(VmExecutionError::from(
+                        RuntimeCheckErrorKind::PoxStxAssetMapOverwrite,
+                    ));
+                }
+            }
+            // No collision is possible, so each entry carries its own amount.
+            for (principal, stacking_amount) in other.stacking_map.drain() {
+                stacking_to_add.push((principal, stacking_amount));
             }
         }
 
@@ -616,7 +679,7 @@ impl AssetMap {
             principal_map.insert(asset, amount);
         }
 
-        for (principal, stacking_amount) in other.stacking_map.drain() {
+        for (principal, stacking_amount) in stacking_to_add.into_iter() {
             self.stacking_map.insert(principal, stacking_amount);
         }
 
@@ -1904,8 +1967,8 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
         sender: &PrincipalData,
         amount: u128,
     ) -> Result<(), VmExecutionError> {
-        self.get_asset_map()?.add_stacking(sender, amount);
-        Ok(())
+        let epoch = self.epoch_id;
+        self.get_asset_map()?.add_stacking(sender, amount, epoch)
     }
 
     pub fn log_pox_action(&mut self, sender: &PrincipalData) -> Result<(), VmExecutionError> {
@@ -2008,7 +2071,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
 
         let out_map = match self.asset_maps.last_mut() {
             Some(tail_back) => {
-                if let Err(e) = tail_back.commit_other(asset_map) {
+                if let Err(e) = tail_back.commit_other(asset_map, self.epoch_id) {
                     self.database.roll_back()?;
                     return Err(e);
                 }
@@ -2364,7 +2427,7 @@ mod test {
         am2.add_token_transfer(&p1, t1.clone(), 1).unwrap();
         am2.add_token_transfer(&p2, t1.clone(), 1).unwrap();
 
-        am1.commit_other(am2).unwrap_err();
+        am1.commit_other(am2, StacksEpochId::Epoch30).unwrap_err();
 
         let table = am1.to_table();
 
@@ -2454,7 +2517,7 @@ mod test {
         am1.add_stx_burn(&p1, 31).unwrap();
         am2.add_stx_burn(&p2, 36).unwrap();
 
-        am1.commit_other(am2).unwrap();
+        am1.commit_other(am2, StacksEpochId::Epoch30).unwrap();
 
         let table = am1.to_table();
 
@@ -2489,6 +2552,52 @@ mod test {
 
         assert_eq!(table[&p1][&t7], AssetMapEntry::Burn(30 + 31));
         assert_eq!(table[&p2][&t7], AssetMapEntry::Burn(35 + 36));
+    }
+
+    /// Merging a child frame whose stacking entry collides with the parent's
+    /// is rejected (`PoxStxAssetMapOverwrite`) before Epoch 4.0, but summed in
+    /// Epoch 4.0+ (PoX-5). A non-colliding entry merges identically in both.
+    #[test]
+    fn test_asset_map_stacking_merge() {
+        let p1 = PrincipalData::from(StandardPrincipalData::transient());
+        let p2 = PrincipalData::Contract(QualifiedContractIdentifier::local("b").unwrap());
+
+        // Pre-Epoch-4.0: a colliding stacking entry is rejected.
+        let mut am1 = AssetMap::new();
+        let mut am2 = AssetMap::new();
+        am1.add_stacking(&p1, 100, StacksEpochId::Epoch40).unwrap();
+        am2.add_stacking(&p1, 50, StacksEpochId::Epoch40).unwrap();
+        assert!(matches!(
+            am1.commit_other(am2, StacksEpochId::Epoch30).unwrap_err(),
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::PoxStxAssetMapOverwrite)
+        ));
+        // `self` is left unchanged by the aborted merge.
+        assert_eq!(am1.get_stacking(&p1), Some(100));
+
+        // Epoch 4.0+: the colliding entry is summed; non-colliding entries pass
+        // through unchanged.
+        let mut am1 = AssetMap::new();
+        let mut am2 = AssetMap::new();
+        am1.add_stacking(&p1, 100, StacksEpochId::Epoch40).unwrap();
+        am2.add_stacking(&p1, 50, StacksEpochId::Epoch40).unwrap();
+        am2.add_stacking(&p2, 25, StacksEpochId::Epoch40).unwrap();
+        am1.commit_other(am2, StacksEpochId::Epoch40).unwrap();
+        assert_eq!(am1.get_stacking(&p1), Some(150));
+        assert_eq!(am1.get_stacking(&p2), Some(25));
+
+        // Epoch 4.0+: a summed stacking amount that overflows `u128` aborts the
+        // merge with an arithmetic error rather than panicking, and leaves
+        // `self` unchanged.
+        let mut am1 = AssetMap::new();
+        let mut am2 = AssetMap::new();
+        am1.add_stacking(&p1, u128::MAX, StacksEpochId::Epoch40)
+            .unwrap();
+        am2.add_stacking(&p1, 1, StacksEpochId::Epoch40).unwrap();
+        assert!(matches!(
+            am1.commit_other(am2, StacksEpochId::Epoch40).unwrap_err(),
+            VmExecutionError::Runtime(RuntimeError::ArithmeticOverflow, _)
+        ));
+        assert_eq!(am1.get_stacking(&p1), Some(u128::MAX));
     }
 
     /// Test the stx-transfer consolidation tx invalidation
@@ -2612,7 +2721,7 @@ mod test {
         // commit_other: merge two maps where sum exceeds u128::MAX
         am2.add_token_transfer(&p1, t1.clone(), u128::MAX).unwrap();
         assert!(matches!(
-            am1.commit_other(am2).unwrap_err(),
+            am1.commit_other(am2, StacksEpochId::Epoch30).unwrap_err(),
             VmExecutionError::Runtime(RuntimeError::ArithmeticOverflow, _)
         ));
     }

--- a/pox-locking/src/pox_5.rs
+++ b/pox-locking/src/pox_5.rs
@@ -571,7 +571,9 @@ pub fn handle_contract_call(
 
     // Record a position-altering PoX action for the affected staker (always
     // `tx-sender`, i.e. `sender_opt`), so that transaction-level `Pox`
-    // post-conditions and `with-pox` allowances can constrain them.
+    // post-conditions and `with-pox` allowances can constrain them. Recorded
+    // whether or not the call succeeded, so an allowance can gate even a failed
+    // attempt.
     if matches!(
         function_name,
         "unstake" | "unstake-sbtc" | "update-bond-registration" | "announce-l1-early-exit"
@@ -2022,6 +2024,70 @@ mod tests {
                 "{function_name} must record a PoX action for the tx-sender",
             );
         }
+    }
+
+    /// A position-altering call records a PoX action even when it returned
+    /// `(err ...)`: a `Pox` post-condition / `with-pox` allowance must be able
+    /// to gate a failed attempt, so the action is logged regardless of outcome.
+    #[test]
+    fn handle_contract_call_logs_pox_action_even_on_error() {
+        let staker: PrincipalData = StandardPrincipalData::transient().into();
+
+        for function_name in [
+            "unstake-sbtc",
+            "update-bond-registration",
+            "announce-l1-early-exit",
+        ] {
+            let mut store = MemoryBackingStore::new();
+            let mut global_context = setup_global_context(&mut store, &staker, 1_000_000);
+            let contract_id = boot_code_id(POX_5_NAME, global_context.mainnet);
+
+            let response = Value::error(Value::UInt(1)).unwrap();
+            handle_contract_call(
+                &mut global_context,
+                Some(&staker),
+                &contract_id,
+                function_name,
+                &[],
+                &response,
+            )
+            .unwrap_or_else(|e| panic!("dispatch of {function_name} should succeed: {e:?}"));
+
+            assert!(
+                global_context
+                    .get_readonly_asset_map()
+                    .expect("asset map should exist")
+                    .did_pox_action(&staker),
+                "errored {function_name} must still record a PoX action for the tx-sender",
+            );
+        }
+    }
+
+    /// In Epoch 4.0+, two stacking logs for the same principal within one
+    /// asset-map frame accumulate (the within-frame analogue of the
+    /// `commit_other` summing). This is the path hit when a single caller frame
+    /// drives more than one PoX-5 lock for the same staker.
+    #[test]
+    fn log_stacking_sums_within_frame_in_epoch_4() {
+        let staker: PrincipalData = StandardPrincipalData::transient().into();
+        let mut store = MemoryBackingStore::new();
+        let mut global_context = setup_global_context(&mut store, &staker, 1_000_000);
+
+        global_context
+            .log_stacking(&staker, 100_000)
+            .expect("first log should succeed");
+        global_context
+            .log_stacking(&staker, 50_000)
+            .expect("second log should succeed");
+
+        assert_eq!(
+            global_context
+                .get_readonly_asset_map()
+                .expect("asset map should exist")
+                .get_stacking(&staker),
+            Some(150_000),
+            "stacking amounts must accumulate within a frame in Epoch 4.0+",
+        );
     }
 
     /// `unstake` must also record a PoX action but it requires some setup.

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -776,6 +776,12 @@ impl StacksEpochId {
         self >= &StacksEpochId::Epoch40
     }
 
+    /// Does this epoch sum stacking entries in the assetmap or just replace
+    ///  and error-on-replace?
+    pub fn sums_stacking_assetmap(&self) -> bool {
+        self >= &StacksEpochId::Epoch40
+    }
+
     pub fn supports_call_with_constant(&self) -> bool {
         self >= &StacksEpochId::Epoch34
     }

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -7621,7 +7621,9 @@ pub mod test {
 
         // Asset map in which the origin staked 100 uSTX.
         let mut stacked = AssetMap::new();
-        stacked.add_stacking(&origin, 100);
+        stacked
+            .add_stacking(&origin, 100, StacksEpochId::Epoch40)
+            .unwrap();
 
         // (expected_pass, post_conditions, mode, epoch)
         let tests = vec![


### PR DESCRIPTION
Rather than erroring on replacement, in Epoch-4.0, we should sum the assetmap entries.