### PR TITLE
feat: update stacks-signer generate-stacking-signature for pox-5

### DIFF
--- a/changelog.d/pox-5-signer-sig-cli.changed
+++ b/changelog.d/pox-5-signer-sig-cli.changed
@@ -1,0 +1,1 @@
+Updated the `stacks-signer generate-stacking-signature` command to generate PoX-5 signer grant signatures.

--- a/changelog.d/pox-5-signer-sig-cli.changed
+++ b/changelog.d/pox-5-signer-sig-cli.changed
@@ -1,1 +1,1 @@
-Updated the `stacks-signer generate-stacking-signature` command to generate PoX-5 signer grant signatures.
+Updated the `stacks-signer generate-staking-signature` command to generate PoX-5 signer grant signatures.

--- a/stacks-signer/README.md
+++ b/stacks-signer/README.md
@@ -61,12 +61,12 @@ Periodically query the current reward cycle's signers' StackerDB slots to verify
 - `--interval`: The polling interval in seconds for querying stackerDB.
 - `--max-age`: The max age in seconds before a signer message is considered stale. 
 
-### `generate-stacking-signature`
+### `generate-staking-signature`
 
 Generate a signature for stacking.
 
 ```bash
-./stacks-signer generate-stacking-signature --config <config_file> --pox-address <address> --reward-cycle <cycle> --period <period> --max-amount <max_amount> --auth-id <auth_id>
+./stacks-signer generate-staking-signature --config <config_file> --signer-manager <signer_manager_principal> --auth-id <auth_id>
 
 ```
 - `--config`: The path to the signer configuration file.

--- a/stacks-signer/README.md
+++ b/stacks-signer/README.md
@@ -63,18 +63,14 @@ Periodically query the current reward cycle's signers' StackerDB slots to verify
 
 ### `generate-staking-signature`
 
-Generate a signature for stacking.
+Generate a PoX-5 signer grant signature for staking.
 
 ```bash
 ./stacks-signer generate-staking-signature --config <config_file> --signer-manager <signer_manager_principal> --auth-id <auth_id>
 
 ```
 - `--config`: The path to the signer configuration file.
-- `--pox-address`: The BTC address used to receive rewards
-- `--reward-cycle`: The reward cycle during which this signature is used
-- `--method`: Stacking metod that can be used
-- `--period`: Number of cycles used as a lock period. Use `1` for stack-aggregation-commit method
-- `--max-amount`: The max amount of uSTX that can be used in this unique transaction
+- `--signer-manager`: The signer-manager principal authorized to register this signer key
 - `--auth-id`: A unique identifier to prevent re-using this authorization
 - `--json`: Output information in JSON format
 

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -17,17 +17,16 @@ use std::io::{self, Read};
 use std::path::PathBuf;
 
 use blockstack_lib::chainstate::stacks::address::PoxAddress;
-use blockstack_lib::util_lib::signed_structured_data::pox4::Pox4SignatureTopic;
 use blockstack_lib::util_lib::signed_structured_data::{
     make_structured_data_domain, structured_data_message_hash,
 };
-use clap::{ArgAction, Parser, ValueEnum};
+use clap::{ArgAction, Parser};
 use clarity::consts::CHAIN_ID_MAINNET;
 use clarity::types::chainstate::StacksPublicKey;
 use clarity::types::{PrivateKey, PublicKey};
 use clarity::util::hash::Sha256Sum;
 use clarity::util::secp256k1::MessageSignature;
-use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, TupleData};
 use clarity::vm::{ClarityName, Value};
 use libsigner::VERSION_ONLY_STRING;
 use serde::{Deserialize, Serialize};
