### PR TITLE
fix: prevent subtraction underflow in `NeighborStats::get_bandwidth`

### DIFF
--- a/changelog.d/7372-get-bandwidth-underflow.fixed
+++ b/changelog.d/7372-get-bandwidth-underflow.fixed
@@ -1,0 +1,1 @@
+Gracefully handle clock skew when computing P2P bandwidth stats.

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -272,7 +272,8 @@ impl NeighborStats {
             }
         }
 
-        if elapsed_time_start == elapsed_time_end {
+        // "greater than" is possible if the system clock was adjusted between recordings
+        if elapsed_time_start >= elapsed_time_end {
             total_bytes as f64
         } else {
             (total_bytes as f64) / ((elapsed_time_end - elapsed_time_start) as f64)
@@ -7420,5 +7421,38 @@ mod test {
             .unwrap()
             .is_some());
         assert_eq!(convo_1.stats.msgs_err, err_before);
+    }
+
+    #[test]
+    fn test_get_bandwidth() {
+        let recently = get_epoch_time_secs() - 1;
+        let longer_ago = recently - 6;
+
+        let mut counts = VecDeque::<(u64, u64)>::new();
+        counts.push_back((recently, 54));
+        counts.push_back((longer_ago, 18));
+        assert_eq!(
+            NeighborStats::get_bandwidth(&counts, 1000),
+            72f64,
+            "non-monotonous timestamps should be treated like 1 second apart"
+        );
+
+        let mut counts = VecDeque::<(u64, u64)>::new();
+        counts.push_back((recently, 54));
+        counts.push_back((recently, 18));
+        assert_eq!(
+            NeighborStats::get_bandwidth(&counts, 1000),
+            72f64,
+            "identical timestamps should be treated like 1 second apart"
+        );
+
+        let mut counts = VecDeque::<(u64, u64)>::new();
+        counts.push_back((longer_ago, 54));
+        counts.push_back((recently, 18));
+        assert_eq!(
+            NeighborStats::get_bandwidth(&counts, 1000),
+            12f64, // 72 divided by 6
+            "properly ordered timestamps should be handled correctly"
+        );
     }
 }


### PR DESCRIPTION
My mock-miner crashed overnight because the subtraction in the `else` branch underflowed. While this won't crash a release build (and is unlikely on a true 24/7 node, which won't go into energy saving like apparently my laptop did), we should still handle it.
