### PR TITLE
feat: add contract analysis max time guard-rails

### DIFF
--- a/changelog.d/contract-analysis-max-time.added
+++ b/changelog.d/contract-analysis-max-time.added
@@ -1,0 +1,3 @@
+Added a wall-clock deadline to the Clarity contract-analysis phase, bounding the time a single transaction can spend being analyzed on the block-assembly (mining) and block-proposal (signer) validation paths. A transaction whose analysis exceeds the deadline is treated as problematic (deterministic replay and block commit remain unbounded).
+Added `max_analysis_time_secs` to the `[miner]` configuration section to bound the per-transaction contract-analysis time (in seconds) during block assembly. Defaults to 30 seconds.
+Added `block_proposal_max_tx_analysis_time_secs` to the `[connection_options]` configuration section to bound the per-transaction contract-analysis time (in seconds) during block-proposal validation. Defaults to 30 seconds.

--- a/clarity/src/vm/analysis/errors.rs
+++ b/clarity/src/vm/analysis/errors.rs
@@ -926,7 +926,6 @@ impl From<CostErrors> for StaticCheckErrorKind {
             ),
             CostErrors::Expect(s) => StaticCheckErrorKind::Unreachable(s),
             CostErrors::ExecutionTimeExpired => StaticCheckErrorKind::ExecutionTimeExpired,
-            CostErrors::AnalysisTimeExpired => StaticCheckErrorKind::AnalysisTimeExpired,
         }
     }
 }
@@ -950,11 +949,6 @@ impl From<CostErrors> for RuntimeCheckErrorKind {
             ),
             CostErrors::Expect(s) => RuntimeCheckErrorKind::Unreachable(s),
             CostErrors::ExecutionTimeExpired => RuntimeCheckErrorKind::ExecutionTimeExpired,
-            // `AnalysisTimeExpired` is produced only by the analysis (type-checking) phase,
-            // never by the runtime cost tracker, so reaching this arm indicates a bug.
-            CostErrors::AnalysisTimeExpired => RuntimeCheckErrorKind::Unreachable(
-                "Unexpected analysis time expired as a runtime cost error".into(),
-            ),
         }
     }
 }

--- a/clarity/src/vm/analysis/errors.rs
+++ b/clarity/src/vm/analysis/errors.rs
@@ -238,6 +238,9 @@ pub enum StaticCheckErrorKind {
     // Time checker errors
     /// Type-checking time exceeds the allowed budget, halting analysis to ensure responsiveness.
     ExecutionTimeExpired,
+    /// Contract-analysis (type-checking) time exceeds the allowed budget, halting analysis to ensure responsiveness.
+    /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable end-to-end.
+    AnalysisTimeExpired,
 
     /// Value exceeds the maximum allowed size for type-checking or serialization.
     ValueTooLarge,
@@ -923,6 +926,7 @@ impl From<CostErrors> for StaticCheckErrorKind {
             ),
             CostErrors::Expect(s) => StaticCheckErrorKind::Unreachable(s),
             CostErrors::ExecutionTimeExpired => StaticCheckErrorKind::ExecutionTimeExpired,
+            CostErrors::AnalysisTimeExpired => StaticCheckErrorKind::AnalysisTimeExpired,
         }
     }
 }
@@ -946,6 +950,11 @@ impl From<CostErrors> for RuntimeCheckErrorKind {
             ),
             CostErrors::Expect(s) => RuntimeCheckErrorKind::Unreachable(s),
             CostErrors::ExecutionTimeExpired => RuntimeCheckErrorKind::ExecutionTimeExpired,
+            // `AnalysisTimeExpired` is produced only by the analysis (type-checking) phase,
+            // never by the runtime cost tracker, so reaching this arm indicates a bug.
+            CostErrors::AnalysisTimeExpired => RuntimeCheckErrorKind::Unreachable(
+                "Unexpected analysis time expired as a runtime cost error".into(),
+            ),
         }
     }
 }
