### PR TITLE
feat: add `marf-squash` crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [alias]
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
-clippy-stacks = "clippy -p stx-genesis -p libstackerdb -p stacks-signer -p pox-locking -p clarity-types -p clarity -p libsigner -p stacks-common -p stacks-codec -p clarity-cli -p stacks-cli -p stacks-inspect -p stacks-profiler -p stacks-profiler-macros --no-deps --tests --all-features -- -D warnings -Aclippy::unnecessary_lazy_evaluations"
+clippy-stacks = "clippy -p stx-genesis -p libstackerdb -p stacks-signer -p pox-locking -p clarity-types -p clarity -p libsigner -p stacks-common -p stacks-codec -p clarity-cli -p stacks-cli -p stacks-inspect -p stacks-profiler -p stacks-profiler-macros -p marf-squash --no-deps --tests --all-features -- -D warnings -Aclippy::unnecessary_lazy_evaluations"
 clippy-stackslib = "clippy -p stackslib --no-deps -- -Aclippy::all -Wclippy::indexing_slicing -Wclippy::nonminimal_bool -Wclippy::clone_on_copy"
 
 # Uncomment to improve performance slightly, at the cost of portability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,6 +2553,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "marf-squash"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "rstest",
+ "rusqlite",
+ "serde",
+ "sha2 0.10.8",
+ "stacks-common 0.0.1",
+ "stackslib 0.0.1",
+ "tempfile",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ members = [
     "stacks-profiler-macros",
     "contrib/stacks-inspect",
     "contrib/clarity-cli",
-    "contrib/stacks-cli"
+    "contrib/stacks-cli",
+    "contrib/marf-squash",
 ]
 
 exclude = ["contrib/tools/config-docs-generator"]

--- a/changelog.d/marf-squash-cli.added
+++ b/changelog.d/marf-squash-cli.added
@@ -1,0 +1,1 @@
+Add the `marf-squash` offline CLI (`contrib/marf-squash`) that produces a bootable Pruned Chainstate Snapshot (PCS) from another chainstate.

--- a/contrib/marf-squash/Cargo.toml
+++ b/contrib/marf-squash/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "marf-squash"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+stackslib = { package = "stackslib", path = "../../stackslib", default-features = false }
+stacks-common = { path = "../../stacks-common" }
+clap = { version = "4.5.44", features = ["derive"] }
+rusqlite = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+toml = { workspace = true }
+
+[target.'cfg(all(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64"), not(any(target_os="windows"))))'.dependencies]
+sha2 = { version = "0.10", features = ["asm"] }
+
+[target.'cfg(any(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")), any(target_os = "windows")))'.dependencies]
+sha2 = { version = "0.10" }
+
+[dev-dependencies]
+tempfile = "3"
+rstest = "0.17.0"

--- a/contrib/marf-squash/README.md
+++ b/contrib/marf-squash/README.md
@@ -1,13 +1,13 @@
 # marf-squash
 
-Offline CLI for producing Genesis State Snapshots (GSS) from a Stacks node's
+Offline CLI for producing Pruned Chainstate Snapshots (PCS) from a Stacks node's
 chainstate. Squashes the three MARFs (Clarity, Index, Sortition), copies
 canonical block data and Bitcoin auxiliary files, and generates a self-describing
 manifest with SHA-256 checksums for the fixed artifacts plus one aggregate hash
 for the epoch-2 block archive.
 
-This crate *produces* a GSS; it does not verify one. Offline verification of a
-GSS against a trusted checkpoint is a separate tool, not provided here.
+This crate *produces* a PCS; it does not verify one. Offline verification of a
+PCS against a trusted checkpoint is a separate tool, not provided here.
 
 ## Build
 
@@ -22,13 +22,13 @@ cargo build -p marf-squash --release
 ```bash
 marf-squash squash \
   --chainstate /data/mainnet \
-  --out-dir /tmp/gss \
+  --out-dir /tmp/pcs \
   --tenure-start-bitcoin-height 880000 \
   --all
 ```
 
 `--all` squashes all three MARFs, copies canonical block data, copies Bitcoin
-auxiliary files, and generates a `GSS_manifest.toml` with SHA-256 checksums for
+auxiliary files, and generates a `PCS_manifest.toml` with SHA-256 checksums for
 the fixed artifacts plus one aggregate hash for the epoch-2 block archive under
 `chainstate/blocks/`.
 
@@ -36,12 +36,12 @@ Individual MARFs can be squashed selectively with `--clarity`, `--index`, or
 `--sortition`. `--blocks` requires `--index` (or `--all`); `--bitcoin` requires
 `--sortition` (or `--all`). A node config can be supplied with `--config`.
 
-## GSS output layout
+## PCS output layout
 
-A full GSS (`--all`) mirrors the node's working directory structure:
+A full PCS (`--all`) mirrors the node's working directory structure:
 
 ```
-/tmp/gss/
+/tmp/pcs/
 ├── chainstate/
 │   ├── vm/
 │   │   ├── clarity/
@@ -58,29 +58,29 @@ A full GSS (`--all`) mirrors the node's working directory structure:
 │   │   └── marf.sqlite.blobs
 │   └── burnchain.sqlite
 ├── headers.sqlite
-└── GSS_manifest.toml
+└── PCS_manifest.toml
 ```
 
-## The GSS manifest
+## The PCS manifest
 
-`GSS_manifest.toml` is a self-describing record of the snapshot: the three MARFs'
+`PCS_manifest.toml` is a self-describing record of the snapshot: the three MARFs'
 squash root node hashes and archival MARF root hashes, the block range, and
 SHA-256 checksums (file-level for the fixed artifacts, one aggregate hash for the
-epoch-2 block archive). It is written by `squash` for a full GSS (`--all`).
+epoch-2 block archive). It is written by `squash` for a full PCS (`--all`).
 
-Nothing in this crate reads it back — it is the artifact format consumed by an
+Nothing in this crate reads it back - it is the artifact format consumed by an
 external/offline verifier. The squash root node hashes are the intended trust
 anchor: a verifier authenticates them against an independently published
 checkpoint. The manifest itself is part of the untrusted artifact and is not
 authenticated.
 
-## Using a GSS to bootstrap a node
+## Using a PCS to bootstrap a node
 
-1. Produce or download a GSS directory.
+1. Produce or download a PCS directory.
 2. (Recommended) Verify it against a trusted checkpoint with the offline verifier
-   — a separate tool, not provided by this crate.
-3. Set `[node].working_dir` in your Stacks config to the **parent** of the GSS
+   - a separate tool, not provided by this crate.
+3. Set `[node].working_dir` in your Stacks config to the **parent** of the PCS
    directory (e.g. `/data/my-node`).
 4. Start the node normally.
 
-The node is unaware it is running from a GSS.
+The node is unaware it is running from a PCS.

--- a/contrib/marf-squash/README.md
+++ b/contrib/marf-squash/README.md
@@ -1,0 +1,86 @@
+# marf-squash
+
+Offline CLI for producing Genesis State Snapshots (GSS) from a Stacks node's
+chainstate. Squashes the three MARFs (Clarity, Index, Sortition), copies
+canonical block data and Bitcoin auxiliary files, and generates a self-describing
+manifest with SHA-256 checksums for the fixed artifacts plus one aggregate hash
+for the epoch-2 block archive.
+
+This crate *produces* a GSS; it does not verify one. Offline verification of a
+GSS against a trusted checkpoint is a separate tool, not provided here.
+
+## Build
+
+From the repository root:
+
+```bash
+cargo build -p marf-squash --release
+```
+
+## Usage
+
+```bash
+marf-squash squash \
+  --chainstate /data/mainnet \
+  --out-dir /tmp/gss \
+  --tenure-start-bitcoin-height 880000 \
+  --all
+```
+
+`--all` squashes all three MARFs, copies canonical block data, copies Bitcoin
+auxiliary files, and generates a `GSS_manifest.toml` with SHA-256 checksums for
+the fixed artifacts plus one aggregate hash for the epoch-2 block archive under
+`chainstate/blocks/`.
+
+Individual MARFs can be squashed selectively with `--clarity`, `--index`, or
+`--sortition`. `--blocks` requires `--index` (or `--all`); `--bitcoin` requires
+`--sortition` (or `--all`). A node config can be supplied with `--config`.
+
+## GSS output layout
+
+A full GSS (`--all`) mirrors the node's working directory structure:
+
+```
+/tmp/gss/
+├── chainstate/
+│   ├── vm/
+│   │   ├── clarity/
+│   │   │   ├── marf.sqlite
+│   │   │   └── marf.sqlite.blobs
+│   │   ├── index.sqlite
+│   │   └── index.sqlite.blobs
+│   └── blocks/
+│       ├── nakamoto.sqlite
+│       └── {XX}/{YY}/{hash}... # Epoch 2.x blocks
+├── burnchain/
+│   ├── sortition/
+│   │   ├── marf.sqlite
+│   │   └── marf.sqlite.blobs
+│   └── burnchain.sqlite
+├── headers.sqlite
+└── GSS_manifest.toml
+```
+
+## The GSS manifest
+
+`GSS_manifest.toml` is a self-describing record of the snapshot: the three MARFs'
+squash root node hashes and archival MARF root hashes, the block range, and
+SHA-256 checksums (file-level for the fixed artifacts, one aggregate hash for the
+epoch-2 block archive). It is written by `squash` for a full GSS (`--all`).
+
+Nothing in this crate reads it back — it is the artifact format consumed by an
+external/offline verifier. The squash root node hashes are the intended trust
+anchor: a verifier authenticates them against an independently published
+checkpoint. The manifest itself is part of the untrusted artifact and is not
+authenticated.
+
+## Using a GSS to bootstrap a node
+
+1. Produce or download a GSS directory.
+2. (Recommended) Verify it against a trusted checkpoint with the offline verifier
+   — a separate tool, not provided by this crate.
+3. Set `[node].working_dir` in your Stacks config to the **parent** of the GSS
+   directory (e.g. `/data/my-node`).
+4. Start the node normally.
+
+The node is unaware it is running from a GSS.

--- a/contrib/marf-squash/src/checksums.rs
+++ b/contrib/marf-squash/src/checksums.rs
@@ -109,6 +109,8 @@ fn checksum_entry(
     Ok(Some((rel_str, hash)))
 }
 
