### PR TITLE
load_wanted_tenures_at_tip: fix off-by-one in "can skip" check

### DIFF
--- a/changelog.d/7354-load-wanted-tenures-skip.fixed
+++ b/changelog.d/7354-load-wanted-tenures-skip.fixed
@@ -1,0 +1,1 @@
+Performance improvement that prevents unnecessary work in the block downloader if nothing has changed.

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -274,8 +274,8 @@ impl NakamotoDownloadStateMachine {
             loaded_so_far.len()
         );
 
-        // "less than" is correct because `Self::load_wanted_tenures` interprets
-        // `last_block_height` as exlusive
+        // "less than or equal" is correct because `Self::load_wanted_tenures` interprets
+        // `last_block_height` as exclusive
         if last_block_height <= first_block_height {
             return Ok(vec![]);
         }

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -286,12 +286,6 @@ impl NakamotoDownloadStateMachine {
             loaded_so_far.len()
         );
 
-        // "less than or equal" is correct because `Self::load_wanted_tenures` interprets
-        // `last_block_height` as exclusive
-        if last_block_height <= first_block_height {
-            return Ok(vec![]);
-        }
-
         let wanted_tenures = Self::load_wanted_tenures(
             sortdb,
             &tip.sortition_id,

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -17,11 +17,12 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::fmt;
 
+use clarity::types::chainstate::SortitionId;
 use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
 use stacks_common::util::get_epoch_time_ms;
 
 use crate::burnchains::{BurnchainView, PoxConstants};
-use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandleConn};
+use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::burn::BlockSnapshot;
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use crate::chainstate::stacks::db::StacksChainState;
@@ -145,10 +146,18 @@ impl NakamotoDownloadStateMachine {
     /// Returns Err(..) on DB error, or if one or both of these heights do not correspond to a
     /// sortition.
     pub(crate) fn load_wanted_tenures(
-        ih: &SortitionHandleConn,
+        sortdb: &SortitionDB,
+        tip: &SortitionId,
         first_block_height: u64,
         last_block_height: u64,
     ) -> Result<Vec<WantedTenure>, NetError> {
+        // "less than or equal" is correct because `last_block_height` is exclusive
+        if last_block_height <= first_block_height {
+            return Ok(vec![]);
+        }
+
+        let ih = sortdb.index_handle(tip);
+
         let mut wanted_tenures = Vec::with_capacity(
             usize::try_from(last_block_height.saturating_sub(first_block_height))
                 .expect("FATAL: infallible: usize can't old a reward cycle"),
@@ -166,7 +175,7 @@ impl NakamotoDownloadStateMachine {
                 StacksBlockId(cursor.winning_stacks_block_hash.0),
                 cursor.block_height,
             ));
-            cursor = SortitionDB::get_block_snapshot(ih, &cursor.parent_sortition_id)?
+            cursor = SortitionDB::get_block_snapshot(&ih, &cursor.parent_sortition_id)?
                 .ok_or(DBError::NotFoundError)?;
         }
         wanted_tenures.reverse();
@@ -213,9 +222,12 @@ impl NakamotoDownloadStateMachine {
         );
 
         // find all sortitions in this reward cycle
-        let ih = sortdb.index_handle(&tip.sortition_id);
-        let mut new_tenures =
-            Self::load_wanted_tenures(&ih, first_block_height, last_block_height)?;
+        let mut new_tenures = Self::load_wanted_tenures(
+            sortdb,
+            &tip.sortition_id,
+            first_block_height,
+            last_block_height,
+        )?;
         wanted_tenures.append(&mut new_tenures);
         Ok(())
     }
@@ -280,8 +292,12 @@ impl NakamotoDownloadStateMachine {
             return Ok(vec![]);
         }
 
