### PR TITLE
feat: add memory guard to rpc read-only functions

### DIFF
--- a/changelog.d/read-only-call-mem-abort.fixed
+++ b/changelog.d/read-only-call-mem-abort.fixed
@@ -1,0 +1,1 @@
+Wired the per-call memory-abort callback and wall-clock execution-time limit into the `/v2/contracts/call-read` and `/v3/contracts/fast-call-read` read-only RPC handlers. Also added a new `read_only_call_max_mem_bytes` connection option (default 1 GB; `0` disables) to bound the heap a single read-only call may allocate.

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1781,6 +1781,10 @@ impl<'a, 'hooks> GlobalContext<'a, 'hooks> {
         self.execution_time_tracker = TimeTracker::from_max_duration(max_execution_time);
     }
 
+    pub fn set_abort_callback(&mut self, callback: AbortCallback) {
+        self.abort_callback = callback;
+    }
+
     fn get_asset_map(&mut self) -> Result<&mut AssetMap, VmExecutionError> {
         self.asset_maps
             .last_mut()

--- a/stacks-node/src/main.rs
+++ b/stacks-node/src/main.rs
@@ -481,6 +481,7 @@ fn main() {
     {
         if conf.miner.max_assembly_mem_bytes > 0
             || conf.connection_options.block_proposal_max_tx_mem_bytes > 0
+            || conf.connection_options.read_only_call_max_mem_bytes > 0
         {
             if !tracking_allocator_installed() {
                 panic!("Tracking allocator must be installed to set a memory limit");

--- a/stacks-node/src/tests/mem_abort.rs
+++ b/stacks-node/src/tests/mem_abort.rs
@@ -130,3 +130,20 @@ fn test_no_abort_callback_allows_large_allocation() {
         "Expected execution to succeed without abort callback, but got: {result:?}"
     );
 }
+
+/// The read-only RPC memory limit must be threaded from `ConnectionOptions`
+/// into the HTTP server state so the handlers can install the abort callback.
+#[test]
+fn test_read_only_call_max_mem_bytes_threaded_into_http() {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use stacks::net::connection::ConnectionOptions;
+    use stacks::net::httpcore::StacksHttp;
+
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let mut conn_opts = ConnectionOptions::default();
+    conn_opts.read_only_call_max_mem_bytes = 12345;
+
+    let http = StacksHttp::new(addr, &conn_opts);
+    assert_eq!(http.read_only_call_max_mem_bytes, 12345);
+}

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -149,6 +149,8 @@ const DEFAULT_MINER_ASSEMBLY_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2 GB
 /// Default maximum memory allocation during block proposal evaluation. Defaults higher than miner default
 ///  to avoid miner/signer environment skews.
 pub const DEFAULT_PROPOSAL_MEMORY_BYTES: u64 = 3 * 1024 * 1024 * 1024; // 3 GB
+/// Default maximum heap allocation for a single read-only RPC call before it is aborted.
+pub const DEFAULT_READ_ONLY_CALL_MAX_MEM_BYTES: u64 = 1024 * 1024 * 1024; // 1 GB
 
 static HELIUM_DEFAULT_CONNECTION_OPTIONS: LazyLock<ConnectionOptions> =
     LazyLock::new(|| ConnectionOptions {
@@ -3730,6 +3732,14 @@ pub struct ConnectionOptionsFile {
     /// @units: seconds
     pub read_only_max_execution_time_secs: Option<u64>,
 
+    /// Maximum bytes a single read-only RPC call may allocate on the heap before
+    /// it is aborted.
+    /// `0` disables the limit.
+    /// ---
+    /// @default: [`DEFAULT_READ_ONLY_CALL_MAX_MEM_BYTES`]
+    /// @units: bytes
+    pub read_only_call_max_mem_bytes: Option<u64>,
+
     /// Maximum time (in seconds) to spend validating a block when processing
     /// a block proposal received via the `/v3/block_proposal` RPC endpoint.
     ///
@@ -3943,6 +3953,9 @@ impl ConnectionOptionsFile {
             read_only_max_execution_time_secs: self
                 .read_only_max_execution_time_secs
                 .unwrap_or(default.read_only_max_execution_time_secs),
+            read_only_call_max_mem_bytes: self
+                .read_only_call_max_mem_bytes
+                .unwrap_or(default.read_only_call_max_mem_bytes),
             block_proposal_validation_timeout_secs: self
                 .block_proposal_validation_timeout_secs
                 .unwrap_or(DEFAULT_BLOCK_PROPOSAL_VALIDATION_TIMEOUT_SECS),

--- a/stackslib/src/net/api/callreadonly.rs
+++ b/stackslib/src/net/api/callreadonly.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::time::Duration;
+
 use clarity::vm::analysis::RuntimeCheckErrorKind;
 use clarity::vm::ast::parser::v1::CLARITY_NAME_REGEX;
 use clarity::vm::clarity::ClarityConnection;
@@ -27,10 +29,11 @@ use regex::{Captures, Regex};
 use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::types::net::PeerHost;
 
+use crate::chainstate::nakamoto::miner::make_mem_abort_callback;
 use crate::net::http::{
     parse_json, Error, HttpContentType, HttpNotFound, HttpRequest, HttpRequestContents,
-    HttpRequestPreamble, HttpResponse, HttpResponseContents, HttpResponsePayload,
-    HttpResponsePreamble,
+    HttpRequestPreamble, HttpRequestTimeout, HttpResponse, HttpResponseContents,
+    HttpResponsePayload, HttpResponsePreamble,
 };
 use crate::net::httpcore::{
     request, HttpRequestContentsExtensions as _, RPCRequestHandler, StacksHttpRequest,
@@ -61,6 +64,8 @@ pub struct CallReadOnlyResponse {
 pub struct RPCCallReadOnlyRequestHandler {
     pub maximum_call_argument_size: u32,
     read_only_call_limit: ExecutionCost,
+    read_only_max_execution_time: Duration,
+    read_only_call_max_mem_bytes: u64,
 
     /// Runtime fields
     pub contract_identifier: Option<QualifiedContractIdentifier>,
@@ -71,10 +76,17 @@ pub struct RPCCallReadOnlyRequestHandler {
 }
 
 impl RPCCallReadOnlyRequestHandler {
-    pub fn new(maximum_call_argument_size: u32, read_only_call_limit: ExecutionCost) -> Self {
+    pub fn new(
+        maximum_call_argument_size: u32,
+        read_only_call_limit: ExecutionCost,
+        read_only_max_execution_time: Duration,
+        read_only_call_max_mem_bytes: u64,
+    ) -> Self {
         Self {
             maximum_call_argument_size,
             read_only_call_limit,
+            read_only_max_execution_time,
+            read_only_call_max_mem_bytes,
             contract_identifier: None,
             function: None,
             sender: None,
@@ -236,6 +248,13 @@ impl RPCRequestHandler for RPCCallReadOnlyRequestHandler {
                             sponsor,
                             cost_track,
                             |exec_state, invoke_ctx| {
+                                exec_state.global_context.set_abort_callback(
+                                    make_mem_abort_callback(self.read_only_call_max_mem_bytes),
+                                );
+                                exec_state
+                                    .global_context
+                                    .set_max_execution_time(self.read_only_max_execution_time);
+
                                 // we want to execute any function as long as no actual writes are made as
                                 // opposed to be limited to purely calling `define-read-only` functions,
                                 // so use `read_only = false`.  This broadens the number of functions that
@@ -279,6 +298,14 @@ impl RPCRequestHandler for RPCCallReadOnlyRequestHandler {
                     result: None,
                     cause: Some("NotReadOnly".to_string()),
                 },
+                ClarityEvalError::Vm(RuntimeCheck(RuntimeCheckErrorKind::ExecutionTimeExpired)) => {
+                    return StacksHttpResponse::new_error(
+                        &preamble,
+                        &HttpRequestTimeout::new("ExecutionTime expired".to_string()),
+                    )
+                    .try_into_contents()
+                    .map_err(NetError::from)
+                }
                 _ => CallReadOnlyResponse {
                     okay: false,
                     result: None,

--- a/stackslib/src/net/api/fastcallreadonly.rs
+++ b/stackslib/src/net/api/fastcallreadonly.rs
@@ -28,6 +28,7 @@ use regex::{Captures, Regex};
 use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::types::net::PeerHost;
 
+use crate::chainstate::nakamoto::miner::make_mem_abort_callback;
 use crate::net::api::callreadonly::{
     CallReadOnlyRequestBody, CallReadOnlyResponse, RPCCallReadOnlyRequestHandler,
 };
@@ -46,6 +47,7 @@ use crate::net::{Error as NetError, StacksNodeState, TipRequest};
 pub struct RPCFastCallReadOnlyRequestHandler {
     pub call_read_only_handler: RPCCallReadOnlyRequestHandler,
     read_only_max_execution_time: Duration,
+    read_only_call_max_mem_bytes: u64,
     pub auth: Option<String>,
 }
 
@@ -53,6 +55,7 @@ impl RPCFastCallReadOnlyRequestHandler {
     pub fn new(
         maximum_call_argument_size: u32,
         read_only_max_execution_time: Duration,
+        read_only_call_max_mem_bytes: u64,
         auth: Option<String>,
     ) -> Self {
         Self {
@@ -65,8 +68,11 @@ impl RPCFastCallReadOnlyRequestHandler {
                     read_count: 0,
                     runtime: 0,
                 },
+                read_only_max_execution_time,
+                read_only_call_max_mem_bytes,
             ),
             read_only_max_execution_time,
+            read_only_call_max_mem_bytes,
             auth,
         }
     }
@@ -232,6 +238,9 @@ impl RPCRequestHandler for RPCFastCallReadOnlyRequestHandler {
                                 // cost tracking in read only calls is meamingful mainly from a security point of view
                                 // for this reason we enforce max_execution_time when cost tracking is disabled/free
 
+                                exec_state.global_context.set_abort_callback(
+                                    make_mem_abort_callback(self.read_only_call_max_mem_bytes),
+                                );
                                 exec_state
                                     .global_context
                                     .set_max_execution_time(self.read_only_max_execution_time);

--- a/stackslib/src/net/api/mod.rs
+++ b/stackslib/src/net/api/mod.rs
@@ -86,10 +86,13 @@ impl StacksHttp {
         self.register_rpc_endpoint(callreadonly::RPCCallReadOnlyRequestHandler::new(
             self.maximum_call_argument_size,
             self.read_only_call_limit.clone(),
+            self.read_only_max_execution_time,
+            self.read_only_call_max_mem_bytes,
         ));
         self.register_rpc_endpoint(fastcallreadonly::RPCFastCallReadOnlyRequestHandler::new(
             self.maximum_call_argument_size,
             self.read_only_max_execution_time,
+            self.read_only_call_max_mem_bytes,
             self.auth_token.clone(),
         ));
         self.register_rpc_endpoint(getaccount::RPCGetAccountRequestHandler::new());

--- a/stackslib/src/net/api/tests/callreadonly.rs
+++ b/stackslib/src/net/api/tests/callreadonly.rs
@@ -58,8 +58,13 @@ fn test_try_parse_request() {
     debug!("Request:\n{}\n", std::str::from_utf8(&bytes).unwrap());
 
     let (parsed_preamble, offset) = http.read_preamble(&bytes).unwrap();
-    let mut handler =
-        callreadonly::RPCCallReadOnlyRequestHandler::new(4096, BLOCK_LIMIT_MAINNET_21);
+    let conn_opts = ConnectionOptions::default();
+    let mut handler = callreadonly::RPCCallReadOnlyRequestHandler::new(
+        4096,
+        BLOCK_LIMIT_MAINNET_21,
+        std::time::Duration::from_secs(conn_opts.read_only_max_execution_time_secs),
+        conn_opts.read_only_call_max_mem_bytes,
+    );
     let mut parsed_request = http
         .handle_try_parse_request(
             &mut handler,

--- a/stackslib/src/net/api/tests/fastcallreadonly.rs
+++ b/stackslib/src/net/api/tests/fastcallreadonly.rs
@@ -64,6 +64,7 @@ fn test_try_parse_request() {
     let mut handler = fastcallreadonly::RPCFastCallReadOnlyRequestHandler::new(
         4096,
         Duration::from_secs(30),
+        ConnectionOptions::default().read_only_call_max_mem_bytes,
         Some("password".into()),
     );
     let mut parsed_request = http

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -28,7 +28,7 @@ use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::pipe::*;
 use stacks_common::util::secp256k1::Secp256k1PublicKey;
 
-use crate::config::DEFAULT_PROPOSAL_MEMORY_BYTES;
+use crate::config::{DEFAULT_PROPOSAL_MEMORY_BYTES, DEFAULT_READ_ONLY_CALL_MAX_MEM_BYTES};
 use crate::monitoring::{update_inbound_bandwidth, update_outbound_bandwidth};
 use crate::net::download::BLOCK_DOWNLOAD_INTERVAL;
 use crate::net::inv::{INV_REWARD_CYCLES, INV_SYNC_INTERVAL};
@@ -495,6 +495,11 @@ pub struct ConnectionOptions {
     /// max execution time of readonly calls when cost tracking is disabled
     pub read_only_max_execution_time_secs: u64,
 
+    /// Maximum bytes a single read-only RPC call may allocate on the heap before
+    /// it is aborted. Tracked via per-thread allocation counters in
+    /// `TrackingAllocator`. A value of `0` disables the limit.
+    pub read_only_call_max_mem_bytes: u64,
+
     /// Maximum time to spend validating a block proposal in seconds
     pub block_proposal_validation_timeout_secs: u64,
 
@@ -624,6 +629,7 @@ impl std::default::Default for ConnectionOptions {
             test_disable_unsolicited_message_authentication: false,
 
             read_only_max_execution_time_secs: 30,
+            read_only_call_max_mem_bytes: DEFAULT_READ_ONLY_CALL_MAX_MEM_BYTES,
             block_proposal_validation_timeout_secs: DEFAULT_BLOCK_PROPOSAL_VALIDATION_TIMEOUT_SECS,
             block_proposal_max_tx_execution_time_secs:
                 DEFAULT_BLOCK_PROPOSAL_MAX_TX_EXECUTION_TIME_SECS,

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -1013,6 +1013,8 @@ pub struct StacksHttp {
     allow_arbitrary_response: bool,
     /// Maximum execution time of a read-only call when in zero cost-tracking mode
     pub read_only_max_execution_time: Duration,
+    /// Maximum heap allocation for a single read-only call before it is aborted
+    pub read_only_call_max_mem_bytes: u64,
 }
 
 impl StacksHttp {
@@ -1035,6 +1037,7 @@ impl StacksHttp {
             read_only_max_execution_time: Duration::from_secs(
                 conn_opts.read_only_max_execution_time_secs,
             ),
+            read_only_call_max_mem_bytes: conn_opts.read_only_call_max_mem_bytes,
         };
         http.register_rpc_methods();
         http
@@ -1059,6 +1062,7 @@ impl StacksHttp {
             read_only_max_execution_time: Duration::from_secs(
                 conn_opts.read_only_max_execution_time_secs,
             ),
+            read_only_call_max_mem_bytes: conn_opts.read_only_call_max_mem_bytes,
         }
     }
 


### PR DESCRIPTION
This adds our existing memory heap allocator guards to read-only RPC functions