### PR TITLE
ci: decouple test jobs from public-only `check-release`

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -133,6 +133,10 @@ jobs:
     needs:
       - check-changelog
       - check-rustfmt
+    # Release detection only matters on the public repo. This job is depended on
+    # only by the release-specific jobs (tests-epoch, create-release); the regular
+    # CI/test jobs are intentionally decoupled from it, so it is safe for this job
+    # to be skipped (and cascade-skip those release jobs) on private forks.
     if: >-
       github.event.repository.visibility == 'public'
     runs-on: *shared_config
@@ -167,7 +171,6 @@ jobs:
     name: "Check: Cargo Hack"
     needs:
       - check-changelog
-      - check-release
       - check-rustfmt
       - setup-env
     if: >-
@@ -181,7 +184,6 @@ jobs:
     name: "Check: Constants"
     needs:
       - check-changelog
-      - check-release
       - check-rustfmt
       - setup-env
     if: >-
@@ -195,11 +197,9 @@ jobs:
     name: "Setup: Test Caches"
     needs:
       - check-changelog
-      - check-release
       - check-rustfmt
       - setup-env
     if: >-
-      needs.check-release.outputs.is_release == 'true' ||
       needs.setup-env.outputs.job-should-run == 'true'
     uses: ./.github/workflows/setup-test-caches.yml
     with:
@@ -213,12 +213,10 @@ jobs:
     name: "Tests: Stacks Core"
     needs:
       - check-changelog
-      - check-release
       - check-rustfmt
       - setup-test-caches
       - setup-env
     if: >-
-      needs.check-release.outputs.is_release == 'true' ||
       needs.setup-env.outputs.job-should-run == 'true'
     uses: ./.github/workflows/tests-stacks-core.yml
     with:
@@ -231,12 +229,10 @@ jobs:
     name: "Tests: Bitcoin"
     needs:
       - check-changelog
-      - check-release
       - check-rustfmt
       - setup-test-caches
       - setup-env
     if: >-
-      needs.check-release.outputs.is_release == 'true' ||
       needs.setup-env.outputs.job-should-run == 'true'
     uses: ./.github/workflows/tests-bitcoin.yml
     with:
@@ -250,11 +246,9 @@ jobs:
     needs:
       - check-changelog
       - check-rustfmt
-      - check-release
       - setup-test-caches
       - setup-env
     if: >-
-      needs.check-release.outputs.is_release == 'true' ||
       needs.setup-env.outputs.job-should-run == 'true'
     uses: ./.github/workflows/tests-bitcoin-rpc.yml
     with:
@@ -269,11 +263,9 @@ jobs:
     needs:
       - check-changelog
       - check-rustfmt
-      - check-release
       - setup-test-caches
       - setup-env
     if: >-
-      needs.check-release.outputs.is_release == 'true' ||
       needs.setup-env.outputs.job-should-run == 'true'
     uses: ./.github/workflows/tests-p2p.yml
     with:

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -124,19 +124,21 @@ jobs:
 
   ############################################################################
   ### Release Check
-  ### 
+  ###
   ### Checks if this is a release build
   ### If true, will execute release jobs
+  ###
+  ### Release detection only matters on the public repo. This job is depended
+  ### on only by the release-specific jobs (tests-epoch, create-release); the
+  ### regular CI/test jobs are intentionally decoupled from it, so it is safe
+  ### for this job to be skipped (and cascade-skip those release jobs) on
+  ### private forks.
   ############################################################################
   check-release:
     name: "Check: Release"
     needs:
       - check-changelog
       - check-rustfmt
-    # Release detection only matters on the public repo. This job is depended on
-    # only by the release-specific jobs (tests-epoch, create-release); the regular
-    # CI/test jobs are intentionally decoupled from it, so it is safe for this job
-    # to be skipped (and cascade-skip those release jobs) on private forks.
     if: >-
       github.event.repository.visibility == 'public'
     runs-on: *shared_config


### PR DESCRIPTION
`check-release` is skipped on private forks, which cascades to those jobs that actually need it. The regular CI tests now only gate on `job-should-run`.

I noticed that tests were not running on a private fork because of this unnecessary dependency.