-        let ih = sortdb.index_handle(&tip.sortition_id);
-        let wanted_tenures = Self::load_wanted_tenures(&ih, first_block_height, last_block_height)?;
+        let wanted_tenures = Self::load_wanted_tenures(
+            sortdb,
+            &tip.sortition_id,
+            first_block_height,
+            last_block_height,
+        )?;
 
         debug!(
             "Loaded tip sortitions between {} and {} (loaded_so_far = {}): {:?}",

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -17,8 +17,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::fmt;
 
-use clarity::types::chainstate::SortitionId;
-use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
+use stacks_common::types::chainstate::{ConsensusHash, SortitionId, StacksBlockId};
 use stacks_common::util::get_epoch_time_ms;
 
 use crate::burnchains::{BurnchainView, PoxConstants};

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -273,7 +273,10 @@ impl NakamotoDownloadStateMachine {
             last_block_height,
             loaded_so_far.len()
         );
-        if last_block_height < first_block_height {
+
+        // "less than" is correct because `Self::load_wanted_tenures` interprets
+        // `last_block_height` as exlusive
+        if last_block_height <= first_block_height {
             return Ok(vec![]);
         }
 

--- a/stackslib/src/net/tests/download/nakamoto.rs
+++ b/stackslib/src/net/tests/download/nakamoto.rs
@@ -95,8 +95,12 @@ impl NakamotoDownloadStateMachine {
         );
 
         // find all sortitions in this reward cycle
-        let ih = sortdb.index_handle(&tip.sortition_id);
-        Self::load_wanted_tenures(&ih, first_block_height, last_block_height)
+        Self::load_wanted_tenures(
+            sortdb,
+            &tip.sortition_id,
+            first_block_height,
+            last_block_height,
+        )
     }
 }
 
@@ -1337,9 +1341,10 @@ fn test_make_tenure_downloaders() {
 
     // test load_wanted_tenures()
     {
-        let ih = peer.sortdb().index_handle(&tip.sortition_id);
+        let sortdb = peer.sortdb();
         let wanted_tenures = NakamotoDownloadStateMachine::load_wanted_tenures(
-            &ih,
+            sortdb,
+            &tip.sortition_id,
             tip.block_height - rc_len,
             tip.block_height,
         )
@@ -1361,7 +1366,8 @@ fn test_make_tenure_downloaders() {
         }
 
         let err = NakamotoDownloadStateMachine::load_wanted_tenures(
-            &ih,
+            sortdb,
+            &tip.sortition_id,
             tip.block_height + 1,
             tip.block_height + 2,
         )
@@ -1369,7 +1375,8 @@ fn test_make_tenure_downloaders() {
         assert!(matches!(err, NetError::DBError(DBError::NotFoundError)));
 
         let wanted_tenures = NakamotoDownloadStateMachine::load_wanted_tenures(
-            &ih,
+            sortdb,
+            &tip.sortition_id,
             tip.block_height + 3,
             tip.block_height,
         )
@@ -1472,9 +1479,9 @@ fn test_make_tenure_downloaders() {
     // test inner_update_processed_wanted_tenures
     {
         let sortdb = peer.sortdb();
-        let ih = peer.sortdb().index_handle(&tip.sortition_id);
         let mut wanted_tenures = NakamotoDownloadStateMachine::load_wanted_tenures(
-            &ih,
+            sortdb,
+            &tip.sortition_id,
             nakamoto_start,
             tip.block_height,
         )


### PR DESCRIPTION
As the added comment says, we can skip the work if `first_block_height` and `last_block_height` are equal, because `load_wanted_tenures` treats the end as exclusive:

- documentation: https://github.com/stacks-network/stacks-core/blob/7e8d141b5360cb6571b94408c5ec50bcfd23c4a7/stackslib/src/net/download/nakamoto/download_state_machine.rs#L142
- implementation (note the `.saturating_sub(1)`): https://github.com/stacks-network/stacks-core/blob/7e8d141b5360cb6571b94408c5ec50bcfd23c4a7/stackslib/src/net/download/nakamoto/download_state_machine.rs#L157

Note that this functionality has test coverage (specifically [here](https://github.com/stacks-network/stacks-core/blob/7e8d141b5360cb6571b94408c5ec50bcfd23c4a7/stackslib/src/net/tests/download/nakamoto.rs#L1448)).

This is significant because skipping prevents unnecessary i/o (MARF and DB reads), and this functionality is called on every run through the RPC/P2P machinery, which in a miner means every couple of milliseconds(!).