@@ -260,76 +259,15 @@ pub struct MonitorSignersArgs {
     pub stackerdb_timeout_secs: u64,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-/// Wrapper around `Pox4SignatureTopic` to implement `ValueEnum`
-pub struct StackingSignatureMethod(Pox4SignatureTopic);
-
-impl StackingSignatureMethod {
-    /// Get the inner `Pox4SignatureTopic`
-    pub const fn topic(&self) -> &Pox4SignatureTopic {
-        &self.0
-    }
-}
-
-impl From<Pox4SignatureTopic> for StackingSignatureMethod {
-    fn from(topic: Pox4SignatureTopic) -> Self {
-        Self(topic)
-    }
-}
-
-impl ValueEnum for StackingSignatureMethod {
-    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
-        Some(clap::builder::PossibleValue::new(self.0.get_name_str()))
-    }
-
-    fn value_variants<'a>() -> &'a [Self] {
-        &[
-            Self(Pox4SignatureTopic::StackStx),
-            Self(Pox4SignatureTopic::StackExtend),
-            Self(Pox4SignatureTopic::AggregationCommit),
-            Self(Pox4SignatureTopic::AggregationIncrease),
-            Self(Pox4SignatureTopic::StackIncrease),
-        ]
-    }
-
-    fn from_str(input: &str, _ignore_case: bool) -> Result<Self, String> {
-        let topic = match input {
-            "aggregation-commit" => Pox4SignatureTopic::AggregationCommit,
-            "aggregation-increase" => Pox4SignatureTopic::AggregationIncrease,
-            method => match Pox4SignatureTopic::lookup_by_name(method) {
-                Some(topic) => topic,
-                None => {
-                    return Err(format!("Invalid topic: {input}"));
-                }
-            },
-        };
-        Ok(topic.into())
-    }
-}
-
 #[derive(Parser, Debug, Clone, PartialEq)]
 /// Arguments for the generate-stacking-signature command
 pub struct GenerateStackingSignatureArgs {
-    /// BTC address used to receive rewards
-    #[arg(short, long, value_parser = parse_pox_addr)]
-    pub pox_address: PoxAddress,
-    /// The reward cycle during which this signature
-    /// can be used
-    #[arg(short, long)]
-    pub reward_cycle: u64,
     /// Path to signer config file
     #[arg(long, short, value_name = "FILE")]
     pub config: PathBuf,
-    /// Stacking method that can be used
-    #[arg(long)]
-    pub method: StackingSignatureMethod,
-    /// Number of cycles used as a lock period.
-    /// Use `1` for stack-aggregation-commit
-    #[arg(long)]
-    pub period: u64,
-    /// The max amount of uSTX that can be used in this unique transaction
-    #[arg(long)]
-    pub max_amount: u128,
+    /// Signer-manager principal authorized to register this signer key
+    #[arg(long, value_parser = parse_principal)]
+    pub signer_manager: PrincipalData,
     /// A unique identifier to prevent re-using this authorization
     #[arg(long)]
     pub auth_id: u128,
@@ -341,6 +279,10 @@ pub struct GenerateStackingSignatureArgs {
 /// Parse the contract ID
 fn parse_contract(contract: &str) -> Result<QualifiedContractIdentifier, String> {
     QualifiedContractIdentifier::parse(contract).map_err(|e| format!("Invalid contract: {e}"))
+}
+
+fn parse_principal(principal: &str) -> Result<PrincipalData, String> {
+    PrincipalData::parse(principal).map_err(|e| format!("Invalid principal: {e}"))
 }
 
 /// Parse a BTC address argument and return a `PoxAddress`.
@@ -403,7 +345,9 @@ fn parse_data(data: &str) -> Result<Vec<u8>, String> {
 #[cfg(test)]
 mod tests {
     use blockstack_lib::chainstate::stacks::address::{PoxAddressType20, PoxAddressType32};
-    use blockstack_lib::util_lib::signed_structured_data::pox4::make_pox_4_signer_key_message_hash;
+    use blockstack_lib::util_lib::signed_structured_data::pox4::{
+        make_pox_4_signer_key_message_hash, Pox4SignatureTopic,
+    };
     use clarity::consts::CHAIN_ID_TESTNET;
     use clarity::util::hash::Sha256Sum;
 
@@ -560,41 +504,5 @@ mod tests {
             }
             _ => panic!("Invalid parsed address"),
         }
-    }
-
-    #[test]
-    fn test_parse_stacking_method() {
-        assert_eq!(
-            StackingSignatureMethod::from_str("agg-increase", true).unwrap(),
-            Pox4SignatureTopic::AggregationIncrease.into()
-        );
-        assert_eq!(
-            StackingSignatureMethod::from_str("agg-commit", true).unwrap(),
-            Pox4SignatureTopic::AggregationCommit.into()
-        );
-        assert_eq!(
-            StackingSignatureMethod::from_str("stack-increase", true).unwrap(),
-            Pox4SignatureTopic::StackIncrease.into()
-        );
-        assert_eq!(
-            StackingSignatureMethod::from_str("stack-extend", true).unwrap(),
-            Pox4SignatureTopic::StackExtend.into()
-        );
-        assert_eq!(
-            StackingSignatureMethod::from_str("stack-stx", true).unwrap(),
-            Pox4SignatureTopic::StackStx.into()
-        );
-
-        // These don't exactly match the enum, but are accepted if passed as
-        // CLI args
-
-        assert_eq!(
-            StackingSignatureMethod::from_str("aggregation-increase", true).unwrap(),
-            Pox4SignatureTopic::AggregationIncrease.into()
-        );
-        assert_eq!(
-            StackingSignatureMethod::from_str("aggregation-commit", true).unwrap(),
-            Pox4SignatureTopic::AggregationCommit.into()
-        );
     }
 }

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -63,7 +63,7 @@ pub enum Command {
     /// Run the signer, waiting for events from the stacker-db instance
     Run(RunSignerArgs),
     /// Generate a signature for Stacking transactions
-    GenerateStackingSignature(GenerateStackingSignatureArgs),
+    GenerateStakingSignature(GenerateStakingSignatureArgs),
     /// Check a configuration file and output config information
     CheckConfig(RunSignerArgs),
     /// Vote for a specified SIP with a yes or no vote
@@ -260,8 +260,8 @@ pub struct MonitorSignersArgs {
 }
 
 #[derive(Parser, Debug, Clone, PartialEq)]
-/// Arguments for the generate-stacking-signature command
-pub struct GenerateStackingSignatureArgs {
+/// Arguments for the generate-staking-signature command
+pub struct GenerateStakingSignatureArgs {
     /// Path to signer config file
     #[arg(long, short, value_name = "FILE")]
     pub config: PathBuf,

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -39,9 +39,8 @@ use stacks_common::util::hash::to_hex;
 use stacks_common::util::secp256k1::MessageSignature;
 use stacks_common::{debug, error};
 use stacks_signer::cli::{
-    Cli, Command, GenerateStackingSignatureArgs, GenerateVoteArgs, GetChunkArgs,
-    GetLatestChunkArgs, MonitorSignersArgs, PutChunkArgs, RunSignerArgs, StackerDBArgs,
-    VerifyVoteArgs,
+    Cli, Command, GenerateStakingSignatureArgs, GenerateVoteArgs, GetChunkArgs, GetLatestChunkArgs,
+    MonitorSignersArgs, PutChunkArgs, RunSignerArgs, StackerDBArgs, VerifyVoteArgs,
 };
 use stacks_signer::config::GlobalConfig;
 use stacks_signer::monitor_signers::SignerMonitor;
@@ -122,8 +121,8 @@ fn handle_run(args: RunSignerArgs) {
     let _ = spawned_signer.join();
 }
 
-fn handle_generate_stacking_signature(
-    args: GenerateStackingSignatureArgs,
+fn handle_generate_staking_signature(
+    args: GenerateStakingSignatureArgs,
     do_print: bool,
 ) -> MessageSignature {
     let config = GlobalConfig::try_from(&args.config).unwrap();
@@ -239,8 +238,8 @@ fn main() {
         Command::Run(args) => {
             handle_run(args);
         }
-        Command::GenerateStackingSignature(args) => {
-            handle_generate_stacking_signature(args, true);
+        Command::GenerateStakingSignature(args) => {
+            handle_generate_staking_signature(args, true);
         }
         Command::CheckConfig(args) => {
             handle_check_config(args);
@@ -269,22 +268,22 @@ pub mod tests {
     use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PublicKey};
     use stacks_signer::cli::{VerifyVoteArgs, Vote, VoteInfo};
 
-    use super::{handle_generate_stacking_signature, *};
-    use crate::{GenerateStackingSignatureArgs, GlobalConfig};
+    use super::{handle_generate_staking_signature, *};
+    use crate::{GenerateStakingSignatureArgs, GlobalConfig};
 
     #[test]
     fn test_generate_stacking_signature() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
         let signer_manager =
             PrincipalData::parse("ST000000000000000000002AMW42H.test-signer").unwrap();
-        let args = GenerateStackingSignatureArgs {
+        let args = GenerateStakingSignatureArgs {
             config: "./src/tests/conf/signer-0.toml".into(),
             signer_manager: signer_manager.clone(),
             auth_id: 1,
             json: false,
         };
 
-        let signature = handle_generate_stacking_signature(args.clone(), false);
+        let signature = handle_generate_staking_signature(args.clone(), false);
 
         let public_key = Secp256k1PublicKey::from_private(&config.stacks_private_key);
 
@@ -305,8 +304,8 @@ pub mod tests {
             PrincipalData::parse("ST000000000000000000002AMW42H.test-signer").unwrap();
         let message_hash =
             make_pox_5_signer_grant_message_hash(&signer_manager, 1, CHAIN_ID_TESTNET);
-        let signature = handle_generate_stacking_signature(
-            GenerateStackingSignatureArgs {
+        let signature = handle_generate_staking_signature(
+            GenerateStakingSignatureArgs {
                 config: "./src/tests/conf/signer-0.toml".into(),
                 signer_manager,
                 auth_id: 1,

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -29,7 +29,7 @@ extern crate toml;
 use std::io::{self, Write};
 use std::time::Duration;
 
-use blockstack_lib::util_lib::signed_structured_data::pox4::make_pox_4_signer_key_signature;
+use blockstack_lib::util_lib::signed_structured_data::pox5::make_pox_5_signer_grant_signature;
 use clap::{CommandFactory, Parser};
 use clarity::types::chainstate::StacksPublicKey;
 use clarity::util::sleep_ms;
@@ -132,15 +132,11 @@ fn handle_generate_stacking_signature(
     let public_key = StacksPublicKey::from_private(&private_key);
     let pk_hex = to_hex(&public_key.to_bytes_compressed());
 
-    let signature = make_pox_4_signer_key_signature(
-        &args.pox_address,
-        &private_key, //
-        args.reward_cycle.into(),
-        args.method.topic(),
-        config.to_chain_id(),
-        args.period.into(),
-        args.max_amount,
+    let signature = make_pox_5_signer_grant_signature(
+        &args.signer_manager,
         args.auth_id,
+        config.to_chain_id(),
+        &private_key,
     )
     .expect("Failed to generate signature");
 
@@ -149,11 +145,7 @@ fn handle_generate_stacking_signature(
             "signerKey": pk_hex,
             "signerSignature": to_hex(signature.to_rsv().as_slice()),
             "authId": format!("{}", args.auth_id),
-            "rewardCycle": args.reward_cycle,
-            "maxAmount": format!("{}", args.max_amount),
-            "period": args.period,
-            "poxAddress": args.pox_address.to_b58(),
-            "method": args.method.topic().to_string(),
+            "signerManager": args.signer_manager.to_string(),
         }))
         .expect("Failed to serialize JSON")
     } else {
@@ -267,125 +259,27 @@ fn main() {
 
 #[cfg(test)]
 pub mod tests {
-    use blockstack_lib::chainstate::stacks::address::PoxAddress;
-    use blockstack_lib::chainstate::stacks::boot::POX_4_CODE;
-    use blockstack_lib::util_lib::signed_structured_data::pox4::{
-        make_pox_4_signer_key_message_hash, Pox4SignatureTopic,
-    };
+    use blockstack_lib::util_lib::signed_structured_data::pox5::make_pox_5_signer_grant_message_hash;
     use clarity::util::secp256k1::Secp256k1PrivateKey;
-    use clarity::vm::{execute_v2, Value};
+    use clarity::vm::types::PrincipalData;
     use rand::{Rng, RngCore};
     use stacks_common::consts::CHAIN_ID_TESTNET;
     use stacks_common::types::PublicKey;
-    use stacks_common::util::secp256k1::Secp256k1PublicKey;
-    use stacks_signer::cli::{parse_pox_addr, VerifyVoteArgs, Vote, VoteInfo};
+    use stacks_common::util::hash::hex_bytes;
+    use stacks_common::util::secp256k1::{MessageSignature, Secp256k1PublicKey};
+    use stacks_signer::cli::{VerifyVoteArgs, Vote, VoteInfo};
 
     use super::{handle_generate_stacking_signature, *};
     use crate::{GenerateStackingSignatureArgs, GlobalConfig};
 
-    #[allow(clippy::too_many_arguments)]
-    fn call_verify_signer_sig(
-        pox_addr: &PoxAddress,
-        reward_cycle: u128,
-        topic: &Pox4SignatureTopic,
-        lock_period: u128,
-        public_key: &Secp256k1PublicKey,
-        signature: Vec<u8>,
-        amount: u128,
-        max_amount: u128,
-        auth_id: u128,
-    ) -> bool {
-        let program = format!(
-            r#"
-            {}
-            (verify-signer-key-sig {} u{} "{}" u{} (some 0x{}) 0x{} u{} u{} u{})
-        "#,
-            &*POX_4_CODE,                                               //s
-            Value::Tuple(pox_addr.clone().as_clarity_tuple().unwrap()), //p
-            reward_cycle,
-            topic.get_name_str(),
-            lock_period,
-            to_hex(signature.as_slice()),
-            to_hex(public_key.to_bytes_compressed().as_slice()),
-            amount,
-            max_amount,
-            auth_id,
-        );
-        execute_v2(&program)
-            .expect("FATAL: could not execute program")
-            .expect("Expected result")
-            .expect_result_ok()
-            .expect("Expected ok result")
-            .expect_bool()
-            .expect("Expected buff")
-    }
-
-    #[test]
-    fn test_stacking_signature_with_pox_code() {
-        let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
-        let btc_address = "bc1p8vg588hldsnv4a558apet4e9ff3pr4awhqj2hy8gy6x2yxzjpmqsvvpta4";
-        let mut args = GenerateStackingSignatureArgs {
-            config: "./src/tests/conf/signer-0.toml".into(),
-            pox_address: parse_pox_addr(btc_address).unwrap(),
-            reward_cycle: 6,
-            method: Pox4SignatureTopic::StackStx.into(),
-            period: 12,
-            max_amount: u128::MAX,
-            auth_id: 1,
-            json: false,
-        };
-
-        let signature = handle_generate_stacking_signature(args.clone(), false);
-        let public_key = Secp256k1PublicKey::from_private(&config.stacks_private_key);
-
-        let valid = call_verify_signer_sig(
-            &args.pox_address,
-            args.reward_cycle.into(),
-            &Pox4SignatureTopic::StackStx,
-            args.period.into(),
-            &public_key,
-            signature.to_rsv(),
-            100,
-            args.max_amount,
-            args.auth_id,
-        );
-        assert!(valid);
-
-        // change up some args
-        args.period = 6;
-        args.method = Pox4SignatureTopic::AggregationCommit.into();
-        args.reward_cycle = 7;
-        args.auth_id = 2;
-        args.max_amount = 100;
-
-        let signature = handle_generate_stacking_signature(args.clone(), false);
-        let public_key = Secp256k1PublicKey::from_private(&config.stacks_private_key);
-
-        let valid = call_verify_signer_sig(
-            &args.pox_address,
-            args.reward_cycle.into(),
-            &Pox4SignatureTopic::AggregationCommit,
-            args.period.into(),
-            &public_key,
-            signature.to_rsv(),
-            100,
-            args.max_amount,
-            args.auth_id,
-        );
-        assert!(valid);
-    }
-
     #[test]
     fn test_generate_stacking_signature() {
         let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
-        let btc_address = "bc1p8vg588hldsnv4a558apet4e9ff3pr4awhqj2hy8gy6x2yxzjpmqsvvpta4";
+        let signer_manager =
+            PrincipalData::parse("ST000000000000000000002AMW42H.test-signer").unwrap();
         let args = GenerateStackingSignatureArgs {
             config: "./src/tests/conf/signer-0.toml".into(),
-            pox_address: parse_pox_addr(btc_address).unwrap(),
-            reward_cycle: 6,
-            method: Pox4SignatureTopic::StackStx.into(),
-            period: 12,
-            max_amount: u128::MAX,
+            signer_manager: signer_manager.clone(),
             auth_id: 1,
             json: false,
         };
@@ -394,19 +288,45 @@ pub mod tests {
 
         let public_key = Secp256k1PublicKey::from_private(&config.stacks_private_key);
 
-        let message_hash = make_pox_4_signer_key_message_hash(
-            &args.pox_address,
-            args.reward_cycle.into(),
-            &Pox4SignatureTopic::StackStx,
-            CHAIN_ID_TESTNET,
-            args.period.into(),
-            args.max_amount,
-            args.auth_id,
-        );
+        let message_hash =
+            make_pox_5_signer_grant_message_hash(&signer_manager, args.auth_id, CHAIN_ID_TESTNET);
 
         let verify_result = public_key.verify(&message_hash.0, &signature);
         assert!(verify_result.is_ok());
         assert!(verify_result.unwrap());
+    }
+
+    /// Use a fixture generated from our typescript implementation
+    /// ([`pox-5-helpers.ts`](../../contrib/core-contract-tests/tests/pox-5/pox-5-helpers.ts))
+    #[test]
+    fn test_pox_5_signer_grant_signature_typescript_fixture() {
+        let config = GlobalConfig::load_from_file("./src/tests/conf/signer-0.toml").unwrap();
+        let signer_manager =
+            PrincipalData::parse("ST000000000000000000002AMW42H.test-signer").unwrap();
+        let message_hash =
+            make_pox_5_signer_grant_message_hash(&signer_manager, 1, CHAIN_ID_TESTNET);
+        let signature = handle_generate_stacking_signature(
+            GenerateStackingSignatureArgs {
+                config: "./src/tests/conf/signer-0.toml".into(),
+                signer_manager,
+                auth_id: 1,
+                json: false,
+            },
+            false,
+        );
+
+        let expected_hash =
+            hex_bytes("41339a30baf6f207fb56882c0d5246a91af8db0e6d3a2c07eb455c2330441256").unwrap();
+        let expected_signature = MessageSignature::from_rsv(
+            &hex_bytes("2c83b6442a993d54ed2696789908fa963a50f748d0d06ca61445baed8bfb809a63f1182b350a46984e3b7cb67baa8e952b6c342f3354370bb7a7060e1bbc535e01").unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(message_hash.as_bytes(), expected_hash.as_slice());
+        assert_eq!(signature, expected_signature);
+        assert!(Secp256k1PublicKey::from_private(&config.stacks_private_key)
+            .verify(message_hash.as_bytes(), &signature)
+            .unwrap());
     }
 
     #[test]


### PR DESCRIPTION
The `stacks-signer` CLI has a `generate-stacking-signature` method. This PR updates it for `pox-5`.

Instead of including the old pox-4 CLI method, I've opted to remove it for simplicity. I figure that, once this version is released, there won't be a reason to use the CLI to make pox-4 signatures. The code still exists (and it used), and you'd still be able to use an older version if necessary.