@@ -1158,6 +1167,7 @@ impl DiagnosableError for StaticCheckErrorKind {
             StaticCheckErrorKind::MemoryBalanceExceeded(a, b) => format!("contract execution cost exceeded memory budget: {a:?} > {b:?}"),
             StaticCheckErrorKind::CostComputationFailed(s) => format!("contract cost computation failed: {s}"),
             StaticCheckErrorKind::ExecutionTimeExpired => "execution time expired".into(),
+            StaticCheckErrorKind::AnalysisTimeExpired => "analysis time expired".into(),
             StaticCheckErrorKind::InvalidTypeDescription => "supplied type description is invalid".into(),
             StaticCheckErrorKind::EmptyTuplesNotAllowed => "tuple types may not be empty".into(),
             StaticCheckErrorKind::UnknownTypeName(name) => format!("failed to parse type: '{name}'"),

--- a/clarity/src/vm/analysis/errors.rs
+++ b/clarity/src/vm/analysis/errors.rs
@@ -238,7 +238,7 @@ pub enum StaticCheckErrorKind {
     // Time checker errors
     /// Type-checking time exceeds the allowed budget, halting analysis to ensure responsiveness.
     ExecutionTimeExpired,
-    /// Contract-analysis (type-checking) time exceeds the allowed budget, halting analysis to ensure responsiveness.
+    /// Contract-analysis time exceeds the allowed budget, halting analysis to ensure responsiveness.
     /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable end-to-end.
     AnalysisTimeExpired,
 

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -49,6 +49,20 @@ use crate::vm::types::QualifiedContractIdentifier;
 #[cfg(feature = "rusqlite")]
 use crate::vm::types::TypeSignature;
 
+/// Cooperative analysis-deadline check shared by analysis passes
+///
+/// This is the single place the analysis-timeout error is constructed. The deadline is
+/// `TimeTracker::MaxTime` only on the non-consensus voting paths (mining / block-proposal
+/// validation); on the deterministic replay/commit path it is `TimeTracker::NoTracking`,
+/// so this never fires during consensus and the surfaced `AnalysisTimeExpired` cannot
+/// affect block validity.
+pub(crate) fn check_analysis_timeout(time_tracker: &TimeTracker) -> Result<(), StaticCheckError> {
+    if time_tracker.is_expired() {
+        return Err(StaticCheckErrorKind::AnalysisTimeExpired.into());
+    }
+    Ok(())
+}
+
 /// Used by CLI tools like the docs generator. Not used in production
 #[cfg(feature = "rusqlite")]
 pub fn mem_type_check(
@@ -143,7 +157,7 @@ pub fn run_analysis(
         version,
     );
     let result = analysis_db.execute(|db| {
-        ReadOnlyChecker::run_pass(&epoch, &mut contract_analysis, db)?;
+        ReadOnlyChecker::run_pass(&epoch, &mut contract_analysis, db, time_tracker)?;
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 TypeChecker2_05::run_pass(&epoch, &mut contract_analysis, db, build_type_map)
@@ -171,8 +185,11 @@ pub fn run_analysis(
                 .into());
             }
         }?;
-        TraitChecker::run_pass(&epoch, &mut contract_analysis, db)?;
+        TraitChecker::run_pass(&epoch, &mut contract_analysis, db, time_tracker)?;
         ArithmeticOnlyChecker::check_contract_cost_eligible(&mut contract_analysis);
+
+        // Final boundary check on the analysis passes
+        check_analysis_timeout(&time_tracker)?;
 
         if STORE_CONTRACT_SRC_INTERFACE {
             let interface = build_contract_interface(&contract_analysis)?;

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -133,6 +133,38 @@ pub fn type_check(
     .map_err(|e| e.0)
 }
 
+/// Run the full static-analysis pipeline (read-only, type, trait and arithmetic
+/// passes) over a parsed contract, optionally persisting the result.
+///
+/// # Arguments
+///
+/// * `contract_identifier` - Identity of the contract being analyzed.
+/// * `expressions` - The parsed top-level expressions (AST) to analyze.
+/// * `analysis_db` - Database used to read referenced contracts and (optionally) write
+///   the resulting analysis.
+/// * `save_contract` - When `true`, the completed analysis is persisted to
+///   `analysis_db`; when `false`, it is only returned to the caller.
+/// * `cost_tracker` - Cost meter bounding the work performed by the analysis. It is
+///   threaded through the passes and handed back to the caller (on both success and
+///   failure) so the consumed budget is preserved.
+/// * `epoch` - Stacks epoch, which selects the type-checker implementation
+///   (2.05 vs 2.1+) and epoch-specific analysis rules.
+/// * `version` - Clarity language version of the contract.
+/// * `build_type_map` - When `true`, the type checker records a full expression →
+///   type map on the resulting analysis (needed by tooling/tests); when `false`, the
+///   map is skipped to save work.
+/// * `time_tracker` - Wall-clock deadline enforced across the analysis passes. The
+///   clock may already have elapsed time on it from AST building by the time it
+///   reaches here. `TimeTracker::MaxTime` is used only on the non-consensus voting
+///   paths (mining / block-proposal validation); `TimeTracker::NoTracking` is used on
+///   the deterministic replay/commit path so consensus stays deterministic, meaning
+///   the deadline never fires there.
+///
+/// # Returns
+///
+/// On success, the completed [`ContractAnalysis`]. On failure, a boxed pair of the
+/// [`StaticCheckError`] and the [`LimitedCostTracker`] recovered from the analysis, so
+/// the caller can continue accounting for the cost already consumed.
 #[allow(clippy::too_many_arguments)]
 pub fn run_analysis(
     contract_identifier: &QualifiedContractIdentifier,
@@ -143,10 +175,6 @@ pub fn run_analysis(
     epoch: StacksEpochId,
     version: ClarityVersion,
     build_type_map: bool,
-    // Wall-clock deadline for the type-checking phase. `TimeTracker::MaxTime` only
-    // on the non-consensus voting paths (mining / block-proposal validation);
-    // `TimeTracker::NoTracking` on deterministic replay/commit (so consensus stays
-    // deterministic).
     time_tracker: TimeTracker,
 ) -> Result<ContractAnalysis, Box<(StaticCheckError, LimitedCostTracker)>> {
     let mut contract_analysis = ContractAnalysis::new(

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -39,11 +39,12 @@ pub use self::types::{AnalysisPass, ContractAnalysis};
 use crate::vm::ClarityVersion;
 #[cfg(feature = "rusqlite")]
 use crate::vm::ast::build_ast;
-use crate::vm::costs::{LimitedCostTracker, TimeTracker};
+use crate::vm::costs::LimitedCostTracker;
 #[cfg(feature = "rusqlite")]
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::database::STORE_CONTRACT_SRC_INTERFACE;
 use crate::vm::representations::SymbolicExpression;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::QualifiedContractIdentifier;
 #[cfg(feature = "rusqlite")]
 use crate::vm::types::TypeSignature;

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -73,7 +73,7 @@ pub fn mem_type_check(
         epoch,
         version,
         true,
-        TimeTracker::NoTracking,
+        TimeTracker::unlimited(),
     ) {
         Ok(x) => {
             // return the first type result of the type checker
@@ -114,7 +114,7 @@ pub fn type_check(
         *epoch,
         *version,
         true,
-        TimeTracker::NoTracking,
+        TimeTracker::unlimited(),
     )
     .map_err(|e| e.0)
 }

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -23,6 +23,8 @@ pub mod trait_checker;
 pub mod type_checker;
 pub mod types;
 
+use std::time::Duration;
+
 use stacks_common::types::StacksEpochId;
 
 pub use self::analysis_db::AnalysisDatabase;
@@ -72,6 +74,7 @@ pub fn mem_type_check(
         epoch,
         version,
         true,
+        None,
     ) {
         Ok(x) => {
             // return the first type result of the type checker
@@ -112,6 +115,7 @@ pub fn type_check(
         *epoch,
         *version,
         true,
+        None,
     )
     .map_err(|e| e.0)
 }
@@ -126,6 +130,12 @@ pub fn run_analysis(
     epoch: StacksEpochId,
     version: ClarityVersion,
     build_type_map: bool,
+    // Wall-clock deadline for the type-checking phase. `Some` only on the
+    // non-consensus voting paths (mining / block-proposal validation); `None`
+    // on deterministic replay/commit (so consensus stays deterministic). Only
+    // the v2_1 checker (live Nakamoto path) honors it; the pre-Nakamoto v2_05
+    // checker runs solely on historical replay and ignores it.
+    max_time: Option<Duration>,
 ) -> Result<ContractAnalysis, Box<(StaticCheckError, LimitedCostTracker)>> {
     let mut contract_analysis = ContractAnalysis::new(
         contract_identifier.clone(),
@@ -149,9 +159,13 @@ pub fn run_analysis(
             | StacksEpochId::Epoch31
             | StacksEpochId::Epoch32
             | StacksEpochId::Epoch33
-            | StacksEpochId::Epoch34 => {
-                TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db, build_type_map)
-            }
+            | StacksEpochId::Epoch34 => TypeChecker2_1::run_pass(
+                &epoch,
+                &mut contract_analysis,
+                db,
+                build_type_map,
+                max_time,
+            ),
             StacksEpochId::Epoch10 => {
                 return Err(StaticCheckErrorKind::Unreachable(
                     "Epoch 1.0 is not a valid epoch for analysis".into(),

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -23,8 +23,6 @@ pub mod trait_checker;
 pub mod type_checker;
 pub mod types;
 
-use std::time::Duration;
-
 use stacks_common::types::StacksEpochId;
 
 pub use self::analysis_db::AnalysisDatabase;
@@ -41,7 +39,7 @@ pub use self::types::{AnalysisPass, ContractAnalysis};
 use crate::vm::ClarityVersion;
 #[cfg(feature = "rusqlite")]
 use crate::vm::ast::build_ast;
-use crate::vm::costs::LimitedCostTracker;
+use crate::vm::costs::{LimitedCostTracker, TimeTracker};
 #[cfg(feature = "rusqlite")]
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::database::STORE_CONTRACT_SRC_INTERFACE;
@@ -74,7 +72,7 @@ pub fn mem_type_check(
         epoch,
         version,
         true,
-        None,
+        TimeTracker::NoTracking,
     ) {
         Ok(x) => {
             // return the first type result of the type checker
@@ -115,7 +113,7 @@ pub fn type_check(
         *epoch,
         *version,
         true,
-        None,
+        TimeTracker::NoTracking,
     )
     .map_err(|e| e.0)
 }
@@ -130,12 +128,11 @@ pub fn run_analysis(
     epoch: StacksEpochId,
     version: ClarityVersion,
     build_type_map: bool,
-    // Wall-clock deadline for the type-checking phase. `Some` only on the
-    // non-consensus voting paths (mining / block-proposal validation); `None`
-    // on deterministic replay/commit (so consensus stays deterministic). Only
-    // the v2_1 checker (live Nakamoto path) honors it; the pre-Nakamoto v2_05
-    // checker runs solely on historical replay and ignores it.
-    max_time: Option<Duration>,
+    // Wall-clock deadline for the type-checking phase. `TimeTracker::MaxTime` only
+    // on the non-consensus voting paths (mining / block-proposal validation);
+    // `TimeTracker::NoTracking` on deterministic replay/commit (so consensus stays
+    // deterministic).
+    time_tracker: TimeTracker,
 ) -> Result<ContractAnalysis, Box<(StaticCheckError, LimitedCostTracker)>> {
     let mut contract_analysis = ContractAnalysis::new(
         contract_identifier.clone(),
@@ -164,7 +161,7 @@ pub fn run_analysis(
                 &mut contract_analysis,
                 db,
                 build_type_map,
-                max_time,
+                time_tracker,
             ),
             StacksEpochId::Epoch10 => {
                 return Err(StaticCheckErrorKind::Unreachable(

--- a/clarity/src/vm/analysis/read_only_checker/mod.rs
+++ b/clarity/src/vm/analysis/read_only_checker/mod.rs
@@ -26,6 +26,7 @@ pub use super::errors::{
     check_argument_count, check_arguments_at_least,
 };
 use crate::vm::ClarityVersion;
+use crate::vm::analysis::check_analysis_timeout;
 use crate::vm::analysis::types::{AnalysisPass, ContractAnalysis};
 use crate::vm::functions::NativeFunctions;
 use crate::vm::functions::define::DefineFunctionsParsed;
@@ -33,6 +34,7 @@ use crate::vm::representations::SymbolicExpressionType::{
     Atom, AtomValue, Field, List, LiteralValue, TraitReference,
 };
 use crate::vm::representations::{SymbolicExpression, SymbolicExpressionType};
+use crate::vm::time_tracker::TimeTracker;
 
 #[cfg(test)]
 mod tests;
@@ -48,6 +50,7 @@ pub struct ReadOnlyChecker<'a, 'b> {
     defined_functions: HashMap<ClarityName, bool>,
     epoch: StacksEpochId,
     clarity_version: ClarityVersion,
+    time_tracker: TimeTracker,
 }
 
 impl AnalysisPass for ReadOnlyChecker<'_, '_> {
@@ -55,9 +58,14 @@ impl AnalysisPass for ReadOnlyChecker<'_, '_> {
         epoch: &StacksEpochId,
         contract_analysis: &mut ContractAnalysis,
         analysis_db: &mut AnalysisDatabase,
+        time_tracker: TimeTracker,
     ) -> Result<(), StaticCheckError> {
-        let mut command =
-            ReadOnlyChecker::new(analysis_db, epoch, &contract_analysis.clarity_version);
+        let mut command = ReadOnlyChecker::new(
+            analysis_db,
+            epoch,
+            &contract_analysis.clarity_version,
+            time_tracker,
+        );
         command.run(contract_analysis)?;
         Ok(())
     }
@@ -68,12 +76,14 @@ impl<'a, 'b> ReadOnlyChecker<'a, 'b> {
         db: &'a mut AnalysisDatabase<'b>,
         epoch: &StacksEpochId,
         version: &ClarityVersion,
+        time_tracker: TimeTracker,
     ) -> ReadOnlyChecker<'a, 'b> {
         Self {
             db,
             defined_functions: HashMap::new(),
             epoch: *epoch,
             clarity_version: *version,
+            time_tracker,
         }
     }
 
@@ -230,6 +240,8 @@ impl<'a, 'b> ReadOnlyChecker<'a, 'b> {
     ///   (2) if valid, returns whether or not they are read only.
     /// Note that because of (1), this function _cannot_ short-circuit on read-only.
     fn check_read_only(&mut self, expr: &SymbolicExpression) -> Result<bool, StaticCheckError> {
+        check_analysis_timeout(&self.time_tracker)?;
+
         match expr.expr {
             AtomValue(_) | LiteralValue(_) | Atom(_) | TraitReference(_, _) | Field(_) => Ok(true),
             List(ref expression) => self.check_expression_application_is_read_only(expression),

--- a/clarity/src/vm/analysis/tests/mod.rs
+++ b/clarity/src/vm/analysis/tests/mod.rs
@@ -25,8 +25,9 @@ use crate::vm::analysis::{
     run_analysis,
 };
 use crate::vm::ast::build_ast;
-use crate::vm::costs::{LimitedCostTracker, TimeTracker};
+use crate::vm::costs::LimitedCostTracker;
 use crate::vm::database::MemoryBackingStore;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::QualifiedContractIdentifier;
 
 mod utils {
@@ -475,8 +476,10 @@ fn test_run_analysis_aborts_when_deadline_already_elapsed() {
 /// analysis deadline, so a valid contract type-checks successfully.
 #[test]
 fn test_run_analysis_no_tracking_is_not_time_limited() {
-    let result =
-        utils::run_analysis_with_tracker("(define-read-only (foo) (+ 1 1))", TimeTracker::free());
+    let result = utils::run_analysis_with_tracker(
+        "(define-read-only (foo) (+ 1 1))",
+        TimeTracker::unlimited(),
+    );
     assert!(
         result.is_ok(),
         "NoTracking analysis should succeed, got {:?}",

--- a/clarity/src/vm/analysis/tests/mod.rs
+++ b/clarity/src/vm/analysis/tests/mod.rs
@@ -14,11 +14,59 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::time::Duration;
+
 use stacks_common::types::StacksEpochId;
 
 use crate::vm::ClarityVersion;
-use crate::vm::analysis::mem_type_check as mem_run_analysis;
 use crate::vm::analysis::type_checker::v2_1::tests::mem_type_check;
+use crate::vm::analysis::{
+    ContractAnalysis, StaticCheckError, StaticCheckErrorKind, mem_type_check as mem_run_analysis,
+    run_analysis,
+};
+use crate::vm::ast::build_ast;
+use crate::vm::costs::{LimitedCostTracker, TimeTracker};
+use crate::vm::database::MemoryBackingStore;
+use crate::vm::types::QualifiedContractIdentifier;
+
+mod utils {
+    use super::*;
+
+    /// Run the full analysis pipeline on `snippet` at the latest epoch / Clarity
+    /// version with the given `time_tracker`, returning the analysis error (if any).
+    ///
+    /// `time_tracker` bounds the type-checking phase: `TimeTracker::MaxTime` on the
+    /// non-consensus voting paths (mining / block-proposal validation), or
+    /// `TimeTracker::NoTracking` on deterministic replay/commit (no limit).
+    pub fn run_analysis_with_tracker(
+        snippet: &str,
+        time_tracker: TimeTracker,
+    ) -> Result<ContractAnalysis, StaticCheckError> {
+        let contract_id = QualifiedContractIdentifier::transient();
+        let version = ClarityVersion::latest();
+        let epoch = StacksEpochId::latest();
+
+        let exprs = build_ast(&contract_id, snippet, &mut (), version, epoch)
+            .expect("test contract should parse")
+            .expressions;
+
+        let mut marf = MemoryBackingStore::new();
+        let mut analysis_db = marf.as_analysis_db();
+
+        run_analysis(
+            &contract_id,
+            &exprs,
+            &mut analysis_db,
+            false, // save_contract
+            LimitedCostTracker::new_free(),
+            epoch,
+            version,
+            false, // build_type_map
+            time_tracker,
+        )
+        .map_err(|e| e.0)
+    }
+}
 
 #[test]
 fn test_list_types_must_match() {
@@ -402,5 +450,51 @@ fn test_write_attempt_in_readonly() {
     assert!(
         format!("{}", err.diagnostic)
             .contains("expecting read-only statements, detected a writing operation")
+    );
+}
+
+/// An already-elapsed deadline trips the per-node analysis check on the
+/// very first `type_check` node, so even a trivial contract is rejected with
+/// [`StaticCheckErrorKind::AnalysisTimeExpired`].
+#[test]
+fn test_run_analysis_aborts_when_deadline_already_elapsed() {
+    let err = utils::run_analysis_with_tracker(
+        "(define-read-only (foo) (+ 1 1))",
+        TimeTracker::from_max_duration(Duration::ZERO),
+    )
+    .expect_err("a zero-duration analysis deadline must abort");
+
+    assert!(
+        matches!(*err.err, StaticCheckErrorKind::AnalysisTimeExpired),
+        "expected AnalysisTimeExpired, got {:?}",
+        err.err
+    );
+}
+
+/// AfFree `TimeTracker` (the deterministic replay/commit path) imposes no
+/// analysis deadline, so a valid contract type-checks successfully.
+#[test]
+fn test_run_analysis_no_tracking_is_not_time_limited() {
+    let result =
+        utils::run_analysis_with_tracker("(define-read-only (foo) (+ 1 1))", TimeTracker::free());
+    assert!(
+        result.is_ok(),
+        "NoTracking analysis should succeed, got {:?}",
+        result.map(|_| ())
+    );
+}
+
+/// A generous deadline is not hit by a trivial contract, so analysis succeeds. This
+/// guards against the per-node check firing spuriously when a deadline is configured.
+#[test]
+fn test_run_analysis_generous_deadline_succeeds() {
+    let result = utils::run_analysis_with_tracker(
+        "(define-read-only (foo) (+ 1 1))",
+        TimeTracker::from_max_duration(Duration::from_secs(300)),
+    );
+    assert!(
+        result.is_ok(),
+        "analysis deadline should not trip on a trivial contract, got {:?}",
+        result.map(|_| ())
     );
 }

--- a/clarity/src/vm/analysis/tests/mod.rs
+++ b/clarity/src/vm/analysis/tests/mod.rs
@@ -468,7 +468,7 @@ fn test_run_analysis_aborts_when_deadline_already_elapsed() {
     );
 }
 
-/// AfFree `TimeTracker` (the deterministic replay/commit path) imposes no
+/// An unlimited [`TimeTracker`] (the deterministic replay/commit path) imposes no
 /// analysis deadline, so a valid contract type-checks successfully.
 #[test]
 fn test_run_analysis_no_tracking_is_not_time_limited() {

--- a/clarity/src/vm/analysis/tests/mod.rs
+++ b/clarity/src/vm/analysis/tests/mod.rs
@@ -35,10 +35,6 @@ mod utils {
 
     /// Run the full analysis pipeline on `snippet` at the latest epoch / Clarity
     /// version with the given `time_tracker`, returning the analysis error (if any).
-    ///
-    /// `time_tracker` bounds the type-checking phase: `TimeTracker::MaxTime` on the
-    /// non-consensus voting paths (mining / block-proposal validation), or
-    /// `TimeTracker::NoTracking` on deterministic replay/commit (no limit).
     pub fn run_analysis_with_tracker(
         snippet: &str,
         time_tracker: TimeTracker,

--- a/clarity/src/vm/analysis/tests/mod.rs
+++ b/clarity/src/vm/analysis/tests/mod.rs
@@ -35,7 +35,7 @@ mod utils {
 
     /// Run the full analysis pipeline on `snippet` at the latest epoch / Clarity
     /// version with the given `time_tracker`, returning the analysis error (if any).
-    pub fn run_analysis_with_tracker(
+    pub fn run_analysis_with_time_tracker(
         snippet: &str,
         time_tracker: TimeTracker,
     ) -> Result<ContractAnalysis, StaticCheckError> {
@@ -455,7 +455,7 @@ fn test_write_attempt_in_readonly() {
 /// [`StaticCheckErrorKind::AnalysisTimeExpired`].
 #[test]
 fn test_run_analysis_aborts_when_deadline_already_elapsed() {
-    let err = utils::run_analysis_with_tracker(
+    let err = utils::run_analysis_with_time_tracker(
         "(define-read-only (foo) (+ 1 1))",
         TimeTracker::from_max_duration(Duration::ZERO),
     )
@@ -472,7 +472,7 @@ fn test_run_analysis_aborts_when_deadline_already_elapsed() {
 /// analysis deadline, so a valid contract type-checks successfully.
 #[test]
 fn test_run_analysis_no_tracking_is_not_time_limited() {
-    let result = utils::run_analysis_with_tracker(
+    let result = utils::run_analysis_with_time_tracker(
         "(define-read-only (foo) (+ 1 1))",
         TimeTracker::unlimited(),
     );
@@ -487,7 +487,7 @@ fn test_run_analysis_no_tracking_is_not_time_limited() {
 /// guards against the per-node check firing spuriously when a deadline is configured.
 #[test]
 fn test_run_analysis_generous_deadline_succeeds() {
-    let result = utils::run_analysis_with_tracker(
+    let result = utils::run_analysis_with_time_tracker(
         "(define-read-only (foo) (+ 1 1))",
         TimeTracker::from_max_duration(Duration::from_secs(300)),
     );

--- a/clarity/src/vm/analysis/trait_checker/mod.rs
+++ b/clarity/src/vm/analysis/trait_checker/mod.rs
@@ -15,12 +15,14 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use stacks_common::types::StacksEpochId;
 
-use crate::vm::analysis::AnalysisDatabase;
 use crate::vm::analysis::errors::{StaticCheckError, StaticCheckErrorKind};
 use crate::vm::analysis::types::{AnalysisPass, ContractAnalysis};
+use crate::vm::analysis::{AnalysisDatabase, check_analysis_timeout};
+use crate::vm::time_tracker::TimeTracker;
 
 pub struct TraitChecker {
     epoch: StacksEpochId,
+    time_tracker: TimeTracker,
 }
 
 impl AnalysisPass for TraitChecker {
@@ -28,16 +30,20 @@ impl AnalysisPass for TraitChecker {
         epoch: &StacksEpochId,
         contract_analysis: &mut ContractAnalysis,
         analysis_db: &mut AnalysisDatabase,
+        time_tracker: TimeTracker,
     ) -> Result<(), StaticCheckError> {
-        let mut command = TraitChecker::new(epoch);
+        let mut command = TraitChecker::new(epoch, time_tracker);
         command.run(contract_analysis, analysis_db)?;
         Ok(())
     }
 }
 
 impl TraitChecker {
-    fn new(epoch: &StacksEpochId) -> Self {
-        Self { epoch: *epoch }
+    fn new(epoch: &StacksEpochId, time_tracker: TimeTracker) -> Self {
+        Self {
+            epoch: *epoch,
+            time_tracker,
+        }
     }
 
     pub fn run(
@@ -46,6 +52,9 @@ impl TraitChecker {
         analysis_db: &mut AnalysisDatabase,
     ) -> Result<(), StaticCheckError> {
         for trait_identifier in &contract_analysis.implemented_traits {
+            // per-trait analysis deadline check
+            check_analysis_timeout(&self.time_tracker)?;
+
             let trait_name = trait_identifier.name.to_string();
             let contract_defining_trait = analysis_db
                 .load_contract(&trait_identifier.contract_identifier, &self.epoch)?

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -18,6 +18,7 @@ pub mod contexts;
 pub mod natives;
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use stacks_common::types::StacksEpochId;
 
@@ -33,7 +34,7 @@ pub use crate::vm::analysis::errors::{
 };
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::{
-    CostErrors, CostOverflowingMath, CostTracker, ExecutionCost, LimitedCostTracker,
+    CostErrors, CostOverflowingMath, CostTracker, ExecutionCost, LimitedCostTracker, TimeTracker,
     analysis_typecheck_cost, runtime_cost,
 };
 use crate::vm::diagnostic::Diagnostic;
@@ -88,6 +89,12 @@ pub struct TypeChecker<'a, 'b> {
     db: &'a mut AnalysisDatabase<'b>,
     pub cost_track: LimitedCostTracker,
     clarity_version: ClarityVersion,
+    /// Wall-clock deadline for the analysis phase. `NoTracking` on the
+    /// deterministic-replay/commit path (so consensus stays deterministic);
+    /// `MaxTime` only on the non-consensus voting paths (mining / block-proposal
+    /// validation). Checked per node in `type_check` via
+    /// `check_analysis_abort_condition`, independent of cost charging.
+    time_tracker: TimeTracker,
 }
 
 impl CostTracker for TypeChecker<'_, '_> {
@@ -128,6 +135,7 @@ impl TypeChecker<'_, '_> {
         contract_analysis: &mut ContractAnalysis,
         analysis_db: &mut AnalysisDatabase,
         build_type_map: bool,
+        max_time: Option<Duration>,
     ) -> Result<(), StaticCheckError> {
         let cost_track = contract_analysis.take_contract_cost_tracker();
         let mut command = TypeChecker::new(
@@ -137,6 +145,7 @@ impl TypeChecker<'_, '_> {
             &contract_analysis.contract_identifier,
             &contract_analysis.clarity_version,
             build_type_map,
+            max_time,
         );
         // run the analysis, and replace the cost tracker whether or not the
         //   analysis succeeded.
@@ -1058,6 +1067,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         contract_identifier: &QualifiedContractIdentifier,
         clarity_version: &ClarityVersion,
         build_type_map: bool,
+        max_time: Option<Duration>,
     ) -> TypeChecker<'a, 'b> {
         Self {
             epoch: *epoch,
@@ -1067,7 +1077,21 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
             function_return_tracker: None,
             type_map: TypeMap::new(build_type_map),
             clarity_version: *clarity_version,
+            time_tracker: TimeTracker::from_opt_max_time(max_time),
         }
+    }
+
+    /// Per-node analysis abort check. Mirrors eval's `check_interpreter_abort_condition`:
+    /// it is invoked from the per-expression type-check loop (`type_check`),
+    /// independent of cost accounting, so any unbounded analysis path is bounded.
+    ///
+    /// Returns [`CostErrors::AnalysisTimeExpired`] once the configured analysis
+    /// deadline has elapsed.
+    fn check_analysis_abort_condition(&self) -> Result<(), CostErrors> {
+        if self.time_tracker.is_expired() {
+            return Err(CostErrors::AnalysisTimeExpired);
+        }
+        Ok(())
     }
 
     fn into_contract_analysis(
@@ -1181,6 +1205,9 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         expr: &SymbolicExpression,
         context: &TypingContext,
     ) -> Result<TypeSignature, StaticCheckError> {
+        // Per-node analysis deadline check (independent of cost accounting).
+        self.check_analysis_abort_condition()?;
+
         runtime_cost(ClarityCostFunction::AnalysisVisit, self, 0)?;
 
         let mut result = self.inner_type_check(expr, context);

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -760,6 +760,7 @@ fn clarity2_check_functions_compatible<T: CostTracker>(
 /// This means that actual_trait implements all functions from expected_trait
 /// with compatible functions, and may optionally include other functions not
 /// included in expected_trait.
+#[allow(clippy::too_many_arguments)]
 pub fn clarity2_trait_check_trait_compliance<T: CostTracker>(
     db: &mut AnalysisDatabase,
     contract_context: Option<&ContractContext>,

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -26,11 +26,11 @@ pub use self::natives::{SimpleNativeFunction, TypedNativeFunction};
 use super::ContractAnalysis;
 use super::contexts::{TypeMap, TypingContext};
 use crate::vm::ClarityVersion;
-use crate::vm::analysis::AnalysisDatabase;
 pub use crate::vm::analysis::errors::{
     StaticCheckError, StaticCheckErrorKind, SyntaxBindingErrorType, check_argument_count,
     check_arguments_at_least, check_arguments_at_most,
 };
+use crate::vm::analysis::{AnalysisDatabase, check_analysis_timeout};
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::{
     CostErrors, CostOverflowingMath, CostTracker, ExecutionCost, LimitedCostTracker,
@@ -756,19 +756,6 @@ fn clarity2_check_functions_compatible<T: CostTracker>(
     Ok(true)
 }
 
-/// Cooperative analysis-deadline check for the trait-compliance / type-admission
-/// recursion, which is threaded a `&TimeTracker` directly (it cannot call
-/// [`TypeChecker::check_analysis_abort_condition`] because it only holds the
-/// type-checker's `cost_track`, not the type-checker itself).
-///
-/// This is the single place the analysis-timeout error is constructed.
-fn check_analysis_timeout(time_tracker: &TimeTracker) -> Result<(), StaticCheckError> {
-    if time_tracker.is_expired() {
-        return Err(StaticCheckErrorKind::AnalysisTimeExpired.into());
-    }
-    Ok(())
-}
-
 /// Returns Ok if actual_trait is compliant with expected_trait.
 /// This means that actual_trait implements all functions from expected_trait
 /// with compatible functions, and may optionally include other functions not
@@ -1140,16 +1127,6 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         }
     }
 
-    /// Per-node analysis abort check.
-    /// It is invoked from the per-expression type-check loop ([`Self::type_check`]),
-    /// independent of cost accounting.
-    ///
-    /// Returns [`StaticCheckErrorKind::AnalysisTimeExpired`] once the configured
-    /// analysis deadline has elapsed.
-    fn check_analysis_abort_condition(&self) -> Result<(), StaticCheckError> {
-        check_analysis_timeout(&self.time_tracker)
-    }
-
     fn into_contract_analysis(
         self,
         contract_analysis: &mut ContractAnalysis,
@@ -1262,7 +1239,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         context: &TypingContext,
     ) -> Result<TypeSignature, StaticCheckError> {
         // Per-node analysis deadline check (independent of cost accounting).
-        self.check_analysis_abort_condition()?;
+        check_analysis_timeout(&self.time_tracker)?;
 
         runtime_cost(ClarityCostFunction::AnalysisVisit, self, 0)?;
 

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -640,6 +640,7 @@ impl FunctionType {
                     &expected_arg.signature,
                     1,
                     &mut LimitedCostTracker::new_free(),
+                    &TimeTracker::unlimited(),
                 )?;
             }
         }
@@ -685,46 +686,87 @@ fn check_function_arg_signature<T: CostTracker>(
     Ok(())
 }
 
+/// Map an error from the trait-compliance recursion to a compatibility verdict.
+///
+/// An analysis-deadline expiry *propagates* (`Err`); every other error collapses
+/// to "not compatible" (`Ok(false)`).
+///
+/// Propagating **only** `AnalysisTimeExpired` is deliberate and consensus-critical.
+/// The deadline is configured only on the non-consensus voting paths (mining
+/// assembly / block-proposal validation) and is `NoTracking` on replay/commit, so
+/// it can never arise during consensus — re-surfacing it changes no deterministic
+/// outcome.
+///
+/// Every other error here is deterministic. In particular `CostBalanceExceeded` /
+/// `CostOverflow` (from the cost charged in `clarity2_lookup_trait` and the
+/// Principal->Trait arm) are currently *masked* as `IncompatibleTrait`. That
+/// masking is a known latent bug, but re-surfacing those as their real error would
+/// change the transaction/block outcome on the replay path — a **consensus break** —
+/// so it must NOT be changed here without an epoch-gated migration.
+fn propagate_or_incompatible(e: StaticCheckError) -> Result<bool, StaticCheckError> {
+    if matches!(*e.err, StaticCheckErrorKind::AnalysisTimeExpired) {
+        Err(e)
+    } else {
+        Ok(false)
+    }
+}
+
 /// Used to check if a function signature is compatible with the function
 /// signature required for a trait.
+///
+/// `Ok(true)`/`Ok(false)` is the compatibility verdict; `Err` is reserved for an
+/// analysis-deadline expiry, which must not be masked as incompatibility (see
+/// [`propagate_or_incompatible`]).
 fn clarity2_check_functions_compatible<T: CostTracker>(
     db: &mut AnalysisDatabase,
     contract_context: Option<&ContractContext>,
     expected_sig: &FunctionSignature,
     actual_sig: &FunctionSignature,
     tracker: &mut T,
-) -> bool {
+    time_tracker: &TimeTracker,
+) -> Result<bool, StaticCheckError> {
     if expected_sig.args.len() != actual_sig.args.len() {
-        return false;
+        return Ok(false);
     }
     let args_iter = expected_sig.args.iter().zip(actual_sig.args.iter());
     for (expected_type, actual_type) in args_iter {
-        if clarity2_inner_type_check_type(
+        if let Err(e) = clarity2_inner_type_check_type(
             db,
             contract_context,
             actual_type,
             expected_type,
             1,
             tracker,
-        )
-        .is_err()
-        {
-            return false;
+            time_tracker,
+        ) {
+            return propagate_or_incompatible(e);
         }
     }
-    if clarity2_inner_type_check_type(
+    if let Err(e) = clarity2_inner_type_check_type(
         db,
         contract_context,
         &actual_sig.returns,
         &expected_sig.returns,
         1,
         tracker,
-    )
-    .is_err()
-    {
-        return false;
+        time_tracker,
+    ) {
+        return propagate_or_incompatible(e);
     }
-    true
+    Ok(true)
+}
+
+/// Cooperative analysis-deadline check for the trait-compliance / type-admission
+/// recursion, which is threaded a `&TimeTracker` directly (it cannot call
+/// [`TypeChecker::check_analysis_abort_condition`] because it only holds the
+/// type-checker's `cost_track`, not the type-checker itself).
+///
+/// This is the single place the analysis-timeout error is constructed.
+fn check_analysis_timeout(time_tracker: &TimeTracker) -> Result<(), StaticCheckError> {
+    if time_tracker.is_expired() {
+        return Err(StaticCheckErrorKind::AnalysisTimeExpired.into());
+    }
+    Ok(())
 }
 
 /// Returns Ok if actual_trait is compliant with expected_trait.
@@ -739,6 +781,7 @@ pub fn clarity2_trait_check_trait_compliance<T: CostTracker>(
     expected_trait_identifier: &TraitIdentifier,
     expected_trait: &BTreeMap<ClarityName, FunctionSignature>,
     tracker: &mut T,
+    time_tracker: &TimeTracker,
 ) -> Result<(), StaticCheckError> {
     // Shortcut for the simple case when the two traits are the same.
     if actual_trait_identifier == expected_trait_identifier {
@@ -753,7 +796,8 @@ pub fn clarity2_trait_check_trait_compliance<T: CostTracker>(
                 expected_sig,
                 func,
                 tracker,
-            ) {
+                time_tracker,
+            )? {
                 return Err(StaticCheckErrorKind::IncompatibleTrait(
                     Box::new(expected_trait_identifier.clone()),
                     Box::new(actual_trait_identifier.clone()),
@@ -780,10 +824,18 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
     expected_type: &TypeSignature,
     depth: u8,
     tracker: &mut T,
+    time_tracker: &TimeTracker,
 ) -> Result<TypeSignature, StaticCheckError> {
     if depth > MAX_TYPE_DEPTH {
         return Err(StaticCheckErrorKind::TypeSignatureTooDeep.into());
     }
+
+    // This recursion (mutually recursive with `clarity2_trait_check_trait_compliance`
+    // / `clarity2_check_functions_compatible`) runs entirely within a single
+    // `type_check` node visit, so the per-node deadline check never fires while it
+    // runs. Re-check the analysis deadline here: every cycle iteration passes
+    // through this function, so one check bounds the whole trait-compliance graph.
+    check_analysis_timeout(time_tracker)?;
 
     // Recurse into values to check embedded traits properly
     match (actual_type, expected_type) {
@@ -798,6 +850,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                 expected_inner_type,
                 depth + 1,
                 tracker,
+                time_tracker,
             )?;
         }
         (
@@ -811,6 +864,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                 &expected_inner_types.0,
                 depth + 1,
                 tracker,
+                time_tracker,
             )?;
             clarity2_inner_type_check_type(
                 db,
@@ -819,6 +873,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                 &expected_inner_types.1,
                 depth + 1,
                 tracker,
+                time_tracker,
             )?;
         }
         (
@@ -833,6 +888,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     expected_list_type.get_list_item_type(),
                     depth + 1,
                     tracker,
+                    time_tracker,
                 )?;
             } else {
                 return Err(StaticCheckErrorKind::TypeError(
@@ -864,6 +920,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                             expected_field_type,
                             depth + 1,
                             tracker,
+                            time_tracker,
                         )?;
                     }
                     None => {
@@ -893,6 +950,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     expected_trait_id,
                     &expected_trait,
                     tracker,
+                    time_tracker,
                 )?;
             }
         }
@@ -939,6 +997,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     expected_type,
                     depth + 1,
                     tracker,
+                    time_tracker,
                 )?;
             }
         }
@@ -1088,10 +1147,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
     /// Returns [`StaticCheckErrorKind::AnalysisTimeExpired`] once the configured
     /// analysis deadline has elapsed.
     fn check_analysis_abort_condition(&self) -> Result<(), StaticCheckError> {
-        if self.time_tracker.is_expired() {
-            return Err(StaticCheckErrorKind::AnalysisTimeExpired.into());
-        }
-        Ok(())
+        check_analysis_timeout(&self.time_tracker)
     }
 
     fn into_contract_analysis(
@@ -1640,6 +1696,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
             expected_type,
             1,
             &mut self.cost_track,
+            &self.time_tracker,
         )?;
 
         // If we reach here with no errors, then the expression can be

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -33,7 +33,7 @@ pub use crate::vm::analysis::errors::{
 };
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::{
-    CostErrors, CostOverflowingMath, CostTracker, ExecutionCost, LimitedCostTracker, TimeTracker,
+    CostErrors, CostOverflowingMath, CostTracker, ExecutionCost, LimitedCostTracker,
     analysis_typecheck_cost, runtime_cost,
 };
 use crate::vm::diagnostic::Diagnostic;
@@ -43,6 +43,7 @@ use crate::vm::representations::SymbolicExpressionType::{
     Atom, AtomValue, Field, List, LiteralValue, TraitReference,
 };
 use crate::vm::representations::{ClarityName, SymbolicExpression, depth_traverse};
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::signatures::{
     CallableSubtype, FunctionArgSignature, FunctionReturnsSignature, FunctionSignature,
 };
@@ -1084,11 +1085,11 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
     /// it is invoked from the per-expression type-check loop (`type_check`),
     /// independent of cost accounting, so any unbounded analysis path is bounded.
     ///
-    /// Returns [`CostErrors::AnalysisTimeExpired`] once the configured analysis
-    /// deadline has elapsed.
-    fn check_analysis_abort_condition(&self) -> Result<(), CostErrors> {
+    /// Returns [`StaticCheckErrorKind::AnalysisTimeExpired`] once the configured
+    /// analysis deadline has elapsed.
+    fn check_analysis_abort_condition(&self) -> Result<(), StaticCheckError> {
         if self.time_tracker.is_expired() {
-            return Err(CostErrors::AnalysisTimeExpired);
+            return Err(StaticCheckErrorKind::AnalysisTimeExpired.into());
         }
         Ok(())
     }

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -811,7 +811,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
     actual_type: &TypeSignature,
     expected_type: &TypeSignature,
     depth: u8,
-    tracker: &mut T,
+    cost_tracker: &mut T,
     time_tracker: &TimeTracker,
 ) -> Result<TypeSignature, StaticCheckError> {
     if depth > MAX_TYPE_DEPTH {
@@ -837,7 +837,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                 atom_inner_type,
                 expected_inner_type,
                 depth + 1,
-                tracker,
+                cost_tracker,
                 time_tracker,
             )?;
         }
@@ -851,7 +851,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                 &atom_inner_types.0,
                 &expected_inner_types.0,
                 depth + 1,
-                tracker,
+                cost_tracker,
                 time_tracker,
             )?;
             clarity2_inner_type_check_type(
@@ -860,7 +860,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                 &atom_inner_types.1,
                 &expected_inner_types.1,
                 depth + 1,
-                tracker,
+                cost_tracker,
                 time_tracker,
             )?;
         }
@@ -875,7 +875,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     atom_list_type.get_list_item_type(),
                     expected_list_type.get_list_item_type(),
                     depth + 1,
-                    tracker,
+                    cost_tracker,
                     time_tracker,
                 )?;
             } else {
@@ -907,7 +907,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                             atom_field_type,
                             expected_field_type,
                             depth + 1,
-                            tracker,
+                            cost_tracker,
                             time_tracker,
                         )?;
                     }
@@ -927,9 +927,9 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
         ) => {
             if atom_trait_id != expected_trait_id {
                 let atom_trait =
-                    clarity2_lookup_trait(db, contract_context, atom_trait_id, tracker)?;
+                    clarity2_lookup_trait(db, contract_context, atom_trait_id, cost_tracker)?;
                 let expected_trait =
-                    clarity2_lookup_trait(db, contract_context, expected_trait_id, tracker)?;
+                    clarity2_lookup_trait(db, contract_context, expected_trait_id, cost_tracker)?;
                 clarity2_trait_check_trait_compliance(
                     db,
                     contract_context,
@@ -937,7 +937,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     &atom_trait,
                     expected_trait_id,
                     &expected_trait,
-                    tracker,
+                    cost_tracker,
                     time_tracker,
                 )?;
             }
@@ -951,13 +951,17 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     Some(contract) => {
                         runtime_cost(
                             ClarityCostFunction::AnalysisFetchContractEntry,
-                            tracker,
+                            cost_tracker,
                             contract_analysis_size(&contract)?,
                         )?;
                         contract
                     }
                     None => {
-                        runtime_cost(ClarityCostFunction::AnalysisFetchContractEntry, tracker, 1)?;
+                        runtime_cost(
+                            ClarityCostFunction::AnalysisFetchContractEntry,
+                            cost_tracker,
+                            1,
+                        )?;
                         return Err(StaticCheckErrorKind::NoSuchContract(
                             contract_identifier.to_string(),
                         )
@@ -965,7 +969,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     }
                 };
             let expected_trait =
-                clarity2_lookup_trait(db, contract_context, expected_trait_id, tracker)?;
+                clarity2_lookup_trait(db, contract_context, expected_trait_id, cost_tracker)?;
             contract_to_check.check_trait_compliance(
                 &StacksEpochId::Epoch21,
                 expected_trait_id,
@@ -984,7 +988,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     &TypeSignature::CallableType(subtype.clone()),
                     expected_type,
                     depth + 1,
-                    tracker,
+                    cost_tracker,
                     time_tracker,
                 )?;
             }

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -18,7 +18,6 @@ pub mod contexts;
 pub mod natives;
 
 use std::collections::BTreeMap;
-use std::time::Duration;
 
 use stacks_common::types::StacksEpochId;
 
@@ -135,7 +134,7 @@ impl TypeChecker<'_, '_> {
         contract_analysis: &mut ContractAnalysis,
         analysis_db: &mut AnalysisDatabase,
         build_type_map: bool,
-        max_time: Option<Duration>,
+        time_tracker: TimeTracker,
     ) -> Result<(), StaticCheckError> {
         let cost_track = contract_analysis.take_contract_cost_tracker();
         let mut command = TypeChecker::new(
@@ -145,7 +144,7 @@ impl TypeChecker<'_, '_> {
             &contract_analysis.contract_identifier,
             &contract_analysis.clarity_version,
             build_type_map,
-            max_time,
+            time_tracker,
         );
         // run the analysis, and replace the cost tracker whether or not the
         //   analysis succeeded.
@@ -1067,7 +1066,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         contract_identifier: &QualifiedContractIdentifier,
         clarity_version: &ClarityVersion,
         build_type_map: bool,
-        max_time: Option<Duration>,
+        time_tracker: TimeTracker,
     ) -> TypeChecker<'a, 'b> {
         Self {
             epoch: *epoch,
@@ -1077,7 +1076,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
             function_return_tracker: None,
             type_map: TypeMap::new(build_type_map),
             clarity_version: *clarity_version,
-            time_tracker: TimeTracker::from_opt_max_time(max_time),
+            time_tracker,
         }
     }
 

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -1081,9 +1081,9 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         }
     }
 
-    /// Per-node analysis abort check. Mirrors eval's `check_interpreter_abort_condition`:
-    /// it is invoked from the per-expression type-check loop (`type_check`),
-    /// independent of cost accounting, so any unbounded analysis path is bounded.
+    /// Per-node analysis abort check.
+    /// It is invoked from the per-expression type-check loop ([`Self::type_check`]),
+    /// independent of cost accounting.
     ///
     /// Returns [`StaticCheckErrorKind::AnalysisTimeExpired`] once the configured
     /// analysis deadline has elapsed.

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -27,9 +27,10 @@ use crate::vm::analysis::{
     mem_type_check as mem_run_analysis, run_analysis,
 };
 use crate::vm::ast::parse;
-use crate::vm::costs::{LimitedCostTracker, TimeTracker};
+use crate::vm::costs::LimitedCostTracker;
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::tests::test_clarity_versions;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::signatures::CallableSubtype;
 use crate::vm::types::{
     BufferLength, ListTypeData, QualifiedContractIdentifier, SequenceSubtype, StringSubtype,

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -83,6 +83,7 @@ pub fn type_check_version(
         epoch,
         version,
         false,
+        None,
     )
     .map_err(|e| e.0)
 }

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -84,7 +84,7 @@ pub fn type_check_version(
         epoch,
         version,
         false,
-        TimeTracker::NoTracking,
+        TimeTracker::unlimited(),
     )
     .map_err(|e| e.0)
 }

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -27,7 +27,7 @@ use crate::vm::analysis::{
     mem_type_check as mem_run_analysis, run_analysis,
 };
 use crate::vm::ast::parse;
-use crate::vm::costs::LimitedCostTracker;
+use crate::vm::costs::{LimitedCostTracker, TimeTracker};
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::tests::test_clarity_versions;
 use crate::vm::types::signatures::CallableSubtype;
@@ -83,7 +83,7 @@ pub fn type_check_version(
         epoch,
         version,
         false,
-        None,
+        TimeTracker::NoTracking,
     )
     .map_err(|e| e.0)
 }

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::time::Duration;
+
 use clarity_types::types::SequenceSubtype;
 #[cfg(test)]
 use rstest::rstest;
@@ -28,7 +30,10 @@ use crate::vm::analysis::types::ContractAnalysis;
 use crate::vm::ast::build_ast;
 use crate::vm::ast::errors::ParseErrorKind;
 use crate::vm::ast::parser::v2::lexer::token::Token;
+use crate::vm::costs::LimitedCostTracker;
+use crate::vm::database::MemoryBackingStore;
 use crate::vm::tests::test_clarity_versions;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::SequenceSubtype::*;
 use crate::vm::types::StringSubtype::*;
 use crate::vm::types::TypeSignature::{BoolType, IntType, PrincipalType, SequenceType, UIntType};
@@ -4307,16 +4312,13 @@ fn test_contract_call_with_non_callable_constant_target(
     }
 }
 
+#[test]
 fn test_clarity2_inner_type_check_type_aborts_when_deadline_elapsed() {
-    use std::time::Duration;
-
-    use crate::vm::costs::LimitedCostTracker;
-    use crate::vm::database::MemoryBackingStore;
-    use crate::vm::time_tracker::TimeTracker;
-
     let mut marf = MemoryBackingStore::new();
     let mut db = marf.as_analysis_db();
-    let mut tracker = LimitedCostTracker::new_free();
+    let mut cost_tracker = LimitedCostTracker::new_free();
+    // A zero-duration deadline is already elapsed at the first check.
+    let time_tracker = TimeTracker::from_max_duration(Duration::ZERO);
 
     let result = super::clarity2_inner_type_check_type(
         &mut db,
@@ -4324,9 +4326,8 @@ fn test_clarity2_inner_type_check_type_aborts_when_deadline_elapsed() {
         &BoolType,
         &BoolType,
         1,
-        &mut tracker,
-        // A zero-duration deadline is already elapsed at the first check.
-        &TimeTracker::from_max_duration(Duration::ZERO),
+        &mut cost_tracker,
+        &time_tracker,
     );
 
     assert!(

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
@@ -4306,3 +4306,31 @@ fn test_contract_call_with_non_callable_constant_target(
         }
     }
 }
+
+fn test_clarity2_inner_type_check_type_aborts_when_deadline_elapsed() {
+    use std::time::Duration;
+
+    use crate::vm::costs::LimitedCostTracker;
+    use crate::vm::database::MemoryBackingStore;
+    use crate::vm::time_tracker::TimeTracker;
+
+    let mut marf = MemoryBackingStore::new();
+    let mut db = marf.as_analysis_db();
+    let mut tracker = LimitedCostTracker::new_free();
+
+    let result = super::clarity2_inner_type_check_type(
+        &mut db,
+        None,
+        &BoolType,
+        &BoolType,
+        1,
+        &mut tracker,
+        // A zero-duration deadline is already elapsed at the first check.
+        &TimeTracker::from_max_duration(Duration::ZERO),
+    );
+
+    assert!(
+        matches!(result, Err(ref e) if matches!(*e.err, StaticCheckErrorKind::AnalysisTimeExpired)),
+        "expected AnalysisTimeExpired, got {result:?}"
+    );
+}

--- a/clarity/src/vm/analysis/types.rs
+++ b/clarity/src/vm/analysis/types.rs
@@ -25,6 +25,7 @@ use crate::vm::analysis::contract_interface_builder::ContractInterface;
 use crate::vm::analysis::errors::{StaticCheckError, StaticCheckErrorKind};
 use crate::vm::analysis::type_checker::contexts::TypeMap;
 use crate::vm::costs::LimitedCostTracker;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::FunctionType;
 use crate::vm::types::signatures::FunctionSignature;
 use crate::vm::{ClarityVersion, SymbolicExpression};
@@ -39,6 +40,10 @@ pub trait AnalysisPass {
         epoch: &StacksEpochId,
         contract_analysis: &mut ContractAnalysis,
         analysis_db: &mut AnalysisDatabase,
+        // Wall-clock deadline for this pass. `MaxTime` only on the non-consensus voting
+        // paths; `NoTracking` on deterministic replay/commit (so consensus stays
+        // deterministic — see `check_analysis_timeout`).
+        time_tracker: TimeTracker,
     ) -> Result<(), StaticCheckError>;
 }
 

--- a/clarity/src/vm/ast/errors.rs
+++ b/clarity/src/vm/ast/errors.rs
@@ -285,6 +285,9 @@ impl From<CostErrors> for ParseError {
             CostErrors::ExecutionTimeExpired => {
                 ParseError::new(ParseErrorKind::ExecutionTimeExpired)
             }
+            // `AnalysisTimeExpired` is produced only by the analysis (type-checking) phase,
+            // never by the AST/parse cost tracker, so reaching this arm indicates a bug.
+            CostErrors::AnalysisTimeExpired => ParseError::new(ParseErrorKind::InterpreterFailure),
         }
     }
 }

--- a/clarity/src/vm/ast/errors.rs
+++ b/clarity/src/vm/ast/errors.rs
@@ -285,9 +285,6 @@ impl From<CostErrors> for ParseError {
             CostErrors::ExecutionTimeExpired => {
                 ParseError::new(ParseErrorKind::ExecutionTimeExpired)
             }
-            // `AnalysisTimeExpired` is produced only by the analysis (type-checking) phase,
-            // never by the AST/parse cost tracker, so reaching this arm indicates a bug.
-            CostErrors::AnalysisTimeExpired => ParseError::new(ParseErrorKind::InterpreterFailure),
         }
     }
 }

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -65,7 +65,7 @@ pub enum ClarityError {
     },
     /// Transaction exceeded the maximum execution time allowed.
     ExecutionTimeExpired,
-    /// Contract analysis (type-checking) exceeded the maximum analysis time allowed.
+    /// Contract analysis exceeded the maximum analysis time allowed.
     /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable end-to-end.
     AnalysisTimeExpired,
 }

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -272,13 +272,18 @@ pub trait TransactionConnection: ClarityConnection {
     where
         F: FnOnce(&mut AnalysisDatabase, LimitedCostTracker) -> (LimitedCostTracker, R);
 
-    /// Analyze a provided smart contract with an optional wall-clock deadline on the
-    /// type-checking phase, but do not write the analysis to the AnalysisDatabase.
+    /// Analyze a provided smart contract with an optional wall-clock deadline covering
+    /// AST building and static analysis, but do not write the analysis to the
+    /// AnalysisDatabase.
     ///
     /// `max_time` must be `Some` only on the non-consensus voting paths
     /// (block assembly / block-proposal validation) and `None` on deterministic
     /// replay/commit, so consensus stays deterministic. When the deadline elapses
     /// the analysis aborts with [`ClarityError::AnalysisTimeExpired`].
+    ///
+    /// The clock starts before AST building so that time counts against the budget;
+    /// the deadline itself is only enforced at the cooperative checkpoints inside the
+    /// analysis passes.
     fn analyze_smart_contract(
         &mut self,
         identifier: &QualifiedContractIdentifier,
@@ -289,6 +294,9 @@ pub trait TransactionConnection: ClarityConnection {
         let epoch_id = self.get_epoch();
 
         self.with_analysis_db(|db, mut cost_track| {
+            // Start the analysis clock here and take into account AST building.
+            let time_tracker = TimeTracker::from_opt_max_duration(max_time);
+
             let ast_result = ast::build_ast(
                 identifier,
                 contract_content,
@@ -302,9 +310,6 @@ pub trait TransactionConnection: ClarityConnection {
                 Err(e) => return (cost_track, Err(e.into())),
             };
 
-            // Start the analysis clock here (after AST building) so the budget bounds only
-            // the analysis phase. `NoTracking` when `max_time` is `None` (replay/commit).
-            let time_tracker = TimeTracker::from_opt_max_duration(max_time);
             let result = analysis::run_analysis(
                 identifier,
                 &contract_ast.expressions,

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -24,7 +24,7 @@ use crate::vm::analysis::{
 use crate::vm::ast::ContractAST;
 use crate::vm::ast::errors::{ParseError, ParseErrorKind};
 use crate::vm::contexts::{AssetMap, ExecutionState, InvocationContext, OwnedEnvironment};
-use crate::vm::costs::{ExecutionCost, LimitedCostTracker};
+use crate::vm::costs::{ExecutionCost, LimitedCostTracker, TimeTracker};
 use crate::vm::database::ClarityDatabase;
 use crate::vm::errors::{ClarityEvalError, VmExecutionError};
 use crate::vm::events::StacksTransactionEvent;
@@ -293,7 +293,7 @@ pub trait TransactionConnection: ClarityConnection {
     /// Analyze a provided smart contract with an optional wall-clock deadline on the
     /// type-checking phase, but do not write the analysis to the AnalysisDatabase.
     ///
-    /// `max_execution_time` must be `Some` only on the non-consensus voting paths
+    /// `max_time` must be `Some` only on the non-consensus voting paths
     /// (block assembly / block-proposal validation) and `None` on deterministic
     /// replay/commit, so consensus stays deterministic. When the deadline elapses
     /// the analysis aborts with [`ClarityError::AnalysisTimeExpired`].
@@ -302,7 +302,7 @@ pub trait TransactionConnection: ClarityConnection {
         identifier: &QualifiedContractIdentifier,
         clarity_version: ClarityVersion,
         contract_content: &str,
-        max_execution_time: Option<Duration>,
+        max_time: Option<Duration>,
     ) -> Result<(ContractAST, ContractAnalysis), ClarityError> {
         let epoch_id = self.get_epoch();
 
@@ -320,6 +320,9 @@ pub trait TransactionConnection: ClarityConnection {
                 Err(e) => return (cost_track, Err(e.into())),
             };
 
+            // Start the analysis clock here (after AST building) so the budget bounds only
+            // the analysis phase. `NoTracking` when `max_time` is `None` (replay/commit).
+            let time_tracker = TimeTracker::from_opt_max_time(max_time);
             let result = analysis::run_analysis(
                 identifier,
                 &contract_ast.expressions,
@@ -329,7 +332,7 @@ pub trait TransactionConnection: ClarityConnection {
                 epoch_id,
                 clarity_version,
                 false,
-                max_execution_time,
+                time_tracker,
             );
 
             match result {

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -271,25 +271,6 @@ pub trait TransactionConnection: ClarityConnection {
     where
         F: FnOnce(&mut AnalysisDatabase, LimitedCostTracker) -> (LimitedCostTracker, R);
 
-    /// Analyze a provided smart contract, but do not write the analysis to the AnalysisDatabase.
-    ///
-    /// The analysis (type-checking) phase runs with no wall-clock deadline. On the
-    /// non-consensus voting paths (mining / block-proposal validation) prefer
-    /// [`Self::analyze_smart_contract_with_deadline`] to bound the analysis time.
-    fn analyze_smart_contract(
-        &mut self,
-        identifier: &QualifiedContractIdentifier,
-        clarity_version: ClarityVersion,
-        contract_content: &str,
-    ) -> Result<(ContractAST, ContractAnalysis), ClarityError> {
-        self.analyze_smart_contract_with_deadline(
-            identifier,
-            clarity_version,
-            contract_content,
-            None,
-        )
-    }
-
     /// Analyze a provided smart contract with an optional wall-clock deadline on the
     /// type-checking phase, but do not write the analysis to the AnalysisDatabase.
     ///
@@ -297,7 +278,7 @@ pub trait TransactionConnection: ClarityConnection {
     /// (block assembly / block-proposal validation) and `None` on deterministic
     /// replay/commit, so consensus stays deterministic. When the deadline elapses
     /// the analysis aborts with [`ClarityError::AnalysisTimeExpired`].
-    fn analyze_smart_contract_with_deadline(
+    fn analyze_smart_contract(
         &mut self,
         identifier: &QualifiedContractIdentifier,
         clarity_version: ClarityVersion,

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use std::fmt;
+use std::time::Duration;
 
 use stacks_common::types::StacksEpochId;
 
@@ -63,6 +64,9 @@ pub enum ClarityError {
     },
     /// Transaction exceeded the maximum execution time allowed.
     ExecutionTimeExpired,
+    /// Contract analysis (type-checking) exceeded the maximum analysis time allowed.
+    /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable end-to-end.
+    AnalysisTimeExpired,
 }
 
 impl fmt::Display for ClarityError {
@@ -79,6 +83,7 @@ impl fmt::Display for ClarityError {
             ClarityError::Interpreter(e) => fmt::Display::fmt(e, f),
             ClarityError::BadTransaction(s) => fmt::Display::fmt(s, f),
             ClarityError::ExecutionTimeExpired => write!(f, "Execution time expired"),
+            ClarityError::AnalysisTimeExpired => write!(f, "Analysis time expired"),
         }
     }
 }
@@ -93,6 +98,7 @@ impl std::error::Error for ClarityError {
             ClarityError::Interpreter(ref e) => Some(e),
             ClarityError::BadTransaction(ref _s) => None,
             ClarityError::ExecutionTimeExpired => None,
+            ClarityError::AnalysisTimeExpired => None,
         }
     }
 }
@@ -108,6 +114,7 @@ impl From<StaticCheckError> for ClarityError {
                 ClarityError::CostError(ExecutionCost::max_value(), ExecutionCost::max_value())
             }
             StaticCheckErrorKind::ExecutionTimeExpired => ClarityError::ExecutionTimeExpired,
+            StaticCheckErrorKind::AnalysisTimeExpired => ClarityError::AnalysisTimeExpired,
             _ => ClarityError::StaticCheck(e),
         }
     }
@@ -264,12 +271,38 @@ pub trait TransactionConnection: ClarityConnection {
     where
         F: FnOnce(&mut AnalysisDatabase, LimitedCostTracker) -> (LimitedCostTracker, R);
 
-    /// Analyze a provided smart contract, but do not write the analysis to the AnalysisDatabase
+    /// Analyze a provided smart contract, but do not write the analysis to the AnalysisDatabase.
+    ///
+    /// The analysis (type-checking) phase runs with no wall-clock deadline. On the
+    /// non-consensus voting paths (mining / block-proposal validation) prefer
+    /// [`Self::analyze_smart_contract_with_deadline`] to bound the analysis time.
     fn analyze_smart_contract(
         &mut self,
         identifier: &QualifiedContractIdentifier,
         clarity_version: ClarityVersion,
         contract_content: &str,
+    ) -> Result<(ContractAST, ContractAnalysis), ClarityError> {
+        self.analyze_smart_contract_with_deadline(
+            identifier,
+            clarity_version,
+            contract_content,
+            None,
+        )
+    }
+
+    /// Analyze a provided smart contract with an optional wall-clock deadline on the
+    /// type-checking phase, but do not write the analysis to the AnalysisDatabase.
+    ///
+    /// `max_execution_time` must be `Some` only on the non-consensus voting paths
+    /// (block assembly / block-proposal validation) and `None` on deterministic
+    /// replay/commit, so consensus stays deterministic. When the deadline elapses
+    /// the analysis aborts with [`ClarityError::AnalysisTimeExpired`].
+    fn analyze_smart_contract_with_deadline(
+        &mut self,
+        identifier: &QualifiedContractIdentifier,
+        clarity_version: ClarityVersion,
+        contract_content: &str,
+        max_execution_time: Option<Duration>,
     ) -> Result<(ContractAST, ContractAnalysis), ClarityError> {
         let epoch_id = self.get_epoch();
 
@@ -296,6 +329,7 @@ pub trait TransactionConnection: ClarityConnection {
                 epoch_id,
                 clarity_version,
                 false,
+                max_execution_time,
             );
 
             match result {

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -322,7 +322,7 @@ pub trait TransactionConnection: ClarityConnection {
 
             // Start the analysis clock here (after AST building) so the budget bounds only
             // the analysis phase. `NoTracking` when `max_time` is `None` (replay/commit).
-            let time_tracker = TimeTracker::from_opt_max_time(max_time);
+            let time_tracker = TimeTracker::from_opt_max_duration(max_time);
             let result = analysis::run_analysis(
                 identifier,
                 &contract_ast.expressions,

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -24,10 +24,11 @@ use crate::vm::analysis::{
 use crate::vm::ast::ContractAST;
 use crate::vm::ast::errors::{ParseError, ParseErrorKind};
 use crate::vm::contexts::{AssetMap, ExecutionState, InvocationContext, OwnedEnvironment};
-use crate::vm::costs::{ExecutionCost, LimitedCostTracker, TimeTracker};
+use crate::vm::costs::{ExecutionCost, LimitedCostTracker};
 use crate::vm::database::ClarityDatabase;
 use crate::vm::errors::{ClarityEvalError, VmExecutionError};
 use crate::vm::events::StacksTransactionEvent;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::{BuffData, PrincipalData, QualifiedContractIdentifier};
 use crate::vm::{ClarityVersion, ContractContext, SymbolicExpression, Value, analysis, ast};
 

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -33,7 +33,7 @@ use crate::vm::callables::{DefinedFunction, FunctionIdentifier};
 use crate::vm::contracts::Contract;
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::execution_cost::ExecutionCost;
-use crate::vm::costs::{CostErrors, CostTracker, LimitedCostTracker, TimeTracker, runtime_cost};
+use crate::vm::costs::{CostErrors, CostTracker, LimitedCostTracker, runtime_cost};
 use crate::vm::database::{
     ClarityDatabase, DataMapMetadata, DataVariableMetadata, FungibleTokenMetadata,
     NonFungibleTokenMetadata,
@@ -44,6 +44,7 @@ use crate::vm::errors::{
 };
 use crate::vm::events::*;
 use crate::vm::representations::SymbolicExpression;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::signatures::FunctionSignature;
 use crate::vm::types::{
     AssetIdentifier, BuffData, CallableData, PrincipalData, QualifiedContractIdentifier,

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -33,7 +33,7 @@ use crate::vm::callables::{DefinedFunction, FunctionIdentifier};
 use crate::vm::contracts::Contract;
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::execution_cost::ExecutionCost;
-use crate::vm::costs::{CostErrors, CostTracker, LimitedCostTracker, runtime_cost};
+use crate::vm::costs::{CostErrors, CostTracker, LimitedCostTracker, TimeTracker, runtime_cost};
 use crate::vm::database::{
     ClarityDatabase, DataMapMetadata, DataVariableMetadata, FungibleTokenMetadata,
     NonFungibleTokenMetadata,
@@ -265,17 +265,6 @@ pub struct EventBatch {
     pub events: Vec<StacksTransactionEvent>,
 }
 
-/** ExecutionTimeTracker keeps track of how much time a contract call is taking.
-   It is checked at every eval call.
-*/
-pub enum ExecutionTimeTracker {
-    NoTracking,
-    MaxTime {
-        start_time: Instant,
-        max_duration: Duration,
-    },
-}
-
 /// Per-`eval` abort check. This operates alongside the execution time
 /// tracker.
 ///
@@ -346,7 +335,7 @@ pub struct GlobalContext<'a, 'hooks> {
     /// This is the chain ID of the transaction
     pub chain_id: u32,
     pub eval_hooks: Option<Vec<&'hooks mut dyn EvalHook>>,
-    pub execution_time_tracker: ExecutionTimeTracker,
+    pub execution_time_tracker: TimeTracker,
     /// Callback checked at every `eval` call. When `check()` returns
     /// `Err(reason)`, execution is aborted with
     /// `VmExecutionError::RuntimeCheck(AbortedByExecutionHook)`. The
@@ -1778,7 +1767,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
             epoch_id,
             chain_id,
             eval_hooks: None,
-            execution_time_tracker: ExecutionTimeTracker::NoTracking,
+            execution_time_tracker: TimeTracker::NoTracking,
             abort_callback: AbortCallback::None,
         }
     }
@@ -1788,7 +1777,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
     }
 
     pub fn set_max_execution_time(&mut self, max_execution_time: Duration) {
-        self.execution_time_tracker = ExecutionTimeTracker::MaxTime {
+        self.execution_time_tracker = TimeTracker::MaxTime {
             start_time: Instant::now(),
             max_duration: max_execution_time,
         }

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -17,7 +17,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::mem::replace;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use clarity_types::representations::ClarityName;
 use serde::Serialize;
@@ -1768,7 +1768,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
             epoch_id,
             chain_id,
             eval_hooks: None,
-            execution_time_tracker: TimeTracker::NoTracking,
+            execution_time_tracker: TimeTracker::unlimited(),
             abort_callback: AbortCallback::None,
         }
     }
@@ -1778,10 +1778,7 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
     }
 
     pub fn set_max_execution_time(&mut self, max_execution_time: Duration) {
-        self.execution_time_tracker = TimeTracker::MaxTime {
-            start_time: Instant::now(),
-            max_duration: max_execution_time,
-        }
+        self.execution_time_tracker = TimeTracker::from_max_duration(max_execution_time);
     }
 
     fn get_asset_map(&mut self) -> Result<&mut AssetMap, VmExecutionError> {

--- a/clarity/src/vm/costs/errors.rs
+++ b/clarity/src/vm/costs/errors.rs
@@ -47,10 +47,6 @@ pub enum CostErrors {
     /// Runtime (eval) execution time exceeds the allowed budget, halting execution to ensure responsiveness.
     /// Invalidates Block: false (soft, node-local limit applied only on the mining / block-proposal paths).
     ExecutionTimeExpired,
-    /// Contract-analysis (type-checking) time exceeds the allowed budget, halting analysis to ensure responsiveness.
-    /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable in logs/metrics and error handling.
-    /// Invalidates Block: false (soft, node-local limit applied only on the mining / block-proposal paths).
-    AnalysisTimeExpired,
     /// Unexpected condition or failure, indicating a bug or invalid state.
     /// Invalidates Block: true.
     InterpreterFailure,
@@ -74,7 +70,6 @@ impl fmt::Display for CostErrors {
             CostErrors::InterpreterFailure => write!(f, "Interpreter failure"),
             CostErrors::Expect(s) => write!(f, "Expectation failed: {s}"),
             CostErrors::ExecutionTimeExpired => write!(f, "Execution time expired"),
-            CostErrors::AnalysisTimeExpired => write!(f, "Analysis time expired"),
         }
     }
 }

--- a/clarity/src/vm/costs/errors.rs
+++ b/clarity/src/vm/costs/errors.rs
@@ -44,9 +44,13 @@ pub enum CostErrors {
     /// Invalidates Block: false.
     CostComputationFailed(String),
     // Time checker errors
-    /// Type-checking time exceeds the allowed budget, halting analysis to ensure responsiveness.
-    /// Invalidates Block: true.
+    /// Runtime (eval) execution time exceeds the allowed budget, halting execution to ensure responsiveness.
+    /// Invalidates Block: false (soft, node-local limit applied only on the mining / block-proposal paths).
     ExecutionTimeExpired,
+    /// Contract-analysis (type-checking) time exceeds the allowed budget, halting analysis to ensure responsiveness.
+    /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable in logs/metrics and error handling.
+    /// Invalidates Block: false (soft, node-local limit applied only on the mining / block-proposal paths).
+    AnalysisTimeExpired,
     /// Unexpected condition or failure, indicating a bug or invalid state.
     /// Invalidates Block: true.
     InterpreterFailure,
@@ -70,6 +74,7 @@ impl fmt::Display for CostErrors {
             CostErrors::InterpreterFailure => write!(f, "Interpreter failure"),
             CostErrors::Expect(s) => write!(f, "Expectation failed: {s}"),
             CostErrors::ExecutionTimeExpired => write!(f, "Execution time expired"),
+            CostErrors::AnalysisTimeExpired => write!(f, "Analysis time expired"),
         }
     }
 }

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 use std::{cmp, fmt};
 
 use costs_1::Costs1;
@@ -59,6 +60,57 @@ pub mod errors;
 pub mod execution_cost;
 
 pub const CLARITY_MEMORY_LIMIT: u64 = 100 * 1000 * 1000;
+
+/// Tracks wall-clock time spent in a single execution phase of one transaction
+/// (Clarity evaluation *or* contract analysis) and signals when a configured
+/// deadline has elapsed.
+///
+/// `NoTracking` is the deterministic-replay / no-limit case (it must be used on
+/// the commit/replay path so consensus stays deterministic). `MaxTime` is used
+/// only on the non-consensus voting paths — block assembly (mining) and
+/// block-proposal validation (signers) — to bound the CPU a single transaction
+/// can spend.
+///
+/// The same type is held both by `GlobalContext` (eval) and by the analysis
+/// `TypeChecker` (type-checking). It is deliberately error-agnostic: callers map
+/// an elapsed deadline to their own phase-specific error (`ExecutionTimeExpired`
+/// for eval, `AnalysisTimeExpired` for analysis). See
+/// `check_interpreter_abort_condition` (eval) and
+/// `TypeChecker::check_analysis_abort_condition` (analysis).
+pub enum TimeTracker {
+    NoTracking,
+    MaxTime {
+        start_time: Instant,
+        max_duration: Duration,
+    },
+}
+
+impl TimeTracker {
+    /// Build a tracker from an optional deadline. `Some(d)` starts the clock now
+    /// and bounds the phase to `d`; `None` disables tracking (deterministic
+    /// replay / no limit).
+    pub fn from_opt_max_time(max_time: Option<Duration>) -> Self {
+        match max_time {
+            Some(max_duration) => TimeTracker::MaxTime {
+                start_time: Instant::now(),
+                max_duration,
+            },
+            None => TimeTracker::NoTracking,
+        }
+    }
+
+    /// Returns `true` if a deadline is configured and has elapsed. Always
+    /// `false` for `NoTracking`.
+    pub fn is_expired(&self) -> bool {
+        match self {
+            TimeTracker::NoTracking => false,
+            TimeTracker::MaxTime {
+                start_time,
+                max_duration,
+            } => start_time.elapsed() >= *max_duration,
+        }
+    }
+}
 
 // TODO: factor out into a boot lib?
 pub const COSTS_1_NAME: &str = "costs";

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -89,14 +89,24 @@ impl TimeTracker {
     /// Build a tracker from an optional deadline. `Some(d)` starts the clock now
     /// and bounds the phase to `d`; `None` disables tracking (deterministic
     /// replay / no limit).
-    pub fn from_opt_max_time(max_time: Option<Duration>) -> Self {
-        match max_time {
-            Some(max_duration) => TimeTracker::MaxTime {
-                start_time: Instant::now(),
-                max_duration,
-            },
-            None => TimeTracker::NoTracking,
+    pub fn from_opt_max_duration(duration: Option<Duration>) -> Self {
+        match duration {
+            Some(max_duration) => Self::from_max_duration(max_duration),
+            None => Self::free(),
         }
+    }
+
+    /// Create a [`Self::MaxTime`] with the given duration and start the clock now.
+    pub fn from_max_duration(duration: Duration) -> Self {
+        TimeTracker::MaxTime {
+            start_time: Instant::now(),
+            max_duration: duration,
+        }
+    }
+
+    /// Create a [`Self::NoTracking`] tracker flavor.
+    pub fn free() -> Self {
+        TimeTracker::NoTracking
     }
 
     /// Returns `true` if a deadline is configured and has elapsed. Always

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
 use std::{cmp, fmt};
 
 use costs_1::Costs1;
@@ -60,67 +59,6 @@ pub mod errors;
 pub mod execution_cost;
 
 pub const CLARITY_MEMORY_LIMIT: u64 = 100 * 1000 * 1000;
-
-/// Tracks wall-clock time spent in a single execution phase of one transaction
-/// (Clarity evaluation *or* contract analysis) and signals when a configured
-/// deadline has elapsed.
-///
-/// `NoTracking` is the deterministic-replay / no-limit case (it must be used on
-/// the commit/replay path so consensus stays deterministic). `MaxTime` is used
-/// only on the non-consensus voting paths — block assembly (mining) and
-/// block-proposal validation (signers) — to bound the CPU a single transaction
-/// can spend.
-///
-/// The same type is held both by `GlobalContext` (eval) and by the analysis
-/// `TypeChecker` (type-checking). It is deliberately error-agnostic: callers map
-/// an elapsed deadline to their own phase-specific error (`ExecutionTimeExpired`
-/// for eval, `AnalysisTimeExpired` for analysis). See
-/// `check_interpreter_abort_condition` (eval) and
-/// `TypeChecker::check_analysis_abort_condition` (analysis).
-pub enum TimeTracker {
-    NoTracking,
-    MaxTime {
-        start_time: Instant,
-        max_duration: Duration,
-    },
-}
-
-impl TimeTracker {
-    /// Build a tracker from an optional deadline. `Some(d)` starts the clock now
-    /// and bounds the phase to `d`; `None` disables tracking (deterministic
-    /// replay / no limit).
-    pub fn from_opt_max_duration(duration: Option<Duration>) -> Self {
-        match duration {
-            Some(max_duration) => Self::from_max_duration(max_duration),
-            None => Self::free(),
-        }
-    }
-
-    /// Create a [`Self::MaxTime`] with the given duration and start the clock now.
-    pub fn from_max_duration(duration: Duration) -> Self {
-        TimeTracker::MaxTime {
-            start_time: Instant::now(),
-            max_duration: duration,
-        }
-    }
-
-    /// Create a [`Self::NoTracking`] tracker flavor.
-    pub fn free() -> Self {
-        TimeTracker::NoTracking
-    }
-
-    /// Returns `true` if a deadline is configured and has elapsed. Always
-    /// `false` for `NoTracking`.
-    pub fn is_expired(&self) -> bool {
-        match self {
-            TimeTracker::NoTracking => false,
-            TimeTracker::MaxTime {
-                start_time,
-                max_duration,
-            } => start_time.elapsed() >= *max_duration,
-        }
-    }
-}
 
 // TODO: factor out into a boot lib?
 pub const COSTS_1_NAME: &str = "costs";

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -30,6 +30,7 @@ pub mod representations;
 
 pub mod callables;
 pub mod functions;
+pub mod time_tracker;
 pub mod variables;
 
 pub mod analysis;

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -60,7 +60,7 @@ use self::costs::ExecutionCost;
 use self::diagnostic::Diagnostic;
 use crate::vm::callables::{CallableType, FunctionIdentifier};
 pub use crate::vm::contexts::{CallStack, ContractContext, LocalContext, MAX_CONTEXT_DEPTH};
-use crate::vm::contexts::{ExecutionState, ExecutionTimeTracker, GlobalContext, InvocationContext};
+use crate::vm::contexts::{ExecutionState, GlobalContext, InvocationContext};
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::{
     CostErrors, CostOverflowingMath, CostTracker, LimitedCostTracker, MemoryConsumer, runtime_cost,
@@ -490,16 +490,8 @@ pub fn apply_evaluated(
 fn check_interpreter_abort_condition(
     global_context: &GlobalContext,
 ) -> Result<(), VmExecutionError> {
-    match global_context.execution_time_tracker {
-        ExecutionTimeTracker::NoTracking => {}
-        ExecutionTimeTracker::MaxTime {
-            start_time,
-            max_duration,
-        } => {
-            if start_time.elapsed() >= max_duration {
-                return Err(CostErrors::ExecutionTimeExpired.into());
-            }
-        }
+    if global_context.execution_time_tracker.is_expired() {
+        return Err(CostErrors::ExecutionTimeExpired.into());
     }
     if let Err(reason) = global_context.abort_callback.check() {
         return Err(VmExecutionError::RuntimeCheck(

--- a/clarity/src/vm/time_tracker.rs
+++ b/clarity/src/vm/time_tracker.rs
@@ -49,31 +49,31 @@ impl TimeTracker {
         }
     }
 
-    /// Creates a [`TimeTracker::MaxTime`] and starts tracking time immediately.
+    /// Creates a [`Self::MaxTime`] and starts tracking time immediately.
     ///
     /// The elapsed time is measured from the moment this function is called,
     /// and the tracker is configured with the provided maximum duration.
     pub fn from_max_duration(duration: Duration) -> Self {
-        TimeTracker::MaxTime {
+        Self::MaxTime {
             start_time: Instant::now(),
             max_duration: duration,
         }
     }
 
-    /// Creates a [`TimeTracker::NoTracking`] instance.
+    /// Creates a [`Self::NoTracking`] instance.
     ///
     /// In this mode, no elapsed time is recorded and no time limit is enforced.
     /// This can be used when timing is irrelevant or intentionally disabled.
     pub fn unlimited() -> Self {
-        TimeTracker::NoTracking
+        Self::NoTracking
     }
 
     /// Returns `true` if a deadline is configured and has elapsed. Always
     /// `false` for `NoTracking`.
     pub fn is_expired(&self) -> bool {
         match self {
-            TimeTracker::NoTracking => false,
-            TimeTracker::MaxTime {
+            Self::NoTracking => false,
+            Self::MaxTime {
                 start_time,
                 max_duration,
             } => start_time.elapsed() >= *max_duration,

--- a/clarity/src/vm/time_tracker.rs
+++ b/clarity/src/vm/time_tracker.rs
@@ -25,10 +25,7 @@ use std::time::{Duration, Instant};
 /// [`TimeTracker::MaxTime`] is used only on the non-consensus voting paths:
 /// block assembly (mining) and block-proposal validation (signers) to bound the time
 /// a single transaction can spend.
-///
-/// Time expiration is checked in the following code path:
-/// - `check_interpreter_abort_condition` (eval)
-/// - `TypeChecker::check_analysis_abort_condition` (analysis).
+#[derive(Clone, Copy)]
 pub enum TimeTracker {
     NoTracking,
     MaxTime {

--- a/clarity/src/vm/time_tracker.rs
+++ b/clarity/src/vm/time_tracker.rs
@@ -19,11 +19,12 @@ use std::time::{Duration, Instant};
 /// (Clarity evaluation *or* contract analysis) and signals when a configured
 /// deadline has elapsed.
 ///
-/// `NoTracking` is the deterministic-replay / no-limit case (it must be used on
-/// the commit/replay path so consensus stays deterministic). `MaxTime` is used
-/// only on the non-consensus voting paths — block assembly (mining) and
-/// block-proposal validation (signers) — to bound the CPU a single transaction
-/// can spend.
+/// [`TimeTracker::NoTracking`] is the deterministic-replay / no-limit case (it must be used on
+/// the commit/replay path so consensus stays deterministic).
+///
+/// [`TimeTracker::MaxTime`] is used only on the non-consensus voting paths:
+/// block assembly (mining) and block-proposal validation (signers) to bound the time
+/// a single transaction can spend.
 ///
 /// Time expiration is checked in the following code path:
 /// - `check_interpreter_abort_condition` (eval)
@@ -43,8 +44,7 @@ impl TimeTracker {
     /// tracker will consider the phase bounded by `duration`.
     ///
     /// If `None` is provided, no time tracking is performed and the tracker
-    /// behaves as an unbounded timer. This is useful for deterministic replay,
-    /// testing, or scenarios where no time limit should be enforced.
+    /// behaves as an unlimited timer.
     pub fn from_opt_max_duration(duration: Option<Duration>) -> Self {
         match duration {
             Some(max_duration) => Self::from_max_duration(max_duration),

--- a/clarity/src/vm/time_tracker.rs
+++ b/clarity/src/vm/time_tracker.rs
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::{Duration, Instant};
+
+/// Tracks wall-clock time spent in a single execution phase of one transaction
+/// (Clarity evaluation *or* contract analysis) and signals when a configured
+/// deadline has elapsed.
+///
+/// `NoTracking` is the deterministic-replay / no-limit case (it must be used on
+/// the commit/replay path so consensus stays deterministic). `MaxTime` is used
+/// only on the non-consensus voting paths — block assembly (mining) and
+/// block-proposal validation (signers) — to bound the CPU a single transaction
+/// can spend.
+///
+/// Time expiration is checked in the following code path:
+/// - `check_interpreter_abort_condition` (eval)
+/// - `TypeChecker::check_analysis_abort_condition` (analysis).
+pub enum TimeTracker {
+    NoTracking,
+    MaxTime {
+        start_time: Instant,
+        max_duration: Duration,
+    },
+}
+
+impl TimeTracker {
+    /// Creates a [`TimeTracker`] from an optional maximum duration.
+    ///
+    /// If `Some(duration)` is provided, tracking starts immediately and the
+    /// tracker will consider the phase bounded by `duration`.
+    ///
+    /// If `None` is provided, no time tracking is performed and the tracker
+    /// behaves as an unbounded timer. This is useful for deterministic replay,
+    /// testing, or scenarios where no time limit should be enforced.
+    pub fn from_opt_max_duration(duration: Option<Duration>) -> Self {
+        match duration {
+            Some(max_duration) => Self::from_max_duration(max_duration),
+            None => Self::unlimited(),
+        }
+    }
+
+    /// Creates a [`TimeTracker::MaxTime`] and starts tracking time immediately.
+    ///
+    /// The elapsed time is measured from the moment this function is called,
+    /// and the tracker is configured with the provided maximum duration.
+    pub fn from_max_duration(duration: Duration) -> Self {
+        TimeTracker::MaxTime {
+            start_time: Instant::now(),
+            max_duration: duration,
+        }
+    }
+
+    /// Creates a [`TimeTracker::NoTracking`] instance.
+    ///
+    /// In this mode, no elapsed time is recorded and no time limit is enforced.
+    /// This can be used when timing is irrelevant or intentionally disabled.
+    pub fn unlimited() -> Self {
+        TimeTracker::NoTracking
+    }
+
+    /// Returns `true` if a deadline is configured and has elapsed. Always
+    /// `false` for `NoTracking`.
+    pub fn is_expired(&self) -> bool {
+        match self {
+            TimeTracker::NoTracking => false,
+            TimeTracker::MaxTime {
+                start_time,
+                max_duration,
+            } => start_time.elapsed() >= *max_duration,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::thread::sleep;
+
+    use super::*;
+
+    #[test]
+    fn test_free_is_no_tracking_and_never_expires() {
+        let tracker = TimeTracker::unlimited();
+        assert!(matches!(tracker, TimeTracker::NoTracking));
+        assert!(!tracker.is_expired());
+    }
+
+    #[test]
+    fn test_zero_duration_is_immediately_expired() {
+        let tracker = TimeTracker::from_max_duration(Duration::ZERO);
+        assert!(matches!(tracker, TimeTracker::MaxTime { .. }));
+        assert!(tracker.is_expired());
+    }
+
+    #[test]
+    fn test_with_duration_expiring() {
+        let tracker = TimeTracker::from_max_duration(Duration::from_millis(100));
+        assert!(!tracker.is_expired());
+
+        sleep(Duration::from_millis(200));
+        assert!(tracker.is_expired());
+    }
+
+    #[test]
+    fn test_from_opt_max_duration_creates_proper_instance() {
+        let tracker = TimeTracker::from_opt_max_duration(None);
+        assert!(matches!(tracker, TimeTracker::NoTracking));
+
+        let tracker = TimeTracker::from_opt_max_duration(Some(Duration::ZERO));
+        assert!(matches!(tracker, TimeTracker::MaxTime { .. }));
+    }
+}

--- a/clarity/src/vm/tooling/mod.rs
+++ b/clarity/src/vm/tooling/mod.rs
@@ -46,6 +46,7 @@ pub fn mem_type_check(
         epoch,
         version,
         true,
+        None,
     ) {
         Ok(x) => {
             // return the first type result of the type checker

--- a/clarity/src/vm/tooling/mod.rs
+++ b/clarity/src/vm/tooling/mod.rs
@@ -47,7 +47,7 @@ pub fn mem_type_check(
         epoch,
         version,
         true,
-        TimeTracker::NoTracking,
+        TimeTracker::unlimited(),
     ) {
         Ok(x) => {
             // return the first type result of the type checker

--- a/clarity/src/vm/tooling/mod.rs
+++ b/clarity/src/vm/tooling/mod.rs
@@ -19,8 +19,9 @@ use super::analysis::ContractAnalysis;
 use super::types::TypeSignature;
 use crate::vm::analysis::{StaticCheckError, run_analysis};
 use crate::vm::ast::build_ast;
-use crate::vm::costs::{LimitedCostTracker, TimeTracker};
+use crate::vm::costs::LimitedCostTracker;
 use crate::vm::database::MemoryBackingStore;
+use crate::vm::time_tracker::TimeTracker;
 use crate::vm::types::QualifiedContractIdentifier;
 
 /// Used by CLI tools like the docs generator. Not used in production

--- a/clarity/src/vm/tooling/mod.rs
+++ b/clarity/src/vm/tooling/mod.rs
@@ -19,7 +19,7 @@ use super::analysis::ContractAnalysis;
 use super::types::TypeSignature;
 use crate::vm::analysis::{StaticCheckError, run_analysis};
 use crate::vm::ast::build_ast;
-use crate::vm::costs::LimitedCostTracker;
+use crate::vm::costs::{LimitedCostTracker, TimeTracker};
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::types::QualifiedContractIdentifier;
 
@@ -46,7 +46,7 @@ pub fn mem_type_check(
         epoch,
         version,
         true,
-        None,
+        TimeTracker::NoTracking,
     ) {
         Ok(x) => {
             // return the first type result of the type checker

--- a/contrib/clarity-cli/src/lib.rs
+++ b/contrib/clarity-cli/src/lib.rs
@@ -247,7 +247,7 @@ fn run_analysis_free<C: ClarityStorage>(
         // no type map data is used in the clarity_cli
         false,
         // CLI tool: no analysis deadline
-        TimeTracker::NoTracking,
+        TimeTracker::unlimited(),
     )
 }
 
@@ -284,7 +284,7 @@ fn run_analysis<C: ClarityStorage>(
         // no type map data is used in the clarity_cli
         false,
         // CLI tool: no analysis deadline
-        TimeTracker::NoTracking,
+        TimeTracker::unlimited(),
     )
 }
 

--- a/contrib/clarity-cli/src/lib.rs
+++ b/contrib/clarity-cli/src/lib.rs
@@ -245,6 +245,8 @@ fn run_analysis_free<C: ClarityStorage>(
         clarity_version,
         // no type map data is used in the clarity_cli
         false,
+        // CLI tool: no analysis deadline
+        None,
     )
 }
 
@@ -280,6 +282,8 @@ fn run_analysis<C: ClarityStorage>(
         clarity_version,
         // no type map data is used in the clarity_cli
         false,
+        // CLI tool: no analysis deadline
+        None,
     )
 }
 

--- a/contrib/clarity-cli/src/lib.rs
+++ b/contrib/clarity-cli/src/lib.rs
@@ -23,7 +23,7 @@ use clarity::vm::analysis::{AnalysisDatabase, ContractAnalysis};
 use clarity::vm::ast::build_ast;
 use clarity::vm::ast::errors::ParseError;
 use clarity::vm::contexts::{AssetMap, GlobalContext, OwnedEnvironment};
-use clarity::vm::costs::{ExecutionCost, LimitedCostTracker};
+use clarity::vm::costs::{ExecutionCost, LimitedCostTracker, TimeTracker};
 use clarity::vm::database::{
     BurnStateDB, ClarityDatabase, HeadersDB, NULL_BURN_STATE_DB, STXBalance,
 };
@@ -246,7 +246,7 @@ fn run_analysis_free<C: ClarityStorage>(
         // no type map data is used in the clarity_cli
         false,
         // CLI tool: no analysis deadline
-        None,
+        TimeTracker::NoTracking,
     )
 }
 
@@ -283,7 +283,7 @@ fn run_analysis<C: ClarityStorage>(
         // no type map data is used in the clarity_cli
         false,
         // CLI tool: no analysis deadline
-        None,
+        TimeTracker::NoTracking,
     )
 }
 

--- a/contrib/clarity-cli/src/lib.rs
+++ b/contrib/clarity-cli/src/lib.rs
@@ -23,12 +23,13 @@ use clarity::vm::analysis::{AnalysisDatabase, ContractAnalysis};
 use clarity::vm::ast::build_ast;
 use clarity::vm::ast::errors::ParseError;
 use clarity::vm::contexts::{AssetMap, GlobalContext, OwnedEnvironment};
-use clarity::vm::costs::{ExecutionCost, LimitedCostTracker, TimeTracker};
+use clarity::vm::costs::{ExecutionCost, LimitedCostTracker};
 use clarity::vm::database::{
     BurnStateDB, ClarityDatabase, HeadersDB, NULL_BURN_STATE_DB, STXBalance,
 };
 use clarity::vm::errors::{ClarityEvalError, StaticCheckError, VmExecutionError};
 use clarity::vm::events::StacksTransactionEvent;
+use clarity::vm::time_tracker::TimeTracker;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use clarity::vm::{
     ClarityVersion, ContractContext, ContractName, SymbolicExpression, Value, analysis, ast,

--- a/stacks-node/src/tests/signer/v0/failed_txs.rs
+++ b/stacks-node/src/tests/signer/v0/failed_txs.rs
@@ -20,7 +20,6 @@ use libsigner::v0::messages::{
     BlockRejection, BlockResponse, MessageSlotID, RejectReason, SignerMessage,
 };
 use libsigner::{SignerSession, StackerDBSession};
-use pinny::tag;
 use stacks::burnchains::Txid;
 use stacks::codec::StacksMessageCodec;
 use stacks::core::test_util::{make_stacks_transfer_serialized, to_addr};

--- a/stacks-node/src/tests/signer/v0/failed_txs.rs
+++ b/stacks-node/src/tests/signer/v0/failed_txs.rs
@@ -34,8 +34,11 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
 use crate::nakamoto_node::miner::TEST_MINE_SKIP;
+use crate::tests::nakamoto_integrations::wait_for;
 use crate::tests::neon_integrations::submit_tx_fallible;
-use crate::tests::signer::v0::{wait_for_block_proposal, wait_for_block_pushed_by_miner_key};
+use crate::tests::signer::v0::{
+    get_stackerdb_signer_messages, wait_for_block_proposal, wait_for_block_pushed_by_miner_key,
+};
 use crate::tests::signer::{test_observer, SignerTest};
 
 /// Holds context from the shared test setup so individual tests can
@@ -267,7 +270,6 @@ fn setup_failed_tx_test(reject_code: ValidateRejectCode) -> FailedTxTestContext 
     }
 }
 
-#[tag(bitcoind)]
 #[test]
 #[ignore]
 /// Test that when a signer rejects a block with a `failed_txid`, the miner
@@ -311,7 +313,6 @@ fn miner_excludes_failed_txid_and_nonce_dependent_txs() {
     ctx.signer_test.shutdown();
 }
 
-#[tag(bitcoind)]
 #[test]
 #[ignore]
 /// Test that when signers reject a block with a `failed_txid` and reject code
@@ -384,4 +385,166 @@ fn miner_permanently_bans_problematic_txid() {
     );
     info!("------------------------- Shutdown -------------------------");
     ctx.signer_test.shutdown();
+}
+
+/// A definitions-only contract: a contract-publish first runs the analysis (type-checking)
+/// phase, then evaluates any top-level expressions. With no top-level expression, the only
+/// phase that can exceed an execution-time deadline is **analysis** — so a rejection of this
+/// contract under a (re)used `max_execution_time` budget unambiguously certifies the Fix B
+/// analysis-phase deadline (not the eval-phase one).
+const ANALYSIS_ONLY_CONTRACT_SRC: &str =
+    "(define-public (dummy (number uint)) (begin (ok (+ number u1))))";
+
+/// Certifies that a contract-publish whose **type-checking (analysis) phase** exceeds the
+/// miner's `max_execution_time_secs` is classified `Problematic` during block assembly and
+/// dropped from the block (and blacklisted from the mempool), so it is never mined and the
+/// sender's nonce never advances — the on-chain inverse of the pre-fix analysis stall.
+#[test]
+#[ignore]
+fn miner_drops_contract_publish_on_analysis_time_expired() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender_sk = StacksPrivateKey::from_seed(&[120; 32]);
+    let sender_addr = to_addr(&sender_sk);
+    let deploy_fee = 1_000_000;
+
+    info!("------------------------- Test Setup -------------------------");
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender_addr.clone(), deploy_fee * 10)],
+        |_| {},
+        |node_config| {
+            // 0s analysis/eval budget: the analysis phase is already over budget at the
+            // first type-check node, so the miner classifies any contract-publish as
+            // Problematic during block assembly and drops + blacklists it.
+            node_config.miner.max_execution_time_secs = 0;
+        },
+        None,
+        None,
+    );
+
+    signer_test.boot_to_epoch_3();
+
+    info!("------------------------- Mine a normal Nakamoto block -------------------------");
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+
+    info!("------------------------- Submit the analysis-gated contract-publish -------------------------");
+    let (txid, deploy_nonce) = signer_test
+        .submit_contract_deploy(
+            &sender_sk,
+            deploy_fee,
+            ANALYSIS_ONLY_CONTRACT_SRC,
+            "dummy-analysis",
+        )
+        .expect("Failed to submit contract deploy");
+
+    info!("------------------------- Give the miner several tenures to (not) mine it -------------------------");
+    for _ in 0..3 {
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+
+    // The publish must never be mined: it is dropped + blacklisted at the analysis stage.
+    let publish_mined = test_observer::get_mined_nakamoto_blocks()
+        .iter()
+        .any(|block| block.tx_events.iter().any(|e| e.txid().to_hex() == txid));
+    assert!(
+        !publish_mined,
+        "contract-publish must never be mined (analysis time expired => Problematic => dropped)"
+    );
+
+    // And the sender's nonce must not advance past the never-processed publish.
+    let nonce_now = signer_test.get_account(&sender_addr).nonce;
+    assert_eq!(
+        nonce_now, deploy_nonce,
+        "publish nonce must not advance (tx never confirmed)"
+    );
+
+    info!("------------------------- Shutdown -------------------------");
+    signer_test.shutdown();
+}
+
+/// Certifies that when a miner proposes a block containing a contract-publish whose
+/// **type-checking (analysis) phase** exceeds the node's
+/// `block_proposal_max_tx_execution_time_secs`, the signers **reject** the proposal during
+/// validation with `ProblematicTransaction` (and `failed_txid` = the publish). This is the
+/// malicious-proposer defense: even a miner that builds the poison block (here, because its
+/// own analysis budget is unbounded) cannot get it signed.
+#[test]
+#[ignore]
+fn signer_rejects_contract_publish_on_analysis_time_expired() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender_sk = StacksPrivateKey::from_seed(&[121; 32]);
+    let sender_addr = to_addr(&sender_sk);
+    let deploy_fee = 1_000_000;
+
+    info!("------------------------- Test Setup -------------------------");
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![(sender_addr.clone(), deploy_fee * 10)],
+        |_| {},
+        |node_config| {
+            // Miner builds blocks with no analysis limit, so it WILL include and propose
+            // the contract-publish...
+            node_config.miner.max_execution_time_secs = u64::MAX;
+            // ...but the node's block-proposal validation (which the signers invoke) bounds
+            // per-tx analysis to 0s, so the contract's type-checking phase is already over
+            // budget => the tx is Problematic => the proposal is rejected.
+            node_config
+                .connection_options
+                .block_proposal_max_tx_execution_time_secs = 0;
+        },
+        None,
+        None,
+    );
+
+    signer_test.boot_to_epoch_3();
+
+    info!("------------------------- Mine a normal Nakamoto block -------------------------");
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+
+    info!("------------------------- Submit the analysis-gated contract-publish -------------------------");
+    let (txid_hex, _deploy_nonce) = signer_test
+        .submit_contract_deploy(
+            &sender_sk,
+            deploy_fee,
+            ANALYSIS_ONLY_CONTRACT_SRC,
+            "dummy-analysis",
+        )
+        .expect("Failed to submit contract deploy");
+    let publish_txid = Txid::from_hex(&txid_hex).expect("Failed to parse publish txid");
+
+    info!("------------------------- Ensure signers reject the proposal containing it -------------------------");
+    // The miner (unbounded) proposes a block containing the publish; the signers' node
+    // validates it with a 0s per-tx analysis budget and rejects the tx as Problematic.
+    // We scan the signer messages directly for a rejection keyed to this txid, which is
+    // robust to the miner immediately reproposing a block without the (failed_txid) tx.
+    wait_for(60, || {
+        Ok(get_stackerdb_signer_messages()
+            .into_iter()
+            .any(|(_chunk, message)| {
+                let SignerMessage::BlockResponse(BlockResponse::Rejected(rejection)) = message
+                else {
+                    return false;
+                };
+                rejection.response_data.failed_txid.as_ref() == Some(&publish_txid)
+                    && rejection.response_data.reject_reason
+                        == RejectReason::ValidationFailed(
+                            ValidateRejectCode::ProblematicTransaction,
+                        )
+            }))
+    })
+    .expect(
+        "Timed out waiting for signers to reject the contract-publish with ProblematicTransaction \
+         (analysis time expired)",
+    );
+
+    info!("------------------------- Shutdown -------------------------");
+    signer_test.shutdown();
 }

--- a/stacks-node/src/tests/signer/v0/failed_txs.rs
+++ b/stacks-node/src/tests/signer/v0/failed_txs.rs
@@ -465,11 +465,9 @@ fn miner_drops_contract_publish_on_analysis_time_expired() {
 }
 
 /// Certifies that when a miner proposes a block containing a contract-publish whose
-/// **type-checking (analysis) phase** exceeds the node's
-/// `block_proposal_max_tx_execution_time_secs`, the signers **reject** the proposal during
-/// validation with `ProblematicTransaction` (and `failed_txid` = the publish). This is the
-/// malicious-proposer defense: even a miner that builds the poison block (here, because its
-/// own analysis budget is unbounded) cannot get it signed.
+/// **analysis phase** exceeds the node's` block_proposal_max_tx_analysis_time_secs`,
+/// the signers **reject** the proposal during validation with `ProblematicTransaction`.
+
 #[test]
 #[ignore]
 fn signer_rejects_contract_publish_on_analysis_time_expired() {
@@ -490,13 +488,13 @@ fn signer_rejects_contract_publish_on_analysis_time_expired() {
         |node_config| {
             // Miner builds blocks with no analysis limit, so it WILL include and propose
             // the contract-publish...
-            node_config.miner.max_execution_time_secs = u64::MAX;
+            node_config.miner.max_analysis_time_secs = u64::MAX;
             // ...but the node's block-proposal validation (which the signers invoke) bounds
             // per-tx analysis to 0s, so the contract's type-checking phase is already over
             // budget => the tx is Problematic => the proposal is rejected.
             node_config
                 .connection_options
-                .block_proposal_max_tx_execution_time_secs = 0;
+                .block_proposal_max_tx_analysis_time_secs = 0;
         },
         None,
         None,

--- a/stacks-node/src/tests/signer/v0/failed_txs.rs
+++ b/stacks-node/src/tests/signer/v0/failed_txs.rs
@@ -389,14 +389,13 @@ fn miner_permanently_bans_problematic_txid() {
 
 /// A definitions-only contract: a contract-publish first runs the analysis (type-checking)
 /// phase, then evaluates any top-level expressions. With no top-level expression, the only
-/// phase that can exceed an execution-time deadline is **analysis** — so a rejection of this
-/// contract under a (re)used `max_execution_time` budget unambiguously certifies the Fix B
-/// analysis-phase deadline (not the eval-phase one).
+/// phase that can exceed a deadline is **analysis** — so a rejection of this contract under a
+/// small `max_analysis_time_secs` budget unambiguously certifies it
 const ANALYSIS_ONLY_CONTRACT_SRC: &str =
     "(define-public (dummy (number uint)) (begin (ok (+ number u1))))";
 
 /// Certifies that a contract-publish whose **type-checking (analysis) phase** exceeds the
-/// miner's `max_execution_time_secs` is classified `Problematic` during block assembly and
+/// miner's `max_analysis_time_secs` is classified `Problematic` during block assembly and
 /// dropped from the block (and blacklisted from the mempool), so it is never mined and the
 /// sender's nonce never advances — the on-chain inverse of the pre-fix analysis stall.
 #[test]
@@ -417,10 +416,9 @@ fn miner_drops_contract_publish_on_analysis_time_expired() {
         vec![(sender_addr.clone(), deploy_fee * 10)],
         |_| {},
         |node_config| {
-            // 0s analysis/eval budget: the analysis phase is already over budget at the
-            // first type-check node, so the miner classifies any contract-publish as
-            // Problematic during block assembly and drops + blacklists it.
-            node_config.miner.max_execution_time_secs = 0;
+            // 0s analysis budget: any contract-publish is over budget right away,
+            // so the miner drops + blacklists it during assembly.
+            node_config.miner.max_analysis_time_secs = 0;
         },
         None,
         None,

--- a/stacks-node/src/tests/signer/v0/failed_txs.rs
+++ b/stacks-node/src/tests/signer/v0/failed_txs.rs
@@ -387,14 +387,7 @@ fn miner_permanently_bans_problematic_txid() {
     ctx.signer_test.shutdown();
 }
 
-/// A definitions-only contract: a contract-publish first runs the analysis (type-checking)
-/// phase, then evaluates any top-level expressions. With no top-level expression, the only
-/// phase that can exceed a deadline is **analysis** — so a rejection of this contract under a
-/// small `max_analysis_time_secs` budget unambiguously certifies it
-const ANALYSIS_ONLY_CONTRACT_SRC: &str =
-    "(define-public (dummy (number uint)) (begin (ok (+ number u1))))";
-
-/// Certifies that a contract-publish whose **type-checking (analysis) phase** exceeds the
+/// Certifies that a contract-publish whose **analysis phase** exceeds the
 /// miner's `max_analysis_time_secs` is classified `Problematic` during block assembly and
 /// dropped from the block (and blacklisted from the mempool), so it is never mined and the
 /// sender's nonce never advances — the on-chain inverse of the pre-fix analysis stall.
@@ -434,7 +427,7 @@ fn miner_drops_contract_publish_on_analysis_time_expired() {
         .submit_contract_deploy(
             &sender_sk,
             deploy_fee,
-            ANALYSIS_ONLY_CONTRACT_SRC,
+            "(define-constant my-const u1)",
             "dummy-analysis",
         )
         .expect("Failed to submit contract deploy");
@@ -465,9 +458,8 @@ fn miner_drops_contract_publish_on_analysis_time_expired() {
 }
 
 /// Certifies that when a miner proposes a block containing a contract-publish whose
-/// **analysis phase** exceeds the node's` block_proposal_max_tx_analysis_time_secs`,
+/// **analysis phase** exceeds the node's `block_proposal_max_tx_analysis_time_secs`,
 /// the signers **reject** the proposal during validation with `ProblematicTransaction`.
-
 #[test]
 #[ignore]
 fn signer_rejects_contract_publish_on_analysis_time_expired() {
@@ -510,17 +502,15 @@ fn signer_rejects_contract_publish_on_analysis_time_expired() {
         .submit_contract_deploy(
             &sender_sk,
             deploy_fee,
-            ANALYSIS_ONLY_CONTRACT_SRC,
+            "(define-constant my-const u1)",
             "dummy-analysis",
         )
         .expect("Failed to submit contract deploy");
     let publish_txid = Txid::from_hex(&txid_hex).expect("Failed to parse publish txid");
 
     info!("------------------------- Ensure signers reject the proposal containing it -------------------------");
-    // The miner (unbounded) proposes a block containing the publish; the signers' node
+    // The miner proposes a block containing the publish; the signers' node
     // validates it with a 0s per-tx analysis budget and rejects the tx as Problematic.
-    // We scan the signer messages directly for a rejection keyed to this txid, which is
-    // robust to the miner immediately reproposing a block without the (failed_txid) tx.
     wait_for(60, || {
         Ok(get_stackerdb_signer_messages()
             .into_iter()

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -129,6 +129,9 @@ pub struct NakamotoBlockBuilder {
     contract_limit_percentage: Option<u8>,
     /// Maximum size of the whole tenure
     pub max_tenure_bytes: u64,
+    /// Wall-clock deadline for the contract-analysis phase of each
+    /// transaction mined by this builder. `None` means no analysis deadline.
+    pub max_analysis_time: Option<std::time::Duration>,
 }
 
 /// NB: No PartialEq implementation is deliberate in order to ensure that we use the appropriate
@@ -269,6 +272,7 @@ impl NakamotoBlockBuilder {
             soft_limit: None,
             contract_limit_percentage: None,
             max_tenure_bytes: u64::from(DEFAULT_MAX_TENURE_BYTES),
+            max_analysis_time: None,
         }
     }
 
@@ -344,6 +348,7 @@ impl NakamotoBlockBuilder {
             soft_limit,
             contract_limit_percentage,
             max_tenure_bytes,
+            max_analysis_time: None,
         })
     }
 
@@ -751,6 +756,9 @@ impl NakamotoBlockBuilder {
         }
 
         builder.soft_limit = soft_limit;
+        // Bound the analysis (type-checking) phase of each mined tx by the miner's
+        // configured analysis deadline (constant for this builder's lifetime).
+        builder.max_analysis_time = settings.max_analysis_time;
 
         let initial_txs: Vec<_> = [
             tenure_info.tenure_change_tx.clone(),
@@ -905,6 +913,7 @@ impl BlockBuilder for NakamotoBlockBuilder {
                 tx,
                 quiet,
                 max_execution_time,
+                self.max_analysis_time,
                 |receipt| {
                     if !receipt.post_condition_aborted {
                         let all_events_valid = receipt.events.iter().all(|event| {

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -756,7 +756,7 @@ impl NakamotoBlockBuilder {
         }
 
         builder.soft_limit = soft_limit;
-        // Bound the analysis (type-checking) phase of each mined tx by the miner's
+        // Bound the analysis phase of each mined tx by the miner's
         // configured analysis deadline (constant for this builder's lifetime).
         builder.max_analysis_time = settings.max_analysis_time;
 

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -5307,7 +5307,12 @@ impl NakamotoChainState {
         let contract_id = boot_code_id(BOOT_TEST_POX_4_AGG_KEY_CONTRACT, false);
         clarity_tx.connection().as_transaction(|clarity| {
             let (ast, analysis) = clarity
-                .analyze_smart_contract(&contract_id, ClarityVersion::Clarity2, &contract_content)
+                .analyze_smart_contract(
+                    &contract_id,
+                    ClarityVersion::Clarity2,
+                    &contract_content,
+                    None,
+                )
                 .unwrap();
             clarity
                 .initialize_smart_contract(

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -1791,7 +1791,7 @@ fn test_deploy_smart_contract(
     version: ClarityVersion,
 ) -> std::result::Result<(), ClarityError> {
     block.as_transaction(|tx| {
-        let (ast, analysis) = tx.analyze_smart_contract(contract_id, version, content)?;
+        let (ast, analysis) = tx.analyze_smart_contract(contract_id, version, content, None)?;
         tx.initialize_smart_contract(contract_id, version, &ast, content, None, |_, _| None, None)?;
         tx.save_analysis(contract_id, &analysis)?;
         return Ok(());

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -1398,6 +1398,7 @@ impl StacksChainState {
                         &boot_code_smart_contract,
                         &boot_code_account,
                         None,
+                        None,
                     )
                 })?;
                 receipts.push(tx_receipt);

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -1383,10 +1383,7 @@ impl StacksChainState {
                 //
                 // `max_analysis_time` bounds the analysis phase on the
                 // non-consensus voting paths (mining / block-proposal validation); it is
-                // `None` on deterministic replay/commit (consensus stays deterministic). An
-                // elapsed deadline surfaces as `ClarityError::AnalysisTimeExpired` and is
-                // routed to a hard `Error::AnalysisTimeExpired` below so the offending
-                // contract-publish is dropped + blacklisted rather than re-mined.
+                // `None` on deterministic replay/commit (consensus stays deterministic).
                 let analysis_resp = clarity_tx.analyze_smart_contract(
                     &contract_id,
                     clarity_version,
@@ -1412,13 +1409,8 @@ impl StacksChainState {
                                     budget.clone(),
                                 ));
                             }
-                            // The analysis (type-checking) phase exceeded its wall-clock deadline
-                            // on a voting path. Route it to a hard error so the miner classifies
-                            // the tx `Problematic` (`is_problematic`) and drops + blacklists it,
-                            // letting the network self-heal instead of re-mining the poison tx.
-                            // This is intentionally NOT keyed on `rejectable_in_epoch` (a soft,
-                            // node-local timeout does not consensus-invalidate a block).
                             ClarityError::AnalysisTimeExpired => {
+                                // The analysis phase exceeded its wall-clock deadline (on a voting path only).
                                 warn!("Contract analysis exceeded the analysis time limit; tx will be dropped from the mempool";
                                       "txid" => %tx.txid(),
                                       "contract_name" => %contract_id,

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -1137,6 +1137,7 @@ impl StacksChainState {
         tx: &StacksTransaction,
         origin_account: &StacksAccount,
         max_execution_time: Option<std::time::Duration>,
+        max_analysis_time: Option<std::time::Duration>,
     ) -> Result<StacksTransactionReceipt, Error> {
         match tx.payload {
             TransactionPayload::TokenTransfer(ref addr, ref amount, ref memo) => {
@@ -1380,14 +1381,12 @@ impl StacksChainState {
                 // The reason for this is that analyzing the transaction is itself an expensive
                 // operation, and the paying account will need to be debited the fee regardless.
                 //
-                // `max_analysis_time` bounds the analysis (type-checking) phase on the
+                // `max_analysis_time` bounds the analysis phase on the
                 // non-consensus voting paths (mining / block-proposal validation); it is
                 // `None` on deterministic replay/commit (consensus stays deterministic). An
                 // elapsed deadline surfaces as `ClarityError::AnalysisTimeExpired` and is
                 // routed to a hard `Error::AnalysisTimeExpired` below so the offending
-                // contract-publish is dropped + blacklisted (self-heal) rather than re-mined.
-                let max_analysis_time = max_execution_time; // TEMPORARY use max_execution_time.
-
+                // contract-publish is dropped + blacklisted rather than re-mined.
                 let analysis_resp = clarity_tx.analyze_smart_contract(
                     &contract_id,
                     clarity_version,
@@ -1710,9 +1709,17 @@ impl StacksChainState {
         quiet: bool,
         max_execution_time: Option<std::time::Duration>,
     ) -> Result<(u64, StacksTransactionReceipt), Error> {
-        Self::process_transaction_with_check(clarity_block, tx, quiet, max_execution_time, |_| {
-            Ok(())
-        })
+        // The generic/replay entry point imposes no analysis deadline (`None`): only the
+        // miner assembly and block-proposal validation paths (which call
+        // `process_transaction_with_check` directly) bound the analysis phase.
+        Self::process_transaction_with_check(
+            clarity_block,
+            tx,
+            quiet,
+            max_execution_time,
+            None,
+            |_| Ok(()),
+        )
     }
 
     pub fn process_transaction_with_check<
@@ -1722,6 +1729,7 @@ impl StacksChainState {
         tx: &StacksTransaction,
         quiet: bool,
         max_execution_time: Option<std::time::Duration>,
+        max_analysis_time: Option<std::time::Duration>,
         mut check: F,
     ) -> Result<(u64, StacksTransactionReceipt), Error> {
         debug!("Process transaction {} ({})", tx.txid(), tx.payload.name());
@@ -1762,6 +1770,7 @@ impl StacksChainState {
                 tx,
                 &origin_account,
                 max_execution_time,
+                max_analysis_time,
             )?;
 
             // update the account nonces
@@ -1789,6 +1798,7 @@ impl StacksChainState {
                 &mut transaction,
                 tx,
                 &origin_account,
+                None,
                 None,
             )?;
 
@@ -1969,6 +1979,7 @@ pub mod test {
                 nonce: 0,
                 stx_balance: STXBalance::Unlocked { amount: 100 },
             },
+            None,
             None,
         )
         .unwrap();

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -1388,7 +1388,7 @@ impl StacksChainState {
                 // contract-publish is dropped + blacklisted (self-heal) rather than re-mined.
                 let max_analysis_time = max_execution_time; // TEMPORARY use max_execution_time.
 
-                let analysis_resp = clarity_tx.analyze_smart_contract_with_deadline(
+                let analysis_resp = clarity_tx.analyze_smart_contract(
                     &contract_id,
                     clarity_version,
                     &contract_code_str,

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -1379,10 +1379,20 @@ impl StacksChainState {
                 // analysis pass -- if this fails, then the transaction is still accepted, but nothing is stored or processed.
                 // The reason for this is that analyzing the transaction is itself an expensive
                 // operation, and the paying account will need to be debited the fee regardless.
-                let analysis_resp = clarity_tx.analyze_smart_contract(
+                //
+                // `max_analysis_time` bounds the analysis (type-checking) phase on the
+                // non-consensus voting paths (mining / block-proposal validation); it is
+                // `None` on deterministic replay/commit (consensus stays deterministic). An
+                // elapsed deadline surfaces as `ClarityError::AnalysisTimeExpired` and is
+                // routed to a hard `Error::AnalysisTimeExpired` below so the offending
+                // contract-publish is dropped + blacklisted (self-heal) rather than re-mined.
+                let max_analysis_time = max_execution_time; // TEMPORARY use max_execution_time.
+
+                let analysis_resp = clarity_tx.analyze_smart_contract_with_deadline(
                     &contract_id,
                     clarity_version,
                     &contract_code_str,
+                    max_analysis_time,
                 );
                 let (contract_ast, contract_analysis) = match analysis_resp {
                     Ok(x) => x,
@@ -1402,6 +1412,19 @@ impl StacksChainState {
                                     cost_after.clone(),
                                     budget.clone(),
                                 ));
+                            }
+                            // The analysis (type-checking) phase exceeded its wall-clock deadline
+                            // on a voting path. Route it to a hard error so the miner classifies
+                            // the tx `Problematic` (`is_problematic`) and drops + blacklists it,
+                            // letting the network self-heal instead of re-mining the poison tx.
+                            // This is intentionally NOT keyed on `rejectable_in_epoch` (a soft,
+                            // node-local timeout does not consensus-invalidate a block).
+                            ClarityError::AnalysisTimeExpired => {
+                                warn!("Contract analysis exceeded the analysis time limit; tx will be dropped from the mempool";
+                                      "txid" => %tx.txid(),
+                                      "contract_name" => %contract_id,
+                                );
+                                return Err(Error::AnalysisTimeExpired);
                             }
                             other_error => {
                                 if let ClarityError::Parse(err) = &other_error {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -742,7 +742,7 @@ impl TransactionResult {
             }
             Error::AnalysisTimeExpired => {
                 // The transaction's contract analysis took too long. Consider it problematic so the
-                // poison contract-publish is dropped and blacklisted instead of being re-mined.
+                // contract-publish is dropped and blacklisted instead of being re-mined.
                 info!("Problematic transaction caused AnalysisTimeExpired";
                       "txid" => %tx.txid(),
                       "origin" => %tx.get_origin().get_address(false),

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -736,6 +736,16 @@ impl TransactionResult {
                 );
                 return (true, Error::ExecutionTimeExpired);
             }
+            Error::AnalysisTimeExpired => {
+                // The transaction's contract analysis took too long. Consider it problematic so the
+                // poison contract-publish is dropped and blacklisted instead of being re-mined.
+                info!("Problematic transaction caused AnalysisTimeExpired";
+                      "txid" => %tx.txid(),
+                      "origin" => %tx.get_origin().get_address(false),
+                      "payload" => ?tx.payload,
+                );
+                return (true, Error::AnalysisTimeExpired);
+            }
             e => e,
         };
         (false, error)

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -243,6 +243,8 @@ pub struct BlockBuilderSettings {
     /// Should the builder attempt to confirm any parent microblocks
     pub confirm_microblocks: bool,
     pub max_execution_time: Option<std::time::Duration>,
+    /// Wall-clock deadline for the contract-analysis phase of a single tx
+    pub max_analysis_time: Option<std::time::Duration>,
     pub max_tenure_bytes: u64,
     /// Transaction IDs to temporarily exclude from block building (e.g., signer-rejected txs)
     pub temporarily_excluded_txids: HashSet<Txid>,
@@ -262,6 +264,7 @@ impl BlockBuilderSettings {
             miner_status: Arc::new(Mutex::new(MinerStatus::make_ready(0))),
             confirm_microblocks: true,
             max_execution_time: None,
+            max_analysis_time: None,
             max_tenure_bytes: u64::from(DEFAULT_MAX_TENURE_BYTES),
             temporarily_excluded_txids: HashSet::new(),
             max_assembly_mem_bytes: 0,
@@ -277,6 +280,7 @@ impl BlockBuilderSettings {
             miner_status: Arc::new(Mutex::new(MinerStatus::make_ready(0))),
             confirm_microblocks: true,
             max_execution_time: None,
+            max_analysis_time: None,
             max_tenure_bytes: u64::from(DEFAULT_MAX_TENURE_BYTES),
             temporarily_excluded_txids: HashSet::new(),
             max_assembly_mem_bytes: 0,

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -133,6 +133,9 @@ pub enum Error {
     Expects(String),
     /// This error indicates that a transaction execution was aborted because it exceeded the maximum allowed execution time.
     ExecutionTimeExpired,
+    /// This error indicates that contract analysis (type-checking) was aborted because it exceeded the maximum allowed analysis time.
+    /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable in logs/metrics and in `is_problematic`.
+    AnalysisTimeExpired,
 }
 
 impl From<marf_error> for Error {
@@ -249,6 +252,7 @@ impl fmt::Display for Error {
             Error::TenureTooBigError => write!(f, "Too much data in tenure"),
             Error::TxWouldNotFitError => write!(f, "Transaction would not fit in this block"),
             Error::ExecutionTimeExpired => write!(f, "Transaction execution time expired"),
+            Error::AnalysisTimeExpired => write!(f, "Transaction analysis time expired"),
             Error::Expects(ref msg) => write!(f, "Unexpected state: {msg}"),
         }
     }
@@ -299,6 +303,7 @@ impl error::Error for Error {
             Error::TenureTooBigError => None,
             Error::TxWouldNotFitError => None,
             Error::ExecutionTimeExpired => None,
+            Error::AnalysisTimeExpired => None,
             Error::Expects(ref _msg) => None,
         }
     }
@@ -349,6 +354,7 @@ impl Error {
             Error::TenureTooBigError => "TenureTooBigError",
             Error::TxWouldNotFitError => "TxWouldNotFitError",
             Error::ExecutionTimeExpired => "ExecutionTimeExpired",
+            Error::AnalysisTimeExpired => "AnalysisTimeExpired",
             Error::Expects(_) => "Expects",
         }
     }

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -133,7 +133,7 @@ pub enum Error {
     Expects(String),
     /// This error indicates that a transaction execution was aborted because it exceeded the maximum allowed execution time.
     ExecutionTimeExpired,
-    /// This error indicates that contract analysis (type-checking) was aborted because it exceeded the maximum allowed analysis time.
+    /// This error indicates that contract analysis was aborted because it exceeded the maximum allowed analysis time.
     /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable in logs/metrics and in `is_problematic`.
     AnalysisTimeExpired,
 }

--- a/stackslib/src/chainstate/tests/mod.rs
+++ b/stackslib/src/chainstate/tests/mod.rs
@@ -296,6 +296,7 @@ impl<'a> TestChainstate<'a> {
                         &boot_code_smart_contract,
                         &boot_code_account,
                         None,
+                        None,
                     )
                     .unwrap()
                 });

--- a/stackslib/src/chainstate/tests/static_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/static_analysis_tests.rs
@@ -63,6 +63,14 @@ fn variant_coverage_report(variant: StaticCheckErrorKind) {
         MemoryBalanceExceeded(_, _) => Tested(vec![static_check_error_memory_balance_exceeded]),
         CostComputationFailed(_) => Unreachable_ExpectLike,
         ExecutionTimeExpired => Unreachable_Functionally("Can only be triggered at runtime."),
+        AnalysisTimeExpired => Unreachable_Functionally(
+            "All consensus-critical code paths (block validation and transaction processing) pass
+             `None` for max_execution_time, so the analysis-phase ExecutionTimeTracker stays
+             NoTracking and check_analysis_abort_condition always returns Ok(()). The analysis
+             deadline is only enforced on the miner-local block-assembly and block-proposal
+             validation paths; it is exercised by the analysis-deadline integration tests, not
+             by this consensus harness.",
+        ),
         ValueTooLarge => Tested(vec![static_check_error_value_too_large]),
         ValueOutOfBounds => Tested(vec![static_check_error_value_out_of_bounds]),
         TypeSignatureTooDeep => Tested(vec![static_check_error_type_signature_too_deep]),

--- a/stackslib/src/chainstate/tests/static_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/static_analysis_tests.rs
@@ -65,8 +65,8 @@ fn variant_coverage_report(variant: StaticCheckErrorKind) {
         ExecutionTimeExpired => Unreachable_Functionally("Can only be triggered at runtime."),
         AnalysisTimeExpired => Unreachable_Functionally(
             "All consensus-critical code paths (block validation and transaction processing) pass
-             `None` for max_execution_time, so the analysis-phase ExecutionTimeTracker stays
-             NoTracking and check_analysis_abort_condition always returns Ok(()). The analysis
+             `None` for max_execution_time, so the analysis-phase time tracking stays
+             unlimited and check_analysis_abort_condition always returns Ok(()). The analysis
              deadline is only enforced on the miner-local block-assembly and block-proposal
              validation paths; it is exercised by the analysis-deadline integration tests, not
              by this consensus harness.",

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -526,6 +526,7 @@ impl ClarityInstance {
                     &boot_code_id("costs", use_mainnet),
                     ClarityVersion::Clarity1,
                     BOOT_CODE_COSTS,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -547,6 +548,7 @@ impl ClarityInstance {
                     &boot_code_id("cost-voting", use_mainnet),
                     ClarityVersion::Clarity1,
                     &*BOOT_CODE_COST_VOTING,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -572,6 +574,7 @@ impl ClarityInstance {
                     &boot_code_id("pox", use_mainnet),
                     ClarityVersion::Clarity1,
                     &*BOOT_CODE_POX_TESTNET,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -624,6 +627,7 @@ impl ClarityInstance {
                     &boot_code_id("costs-2", use_mainnet),
                     ClarityVersion::Clarity1,
                     BOOT_CODE_COSTS_2,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -645,6 +649,7 @@ impl ClarityInstance {
                     &boot_code_id("costs-3", use_mainnet),
                     ClarityVersion::Clarity2,
                     BOOT_CODE_COSTS_3,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -666,6 +671,7 @@ impl ClarityInstance {
                     &boot_code_id("pox-2", use_mainnet),
                     ClarityVersion::Clarity2,
                     &*POX_2_TESTNET_CODE,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -2441,6 +2447,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                 })
                 .unwrap_err();
@@ -2453,6 +2460,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                 })
                 .unwrap_err();
@@ -2500,6 +2508,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 conn.initialize_smart_contract(
@@ -2553,6 +2562,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 tx.initialize_smart_contract(
@@ -2581,6 +2591,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 tx.initialize_smart_contract(
@@ -2611,6 +2622,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 assert!(format!(
@@ -2665,6 +2677,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 conn.initialize_smart_contract(
@@ -2726,6 +2739,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 conn.initialize_smart_contract(
@@ -2818,6 +2832,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 conn.initialize_smart_contract(
@@ -2949,6 +2964,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 conn.initialize_smart_contract(
@@ -3321,6 +3337,7 @@ mod tests {
                         &contract_identifier,
                         ClarityVersion::Clarity1,
                         contract,
+                        None,
                     )
                     .unwrap();
                 conn.initialize_smart_contract(
@@ -3409,6 +3426,7 @@ mod tests {
                     &contract_identifier,
                     ClarityVersion::Clarity1,
                     contract_src,
+                    None,
                 )
                 .unwrap();
             tx.initialize_smart_contract(

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -1086,6 +1086,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     &costs_2_contract_tx,
                     &boot_code_account,
                     None,
+                    None,
                 )
                 .expect("FATAL: Failed to process PoX 2 contract initialization")
             });
@@ -1196,6 +1197,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     &pox_2_contract_tx,
                     &boot_code_account,
                     None,
+                    None,
                 )
                 .expect("FATAL: Failed to process PoX 2 contract initialization");
 
@@ -1266,6 +1268,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     tx_conn,
                     &costs_3_contract_tx,
                     &boot_code_account,
+                    None,
                     None,
                 )
                 .expect("FATAL: Failed to process costs-3 contract initialization");
@@ -1435,6 +1438,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     &pox_3_contract_tx,
                     &boot_code_account,
                     None,
+                    None,
                 )
                 .expect("FATAL: Failed to process PoX 3 contract initialization");
 
@@ -1553,6 +1557,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     &pox_4_contract_tx,
                     &boot_code_account,
                     None,
+                    None,
                 )
                 .expect("FATAL: Failed to process PoX 4 contract initialization");
 
@@ -1612,6 +1617,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     &signers_contract_tx,
                     &boot_code_account,
                     None,
+                    None,
                 )
                 .expect("FATAL: Failed to process .signers contract initialization");
                 receipt
@@ -1658,6 +1664,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                             &signers_contract_tx,
                             &boot_code_account,
                             None,
+                            None,
                         )
                         .expect("FATAL: Failed to process .signers DB contract initialization");
                         receipt
@@ -1696,6 +1703,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     tx_conn,
                     &signers_contract_tx,
                     &boot_code_account,
+                    None,
                     None,
                 )
                 .expect("FATAL: Failed to process .signers-voting contract initialization");
@@ -1828,6 +1836,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     &sip_031_contract_tx,
                     &boot_code_account,
                     None,
+                    None,
                 )
                 .expect("FATAL: Failed to process .sip-031 contract initialization");
                 receipt
@@ -1941,6 +1950,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                     tx_conn,
                     &costs_4_contract_tx,
                     &boot_code_account,
+                    None,
                     None,
                 )
                 .expect("FATAL: Failed to process costs-4 contract initialization");
@@ -3178,20 +3188,24 @@ mod tests {
             );
 
             conn.as_transaction(|clarity_tx| {
-                let receipt =
-                    StacksChainState::process_transaction_payload(clarity_tx, &tx1, &account, None)
-                        .unwrap();
+                let receipt = StacksChainState::process_transaction_payload(
+                    clarity_tx, &tx1, &account, None, None,
+                )
+                .unwrap();
                 assert!(receipt.post_condition_aborted);
             });
             conn.as_transaction(|clarity_tx| {
-                StacksChainState::process_transaction_payload(clarity_tx, &tx2, &account, None)
-                    .unwrap();
+                StacksChainState::process_transaction_payload(
+                    clarity_tx, &tx2, &account, None, None,
+                )
+                .unwrap();
             });
 
             conn.as_transaction(|clarity_tx| {
-                let receipt =
-                    StacksChainState::process_transaction_payload(clarity_tx, &tx3, &account, None)
-                        .unwrap();
+                let receipt = StacksChainState::process_transaction_payload(
+                    clarity_tx, &tx3, &account, None, None,
+                )
+                .unwrap();
 
                 assert!(receipt.post_condition_aborted);
             });

--- a/stackslib/src/clarity_vm/tests/analysis_costs.rs
+++ b/stackslib/src/clarity_vm/tests/analysis_costs.rs
@@ -107,7 +107,7 @@ fn setup_tracked_cost_test(
 
         conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
-                .analyze_smart_contract(&trait_contract_id, version, contract_trait)
+                .analyze_smart_contract(&trait_contract_id, version, contract_trait, None)
                 .unwrap();
             conn.initialize_smart_contract(
                 &trait_contract_id,
@@ -136,7 +136,7 @@ fn setup_tracked_cost_test(
 
         conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
-                .analyze_smart_contract(&other_contract_id, version, contract_other)
+                .analyze_smart_contract(&other_contract_id, version, contract_other, None)
                 .unwrap();
             conn.initialize_smart_contract(
                 &other_contract_id,
@@ -204,7 +204,7 @@ fn test_tracked_costs(
 
         conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
-                .analyze_smart_contract(&self_contract_id, version, &contract_self)
+                .analyze_smart_contract(&self_contract_id, version, &contract_self, None)
                 .unwrap();
             conn.initialize_smart_contract(
                 &self_contract_id,
@@ -321,6 +321,7 @@ fn undefined_top_variable_error(#[case] use_mainnet: bool, #[case] epoch: Stacks
                 &self_contract_id,
                 ClarityVersion::Clarity1,
                 &contract_self,
+                None,
             );
             let Err(ClarityError::StaticCheck(static_check_error)) = analysis_result else {
                 panic!("Bad analysis result: {analysis_result:?}");

--- a/stackslib/src/clarity_vm/tests/contracts.rs
+++ b/stackslib/src/clarity_vm/tests/contracts.rs
@@ -46,8 +46,12 @@ fn test_get_burn_block_info_eval() {
         let epoch = conn.get_epoch();
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
-            let res =
-                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
+            let res = clarity_db.analyze_smart_contract(
+                &contract_identifier,
+                clarity_version,
+                contract,
+                None,
+            );
             if let Err(ClarityError::StaticCheck(static_check_error)) = res {
                 if let StaticCheckErrorKind::UnknownFunction(func_name) = *static_check_error.err {
                     assert_eq!(func_name, "get-burn-block-info?");
@@ -67,8 +71,12 @@ fn test_get_burn_block_info_eval() {
         let epoch = conn.get_epoch();
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
-            let res =
-                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
+            let res = clarity_db.analyze_smart_contract(
+                &contract_identifier,
+                clarity_version,
+                contract,
+                None,
+            );
             if let Err(ClarityError::StaticCheck(static_check_error)) = res {
                 if let StaticCheckErrorKind::UnknownFunction(func_name) = *static_check_error.err {
                     assert_eq!(func_name, "get-burn-block-info?");
@@ -89,7 +97,7 @@ fn test_get_burn_block_info_eval() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_identifier, clarity_version, contract)
+                .analyze_smart_contract(&contract_identifier, clarity_version, contract, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -159,8 +167,12 @@ fn test_get_block_info_eval_v210() {
         let epoch = conn.get_epoch();
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
-            let res =
-                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
+            let res = clarity_db.analyze_smart_contract(
+                &contract_identifier,
+                clarity_version,
+                contract,
+                None,
+            );
             if let Err(ClarityError::StaticCheck(static_check_error)) = res {
                 if let StaticCheckErrorKind::NoSuchBlockInfoProperty(name) = *static_check_error.err
                 {
@@ -181,8 +193,12 @@ fn test_get_block_info_eval_v210() {
         let epoch = conn.get_epoch();
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
-            let res =
-                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
+            let res = clarity_db.analyze_smart_contract(
+                &contract_identifier,
+                clarity_version,
+                contract,
+                None,
+            );
             if let Err(ClarityError::StaticCheck(static_check_error)) = res {
                 if let StaticCheckErrorKind::NoSuchBlockInfoProperty(name) = *static_check_error.err
                 {
@@ -206,7 +222,7 @@ fn test_get_block_info_eval_v210() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_identifier, clarity_version, contract)
+                .analyze_smart_contract(&contract_identifier, clarity_version, contract, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(&contract_identifier, clarity_version, &ast, contract, None, |_, _| None, None)
@@ -286,7 +302,7 @@ fn publish_contract(
     version: ClarityVersion,
 ) -> Result<(), ClarityError> {
     bc.as_transaction(|tx| {
-        let (ast, analysis) = tx.analyze_smart_contract(contract_id, version, contract)?;
+        let (ast, analysis) = tx.analyze_smart_contract(contract_id, version, contract, None)?;
         tx.initialize_smart_contract(
             contract_id,
             version,
@@ -572,7 +588,7 @@ fn trait_with_trait_invocation_cross_epoch() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&math_contract_id, clarity_version, math_trait)
+                .analyze_smart_contract(&math_contract_id, clarity_version, math_trait, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -592,7 +608,7 @@ fn trait_with_trait_invocation_cross_epoch() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&compute_contract_id, clarity_version, compute_trait)
+                .analyze_smart_contract(&compute_contract_id, clarity_version, compute_trait, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -612,7 +628,7 @@ fn trait_with_trait_invocation_cross_epoch() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&impl_compute_id, clarity_version, impl_compute)
+                .analyze_smart_contract(&impl_compute_id, clarity_version, impl_compute, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -632,7 +648,7 @@ fn trait_with_trait_invocation_cross_epoch() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&impl_math_id, clarity_version, impl_math)
+                .analyze_smart_contract(&impl_math_id, clarity_version, impl_math, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -652,7 +668,7 @@ fn trait_with_trait_invocation_cross_epoch() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&use_compute_20_id, clarity_version, use_compute)
+                .analyze_smart_contract(&use_compute_20_id, clarity_version, use_compute, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -679,7 +695,7 @@ fn trait_with_trait_invocation_cross_epoch() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::Clarity1;
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&use_compute_21_c1_id, clarity_version, use_compute)
+                .analyze_smart_contract(&use_compute_21_c1_id, clarity_version, use_compute, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -699,7 +715,7 @@ fn trait_with_trait_invocation_cross_epoch() {
         conn.as_transaction(|clarity_db| {
             let clarity_version = ClarityVersion::Clarity2;
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&use_compute_21_c2_id, clarity_version, use_compute)
+                .analyze_smart_contract(&use_compute_21_c2_id, clarity_version, use_compute, None)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(
@@ -869,13 +885,13 @@ fn test_block_heights() {
             let (ast, analysis) = clarity_db.analyze_smart_contract(
                 &contract_identifier1,
                 ClarityVersion::Clarity1,
-                contract_clarity1,
+                contract_clarity1, None,
             ).unwrap();
 
             let res = clarity_db.analyze_smart_contract(
                 &contract_identifier2,
                 ClarityVersion::Clarity1,
-                contract_clarity3,
+                contract_clarity3, None,
             );
             if let Err(ClarityError::StaticCheck(static_check_error)) = res {
                 if let StaticCheckErrorKind::UndefinedVariable(var_name) = *static_check_error.err {
@@ -903,13 +919,13 @@ fn test_block_heights() {
             let (ast, analysis) = clarity_db.analyze_smart_contract(
                 &contract_identifier1,
                 ClarityVersion::Clarity2,
-                contract_clarity1,
+                contract_clarity1, None,
             ).unwrap();
 
             let res = clarity_db.analyze_smart_contract(
                 &contract_identifier2,
                 ClarityVersion::Clarity2,
-                contract_clarity3,
+                contract_clarity3, None,
             );
             if let Err(ClarityError::StaticCheck(static_check_error)) = res {
                 if let StaticCheckErrorKind::UndefinedVariable(var_name) = *static_check_error.err {
@@ -925,7 +941,7 @@ fn test_block_heights() {
             let res = clarity_db.analyze_smart_contract(
                 &contract_identifier1,
                 ClarityVersion::Clarity3,
-                contract_clarity1,
+                contract_clarity1, None,
             );
             if let Err(ClarityError::StaticCheck(static_check_error)) = res {
                 if let StaticCheckErrorKind::UndefinedVariable(var_name) = *static_check_error.err {
@@ -940,7 +956,7 @@ fn test_block_heights() {
             let (ast, analysis) = clarity_db.analyze_smart_contract(
                 &contract_identifier2,
                 ClarityVersion::Clarity3,
-                contract_clarity3,
+                contract_clarity3, None,
             ).unwrap();
 
             // Publish the Clarity 3 contract
@@ -1204,6 +1220,7 @@ fn test_block_heights_across_versions() {
                     &contract_id_e2c1,
                     ClarityVersion::Clarity1,
                     contract_e2c1_2,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -1234,6 +1251,7 @@ fn test_block_heights_across_versions() {
                     &contract_id_e2c2,
                     ClarityVersion::Clarity2,
                     contract_e2c1_2,
+                    None,
                 )
                 .unwrap();
             clarity_db
@@ -1265,7 +1283,12 @@ fn test_block_heights_across_versions() {
         conn.as_transaction(|clarity_db| {
             // Analyze the Clarity 3 contract
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_id_e3c3, ClarityVersion::Clarity3, &contract_e3c3)
+                .analyze_smart_contract(
+                    &contract_id_e3c3,
+                    ClarityVersion::Clarity3,
+                    &contract_e3c3,
+                    None,
+                )
                 .unwrap();
 
             // Publish the Clarity 3 contract
@@ -1332,6 +1355,7 @@ fn test_block_heights_across_versions_traits_3_from_2() {
                     &contract_id_e2c1,
                     ClarityVersion::Clarity1,
                     contract_e2c1_2,
+                    None,
                 )
                 .unwrap();
 
@@ -1359,6 +1383,7 @@ fn test_block_heights_across_versions_traits_3_from_2() {
                     &contract_id_e2c2,
                     ClarityVersion::Clarity2,
                     contract_e2c1_2,
+                    None,
                 )
                 .unwrap();
 
@@ -1387,7 +1412,12 @@ fn test_block_heights_across_versions_traits_3_from_2() {
         conn.as_transaction(|clarity_db| {
             // Analyze the Clarity 3 contract
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_id_e3c3, ClarityVersion::Clarity3, &contract_e3c3)
+                .analyze_smart_contract(
+                    &contract_id_e3c3,
+                    ClarityVersion::Clarity3,
+                    &contract_e3c3,
+                    None,
+                )
                 .unwrap();
 
             // Publish the Clarity 3 contract
@@ -1473,6 +1503,7 @@ fn test_block_heights_across_versions_traits_2_from_3() {
                     &contract_id_e2c1,
                     ClarityVersion::Clarity1,
                     contract_e2c1_2,
+                    None,
                 )
                 .unwrap();
 
@@ -1500,6 +1531,7 @@ fn test_block_heights_across_versions_traits_2_from_3() {
                     &contract_id_e2c2,
                     ClarityVersion::Clarity2,
                     contract_e2c1_2,
+                    None,
                 )
                 .unwrap();
 
@@ -1528,7 +1560,12 @@ fn test_block_heights_across_versions_traits_2_from_3() {
         conn.as_transaction(|clarity_db| {
             // Analyze the Clarity 3 contract
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_id_e3c3, ClarityVersion::Clarity3, &contract_e3c3)
+                .analyze_smart_contract(
+                    &contract_id_e3c3,
+                    ClarityVersion::Clarity3,
+                    &contract_e3c3,
+                    None,
+                )
                 .unwrap();
 
             // Publish the Clarity 3 contract
@@ -1604,7 +1641,7 @@ fn test_block_heights_at_block() {
             let (ast, analysis) = clarity_db.analyze_smart_contract(
                 &contract_identifier,
                 ClarityVersion::Clarity3,
-                contract,
+                contract, None,
             ).unwrap();
 
             // Publish the contract
@@ -1662,7 +1699,12 @@ fn test_get_block_info_time() {
         conn.as_transaction(|clarity_db| {
             // Analyze the contract as Clarity 2
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_identifier2, ClarityVersion::Clarity2, contract2)
+                .analyze_smart_contract(
+                    &contract_identifier2,
+                    ClarityVersion::Clarity2,
+                    contract2,
+                    None,
+                )
                 .unwrap();
 
             // Publish the contract as Clarity 2
@@ -1680,7 +1722,12 @@ fn test_get_block_info_time() {
 
             // Analyze the contract as Clarity 3
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_identifier3, ClarityVersion::Clarity3, contract3)
+                .analyze_smart_contract(
+                    &contract_identifier3,
+                    ClarityVersion::Clarity3,
+                    contract3,
+                    None,
+                )
                 .unwrap();
 
             // Publish the contract as Clarity 3
@@ -1702,6 +1749,7 @@ fn test_get_block_info_time() {
                     &contract_identifier3_3,
                     ClarityVersion::Clarity3,
                     contract3_3,
+                    None,
                 )
                 .unwrap();
 

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -1301,7 +1301,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
         {
             block_conn.as_transaction(|tx| {
                 let (ast, analysis) = tx
-                    .analyze_smart_contract(contract_name, clarity_version, contract_src)
+                    .analyze_smart_contract(contract_name, clarity_version, contract_src, None)
                     .unwrap();
                 tx.initialize_smart_contract(
                     contract_name,
@@ -1593,7 +1593,7 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
         {
             block_conn.as_transaction(|tx| {
                 let (ast, analysis) = tx
-                    .analyze_smart_contract(contract_name, clarity_version, contract_src)
+                    .analyze_smart_contract(contract_name, clarity_version, contract_src, None)
                     .unwrap();
                 tx.initialize_smart_contract(
                     contract_name,

--- a/stackslib/src/clarity_vm/tests/large_contract.rs
+++ b/stackslib/src/clarity_vm/tests/large_contract.rs
@@ -157,6 +157,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion, #[case] epoch: Stac
                         &boot_code_id("costs-2", false),
                         ClarityVersion::Clarity1,
                         BOOT_CODE_COSTS_2,
+                        None,
                     )
                     .unwrap();
                 tx.initialize_smart_contract(
@@ -183,6 +184,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion, #[case] epoch: Stac
                         &boot_code_id("costs-3", false),
                         ClarityVersion::Clarity2,
                         BOOT_CODE_COSTS_3,
+                        None,
                     )
                     .unwrap();
                 tx.initialize_smart_contract(
@@ -202,6 +204,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion, #[case] epoch: Stac
                         &boot_code_id("costs-4", false),
                         ClarityVersion::Clarity2,
                         BOOT_CODE_COSTS_4,
+                        None,
                     )
                     .unwrap();
                 tx.initialize_smart_contract(
@@ -793,7 +796,7 @@ pub fn rollback_log_memory_test(
 
         conn.as_transaction(|conn| {
             let (ct_ast, _ct_analysis) = conn
-                .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
+                .analyze_smart_contract(&contract_identifier, clarity_version, &contract, None)
                 .unwrap();
             assert!(format!(
                 "{:?}",
@@ -865,7 +868,7 @@ pub fn let_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_id
 
         conn.as_transaction(|conn| {
             let (ct_ast, _ct_analysis) = conn
-                .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
+                .analyze_smart_contract(&contract_identifier, clarity_version, &contract, None)
                 .unwrap();
             assert!(format!(
                 "{:?}",
@@ -940,7 +943,7 @@ pub fn argument_memory_test(
 
         conn.as_transaction(|conn| {
             let (ct_ast, _ct_analysis) = conn
-                .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
+                .analyze_smart_contract(&contract_identifier, clarity_version, &contract, None)
                 .unwrap();
             assert!(format!(
                 "{:?}",
@@ -1031,7 +1034,7 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
 
         conn.as_transaction(|conn| {
             let (ct_ast, _ct_analysis) = conn
-                .analyze_smart_contract(&contract_identifier, clarity_version, &contract_ok)
+                .analyze_smart_contract(&contract_identifier, clarity_version, &contract_ok, None)
                 .unwrap();
             assert!(match conn
                 .initialize_smart_contract(
@@ -1053,7 +1056,7 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
 
         conn.as_transaction(|conn| {
             let (ct_ast, _ct_analysis) = conn
-                .analyze_smart_contract(&contract_identifier, clarity_version, &contract_err)
+                .analyze_smart_contract(&contract_identifier, clarity_version, &contract_err, None)
                 .unwrap();
             assert!(format!(
                 "{:?}",
@@ -1137,7 +1140,12 @@ pub fn ccall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
             if i < (CONTRACTS - 1) {
                 conn.as_transaction(|conn| {
                     let (ct_ast, ct_analysis) = conn
-                        .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
+                        .analyze_smart_contract(
+                            &contract_identifier,
+                            clarity_version,
+                            &contract,
+                            None,
+                        )
                         .unwrap();
                     conn.initialize_smart_contract(
                         &contract_identifier,
@@ -1155,7 +1163,12 @@ pub fn ccall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
             } else {
                 conn.as_transaction(|conn| {
                     let (ct_ast, _ct_analysis) = conn
-                        .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
+                        .analyze_smart_contract(
+                            &contract_identifier,
+                            clarity_version,
+                            &contract,
+                            None,
+                        )
                         .unwrap();
                     assert!(format!(
                         "{:?}",
@@ -1212,8 +1225,12 @@ fn test_deep_tuples() {
         let _res = block.as_transaction(|tx| {
             //  basically, without the new stack depth checks in the lexer/parser,
             //    and without the VaryStackDepthChecker, this next call will return a StaticCheckError
-            let analysis_resp =
-                tx.analyze_smart_contract(&contract_identifier, *version, &meets_stack_depth_tuple);
+            let analysis_resp = tx.analyze_smart_contract(
+                &contract_identifier,
+                *version,
+                &meets_stack_depth_tuple,
+                None,
+            );
             eprintln!(
                 "analyze_smart_contract() with meets_stack_depth_tuple: {}",
                 analysis_resp.is_ok()
@@ -1234,6 +1251,7 @@ fn test_deep_tuples() {
                 &contract_identifier,
                 *version,
                 &exceeds_stack_depth_tuple,
+                None,
             );
             analysis_resp.unwrap_err()
         });
@@ -1302,6 +1320,7 @@ fn test_deep_tuples_ast_precheck() {
                 &contract_identifier,
                 *version,
                 &exceeds_stack_depth_tuple,
+                None,
             );
             analysis_resp.unwrap_err()
         });
@@ -1375,8 +1394,12 @@ fn test_deep_type_nesting() {
             }
             //  basically, without the new stack depth checks in the lexer/parser,
             //    and without the VaryStackDepthChecker, this next call will return a StaticCheckError
-            let analysis_resp =
-                tx.analyze_smart_contract(&contract_identifier, *version, &exceeds_type_depth);
+            let analysis_resp = tx.analyze_smart_contract(
+                &contract_identifier,
+                *version,
+                &exceeds_type_depth,
+                None,
+            );
             analysis_resp.unwrap_err()
         });
 

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -136,6 +136,9 @@ const DEFAULT_EMPTY_MEMPOOL_SLEEP_MS: u64 = 2_500;
 /// Default maximum execution time in seconds for a miner to process a transaction
 /// before timing out.
 const DEFAULT_MAX_EXECUTION_TIME_SECS: u64 = 30;
+/// Default maximum wall-clock time in seconds for a miner to run contract-analysis
+/// phase of a transaction before timing out.
+const DEFAULT_MAX_ANALYSIS_TIME_SECS: u64 = 30;
 /// Default number of seconds that a miner should wait before timing out an HTTP request to StackerDB.
 const DEFAULT_STACKERDB_TIMEOUT_SECS: u64 = 120;
 /// Default maximum size for a tenure (note: the counter is reset on tenure extend).
@@ -1161,6 +1164,7 @@ impl Config {
             miner_status,
             confirm_microblocks: false,
             max_execution_time: Some(Duration::from_secs(miner_config.max_execution_time_secs)),
+            max_analysis_time: Some(Duration::from_secs(miner_config.max_analysis_time_secs)),
             max_tenure_bytes: miner_config.max_tenure_bytes,
             temporarily_excluded_txids: HashSet::new(),
             max_assembly_mem_bytes: miner_config.max_assembly_mem_bytes,
@@ -1210,6 +1214,7 @@ impl Config {
             miner_status,
             confirm_microblocks: true,
             max_execution_time: Some(Duration::from_secs(miner_config.max_execution_time_secs)),
+            max_analysis_time: Some(Duration::from_secs(miner_config.max_analysis_time_secs)),
             max_tenure_bytes: miner_config.max_tenure_bytes,
             temporarily_excluded_txids: HashSet::new(),
             max_assembly_mem_bytes: miner_config.max_assembly_mem_bytes,
@@ -3130,6 +3135,14 @@ pub struct MinerConfig {
     /// @default: [`DEFAULT_MAX_EXECUTION_TIME_SECS`]
     /// @units: seconds
     pub max_execution_time_secs: u64,
+    /// Maximum wall-clock time (in seconds) that the contract-analysis
+    /// phase of a single transaction may take during mining before timing out.
+    ///
+    /// If analysis exceeds this limit, the transaction is classified as problematic.
+    /// ---
+    /// @default: [`DEFAULT_MAX_ANALYSIS_TIME_SECS`]
+    /// @units: seconds
+    pub max_analysis_time_secs: u64,
     /// TODO: remove this option when its no longer a testing feature and it becomes default behaviour
     /// The miner will attempt to replay transactions that a threshold number of signers are expecting in the next block
     pub replay_transactions: bool,
@@ -3212,6 +3225,7 @@ impl Default for MinerConfig {
                 rejections_timeouts_default_map
             },
             max_execution_time_secs: DEFAULT_MAX_EXECUTION_TIME_SECS,
+            max_analysis_time_secs: DEFAULT_MAX_ANALYSIS_TIME_SECS,
             replay_transactions: false,
             stackerdb_timeout: Duration::from_secs(DEFAULT_STACKERDB_TIMEOUT_SECS),
             max_tenure_bytes: DEFAULT_MAX_TENURE_BYTES,
@@ -4197,6 +4211,7 @@ pub struct MinerConfigFile {
     pub tenure_extend_cost_threshold: Option<u64>,
     pub block_rejection_timeout_steps: Option<HashMap<String, u64>>,
     pub max_execution_time_secs: Option<u64>,
+    pub max_analysis_time_secs: Option<u64>,
     /// TODO: remove this config option once its no longer a testing feature
     pub replay_transactions: Option<bool>,
     pub stackerdb_timeout_secs: Option<u64>,
@@ -4395,6 +4410,9 @@ impl MinerConfigFile {
             max_execution_time_secs: self
                 .max_execution_time_secs
                 .unwrap_or(miner_default_config.max_execution_time_secs),
+            max_analysis_time_secs: self
+                .max_analysis_time_secs
+                .unwrap_or(miner_default_config.max_analysis_time_secs),
             replay_transactions: self.replay_transactions.unwrap_or_default(),
             stackerdb_timeout: self.stackerdb_timeout_secs.map(Duration::from_secs).unwrap_or(miner_default_config.stackerdb_timeout),
             max_tenure_bytes: self.max_tenure_bytes.unwrap_or(miner_default_config.max_tenure_bytes),

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -3132,6 +3132,8 @@ pub struct MinerConfig {
     ///
     /// Mining always enforces a limit; there is no way to disable it. To effectively
     /// "turn it off," set this to a value larger than any tx is expected to take.
+    ///
+    /// If execution exceeds this limit, the transaction is classified as problematic.
     /// ---
     /// @default: [`DEFAULT_MAX_EXECUTION_TIME_SECS`]
     /// @units: seconds

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -59,6 +59,7 @@ use crate::cost_estimates::{CostEstimator, FeeEstimator, PessimisticEstimator, U
 use crate::net::atlas::AtlasConfig;
 use crate::net::connection::{
     ConnectionOptions, DEFAULT_BLOCK_PROPOSAL_MAX_AGE_SECS,
+    DEFAULT_BLOCK_PROPOSAL_MAX_TX_ANALYSIS_TIME_SECS,
     DEFAULT_BLOCK_PROPOSAL_MAX_TX_EXECUTION_TIME_SECS,
     DEFAULT_BLOCK_PROPOSAL_VALIDATION_TIMEOUT_SECS,
 };
@@ -3749,6 +3750,15 @@ pub struct ConnectionOptionsFile {
     /// @units: seconds
     pub block_proposal_max_tx_execution_time_secs: Option<u64>,
 
+    /// Maximum time (in seconds) to spend on the contract-analysis
+    /// phase of a single transaction during block proposal validation.
+    /// A transaction whose analysis exceeds this on its own is
+    /// classified as problematic.
+    /// ---
+    /// @default: [`DEFAULT_BLOCK_PROPOSAL_MAX_TX_ANALYSIS_TIME_SECS`]
+    /// @units: seconds
+    pub block_proposal_max_tx_analysis_time_secs: Option<u64>,
+
     /// Maximum bytes a single transaction may allocate on the heap during
     /// block-proposal validation before it is rejected.
     /// `0` disables the limit.
@@ -3916,6 +3926,9 @@ impl ConnectionOptionsFile {
             block_proposal_max_tx_execution_time_secs: self
                 .block_proposal_max_tx_execution_time_secs
                 .unwrap_or(DEFAULT_BLOCK_PROPOSAL_MAX_TX_EXECUTION_TIME_SECS),
+            block_proposal_max_tx_analysis_time_secs: self
+                .block_proposal_max_tx_analysis_time_secs
+                .unwrap_or(DEFAULT_BLOCK_PROPOSAL_MAX_TX_ANALYSIS_TIME_SECS),
             block_proposal_max_tx_mem_bytes: self
                 .block_proposal_max_tx_mem_bytes
                 .unwrap_or(default.block_proposal_max_tx_mem_bytes),

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -744,6 +744,11 @@ impl NakamotoBlockProposal {
 
         let block_deadline = Instant::now() + Duration::from_secs(timeout_secs);
         let per_tx_max_execution_time = Duration::from_secs(max_tx_execution_time_secs);
+        // Phase-1 reuse: bound the analysis (type-checking) phase during proposal
+        // validation by the same per-tx execution-time budget. A dedicated signer-side
+        // analysis config (`block_proposal_max_tx_analysis_execution_time_secs`) is the
+        // remaining phase-2 item.
+        builder.max_analysis_time = Some(per_tx_max_execution_time);
         let mut receipts_total = 0u64;
         for (i, tx) in self.block.txs.iter().enumerate() {
             // Enforce the overall block validation budget between txs. A tx

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -747,7 +747,7 @@ impl NakamotoBlockProposal {
 
         let block_deadline = Instant::now() + Duration::from_secs(timeout_secs);
         let per_tx_max_execution_time = Duration::from_secs(max_tx_execution_time_secs);
-        // Bound the analysis (type-checking) phase during proposal validation by the
+        // Bound the analysis phase during proposal validation by the
         // dedicated per-tx analysis budget, independently of the eval budget above.
         builder.max_analysis_time = Some(Duration::from_secs(max_tx_analysis_time_secs));
         let mut receipts_total = 0u64;

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -356,6 +356,7 @@ impl NakamotoBlockProposal {
     ) -> Result<JoinHandle<()>, std::io::Error> {
         let timeout_secs = connection_opts.block_proposal_validation_timeout_secs;
         let max_tx_execution_time_secs = connection_opts.block_proposal_max_tx_execution_time_secs;
+        let max_tx_analysis_time_secs = connection_opts.block_proposal_max_tx_analysis_time_secs;
         let max_tx_mem_bytes = connection_opts.block_proposal_max_tx_mem_bytes;
         let auth_token = connection_opts.auth_token.clone();
         thread::Builder::new()
@@ -367,6 +368,7 @@ impl NakamotoBlockProposal {
                         &mut chainstate,
                         timeout_secs,
                         max_tx_execution_time_secs,
+                        max_tx_analysis_time_secs,
                         max_tx_mem_bytes,
                         auth_token,
                     )
@@ -544,6 +546,7 @@ impl NakamotoBlockProposal {
         chainstate: &mut StacksChainState, // not directly used; used as a handle to open other chainstates
         timeout_secs: u64,
         max_tx_execution_time_secs: u64,
+        max_tx_analysis_time_secs: u64,
         max_tx_mem_bytes: u64,
         auth_token: Option<String>,
     ) -> Result<BlockValidateOk, BlockValidateRejectReason> {
@@ -744,11 +747,9 @@ impl NakamotoBlockProposal {
 
         let block_deadline = Instant::now() + Duration::from_secs(timeout_secs);
         let per_tx_max_execution_time = Duration::from_secs(max_tx_execution_time_secs);
-        // Phase-1 reuse: bound the analysis (type-checking) phase during proposal
-        // validation by the same per-tx execution-time budget. A dedicated signer-side
-        // analysis config (`block_proposal_max_tx_analysis_execution_time_secs`) is the
-        // remaining phase-2 item.
-        builder.max_analysis_time = Some(per_tx_max_execution_time);
+        // Bound the analysis (type-checking) phase during proposal validation by the
+        // dedicated per-tx analysis budget, independently of the eval budget above.
+        builder.max_analysis_time = Some(Duration::from_secs(max_tx_analysis_time_secs));
         let mut receipts_total = 0u64;
         for (i, tx) in self.block.txs.iter().enumerate() {
             // Enforce the overall block validation budget between txs. A tx

--- a/stackslib/src/net/api/tests/mod.rs
+++ b/stackslib/src/net/api/tests/mod.rs
@@ -906,7 +906,7 @@ impl<'a> TestRPC<'a> {
         ]];
 
         let (mut peer, mut other_peers) =
-            make_nakamoto_peers_from_invs_ext(function_name!(), observer, bitvecs, |boot_plan| {
+            make_nakamoto_peers_from_invs_ext(test_name, observer, bitvecs, |boot_plan| {
                 boot_plan
                     .with_pox_constants(10, 3)
                     .with_extra_peers(1)

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -707,6 +707,183 @@ fn test_block_proposal_validation_timeout_blames_tx() {
     }
 }
 
+/// Test that when a transaction's contract-analysis phase
+/// exceeds the dedicated per-tx analysis budget during block-proposal
+/// validation, the block is rejected as containing a problematic transaction,
+/// and the rejection blames the offending txid so the miner can drop it from
+/// the next proposal.
+#[test]
+fn test_block_proposal_validation_analysis_time_expired_blames_tx() {
+    let test_observer = TestEventObserver::new();
+    let mut rpc_test = TestRPC::setup_nakamoto(function_name!(), &test_observer);
+
+    // Force every contract-analysis to exceed its budget: a 0s deadline is
+    // already elapsed at the first per-node check. The overall validation
+    // timeout is left at its (non-zero) default, so the per-tx analysis limit
+    // is what fires here, not the block-level deadline.
+    rpc_test
+        .peer_1
+        .network
+        .connection_opts
+        .block_proposal_max_tx_analysis_time_secs = 0;
+    rpc_test
+        .peer_2
+        .network
+        .connection_opts
+        .block_proposal_max_tx_analysis_time_secs = 0;
+
+    let (stacks_tip_ch, stacks_tip_bhh) = SortitionDB::get_canonical_stacks_chain_tip_hash(
+        rpc_test.peer_1.chain.sortdb.as_ref().unwrap().conn(),
+    )
+    .unwrap();
+    let stacks_tip = StacksBlockId::new(&stacks_tip_ch, &stacks_tip_bhh);
+
+    let miner_privk = &rpc_test.peer_1.chain.miner.nakamoto_miner_key();
+    let contract_code = "(define-public (ping) (ok u0))";
+
+    let deploy_tx_bytes = make_contract_publish(
+        miner_privk,
+        36,
+        1000,
+        CHAIN_ID_TESTNET,
+        "analysis-time-contract",
+        contract_code,
+    );
+    let deploy_tx =
+        StacksTransaction::consensus_deserialize(&mut deploy_tx_bytes.as_slice()).unwrap();
+
+    // Build a valid block containing the deploy. This builder has no analysis
+    // limit, so the contract publishes cleanly; the analysis budget is applied
+    // only later, by proposal validation.
+    let mut block = {
+        let chainstate = rpc_test.peer_1.chainstate();
+        let parent_stacks_header =
+            NakamotoChainState::get_block_header(chainstate.db(), &stacks_tip)
+                .unwrap()
+                .unwrap();
+
+        let mut builder = NakamotoBlockBuilder::new(
+            &parent_stacks_header,
+            &parent_stacks_header.consensus_hash,
+            26000,
+            None,
+            None,
+            8,
+            None,
+            None,
+            None,
+            u64::from(DEFAULT_MAX_TENURE_BYTES),
+        )
+        .unwrap();
+
+        rpc_test
+            .peer_1
+            .with_db_state(
+                |sort_db: &mut SortitionDB,
+                 chainstate: &mut StacksChainState,
+                 _: &mut Relayer,
+                 _: &mut MemPoolDB| {
+                    let burn_dbconn = sort_db.index_handle_at_tip();
+                    let mut miner_tenure_info = builder
+                        .load_tenure_info(
+                            chainstate,
+                            &burn_dbconn,
+                            MinerTenureInfoCause::NoTenureChange,
+                        )
+                        .unwrap();
+                    let burn_chain_height = miner_tenure_info.burn_tip_height;
+                    let mut tenure_tx = builder
+                        .tenure_begin(&burn_dbconn, &mut miner_tenure_info)
+                        .unwrap();
+                    let tx_result = builder.try_mine_tx_with_len(
+                        &mut tenure_tx,
+                        &deploy_tx,
+                        deploy_tx.tx_len(),
+                        &BlockLimitFunction::NO_LIMIT_HIT,
+                        None,
+                        &mut 0,
+                    );
+                    assert!(matches!(tx_result, TransactionResult::Success(_)));
+                    let block = builder.mine_nakamoto_block(&mut tenure_tx, burn_chain_height);
+                    Ok(block)
+                },
+            )
+            .unwrap()
+    };
+
+    block.header.timestamp += 1;
+    rpc_test.peer_1.chain.miner.sign_nakamoto_block(&mut block);
+
+    let proposal = NakamotoBlockProposal {
+        block,
+        chain_id: CHAIN_ID_TESTNET,
+        replay_txs: None,
+    };
+
+    let mut request = StacksHttpRequest::new_for_peer(
+        rpc_test.peer_1.to_peer_host(),
+        "POST".into(),
+        "/v3/block_proposal".into(),
+        HttpRequestContents::new().payload_json(serde_json::to_value(proposal).unwrap()),
+    )
+    .expect("failed to construct request");
+    request.add_header("authorization".into(), "password".into());
+
+    let observer = ProposalTestObserver::new();
+    let proposal_observer = Arc::clone(&observer.proposal_observer);
+
+    let wait_for = |peer_1: &mut TestPeer, peer_2: &mut TestPeer| {
+        !peer_1.network.is_proposal_thread_running() && !peer_2.network.is_proposal_thread_running()
+    };
+
+    let responses = rpc_test.run_with_observer(vec![request], Some(&observer), wait_for);
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].preamble().status_code, 202);
+
+    let start = Instant::now();
+    loop {
+        {
+            let observer_guard = proposal_observer.lock().unwrap();
+            if observer_guard.results.lock().unwrap().len() >= 1 {
+                break;
+            }
+        }
+        assert!(
+            start.elapsed().as_secs() < 60,
+            "Timed out waiting for proposal result"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    let observer_guard = proposal_observer.lock().unwrap();
+    let mut results = observer_guard.results.lock().unwrap();
+    let result = results.remove(0);
+    drop(results);
+    drop(observer_guard);
+
+    match result {
+        Ok(_) => panic!("expected analysis-time-expired tx to reject block"),
+        Err(postblock_proposal::BlockValidateReject {
+            reason_code,
+            reason,
+            failed_txid,
+            ..
+        }) => {
+            assert_eq!(reason_code, ValidateRejectCode::ProblematicTransaction);
+            assert_eq!(
+                failed_txid,
+                Some(deploy_tx.txid()),
+                "Rejection should blame the contract-publish tx whose analysis timed out"
+            );
+            assert!(
+                reason.contains("analysis time expired"),
+                "Expected rejection reason to mention analysis time, got: {reason}"
+            );
+        }
+    }
+}
+
 #[warn(unused)]
 fn replay_validation_test(
     setup_fn: impl FnOnce(&mut TestRPC) -> (VecDeque<StacksTransaction>, Vec<StacksTransaction>),

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -51,6 +51,10 @@ pub const DEFAULT_BLOCK_PROPOSAL_VALIDATION_TIMEOUT_SECS: u64 = 60;
 /// transaction during block proposal validation.
 pub const DEFAULT_BLOCK_PROPOSAL_MAX_TX_EXECUTION_TIME_SECS: u64 = 30;
 
+/// The default maximum time, in seconds, to spend on the contract-analysis
+/// phase of a single transaction during block proposal validation.
+pub const DEFAULT_BLOCK_PROPOSAL_MAX_TX_ANALYSIS_TIME_SECS: u64 = 30;
+
 /// Receiver notification handle.
 /// When a message with the expected `seq` value arrives, send it to an expected receiver (possibly
 /// in another thread) via the given `receiver_input` channel.
@@ -496,6 +500,12 @@ pub struct ConnectionOptions {
     /// exceeded is not.
     pub block_proposal_max_tx_execution_time_secs: u64,
 
+    /// Maximum time, in seconds, to spend on the contract-analysis
+    /// phase of a single transaction during block proposal validation.
+    /// A transaction whose analysis exceeds this on its own is
+    /// classified as problematic.
+    pub block_proposal_max_tx_analysis_time_secs: u64,
+
     /// Maximum bytes a single transaction may allocate on the heap during
     /// block-proposal validation before it is rejected. Tracked via
     /// per-thread allocation counters in `TrackingAllocator`.
@@ -612,6 +622,8 @@ impl std::default::Default for ConnectionOptions {
             block_proposal_validation_timeout_secs: DEFAULT_BLOCK_PROPOSAL_VALIDATION_TIMEOUT_SECS,
             block_proposal_max_tx_execution_time_secs:
                 DEFAULT_BLOCK_PROPOSAL_MAX_TX_EXECUTION_TIME_SECS,
+            block_proposal_max_tx_analysis_time_secs:
+                DEFAULT_BLOCK_PROPOSAL_MAX_TX_ANALYSIS_TIME_SECS,
             block_proposal_max_tx_mem_bytes: DEFAULT_PROPOSAL_MEMORY_BYTES,
         }
     }

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -245,7 +245,7 @@ pub mod pox4 {
                 conn.as_transaction(|clarity_db| {
                     let clarity_version = ClarityVersion::Clarity2;
                     let (ast, analysis) = clarity_db
-                        .analyze_smart_contract(&pox_contract_id, clarity_version, body)
+                        .analyze_smart_contract(&pox_contract_id, clarity_version, body, None)
                         .unwrap();
                     clarity_db
                         .initialize_smart_contract(


### PR DESCRIPTION
### Description

This PR adds a wall-clock deadline to the Clarity contract-analysis phase, bounding the time a single transaction can spend being analyzed on the block-assembly (mining) and block-proposal (signer) validation paths. A transaction whose analysis exceeds the deadline is treated as problematic, while deterministic replay and block commit remain unbounded.

The elapsed time check is performed:
- in `TypeChecker`: in `clarity2_inner_type_check_type` and `type_check` as hooks for recursive behaviour
- in `TraitChecker`: in `run` while iterating on traits
- in `ReadOnlyChecker`: in `check_read_only` as hook for recursive behaviour
- only for type checker v2.1: this is the one also used for block assembly/proposal while previous type checker (v2.05) is only used for consensus related opeartions (e.g. replaying block)
- to be cost tracking independent.

This also add a couple of configuration options:
- for `miner`: `max_analysis_time_secs` (default to 30 seconds)
- for `signer`-node: `block_proposal_max_tx_analysis_time_secs` (default to 30 seconds)

### Applicable issues

- fixes #7339

### Additional info (benefits, drawbacks, caveats)

While implementing this feature, I followed the existing max_execution_time implementation as a reference. However, I intentionally introduced a few asymmetries because I believe the same approach could also be applied to `max_execution_time` in follow-up PRs, simplifying the code paths and Clarity error mappings.

The most relevant differences are:
- When the analysis time limit is reached, the code now directly returns the new `StaticCheckErrorKind::AnalysisTimeExpired` variant instead of introducing a dedicated `CostErrors` variant. This avoids the need to remap the error through both static and runtime error layers. A similar approach could potentially be adopted for execution timeouts by removing `CostErrors::ExecutionTimeExpired` and the associated error remapping logic.
- Added a `max_analysis_time` field to `NakamotoBlockBuilder`. Since `try_mine_tx_with_len` already depends on the builder configuration, this avoids extending the `try_mine_tx_with_len` trait signature with an additional parameter. We could potentially apply the same pattern to `max_execution_time` and remove that argument from `try_mine_tx_with_len` as well.

Futhermore, while implementing block proposal RPC test, I noticed that we have a bunch of RPC tests that never run in CI. Added this issue #7350 for fixing this situation


### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