+/// Compute a single SHA-256 over the contents of `rel_paths` (relative to
+/// `base_dir`), hashed in sorted path order so the result is deterministic.
 pub fn compute_aggregate_checksum(base_dir: &Path, rel_paths: &[String]) -> Result<String, String> {
     let mut hasher = Sha256::new();
     let mut sorted_paths: Vec<&String> = rel_paths.iter().collect();

--- a/contrib/marf-squash/src/checksums.rs
+++ b/contrib/marf-squash/src/checksums.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
-use std::io::Read;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
@@ -142,19 +142,7 @@ fn hash_one_aggregate_entry(
     }
     hasher.update(metadata.len().to_le_bytes());
 
-    let mut file =
-        fs::File::open(&file_path).map_err(|e| format!("open {}: {e}", file_path.display()))?;
-    let mut buf = [0u8; 65536];
-    loop {
-        let n = file
-            .read(&mut buf)
-            .map_err(|e| format!("read {}: {e}", file_path.display()))?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    Ok(())
+    hash_file_into(hasher, &file_path)
 }
 
 /// Recursively collect regular files, rejecting symlinks and non-regular
@@ -204,19 +192,35 @@ pub fn collect_files_recursive(
     Ok(())
 }
 
-/// Compute the SHA-256 hex digest of a file using streaming reads.
+/// Stream `path`'s contents into `hasher`. Shared by [`sha256_file`] and
+/// [`hash_one_aggregate_entry`].
+fn hash_file_into(hasher: &mut Sha256, path: &Path) -> Result<(), String> {
+    let file = fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+    let mut reader = BufReader::with_capacity(65536, file);
+    std::io::copy(&mut reader, hasher).map_err(|e| format!("read {}: {e}", path.display()))?;
+    Ok(())
+}
+
+/// Compute the SHA-256 hex digest of a file.
 pub fn sha256_file(path: &Path) -> Result<String, String> {
-    let mut file = fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
     let mut hasher = Sha256::new();
-    let mut buf = [0u8; 65536];
-    loop {
-        let n = file
-            .read(&mut buf)
-            .map_err(|e| format!("read {}: {e}", path.display()))?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
+    hash_file_into(&mut hasher, path)?;
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sha256_file;
+
+    /// Known-answer vector: SHA-256("abc"). Guards the streaming-hash refactor.
+    #[test]
+    fn sha256_file_matches_known_vector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f");
+        std::fs::write(&path, b"abc").unwrap();
+        assert_eq!(
+            sha256_file(&path).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
 }

--- a/contrib/marf-squash/src/checksums.rs
+++ b/contrib/marf-squash/src/checksums.rs
@@ -1,4 +1,19 @@
-//! SHA-256 checksum computation and directory traversal for GSS artifacts.
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! SHA-256 checksum computation and directory traversal for PCS artifacts.
 
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
@@ -7,7 +22,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use crate::layout::{GSS_MANIFEST, SQLITE_SIDECAR_EXTENSIONS};
+use crate::layout::{PCS_MANIFEST, SQLITE_SIDECAR_EXTENSIONS};
 
 /// Compute SHA-256 checksums for selected files in `out_dir`, allowing a set of
 /// files to be present on disk without materializing individual checksum
@@ -71,7 +86,7 @@ fn checksum_entry(
     let rel_str = rel.to_string_lossy().replace('\\', "/");
 
     // Skip the manifest files themselves.
-    if rel_str == GSS_MANIFEST {
+    if rel_str == PCS_MANIFEST {
         return Ok(None);
     }
 
@@ -157,7 +172,7 @@ pub fn collect_files_recursive(
         // Reject symlinks.
         if metadata.is_symlink() {
             return Err(format!(
-                "symlink found in GSS directory: {}",
+                "symlink found in PCS directory: {}",
                 path.strip_prefix(base).unwrap_or(&path).display()
             ));
         }
@@ -169,7 +184,7 @@ pub fn collect_files_recursive(
 
         if !metadata.is_file() {
             return Err(format!(
-                "non-regular file in GSS directory: {}",
+                "non-regular file in PCS directory: {}",
                 path.strip_prefix(base).unwrap_or(&path).display()
             ));
         }

--- a/contrib/marf-squash/src/checksums.rs
+++ b/contrib/marf-squash/src/checksums.rs
@@ -1,0 +1,205 @@
+//! SHA-256 checksum computation and directory traversal for GSS artifacts.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::layout::{GSS_MANIFEST, SQLITE_SIDECAR_EXTENSIONS};
+
+/// Compute SHA-256 checksums for selected files in `out_dir`, allowing a set of
+/// files to be present on disk without materializing individual checksum
+/// entries for them.
+pub fn compute_checksums(
+    out_dir: &Path,
+    expected_files: Option<&HashSet<String>>,
+    skipped_files: Option<&HashSet<String>>,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut checksums = BTreeMap::new();
+    let mut entries: Vec<PathBuf> = Vec::new();
+    let empty_skipped = HashSet::new();
+    let skipped_files = skipped_files.unwrap_or(&empty_skipped);
+
+    collect_files_recursive(out_dir, out_dir, &mut entries)?;
+    entries.sort();
+
+    for path in &entries {
+        if let Some((rel_str, hash)) = checksum_entry(out_dir, path, expected_files, skipped_files)?
+        {
+            checksums.insert(rel_str, hash);
+        }
+    }
+
+    // When an expected set is provided, verify all expected files were found.
+    if let Some(expected) = expected_files {
+        verify_all_expected_present(&checksums, expected)?;
+    }
+
+    Ok(checksums)
+}
+
+/// Error if any name in `expected` has no checksum entry (i.e. an expected file
+/// was missing from the output directory).
+fn verify_all_expected_present(
+    checksums: &BTreeMap<String, String>,
+    expected: &HashSet<String>,
+) -> Result<(), String> {
+    for name in expected {
+        if !checksums.contains_key(name) {
+            return Err(format!(
+                "expected file missing from output directory: {name}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve one collected `path` to its `(rel_str, hash)` checksum entry, or
+/// `None` if it is skipped (the manifest itself or a `skipped_files` member).
+/// Errors when `expected_files` is provided and the file is not in it.
+fn checksum_entry(
+    out_dir: &Path,
+    path: &Path,
+    expected_files: Option<&HashSet<String>>,
+    skipped_files: &HashSet<String>,
+) -> Result<Option<(String, String)>, String> {
+    let rel = path
+        .strip_prefix(out_dir)
+        .map_err(|e| format!("strip_prefix: {e}"))?;
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+
+    // Skip the manifest files themselves.
+    if rel_str == GSS_MANIFEST {
+        return Ok(None);
+    }
+
+    // Allow some files to be present without individual checksum entries.
+    if skipped_files.contains(&rel_str) {
+        return Ok(None);
+    }
+
+    // When an expected set is provided, reject unexpected files.
+    if let Some(expected) = expected_files
+        && !expected.contains(&rel_str)
+    {
+        return Err(format!(
+            "unexpected file in output directory: {rel_str} \
+                 (reuse a clean --out-dir or remove stale files)"
+        ));
+    }
+
+    let hash = sha256_file(path)?;
+    Ok(Some((rel_str, hash)))
+}
+
+pub fn compute_aggregate_checksum(base_dir: &Path, rel_paths: &[String]) -> Result<String, String> {
+    let mut hasher = Sha256::new();
+    let mut sorted_paths: Vec<&String> = rel_paths.iter().collect();
+    sorted_paths.sort();
+
+    for rel_path in sorted_paths {
+        hash_one_aggregate_entry(&mut hasher, base_dir, rel_path)?;
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Fold one `rel_path`'s length-prefixed name, byte length, and contents into
+/// `hasher`. Errors if the path is not a regular file.
+fn hash_one_aggregate_entry(
+    hasher: &mut Sha256,
+    base_dir: &Path,
+    rel_path: &str,
+) -> Result<(), String> {
+    let file_path = base_dir.join(rel_path);
+    let rel_bytes = rel_path.as_bytes();
+    hasher.update((rel_bytes.len() as u64).to_le_bytes());
+    hasher.update(rel_bytes);
+
+    let metadata =
+        fs::metadata(&file_path).map_err(|e| format!("metadata {}: {e}", file_path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!("expected regular file: {}", file_path.display()));
+    }
+    hasher.update(metadata.len().to_le_bytes());
+
+    let mut file =
+        fs::File::open(&file_path).map_err(|e| format!("open {}: {e}", file_path.display()))?;
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("read {}: {e}", file_path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(())
+}
+
+/// Recursively collect regular files, rejecting symlinks and non-regular
+/// files. SQLite sidecars are ignored.
+pub fn collect_files_recursive(
+    base: &Path,
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    let read_dir = fs::read_dir(dir).map_err(|e| format!("read_dir {}: {e}", dir.display()))?;
+    for entry in read_dir {
+        let entry = entry.map_err(|e| format!("dir entry: {e}"))?;
+        let path = entry.path();
+        let metadata =
+            fs::symlink_metadata(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+
+        // Reject symlinks.
+        if metadata.is_symlink() {
+            return Err(format!(
+                "symlink found in GSS directory: {}",
+                path.strip_prefix(base).unwrap_or(&path).display()
+            ));
+        }
+
+        if metadata.is_dir() {
+            collect_files_recursive(base, &path, out)?;
+            continue;
+        }
+
+        if !metadata.is_file() {
+            return Err(format!(
+                "non-regular file in GSS directory: {}",
+                path.strip_prefix(base).unwrap_or(&path).display()
+            ));
+        }
+
+        // Ignore transient SQLite sidecars. These can legitimately appear
+        // around WAL-mode databases and should not be hashed or manifested.
+        if let Some(ext) = path.extension().and_then(|e| e.to_str())
+            && SQLITE_SIDECAR_EXTENSIONS.contains(&ext)
+        {
+            continue;
+        }
+
+        out.push(path);
+    }
+    Ok(())
+}
+
+/// Compute the SHA-256 hex digest of a file using streaming reads.
+pub fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file = fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("read {}: {e}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}

--- a/contrib/marf-squash/src/checksums.rs
+++ b/contrib/marf-squash/src/checksums.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use crate::layout::{PCS_MANIFEST, SQLITE_SIDECAR_EXTENSIONS};
+use crate::layout::{PCS_MANIFEST, SQLITE_SIDECAR_EXTENSIONS, canonical_rel_path};
 
 /// Compute SHA-256 checksums for selected files in `out_dir`, allowing a set of
 /// files to be present on disk without materializing individual checksum
@@ -83,7 +83,7 @@ fn checksum_entry(
     let rel = path
         .strip_prefix(out_dir)
         .map_err(|e| format!("strip_prefix: {e}"))?;
-    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    let rel_str = canonical_rel_path(rel);
 
     // Skip the manifest files themselves.
     if rel_str == PCS_MANIFEST {

--- a/contrib/marf-squash/src/cli.rs
+++ b/contrib/marf-squash/src/cli.rs
@@ -1,3 +1,18 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};

--- a/contrib/marf-squash/src/cli.rs
+++ b/contrib/marf-squash/src/cli.rs
@@ -64,11 +64,11 @@ pub struct SquashArgs {
     #[arg(long)]
     pub all: bool,
     /// Copy canonical block data (epoch 2.x files, confirmed microblocks, nakamoto.sqlite).
-    /// Requires --index (or --all).
+    /// Requires --index (is implied by --all).
     #[arg(long)]
     pub blocks: bool,
     /// Copy Bitcoin auxiliary files (burnchain.sqlite + headers.sqlite).
-    /// Requires --sortition (or --all).
+    /// Requires --sortition (is implied by --all).
     #[arg(long)]
     pub bitcoin: bool,
     /// Path to the node config TOML file. Used to extract PoX constants

--- a/contrib/marf-squash/src/cli.rs
+++ b/contrib/marf-squash/src/cli.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+/// Offline squashing CLI for Index, Clarity, and Sortition MARF snapshots.
+#[derive(Parser, Debug)]
+#[command(
+    name = "marf-squash",
+    about = "Offline squashing tool for Index, Clarity, and Sortition MARFs"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Create squashed MARFs from a source chainstate.
+    Squash(SquashArgs),
+}
+
+/// Arguments for generating squashed MARFs.
+#[derive(Parser, Debug)]
+pub struct SquashArgs {
+    /// Path to the chainstate folder (the parent of chainstate/ and burnchain/).
+    #[arg(long, value_name = "DIR")]
+    pub chainstate: PathBuf,
+    /// Output directory -- the node's `working_dir`. The squash writes a
+    /// directly bootable `<out-dir>/<network>/` tree. `<network>` is `mainnet`
+    /// for a mainnet chainstate, otherwise the source chainstate's own
+    /// subdirectory name (e.g. `krypton`).
+    #[arg(long = "out-dir", value_name = "DIR")]
+    pub out_dir: PathBuf,
+    /// Bitcoin block height where a Nakamoto tenure started (sortition=true).
+    /// The snapshot includes the complete tenure: all Stacks blocks produced
+    /// by the miner who won this sortition. Epoch 3.x (Nakamoto) only.
+    #[arg(long, value_name = "HEIGHT")]
+    pub tenure_start_bitcoin_height: u32,
+    /// Squash the Clarity MARF (chainstate/vm/clarity/marf.sqlite).
+    #[arg(long)]
+    pub clarity: bool,
+    /// Squash the Index MARF (chainstate/vm/index.sqlite).
+    #[arg(long)]
+    pub index: bool,
+    /// Squash the Sortition MARF (burnchain/sortition/marf.sqlite).
+    #[arg(long)]
+    pub sortition: bool,
+    /// Squash all three MARFs and copy all auxiliary data (blocks + bitcoin).
+    #[arg(long)]
+    pub all: bool,
+    /// Copy canonical block data (epoch 2.x files, confirmed microblocks, nakamoto.sqlite).
+    /// Requires --index (or --all).
+    #[arg(long)]
+    pub blocks: bool,
+    /// Copy Bitcoin auxiliary files (burnchain.sqlite + headers.sqlite).
+    /// Requires --sortition (or --all).
+    #[arg(long)]
+    pub bitcoin: bool,
+    /// Path to the node config TOML file. Used to extract PoX constants
+    /// Required for testnet.
+    #[arg(long, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+}

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -19,10 +19,7 @@ use crate::ops::{
     BitcoinAuxFiles, SideTableMode, SquashJob, copy_bitcoin_aux_files, die_with_cleanup,
     squash_and_copy_one,
 };
-use crate::targets::{
-    CanonicalSquashTargets, SquashTargetQuery, resolve_canonical_squash_targets,
-    warn_if_in_prepare_phase,
-};
+use crate::targets::{CanonicalSquashTargets, SquashTargetQuery, resolve_canonical_squash_targets};
 
 /// The resolved set of squash targets for one `squash` invocation. `--all`
 /// selects all five; `from_args` validates that at least one target is selected
@@ -440,13 +437,6 @@ fn resolve_targets(
         targets.stacks_tip,
         targets.squash_bitcoin_height,
         targets.sortition_marf_height
-    );
-
-    // Prepare-phase warning.
-    warn_if_in_prepare_phase(
-        tenure_start_bitcoin_height,
-        pox,
-        targets.first_bitcoin_height,
     );
 
     targets

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -489,7 +489,7 @@ pub fn run_squash(args: SquashArgs) {
         let i_out = outputs
             .index
             .as_ref()
-            .expect("--blocks requires --index; index_out must be set");
+            .expect("--blocks requires --index; outputs.index must be set");
         copy_blocks(&args, &out_root, &paths, i_out)
     });
 

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -1,0 +1,649 @@
+use std::path::{Path, PathBuf};
+
+use stackslib::chainstate::stacks::db::snapshot::{
+    Epoch2BlockFileCopyStats, Epoch2MicroblockCopyStats, NakamotoBlockCopyStats,
+    SortitionTipCopyBoundary, copy_confirmed_epoch2_microblocks, copy_epoch2_block_files,
+    copy_nakamoto_staging_blocks,
+};
+
+use crate::cli::SquashArgs;
+use crate::config::{build_pox_constants, enforce_minimum_tenure_height};
+use crate::db::{DbConfig, read_db_config, read_marf_open_opts};
+use crate::layout::{
+    BLOCKS_DIR_REL, BURNCHAIN_DB_REL, CLARITY_MARF_REL, ChainstatePaths, HEADERS_DB_REL,
+    INDEX_DB_REL, NAKAMOTO_DB_REL, SORTITION_MARF_REL, TargetPaths, chainstate_paths,
+    target_out_paths,
+};
+use crate::manifest::{BlocksSection, ManifestInputs, generate_manifest};
+use crate::ops::{
+    BitcoinAuxFiles, SideTableMode, SquashJob, copy_bitcoin_aux_files, die_with_cleanup,
+    squash_and_copy_one,
+};
+use crate::targets::{
+    CanonicalSquashTargets, SquashTargetQuery, resolve_canonical_squash_targets,
+    warn_if_in_prepare_phase,
+};
+
+/// The resolved set of squash targets for one `squash` invocation. `--all`
+/// selects all five; `from_args` validates that at least one target is selected
+/// and that the `blocks ⇒ index` and `bitcoin ⇒ sortition` dependencies hold, so
+/// an invalid flag combo is rejected before any output is created.
+pub struct SquashPlan {
+    pub clarity: bool,
+    pub index: bool,
+    pub sortition: bool,
+    pub blocks: bool,
+    pub bitcoin: bool,
+}
+
+impl SquashPlan {
+    pub fn from_args(args: &SquashArgs) -> Self {
+        let plan = SquashPlan {
+            clarity: args.clarity || args.all,
+            index: args.index || args.all,
+            sortition: args.sortition || args.all,
+            blocks: args.blocks || args.all,
+            bitcoin: args.bitcoin || args.all,
+        };
+        if !plan.has_any_target() {
+            eprintln!(
+                "Must specify at least one target: --clarity, --index, --sortition, --blocks, --bitcoin, or --all"
+            );
+            std::process::exit(1);
+        }
+        // Fail fast on invalid flag combos, before any output is created:
+        // --blocks copies into the squashed index, --bitcoin needs the squashed
+        // sortition DB.
+        ensure_flag_requires("blocks", plan.blocks, "index", plan.index);
+        ensure_flag_requires("bitcoin", plan.bitcoin, "sortition", plan.sortition);
+        plan
+    }
+
+    /// Whether at least one target is selected.
+    fn has_any_target(&self) -> bool {
+        self.clarity || self.index || self.sortition || self.blocks || self.bitcoin
+    }
+
+    /// Whether this is a complete GSS (all three MARFs + blocks + bitcoin aux) --
+    /// the only case for which a manifest is written.
+    pub fn is_full_gss(&self) -> bool {
+        self.clarity && self.index && self.sortition && self.blocks && self.bitcoin
+    }
+}
+
+/// Verify that `--{flag}` is only used when `--{dep}` (or `--all`) is also set.
+fn ensure_flag_requires(flag: &str, flag_val: bool, dep: &str, dep_val: bool) {
+    if flag_val && !dep_val {
+        eprintln!("--{flag} requires --{dep} (or --all)");
+        std::process::exit(1);
+    }
+}
+
+fn sortition_tip_copy_boundary(targets: &CanonicalSquashTargets) -> SortitionTipCopyBoundary {
+    SortitionTipCopyBoundary {
+        max_stacks_height: u64::from(targets.stacks_height),
+        anchor_consensus_hash: targets.stacks_tip_consensus_hash.clone(),
+        anchor_burn_view_consensus_hash: targets.stacks_tip_burn_view_consensus_hash.clone(),
+        anchor_block_hash: targets.stacks_tip_block_hash.clone(),
+        anchor_block_height: u64::from(targets.stacks_height),
+    }
+}
+
+/// Network subdirectories marf-squash can target. A squash requires epoch 3.4
+/// (Nakamoto), so only the persistent Nakamoto networks qualify: mainnet and
+/// the krypton testnet.
+const KNOWN_NETWORK_SUBDIRS: &[&str] = &["mainnet", "krypton"];
+
+fn is_known_network(subdir: &str) -> bool {
+    KNOWN_NETWORK_SUBDIRS.contains(&subdir)
+}
+
+/// Resolve the `working_dir/<network>/` subdirectory for the squash output.
+///
+/// Mainnet is unambiguous. For any other network the mode (`krypton`, `xenon`,
+/// ...) is not recoverable from the chainstate alone (testnet/regtest share a
+/// chain id), so mirror the source chainstate's own subdirectory name.
+fn network_subdir(mainnet: bool, chainstate: &Path) -> Result<String, String> {
+    if mainnet {
+        return Ok("mainnet".to_string());
+    }
+    let subdir = chainstate
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            format!(
+                "cannot derive the network subdirectory from --chainstate '{}'; \
+                 pass a path ending in the network name, e.g. /stacks/krypton",
+                chainstate.display()
+            )
+        })?;
+    if subdir == "mainnet" {
+        return Err(format!(
+            "--chainstate '{}' ends in 'mainnet' but the chainstate is not mainnet; \
+             refusing to write a 'mainnet' subdirectory for a testnet/regtest chainstate",
+            chainstate.display()
+        ));
+    }
+    if !is_known_network(&subdir) {
+        return Err(format!(
+            "'{subdir}' is not a recognized stacks-node network ({}); stacks-node would reject \
+             this mode. Point --chainstate at a path ending in the network name.",
+            KNOWN_NETWORK_SUBDIRS.join(", ")
+        ));
+    }
+    Ok(subdir)
+}
+
+/// Resolve the `<out-dir>/<network>/` output root and ensure it exists and is
+/// empty. Exits on an undeterminable network or a non-empty existing tree.
+fn prepare_output_dir(args: &SquashArgs, mainnet: bool) -> PathBuf {
+    let subdir = network_subdir(mainnet, &args.chainstate).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    });
+    let out_root = args.out_dir.join(&subdir);
+
+    // Require the destination network dir to be absent or empty. Re-running into
+    // an existing tree can leave partial or duplicate data (e.g. nakamoto.sqlite
+    // rows inserted twice) that is difficult to diagnose.
+    if out_root.exists() {
+        let is_empty = std::fs::read_dir(&out_root)
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(false);
+        if !is_empty {
+            eprintln!(
+                "Error: output '{}' already exists and is not empty.\n\
+                 Remove it or choose a different --out-dir to avoid partial/duplicate output.",
+                out_root.display()
+            );
+            std::process::exit(1);
+        }
+    }
+    std::fs::create_dir_all(&out_root).unwrap_or_else(|e| {
+        eprintln!("Failed to create output dir {}: {e}", out_root.display());
+        std::process::exit(1);
+    });
+    out_root
+}
+
+/// Output paths produced by [`squash_marfs`] for each selected MARF, plus the
+/// sortition MARF squash height (set whenever `sortition` is). Later phases and
+/// the manifest reference these.
+struct SquashOutputs {
+    clarity: Option<TargetPaths>,
+    index: Option<TargetPaths>,
+    sortition: Option<TargetPaths>,
+    sortition_marf_height: u32,
+}
+
+/// Phase 1: squash each selected MARF and copy its side tables. Both Stacks
+/// MARFs (Clarity, Index) anchor at the tenure-start Stacks tip/height; the
+/// sortition MARF anchors at the canonical sortition tip/height. The source's
+/// open-opts are auto-detected (external blob storage from the `.blobs` sidecar).
+fn squash_marfs(
+    plan: &SquashPlan,
+    paths: &ChainstatePaths,
+    out_root: &Path,
+    targets: &CanonicalSquashTargets,
+    pox: &stackslib::burnchains::PoxConstants,
+) -> SquashOutputs {
+    let stacks_tip = &targets.stacks_tip;
+    let stacks_height = targets.stacks_height;
+    let sortition_tip = &targets.sortition_canonical_tip;
+    let sortition_marf_height = targets.sortition_marf_height;
+
+    let clarity_out = plan.clarity.then(|| {
+        let out = target_out_paths(out_root, CLARITY_MARF_REL);
+        squash_and_copy_one(SquashJob {
+            label: "clarity",
+            source: &paths.clarity,
+            out: &out,
+            tip: stacks_tip,
+            squash_height: stacks_height,
+            side_table_mode: SideTableMode::Clarity,
+            open_opts: read_marf_open_opts(&paths.clarity.db),
+        });
+        out
+    });
+
+    let index_out = plan.index.then(|| {
+        let out = target_out_paths(out_root, INDEX_DB_REL);
+        squash_and_copy_one(SquashJob {
+            label: "index",
+            source: &paths.index,
+            out: &out,
+            tip: stacks_tip,
+            squash_height: stacks_height,
+            side_table_mode: SideTableMode::Index {
+                first_bitcoin_height: targets.first_bitcoin_height,
+                reward_cycle_len: pox.reward_cycle_length,
+            },
+            open_opts: read_marf_open_opts(&paths.index.db),
+        });
+        out
+    });
+
+    let sortition_out = plan.sortition.then(|| {
+        let out = target_out_paths(out_root, SORTITION_MARF_REL);
+        squash_and_copy_one(SquashJob {
+            label: "sortition",
+            source: &paths.sortition,
+            out: &out,
+            tip: sortition_tip,
+            squash_height: sortition_marf_height,
+            side_table_mode: SideTableMode::Sortition {
+                stacks_tip_boundary: sortition_tip_copy_boundary(targets),
+            },
+            open_opts: read_marf_open_opts(&paths.sortition.db),
+        });
+        out
+    });
+
+    SquashOutputs {
+        clarity: clarity_out,
+        index: index_out,
+        sortition: sortition_out,
+        sortition_marf_height,
+    }
+}
+
+/// Phase 2: copy canonical block data (epoch-2 microblocks, epoch-2 block files,
+/// nakamoto staging blocks) into the squashed index. `index_out` is the squashed
+/// index produced by [`squash_marfs`]. Exits on any copy failure.
+fn copy_blocks(
+    args: &SquashArgs,
+    out_root: &Path,
+    paths: &ChainstatePaths,
+    index_out: &TargetPaths,
+) -> BlocksSection {
+    let src_blocks_dir = args.chainstate.join(BLOCKS_DIR_REL);
+    let dst_blocks_dir = out_root.join(BLOCKS_DIR_REL);
+    let src_nakamoto = args.chainstate.join(NAKAMOTO_DB_REL);
+    let dst_nakamoto = out_root.join(NAKAMOTO_DB_REL);
+
+    // Ensure destination blocks directory exists before any copy step.
+    std::fs::create_dir_all(&dst_blocks_dir).unwrap_or_else(|e| {
+        eprintln!(
+            "Failed to create blocks dir {}: {e}",
+            dst_blocks_dir.display()
+        );
+        std::process::exit(1);
+    });
+
+    let src_index_path = paths.index.db.to_str().unwrap();
+    let dst_index_path = index_out.db.to_str().unwrap();
+
+    let mblock_stats = copy_microblock_streams(src_index_path, dst_index_path, index_out);
+    let file_stats = copy_epoch2_files(dst_index_path, &src_blocks_dir, &dst_blocks_dir);
+    let nak_stats = copy_nakamoto_blocks(&src_nakamoto, &dst_nakamoto, dst_index_path, index_out);
+
+    BlocksSection {
+        epoch2x_files: file_stats.files_copied,
+        epoch2x_bytes: file_stats.total_bytes,
+        epoch2x_microblock_rows: mblock_stats.microblock_rows_copied,
+        epoch2x_microblock_bytes: mblock_stats.microblock_bytes_copied,
+        nakamoto_rows: nak_stats.rows_copied,
+        nakamoto_bytes: nak_stats.total_blob_bytes,
+    }
+}
+
+/// Copy confirmed epoch-2 microblock streams between the source and squashed
+/// index DBs. On failure, deletes the partial squashed index and exits.
+fn copy_microblock_streams(
+    src_index_path: &str,
+    dst_index_path: &str,
+    index_out: &TargetPaths,
+) -> Epoch2MicroblockCopyStats {
+    println!("Copying confirmed epoch-2 microblock streams...");
+    match copy_confirmed_epoch2_microblocks(src_index_path, dst_index_path) {
+        Ok(st) => {
+            println!(
+                "Microblock copy complete: streams_copied={}, streams_skipped={}, rows={}, bytes={}",
+                st.streams_copied,
+                st.streams_skipped,
+                st.microblock_rows_copied,
+                st.microblock_bytes_copied
+            );
+            st
+        }
+        Err(e) => die_with_cleanup(
+            &format!("Failed to copy microblock streams: {e:?}"),
+            &[&index_out.db],
+        ),
+    }
+}
+
+/// Copy epoch 2.x block files from `src_blocks_dir` to `dst_blocks_dir`,
+/// recording them against the squashed index. Exits on failure.
+fn copy_epoch2_files(
+    dst_index_path: &str,
+    src_blocks_dir: &Path,
+    dst_blocks_dir: &Path,
+) -> Epoch2BlockFileCopyStats {
+    println!("Copying epoch 2.x block files...");
+    match copy_epoch2_block_files(
+        dst_index_path,
+        src_blocks_dir.to_str().unwrap(),
+        dst_blocks_dir.to_str().unwrap(),
+    ) {
+        Ok(st) => {
+            println!(
+                "Epoch 2.x block files copied: files={}, bytes={}, genesis_skipped={}",
+                st.files_copied, st.total_bytes, st.genesis_skipped
+            );
+            st
+        }
+        Err(e) => {
+            eprintln!("Failed to copy epoch 2.x block files: {e:?}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Copy nakamoto staging blocks into the squashed nakamoto.sqlite, recording
+/// them against the squashed index. On failure, deletes the partial nakamoto DB
+/// and squashed index and exits.
+fn copy_nakamoto_blocks(
+    src_nakamoto: &Path,
+    dst_nakamoto: &Path,
+    dst_index_path: &str,
+    index_out: &TargetPaths,
+) -> NakamotoBlockCopyStats {
+    if !src_nakamoto.exists() {
+        eprintln!(
+            "Source nakamoto.sqlite not found at {}; required for --blocks",
+            src_nakamoto.display()
+        );
+        std::process::exit(1);
+    }
+    println!("Copying nakamoto staging blocks...");
+    match copy_nakamoto_staging_blocks(
+        src_nakamoto.to_str().unwrap(),
+        dst_nakamoto.to_str().unwrap(),
+        dst_index_path,
+    ) {
+        Ok(st) => {
+            println!(
+                "Nakamoto blocks copied: rows={}, blob_bytes={}",
+                st.rows_copied, st.total_blob_bytes
+            );
+            st
+        }
+        Err(e) => die_with_cleanup(
+            &format!("Failed to copy nakamoto staging blocks: {e:?}"),
+            &[dst_nakamoto, &index_out.db],
+        ),
+    }
+}
+
+/// Phase 3: copy the Bitcoin auxiliary files (burnchain.sqlite + headers.sqlite).
+fn copy_bitcoin_aux(args: &SquashArgs, out_root: &Path, squash_bitcoin_height: u32) {
+    let src_bc_db = args.chainstate.join(BURNCHAIN_DB_REL);
+    let dst_bc_db = out_root.join(BURNCHAIN_DB_REL);
+    let squashed_sort = out_root.join(SORTITION_MARF_REL);
+    let src_hdr = args.chainstate.join(HEADERS_DB_REL);
+    let dst_hdr = out_root.join(HEADERS_DB_REL);
+
+    copy_bitcoin_aux_files(BitcoinAuxFiles {
+        src_bc_db: &src_bc_db,
+        dst_bc_db: &dst_bc_db,
+        squashed_sort: &squashed_sort,
+        src_hdr: &src_hdr,
+        dst_hdr: &dst_hdr,
+        bitcoin_height: u64::from(squash_bitcoin_height),
+    });
+}
+
+/// Resolve the canonical squash targets from the source chainstate/sortition
+/// DBs, log the resolved boundary, and warn if it lands in the prepare phase.
+/// Exits on resolution failure.
+fn resolve_targets(
+    paths: &ChainstatePaths,
+    tenure_start_bitcoin_height: u32,
+    db_config: &DbConfig,
+    pox: &stackslib::burnchains::PoxConstants,
+) -> CanonicalSquashTargets {
+    // Derive chainstate root: paths.index.db = ".../chainstate/vm/index.sqlite"
+    let chainstate_root = paths
+        .index
+        .db
+        .parent() // .../chainstate/vm
+        .and_then(|p| p.parent()) // .../chainstate
+        .expect("cannot derive chainstate root from index path");
+
+    // Derive the sortition DB directory path (parent of marf.sqlite).
+    let sortition_db_dir = paths
+        .sortition
+        .db
+        .parent()
+        .expect("cannot derive sortition dir from sortition db path");
+
+    let targets = resolve_canonical_squash_targets(SquashTargetQuery {
+        chainstate_root: chainstate_root.to_str().unwrap(),
+        sortition_db_dir: sortition_db_dir.to_str().unwrap(),
+        tenure_start_bitcoin_height,
+        mainnet: db_config.mainnet,
+        chain_id: db_config.chain_id,
+        pox_constants: pox.clone(),
+    })
+    .unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(1);
+    });
+
+    eprintln!(
+        "Squash at tenure start Bitcoin height {tenure_start_bitcoin_height}, \
+         Stacks tenure-start anchor height {}, anchor tip {} \
+         (squash Bitcoin height {}, sortition MARF height {})",
+        targets.stacks_height,
+        targets.stacks_tip,
+        targets.squash_bitcoin_height,
+        targets.sortition_marf_height
+    );
+
+    // Prepare-phase warning.
+    warn_if_in_prepare_phase(
+        tenure_start_bitcoin_height,
+        pox,
+        targets.first_bitcoin_height,
+    );
+
+    targets
+}
+
+pub fn run_squash(args: SquashArgs) {
+    let plan = SquashPlan::from_args(&args);
+
+    let paths = chainstate_paths(&args.chainstate);
+    let tenure_start_bitcoin_height = args.tenure_start_bitcoin_height;
+    let db_config = read_db_config(&paths.index.db);
+
+    let out_root = prepare_output_dir(&args, db_config.mainnet);
+
+    let pox = build_pox_constants(db_config.mainnet, args.config.as_deref());
+
+    // A squashed snapshot is only usable from epoch 3.4 onwards.
+    enforce_minimum_tenure_height(
+        tenure_start_bitcoin_height,
+        db_config.mainnet,
+        args.config.as_deref(),
+    );
+
+    let targets = resolve_targets(&paths, tenure_start_bitcoin_height, &db_config, &pox);
+    let stacks_height = targets.stacks_height;
+    let squash_bitcoin_height = targets.squash_bitcoin_height;
+
+    // Phase 1: Squash & Copy
+    let outputs = squash_marfs(&plan, &paths, &out_root, &targets, &pox);
+
+    // Phase 2: Block preservation (the --blocks ⇒ --index dependency is enforced
+    // in SquashPlan::from_args).
+    let blocks_stats = plan.blocks.then(|| {
+        let i_out = outputs
+            .index
+            .as_ref()
+            .expect("--blocks requires --index; index_out must be set");
+        copy_blocks(&args, &out_root, &paths, i_out)
+    });
+
+    // Phase 3: Bitcoin auxiliary files (the --bitcoin ⇒ --sortition dependency is
+    // enforced in SquashPlan::from_args; --sortition provides the squashed
+    // sortition DB and burn heights).
+    if plan.bitcoin {
+        copy_bitcoin_aux(&args, &out_root, squash_bitcoin_height);
+    }
+
+    // Generate manifest only for a complete GSS (all MARFs + blocks + bitcoin aux).
+    if plan.is_full_gss() {
+        let sort_paths = outputs.sortition.unwrap();
+        generate_manifest(ManifestInputs {
+            out_dir: &out_root,
+            clarity_out: outputs.clarity.as_ref().unwrap(),
+            index_out: outputs.index.as_ref().unwrap(),
+            sortition_paths: &sort_paths,
+            stacks_height,
+            bitcoin_height: squash_bitcoin_height,
+            sortition_marf_height: outputs.sortition_marf_height,
+            expected_stacks_tip: &targets.stacks_tip,
+            expected_sortition_tip: &targets.sortition_canonical_tip,
+            blocks_section: blocks_stats.unwrap(),
+        });
+    }
+
+    eprintln!(
+        "Squash complete. Output: {}\n  \
+         - Boot: set the node's working_dir = \"{}\"",
+        out_root.display(),
+        args.out_dir.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use rstest::rstest;
+
+    use super::{SquashPlan, is_known_network, network_subdir};
+    use crate::cli::SquashArgs;
+
+    /// Build a `SquashArgs` from the target-flag tuple
+    /// `(clarity, index, sortition, blocks, bitcoin, all)`; the non-flag fields
+    /// are fixed placeholders.
+    fn args_with_flags(flags: (bool, bool, bool, bool, bool, bool)) -> SquashArgs {
+        let (clarity, index, sortition, blocks, bitcoin, all) = flags;
+        SquashArgs {
+            chainstate: PathBuf::from("/tmp/chainstate"),
+            out_dir: PathBuf::from("/tmp/out"),
+            tenure_start_bitcoin_height: 100,
+            clarity,
+            index,
+            sortition,
+            all,
+            blocks,
+            bitcoin,
+            config: None,
+        }
+    }
+
+    /// `from_args` over (input flags `clarity,index,sortition,blocks,bitcoin,all`)
+    /// → (expected plan fields `clarity,index,sortition,blocks,bitcoin`, full GSS).
+    /// Each case satisfies the `blocks ⇒ index` / `bitcoin ⇒ sortition`
+    /// dependencies, so none triggers the fail-fast exit.
+    #[rstest]
+    // --all selects everything (full GSS).
+    #[case((false, false, false, false, false, true), (true, true, true, true, true), true)]
+    // --index alone.
+    #[case((false, true, false, false, false, false), (false, true, false, false, false), false)]
+    // --clarity alone.
+    #[case((true, false, false, false, false, false), (true, false, false, false, false), false)]
+    // --blocks with --index and --bitcoin with --sortition both satisfy their deps.
+    #[case((false, true, true, true, true, false), (false, true, true, true, true), false)]
+    fn from_args_selection(
+        #[case] flags: (bool, bool, bool, bool, bool, bool),
+        #[case] expected: (bool, bool, bool, bool, bool),
+        #[case] is_full_gss: bool,
+    ) {
+        let plan = SquashPlan::from_args(&args_with_flags(flags));
+        let (e_clarity, e_index, e_sortition, e_blocks, e_bitcoin) = expected;
+        assert_eq!(plan.clarity, e_clarity);
+        assert_eq!(plan.index, e_index);
+        assert_eq!(plan.sortition, e_sortition);
+        assert_eq!(plan.blocks, e_blocks);
+        assert_eq!(plan.bitcoin, e_bitcoin);
+        assert_eq!(plan.is_full_gss(), is_full_gss);
+    }
+
+    // The failure paths of `from_args` (no target selected; `--blocks` without
+    // `--index`; `--bitcoin` without `--sortition`) call `std::process::exit`,
+    // which would abort the test process. They are intentionally not exercised
+    // here: testing them would require introducing a `Result` error model purely
+    // for tests, which the crate deliberately avoids in favor of `eprintln!` +
+    // `exit`. The passing selection cases above cover the field wiring.
+
+    /// `network_subdir` over (mainnet, source path) → expected `Ok(subdir)` or an
+    /// `Err`. Mainnet is forced to `mainnet/` regardless of the path; a testnet
+    /// path mirrors its own last component (trailing slash stripped); an
+    /// undeterminable path, a `mainnet`-named non-mainnet path, and an unknown
+    /// network all error.
+    #[rstest]
+    // Mainnet is forced to `mainnet/`, regardless of the source path.
+    #[case(true, "/stacks/anything", Some("mainnet"))]
+    #[case(true, "/", Some("mainnet"))]
+    // Testnet mirrors its own subdir name.
+    #[case(false, "/stacks/krypton", Some("krypton"))]
+    // Trailing slash is stripped.
+    #[case(false, "/stacks/krypton/", Some("krypton"))]
+    // Undeterminable paths error.
+    #[case(false, "/", None)]
+    #[case(false, "..", None)]
+    // A testnet/regtest chainstate can never boot as mainnet.
+    #[case(false, "/stacks/mainnet", None)]
+    // An unrecognized network errors.
+    #[case(false, "/stacks/weirdnet", None)]
+    fn network_subdir_cases(
+        #[case] mainnet: bool,
+        #[case] path: &str,
+        #[case] expected: Option<&str>,
+    ) {
+        let result = network_subdir(mainnet, Path::new(path));
+        match expected {
+            Some(subdir) => assert_eq!(result.unwrap(), subdir),
+            None => assert!(result.is_err()),
+        }
+    }
+
+    #[test]
+    fn known_networks() {
+        assert!(is_known_network("krypton"));
+        assert!(is_known_network("mainnet"));
+        assert!(!is_known_network("weirdnet"));
+    }
+
+    #[test]
+    fn output_lands_under_network_subdir() {
+        use crate::layout::{CLARITY_MARF_REL, INDEX_DB_REL, target_out_paths};
+
+        // The layout contract: `--out-dir` is the working_dir, and the squash
+        // targets land at `<out-dir>/<network>/...`.
+        let out_dir = Path::new("/tmp/out");
+
+        // Testnet: the source subdir is mirrored.
+        let subdir = network_subdir(false, Path::new("/data/krypton")).unwrap();
+        let out_root = out_dir.join(subdir);
+        let tp = target_out_paths(&out_root, CLARITY_MARF_REL);
+        assert_eq!(
+            tp.db.to_str().unwrap(),
+            "/tmp/out/krypton/chainstate/vm/clarity/marf.sqlite"
+        );
+
+        // Mainnet is forced into `mainnet/` regardless of the source path.
+        let mainnet_root = out_dir.join(network_subdir(true, Path::new("/data/x")).unwrap());
+        let tp_m = target_out_paths(&mainnet_root, INDEX_DB_REL);
+        assert_eq!(
+            tp_m.db.to_str().unwrap(),
+            "/tmp/out/mainnet/chainstate/vm/index.sqlite"
+        );
+    }
+}

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -282,11 +282,11 @@ fn copy_blocks(
     });
 
     let src_index_path = paths.index.db.to_str().unwrap();
-    let dst_index_path = index_out.db.to_str().unwrap();
+    let squashed_index_path = index_out.db.to_str().unwrap();
 
-    let mblock_stats = copy_microblock_streams(src_index_path, dst_index_path);
-    let file_stats = copy_epoch2_files(dst_index_path, &src_blocks_dir, &dst_blocks_dir);
-    let nak_stats = copy_nakamoto_blocks(&src_nakamoto, &dst_nakamoto, dst_index_path);
+    let mblock_stats = copy_microblock_streams(src_index_path, squashed_index_path);
+    let file_stats = copy_epoch2_files(squashed_index_path, &src_blocks_dir, &dst_blocks_dir);
+    let nak_stats = copy_nakamoto_blocks(squashed_index_path, &src_nakamoto, &dst_nakamoto);
 
     BlocksSection {
         epoch2x_files: file_stats.files_copied,
@@ -302,10 +302,10 @@ fn copy_blocks(
 /// index DBs. Exits on failure, leaving the partial output in place for inspection.
 fn copy_microblock_streams(
     src_index_path: &str,
-    dst_index_path: &str,
+    squashed_index_path: &str,
 ) -> Epoch2MicroblockCopyStats {
     println!("Copying confirmed epoch-2 microblock streams...");
-    match copy_confirmed_epoch2_microblocks(src_index_path, dst_index_path) {
+    match copy_confirmed_epoch2_microblocks(src_index_path, squashed_index_path) {
         Ok(st) => {
             println!(
                 "Microblock copy complete: streams_copied={}, streams_skipped={}, rows={}, bytes={}",
@@ -326,13 +326,13 @@ fn copy_microblock_streams(
 /// Copy epoch 2.x block files from `src_blocks_dir` to `dst_blocks_dir`,
 /// recording them against the squashed index. Exits on failure.
 fn copy_epoch2_files(
-    dst_index_path: &str,
+    squashed_index_path: &str,
     src_blocks_dir: &Path,
     dst_blocks_dir: &Path,
 ) -> Epoch2BlockFileCopyStats {
     println!("Copying epoch 2.x block files...");
     match copy_epoch2_block_files(
-        dst_index_path,
+        squashed_index_path,
         src_blocks_dir.to_str().unwrap(),
         dst_blocks_dir.to_str().unwrap(),
     ) {
@@ -354,9 +354,9 @@ fn copy_epoch2_files(
 /// them against the squashed index. Exits on failure, leaving the partial output
 /// in place for inspection.
 fn copy_nakamoto_blocks(
+    squashed_index_path: &str,
     src_nakamoto: &Path,
     dst_nakamoto: &Path,
-    dst_index_path: &str,
 ) -> NakamotoBlockCopyStats {
     if !src_nakamoto.exists() {
         eprintln!(
@@ -367,9 +367,9 @@ fn copy_nakamoto_blocks(
     }
     println!("Copying nakamoto staging blocks...");
     match copy_nakamoto_staging_blocks(
+        squashed_index_path,
         src_nakamoto.to_str().unwrap(),
         dst_nakamoto.to_str().unwrap(),
-        dst_index_path,
     ) {
         Ok(st) => {
             println!(

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -465,8 +465,6 @@ pub fn run_squash(args: SquashArgs) {
     let tenure_start_bitcoin_height = args.tenure_start_bitcoin_height;
     let db_config = read_db_config(&paths.index.db);
 
-    let out_root = prepare_output_dir(&args, db_config.mainnet);
-
     let pox = build_pox_constants(db_config.mainnet, args.config.as_deref());
 
     // A squashed snapshot is only usable from epoch 3.4 onwards.
@@ -479,6 +477,8 @@ pub fn run_squash(args: SquashArgs) {
     let targets = resolve_targets(&paths, tenure_start_bitcoin_height, &db_config, &pox);
     let stacks_height = targets.stacks_height;
     let squash_bitcoin_height = targets.squash_bitcoin_height;
+
+    let out_root = prepare_output_dir(&args, db_config.mainnet);
 
     // Phase 1: Squash & Copy
     let outputs = squash_marfs(&plan, &paths, &out_root, &targets, &pox);

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -31,8 +31,7 @@ use crate::layout::{
 };
 use crate::manifest::{BlocksSection, ManifestInputs, generate_manifest};
 use crate::ops::{
-    BitcoinAuxFiles, SideTableMode, SquashJob, copy_bitcoin_aux_files, die_with_cleanup,
-    squash_and_copy_one,
+    BitcoinAuxFiles, SideTableMode, SquashJob, copy_bitcoin_aux_files, squash_and_copy_one,
 };
 use crate::targets::{CanonicalSquashTargets, SquashTargetQuery, resolve_canonical_squash_targets};
 
@@ -285,9 +284,9 @@ fn copy_blocks(
     let src_index_path = paths.index.db.to_str().unwrap();
     let dst_index_path = index_out.db.to_str().unwrap();
 
-    let mblock_stats = copy_microblock_streams(src_index_path, dst_index_path, index_out);
+    let mblock_stats = copy_microblock_streams(src_index_path, dst_index_path);
     let file_stats = copy_epoch2_files(dst_index_path, &src_blocks_dir, &dst_blocks_dir);
-    let nak_stats = copy_nakamoto_blocks(&src_nakamoto, &dst_nakamoto, dst_index_path, index_out);
+    let nak_stats = copy_nakamoto_blocks(&src_nakamoto, &dst_nakamoto, dst_index_path);
 
     BlocksSection {
         epoch2x_files: file_stats.files_copied,
@@ -300,11 +299,10 @@ fn copy_blocks(
 }
 
 /// Copy confirmed epoch-2 microblock streams between the source and squashed
-/// index DBs. On failure, deletes the partial squashed index and exits.
+/// index DBs. Exits on failure, leaving the partial output in place for inspection.
 fn copy_microblock_streams(
     src_index_path: &str,
     dst_index_path: &str,
-    index_out: &TargetPaths,
 ) -> Epoch2MicroblockCopyStats {
     println!("Copying confirmed epoch-2 microblock streams...");
     match copy_confirmed_epoch2_microblocks(src_index_path, dst_index_path) {
@@ -318,10 +316,10 @@ fn copy_microblock_streams(
             );
             st
         }
-        Err(e) => die_with_cleanup(
-            &format!("Failed to copy microblock streams: {e:?}"),
-            &[&index_out.db],
-        ),
+        Err(e) => {
+            eprintln!("Failed to copy microblock streams: {e:?}");
+            std::process::exit(1);
+        }
     }
 }
 
@@ -353,13 +351,12 @@ fn copy_epoch2_files(
 }
 
 /// Copy nakamoto staging blocks into the squashed nakamoto.sqlite, recording
-/// them against the squashed index. On failure, deletes the partial nakamoto DB
-/// and squashed index and exits.
+/// them against the squashed index. Exits on failure, leaving the partial output
+/// in place for inspection.
 fn copy_nakamoto_blocks(
     src_nakamoto: &Path,
     dst_nakamoto: &Path,
     dst_index_path: &str,
-    index_out: &TargetPaths,
 ) -> NakamotoBlockCopyStats {
     if !src_nakamoto.exists() {
         eprintln!(
@@ -381,10 +378,10 @@ fn copy_nakamoto_blocks(
             );
             st
         }
-        Err(e) => die_with_cleanup(
-            &format!("Failed to copy nakamoto staging blocks: {e:?}"),
-            &[dst_nakamoto, &index_out.db],
-        ),
+        Err(e) => {
+            eprintln!("Failed to copy nakamoto staging blocks: {e:?}");
+            std::process::exit(1);
+        }
     }
 }
 

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -49,6 +49,8 @@ pub struct SquashPlan {
 }
 
 impl SquashPlan {
+    /// Resolve the selected targets from the CLI flags, applying `--all` and
+    /// validating the selection. Exits on an empty or invalid flag combo.
     pub fn from_args(args: &SquashArgs) -> Self {
         let plan = SquashPlan {
             clarity: args.clarity || args.all,
@@ -454,6 +456,8 @@ fn resolve_targets(
     targets
 }
 
+/// Run the `squash` subcommand: resolve the boundary, squash the selected MARFs,
+/// copy block/Bitcoin data, and write the manifest for a full PCS. Exits on error.
 pub fn run_squash(args: SquashArgs) {
     let plan = SquashPlan::from_args(&args);
 

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -1,3 +1,18 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::path::{Path, PathBuf};
 
 use stackslib::chainstate::stacks::db::snapshot::{
@@ -48,7 +63,6 @@ impl SquashPlan {
             );
             std::process::exit(1);
         }
-        // Fail fast on invalid flag combos, before any output is created:
         // --blocks copies into the squashed index, --bitcoin needs the squashed
         // sortition DB.
         ensure_flag_requires("blocks", plan.blocks, "index", plan.index);
@@ -61,9 +75,9 @@ impl SquashPlan {
         self.clarity || self.index || self.sortition || self.blocks || self.bitcoin
     }
 
-    /// Whether this is a complete GSS (all three MARFs + blocks + bitcoin aux) --
+    /// Whether this is a complete PCS (all three MARFs + blocks + bitcoin aux) --
     /// the only case for which a manifest is written.
-    pub fn is_full_gss(&self) -> bool {
+    pub fn is_full_pcs(&self) -> bool {
         self.clarity && self.index && self.sortition && self.blocks && self.bitcoin
     }
 }
@@ -86,9 +100,7 @@ fn sortition_tip_copy_boundary(targets: &CanonicalSquashTargets) -> SortitionTip
     }
 }
 
-/// Network subdirectories marf-squash can target. A squash requires epoch 3.4
-/// (Nakamoto), so only the persistent Nakamoto networks qualify: mainnet and
-/// the krypton testnet.
+/// Network subdirectories marf-squash can target.
 const KNOWN_NETWORK_SUBDIRS: &[&str] = &["mainnet", "krypton"];
 
 fn is_known_network(subdir: &str) -> bool {
@@ -484,8 +496,8 @@ pub fn run_squash(args: SquashArgs) {
         copy_bitcoin_aux(&args, &out_root, squash_bitcoin_height);
     }
 
-    // Generate manifest only for a complete GSS (all MARFs + blocks + bitcoin aux).
-    if plan.is_full_gss() {
+    // Generate manifest only for a complete PCS (all MARFs + blocks + bitcoin aux).
+    if plan.is_full_pcs() {
         let sort_paths = outputs.sortition.unwrap();
         generate_manifest(ManifestInputs {
             out_dir: &out_root,
@@ -496,7 +508,7 @@ pub fn run_squash(args: SquashArgs) {
             bitcoin_height: squash_bitcoin_height,
             sortition_marf_height: outputs.sortition_marf_height,
             expected_stacks_tip: &targets.stacks_tip,
-            expected_sortition_tip: &targets.sortition_canonical_tip,
+            expected_sortition_tip: &targets.sortition_boundary_tip,
             blocks_section: blocks_stats.unwrap(),
         });
     }
@@ -538,11 +550,11 @@ mod tests {
     }
 
     /// `from_args` over (input flags `clarity,index,sortition,blocks,bitcoin,all`)
-    /// → (expected plan fields `clarity,index,sortition,blocks,bitcoin`, full GSS).
+    /// → (expected plan fields `clarity,index,sortition,blocks,bitcoin`, full PCS).
     /// Each case satisfies the `blocks ⇒ index` / `bitcoin ⇒ sortition`
     /// dependencies, so none triggers the fail-fast exit.
     #[rstest]
-    // --all selects everything (full GSS).
+    // --all selects everything (full PCS).
     #[case((false, false, false, false, false, true), (true, true, true, true, true), true)]
     // --index alone.
     #[case((false, true, false, false, false, false), (false, true, false, false, false), false)]
@@ -553,7 +565,7 @@ mod tests {
     fn from_args_selection(
         #[case] flags: (bool, bool, bool, bool, bool, bool),
         #[case] expected: (bool, bool, bool, bool, bool),
-        #[case] is_full_gss: bool,
+        #[case] is_full_pcs: bool,
     ) {
         let plan = SquashPlan::from_args(&args_with_flags(flags));
         let (e_clarity, e_index, e_sortition, e_blocks, e_bitcoin) = expected;
@@ -562,7 +574,7 @@ mod tests {
         assert_eq!(plan.sortition, e_sortition);
         assert_eq!(plan.blocks, e_blocks);
         assert_eq!(plan.bitcoin, e_bitcoin);
-        assert_eq!(plan.is_full_gss(), is_full_gss);
+        assert_eq!(plan.is_full_pcs(), is_full_pcs);
     }
 
     // The failure paths of `from_args` (no target selected; `--blocks` without

--- a/contrib/marf-squash/src/commands.rs
+++ b/contrib/marf-squash/src/commands.rs
@@ -404,8 +404,7 @@ fn copy_bitcoin_aux(args: &SquashArgs, out_root: &Path, squash_bitcoin_height: u
 }
 
 /// Resolve the canonical squash targets from the source chainstate/sortition
-/// DBs, log the resolved boundary, and warn if it lands in the prepare phase.
-/// Exits on resolution failure.
+/// DBs and log the resolved boundary. Exits on resolution failure.
 fn resolve_targets(
     paths: &ChainstatePaths,
     tenure_start_bitcoin_height: u32,

--- a/contrib/marf-squash/src/config.rs
+++ b/contrib/marf-squash/src/config.rs
@@ -1,3 +1,18 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //! Node-config loading: PoX constants, config-TOML overrides, and the
 //! minimum-tenure-height policy.
 

--- a/contrib/marf-squash/src/config.rs
+++ b/contrib/marf-squash/src/config.rs
@@ -22,20 +22,18 @@ use stacks_common::types::StacksEpochId;
 use stackslib::burnchains::PoxConstants;
 use stackslib::config::{Config, ConfigFile};
 
-/// On mainnet, Bitcoin height 943332 was a fast-block (no Stacks tenure
-/// started there), so the last tenure that belongs entirely to epoch 3.3
-/// is at height 943331. This is the minimum acceptable value for
-/// squash on mainnet.
-const MAINNET_MIN_TENURE_HEIGHT: u64 = 943_331;
+/// Mainnet minimum: the first tenure of epoch 3.4. 3.4 activated at Bitcoin height
+/// 943333, but that block had no sortition, so the first 3.4 tenure is 943334.
+const MAINNET_MIN_TENURE_HEIGHT: u64 = 943_334;
 
-/// Enforce that `bitcoin_height` is at least the last tenure of epoch 3.3.
+/// Enforce that `bitcoin_height` selects a tenure in epoch 3.4 or later.
 ///
-/// A squashed snapshot is only usable from epoch 3.4 onwards, so the
-/// selected tenure must be the last tenure of epoch 3.3 or later.
+/// A squashed snapshot is only usable from epoch 3.4 onwards, and the squash anchors
+/// at the selected tenure's first Nakamoto block, so that block must already be in
+/// epoch 3.4.
 ///
-/// * Mainnet: the minimum is [`MAINNET_MIN_TENURE_HEIGHT`]
-/// * non-mainnet: the minimum is `epoch_3.4_start_height - 1`, derived
-///   from the node config TOML.
+/// * Mainnet: [`MAINNET_MIN_TENURE_HEIGHT`].
+/// * non-mainnet: epoch 3.4's `start_height`, from the node config TOML.
 pub fn enforce_minimum_tenure_height(
     bitcoin_height: u32,
     mainnet: bool,
@@ -69,16 +67,24 @@ pub fn enforce_minimum_tenure_height(
             );
             std::process::exit(1);
         });
-        epoch_34.start_height - 1
+        if epoch_34.start_height == 0 {
+            eprintln!(
+                "Error: config '{}' defines epoch 3.4 starting at height 0; \
+                 a real network activates 3.4 well after genesis.",
+                config_path.display()
+            );
+            std::process::exit(1);
+        }
+        epoch_34.start_height
     };
 
     if bitcoin_height < min {
         eprintln!(
             "Error: --tenure-start-bitcoin-height {bitcoin_height} is below the minimum \
              acceptable height {min}.\n\
-             A squashed snapshot can only be used from epoch 3.4 onwards. The tenure at \
-             height {min} is the last tenure of epoch 3.3; its blocks are the last ones \
-             included before epoch 3.4 activates."
+             A squashed snapshot can only be used from epoch 3.4 onwards, and the squash \
+             anchors at the tenure's first Nakamoto block, so the tenure must start at or \
+             after the first tenure of epoch 3.4 (height {min})."
         );
         std::process::exit(1);
     }

--- a/contrib/marf-squash/src/config.rs
+++ b/contrib/marf-squash/src/config.rs
@@ -1,0 +1,132 @@
+//! Node-config loading: PoX constants, config-TOML overrides, and the
+//! minimum-tenure-height policy.
+
+use std::path::Path;
+
+use stacks_common::types::StacksEpochId;
+use stackslib::burnchains::PoxConstants;
+use stackslib::config::{Config, ConfigFile};
+
+/// On mainnet, Bitcoin height 943332 was a fast-block (no Stacks tenure
+/// started there), so the last tenure that belongs entirely to epoch 3.3
+/// is at height 943331. This is the minimum acceptable value for
+/// squash on mainnet.
+const MAINNET_MIN_TENURE_HEIGHT: u64 = 943_331;
+
+/// Enforce that `bitcoin_height` is at least the last tenure of epoch 3.3.
+///
+/// A squashed snapshot is only usable from epoch 3.4 onwards, so the
+/// selected tenure must be the last tenure of epoch 3.3 or later.
+///
+/// * Mainnet: the minimum is [`MAINNET_MIN_TENURE_HEIGHT`]
+/// * non-mainnet: the minimum is `epoch_3.4_start_height - 1`, derived
+///   from the node config TOML.
+pub fn enforce_minimum_tenure_height(
+    bitcoin_height: u32,
+    mainnet: bool,
+    config_path: Option<&Path>,
+) {
+    let bitcoin_height = u64::from(bitcoin_height);
+    let min = if mainnet {
+        MAINNET_MIN_TENURE_HEIGHT
+    } else {
+        let config_path = config_path
+            .expect("enforce_minimum_tenure_height called for non-mainnet without --config");
+        let config_file =
+            ConfigFile::from_path(config_path.to_str().unwrap()).unwrap_or_else(|e| {
+                eprintln!(
+                    "Failed to parse config file '{}': {e}",
+                    config_path.display()
+                );
+                std::process::exit(1);
+            });
+        let config = Config::from_config_file(config_file, false).unwrap_or_else(|e| {
+            eprintln!("Failed to load config '{}': {e}", config_path.display());
+            std::process::exit(1);
+        });
+        let epochs = config.burnchain.get_epoch_list();
+        let epoch_34 = epochs.get(StacksEpochId::Epoch34).unwrap_or_else(|| {
+            eprintln!(
+                "Error: config '{}' does not define epoch 3.4.\n\
+                 Epoch 3.4 activation height is required to validate \
+                 --tenure-start-bitcoin-height.",
+                config_path.display()
+            );
+            std::process::exit(1);
+        });
+        epoch_34.start_height - 1
+    };
+
+    if bitcoin_height < min {
+        eprintln!(
+            "Error: --tenure-start-bitcoin-height {bitcoin_height} is below the minimum \
+             acceptable height {min}.\n\
+             A squashed snapshot can only be used from epoch 3.4 onwards. The tenure at \
+             height {min} is the last tenure of epoch 3.3; its blocks are the last ones \
+             included before epoch 3.4 activates."
+        );
+        std::process::exit(1);
+    }
+}
+
+/// Build PoxConstants. For mainnet the built-in constants are canonical.
+/// For any other network, the node config TOML is required because each
+/// testnet has its own PoX parameters.
+pub fn build_pox_constants(mainnet: bool, config_path: Option<&Path>) -> PoxConstants {
+    if mainnet {
+        let mut pox = PoxConstants::mainnet_default();
+        if let Some(p) = config_path {
+            apply_config_overrides(p, &mut pox);
+        }
+        pox
+    } else {
+        let config_path = config_path.unwrap_or_else(|| {
+            eprintln!(
+                "Error: --config is required for non-mainnet networks.\n\
+                 Each testnet has its own PoX parameters (reward cycle length, \
+                 prepare phase length, etc.) that cannot be inferred from the \
+                 database. Pass the node config TOML with --config."
+            );
+            std::process::exit(1);
+        });
+        // Start from nakamoto_testnet_default as a baseline, then apply
+        // overrides from the config file.
+        let mut pox = PoxConstants::nakamoto_testnet_default();
+        apply_config_overrides(config_path, &mut pox);
+        pox
+    }
+}
+
+/// Apply PoX overrides from a node config TOML file to the given PoxConstants.
+/// Reads the [burnchain] section and applies any pox_reward_length,
+/// pox_prepare_length, sunset_start, and sunset_end overrides.
+pub fn apply_config_overrides(config_path: &Path, pox: &mut PoxConstants) {
+    let config = ConfigFile::from_path(config_path.to_str().unwrap()).unwrap_or_else(|e| {
+        eprintln!(
+            "Failed to parse config file '{}': {e}",
+            config_path.display()
+        );
+        std::process::exit(1);
+    });
+    let bc = match config.burnchain {
+        Some(bc) => bc,
+        None => return,
+    };
+    if let Some(v) = bc.pox_reward_length {
+        eprintln!("Config override: pox_reward_length = {v}");
+        pox.reward_cycle_length = v;
+    }
+    if let Some(v) = bc.pox_prepare_length {
+        eprintln!("Config override: pox_prepare_length = {v}");
+        pox.prepare_length = v;
+    }
+    if let Some(v) = bc.sunset_start {
+        pox.sunset_start = v as u64;
+    }
+    if let Some(v) = bc.sunset_end {
+        pox.sunset_end = v as u64;
+    }
+    if let Some(v) = bc.pox_2_activation {
+        pox.v1_unlock_height = v;
+    }
+}

--- a/contrib/marf-squash/src/db.rs
+++ b/contrib/marf-squash/src/db.rs
@@ -40,7 +40,7 @@ pub struct DbConfig {
 
 /// Read the network identity from an open index-DB connection's `db_config`.
 pub fn read_db_config_from_conn(conn: &rusqlite::Connection) -> DbConfig {
-    let (mainnet_i, chain_id): (i64, i64) = conn
+    let (mainnet, chain_id): (bool, u32) = conn
         .query_row(
             "SELECT mainnet, chain_id FROM db_config LIMIT 1",
             [],
@@ -50,10 +50,7 @@ pub fn read_db_config_from_conn(conn: &rusqlite::Connection) -> DbConfig {
             eprintln!("Failed to read db_config: {e}");
             std::process::exit(1);
         });
-    DbConfig {
-        mainnet: mainnet_i != 0,
-        chain_id: chain_id as u32,
-    }
+    DbConfig { mainnet, chain_id }
 }
 
 /// Read the network identity from the index DB at `index_db_path` (read-only).

--- a/contrib/marf-squash/src/db.rs
+++ b/contrib/marf-squash/src/db.rs
@@ -1,0 +1,99 @@
+//! Source/output DB open-options and read helpers used during squash.
+
+use std::path::{Path, PathBuf};
+
+use stacks_common::types::chainstate::StacksBlockId;
+use stackslib::chainstate::stacks::index::marf::MARFOpenOpts;
+use stackslib::util_lib::db::sqlite_open;
+
+use crate::layout::epoch2_block_rel_path;
+
+/// Open-opts for read-only scanning a MARF during squash (deferred hashing, no
+/// cache). `external_blobs` is detected from the sidecar `.blobs`: present for
+/// Clarity/Index and squashed sortitions, absent for an archival sortition.
+pub fn read_marf_open_opts(db_path: &Path) -> MARFOpenOpts {
+    let mut open_opts = MARFOpenOpts::default();
+    open_opts.external_blobs = PathBuf::from(format!("{}.blobs", db_path.display())).exists();
+    open_opts
+}
+
+/// Assert that `blobs_path` is the `.blobs` sidecar of `db_path`. Exits on mismatch.
+pub fn ensure_blobs_match(db_path: &str, blobs_path: &str) {
+    let expected_blobs = PathBuf::from(format!("{db_path}.blobs"));
+    if expected_blobs != Path::new(blobs_path) {
+        eprintln!(
+            "Expected blobs path '{blobs_path}' to match '{}'",
+            expected_blobs.display()
+        );
+        std::process::exit(1);
+    }
+}
+
+/// Network identity read from a chainstate index DB's `db_config`.
+pub struct DbConfig {
+    pub mainnet: bool,
+    pub chain_id: u32,
+}
+
+/// Read the network identity from an open index-DB connection's `db_config`.
+pub fn read_db_config_from_conn(conn: &rusqlite::Connection) -> DbConfig {
+    let (mainnet_i, chain_id): (i64, i64) = conn
+        .query_row(
+            "SELECT mainnet, chain_id FROM db_config LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to read db_config: {e}");
+            std::process::exit(1);
+        });
+    DbConfig {
+        mainnet: mainnet_i != 0,
+        chain_id: chain_id as u32,
+    }
+}
+
+/// Read the network identity from the index DB at `index_db_path` (read-only).
+pub fn read_db_config(index_db_path: &Path) -> DbConfig {
+    // Read-only: never touch or create files on the source chainstate.
+    let conn = sqlite_open(
+        index_db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        false,
+    )
+    .unwrap_or_else(|e| {
+        eprintln!(
+            "Failed to open index DB '{}' for db_config: {e}",
+            index_db_path.display()
+        );
+        std::process::exit(1);
+    });
+    read_db_config_from_conn(&conn)
+}
+
+/// The expected relative paths of the canonical epoch-2.x block files, derived
+/// from the (squashed) index DB's `block_headers`.
+pub fn derive_expected_epoch2_block_rel_paths(
+    conn: &rusqlite::Connection,
+) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare("SELECT index_block_hash, block_height FROM block_headers ORDER BY block_height")
+        .map_err(|e| format!("prepare block_headers query: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, StacksBlockId>(0)?, row.get::<_, u64>(1)?))
+        })
+        .map_err(|e| format!("query block_headers: {e}"))?;
+
+    let mut rel_paths = Vec::new();
+    for row in rows {
+        let (index_block_hash, block_height) =
+            row.map_err(|e| format!("read block_headers row: {e}"))?;
+        if block_height == 0 {
+            continue;
+        }
+        rel_paths.push(epoch2_block_rel_path(&index_block_hash));
+    }
+
+    Ok(rel_paths)
+}

--- a/contrib/marf-squash/src/db.rs
+++ b/contrib/marf-squash/src/db.rs
@@ -76,22 +76,20 @@ pub fn read_db_config(index_db_path: &Path) -> DbConfig {
 pub fn derive_expected_epoch2_block_rel_paths(
     conn: &rusqlite::Connection,
 ) -> Result<Vec<String>, String> {
+    // Skip the genesis boot block: it has no on-disk epoch-2.x block file.
     let mut stmt = conn
-        .prepare("SELECT index_block_hash, block_height FROM block_headers ORDER BY block_height")
+        .prepare(
+            "SELECT index_block_hash FROM block_headers WHERE block_height > 0 \
+             ORDER BY block_height",
+        )
         .map_err(|e| format!("prepare block_headers query: {e}"))?;
     let rows = stmt
-        .query_map([], |row| {
-            Ok((row.get::<_, StacksBlockId>(0)?, row.get::<_, u64>(1)?))
-        })
+        .query_map([], |row| row.get::<_, StacksBlockId>(0))
         .map_err(|e| format!("query block_headers: {e}"))?;
 
     let mut rel_paths = Vec::new();
     for row in rows {
-        let (index_block_hash, block_height) =
-            row.map_err(|e| format!("read block_headers row: {e}"))?;
-        if block_height == 0 {
-            continue;
-        }
+        let index_block_hash = row.map_err(|e| format!("read block_headers row: {e}"))?;
         rel_paths.push(epoch2_block_rel_path(&index_block_hash));
     }
 

--- a/contrib/marf-squash/src/db.rs
+++ b/contrib/marf-squash/src/db.rs
@@ -17,18 +17,6 @@ pub fn read_marf_open_opts(db_path: &Path) -> MARFOpenOpts {
     open_opts
 }
 
-/// Assert that `blobs_path` is the `.blobs` sidecar of `db_path`. Exits on mismatch.
-pub fn ensure_blobs_match(db_path: &str, blobs_path: &str) {
-    let expected_blobs = PathBuf::from(format!("{db_path}.blobs"));
-    if expected_blobs != Path::new(blobs_path) {
-        eprintln!(
-            "Expected blobs path '{blobs_path}' to match '{}'",
-            expected_blobs.display()
-        );
-        std::process::exit(1);
-    }
-}
-
 /// Network identity read from a chainstate index DB's `db_config`.
 pub struct DbConfig {
     pub mainnet: bool,

--- a/contrib/marf-squash/src/db.rs
+++ b/contrib/marf-squash/src/db.rs
@@ -1,3 +1,18 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //! Source/output DB open-options and read helpers used during squash.
 
 use std::path::{Path, PathBuf};

--- a/contrib/marf-squash/src/layout.rs
+++ b/contrib/marf-squash/src/layout.rs
@@ -1,4 +1,19 @@
-//! Single source of truth for the GSS on-disk layout: the relative paths of the
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Single source of truth for the PCS on-disk layout: the relative paths of the
 //! databases and directories within a chainstate / squashed-output tree, the
 //! manifest file name, and helpers to derive per-target paths.
 
@@ -23,7 +38,7 @@ pub const BLOCKS_DIR_REL: &str = "chainstate/blocks";
 pub const NAKAMOTO_DB_REL: &str = "chainstate/blocks/nakamoto.sqlite";
 
 /// Manifest file name.
-pub const GSS_MANIFEST: &str = "GSS_manifest.toml";
+pub const PCS_MANIFEST: &str = "PCS_manifest.toml";
 
 /// File extensions that indicate SQLite sidecars (WAL, SHM, journal).
 pub const SQLITE_SIDECAR_EXTENSIONS: &[&str] = &["sqlite-wal", "sqlite-shm", "sqlite-journal"];

--- a/contrib/marf-squash/src/layout.rs
+++ b/contrib/marf-squash/src/layout.rs
@@ -20,7 +20,7 @@
 use std::path::{Path, PathBuf};
 
 use stacks_common::types::chainstate::StacksBlockId;
-use stacks_common::util::hash::to_hex;
+use stackslib::chainstate::stacks::db::StacksChainState;
 
 /// Relative path of the Clarity MARF within a chainstate tree.
 pub const CLARITY_MARF_REL: &str = "chainstate/vm/clarity/marf.sqlite";
@@ -80,15 +80,20 @@ pub fn chainstate_paths(root: &Path) -> ChainstatePaths {
     }
 }
 
-/// Relative path of an epoch-2.x block file, sharded by the first two bytes of
-/// its index block hash.
+/// A relative path as a `/`-separated string. Normalizes Windows `\` so manifest
+/// entries and checksum keys match across host OSes (no-op on POSIX).
+pub fn canonical_rel_path(rel: &Path) -> String {
+    rel.to_string_lossy().replace('\\', "/")
+}
+
+/// Relative path of an epoch-2.x block file: the blocks dir followed by the
+/// node's own index-hash sharding ([`StacksChainState::index_block_hash_to_rel_path`]).
 pub fn epoch2_block_rel_path(index_block_hash: &StacksBlockId) -> String {
-    let block_hash_bytes = index_block_hash.as_bytes();
     format!(
-        "{BLOCKS_DIR_REL}/{}/{}/{}",
-        to_hex(&block_hash_bytes[0..2]),
-        to_hex(&block_hash_bytes[2..4]),
-        index_block_hash
+        "{BLOCKS_DIR_REL}/{}",
+        canonical_rel_path(&StacksChainState::index_block_hash_to_rel_path(
+            index_block_hash
+        ))
     )
 }
 

--- a/contrib/marf-squash/src/layout.rs
+++ b/contrib/marf-squash/src/layout.rs
@@ -1,0 +1,152 @@
+//! Single source of truth for the GSS on-disk layout: the relative paths of the
+//! databases and directories within a chainstate / squashed-output tree, the
+//! manifest file name, and helpers to derive per-target paths.
+
+use std::path::{Path, PathBuf};
+
+use stacks_common::types::chainstate::StacksBlockId;
+use stacks_common::util::hash::to_hex;
+
+/// Relative path of the Clarity MARF within a chainstate tree.
+pub const CLARITY_MARF_REL: &str = "chainstate/vm/clarity/marf.sqlite";
+/// Relative path of the Index MARF.
+pub const INDEX_DB_REL: &str = "chainstate/vm/index.sqlite";
+/// Relative path of the Sortition MARF.
+pub const SORTITION_MARF_REL: &str = "burnchain/sortition/marf.sqlite";
+/// Relative path of the burnchain DB.
+pub const BURNCHAIN_DB_REL: &str = "burnchain/burnchain.sqlite";
+/// Relative path of the SPV headers DB.
+pub const HEADERS_DB_REL: &str = "headers.sqlite";
+/// Relative path of the blocks directory.
+pub const BLOCKS_DIR_REL: &str = "chainstate/blocks";
+/// Relative path of the Nakamoto staging DB.
+pub const NAKAMOTO_DB_REL: &str = "chainstate/blocks/nakamoto.sqlite";
+
+/// Manifest file name.
+pub const GSS_MANIFEST: &str = "GSS_manifest.toml";
+
+/// File extensions that indicate SQLite sidecars (WAL, SHM, journal).
+pub const SQLITE_SIDECAR_EXTENSIONS: &[&str] = &["sqlite-wal", "sqlite-shm", "sqlite-journal"];
+
+/// A MARF database plus its optional external `.blobs` sidecar.
+#[derive(Debug, Clone)]
+pub struct TargetPaths {
+    pub db: PathBuf,
+    pub blobs: Option<PathBuf>,
+}
+
+/// The three source MARFs within a chainstate tree.
+#[derive(Debug, Clone)]
+pub struct ChainstatePaths {
+    pub clarity: TargetPaths,
+    pub index: TargetPaths,
+    pub sortition: TargetPaths,
+}
+
+/// Derive the source MARF paths from a chainstate root.
+pub fn chainstate_paths(root: &Path) -> ChainstatePaths {
+    let clarity_db = root.join(CLARITY_MARF_REL);
+    let index_db = root.join(INDEX_DB_REL);
+    let sortition_db = root.join(SORTITION_MARF_REL);
+    let sortition_blobs = PathBuf::from(format!("{}.blobs", sortition_db.display()));
+    ChainstatePaths {
+        clarity: TargetPaths {
+            blobs: Some(PathBuf::from(format!("{}.blobs", clarity_db.display()))),
+            db: clarity_db,
+        },
+        index: TargetPaths {
+            blobs: Some(PathBuf::from(format!("{}.blobs", index_db.display()))),
+            db: index_db,
+        },
+        sortition: TargetPaths {
+            blobs: sortition_blobs.exists().then_some(sortition_blobs),
+            db: sortition_db,
+        },
+    }
+}
+
+/// Relative path of an epoch-2.x block file, sharded by the first two bytes of
+/// its index block hash.
+pub fn epoch2_block_rel_path(index_block_hash: &StacksBlockId) -> String {
+    let block_hash_bytes = index_block_hash.as_bytes();
+    format!(
+        "{BLOCKS_DIR_REL}/{}/{}/{}",
+        to_hex(&block_hash_bytes[0..2]),
+        to_hex(&block_hash_bytes[2..4]),
+        index_block_hash
+    )
+}
+
+/// Output paths for a target MARF: `out_dir` joined with the target's canonical
+/// relative path (one of [`CLARITY_MARF_REL`], [`INDEX_DB_REL`],
+/// [`SORTITION_MARF_REL`]), plus its derived `.blobs` sidecar. The output layout
+/// is fixed by the layout consts and does not depend on the source path's shape.
+pub fn target_out_paths(out_dir: &Path, rel: &str) -> TargetPaths {
+    let out_db = out_dir.join(rel);
+    TargetPaths {
+        blobs: Some(PathBuf::from(format!("{}.blobs", out_db.display()))),
+        db: out_db,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use rstest::rstest;
+
+    use super::{CLARITY_MARF_REL, INDEX_DB_REL, SORTITION_MARF_REL, target_out_paths};
+
+    /// `target_out_paths` over (`out_dir`, rel-const) → expected `(db, blobs)`
+    /// output paths. The output is always `out_dir.join(rel)` plus its `.blobs`
+    /// sidecar, fixed by the layout consts.
+    ///
+    /// The last two cases are the regression for a nested `chainstate`/`burnchain`
+    /// component in the `out_dir` itself (e.g. `…/chainstate/mainnet`): the
+    /// previous component-scan derived the output from the source path's shape and
+    /// would mis-map such a tree, whereas the output now depends solely on
+    /// `out_dir` + the const.
+    #[rstest]
+    #[case(
+        "/tmp/out/mainnet",
+        CLARITY_MARF_REL,
+        "/tmp/out/mainnet/chainstate/vm/clarity/marf.sqlite",
+        "/tmp/out/mainnet/chainstate/vm/clarity/marf.sqlite.blobs"
+    )]
+    #[case(
+        "/tmp/out/mainnet",
+        INDEX_DB_REL,
+        "/tmp/out/mainnet/chainstate/vm/index.sqlite",
+        "/tmp/out/mainnet/chainstate/vm/index.sqlite.blobs"
+    )]
+    #[case(
+        "/tmp/out/mainnet",
+        SORTITION_MARF_REL,
+        "/tmp/out/mainnet/burnchain/sortition/marf.sqlite",
+        "/tmp/out/mainnet/burnchain/sortition/marf.sqlite.blobs"
+    )]
+    // Regression: a nested `chainstate` component in `out_dir` does not perturb
+    // the destination layout.
+    #[case(
+        "/data/chainstate/mainnet/chainstate/mainnet",
+        INDEX_DB_REL,
+        "/data/chainstate/mainnet/chainstate/mainnet/chainstate/vm/index.sqlite",
+        "/data/chainstate/mainnet/chainstate/mainnet/chainstate/vm/index.sqlite.blobs"
+    )]
+    #[case(
+        "/data/burnchain/krypton/burnchain/krypton",
+        SORTITION_MARF_REL,
+        "/data/burnchain/krypton/burnchain/krypton/burnchain/sortition/marf.sqlite",
+        "/data/burnchain/krypton/burnchain/krypton/burnchain/sortition/marf.sqlite.blobs"
+    )]
+    fn target_out_paths_uses_layout_consts(
+        #[case] out_dir: &str,
+        #[case] rel: &str,
+        #[case] expected_db: &str,
+        #[case] expected_blobs: &str,
+    ) {
+        let tp = target_out_paths(Path::new(out_dir), rel);
+        assert_eq!(tp.db.to_str().unwrap(), expected_db);
+        assert_eq!(tp.blobs.unwrap().to_str().unwrap(), expected_blobs);
+    }
+}

--- a/contrib/marf-squash/src/main.rs
+++ b/contrib/marf-squash/src/main.rs
@@ -1,0 +1,158 @@
+mod checksums;
+mod cli;
+mod commands;
+mod config;
+mod db;
+mod layout;
+mod manifest;
+mod ops;
+mod targets;
+
+use clap::Parser;
+use cli::{Cli, Command};
+use commands::run_squash;
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Squash(args) => run_squash(args),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use clap::Parser;
+    use rstest::rstest;
+
+    use crate::checksums::{compute_checksums, sha256_file};
+    use crate::cli::{Cli, Command};
+    use crate::layout::GSS_MANIFEST;
+
+    //  Helpers
+
+    fn create_test_gss_dir(dir: &std::path::Path, files: &[&str]) {
+        for f in files {
+            let path = dir.join(f);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&path, format!("content of {f}")).unwrap();
+        }
+    }
+
+    //  CLI parsing
+
+    /// Parse `squash` argv over (selected target flag) → expected
+    /// `(clarity, index, sortition)` flag values. `--chainstate`,
+    /// `--tenure-start-bitcoin-height`, and `--out-dir` are fixed and asserted in
+    /// every case.
+    #[rstest]
+    #[case("--index", (false, true, false))]
+    #[case("--sortition", (false, false, true))]
+    fn test_parse_squash_args(#[case] target_flag: &str, #[case] expected: (bool, bool, bool)) {
+        let args = vec![
+            "marf-squash",
+            "squash",
+            "--chainstate",
+            "/tmp/chainstate",
+            "--tenure-start-bitcoin-height",
+            "869704",
+            "--out-dir",
+            "/tmp/out",
+            target_flag,
+        ]
+        .into_iter()
+        .map(String::from);
+
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Command::Squash(args) => {
+                assert_eq!(args.chainstate, PathBuf::from("/tmp/chainstate"));
+                assert_eq!(args.tenure_start_bitcoin_height, 869704);
+                let (clarity, index, sortition) = expected;
+                assert_eq!(args.clarity, clarity);
+                assert_eq!(args.index, index);
+                assert_eq!(args.sortition, sortition);
+            }
+        }
+    }
+
+    //  compute_checksums / collect_files_recursive
+
+    #[test]
+    fn test_compute_checksums_clean_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        create_test_gss_dir(dir, &["a.sqlite", "sub/b.sqlite"]);
+        std::fs::write(dir.join(GSS_MANIFEST), "dummy").unwrap();
+
+        let checksums = compute_checksums(dir, None, None).unwrap();
+        assert_eq!(checksums.len(), 2);
+        assert!(checksums.contains_key("a.sqlite"));
+        assert!(checksums.contains_key("sub/b.sqlite"));
+        let expected = sha256_file(&dir.join("a.sqlite")).unwrap();
+        assert_eq!(checksums["a.sqlite"], expected);
+    }
+
+    #[test]
+    fn test_compute_checksums_ignores_sqlite_sidecars() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        create_test_gss_dir(dir, &["a.sqlite", "a.sqlite-wal"]);
+
+        let checksums = compute_checksums(dir, None, None).unwrap();
+        assert_eq!(checksums.len(), 1);
+        assert!(checksums.contains_key("a.sqlite"));
+    }
+
+    #[test]
+    fn test_manifest_rejects_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        create_test_gss_dir(dir, &["a.sqlite"]);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(dir.join("a.sqlite"), dir.join("link.sqlite")).unwrap();
+
+        #[cfg(unix)]
+        {
+            let result = compute_checksums(dir, None, None);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("symlink"));
+        }
+    }
+
+    #[test]
+    fn test_manifest_rejects_extra_file_in_outdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        create_test_gss_dir(dir, &["expected.sqlite", "stale.sqlite"]);
+
+        let mut expected = std::collections::HashSet::new();
+        expected.insert("expected.sqlite".to_string());
+
+        let result = compute_checksums(dir, Some(&expected), None);
+        let err = result.unwrap_err();
+        assert!(err.contains("unexpected file"), "got: {err}");
+        assert!(err.contains("stale.sqlite"), "got: {err}");
+    }
+
+    #[test]
+    fn test_compute_checksums_rejects_stale_block_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let blocks_dir = dir.join("chainstate/blocks/ab/cd");
+        std::fs::create_dir_all(&blocks_dir).unwrap();
+        std::fs::write(blocks_dir.join("legit_block"), "data").unwrap();
+        std::fs::write(blocks_dir.join("stale_block"), "old data").unwrap();
+
+        let mut expected = std::collections::HashSet::new();
+        expected.insert("chainstate/blocks/ab/cd/legit_block".to_string());
+
+        let result = compute_checksums(dir, Some(&expected), None);
+        let err = result.unwrap_err();
+        assert!(err.contains("unexpected file"), "got: {err}");
+        assert!(err.contains("stale_block"), "got: {err}");
+    }
+}

--- a/contrib/marf-squash/src/main.rs
+++ b/contrib/marf-squash/src/main.rs
@@ -1,3 +1,18 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 mod checksums;
 mod cli;
 mod commands;
@@ -28,11 +43,11 @@ mod tests {
 
     use crate::checksums::{compute_checksums, sha256_file};
     use crate::cli::{Cli, Command};
-    use crate::layout::GSS_MANIFEST;
+    use crate::layout::PCS_MANIFEST;
 
     //  Helpers
 
-    fn create_test_gss_dir(dir: &std::path::Path, files: &[&str]) {
+    fn create_test_pcs_dir(dir: &std::path::Path, files: &[&str]) {
         for f in files {
             let path = dir.join(f);
             if let Some(parent) = path.parent() {
@@ -85,8 +100,8 @@ mod tests {
     fn test_compute_checksums_clean_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        create_test_gss_dir(dir, &["a.sqlite", "sub/b.sqlite"]);
-        std::fs::write(dir.join(GSS_MANIFEST), "dummy").unwrap();
+        create_test_pcs_dir(dir, &["a.sqlite", "sub/b.sqlite"]);
+        std::fs::write(dir.join(PCS_MANIFEST), "dummy").unwrap();
 
         let checksums = compute_checksums(dir, None, None).unwrap();
         assert_eq!(checksums.len(), 2);
@@ -100,7 +115,7 @@ mod tests {
     fn test_compute_checksums_ignores_sqlite_sidecars() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        create_test_gss_dir(dir, &["a.sqlite", "a.sqlite-wal"]);
+        create_test_pcs_dir(dir, &["a.sqlite", "a.sqlite-wal"]);
 
         let checksums = compute_checksums(dir, None, None).unwrap();
         assert_eq!(checksums.len(), 1);
@@ -111,7 +126,7 @@ mod tests {
     fn test_manifest_rejects_symlinks() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        create_test_gss_dir(dir, &["a.sqlite"]);
+        create_test_pcs_dir(dir, &["a.sqlite"]);
         #[cfg(unix)]
         std::os::unix::fs::symlink(dir.join("a.sqlite"), dir.join("link.sqlite")).unwrap();
 
@@ -127,7 +142,7 @@ mod tests {
     fn test_manifest_rejects_extra_file_in_outdir() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        create_test_gss_dir(dir, &["expected.sqlite", "stale.sqlite"]);
+        create_test_pcs_dir(dir, &["expected.sqlite", "stale.sqlite"]);
 
         let mut expected = std::collections::HashSet::new();
         expected.insert("expected.sqlite".to_string());

--- a/contrib/marf-squash/src/manifest.rs
+++ b/contrib/marf-squash/src/manifest.rs
@@ -38,7 +38,10 @@ use crate::checksums::{compute_aggregate_checksum, compute_checksums};
 use crate::db::{
     DbConfig, derive_expected_epoch2_block_rel_paths, read_db_config_from_conn, read_marf_open_opts,
 };
-use crate::layout::{BURNCHAIN_DB_REL, HEADERS_DB_REL, NAKAMOTO_DB_REL, PCS_MANIFEST, TargetPaths};
+use crate::layout::{
+    BURNCHAIN_DB_REL, HEADERS_DB_REL, NAKAMOTO_DB_REL, PCS_MANIFEST, TargetPaths,
+    canonical_rel_path,
+};
 
 #[derive(Serialize, Deserialize)]
 pub struct SquashManifest {
@@ -159,7 +162,7 @@ pub fn read_squash_metadata<T: MarfTrieId + std::fmt::Display>(
 /// Insert the relative path of `abs_path` (relative to `base`) into `set`.
 fn insert_expected_rel(base: &Path, abs_path: &Path, set: &mut HashSet<String>) {
     if let Ok(rel) = abs_path.strip_prefix(base) {
-        set.insert(rel.to_string_lossy().replace('\\', "/"));
+        set.insert(canonical_rel_path(rel));
     }
 }
 

--- a/contrib/marf-squash/src/manifest.rs
+++ b/contrib/marf-squash/src/manifest.rs
@@ -1,0 +1,492 @@
+//! `GSS_manifest.toml` — its schema and writer. The manifest is the
+//! self-describing record of a Genesis State Snapshot: the three MARFs' squash
+//! root node hashes and archival root hashes, the block range, and SHA-256
+//! checksums (file-level for the fixed artifacts, one aggregate hash for the
+//! epoch-2 block archive).
+//!
+//! `squash` writes this for a full GSS (`--all`); nothing in this crate reads it
+//! back. It is the artifact format consumed by an external/offline verifier (a
+//! separate tool). The manifest is part of the untrusted artifact and is not
+//! itself authenticated.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use stacks_common::types::chainstate::{SortitionId, StacksBlockId};
+use stackslib::chainstate::stacks::index::marf::{MARF, MARFOpenOpts, MarfConnection};
+use stackslib::chainstate::stacks::index::{MarfTrieId, trie_sql};
+use stackslib::util_lib::db::sqlite_open;
+
+use crate::checksums::{compute_aggregate_checksum, compute_checksums};
+use crate::db::{
+    DbConfig, derive_expected_epoch2_block_rel_paths, read_db_config_from_conn, read_marf_open_opts,
+};
+use crate::layout::{BURNCHAIN_DB_REL, GSS_MANIFEST, HEADERS_DB_REL, NAKAMOTO_DB_REL, TargetPaths};
+
+#[derive(Serialize, Deserialize)]
+pub struct SquashManifest {
+    pub snapshot: SnapshotSection,
+    pub roots: RootsSection,
+    pub squash_roots: SquashRootsSection,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocks: Option<BlocksSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksums: Option<ChecksumsSection>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SnapshotSection {
+    pub version: u32,
+    pub stacks_height: u32,
+    pub bitcoin_height: u32,
+    pub block_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bitcoin_block_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    pub chain_id: u32,
+    pub mainnet: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RootsSection {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clarity_archival_marf_root_hash: Option<String>,
+    pub index_archival_marf_root_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sortition_archival_marf_root_hash: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SquashRootsSection {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clarity_squash_root_node_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_squash_root_node_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sortition_squash_root_node_hash: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlocksSection {
+    pub epoch2x_files: u64,
+    pub epoch2x_bytes: u64,
+    pub epoch2x_microblock_rows: u64,
+    pub epoch2x_microblock_bytes: u64,
+    pub nakamoto_rows: u64,
+    pub nakamoto_bytes: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ChecksumsSection {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epoch2_block_archive_hash: Option<String>,
+    pub files: BTreeMap<String, String>,
+}
+
+/// The inputs needed to write a GSS manifest: the three squashed MARF output
+/// paths, the resolved squash boundary (heights + the anchor tips the squash was
+/// resolved against), and the block-copy stats. Threaded through the manifest
+/// builders so each reads only the fields it needs.
+pub struct ManifestInputs<'a> {
+    pub out_dir: &'a Path,
+    pub clarity_out: &'a TargetPaths,
+    pub index_out: &'a TargetPaths,
+    pub sortition_paths: &'a TargetPaths,
+    pub stacks_height: u32,
+    pub bitcoin_height: u32,
+    pub sortition_marf_height: u32,
+    pub expected_stacks_tip: &'a StacksBlockId,
+    pub expected_sortition_tip: &'a SortitionId,
+    pub blocks_section: BlocksSection,
+}
+
+/// Squash metadata read from a just-squashed MARF DB.
+pub struct ReadSquashMetadata<T: MarfTrieId> {
+    pub tip: T,
+    pub archival_root_hash: String,
+    pub squash_root_node_hash: String,
+    pub squash_height: u32,
+}
+
+/// Read squash metadata from a just-squashed MARF DB.
+pub fn read_squash_metadata<T: MarfTrieId + std::fmt::Display>(
+    db_path: &str,
+    open_opts: MARFOpenOpts,
+) -> ReadSquashMetadata<T> {
+    let marf = MARF::<T>::from_path(db_path, open_opts).unwrap_or_else(|e| {
+        eprintln!("Failed to open squashed MARF for manifest: {e:?}");
+        std::process::exit(1);
+    });
+    let tip = trie_sql::get_latest_confirmed_block_hash(marf.sqlite_conn()).unwrap_or_else(|e| {
+        eprintln!("Failed to read latest block hash: {e:?}");
+        std::process::exit(1);
+    });
+    let info = trie_sql::read_squash_info(marf.sqlite_conn())
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to read squash info: {e:?}");
+            std::process::exit(1);
+        })
+        .unwrap_or_else(|| {
+            eprintln!("No squash info found in DB");
+            std::process::exit(1);
+        });
+    ReadSquashMetadata {
+        tip,
+        archival_root_hash: format!("0x{}", info.archival_marf_root_hash),
+        squash_root_node_hash: format!("0x{}", info.squash_root_node_hash),
+        squash_height: info.squash_height,
+    }
+}
+
+/// Insert the relative path of `abs_path` (relative to `base`) into `set`.
+fn insert_expected_rel(base: &Path, abs_path: &Path, set: &mut HashSet<String>) {
+    if let Ok(rel) = abs_path.strip_prefix(base) {
+        set.insert(rel.to_string_lossy().replace('\\', "/"));
+    }
+}
+
+/// Assert that a squashed DB stores the squash height the caller expected.
+/// Exits on mismatch.
+fn assert_squash_height(label: &str, actual: u32, expected: u32) {
+    if actual != expected {
+        eprintln!("Manifest error: {label} squash MARF height {actual} != expected {expected}");
+        std::process::exit(1);
+    }
+}
+
+/// Read the squashed sortition ID stored at `sortition_marf_height` in the
+/// squashed sortition DB's `marf_squashed_blocks` table. Exits on failure.
+fn read_sortition_id_at_height(conn: &rusqlite::Connection, sortition_marf_height: u32) -> String {
+    conn.query_row(
+        "SELECT lower(hex(block_hash)) FROM marf_squashed_blocks WHERE height = ?1",
+        [sortition_marf_height],
+        |row| row.get(0),
+    )
+    .unwrap_or_else(|e| {
+        eprintln!(
+            "Failed to read sortition ID at sortition MARF height {sortition_marf_height} from squashed sortition DB: {e}"
+        );
+        std::process::exit(1);
+    })
+}
+
+/// Convert a Unix timestamp to ISO-8601 UTC without an external crate.
+fn format_timestamp(unix_ts: i64) -> String {
+    const SECS_PER_DAY: i64 = 86400;
+    const SECS_PER_HOUR: i64 = 3600;
+    const SECS_PER_MIN: i64 = 60;
+
+    let days = unix_ts / SECS_PER_DAY;
+    let rem = unix_ts % SECS_PER_DAY;
+    let hour = rem / SECS_PER_HOUR;
+    let min = (rem % SECS_PER_HOUR) / SECS_PER_MIN;
+    let sec = rem % SECS_PER_MIN;
+
+    // Civil date from days since 1970-01-01 (algorithm from Howard Hinnant).
+    let z = days + 719468;
+    let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+/// Read the burn_header_timestamp for the snapshot at the squash height
+/// from the squashed sortition DB. Exits on failure.
+pub fn read_snapshot_timestamp(conn: &rusqlite::Connection, sortition_marf_height: u32) -> String {
+    let sort_id = read_sortition_id_at_height(conn, sortition_marf_height);
+    let ts: i64 = conn
+        .query_row(
+            "SELECT burn_header_timestamp FROM snapshots WHERE sortition_id = ?1",
+            [&sort_id],
+            |row| row.get(0),
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to read burn_header_timestamp for sortition_id {sort_id}: {e}");
+            std::process::exit(1);
+        });
+    format_timestamp(ts)
+}
+
+/// Assert that a squashed MARF's tip is the anchor the squash was resolved
+/// against, catching a cross-wired anchor. Exits on mismatch.
+fn assert_squash_tip<T: MarfTrieId + std::fmt::Display>(label: &str, actual: &T, expected: &T) {
+    if actual != expected {
+        eprintln!(
+            "Manifest error: {label} squash MARF tip {actual} != expected anchor tip {expected}"
+        );
+        std::process::exit(1);
+    }
+}
+
+/// Read squash metadata for the three MARFs, asserting their squash heights, that
+/// Clarity and Index squashed the same tip, and that the squashed Index/Clarity
+/// and sortition tips equal the resolved anchor tips (`expected_stacks_tip`,
+/// `expected_sortition_tip`). Returns `(clarity, index, sortition)`. Exits on any
+/// mismatch.
+#[allow(clippy::type_complexity)]
+fn read_all_marf_metadata(
+    inputs: &ManifestInputs,
+) -> (
+    ReadSquashMetadata<StacksBlockId>,
+    ReadSquashMetadata<StacksBlockId>,
+    ReadSquashMetadata<SortitionId>,
+) {
+    let index_meta = read_squash_metadata::<StacksBlockId>(
+        inputs.index_out.db.to_str().unwrap(),
+        read_marf_open_opts(&inputs.index_out.db),
+    );
+    assert_squash_height("Index", index_meta.squash_height, inputs.stacks_height);
+    assert_squash_tip("Index", &index_meta.tip, inputs.expected_stacks_tip);
+
+    let clarity_meta = read_squash_metadata::<StacksBlockId>(
+        inputs.clarity_out.db.to_str().unwrap(),
+        read_marf_open_opts(&inputs.clarity_out.db),
+    );
+    assert_squash_height("Clarity", clarity_meta.squash_height, inputs.stacks_height);
+    if clarity_meta.tip != index_meta.tip {
+        eprintln!(
+            "Manifest error: Clarity tip {} != Index tip {}",
+            clarity_meta.tip, index_meta.tip
+        );
+        std::process::exit(1);
+    }
+
+    let sortition_meta = read_squash_metadata::<SortitionId>(
+        inputs.sortition_paths.db.to_str().unwrap(),
+        read_marf_open_opts(&inputs.sortition_paths.db),
+    );
+    assert_squash_height(
+        "Sortition",
+        sortition_meta.squash_height,
+        inputs.sortition_marf_height,
+    );
+    assert_squash_tip(
+        "Sortition",
+        &sortition_meta.tip,
+        inputs.expected_sortition_tip,
+    );
+
+    (clarity_meta, index_meta, sortition_meta)
+}
+
+/// Read the boundary sortition's burn header hash, asserting it sits at
+/// `bitcoin_height` (a mismatch means the snapshot's `bitcoin_height` disagrees
+/// with the sortition MARF it squashed). Exits on mismatch.
+fn read_bitcoin_block_hash(
+    sortition_conn: &rusqlite::Connection,
+    sortition_marf_height: u32,
+    bitcoin_height: u32,
+) -> String {
+    let sort_id = read_sortition_id_at_height(sortition_conn, sortition_marf_height);
+    let (btc_hash, snapshot_burn_height): (String, i64) = sortition_conn
+        .query_row(
+            "SELECT burn_header_hash, block_height FROM snapshots WHERE sortition_id = ?1",
+            [&sort_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to read snapshot for sortition_id {sort_id}: {e}");
+            std::process::exit(1);
+        });
+    if snapshot_burn_height != i64::from(bitcoin_height) {
+        eprintln!(
+            "Manifest error: boundary sortition Bitcoin height {snapshot_burn_height} != manifest bitcoin_height {bitcoin_height}"
+        );
+        std::process::exit(1);
+    }
+    format!("0x{btc_hash}")
+}
+
+/// Assemble the manifest's `[snapshot]` section, reading `db_config`, the
+/// snapshot timestamp, and the boundary Bitcoin block hash from the squashed DBs.
+fn build_snapshot_section(
+    inputs: &ManifestInputs,
+    index_conn: &rusqlite::Connection,
+    sortition_conn: &rusqlite::Connection,
+    index_tip: &StacksBlockId,
+) -> SnapshotSection {
+    let DbConfig { mainnet, chain_id } = read_db_config_from_conn(index_conn);
+    let timestamp = Some(read_snapshot_timestamp(
+        sortition_conn,
+        inputs.sortition_marf_height,
+    ));
+    let bitcoin_block_hash = read_bitcoin_block_hash(
+        sortition_conn,
+        inputs.sortition_marf_height,
+        inputs.bitcoin_height,
+    );
+    SnapshotSection {
+        version: 1,
+        stacks_height: inputs.stacks_height,
+        bitcoin_height: inputs.bitcoin_height,
+        block_hash: format!("0x{index_tip}"),
+        bitcoin_block_hash: Some(bitcoin_block_hash),
+        timestamp,
+        chain_id,
+        mainnet,
+    }
+}
+
+/// The set of individually hashed output files (MARF dbs + blobs, bitcoin aux,
+/// `nakamoto.sqlite`), so that stale files in a reused out-dir are rejected
+/// rather than blessed into the manifest. Epoch-2 block files are covered by a
+/// single aggregate hash, not listed here.
+fn build_expected_files(
+    out_dir: &Path,
+    clarity_out: &TargetPaths,
+    index_out: &TargetPaths,
+    sortition_paths: &TargetPaths,
+) -> HashSet<String> {
+    let mut expected = HashSet::new();
+
+    // MARF databases + blobs.
+    insert_expected_rel(out_dir, &clarity_out.db, &mut expected);
+    if let Some(b) = &clarity_out.blobs {
+        insert_expected_rel(out_dir, b, &mut expected);
+    }
+    insert_expected_rel(out_dir, &index_out.db, &mut expected);
+    if let Some(b) = &index_out.blobs {
+        insert_expected_rel(out_dir, b, &mut expected);
+    }
+    insert_expected_rel(out_dir, &sortition_paths.db, &mut expected);
+    if let Some(b) = &sortition_paths.blobs {
+        insert_expected_rel(out_dir, b, &mut expected);
+    }
+
+    // Bitcoin auxiliary files + nakamoto.sqlite.
+    expected.insert(BURNCHAIN_DB_REL.to_string());
+    expected.insert(HEADERS_DB_REL.to_string());
+    expected.insert(NAKAMOTO_DB_REL.to_string());
+    expected
+}
+
+/// Assemble the manifest's `[checksums]` section: per-file SHA-256 over the
+/// `expected` set plus one aggregate hash over the epoch-2 block archive. Asserts
+/// the index's epoch-2 file count matches the copy's. Exits on any mismatch.
+fn build_checksums_section(
+    out_dir: &Path,
+    index_conn: &rusqlite::Connection,
+    expected: &HashSet<String>,
+    blocks_section: &BlocksSection,
+) -> ChecksumsSection {
+    let epoch2_block_rel_paths =
+        derive_expected_epoch2_block_rel_paths(index_conn).unwrap_or_else(|e| {
+            eprintln!("Failed to derive epoch-2 block files from index.sqlite: {e}");
+            std::process::exit(1);
+        });
+    if epoch2_block_rel_paths.len() as u64 != blocks_section.epoch2x_files {
+        eprintln!(
+            "Manifest error: index lists {} epoch-2 block files, but the copy reported {}",
+            epoch2_block_rel_paths.len(),
+            blocks_section.epoch2x_files
+        );
+        std::process::exit(1);
+    }
+
+    let skipped_epoch2: HashSet<String> = epoch2_block_rel_paths.iter().cloned().collect();
+    let files =
+        compute_checksums(out_dir, Some(expected), Some(&skipped_epoch2)).unwrap_or_else(|e| {
+            eprintln!("Failed to compute checksums: {e}");
+            std::process::exit(1);
+        });
+    let epoch2_block_archive_hash = compute_aggregate_checksum(out_dir, &epoch2_block_rel_paths)
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to compute epoch-2 block archive hash: {e}");
+            std::process::exit(1);
+        });
+    println!(
+        "Computed SHA-256 checksums for {} files plus one epoch-2 block archive hash",
+        files.len()
+    );
+    ChecksumsSection {
+        files,
+        epoch2_block_archive_hash: Some(epoch2_block_archive_hash),
+    }
+}
+
+/// Serialize `manifest` to TOML and write it to `<out_dir>/GSS_manifest.toml`.
+fn write_manifest_file(out_dir: &Path, manifest: &SquashManifest) {
+    let toml_str = toml::to_string(manifest).unwrap_or_else(|e| {
+        eprintln!("Failed to serialize manifest: {e}");
+        std::process::exit(1);
+    });
+    let manifest_path = out_dir.join(GSS_MANIFEST);
+    fs::write(&manifest_path, toml_str).unwrap_or_else(|e| {
+        eprintln!(
+            "Failed to write manifest to '{}': {e}",
+            manifest_path.display()
+        );
+        std::process::exit(1);
+    });
+    println!("Manifest written to {}", manifest_path.display());
+}
+
+/// Generate the GSS manifest. Only called for a complete GSS (all MARFs +
+/// blocks + bitcoin aux).
+pub fn generate_manifest(inputs: ManifestInputs) {
+    let (clarity_meta, index_meta, sortition_meta) = read_all_marf_metadata(&inputs);
+
+    // One read-only connection per squashed output DB, reused by all the
+    // metadata reads below.
+    let index_conn = sqlite_open(
+        &inputs.index_out.db,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        false,
+    )
+    .unwrap_or_else(|e| {
+        eprintln!("Failed to open squashed index DB: {e}");
+        std::process::exit(1);
+    });
+    let sortition_conn = sqlite_open(
+        &inputs.sortition_paths.db,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        false,
+    )
+    .unwrap_or_else(|e| {
+        eprintln!("Failed to open squashed sortition DB: {e}");
+        std::process::exit(1);
+    });
+
+    let snapshot = build_snapshot_section(&inputs, &index_conn, &sortition_conn, &index_meta.tip);
+
+    let expected = build_expected_files(
+        inputs.out_dir,
+        inputs.clarity_out,
+        inputs.index_out,
+        inputs.sortition_paths,
+    );
+    let checksums = build_checksums_section(
+        inputs.out_dir,
+        &index_conn,
+        &expected,
+        &inputs.blocks_section,
+    );
+
+    let manifest = SquashManifest {
+        snapshot,
+        roots: RootsSection {
+            clarity_archival_marf_root_hash: Some(clarity_meta.archival_root_hash),
+            index_archival_marf_root_hash: index_meta.archival_root_hash,
+            sortition_archival_marf_root_hash: Some(sortition_meta.archival_root_hash),
+        },
+        squash_roots: SquashRootsSection {
+            clarity_squash_root_node_hash: Some(clarity_meta.squash_root_node_hash),
+            index_squash_root_node_hash: Some(index_meta.squash_root_node_hash),
+            sortition_squash_root_node_hash: Some(sortition_meta.squash_root_node_hash),
+        },
+        blocks: Some(inputs.blocks_section),
+        checksums: Some(checksums),
+    };
+
+    write_manifest_file(inputs.out_dir, &manifest);
+}

--- a/contrib/marf-squash/src/manifest.rs
+++ b/contrib/marf-squash/src/manifest.rs
@@ -1,10 +1,25 @@
-//! `GSS_manifest.toml` — its schema and writer. The manifest is the
-//! self-describing record of a Genesis State Snapshot: the three MARFs' squash
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! `PCS_manifest.toml` - its schema and writer. The manifest is the
+//! self-describing record of a Pruned Chainstate Snapshot: the three MARFs' squash
 //! root node hashes and archival root hashes, the block range, and SHA-256
 //! checksums (file-level for the fixed artifacts, one aggregate hash for the
 //! epoch-2 block archive).
 //!
-//! `squash` writes this for a full GSS (`--all`); nothing in this crate reads it
+//! `squash` writes this for a full PCS (`--all`); nothing in this crate reads it
 //! back. It is the artifact format consumed by an external/offline verifier (a
 //! separate tool). The manifest is part of the untrusted artifact and is not
 //! itself authenticated.
@@ -23,7 +38,7 @@ use crate::checksums::{compute_aggregate_checksum, compute_checksums};
 use crate::db::{
     DbConfig, derive_expected_epoch2_block_rel_paths, read_db_config_from_conn, read_marf_open_opts,
 };
-use crate::layout::{BURNCHAIN_DB_REL, GSS_MANIFEST, HEADERS_DB_REL, NAKAMOTO_DB_REL, TargetPaths};
+use crate::layout::{BURNCHAIN_DB_REL, HEADERS_DB_REL, NAKAMOTO_DB_REL, PCS_MANIFEST, TargetPaths};
 
 #[derive(Serialize, Deserialize)]
 pub struct SquashManifest {
@@ -86,7 +101,7 @@ pub struct ChecksumsSection {
     pub files: BTreeMap<String, String>,
 }
 
-/// The inputs needed to write a GSS manifest: the three squashed MARF output
+/// The inputs needed to write a PCS manifest: the three squashed MARF output
 /// paths, the resolved squash boundary (heights + the anchor tips the squash was
 /// resolved against), and the block-copy stats. Threaded through the manifest
 /// builders so each reads only the fields it needs.
@@ -414,13 +429,13 @@ fn build_checksums_section(
     }
 }
 
-/// Serialize `manifest` to TOML and write it to `<out_dir>/GSS_manifest.toml`.
+/// Serialize `manifest` to TOML and write it to `<out_dir>/PCS_manifest.toml`.
 fn write_manifest_file(out_dir: &Path, manifest: &SquashManifest) {
     let toml_str = toml::to_string(manifest).unwrap_or_else(|e| {
         eprintln!("Failed to serialize manifest: {e}");
         std::process::exit(1);
     });
-    let manifest_path = out_dir.join(GSS_MANIFEST);
+    let manifest_path = out_dir.join(PCS_MANIFEST);
     fs::write(&manifest_path, toml_str).unwrap_or_else(|e| {
         eprintln!(
             "Failed to write manifest to '{}': {e}",
@@ -431,7 +446,7 @@ fn write_manifest_file(out_dir: &Path, manifest: &SquashManifest) {
     println!("Manifest written to {}", manifest_path.display());
 }
 
-/// Generate the GSS manifest. Only called for a complete GSS (all MARFs +
+/// Generate the PCS manifest. Only called for a complete PCS (all MARFs +
 /// blocks + bitcoin aux).
 pub fn generate_manifest(inputs: ManifestInputs) {
     let (clarity_meta, index_meta, sortition_meta) = read_all_marf_metadata(&inputs);

--- a/contrib/marf-squash/src/ops.rs
+++ b/contrib/marf-squash/src/ops.rs
@@ -1,3 +1,18 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::fs;
 use std::path::Path;
 

--- a/contrib/marf-squash/src/ops.rs
+++ b/contrib/marf-squash/src/ops.rs
@@ -1,0 +1,306 @@
+use std::fs;
+use std::path::Path;
+
+use stackslib::chainstate::stacks::db::snapshot::{
+    SortitionTipCopyBoundary, copy_burnchain_db, copy_clarity_side_tables, copy_index_side_tables,
+    copy_sortition_side_tables_with_boundary, copy_spv_headers,
+};
+use stackslib::chainstate::stacks::index::MarfTrieId;
+use stackslib::chainstate::stacks::index::marf::{MARF, MARFOpenOpts};
+
+use crate::db::ensure_blobs_match;
+use crate::layout::TargetPaths;
+
+/// Print `msg`, best-effort delete each path, then `exit(1)`. Needed because the
+/// offline-write helper runs with `journal_mode = OFF`: any mid-flight error
+/// leaves dst in an undefined state, so a clean re-run requires deleting it.
+pub fn die_with_cleanup(msg: &str, paths: &[&Path]) -> ! {
+    eprintln!("{msg}");
+    for p in paths {
+        let _ = fs::remove_file(p);
+    }
+    std::process::exit(1);
+}
+
+#[derive(Clone)]
+pub enum SideTableMode {
+    Clarity,
+    Index {
+        first_bitcoin_height: u32,
+        reward_cycle_len: u32,
+    },
+    Sortition {
+        stacks_tip_boundary: SortitionTipCopyBoundary,
+    },
+}
+
+/// The source and output endpoints of a single squash: the MARF being squashed
+/// and the MARF being written. The recurring pair the per-step helpers operate on.
+#[derive(Clone, Copy)]
+pub struct SquashIo<'a> {
+    pub source: &'a TargetPaths,
+    pub out: &'a TargetPaths,
+}
+
+/// One MARF squash job: the source/output paths, the boundary (`tip` +
+/// `squash_height`) to squash to, the side tables to copy, and the open-opts for
+/// the source DB.
+pub struct SquashJob<'a, T: MarfTrieId + Send + Sync> {
+    pub label: &'a str,
+    pub source: &'a TargetPaths,
+    pub out: &'a TargetPaths,
+    pub tip: &'a T,
+    pub squash_height: u32,
+    pub side_table_mode: SideTableMode,
+    pub open_opts: MARFOpenOpts,
+}
+
+/// Squash a single MARF target and copy its side tables. Exits on error.
+pub fn squash_and_copy_one<T: MarfTrieId + Send + Sync>(job: SquashJob<T>) {
+    let SquashJob {
+        label,
+        source,
+        out,
+        tip,
+        squash_height,
+        side_table_mode,
+        open_opts,
+    } = job;
+    let io = SquashIo { source, out };
+
+    if let Some(ref blobs) = source.blobs {
+        ensure_blobs_match(source.db.to_str().unwrap(), blobs.to_str().unwrap());
+    }
+
+    if let Some(parent) = out.db.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        eprintln!(
+            "Failed to create output directory '{}': {e}",
+            parent.display()
+        );
+        std::process::exit(1);
+    }
+
+    let stats = match MARF::squash_to_path(
+        source.db.to_str().unwrap(),
+        out.db.to_str().unwrap(),
+        open_opts,
+        tip,
+        squash_height,
+        label,
+    ) {
+        Ok(stats) => stats,
+        Err(e) => {
+            eprintln!("Failed to squash {label} MARF: {e:?}");
+            std::process::exit(1);
+        }
+    };
+
+    copy_side_tables(io, &side_table_mode);
+    report_size_savings(io, label, squash_height, stats.node_count);
+}
+
+/// Best-effort cleanup target for a failed copy: the output DB plus its `.blobs`
+/// sidecar when present (the offline-write helper can leave both inconsistent).
+fn cleanup_paths(out: &TargetPaths) -> Vec<&Path> {
+    match out.blobs.as_ref() {
+        Some(blobs) => vec![&out.db, blobs],
+        None => vec![&out.db],
+    }
+}
+
+/// Copy the side tables selected by `side_table_mode` from source into output.
+/// On any copy failure, deletes the partial output and exits.
+fn copy_side_tables(io: SquashIo, side_table_mode: &SideTableMode) {
+    match side_table_mode {
+        SideTableMode::Clarity => copy_clarity_tables(io),
+        SideTableMode::Index {
+            first_bitcoin_height,
+            reward_cycle_len,
+        } => copy_index_tables(io, *first_bitcoin_height, *reward_cycle_len),
+        SideTableMode::Sortition {
+            stacks_tip_boundary,
+        } => copy_sortition_tables(io, stacks_tip_boundary),
+    }
+}
+
+/// Copy the Clarity side tables; on failure, delete the partial output and exit.
+fn copy_clarity_tables(io: SquashIo) {
+    println!("Copying Clarity side tables...");
+    match copy_clarity_side_tables(io.source.db.to_str().unwrap(), io.out.db.to_str().unwrap()) {
+        Ok(st) => {
+            println!(
+                "Side-table copy complete: data_table={} rows, metadata_table={} rows",
+                st.data_table_rows, st.metadata_table_rows
+            );
+        }
+        Err(e) => die_with_cleanup(
+            &format!("Failed to copy Clarity side tables: {e:?}"),
+            &cleanup_paths(io.out),
+        ),
+    }
+}
+
+/// Copy the index side tables; on failure, delete the partial output and exit.
+fn copy_index_tables(io: SquashIo, first_bitcoin_height: u32, reward_cycle_len: u32) {
+    println!("Copying index side tables...");
+    match copy_index_side_tables(
+        io.source.db.to_str().unwrap(),
+        io.out.db.to_str().unwrap(),
+        u64::from(first_bitcoin_height),
+        u64::from(reward_cycle_len),
+    ) {
+        Ok(st) => {
+            println!(
+                "Index side-table copy complete: block_headers={}, nakamoto_headers={}, payments={}, transactions={}, tenure_events={}, reward_sets={}, signer_stats={}, matured_rewards={}, burnchain_txids={}, epoch_transitions={}, staging_blocks={}, fork_storage={}",
+                st.block_headers_rows,
+                st.nakamoto_block_headers_rows,
+                st.payments_rows,
+                st.transactions_rows,
+                st.nakamoto_tenure_events_rows,
+                st.nakamoto_reward_sets_rows,
+                st.signer_stats_rows,
+                st.matured_rewards_rows,
+                st.burnchain_txids_rows,
+                st.epoch_transitions_rows,
+                st.staging_blocks_rows,
+                st.fork_storage_rows
+            );
+        }
+        Err(e) => die_with_cleanup(
+            &format!("Failed to copy index side tables: {e:?}"),
+            &cleanup_paths(io.out),
+        ),
+    }
+}
+
+/// Copy the sortition side tables; on failure, delete the partial output and exit.
+fn copy_sortition_tables(io: SquashIo, stacks_tip_boundary: &SortitionTipCopyBoundary) {
+    println!("Copying sortition side tables...");
+    match copy_sortition_side_tables_with_boundary(
+        io.source.db.to_str().unwrap(),
+        io.out.db.to_str().unwrap(),
+        Some(stacks_tip_boundary),
+    ) {
+        Ok(st) => {
+            println!(
+                "Sortition side-table copy complete: snapshots={}, leader_keys={}, block_commits={}, epochs={}, fork_storage={}",
+                st.snapshots_rows,
+                st.leader_keys_rows,
+                st.block_commits_rows,
+                st.epochs_rows,
+                st.fork_storage_rows
+            );
+        }
+        Err(e) => die_with_cleanup(
+            &format!("Failed to copy sortition side tables: {e:?}"),
+            &cleanup_paths(io.out),
+        ),
+    }
+}
+
+/// Print the original-vs-squashed size summary and the squash stats.
+fn report_size_savings(io: SquashIo, label: &str, squash_height: u32, node_count: u64) {
+    let source = io.source;
+    let out = io.out;
+    let original_db_size = fs::metadata(&source.db).map(|m| m.len()).unwrap_or(0);
+    let original_blobs_size = source
+        .blobs
+        .as_ref()
+        .and_then(|b| fs::metadata(b).ok())
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let squashed_db_size = fs::metadata(&out.db).map(|m| m.len()).unwrap_or(0);
+    let squashed_blobs_size = out
+        .blobs
+        .as_ref()
+        .and_then(|b| fs::metadata(b).ok())
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    let original_total = original_db_size + original_blobs_size;
+    let squashed_total = squashed_db_size + squashed_blobs_size;
+    let savings = original_total.saturating_sub(squashed_total);
+    let savings_pct = if original_total == 0 {
+        0.0
+    } else {
+        (savings as f64 / original_total as f64) * 100.0
+    };
+
+    println!("Squash complete ({label}) at MARF height {squash_height}");
+    println!("Node count: {node_count}");
+    println!(
+        "Original: db={original_db_size} bytes, blobs={original_blobs_size} bytes, total={original_total} bytes"
+    );
+    println!(
+        "Squashed: db={squashed_db_size} bytes, blobs={squashed_blobs_size} bytes, total={squashed_total} bytes"
+    );
+    println!("Savings: {savings} bytes ({savings_pct:.2}%)");
+    println!("Output db: {}", out.db.display());
+    if let Some(ref blobs) = out.blobs {
+        println!("Output blobs: {}", blobs.display());
+    }
+}
+
+/// Source/destination paths for the Bitcoin auxiliary files plus the squashed
+/// sortition DB and the boundary Bitcoin height, as needed by
+/// [`copy_bitcoin_aux_files`].
+pub struct BitcoinAuxFiles<'a> {
+    pub src_bc_db: &'a Path,
+    pub dst_bc_db: &'a Path,
+    pub squashed_sort: &'a Path,
+    pub src_hdr: &'a Path,
+    pub dst_hdr: &'a Path,
+    pub bitcoin_height: u64,
+}
+
+/// Copy Bitcoin auxiliary files (burnchain.sqlite + headers.sqlite).
+/// Exits on error.
+pub fn copy_bitcoin_aux_files(files: BitcoinAuxFiles) {
+    let BitcoinAuxFiles {
+        src_bc_db,
+        dst_bc_db,
+        squashed_sort,
+        src_hdr,
+        dst_hdr,
+        bitcoin_height,
+    } = files;
+
+    println!("Copying burnchain.sqlite (canonical only)...");
+    match copy_burnchain_db(
+        src_bc_db.to_str().unwrap(),
+        dst_bc_db.to_str().unwrap(),
+        squashed_sort.to_str().unwrap(),
+        bitcoin_height,
+    ) {
+        Ok(bc_stats) => {
+            println!(
+                "  block_headers={}, block_ops={}, commit_metadata={}, anchor_blocks={}",
+                bc_stats.block_headers_rows,
+                bc_stats.block_ops_rows,
+                bc_stats.block_commit_metadata_rows,
+                bc_stats.anchor_blocks_rows,
+            );
+        }
+        Err(e) => die_with_cleanup(
+            &format!("Failed to copy burnchain.sqlite: {e:?}"),
+            &[dst_bc_db],
+        ),
+    }
+
+    println!("Copying headers.sqlite (SPV, up to Bitcoin height {bitcoin_height})...");
+    match copy_spv_headers(
+        src_hdr.to_str().unwrap(),
+        dst_hdr.to_str().unwrap(),
+        bitcoin_height,
+    ) {
+        Ok(spv_stats) => {
+            println!(
+                "  headers={}, chain_work={}",
+                spv_stats.headers_rows, spv_stats.chain_work_rows
+            );
+        }
+        Err(e) => die_with_cleanup(&format!("Failed to copy headers.sqlite: {e:?}"), &[dst_hdr]),
+    };
+}

--- a/contrib/marf-squash/src/ops.rs
+++ b/contrib/marf-squash/src/ops.rs
@@ -8,7 +8,6 @@ use stackslib::chainstate::stacks::db::snapshot::{
 use stackslib::chainstate::stacks::index::MarfTrieId;
 use stackslib::chainstate::stacks::index::marf::{MARF, MARFOpenOpts};
 
-use crate::db::ensure_blobs_match;
 use crate::layout::TargetPaths;
 
 /// Print `msg`, best-effort delete each path, then `exit(1)`. Needed because the
@@ -67,10 +66,6 @@ pub fn squash_and_copy_one<T: MarfTrieId + Send + Sync>(job: SquashJob<T>) {
         open_opts,
     } = job;
     let io = SquashIo { source, out };
-
-    if let Some(ref blobs) = source.blobs {
-        ensure_blobs_match(source.db.to_str().unwrap(), blobs.to_str().unwrap());
-    }
 
     if let Some(parent) = out.db.parent()
         && let Err(e) = fs::create_dir_all(parent)

--- a/contrib/marf-squash/src/ops.rs
+++ b/contrib/marf-squash/src/ops.rs
@@ -25,17 +25,6 @@ use stackslib::chainstate::stacks::index::marf::{MARF, MARFOpenOpts};
 
 use crate::layout::TargetPaths;
 
-/// Print `msg`, best-effort delete each path, then `exit(1)`. Needed because the
-/// offline-write helper runs with `journal_mode = OFF`: any mid-flight error
-/// leaves dst in an undefined state, so a clean re-run requires deleting it.
-pub fn die_with_cleanup(msg: &str, paths: &[&Path]) -> ! {
-    eprintln!("{msg}");
-    for p in paths {
-        let _ = fs::remove_file(p);
-    }
-    std::process::exit(1);
-}
-
 #[derive(Clone)]
 pub enum SideTableMode {
     Clarity,
@@ -111,17 +100,8 @@ pub fn squash_and_copy_one<T: MarfTrieId + Send + Sync>(job: SquashJob<T>) {
     report_size_savings(io, label, squash_height, stats.node_count);
 }
 
-/// Best-effort cleanup target for a failed copy: the output DB plus its `.blobs`
-/// sidecar when present (the offline-write helper can leave both inconsistent).
-fn cleanup_paths(out: &TargetPaths) -> Vec<&Path> {
-    match out.blobs.as_ref() {
-        Some(blobs) => vec![&out.db, blobs],
-        None => vec![&out.db],
-    }
-}
-
 /// Copy the side tables selected by `side_table_mode` from source into output.
-/// On any copy failure, deletes the partial output and exits.
+/// Exits on any copy failure, leaving the partial output in place for inspection.
 fn copy_side_tables(io: SquashIo, side_table_mode: &SideTableMode) {
     match side_table_mode {
         SideTableMode::Clarity => copy_clarity_tables(io),
@@ -135,7 +115,7 @@ fn copy_side_tables(io: SquashIo, side_table_mode: &SideTableMode) {
     }
 }
 
-/// Copy the Clarity side tables; on failure, delete the partial output and exit.
+/// Copy the Clarity side tables; exits on failure.
 fn copy_clarity_tables(io: SquashIo) {
     println!("Copying Clarity side tables...");
     match copy_clarity_side_tables(io.source.db.to_str().unwrap(), io.out.db.to_str().unwrap()) {
@@ -145,14 +125,14 @@ fn copy_clarity_tables(io: SquashIo) {
                 st.data_table_rows, st.metadata_table_rows
             );
         }
-        Err(e) => die_with_cleanup(
-            &format!("Failed to copy Clarity side tables: {e:?}"),
-            &cleanup_paths(io.out),
-        ),
+        Err(e) => {
+            eprintln!("Failed to copy Clarity side tables: {e:?}");
+            std::process::exit(1);
+        }
     }
 }
 
-/// Copy the index side tables; on failure, delete the partial output and exit.
+/// Copy the index side tables; exits on failure.
 fn copy_index_tables(io: SquashIo, first_bitcoin_height: u32, reward_cycle_len: u32) {
     println!("Copying index side tables...");
     match copy_index_side_tables(
@@ -178,14 +158,14 @@ fn copy_index_tables(io: SquashIo, first_bitcoin_height: u32, reward_cycle_len: 
                 st.fork_storage_rows
             );
         }
-        Err(e) => die_with_cleanup(
-            &format!("Failed to copy index side tables: {e:?}"),
-            &cleanup_paths(io.out),
-        ),
+        Err(e) => {
+            eprintln!("Failed to copy index side tables: {e:?}");
+            std::process::exit(1);
+        }
     }
 }
 
-/// Copy the sortition side tables; on failure, delete the partial output and exit.
+/// Copy the sortition side tables; exits on failure.
 fn copy_sortition_tables(io: SquashIo, stacks_tip_boundary: &SortitionTipCopyBoundary) {
     println!("Copying sortition side tables...");
     match copy_sortition_side_tables_with_boundary(
@@ -203,10 +183,10 @@ fn copy_sortition_tables(io: SquashIo, stacks_tip_boundary: &SortitionTipCopyBou
                 st.fork_storage_rows
             );
         }
-        Err(e) => die_with_cleanup(
-            &format!("Failed to copy sortition side tables: {e:?}"),
-            &cleanup_paths(io.out),
-        ),
+        Err(e) => {
+            eprintln!("Failed to copy sortition side tables: {e:?}");
+            std::process::exit(1);
+        }
     }
 }
 
@@ -293,10 +273,10 @@ pub fn copy_bitcoin_aux_files(files: BitcoinAuxFiles) {
                 bc_stats.anchor_blocks_rows,
             );
         }
-        Err(e) => die_with_cleanup(
-            &format!("Failed to copy burnchain.sqlite: {e:?}"),
-            &[dst_bc_db],
-        ),
+        Err(e) => {
+            eprintln!("Failed to copy burnchain.sqlite: {e:?}");
+            std::process::exit(1);
+        }
     }
 
     println!("Copying headers.sqlite (SPV, up to Bitcoin height {bitcoin_height})...");
@@ -311,6 +291,9 @@ pub fn copy_bitcoin_aux_files(files: BitcoinAuxFiles) {
                 spv_stats.headers_rows, spv_stats.chain_work_rows
             );
         }
-        Err(e) => die_with_cleanup(&format!("Failed to copy headers.sqlite: {e:?}"), &[dst_hdr]),
+        Err(e) => {
+            eprintln!("Failed to copy headers.sqlite: {e:?}");
+            std::process::exit(1);
+        }
     };
 }

--- a/contrib/marf-squash/src/targets.rs
+++ b/contrib/marf-squash/src/targets.rs
@@ -1,5 +1,20 @@
+// Copyright (C) 2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //! Resolution of the canonical Stacks + sortition boundaries that a squash must
-//! anchor on, and the prepare-phase warning.
+//! anchor on.
 
 use stacks_common::types::chainstate::{
     BlockHeaderHash, ConsensusHash, SortitionId, StacksBlockId,

--- a/contrib/marf-squash/src/targets.rs
+++ b/contrib/marf-squash/src/targets.rs
@@ -25,6 +25,11 @@ use stackslib::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandleConn};
 use stackslib::chainstate::nakamoto::NakamotoChainState;
 use stackslib::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
 
+/// Mainnet only: the squash boundary must sit at least this many Bitcoin blocks
+/// behind the canonical burn tip, so the squashed tenure is final and cannot be
+/// reorged out from under a booted node. 6 is the standard Bitcoin finality depth.
+const MAINNET_MIN_BURN_CONFIRMATIONS: u64 = 6;
+
 /// Canonical Stacks and sortition MARF boundaries that must be squashed together.
 #[derive(Debug, Clone)]
 pub struct CanonicalSquashTargets {
@@ -34,11 +39,11 @@ pub struct CanonicalSquashTargets {
     pub stacks_tip: StacksBlockId,
     /// Consensus hash of the tenure-start tip.
     pub stacks_tip_consensus_hash: ConsensusHash,
-    /// Burn view consensus hash shared by the tenure-start and tenure-end headers.
+    /// Burn view of the tenure-start block - the sortition boundary.
     pub stacks_tip_burn_view_consensus_hash: ConsensusHash,
     /// Block hash of the tenure-start tip.
     pub stacks_tip_block_hash: BlockHeaderHash,
-    /// Bitcoin height of the squash boundary (the tenure tip's `burn_view`).
+    /// Bitcoin height of the squash boundary (the tenure-start block's `burn_view`).
     pub squash_bitcoin_height: u32,
     /// Sortition MARF height for `squash_bitcoin_height`.
     pub sortition_marf_height: u32,
@@ -48,64 +53,6 @@ pub struct CanonicalSquashTargets {
     pub sortition_boundary_tip: SortitionId,
     /// Sortition DB's first Bitcoin block height (used to derive MARF heights).
     pub first_bitcoin_height: u32,
-}
-
-fn find_tenure_start_ancestor_from_end(
-    chainstate: &StacksChainState,
-    tenure_ch: &ConsensusHash,
-    end_header: &StacksHeaderInfo,
-) -> Result<StacksHeaderInfo, String> {
-    if end_header.consensus_hash != *tenure_ch {
-        return Err(format!(
-            "Tenure CH mismatch: tenure-start sortition has CH {tenure_ch}, but \
-             tenure end header has CH {}.",
-            end_header.consensus_hash
-        ));
-    }
-
-    let mut cursor = end_header.clone();
-    for _ in 0..=end_header.stacks_block_height {
-        let cursor_id = cursor.index_block_hash();
-        let parent_id =
-            NakamotoChainState::get_nakamoto_parent_block_id(chainstate.db(), &cursor_id)
-                .map_err(|e| format!("Failed to load parent of Nakamoto block {cursor_id}: {e}"))?
-                .ok_or_else(|| {
-                    format!(
-                        "Nakamoto block {cursor_id} at height {} has no parent_block_id row",
-                        cursor.stacks_block_height
-                    )
-                })?;
-
-        let Some(parent_header) = NakamotoChainState::get_block_header(chainstate.db(), &parent_id)
-            .map_err(|e| format!("Failed to load parent header {parent_id}: {e}"))?
-        else {
-            return Err(format!(
-                "Nakamoto block {cursor_id} at height {} points to missing parent {parent_id}",
-                cursor.stacks_block_height
-            ));
-        };
-
-        if parent_header.consensus_hash != *tenure_ch {
-            return Ok(cursor);
-        }
-
-        if parent_header.stacks_block_height >= cursor.stacks_block_height {
-            return Err(format!(
-                "Nakamoto ancestry is not height-decreasing: parent {parent_id} height {} \
-                 is not below child {cursor_id} height {}",
-                parent_header.stacks_block_height, cursor.stacks_block_height
-            ));
-        }
-
-        cursor = parent_header;
-    }
-
-    Err(format!(
-        "Could not find tenure start ancestor for tenure {tenure_ch} before walking \
-         {} parent links from {}",
-        end_header.stacks_block_height,
-        end_header.index_block_hash()
-    ))
 }
 
 /// Build the error for a `--tenure-start-bitcoin-height` that did not start a
@@ -147,54 +94,6 @@ fn format_no_tenure_start_error(
         "Bitcoin height {start_height} did not start a Nakamoto tenure \
          (sortition=false).{nearby_str}"
     )
-}
-
-/// STRICT BOUNDARY PREDICATE: assert the tenure starting at `start_height` is
-/// exactly one burn block long.
-///
-/// The squashed boot path is simple iff sub-boundary MARF reads never fire. For
-/// the sortition MARF, that holds when the tenure being squashed is exactly one
-/// burn block long: in that case the next post-boundary block's
-/// `parent_sortition_id` lands AT the boundary, not below. The constraint is:
-/// the burn block immediately after `start_height` has its own sortition (i.e.
-/// starts a NEW tenure), so the current tenure does not extend forward via flash
-/// blocks.
-///
-/// The boundary is the first block in the tenure; intra-tenure descendants above
-/// it are dropped from the artifact and re-synced from peers on boot. Sortition
-/// remains anchored at the tenure's burn view, whose runtime canonical tip is the
-/// highest canonical block in the tenure.
-fn assert_single_burn_block_tenure(
-    sortition_db: &SortitionDB,
-    canonical_sortition_id: &SortitionId,
-    start_height: u64,
-) -> Result<(), String> {
-    let ic = sortition_db.index_handle_at_tip();
-    let next_height = start_height
-        .checked_add(1)
-        .ok_or_else(|| format!("Bitcoin height {start_height} + 1 overflows u64"))?;
-    let next_snapshot =
-        SortitionDB::get_ancestor_snapshot(&ic, next_height, canonical_sortition_id)
-            .map_err(|e| {
-                format!("Failed to get ancestor snapshot at Bitcoin height {next_height}: {e}")
-            })?
-            .ok_or_else(|| {
-                format!(
-                    "No canonical sortition at Bitcoin height {next_height}. The chain has \
-                     not yet progressed past `tenure_start_bitcoin_height`; pick a boundary \
-                     that is at least one burn block behind the canonical tip."
-                )
-            })?;
-    if !next_snapshot.sortition {
-        return Err(format!(
-            "Bitcoin height {start_height} starts a Nakamoto tenure that extends \
-             into burn block {next_height} via a flash block (sortition=false). \
-             Refusing to squash: the tenure must be exactly one burn block long. \
-             Bump --tenure-start-bitcoin-height to a tenure followed by its own \
-             sortition."
-        ));
-    }
-    Ok(())
 }
 
 /// Inputs to [`resolve_canonical_squash_targets`]: the source DB locations, the
@@ -286,79 +185,11 @@ fn resolve_tenure_start_snapshot(
     Ok(start_snapshot)
 }
 
-/// Find the highest known Nakamoto block header in the tenure starting at
-/// `start_height`, requiring its consensus hash to match the tenure-start
-/// sortition's.
-fn resolve_tenure_end_header(
-    chainstate: &StacksChainState,
-    sortition_db: &SortitionDB,
-    start_height: u64,
-    tenure_ch: &ConsensusHash,
-) -> Result<StacksHeaderInfo, String> {
-    let end_header = NakamotoChainState::find_highest_known_block_header_in_tenure_by_block_height(
-        chainstate,
-        sortition_db,
-        start_height,
-    )
-    .map_err(|e| format!("Failed to find tenure end at Bitcoin height {start_height}: {e}"))?
-    .ok_or_else(|| {
-        format!(
-            "No Nakamoto blocks found at Bitcoin height {start_height}. \
-             This may predate Nakamoto activation."
-        )
-    })?;
-
-    if end_header.consensus_hash != *tenure_ch {
-        return Err(format!(
-            "Tenure CH mismatch: tenure-start sortition has CH {tenure_ch}, but \
-             highest known block in tenure has CH {}. Likely a re-org between \
-             the start sortition and the block headers table.",
-            end_header.consensus_hash
-        ));
-    }
-    Ok(end_header)
-}
-
-/// Extract and validate the tenure's burn_view: both the tenure-start and
-/// tenure-end headers must carry a `burn_view`, and the two must agree.
-/// `stacks_height` is the (already u32-checked) tenure-start height, used only in
-/// error messages.
-fn resolve_tenure_burn_view(
-    start_header: &StacksHeaderInfo,
-    end_header: &StacksHeaderInfo,
-    stacks_height: u32,
-) -> Result<ConsensusHash, String> {
-    let stacks_tip = start_header.index_block_hash();
-    let end_stacks_tip = end_header.index_block_hash();
-    let header_burn_view = start_header.burn_view.clone().ok_or_else(|| {
-        format!(
-            "Nakamoto tenure start {stacks_tip} (height {stacks_height}) has no \
-             burn_view set. Squash requires a Nakamoto block header with a \
-             burn_view."
-        )
-    })?;
-    let end_header_burn_view = end_header.burn_view.clone().ok_or_else(|| {
-        format!(
-            "Nakamoto tenure end {end_stacks_tip} (height {}) has no \
-             burn_view set. Squash requires a Nakamoto block header with a \
-             burn_view.",
-            end_header.stacks_block_height
-        )
-    })?;
-    if end_header_burn_view != header_burn_view {
-        return Err(format!(
-            "Tenure burn_view mismatch: tenure start {stacks_tip} has \
-             burn_view {header_burn_view}, but tenure end {end_stacks_tip} \
-             has burn_view {end_header_burn_view}. Refusing to split the \
-             Stacks and sortition squash anchors across different burn views."
-        ));
-    }
-    Ok(header_burn_view)
-}
-
-/// Load the burn_view's sortition snapshot, confirm it sits on the canonical
-/// burn-chain fork, and resolve the squash Bitcoin height (bounded by both the
-/// tenure-start height and the sortition DB's first block height). Returns
+/// Load the tenure-start block's `burn_view` sortition snapshot, confirm it sits
+/// on the canonical burn-chain fork, and resolve the squash Bitcoin height. Under
+/// first-block anchoring the tenure-start block's `burn_view` IS the tenure-start
+/// sortition, so the resolved height must equal `tenure_start_bitcoin_height`; a
+/// mismatch means the anchor is not the tenure's first block. Returns
 /// `(burn_view_snapshot, squash_bitcoin_height)`.
 fn resolve_squash_burn_view_snapshot(
     ctx: &SortitionReadCtx,
@@ -407,10 +238,13 @@ fn resolve_squash_burn_view_snapshot(
             burn_view_snapshot.block_height
         )
     })?;
-    if squash_bitcoin_height < tenure_start_bitcoin_height {
+    if squash_bitcoin_height != tenure_start_bitcoin_height {
         return Err(format!(
-            "Tenure burn-view Bitcoin height {squash_bitcoin_height} is earlier than \
-             tenure-start Bitcoin height {tenure_start_bitcoin_height}. Refusing to squash."
+            "Tenure-start block's burn-view Bitcoin height {squash_bitcoin_height} does not \
+             equal the requested tenure-start Bitcoin height {tenure_start_bitcoin_height}. \
+             Under first-block anchoring the tenure-start block's burn_view is the tenure-start \
+             sortition, so these must match; a mismatch means the resolved anchor is not the \
+             tenure's first block. Refusing to squash."
         ));
     }
     if squash_bitcoin_height < first_bitcoin_height {
@@ -423,77 +257,47 @@ fn resolve_squash_burn_view_snapshot(
     Ok((burn_view_snapshot, squash_bitcoin_height))
 }
 
-/// Confirm the sortition boundary snapshot reconstructs the tenure-end canonical
-/// Stacks tip: the runtime tip's StacksBlockId, height, and burn_view must all
-/// match the tenure end / tenure burn_view. Catches a boundary that would leave
-/// the destination internally inconsistent.
-fn validate_runtime_tip_reconstruction(
+/// Resolve the tenure's FIRST Nakamoto block (the BlockFound block) canonically:
+/// walk the Stacks index from the canonical Stacks tip back to the tenure start for
+/// `tenure_ch`. For a tenure-extend, the later intra-tenure and extend blocks share
+/// `tenure_ch` but are not the tenure start, so they fall above the boundary and are
+/// re-synced from peers on boot.
+fn resolve_tenure_start_anchor(
+    chainstate: &StacksChainState,
     sortition_db: &SortitionDB,
-    burn_view_snapshot: &BlockSnapshot,
-    end_header: &StacksHeaderInfo,
-    header_burn_view: &ConsensusHash,
-) -> Result<(), String> {
-    let end_stacks_tip = end_header.index_block_hash();
-    let sortition_boundary_id = &burn_view_snapshot.sortition_id;
-
-    // The sortition boundary snapshot must resolve back to the tenure-end
-    // canonical Stacks tip, even though Clarity/Index are anchored at the
-    // tenure-start block.
-    let runtime_tip = SortitionDB::get_canonical_nakamoto_tip_hash_and_height_and_burn_view(
-        sortition_db.conn(),
-        burn_view_snapshot,
+    tenure_ch: &ConsensusHash,
+    start_height: u64,
+) -> Result<StacksHeaderInfo, String> {
+    let (canonical_ch, canonical_bhh) =
+        SortitionDB::get_canonical_stacks_chain_tip_hash(sortition_db.conn())
+            .map_err(|e| format!("Failed to read canonical Stacks chain tip: {e}"))?;
+    let canonical_stacks_tip = StacksBlockId::new(&canonical_ch, &canonical_bhh);
+    NakamotoChainState::get_nakamoto_tenure_start_block_header(
+        &mut chainstate.index_conn(),
+        &canonical_stacks_tip,
+        tenure_ch,
     )
-    .map_err(|e| {
-        format!(
-            "Failed to resolve runtime canonical Nakamoto tip from boundary \
-             snapshot {sortition_boundary_id}: {e}"
-        )
-    })?
+    .map_err(|e| format!("Failed to resolve tenure-start block for {tenure_ch}: {e}"))?
     .ok_or_else(|| {
         format!(
-            "Runtime canonical Nakamoto tip resolution returned None from \
-             boundary snapshot {sortition_boundary_id}"
+            "Tenure {tenure_ch} (Bitcoin height {start_height}) has no canonical Nakamoto \
+             tenure-start block. Either the elected tenure produced no canonical blocks, or \
+             this predates Nakamoto activation."
         )
-    })?;
-
-    let (runtime_ch, runtime_burn_view, runtime_bhh, runtime_height) = runtime_tip;
-    let runtime_block_id = StacksBlockId::new(&runtime_ch, &runtime_bhh);
-    if runtime_block_id != end_stacks_tip {
-        return Err(format!(
-            "Runtime canonical tip reconstruction mismatch: boundary snapshot \
-             {sortition_boundary_id} resolves to StacksBlockId {runtime_block_id} \
-             at height {runtime_height}, but the tenure end header is \
-             StacksBlockId {end_stacks_tip} at height {}. The squash boundary \
-             would leave the destination internally inconsistent.",
-            end_header.stacks_block_height
-        ));
-    }
-    if runtime_height != end_header.stacks_block_height {
-        return Err(format!(
-            "Runtime canonical tip height mismatch: boundary snapshot resolves \
-             to height {runtime_height} but tenure tip is at height \
-             {}",
-            end_header.stacks_block_height
-        ));
-    }
-    // The block id can match even when the burn-view mapping is corrupt.
-    if runtime_burn_view != *header_burn_view {
-        return Err(format!(
-            "Runtime canonical tip burn_view mismatch: boundary snapshot \
-             resolves to burn_view {runtime_burn_view} but the tenure \
-             burn_view is {header_burn_view}. The sortition DB's \
-             `stacks_chain_tips_by_burn_view` row for sortition \
-             {sortition_boundary_id} is internally inconsistent."
-        ));
-    }
-    Ok(())
+    })
 }
 
 /// Resolve the canonical Stacks and sortition boundaries to squash to from the
-/// tenure starting at `query.tenure_start_bitcoin_height`. Validates that the
-/// tenure is a single burn block long, that its burn view is canonical and
-/// consistent across the tenure-start and tenure-end headers, and that the
-/// boundary reconstructs the tenure-end runtime tip.
+/// tenure starting at `query.tenure_start_bitcoin_height`.
+///
+/// Clarity and Index anchor at the tenure's FIRST Nakamoto block (the BlockFound
+/// block). For a tenure-extend tenure (one spanning several burn blocks), the
+/// later intra-tenure blocks are dropped from the artifact and re-synced from
+/// peers on boot; the sortition boundary is the tenure-start sortition (the first
+/// block's `burn_view`).
+///
+/// Validates that the tenure exists and that the boundary burn_view is on the
+/// canonical burn fork.
 pub fn resolve_canonical_squash_targets(
     query: SquashTargetQuery,
 ) -> Result<CanonicalSquashTargets, String> {
@@ -508,26 +312,14 @@ pub fn resolve_canonical_squash_targets(
         ic: &ic,
         canonical_tip: &canonical_tip,
     };
-    let start_snapshot = resolve_tenure_start_snapshot(&ctx, start_height)?;
 
+    // Rule: a tenure must exist at the requested Bitcoin height.
+    let start_snapshot = resolve_tenure_start_snapshot(&ctx, start_height)?;
     let tenure_ch = start_snapshot.consensus_hash.clone();
 
-    // The squash boundary must be exactly one burn block long (see the predicate
-    // doc); otherwise the squashed boot path would need sub-boundary MARF reads.
-    assert_single_burn_block_tenure(&sortition_db, &canonical_tip.sortition_id, start_height)?;
-
-    let end_header =
-        resolve_tenure_end_header(&chainstate, &sortition_db, start_height, &tenure_ch)?;
-
-    let start_header = find_tenure_start_ancestor_from_end(&chainstate, &tenure_ch, &end_header)?;
-
-    if start_header.stacks_block_height > end_header.stacks_block_height {
-        return Err(format!(
-            "Tenure block ordering mismatch: tenure start height {} is greater \
-             than tenure end height {} at Bitcoin height {start_height}.",
-            start_header.stacks_block_height, end_header.stacks_block_height
-        ));
-    }
+    // Anchor at the tenure's FIRST Nakamoto block (the BlockFound block).
+    let start_header =
+        resolve_tenure_start_anchor(&chainstate, &sortition_db, &tenure_ch, start_height)?;
 
     let stacks_height: u32 = start_header.stacks_block_height.try_into().map_err(|_| {
         format!(
@@ -539,7 +331,13 @@ pub fn resolve_canonical_squash_targets(
     let stacks_tip_consensus_hash = start_header.consensus_hash.clone();
     let stacks_tip_block_hash = start_header.anchored_header.block_hash();
 
-    let header_burn_view = resolve_tenure_burn_view(&start_header, &end_header, stacks_height)?;
+    let header_burn_view = start_header.burn_view.clone().ok_or_else(|| {
+        format!(
+            "Nakamoto tenure start {stacks_tip} (height {stacks_height}) has no \
+             burn_view set. Squash requires a Nakamoto block header with a \
+             burn_view."
+        )
+    })?;
 
     let (burn_view_snapshot, squash_bitcoin_height) = resolve_squash_burn_view_snapshot(
         &ctx,
@@ -548,17 +346,25 @@ pub fn resolve_canonical_squash_targets(
         first_bitcoin_height,
     )?;
 
-    let sortition_marf_height = squash_bitcoin_height - first_bitcoin_height;
+    // Mainnet fork-safety: only squash finalized tenures. If the boundary burn
+    // block is too close to the canonical burn tip it could still be reorged,
+    // leaving a node booted from the snapshot stranded on a dead fork.
+    if query.mainnet {
+        let tip_height = canonical_tip.block_height;
+        let boundary = u64::from(squash_bitcoin_height);
+        if boundary + MAINNET_MIN_BURN_CONFIRMATIONS > tip_height {
+            return Err(format!(
+                "Refusing to squash: boundary Bitcoin height {boundary} is only {} burn block(s) \
+                 behind the canonical burn tip {tip_height}. Mainnet requires at least \
+                 {MAINNET_MIN_BURN_CONFIRMATIONS} for finality.",
+                tip_height.saturating_sub(boundary)
+            ));
+        }
+    }
 
+    let sortition_marf_height = squash_bitcoin_height - first_bitcoin_height;
     let sortition_canonical_tip = canonical_tip.sortition_id.clone();
     let sortition_boundary_tip = burn_view_snapshot.sortition_id.clone();
-
-    validate_runtime_tip_reconstruction(
-        &sortition_db,
-        &burn_view_snapshot,
-        &end_header,
-        &header_burn_view,
-    )?;
 
     Ok(CanonicalSquashTargets {
         stacks_height,

--- a/contrib/marf-squash/src/targets.rs
+++ b/contrib/marf-squash/src/targets.rs
@@ -542,33 +542,3 @@ pub fn resolve_canonical_squash_targets(
         first_bitcoin_height,
     })
 }
-
-/// Warn if the tenure-start Bitcoin height is inside the Nakamoto prepare
-/// phase. Uses `is_in_naka_prepare_phase()` which excludes the `mod 0`
-/// block (unlike the broader `is_in_prepare_phase()`).
-///
-/// The cycle number is derived from the burn height directly using Nakamoto
-/// prepare-phase semantics: if inside the prepare phase, the corresponding
-/// cycle is the one being prepared for (i.e., the next cycle).
-pub fn warn_if_in_prepare_phase(
-    bitcoin_height: u32,
-    pox: &PoxConstants,
-    first_bitcoin_height: u32,
-) {
-    let bitcoin_height = u64::from(bitcoin_height);
-    let first_bitcoin_height = u64::from(first_bitcoin_height);
-    if pox.is_in_naka_prepare_phase(first_bitcoin_height, bitcoin_height) {
-        // Derive the cycle being prepared for using the same Nakamoto-specific
-        // semantics. In Nakamoto prepare phase (which excludes the mod-0 block),
-        // the corresponding cycle is always current_cycle + 1.
-        let current_cycle = pox.block_height_to_reward_cycle(first_bitcoin_height, bitcoin_height);
-        if let Some(cycle) = current_cycle {
-            let preparing_for = cycle + 1;
-            eprintln!(
-                "Warning: Bitcoin height {bitcoin_height} is inside the Nakamoto prepare \
-                 phase for reward cycle {preparing_for}. The node may stall on startup \
-                 for missing the anchor block for cycle {preparing_for}."
-            );
-        }
-    }
-}

--- a/contrib/marf-squash/src/targets.rs
+++ b/contrib/marf-squash/src/targets.rs
@@ -28,16 +28,25 @@ use stackslib::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
 /// Canonical Stacks and sortition MARF boundaries that must be squashed together.
 #[derive(Debug, Clone)]
 pub struct CanonicalSquashTargets {
+    /// Tenure-start Stacks block height that Clarity and Index squash to.
     pub stacks_height: u32,
+    /// Tenure-start Stacks tip that Clarity and Index squash to.
     pub stacks_tip: StacksBlockId,
+    /// Consensus hash of the tenure-start tip.
     pub stacks_tip_consensus_hash: ConsensusHash,
+    /// Burn view consensus hash shared by the tenure-start and tenure-end headers.
     pub stacks_tip_burn_view_consensus_hash: ConsensusHash,
+    /// Block hash of the tenure-start tip.
     pub stacks_tip_block_hash: BlockHeaderHash,
-    /// Resolved Bitcoin height of the squash boundary (the tenure tip's `burn_view`).
+    /// Bitcoin height of the squash boundary (the tenure tip's `burn_view`).
     pub squash_bitcoin_height: u32,
     /// Sortition MARF height for `squash_bitcoin_height`.
     pub sortition_marf_height: u32,
+    /// Source canonical burn tip - the fork selector for `MARF::squash_to_path`.
     pub sortition_canonical_tip: SortitionId,
+    /// Squash boundary sortition (at `squash_bitcoin_height`) that the squashed output holds.
+    pub sortition_boundary_tip: SortitionId,
+    /// Sortition DB's first Bitcoin block height (used to derive MARF heights).
     pub first_bitcoin_height: u32,
 }
 
@@ -537,6 +546,7 @@ pub fn resolve_canonical_squash_targets(
     let sortition_marf_height = squash_bitcoin_height - first_bitcoin_height;
 
     let sortition_canonical_tip = canonical_tip.sortition_id.clone();
+    let sortition_boundary_tip = burn_view_snapshot.sortition_id.clone();
 
     validate_runtime_tip_reconstruction(
         &sortition_db,
@@ -554,6 +564,7 @@ pub fn resolve_canonical_squash_targets(
         squash_bitcoin_height,
         sortition_marf_height,
         sortition_canonical_tip,
+        sortition_boundary_tip,
         first_bitcoin_height,
     })
 }

--- a/contrib/marf-squash/src/targets.rs
+++ b/contrib/marf-squash/src/targets.rs
@@ -489,6 +489,11 @@ fn validate_runtime_tip_reconstruction(
     Ok(())
 }
 
+/// Resolve the canonical Stacks and sortition boundaries to squash to from the
+/// tenure starting at `query.tenure_start_bitcoin_height`. Validates that the
+/// tenure is a single burn block long, that its burn view is canonical and
+/// consistent across the tenure-start and tenure-end headers, and that the
+/// boundary reconstructs the tenure-end runtime tip.
 pub fn resolve_canonical_squash_targets(
     query: SquashTargetQuery,
 ) -> Result<CanonicalSquashTargets, String> {

--- a/contrib/marf-squash/src/targets.rs
+++ b/contrib/marf-squash/src/targets.rs
@@ -1,0 +1,574 @@
+//! Resolution of the canonical Stacks + sortition boundaries that a squash must
+//! anchor on, and the prepare-phase warning.
+
+use stacks_common::types::chainstate::{
+    BlockHeaderHash, ConsensusHash, SortitionId, StacksBlockId,
+};
+use stackslib::burnchains::PoxConstants;
+use stackslib::chainstate::burn::BlockSnapshot;
+use stackslib::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandleConn};
+use stackslib::chainstate::nakamoto::NakamotoChainState;
+use stackslib::chainstate::stacks::db::{StacksChainState, StacksHeaderInfo};
+
+/// Canonical Stacks and sortition MARF boundaries that must be squashed together.
+#[derive(Debug, Clone)]
+pub struct CanonicalSquashTargets {
+    pub stacks_height: u32,
+    pub stacks_tip: StacksBlockId,
+    pub stacks_tip_consensus_hash: ConsensusHash,
+    pub stacks_tip_burn_view_consensus_hash: ConsensusHash,
+    pub stacks_tip_block_hash: BlockHeaderHash,
+    /// Resolved Bitcoin height of the squash boundary (the tenure tip's `burn_view`).
+    pub squash_bitcoin_height: u32,
+    /// Sortition MARF height for `squash_bitcoin_height`.
+    pub sortition_marf_height: u32,
+    pub sortition_canonical_tip: SortitionId,
+    pub first_bitcoin_height: u32,
+}
+
+fn find_tenure_start_ancestor_from_end(
+    chainstate: &StacksChainState,
+    tenure_ch: &ConsensusHash,
+    end_header: &StacksHeaderInfo,
+) -> Result<StacksHeaderInfo, String> {
+    if end_header.consensus_hash != *tenure_ch {
+        return Err(format!(
+            "Tenure CH mismatch: tenure-start sortition has CH {tenure_ch}, but \
+             tenure end header has CH {}.",
+            end_header.consensus_hash
+        ));
+    }
+
+    let mut cursor = end_header.clone();
+    for _ in 0..=end_header.stacks_block_height {
+        let cursor_id = cursor.index_block_hash();
+        let parent_id =
+            NakamotoChainState::get_nakamoto_parent_block_id(chainstate.db(), &cursor_id)
+                .map_err(|e| format!("Failed to load parent of Nakamoto block {cursor_id}: {e}"))?
+                .ok_or_else(|| {
+                    format!(
+                        "Nakamoto block {cursor_id} at height {} has no parent_block_id row",
+                        cursor.stacks_block_height
+                    )
+                })?;
+
+        let Some(parent_header) = NakamotoChainState::get_block_header(chainstate.db(), &parent_id)
+            .map_err(|e| format!("Failed to load parent header {parent_id}: {e}"))?
+        else {
+            return Err(format!(
+                "Nakamoto block {cursor_id} at height {} points to missing parent {parent_id}",
+                cursor.stacks_block_height
+            ));
+        };
+
+        if parent_header.consensus_hash != *tenure_ch {
+            return Ok(cursor);
+        }
+
+        if parent_header.stacks_block_height >= cursor.stacks_block_height {
+            return Err(format!(
+                "Nakamoto ancestry is not height-decreasing: parent {parent_id} height {} \
+                 is not below child {cursor_id} height {}",
+                parent_header.stacks_block_height, cursor.stacks_block_height
+            ));
+        }
+
+        cursor = parent_header;
+    }
+
+    Err(format!(
+        "Could not find tenure start ancestor for tenure {tenure_ch} before walking \
+         {} parent links from {}",
+        end_header.stacks_block_height,
+        end_header.index_block_hash()
+    ))
+}
+
+/// Build the error for a `--tenure-start-bitcoin-height` that did not start a
+/// Nakamoto tenure, listing nearby tenure starts to help the caller pick one.
+fn format_no_tenure_start_error(
+    sortition_db: &SortitionDB,
+    canonical_sortition_id: &SortitionId,
+    start_height: u64,
+) -> String {
+    let ic = sortition_db.index_handle_at_tip();
+    // Find nearby tenure starts for a helpful error message.
+    let mut nearby = Vec::new();
+    let search_radius = 10u64;
+    let search_start = start_height.saturating_sub(search_radius);
+    let search_end = start_height.saturating_add(search_radius);
+    for h in search_start..=search_end {
+        if h == start_height {
+            continue;
+        }
+        if let Ok(Some(s)) = SortitionDB::get_ancestor_snapshot(&ic, h, canonical_sortition_id)
+            && s.sortition
+        {
+            nearby.push(h);
+        }
+    }
+    let nearby_str = if nearby.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n  Nearby tenure starts: {}",
+            nearby
+                .iter()
+                .map(|h| h.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    format!(
+        "Bitcoin height {start_height} did not start a Nakamoto tenure \
+         (sortition=false).{nearby_str}"
+    )
+}
+
+/// STRICT BOUNDARY PREDICATE: assert the tenure starting at `start_height` is
+/// exactly one burn block long.
+///
+/// The squashed boot path is simple iff sub-boundary MARF reads never fire. For
+/// the sortition MARF, that holds when the tenure being squashed is exactly one
+/// burn block long: in that case the next post-boundary block's
+/// `parent_sortition_id` lands AT the boundary, not below. The constraint is:
+/// the burn block immediately after `start_height` has its own sortition (i.e.
+/// starts a NEW tenure), so the current tenure does not extend forward via flash
+/// blocks.
+///
+/// The boundary is the first block in the tenure; intra-tenure descendants above
+/// it are dropped from the artifact and re-synced from peers on boot. Sortition
+/// remains anchored at the tenure's burn view, whose runtime canonical tip is the
+/// highest canonical block in the tenure.
+fn assert_single_burn_block_tenure(
+    sortition_db: &SortitionDB,
+    canonical_sortition_id: &SortitionId,
+    start_height: u64,
+) -> Result<(), String> {
+    let ic = sortition_db.index_handle_at_tip();
+    let next_height = start_height
+        .checked_add(1)
+        .ok_or_else(|| format!("Bitcoin height {start_height} + 1 overflows u64"))?;
+    let next_snapshot =
+        SortitionDB::get_ancestor_snapshot(&ic, next_height, canonical_sortition_id)
+            .map_err(|e| {
+                format!("Failed to get ancestor snapshot at Bitcoin height {next_height}: {e}")
+            })?
+            .ok_or_else(|| {
+                format!(
+                    "No canonical sortition at Bitcoin height {next_height}. The chain has \
+                     not yet progressed past `tenure_start_bitcoin_height`; pick a boundary \
+                     that is at least one burn block behind the canonical tip."
+                )
+            })?;
+    if !next_snapshot.sortition {
+        return Err(format!(
+            "Bitcoin height {start_height} starts a Nakamoto tenure that extends \
+             into burn block {next_height} via a flash block (sortition=false). \
+             Refusing to squash: the tenure must be exactly one burn block long. \
+             Bump --tenure-start-bitcoin-height to a tenure followed by its own \
+             sortition."
+        ));
+    }
+    Ok(())
+}
+
+/// Inputs to [`resolve_canonical_squash_targets`]: the source DB locations, the
+/// network identity, the tenure-start Bitcoin height, and the PoX constants.
+pub struct SquashTargetQuery<'a> {
+    pub chainstate_root: &'a str,
+    pub sortition_db_dir: &'a str,
+    pub tenure_start_bitcoin_height: u32,
+    pub mainnet: bool,
+    pub chain_id: u32,
+    pub pox_constants: PoxConstants,
+}
+
+/// The sortition read context shared by the boundary-resolution steps: the open
+/// sortition DB, an index handle at its tip, and the canonical burn-chain tip
+/// that ancestor lookups are anchored on.
+struct SortitionReadCtx<'a> {
+    sortition_db: &'a SortitionDB,
+    ic: &'a SortitionHandleConn<'a>,
+    canonical_tip: &'a BlockSnapshot,
+}
+
+/// Open the source chainstate and sortition DBs, and read the sortition DB's
+/// `first_block_height` (as u32) and canonical burn-chain tip. Returns
+/// `(chainstate, sortition_db, first_bitcoin_height, canonical_tip)`.
+fn open_squash_dbs(
+    query: &SquashTargetQuery,
+) -> Result<(StacksChainState, SortitionDB, u32, BlockSnapshot), String> {
+    let (chainstate, _) =
+        StacksChainState::open(query.mainnet, query.chain_id, query.chainstate_root, None)
+            .map_err(|e| {
+                format!(
+                    "Failed to open chainstate at '{}': {e}",
+                    query.chainstate_root
+                )
+            })?;
+
+    let sortition_db = SortitionDB::open(
+        query.sortition_db_dir,
+        false,
+        query.pox_constants.clone(),
+        None,
+    )
+    .map_err(|e| {
+        format!(
+            "Failed to open sortition DB at '{}': {e}",
+            query.sortition_db_dir
+        )
+    })?;
+
+    let first_bitcoin_height: u32 = sortition_db.first_block_height.try_into().map_err(|_| {
+        format!(
+            "Sortition first_block_height {} does not fit in u32",
+            sortition_db.first_block_height
+        )
+    })?;
+
+    let canonical_tip = SortitionDB::get_canonical_burn_chain_tip(sortition_db.conn())
+        .map_err(|e| format!("Failed to get canonical burn tip: {e}"))?;
+
+    Ok((
+        chainstate,
+        sortition_db,
+        first_bitcoin_height,
+        canonical_tip,
+    ))
+}
+
+/// Resolve the tenure-start sortition snapshot at `start_height`, requiring it to
+/// have started a Nakamoto tenure (`sortition=true`).
+fn resolve_tenure_start_snapshot(
+    ctx: &SortitionReadCtx,
+    start_height: u64,
+) -> Result<BlockSnapshot, String> {
+    let start_snapshot =
+        SortitionDB::get_ancestor_snapshot(ctx.ic, start_height, &ctx.canonical_tip.sortition_id)
+            .map_err(|e| {
+                format!("Failed to get ancestor snapshot at Bitcoin height {start_height}: {e}")
+            })?
+            .ok_or_else(|| format!("No canonical sortition at Bitcoin height {start_height}"))?;
+
+    if !start_snapshot.sortition {
+        return Err(format_no_tenure_start_error(
+            ctx.sortition_db,
+            &ctx.canonical_tip.sortition_id,
+            start_height,
+        ));
+    }
+    Ok(start_snapshot)
+}
+
+/// Find the highest known Nakamoto block header in the tenure starting at
+/// `start_height`, requiring its consensus hash to match the tenure-start
+/// sortition's.
+fn resolve_tenure_end_header(
+    chainstate: &StacksChainState,
+    sortition_db: &SortitionDB,
+    start_height: u64,
+    tenure_ch: &ConsensusHash,
+) -> Result<StacksHeaderInfo, String> {
+    let end_header = NakamotoChainState::find_highest_known_block_header_in_tenure_by_block_height(
+        chainstate,
+        sortition_db,
+        start_height,
+    )
+    .map_err(|e| format!("Failed to find tenure end at Bitcoin height {start_height}: {e}"))?
+    .ok_or_else(|| {
+        format!(
+            "No Nakamoto blocks found at Bitcoin height {start_height}. \
+             This may predate Nakamoto activation."
+        )
+    })?;
+
+    if end_header.consensus_hash != *tenure_ch {
+        return Err(format!(
+            "Tenure CH mismatch: tenure-start sortition has CH {tenure_ch}, but \
+             highest known block in tenure has CH {}. Likely a re-org between \
+             the start sortition and the block headers table.",
+            end_header.consensus_hash
+        ));
+    }
+    Ok(end_header)
+}
+
+/// Extract and validate the tenure's burn_view: both the tenure-start and
+/// tenure-end headers must carry a `burn_view`, and the two must agree.
+/// `stacks_height` is the (already u32-checked) tenure-start height, used only in
+/// error messages.
+fn resolve_tenure_burn_view(
+    start_header: &StacksHeaderInfo,
+    end_header: &StacksHeaderInfo,
+    stacks_height: u32,
+) -> Result<ConsensusHash, String> {
+    let stacks_tip = start_header.index_block_hash();
+    let end_stacks_tip = end_header.index_block_hash();
+    let header_burn_view = start_header.burn_view.clone().ok_or_else(|| {
+        format!(
+            "Nakamoto tenure start {stacks_tip} (height {stacks_height}) has no \
+             burn_view set. Squash requires a Nakamoto block header with a \
+             burn_view."
+        )
+    })?;
+    let end_header_burn_view = end_header.burn_view.clone().ok_or_else(|| {
+        format!(
+            "Nakamoto tenure end {end_stacks_tip} (height {}) has no \
+             burn_view set. Squash requires a Nakamoto block header with a \
+             burn_view.",
+            end_header.stacks_block_height
+        )
+    })?;
+    if end_header_burn_view != header_burn_view {
+        return Err(format!(
+            "Tenure burn_view mismatch: tenure start {stacks_tip} has \
+             burn_view {header_burn_view}, but tenure end {end_stacks_tip} \
+             has burn_view {end_header_burn_view}. Refusing to split the \
+             Stacks and sortition squash anchors across different burn views."
+        ));
+    }
+    Ok(header_burn_view)
+}
+
+/// Load the burn_view's sortition snapshot, confirm it sits on the canonical
+/// burn-chain fork, and resolve the squash Bitcoin height (bounded by both the
+/// tenure-start height and the sortition DB's first block height). Returns
+/// `(burn_view_snapshot, squash_bitcoin_height)`.
+fn resolve_squash_burn_view_snapshot(
+    ctx: &SortitionReadCtx,
+    header_burn_view: &ConsensusHash,
+    tenure_start_bitcoin_height: u32,
+    first_bitcoin_height: u32,
+) -> Result<(BlockSnapshot, u32), String> {
+    let burn_view_snapshot =
+        SortitionDB::get_block_snapshot_consensus(ctx.sortition_db.conn(), header_burn_view)
+            .map_err(|e| format!("Failed to load snapshot for burn_view {header_burn_view}: {e}"))?
+            .ok_or_else(|| {
+                format!("No snapshot found for tenure start's burn_view {header_burn_view}")
+            })?;
+
+    let canonical_at_height = SortitionDB::get_ancestor_snapshot(
+        ctx.ic,
+        burn_view_snapshot.block_height,
+        &ctx.canonical_tip.sortition_id,
+    )
+    .map_err(|e| {
+        format!(
+            "Failed to get canonical ancestor at Bitcoin height {}: {e}",
+            burn_view_snapshot.block_height
+        )
+    })?
+    .ok_or_else(|| {
+        format!(
+            "No canonical sortition at Bitcoin height {} (burn_view {header_burn_view})",
+            burn_view_snapshot.block_height
+        )
+    })?;
+
+    if canonical_at_height.sortition_id != burn_view_snapshot.sortition_id {
+        return Err(format!(
+            "Tenure start's burn_view {header_burn_view} points at sortition_id \
+             {} (Bitcoin height {}), which is not on the canonical burn-chain \
+             fork. Cowardly refusing to squash a tenure that landed on an \
+             orphan burn fork.",
+            burn_view_snapshot.sortition_id, burn_view_snapshot.block_height
+        ));
+    }
+
+    let squash_bitcoin_height: u32 = burn_view_snapshot.block_height.try_into().map_err(|_| {
+        format!(
+            "Tenure burn-view Bitcoin height {} does not fit in u32",
+            burn_view_snapshot.block_height
+        )
+    })?;
+    if squash_bitcoin_height < tenure_start_bitcoin_height {
+        return Err(format!(
+            "Tenure burn-view Bitcoin height {squash_bitcoin_height} is earlier than \
+             tenure-start Bitcoin height {tenure_start_bitcoin_height}. Refusing to squash."
+        ));
+    }
+    if squash_bitcoin_height < first_bitcoin_height {
+        return Err(format!(
+            "Tenure burn-view Bitcoin height {squash_bitcoin_height} is below the \
+             sortition DB's first_bitcoin_height {first_bitcoin_height}"
+        ));
+    }
+
+    Ok((burn_view_snapshot, squash_bitcoin_height))
+}
+
+/// Confirm the sortition boundary snapshot reconstructs the tenure-end canonical
+/// Stacks tip: the runtime tip's StacksBlockId, height, and burn_view must all
+/// match the tenure end / tenure burn_view. Catches a boundary that would leave
+/// the destination internally inconsistent.
+fn validate_runtime_tip_reconstruction(
+    sortition_db: &SortitionDB,
+    burn_view_snapshot: &BlockSnapshot,
+    end_header: &StacksHeaderInfo,
+    header_burn_view: &ConsensusHash,
+) -> Result<(), String> {
+    let end_stacks_tip = end_header.index_block_hash();
+    let sortition_boundary_id = &burn_view_snapshot.sortition_id;
+
+    // The sortition boundary snapshot must resolve back to the tenure-end
+    // canonical Stacks tip, even though Clarity/Index are anchored at the
+    // tenure-start block.
+    let runtime_tip = SortitionDB::get_canonical_nakamoto_tip_hash_and_height_and_burn_view(
+        sortition_db.conn(),
+        burn_view_snapshot,
+    )
+    .map_err(|e| {
+        format!(
+            "Failed to resolve runtime canonical Nakamoto tip from boundary \
+             snapshot {sortition_boundary_id}: {e}"
+        )
+    })?
+    .ok_or_else(|| {
+        format!(
+            "Runtime canonical Nakamoto tip resolution returned None from \
+             boundary snapshot {sortition_boundary_id}"
+        )
+    })?;
+
+    let (runtime_ch, runtime_burn_view, runtime_bhh, runtime_height) = runtime_tip;
+    let runtime_block_id = StacksBlockId::new(&runtime_ch, &runtime_bhh);
+    if runtime_block_id != end_stacks_tip {
+        return Err(format!(
+            "Runtime canonical tip reconstruction mismatch: boundary snapshot \
+             {sortition_boundary_id} resolves to StacksBlockId {runtime_block_id} \
+             at height {runtime_height}, but the tenure end header is \
+             StacksBlockId {end_stacks_tip} at height {}. The squash boundary \
+             would leave the destination internally inconsistent.",
+            end_header.stacks_block_height
+        ));
+    }
+    if runtime_height != end_header.stacks_block_height {
+        return Err(format!(
+            "Runtime canonical tip height mismatch: boundary snapshot resolves \
+             to height {runtime_height} but tenure tip is at height \
+             {}",
+            end_header.stacks_block_height
+        ));
+    }
+    // The block id can match even when the burn-view mapping is corrupt.
+    if runtime_burn_view != *header_burn_view {
+        return Err(format!(
+            "Runtime canonical tip burn_view mismatch: boundary snapshot \
+             resolves to burn_view {runtime_burn_view} but the tenure \
+             burn_view is {header_burn_view}. The sortition DB's \
+             `stacks_chain_tips_by_burn_view` row for sortition \
+             {sortition_boundary_id} is internally inconsistent."
+        ));
+    }
+    Ok(())
+}
+
+pub fn resolve_canonical_squash_targets(
+    query: SquashTargetQuery,
+) -> Result<CanonicalSquashTargets, String> {
+    let tenure_start_bitcoin_height = query.tenure_start_bitcoin_height;
+    let start_height = u64::from(tenure_start_bitcoin_height);
+
+    let (chainstate, sortition_db, first_bitcoin_height, canonical_tip) = open_squash_dbs(&query)?;
+
+    let ic = sortition_db.index_handle_at_tip();
+    let ctx = SortitionReadCtx {
+        sortition_db: &sortition_db,
+        ic: &ic,
+        canonical_tip: &canonical_tip,
+    };
+    let start_snapshot = resolve_tenure_start_snapshot(&ctx, start_height)?;
+
+    let tenure_ch = start_snapshot.consensus_hash.clone();
+
+    // The squash boundary must be exactly one burn block long (see the predicate
+    // doc); otherwise the squashed boot path would need sub-boundary MARF reads.
+    assert_single_burn_block_tenure(&sortition_db, &canonical_tip.sortition_id, start_height)?;
+
+    let end_header =
+        resolve_tenure_end_header(&chainstate, &sortition_db, start_height, &tenure_ch)?;
+
+    let start_header = find_tenure_start_ancestor_from_end(&chainstate, &tenure_ch, &end_header)?;
+
+    if start_header.stacks_block_height > end_header.stacks_block_height {
+        return Err(format!(
+            "Tenure block ordering mismatch: tenure start height {} is greater \
+             than tenure end height {} at Bitcoin height {start_height}.",
+            start_header.stacks_block_height, end_header.stacks_block_height
+        ));
+    }
+
+    let stacks_height: u32 = start_header.stacks_block_height.try_into().map_err(|_| {
+        format!(
+            "Tenure start Stacks height {} does not fit in u32",
+            start_header.stacks_block_height
+        )
+    })?;
+    let stacks_tip = start_header.index_block_hash();
+    let stacks_tip_consensus_hash = start_header.consensus_hash.clone();
+    let stacks_tip_block_hash = start_header.anchored_header.block_hash();
+
+    let header_burn_view = resolve_tenure_burn_view(&start_header, &end_header, stacks_height)?;
+
+    let (burn_view_snapshot, squash_bitcoin_height) = resolve_squash_burn_view_snapshot(
+        &ctx,
+        &header_burn_view,
+        tenure_start_bitcoin_height,
+        first_bitcoin_height,
+    )?;
+
+    let sortition_marf_height = squash_bitcoin_height - first_bitcoin_height;
+
+    let sortition_canonical_tip = canonical_tip.sortition_id.clone();
+
+    validate_runtime_tip_reconstruction(
+        &sortition_db,
+        &burn_view_snapshot,
+        &end_header,
+        &header_burn_view,
+    )?;
+
+    Ok(CanonicalSquashTargets {
+        stacks_height,
+        stacks_tip,
+        stacks_tip_consensus_hash,
+        stacks_tip_burn_view_consensus_hash: header_burn_view,
+        stacks_tip_block_hash,
+        squash_bitcoin_height,
+        sortition_marf_height,
+        sortition_canonical_tip,
+        first_bitcoin_height,
+    })
+}
+
+/// Warn if the tenure-start Bitcoin height is inside the Nakamoto prepare
+/// phase. Uses `is_in_naka_prepare_phase()` which excludes the `mod 0`
+/// block (unlike the broader `is_in_prepare_phase()`).
+///
+/// The cycle number is derived from the burn height directly using Nakamoto
+/// prepare-phase semantics: if inside the prepare phase, the corresponding
+/// cycle is the one being prepared for (i.e., the next cycle).
+pub fn warn_if_in_prepare_phase(
+    bitcoin_height: u32,
+    pox: &PoxConstants,
+    first_bitcoin_height: u32,
+) {
+    let bitcoin_height = u64::from(bitcoin_height);
+    let first_bitcoin_height = u64::from(first_bitcoin_height);
+    if pox.is_in_naka_prepare_phase(first_bitcoin_height, bitcoin_height) {
+        // Derive the cycle being prepared for using the same Nakamoto-specific
+        // semantics. In Nakamoto prepare phase (which excludes the mod-0 block),
+        // the corresponding cycle is always current_cycle + 1.
+        let current_cycle = pox.block_height_to_reward_cycle(first_bitcoin_height, bitcoin_height);
+        if let Some(cycle) = current_cycle {
+            let preparing_for = cycle + 1;
+            eprintln!(
+                "Warning: Bitcoin height {bitcoin_height} is inside the Nakamoto prepare \
+                 phase for reward cycle {preparing_for}. The node may stall on startup \
+                 for missing the anchor block for cycle {preparing_for}."
+            );
+        }
+    }
+}

--- a/contrib/nix/flake.nix
+++ b/contrib/nix/flake.nix
@@ -140,6 +140,7 @@
               (craneLib.fileset.commonCargoSources ../../contrib/stacks-inspect)
               (craneLib.fileset.commonCargoSources ../../contrib/stacks-cli)
               (craneLib.fileset.commonCargoSources ../../contrib/clarity-cli)
+              (craneLib.fileset.commonCargoSources ../../contrib/marf-squash)
               (craneLib.fileset.commonCargoSources ../../stacks-signer)
             ];
           };
@@ -199,6 +200,16 @@
           }
         );
 
+        marf-squash = craneLib.buildPackage (
+          individualCrateArgs
+          // rec {
+            inherit version;
+            pname = "marf-squash";
+            cargoExtraArgs = "-p ${pname}";
+            src = fileSetForCrate ../../contrib/marf-squash;
+          }
+        );
+
         stacks-node-app = {
           type = "app";
           program = "${stacks-core}/bin/stacks-node";
@@ -230,6 +241,7 @@
             stacks-cli
             clarity-cli
             stacks-inspect
+            marf-squash
             ;
           default = stacks-core;
         };

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -412,7 +412,7 @@ impl StagingMicroblock {
 impl StacksChainState {
     /// Relative path, under a blocks dir, at which the block with this index
     /// hash is stored: two 2-byte hex directory segments, then the full hash.
-    pub(crate) fn index_block_hash_to_rel_path(index_block_hash: &StacksBlockId) -> PathBuf {
+    pub fn index_block_hash_to_rel_path(index_block_hash: &StacksBlockId) -> PathBuf {
         let block_hash_bytes = index_block_hash.as_bytes();
 
         PathBuf::from(to_hex(&block_hash_bytes[0..2]))

--- a/stackslib/src/chainstate/stacks/db/snapshot/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/blocks.rs
@@ -348,9 +348,9 @@ pub(super) fn nakamoto_copy_specs() -> Vec<TableCopySpec> {
 ///
 /// Returns an error if `dst_nakamoto_path` already exists.
 pub fn copy_nakamoto_staging_blocks(
+    squashed_index_path: &str,
     src_nakamoto_path: &str,
     dst_nakamoto_path: &str,
-    squashed_index_path: &str,
 ) -> Result<NakamotoBlockCopyStats, Error> {
     // Reject an unrecognized source schema before any destination work.
     let src_conn = sqlite_open(src_nakamoto_path, OpenFlags::SQLITE_OPEN_READ_ONLY, false)?;

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/blocks.rs
@@ -196,9 +196,9 @@ fn test_unclassified_source_table_is_rejected() {
     create_nakamoto_headers_index(&idx_path, &["canonical_ibh_1"]);
 
     let err = copy_nakamoto_staging_blocks(
+        idx_path.to_str().unwrap(),
         src_nak_path.to_str().unwrap(),
         dst_nak_path.to_str().unwrap(),
-        idx_path.to_str().unwrap(),
     )
     .expect_err("unclassified source table must be rejected");
     match err {
@@ -768,9 +768,9 @@ fn test_nakamoto_copy() {
 
     // Copy.
     let stats = copy_nakamoto_staging_blocks(
+        idx_path.to_str().unwrap(),
         src_nak_path.to_str().unwrap(),
         dst_nak_path.to_str().unwrap(),
-        idx_path.to_str().unwrap(),
     )
     .unwrap();
 
@@ -851,9 +851,9 @@ fn test_nakamoto_copy_existing_destination_is_error() {
     std::fs::write(&dst_nak_path, b"stale data").unwrap();
 
     let err = copy_nakamoto_staging_blocks(
+        idx_path.to_str().unwrap(),
         src_nak_path.to_str().unwrap(),
         dst_nak_path.to_str().unwrap(),
-        idx_path.to_str().unwrap(),
     )
     .expect_err("existing destination should error");
     assert!(
@@ -924,9 +924,9 @@ fn test_nakamoto_copy_excludes_post_boundary_blocks() {
 
     // Copy: only the two <=H blocks are retained.
     let stats = copy_nakamoto_staging_blocks(
+        idx_path.to_str().unwrap(),
         src_nak_path.to_str().unwrap(),
         dst_nak_path.to_str().unwrap(),
-        idx_path.to_str().unwrap(),
     )
     .unwrap();
     assert_eq!(stats.rows_copied, 2, "only <=H blocks should be copied");


### PR DESCRIPTION
### Description

Adds `contrib/marf-squash`, an offline CLI that produces a pruned chainstate snapshot from an archival chainstate: it squashes the three MARFs at a chosen tenure boundary, copies the canonical block and Bitcoin data, and writes a self-describing manifest. The output is a directly-bootable `<out-dir>/<network>/` tree  (a node started from it is unaware it booted from a pruned snapshot and syncs forward normally)

### What it does

`marf-squash squash --chainstate <dir> --out-dir <dir> --tenure-start-bitcoin-height <h> --all`

  - **Squashes** the Clarity, Index, and Sortition MARFs to a tenure boundary, the authenticated root hash.
  - **Copies** canonical block data (epoch-2.x block files, confirmed microblocks, `nakamoto.sqlite`) and Bitcoin auxiliary files (`burnchain.sqlite`, `headers.sqlite`).
  - **Writes** `PCS_manifest.toml`: the three MARFs' squash-root and archival-root hashes, the block range, and SHA-256 checksums (per-file for fixed artifacts, one aggregate hash for the epoch-2 block archive).

Individual MARFs can be squashed selectively (`--clarity`, `--index`, `--sortition`); `--blocks` requires `--index`, `--bitcoin` requires `--sortition`.
Testnet networks require `--config` for PoX/epoch parameters.

Note that the crate is expected to be used as an offline process, and it uses an exit or error approach - I am open to revisit that.


### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
