### PR TITLE
chore: bump Rust toolchain to `1.96.0` and fix new `clippy` lint warnings

### DIFF
--- a/changelog.d/7348-rust-toolchain-1.96.0.changed
+++ b/changelog.d/7348-rust-toolchain-1.96.0.changed
@@ -1,0 +1,1 @@
+Rust toolchain bumped from 1.94.0 to 1.96.0 and new clippy lint warnings addressed

--- a/clarity/src/vm/ast/parser/v2/lexer/mod.rs
+++ b/clarity/src/vm/ast/parser/v2/lexer/mod.rs
@@ -845,18 +845,18 @@ impl<'a> Lexer<'a> {
             | Token::Less
             | Token::LessEqual
             | Token::Greater
-            | Token::GreaterEqual => {
-                if !is_separator(self.next) {
-                    self.add_diagnostic(
-                        LexerError::ExpectedSeparator,
-                        Span {
-                            start_line: self.line as u32,
-                            start_column: self.column as u32,
-                            end_line: self.line as u32,
-                            end_column: self.column as u32,
-                        },
-                    )?;
-                }
+            | Token::GreaterEqual
+                if !is_separator(self.next) =>
+            {
+                self.add_diagnostic(
+                    LexerError::ExpectedSeparator,
+                    Span {
+                        start_line: self.line as u32,
+                        start_column: self.column as u32,
+                        end_line: self.line as u32,
+                        end_column: self.column as u32,
+                    },
+                )?;
             }
             _ => (),
         }

--- a/clarity/src/vm/docs/contracts.rs
+++ b/clarity/src/vm/docs/contracts.rs
@@ -147,8 +147,8 @@ pub fn make_docs(
         .collect();
 
     let ecode_names = variable_types
-        .iter()
-        .filter_map(|(var_name, _)| {
+        .keys()
+        .filter_map(|var_name| {
             if var_name.starts_with("ERR_") {
                 Some(format!("{}: {}", var_name.as_str(), var_name.as_str()))
             } else {

--- a/clarity/src/vm/tests/datamaps.rs
+++ b/clarity/src/vm/tests/datamaps.rs
@@ -666,7 +666,7 @@ fn bad_define_maps() {
         .into(),
     ];
 
-    for (test, expected_err) in tests.iter().zip(expected.into_iter()) {
+    for (test, expected_err) in tests.iter().zip(expected) {
         let outcome = execute(test).unwrap_err();
         assert_eq!(outcome, expected_err);
     }
@@ -691,7 +691,7 @@ fn bad_tuples() {
         RuntimeCheckErrorKind::Unreachable("Expected name".to_string()),
     ];
 
-    for (test, expected_err) in tests.iter().zip(expected.into_iter()) {
+    for (test, expected_err) in tests.iter().zip(expected) {
         let outcome = execute(test).unwrap_err();
         assert_eq!(outcome, expected_err.into());
     }

--- a/contrib/nix/flake.lock
+++ b/contrib/nix/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774321696,
-        "narHash": "sha256-g18xMjMNla/nsF5XyQCNyWmtb2UlZpkY0XE8KinIXAA=",
+        "lastModified": 1782184651,
+        "narHash": "sha256-4XHdXp3MRa++XiGkltJChCtdbCmSlNTwQRfWQOhqbRw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "49a67e6894d4cb782842ee6faa466aa90c92812d",
+        "rev": "f59bc28dd0b89e9c0240d1b80195559fc79c2471",
         "type": "github"
       },
       "original": {

--- a/contrib/stacks-inspect/src/main.rs
+++ b/contrib/stacks-inspect/src/main.rs
@@ -667,16 +667,18 @@ fn main() {
 
         Command::CheckDeserData { check_file } => {
             let file = File::open(&check_file).unwrap();
-            let mut i = 1;
-            for line in io::BufReader::new(file).lines() {
-                if i % 100000 == 0 {
-                    println!("{i}...");
-                }
-                i += 1;
+            for (line_no, line) in io::BufReader::new(file).lines().enumerate() {
+                let line_no = line_no + 1;
                 let line = line.unwrap().trim().to_string();
+
+                if line_no % 100000 == 0 {
+                    println!("{line_no}...");
+                }
+
                 if line.is_empty() {
                     continue;
                 }
+
                 let vals: Vec<_> = line.split(" => ").map(|x| x.trim()).collect();
                 let hex_string = &vals[0];
                 let expected_value_display = &vals[1];

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/stacks-codec/src/transaction.rs
+++ b/stacks-codec/src/transaction.rs
@@ -2965,20 +2965,20 @@ impl StacksTransaction {
         // Otherwise, if the offending leader is the next leader, they can just orphan their proof
         // of malfeasance.
         match payload {
-            TransactionPayload::PoisonMicroblock(_, _) => {
-                if anchor_mode != TransactionAnchorMode::OnChainOnly {
-                    return Err(codec_error::DeserializeError(
-                        "Failed to parse transaction: invalid anchor mode for PoisonMicroblock"
-                            .to_string(),
-                    ));
-                }
+            TransactionPayload::PoisonMicroblock(_, _)
+                if anchor_mode != TransactionAnchorMode::OnChainOnly =>
+            {
+                return Err(codec_error::DeserializeError(
+                    "Failed to parse transaction: invalid anchor mode for PoisonMicroblock"
+                        .to_string(),
+                ));
             }
-            TransactionPayload::Coinbase(..) => {
-                if anchor_mode != TransactionAnchorMode::OnChainOnly {
-                    return Err(codec_error::DeserializeError(
-                        "Failed to parse transaction: invalid anchor mode for Coinbase".to_string(),
-                    ));
-                }
+            TransactionPayload::Coinbase(..)
+                if anchor_mode != TransactionAnchorMode::OnChainOnly =>
+            {
+                return Err(codec_error::DeserializeError(
+                    "Failed to parse transaction: invalid anchor mode for Coinbase".to_string(),
+                ));
             }
             _ => {}
         }

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -1145,12 +1145,11 @@ impl StacksAddress {
 
         // address hash mode must be consistent with the number of keys
         match *hash_mode {
-            AddressHashMode::SerializeP2PKH | AddressHashMode::SerializeP2WPKH => {
+            AddressHashMode::SerializeP2PKH | AddressHashMode::SerializeP2WPKH
                 // must be a single public key, and must require one signature
-                if num_sigs != 1 || pubkeys.len() != 1 {
+                if (num_sigs != 1 || pubkeys.len() != 1) => {
                     return None;
                 }
-            }
             _ => {}
         }
 

--- a/stacks-node/src/tests/signer/multiversion.rs
+++ b/stacks-node/src/tests/signer/multiversion.rs
@@ -20,19 +20,22 @@ use libsigner::v0::messages::{
     SignerMessageMetadata,
 };
 use libsigner::v0::signer_state::{MinerState, ReplayTransactionSet, SignerStateMachine};
+use libsigner_v3_3_0_0_5;
 use libsigner_v3_3_0_0_5::v0::messages::SignerMessage as OldSignerMessage;
+use signer_v3_3_0_0_5_0;
 use signer_v3_3_0_0_5_0::v0::signer_state::SUPPORTED_SIGNER_PROTOCOL_VERSION as OldSupportedVersion;
 use stacks::chainstate::stacks::StacksTransaction;
 use stacks::util::hash::{Hash160, Sha512Trunc256Sum};
 use stacks::util::secp256k1::{MessageSignature, Secp256k1PrivateKey};
 use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
+use stacks_common_v3_3_0_0_5;
 use stacks_common_v3_3_0_0_5::codec::StacksMessageCodec as OldStacksMessageCodec;
 use stacks_signer::runloop::{RewardCycleInfo, State, StateInfo};
 use stacks_signer::v0::signer_state::{
     LocalStateMachine, SUPPORTED_SIGNER_PROTOCOL_VERSION as NewSupportedVersion,
 };
 use stacks_signer::v0::SpawnedSigner;
-use {libsigner_v3_3_0_0_5, signer_v3_3_0_0_5_0, stacks_common_v3_3_0_0_5, stacks_v3_3_0_0_5};
+use stacks_v3_3_0_0_5;
 
 use super::SpawnedSignerTrait;
 use crate::stacks_common::codec::StacksMessageCodec;

--- a/stacks-node/src/tests/stackerdb.rs
+++ b/stacks-node/src/tests/stackerdb.rs
@@ -18,12 +18,13 @@ use std::{env, thread};
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use clarity::vm::ContractName;
+use reqwest;
+use serde_json;
 use stacks::chainstate::stacks::StacksPrivateKey;
 use stacks::config::{EventKeyType, InitialBalance};
 use stacks::libstackerdb::{StackerDBChunkAckData, StackerDBChunkData};
 use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::util::hash::Sha512Trunc256Sum;
-use {reqwest, serde_json};
 
 use crate::burnchains::bitcoin::core_controller::BitcoinCoreController;
 use crate::burnchains::BurnchainController;

--- a/stacks-signer/src/client/stacks_client.rs
+++ b/stacks-signer/src/client/stacks_client.rs
@@ -350,7 +350,7 @@ impl StacksClient {
                         .into(),
                 ));
             }
-            tenures.extend(next_results.into_iter());
+            tenures.extend(next_results);
         }
 
         Ok(tenures.into_iter().collect())

--- a/stackslib/src/net/http/response.rs
+++ b/stackslib/src/net/http/response.rs
@@ -18,6 +18,8 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::io::{Read, Write};
 
+use serde;
+use serde_json;
 use stacks_common::codec::{Error as CodecError, StacksMessageCodec};
 use stacks_common::deps_common::httparse;
 use stacks_common::util::chunked_encoding::{
@@ -25,7 +27,6 @@ use stacks_common::util::chunked_encoding::{
 };
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::pipe::PipeWrite;
-use {serde, serde_json};
 
 use crate::net::http::common::{
     HttpReservedHeader, HTTP_PREAMBLE_MAX_ENCODED_SIZE, HTTP_PREAMBLE_MAX_NUM_HEADERS,


### PR DESCRIPTION
### Description

Bumps the Rust toolchain in `rust-toolchain.toml` from `1.94.0` to `1.96.0`, addresses a handful of new `clippy` warnings/lints and bumps the `nix` `rust-overlay` flake to `1.96` as well.
