### PR TITLE
chore: fix clippy stacks-profiler

### DIFF
--- a/stacks-profiler/src/platform.rs
+++ b/stacks-profiler/src/platform.rs
@@ -105,6 +105,7 @@ mod linux {
 mod windows {
     /// Win32 FILETIME (100-nanosecond intervals).
     #[repr(C)]
+    #[allow(clippy::upper_case_acronyms)]
     struct FILETIME {
         low: u32,
         high: u32,


### PR DESCRIPTION
### Description

running `cargo clippy-stacks` fails like this (since rust 1.94.0):

```
Checking stacks-profiler v0.0.1 (C:\stacks-core\stacks-profiler)                                    
error: name `FILETIME` contains a capitalized acronym                                                                                          
   --> stacks-profiler\src\platform.rs:108:12
    |
108 |     struct FILETIME {
    |            ^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `Filetime`
    |
```

This patch add `#[allow(clippy::upper_case_acronyms)]` tag to the `struct LIFETIME`.


### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
