### PR TITLE
fix: tuple-merge oversize size check (epoch gated)

### DIFF
--- a/changelog.d/tuple-merge-size-epoch40-gate.fixed
+++ b/changelog.d/tuple-merge-size-epoch40-gate.fixed
@@ -1,0 +1,1 @@
+Fix tuple `merge` producing an oversized value: starting in Epoch 4.0, a `merge` whose combined size exceeds the maximum value size is rejected cleanly with `ValueTooLarge` at the merge site (in both static analysis and at runtime), instead of aborting the block. Behavior in earlier epochs is unchanged.

--- a/clarity-types/src/types/signatures.rs
+++ b/clarity-types/src/types/signatures.rs
@@ -1520,6 +1520,18 @@ impl TupleTypeSignature {
         })
     }
 
+    /// Serialized value size of the tuple, or [`ClarityTypeError::ValueTooLarge`] if it
+    /// exceeds [`MAX_VALUE_SIZE`].
+    ///
+    /// This differs from [`Self::size`] only in the error variant: `size` reports an oversized
+    /// tuple as an `InvariantViolation` (a "should never happen" signal that block-invalidates),
+    /// whereas this reports it as the checked `ValueTooLarge` rejection. Used at the tuple
+    /// `merge` site (static analysis and runtime) to reject an oversized merged tuple cleanly.
+    pub fn checked_value_size(&self) -> Result<u32, ClarityTypeError> {
+        // inner_size() returns Ok(None) exactly when the tuple is oversized.
+        self.inner_size()?.ok_or(ClarityTypeError::ValueTooLarge)
+    }
+
     fn max_depth(&self) -> u8 {
         let mut max = 0;
         for (_name, type_signature) in self.type_map.iter() {

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/mod.rs
@@ -228,6 +228,13 @@ fn check_special_merge(
     )?;
 
     base.shallow_merge(&mut update);
+    if checker.epoch.fixes_tuple_merge_size_check() {
+        // 4.0+: reject an oversized merged tuple cleanly with `ValueTooLarge` at the merge
+        // site. `?` converts `ClarityTypeError::ValueTooLarge` into `StaticCheckError`.
+        // Pre-4.0 the check is absent, so the oversized type propagates exactly as before
+        // (surfacing later as a block-invalidating `InvariantViolation` when it is sized).
+        base.checked_value_size()?;
+    }
     Ok(TypeSignature::TupleType(base))
 }
 

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/mod.rs
@@ -3075,6 +3075,59 @@ fn test_combine_tuples() {
     mem_type_check("(merge { a: 1, b: 2, c: 3 } 5)").unwrap_err();
 }
 
+/// Static-analysis epoch gate for an oversized tuple `merge`.
+///
+/// Two individually-valid `(buff 524288)`-typed fields merge into a tuple type whose value
+/// size exceeds `MAX_VALUE_SIZE`. The failure mode flips at the 4.0 boundary:
+/// - epoch < 4.0: `check_special_merge` does not size the merged tuple; the oversized type
+///   propagates and only fails when `new_response` (the `ok`) sizes it, surfacing as a
+///   block-invalidating `Unreachable` (wrapping an `InvariantViolation`).
+/// - epoch >= 4.0: `check_special_merge` rejects the oversized merge at the merge site with a
+///   clean `ValueTooLarge`.
+#[test]
+fn tuple_merge_oversized_analysis_gate_epoch40() {
+    let snippet = "(define-private (f (x (buff 524288)))
+        (ok (merge (tuple (a x)) (tuple (b x)))))";
+
+    // epoch < 4.0 (legacy): block-invalidating `Unreachable` from the later `.size()`.
+    let legacy_err =
+        mem_run_analysis(snippet, ClarityVersion::Clarity3, StacksEpochId::Epoch34).unwrap_err();
+    assert!(
+        matches!(*legacy_err.err, StaticCheckErrorKind::Unreachable(_)),
+        "expected a pre-4.0 Unreachable failure, got {:?}",
+        legacy_err.err
+    );
+
+    // epoch >= 4.0: clean `ValueTooLarge` at the merge site.
+    let gated_err =
+        mem_run_analysis(snippet, ClarityVersion::Clarity3, StacksEpochId::Epoch40).unwrap_err();
+    assert_eq!(*gated_err.err, StaticCheckErrorKind::ValueTooLarge);
+}
+
+/// Static-analysis epoch gate for an oversized tuple `merge` whose result is **never sized**.
+///
+/// The merge result is bound in a `let` but never used (the function returns `(ok true)`), so
+/// nothing computes its size during analysis. This is the case that pre-4.0 slipped past the
+/// static checker entirely — the contract type-checks and deploys, then becomes uncallable.
+/// The 4.0 gate rejects it at the merge site regardless of whether the result is ever used.
+/// - epoch < 4.0: analysis accepts the contract (no sizing occurs).
+/// - epoch >= 4.0: `check_special_merge` rejects it with `ValueTooLarge`.
+#[test]
+fn tuple_merge_unused_oversized_analysis_gate_epoch40() {
+    let snippet = "(define-private (f (x (buff 524288)))
+        (let ((m (merge (tuple (a x)) (tuple (b x)))))
+            (ok true)))";
+
+    // epoch < 4.0 (legacy): analysis accepts the unused oversized merge.
+    mem_run_analysis(snippet, ClarityVersion::Clarity3, StacksEpochId::Epoch34)
+        .expect("pre-4.0 analysis must accept an unused oversized merge");
+
+    // epoch >= 4.0: rejected at the merge site with `ValueTooLarge`, even though unused.
+    let gated_err =
+        mem_run_analysis(snippet, ClarityVersion::Clarity3, StacksEpochId::Epoch40).unwrap_err();
+    assert_eq!(*gated_err.err, StaticCheckErrorKind::ValueTooLarge);
+}
+
 #[test]
 fn test_using_merge() {
     let t = "(define-map users uint

--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -364,7 +364,7 @@ pub fn lookup_reserved_functions(name: &str, version: &ClarityVersion) -> Option
             TupleGet => SpecialFunction("special_get-tuple", &tuples::tuple_get),
             TupleMerge => NativeFunction205(
                 "native_merge-tuple",
-                NativeHandle::DoubleArg(&tuples::tuple_merge),
+                NativeHandle::MoreArgEnv(&tuples::tuple_merge),
                 ClarityCostFunction::TupleMerge,
                 &cost_input_sized_vararg,
             ),

--- a/clarity/src/vm/functions/tuples.rs
+++ b/clarity/src/vm/functions/tuples.rs
@@ -100,7 +100,20 @@ pub fn tuple_get(
     }
 }
 
-pub fn tuple_merge(base: Value, update: Value) -> Result<Value, VmExecutionError> {
+pub fn tuple_merge(
+    mut args: Vec<Value>,
+    exec_state: &mut ExecutionState,
+    _invoke_ctx: &InvocationContext,
+) -> Result<Value, VmExecutionError> {
+    check_argument_count(2, &args)?;
+    // `merge` is dispatched with two evaluated arguments; extract them in order.
+    let update = args
+        .pop()
+        .ok_or_else(|| VmInternalError::Expect("Unexpected list length".into()))?;
+    let base = args
+        .pop()
+        .ok_or_else(|| VmInternalError::Expect("Unexpected list length".into()))?;
+
     let initial_values = match base {
         Value::Tuple(initial_values) => Ok(initial_values),
         _ => Err(RuntimeCheckErrorKind::Unreachable(format!(
@@ -118,5 +131,12 @@ pub fn tuple_merge(base: Value, update: Value) -> Result<Value, VmExecutionError
     }?;
 
     let combined = TupleData::shallow_merge(initial_values, new_values);
+    if exec_state.epoch().fixes_tuple_merge_size_check() {
+        // 4.0+: reject an oversized merged tuple cleanly with `ValueTooLarge` instead of
+        // block-invalidating later (the pre-4.0 behavior: the oversized value propagates and
+        // fails during cost calculation with an `InvariantViolation`). This mirrors the
+        // static-analysis gate in `check_special_merge` so no oversized tuple can exist at 4.0+.
+        combined.type_signature.checked_value_size()?;
+    }
     Ok(Value::Tuple(combined))
 }

--- a/clarity/src/vm/tests/simple_apply_eval.rs
+++ b/clarity/src/vm/tests/simple_apply_eval.rs
@@ -34,6 +34,7 @@ use crate::vm::costs::LimitedCostTracker;
 use crate::vm::database::MemoryBackingStore;
 use crate::vm::errors::{
     ClarityEvalError, EarlyReturnError, RuntimeCheckErrorKind, RuntimeError, VmExecutionError,
+    VmInternalError,
 };
 use crate::vm::tests::{execute, test_clarity_versions};
 use crate::vm::types::signatures::*;
@@ -1715,6 +1716,76 @@ fn merge_update_type_signature_2239() {
         .for_each(|(program, expectation)| {
             assert_eq!(expectation.to_string(), execute(program).to_string())
         });
+}
+
+/// Runtime epoch gate for an oversized tuple `merge`.
+///
+/// Builds two individually-valid ~512 KiB tuples whose combined size exceeds `MAX_VALUE_SIZE`
+/// and merges them at runtime.
+/// The merge result is bound in a `let` but never sized, isolating the merge itself:
+/// - epoch < 4.0: `merge` is infallible (legacy), so the program returns `true`.
+/// - epoch >= 4.0: `merge` rejects the oversized result cleanly with `ValueTooLarge`.
+#[test]
+fn tuple_merge_runtime_size_gate_epoch40() {
+    let program = r#"
+        (define-private (make-buff-256)
+            (let ((b16 0x00112233445566778899aabbccddeeff)
+                  (b32 (concat b16 b16))
+                  (b64 (concat b32 b32))
+                  (b128 (concat b64 b64))
+                  (b256 (concat b128 b128)))
+              b256))
+        (define-private (make-buff-4096)
+            (let ((b256 (make-buff-256))
+                  (b512 (concat b256 b256))
+                  (b1024 (concat b512 b512))
+                  (b2048 (concat b1024 b1024))
+                  (b4096 (concat b2048 b2048)))
+              b4096))
+        (define-private (make-buff-65536)
+            (let ((b4096 (make-buff-4096))
+                  (b8192 (concat b4096 b4096))
+                  (b16384 (concat b8192 b8192))
+                  (b32768 (concat b16384 b16384))
+                  (b65536 (concat b32768 b32768)))
+              b65536))
+        (define-private (make-buff-524288)
+            (let ((b65536 (make-buff-65536))
+                  (b131072 (concat b65536 b65536))
+                  (b262144 (concat b131072 b131072))
+                  (b524288 (concat b262144 b262144)))
+              b524288))
+        (let ((big (unwrap-panic (as-max-len? (make-buff-524288) u524288))))
+            (let ((m (merge (tuple (a big)) (tuple (b big)))))
+                true))
+    "#;
+
+    // epoch < 4.0 (legacy): the infallible merge yields an oversized value that later fails
+    // during cost calculation with a block-invalidating internal `Expect`.
+    let legacy_err = execute_with_parameters(
+        program,
+        ClarityVersion::Clarity3,
+        StacksEpochId::Epoch34,
+        false,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            legacy_err,
+            ClarityEvalError::Vm(VmExecutionError::Internal(VmInternalError::Expect(_)))
+        ),
+        "expected a pre-4.0 Expect failure, got {legacy_err:?}"
+    );
+
+    // epoch >= 4.0: the oversized merge is rejected cleanly with `ValueTooLarge`.
+    let gated_err = execute_with_parameters(
+        program,
+        ClarityVersion::Clarity3,
+        StacksEpochId::Epoch40,
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(gated_err, RuntimeCheckErrorKind::ValueTooLarge.into());
 }
 
 #[test]

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -801,6 +801,19 @@ impl StacksEpochId {
         self >= &StacksEpochId::Epoch40
     }
 
+    /// Whether this epoch eagerly rejects a tuple `merge` whose combined size
+    /// exceeds `MAX_VALUE_SIZE`, at the merge site, with `ValueTooLarge` — both at
+    /// static-analysis time and at runtime.
+    ///
+    /// Before this epoch, an oversized merge was not checked at the merge site: the
+    /// oversized tuple type/value propagated and only failed later (block-invalidating
+    /// `InvariantViolation` when its size was eventually computed — or, if never
+    /// sized, the contract deployed and became uncallable). Gated here so the
+    /// behavior changes atomically at the epoch boundary. See PR #6946.
+    pub fn fixes_tuple_merge_size_check(&self) -> bool {
+        self >= &StacksEpochId::Epoch40
+    }
+
     pub fn supports_call_with_constant(&self) -> bool {
         self >= &StacksEpochId::Epoch34
     }

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_exceeds_max_value_size_cdeploy.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_exceeds_max_value_size_cdeploy.snap
@@ -1,0 +1,206 @@
+---
+source: stackslib/src/chainstate/tests/static_analysis_tests.rs
+expression: result.get_expected_results()
+---
+[
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 7f3c5f96cb4f197ca68a7874be1540bd01101e075acb12133ec5d8911654ca4f: ClarityError(StaticCheck(StaticCheckError { err: Unreachable(\"Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\"), expressions: Some([SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"ok\")), id: 172 }, SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"merge\")), id: 174 }, SymbolicExpression { expr: Atom(ClarityName(\"ta\")), id: 175 }, SymbolicExpression { expr: Atom(ClarityName(\"tb\")), id: 176 }]), id: 173 }]), id: 171 }]), diagnostic: Diagnostic { level: Error, message: \"unexpected and unacceptable interpreter behavior: Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\", spans: [Span { start_line: 0, start_column: 0, end_line: 0, end_column: 0 }], suggestion: None } }))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 8d410360f261cb58308107354ca0364cb97c5d3d013f09d6afc5e475d22cf883: ClarityError(StaticCheck(StaticCheckError { err: Unreachable(\"Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\"), expressions: Some([SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"ok\")), id: 172 }, SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"merge\")), id: 174 }, SymbolicExpression { expr: Atom(ClarityName(\"ta\")), id: 175 }, SymbolicExpression { expr: Atom(ClarityName(\"tb\")), id: 176 }]), id: 173 }]), id: 171 }]), diagnostic: Diagnostic { level: Error, message: \"unexpected and unacceptable interpreter behavior: Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\", spans: [Span { start_line: 0, start_column: 0, end_line: 0, end_column: 0 }], suggestion: None } }))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 205cc88fab70caaad191752ff1be37eeac53efcec95d30434df0d6e0ca834036: ClarityError(StaticCheck(StaticCheckError { err: Unreachable(\"Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\"), expressions: Some([SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"ok\")), id: 172 }, SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"merge\")), id: 174 }, SymbolicExpression { expr: Atom(ClarityName(\"ta\")), id: 175 }, SymbolicExpression { expr: Atom(ClarityName(\"tb\")), id: 176 }]), id: 173 }]), id: 171 }]), diagnostic: Diagnostic { level: Error, message: \"unexpected and unacceptable interpreter behavior: Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\", spans: [Span { start_line: 0, start_column: 0, end_line: 0, end_column: 0 }], suggestion: None } }))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 25bf074211108f1013927ee8ab8fcfc90f669aae3634317313d92a7b8f7af3e6: ClarityError(StaticCheck(StaticCheckError { err: Unreachable(\"Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\"), expressions: Some([SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"ok\")), id: 172 }, SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"merge\")), id: 174 }, SymbolicExpression { expr: Atom(ClarityName(\"ta\")), id: 175 }, SymbolicExpression { expr: Atom(ClarityName(\"tb\")), id: 176 }]), id: 173 }]), id: 171 }]), diagnostic: Diagnostic { level: Error, message: \"unexpected and unacceptable interpreter behavior: Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\", spans: [Span { start_line: 0, start_column: 0, end_line: 0, end_column: 0 }], suggestion: None } }))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 3ccc7959909eb66e4071780c595ac12e8236872140cd9898fd3b3ddf4ddd118e: ClarityError(StaticCheck(StaticCheckError { err: Unreachable(\"Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\"), expressions: Some([SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"ok\")), id: 172 }, SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"merge\")), id: 174 }, SymbolicExpression { expr: Atom(ClarityName(\"ta\")), id: 175 }, SymbolicExpression { expr: Atom(ClarityName(\"tb\")), id: 176 }]), id: 173 }]), id: 171 }]), diagnostic: Diagnostic { level: Error, message: \"unexpected and unacceptable interpreter behavior: Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\", spans: [Span { start_line: 0, start_column: 0, end_line: 0, end_column: 0 }], suggestion: None } }))",
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "0706781c0e7f10e898bfcd1f76f53774de7306c05061f015155854b9ffd5ef68",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: tuple-merge-overflow-Epoch4_0-Clarity1, code_body: [..], clarity_version: Some(Clarity1))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 177,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 52162,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 177,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 52162,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "ac59ce48653bd6296ac8324f9fcf008e4b46339e6342198273f8ad061eeb174d",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: tuple-merge-overflow-Epoch4_0-Clarity2, code_body: [..], clarity_version: Some(Clarity2))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 177,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 52162,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 177,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 52162,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "e27ad5c5824696e024af5ad0e61ba88d3595da42833bca8f13fa9f8c9c4db1dd",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: tuple-merge-overflow-Epoch4_0-Clarity3, code_body: [..], clarity_version: Some(Clarity3))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 177,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 52162,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 177,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 52162,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "816a20c7bec16fc955b5e3a0612c5abb56db1cc4618bf7ed87687a459e62b418",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: tuple-merge-overflow-Epoch4_0-Clarity4, code_body: [..], clarity_version: Some(Clarity4))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 177,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 52162,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 177,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 52162,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "d940e06d498cd55f9a8d682dabe00e9af0c0fc5314ee4bc90d34f38a7346d1f5",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: tuple-merge-overflow-Epoch4_0-Clarity5, code_body: [..], clarity_version: Some(Clarity5))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 177,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 52162,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 177,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 52162,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "7a2bff30b2751c33243c9c8cf8e654d12612897905d784796835b613745a2f41",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: tuple-merge-overflow-Epoch4_0-Clarity6, code_body: [..], clarity_version: Some(Clarity6))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 177,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 52162,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 177,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 52162,
+    ),
+  )),
+]

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_overflow_unused_runtime_ccall.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_overflow_unused_runtime_ccall.snap
@@ -1,0 +1,128 @@
+---
+source: stackslib/src/chainstate/tests/static_analysis_tests.rs
+expression: result.get_expected_results()
+---
+[
+  Success(ExpectedBlockOutput(
+    marf_hash: "296d9cf772c7ae34434f75ca02a3776ed7dc7e08abce0a4b3047c564e4871045",
+    evaluated_epoch: Epoch34,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch3_4-Clarity3, code_body: [..], clarity_version: Some(Clarity3))",
+        vm_error: "None [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: true,
+          data: Bool(true),
+        )),
+        cost: ExecutionCost(
+          write_length: 1541,
+          write_count: 2,
+          read_length: 1,
+          read_count: 1,
+          runtime: 74017,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 1541,
+      write_count: 2,
+      read_length: 1,
+      read_count: 1,
+      runtime: 74017,
+    ),
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 94e7ffdc3dc3e804a83b6c98c9c7a4196f3e4dbcbeed9471a46c9692a613ad9a: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "2526d7c53cb5d8dae46590f366f34076359b160b5b4bd14943e029729380c0e7",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch4_0-Clarity3, code_body: [..], clarity_version: Some(Clarity3))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 174,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 50516,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 174,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 50516,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "e702b59b17a5e72359cb383e2a008aa759c800d680f2988ebafc38afae1b48f7",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch3_4-Clarity3, function_name: run, function_args: [[]])",
+        vm_error: "Some(ValueTooLarge) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 1367,
+          read_count: 3,
+          runtime: 48387181,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 1367,
+      read_count: 3,
+      runtime: 48387181,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "f88bda8ff76ba692c60e12a22f41d0587c0dd046dc951fdd52703dde925178e2",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch4_0-Clarity3, function_name: run, function_args: [[]])",
+        vm_error: "Some(NoSuchContract(\"ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP.merge-unused-Epoch4_0-Clarity3\")) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 0,
+          read_count: 0,
+          runtime: 0,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 0,
+      read_count: 0,
+      runtime: 0,
+    ),
+  )),
+]

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_overflow_unused_runtime_ccall.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_overflow_unused_runtime_ccall.snap
@@ -4,7 +4,63 @@ expression: result.get_expected_results()
 ---
 [
   Success(ExpectedBlockOutput(
-    marf_hash: "296d9cf772c7ae34434f75ca02a3776ed7dc7e08abce0a4b3047c564e4871045",
+    marf_hash: "8205600be780ecc963f4aad50ecb9ee223029a72ef4af1f42d4a666eee684307",
+    evaluated_epoch: Epoch34,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch3_4-Clarity1, code_body: [..], clarity_version: Some(Clarity1))",
+        vm_error: "None [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: true,
+          data: Bool(true),
+        )),
+        cost: ExecutionCost(
+          write_length: 1541,
+          write_count: 2,
+          read_length: 1,
+          read_count: 1,
+          runtime: 74017,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 1541,
+      write_count: 2,
+      read_length: 1,
+      read_count: 1,
+      runtime: 74017,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "f8015448a18711ec0b7ce97d78e83004e499a640bc2febded8d3263be028e21c",
+    evaluated_epoch: Epoch34,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch3_4-Clarity2, code_body: [..], clarity_version: Some(Clarity2))",
+        vm_error: "None [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: true,
+          data: Bool(true),
+        )),
+        cost: ExecutionCost(
+          write_length: 1541,
+          write_count: 2,
+          read_length: 1,
+          read_count: 1,
+          runtime: 74017,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 1541,
+      write_count: 2,
+      read_length: 1,
+      read_count: 1,
+      runtime: 74017,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "2bf9eebacc64fd5e530dbb342f86bf217a3a3095ec733cc823a8b5dcb2b99b58",
     evaluated_epoch: Epoch34,
     transactions: [
       ExpectedTransactionOutput(
@@ -31,12 +87,144 @@ expression: result.get_expected_results()
       runtime: 74017,
     ),
   )),
-  Failure(ExpectedFailureOutput(
+  Success(ExpectedBlockOutput(
+    marf_hash: "3ad2821d99f6b9f1bf88e90cda7d375405ae6becab381b3486064f37902eb800",
     evaluated_epoch: Epoch34,
-    error: "Invalid Stacks block 94e7ffdc3dc3e804a83b6c98c9c7a4196f3e4dbcbeed9471a46c9692a613ad9a: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch3_4-Clarity4, code_body: [..], clarity_version: Some(Clarity4))",
+        vm_error: "None [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: true,
+          data: Bool(true),
+        )),
+        cost: ExecutionCost(
+          write_length: 1541,
+          write_count: 2,
+          read_length: 1,
+          read_count: 1,
+          runtime: 74017,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 1541,
+      write_count: 2,
+      read_length: 1,
+      read_count: 1,
+      runtime: 74017,
+    ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "2526d7c53cb5d8dae46590f366f34076359b160b5b4bd14943e029729380c0e7",
+    marf_hash: "1f0d8318a2e4e04d65b7626a31f51581f726251a99244e50d6165bbf00a9408d",
+    evaluated_epoch: Epoch34,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch3_4-Clarity5, code_body: [..], clarity_version: Some(Clarity5))",
+        vm_error: "None [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: true,
+          data: Bool(true),
+        )),
+        cost: ExecutionCost(
+          write_length: 1541,
+          write_count: 2,
+          read_length: 1,
+          read_count: 1,
+          runtime: 74017,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 1541,
+      write_count: 2,
+      read_length: 1,
+      read_count: 1,
+      runtime: 74017,
+    ),
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block a5d4fe7acb883a5849b924ec925ae090ee44c6bb69baf27ffb5226a72dab700a: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 89be00578d29ba61693ec811fd035c1fb49270f77acdf247e4d8a9be3cfdeaf6: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 88f85b87c5ede025f42ecd0dc9a4602732ee6dd0133527866c32f422755690d5: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block 509e2d91e2d6d027bbc17fec40481125ab4b4ba44aaee51015339d8fdedc8f44: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
+  )),
+  Failure(ExpectedFailureOutput(
+    evaluated_epoch: Epoch34,
+    error: "Invalid Stacks block dcb41433e1bf6af548bfda3aacb6c787e7834df448bbca12306ce4591f63d6ba: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "c9ceff263c245f9c823458eea2923f27f687772611e4ba9748fe93b4f50e960e",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch4_0-Clarity1, code_body: [..], clarity_version: Some(Clarity1))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 174,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 50516,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 174,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 50516,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "aeb1a9bbc08bc4bdc0e6e205fbe36750fc4e15f593251799f070579954730ce5",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch4_0-Clarity2, code_body: [..], clarity_version: Some(Clarity2))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 174,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 50516,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 174,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 50516,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "0fb874e825d1dd93b6d82aea0db46b542e145a0a705b171de3ac40f51b4f34f9",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -66,7 +254,157 @@ expression: result.get_expected_results()
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "e702b59b17a5e72359cb383e2a008aa759c800d680f2988ebafc38afae1b48f7",
+    marf_hash: "4bf53fecd13643b6609f441653e5431f15e175268397e3c41541d76f8a690bb5",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch4_0-Clarity4, code_body: [..], clarity_version: Some(Clarity4))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 174,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 50516,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 174,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 50516,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "d7c3edce06b7c99077d128fb1a37e3c31dbed6522d93de6eacddf917c3d33e53",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch4_0-Clarity5, code_body: [..], clarity_version: Some(Clarity5))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 174,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 50516,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 174,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 50516,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "8705ba0ead2ded5d4604681a671e9b525faf0c4c13c9b81b9b04d330b4368fcd",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "SmartContract(name: merge-unused-Epoch4_0-Clarity6, code_body: [..], clarity_version: Some(Clarity6))",
+        vm_error: "Some(:0:0: created a type which was greater than maximum allowed value size) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 174,
+          write_count: 1,
+          read_length: 1,
+          read_count: 1,
+          runtime: 50516,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 174,
+      write_count: 1,
+      read_length: 1,
+      read_count: 1,
+      runtime: 50516,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "beed1fc3f146e3807fecf58ce60e56ee4ab11d73d11748add8c81bfbb73b1dfe",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch3_4-Clarity1, function_name: run, function_args: [[]])",
+        vm_error: "Some(ValueTooLarge) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 1367,
+          read_count: 3,
+          runtime: 48387181,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 1367,
+      read_count: 3,
+      runtime: 48387181,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "894c4acc037dd72698de838c110e271ec9e28385cf5351e30fe2b8335816c708",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch3_4-Clarity2, function_name: run, function_args: [[]])",
+        vm_error: "Some(ValueTooLarge) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 1367,
+          read_count: 3,
+          runtime: 48387181,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 1367,
+      read_count: 3,
+      runtime: 48387181,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "8af710f6e17a676b1efe13e96f81bcdc948138e595b4cdc0d6241cd844c855d8",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -96,12 +434,222 @@ expression: result.get_expected_results()
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "f88bda8ff76ba692c60e12a22f41d0587c0dd046dc951fdd52703dde925178e2",
+    marf_hash: "9123e9c568400fa0e514e8cfb3499c75b81633ecb541041f99aab10a1e560931",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch3_4-Clarity4, function_name: run, function_args: [[]])",
+        vm_error: "Some(ValueTooLarge) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 1367,
+          read_count: 3,
+          runtime: 48387181,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 1367,
+      read_count: 3,
+      runtime: 48387181,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "8300ebc5c561d07c3a0a1484bc785815c77582abcca439e065b01a67982d13a6",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch3_4-Clarity5, function_name: run, function_args: [[]])",
+        vm_error: "Some(ValueTooLarge) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 1367,
+          read_count: 3,
+          runtime: 48387181,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 1367,
+      read_count: 3,
+      runtime: 48387181,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "ffacdc7e042f8b70dcf69b034137738438fd914f52630accdf8efb0691b7b071",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch4_0-Clarity1, function_name: run, function_args: [[]])",
+        vm_error: "Some(NoSuchContract(\"ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP.merge-unused-Epoch4_0-Clarity1\")) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 0,
+          read_count: 0,
+          runtime: 0,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 0,
+      read_count: 0,
+      runtime: 0,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "8f76824ee160e8c2c0863128e58ca12e534fd2b6309ba502e93ae021309a8e6f",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch4_0-Clarity2, function_name: run, function_args: [[]])",
+        vm_error: "Some(NoSuchContract(\"ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP.merge-unused-Epoch4_0-Clarity2\")) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 0,
+          read_count: 0,
+          runtime: 0,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 0,
+      read_count: 0,
+      runtime: 0,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "201d77f807f95f07d232544abe2423ec4fab2dd66fb5f3748f4f7d6b02453ab7",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
         tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch4_0-Clarity3, function_name: run, function_args: [[]])",
         vm_error: "Some(NoSuchContract(\"ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP.merge-unused-Epoch4_0-Clarity3\")) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 0,
+          read_count: 0,
+          runtime: 0,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 0,
+      read_count: 0,
+      runtime: 0,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "5c09c95bee285d2cb436a1aa27b1c2afa3d4ea2784915dc809f9731b939005cc",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch4_0-Clarity4, function_name: run, function_args: [[]])",
+        vm_error: "Some(NoSuchContract(\"ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP.merge-unused-Epoch4_0-Clarity4\")) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 0,
+          read_count: 0,
+          runtime: 0,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 0,
+      read_count: 0,
+      runtime: 0,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "c02a12257fc4e0ed78612162a6905eebf953f7151f03ea99fb0ffbbb02eacd98",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch4_0-Clarity5, function_name: run, function_args: [[]])",
+        vm_error: "Some(NoSuchContract(\"ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP.merge-unused-Epoch4_0-Clarity5\")) [NON-CONSENSUS BREAKING]",
+        return_type: Response(ResponseData(
+          committed: false,
+          data: Optional(OptionalData(
+            data: None,
+          )),
+        )),
+        cost: ExecutionCost(
+          write_length: 0,
+          write_count: 0,
+          read_length: 0,
+          read_count: 0,
+          runtime: 0,
+        ),
+      ),
+    ],
+    total_block_cost: ExecutionCost(
+      write_length: 0,
+      write_count: 0,
+      read_length: 0,
+      read_count: 0,
+      runtime: 0,
+    ),
+  )),
+  Success(ExpectedBlockOutput(
+    marf_hash: "2e9bf4d37788612c6c61341fcfc2f632a9721d043afa1093d7c8078f50e4dbba",
+    evaluated_epoch: Epoch40,
+    transactions: [
+      ExpectedTransactionOutput(
+        tx: "ContractCall(address: ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP, contract_name: merge-unused-Epoch4_0-Clarity6, function_name: run, function_args: [[]])",
+        vm_error: "Some(NoSuchContract(\"ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP.merge-unused-Epoch4_0-Clarity6\")) [NON-CONSENSUS BREAKING]",
         return_type: Response(ResponseData(
           committed: false,
           data: Optional(OptionalData(

--- a/stackslib/src/chainstate/tests/static_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/static_analysis_tests.rs
@@ -25,8 +25,9 @@ use clarity::vm::types::MAX_TYPE_DEPTH;
 use clarity::vm::ClarityVersion;
 
 use crate::chainstate::tests::consensus::{
-    clarity_versions_for_epoch, contract_deploy_consensus_snap_test, tested_epochs_since,
-    ConsensusTest, ConsensusUtils, SetupContract, TestBlock, EPOCHS_TO_TEST,
+    clarity_versions_for_epoch, contract_call_consensus_snap_test,
+    contract_deploy_consensus_snap_test, tested_epochs_since, ConsensusTest, ConsensusUtils,
+    SetupContract, TestBlock, EPOCHS_TO_TEST,
 };
 use crate::core::BLOCK_LIMIT_MAINNET_21;
 use crate::util_lib::boot::boot_code_test_addr;
@@ -68,7 +69,9 @@ fn variant_coverage_report(variant: StaticCheckErrorKind) {
         TypeSignatureTooDeep => Tested(vec![static_check_error_type_signature_too_deep]),
         ExpectedName => Tested(vec![static_check_error_expected_name]),
         SupertypeTooLarge => Tested(vec![static_check_error_supertype_too_large]),
-        Unreachable(_) => Unreachable_ExpectLike,
+        // Normally a "Unreachable_ExpectLike", but an oversized tuple `merge` reaches it
+        // via an `InvariantViolation` from `.size()` in `new_response`.
+        Unreachable(_) => Tested(vec![tuple_merge_exceeds_max_value_size_cdeploy]),
         BadMatchOptionSyntax(static_check_error_kind) => {
             Tested(vec![static_check_error_bad_match_option_syntax])
         }
@@ -1417,4 +1420,106 @@ fn error_invalid_stacks_transaction_duplicate_contract() {
     let result = ConsensusTest::new(function_name!(), vec![], epochs_blocks).run();
 
     insta::assert_ron_snapshot!(result);
+}
+
+/// StaticCheckErrorKind: [`StaticCheckErrorKind::Unreachable`]
+/// Caused by: `(ok (merge ta tb))` of two individually-valid ~512 KiB tuples whose combined
+/// size exceeds `MAX_VALUE_SIZE`; `new_response` calls `.size()` on the merged tuple type,
+/// which raises `InvariantViolation` and is surfaced as `Unreachable`. Demonstrates that the
+/// `Unreachable` catch-all is in fact reachable via an oversized tuple `merge`.
+/// Outcome: block rejected.
+#[test]
+fn tuple_merge_exceeds_max_value_size_cdeploy() {
+    contract_deploy_consensus_snap_test!(
+        contract_name: "tuple-merge-overflow",
+        contract_code: r#"
+        (define-private (make-buff-256)
+            (let ((b16 0x00112233445566778899aabbccddeeff)
+                  (b32 (concat b16 b16))
+                  (b64 (concat b32 b32))
+                  (b128 (concat b64 b64))
+                  (b256 (concat b128 b128)))
+              b256))
+
+        (define-private (make-buff-4096)
+            (let ((b256 (make-buff-256))
+                  (b512 (concat b256 b256))
+                  (b1024 (concat b512 b512))
+                  (b2048 (concat b1024 b1024))
+                  (b4096 (concat b2048 b2048)))
+              b4096))
+
+        (define-private (make-buff-65536)
+            (let ((b4096 (make-buff-4096))
+                  (b8192 (concat b4096 b4096))
+                  (b16384 (concat b8192 b8192))
+                  (b32768 (concat b16384 b16384))
+                  (b65536 (concat b32768 b32768)))
+              b65536))
+
+        (define-private (make-buff-524288)
+            (let ((b65536 (make-buff-65536))
+                  (b131072 (concat b65536 b65536))
+                  (b262144 (concat b131072 b131072))
+                  (b524288 (concat b262144 b262144)))
+              b524288))
+
+        (define-public (trigger-merge-overflow)
+            (let ((big (unwrap-panic (as-max-len? (make-buff-524288) u524288))))
+                (let ((ta (tuple (a big)))
+                      (tb (tuple (b big))))
+                    (ok (merge ta tb)))))
+    "#,
+    deploy_epochs: &[StacksEpochId::Epoch34, StacksEpochId::Epoch40],
+    );
+}
+
+/// Runtime reachability check (ORIGINAL code): oversized `(merge ta tb)` bound in a `let`
+/// but NEVER sized (function returns `(ok true)`). No `new_response`/`.size()` is triggered
+/// at analysis, so the oversized type slips past the static checker, the contract DEPLOYS,
+/// and the runtime `merge` actually executes. This pins the true pre-PR runtime behavior so
+/// we know what an epoch gate must preserve for epochs < 4.0.
+#[test]
+fn tuple_merge_overflow_unused_runtime_ccall() {
+    contract_call_consensus_snap_test!(
+        contract_name: "merge-unused",
+        contract_code: r#"
+        (define-private (make-buff-256)
+            (let ((b16 0x00112233445566778899aabbccddeeff)
+                  (b32 (concat b16 b16))
+                  (b64 (concat b32 b32))
+                  (b128 (concat b64 b64))
+                  (b256 (concat b128 b128)))
+              b256))
+        (define-private (make-buff-4096)
+            (let ((b256 (make-buff-256))
+                  (b512 (concat b256 b256))
+                  (b1024 (concat b512 b512))
+                  (b2048 (concat b1024 b1024))
+                  (b4096 (concat b2048 b2048)))
+              b4096))
+        (define-private (make-buff-65536)
+            (let ((b4096 (make-buff-4096))
+                  (b8192 (concat b4096 b4096))
+                  (b16384 (concat b8192 b8192))
+                  (b32768 (concat b16384 b16384))
+                  (b65536 (concat b32768 b32768)))
+              b65536))
+        (define-private (make-buff-524288)
+            (let ((b65536 (make-buff-65536))
+                  (b131072 (concat b65536 b65536))
+                  (b262144 (concat b131072 b131072))
+                  (b524288 (concat b262144 b262144)))
+              b524288))
+        (define-public (run)
+            (let ((big (unwrap-panic (as-max-len? (make-buff-524288) u524288))))
+                (let ((m (merge (tuple (a big)) (tuple (b big)))))
+                    (ok true))))
+    "#,
+        function_name: "run",
+        function_args: &[],
+        deploy_epochs: &[StacksEpochId::Epoch34, StacksEpochId::Epoch40],
+        call_epochs: &[StacksEpochId::Epoch34, StacksEpochId::Epoch40],
+        clarity_versions: &[ClarityVersion::Clarity3],
+    );
 }

--- a/stackslib/src/chainstate/tests/static_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/static_analysis_tests.rs
@@ -64,13 +64,20 @@ fn variant_coverage_report(variant: StaticCheckErrorKind) {
         MemoryBalanceExceeded(_, _) => Tested(vec![static_check_error_memory_balance_exceeded]),
         CostComputationFailed(_) => Unreachable_ExpectLike,
         ExecutionTimeExpired => Unreachable_Functionally("Can only be triggered at runtime."),
-        ValueTooLarge => Tested(vec![static_check_error_value_too_large]),
+        // `tuple_merge_exceeds_max_value_size_cdeploy` produces `ValueTooLarge` at 4.0+ (an
+        // oversized tuple `merge` rejected at the merge site); pre-4.0 the same test surfaces
+        // as `Unreachable` (see that arm below).
+        ValueTooLarge => Tested(vec![
+            static_check_error_value_too_large,
+            tuple_merge_exceeds_max_value_size_cdeploy,
+        ]),
         ValueOutOfBounds => Tested(vec![static_check_error_value_out_of_bounds]),
         TypeSignatureTooDeep => Tested(vec![static_check_error_type_signature_too_deep]),
         ExpectedName => Tested(vec![static_check_error_expected_name]),
         SupertypeTooLarge => Tested(vec![static_check_error_supertype_too_large]),
-        // Normally a "Unreachable_ExpectLike", but an oversized tuple `merge` reaches it
-        // via an `InvariantViolation` from `.size()` in `new_response`.
+        // Normally a "Unreachable_ExpectLike", but pre-4.0 an oversized tuple `merge` reaches
+        // it via an `InvariantViolation` from `.size()` in `new_response`. (At 4.0+ the same
+        // test is rejected earlier as `ValueTooLarge` — see that arm above.)
         Unreachable(_) => Tested(vec![tuple_merge_exceeds_max_value_size_cdeploy]),
         BadMatchOptionSyntax(static_check_error_kind) => {
             Tested(vec![static_check_error_bad_match_option_syntax])
@@ -1422,12 +1429,17 @@ fn error_invalid_stacks_transaction_duplicate_contract() {
     insta::assert_ron_snapshot!(result);
 }
 
-/// StaticCheckErrorKind: [`StaticCheckErrorKind::Unreachable`]
+/// StaticCheckErrorKind: [`StaticCheckErrorKind::Unreachable`] pre-4.0 /
+///   [`StaticCheckErrorKind::ValueTooLarge`] 4.0+.
 /// Caused by: `(ok (merge ta tb))` of two individually-valid ~512 KiB tuples whose combined
-/// size exceeds `MAX_VALUE_SIZE`; `new_response` calls `.size()` on the merged tuple type,
-/// which raises `InvariantViolation` and is surfaced as `Unreachable`. Demonstrates that the
-/// `Unreachable` catch-all is in fact reachable via an oversized tuple `merge`.
-/// Outcome: block rejected.
+/// size exceeds `MAX_VALUE_SIZE`.
+///   - pre-4.0: `check_special_merge` does not size the merge, so the oversized type
+///     propagates until `new_response` calls `.size()` on it, raising `InvariantViolation`
+///     surfaced as `Unreachable` (demonstrating the `Unreachable` catch-all is in fact
+///     reachable via an oversized tuple `merge`).
+///   - 4.0+: `check_special_merge` rejects the oversized merge at the merge site with the
+///     checked `ValueTooLarge`.
+/// Outcome: block rejected pre-4.0, accepted 4.0+ (deploy tx mined with `committed:false`).
 #[test]
 fn tuple_merge_exceeds_max_value_size_cdeploy() {
     contract_deploy_consensus_snap_test!(
@@ -1474,11 +1486,25 @@ fn tuple_merge_exceeds_max_value_size_cdeploy() {
     );
 }
 
-/// Runtime reachability check (ORIGINAL code): oversized `(merge ta tb)` bound in a `let`
-/// but NEVER sized (function returns `(ok true)`). No `new_response`/`.size()` is triggered
-/// at analysis, so the oversized type slips past the static checker, the contract DEPLOYS,
-/// and the runtime `merge` actually executes. This pins the true pre-PR runtime behavior so
-/// we know what an epoch gate must preserve for epochs < 4.0.
+/// Runtime reachability of an oversized tuple `merge`: `(merge ta tb)` bound in a `let` but
+/// NEVER sized (the function returns `(ok true)`). Because nothing sizes the merged type at
+/// analysis, this is the case that slips past the static checker pre-4.0. The test deploys in
+/// both Epoch34 and Epoch40 and calls `run` in both, exercising the static gate (deploy) and
+/// the runtime gate (call) across the boundary.
+///
+/// Error family: `VmInternalError::Expect` (block-invalidating) pre-4.0 at runtime;
+///   [`StaticCheckErrorKind::ValueTooLarge`] 4.0+ at analysis time.
+///
+/// Behavior:
+///   - pre-4.0: the contract DEPLOYS (analysis never sizes the merge); calling `run` then
+///     executes the runtime `merge`, and computing the oversized value size during cost
+///     calculation raises a block-invalidating `InvariantViolation`/`Expect`.
+///   - 4.0+: the deploy is rejected at analysis (`ValueTooLarge`, tx `committed:false`); and a
+///     contract deployed pre-4.0 but called at 4.0+ reaches the runtime gate, which rejects
+///     the oversized `merge` cleanly with `ValueTooLarge` (tx `committed:false`) instead of
+///     invalidating the block.
+/// Outcome: the `run` call invalidates the block pre-4.0, but is accepted at 4.0+ (both the
+/// deploy and the call are mined with `committed:false`).
 #[test]
 fn tuple_merge_overflow_unused_runtime_ccall() {
     contract_call_consensus_snap_test!(
@@ -1520,6 +1546,5 @@ fn tuple_merge_overflow_unused_runtime_ccall() {
         function_args: &[],
         deploy_epochs: &[StacksEpochId::Epoch34, StacksEpochId::Epoch40],
         call_epochs: &[StacksEpochId::Epoch34, StacksEpochId::Epoch40],
-        clarity_versions: &[ClarityVersion::Clarity3],
     );
 }


### PR DESCRIPTION
### Description

Merging two individually-valid tuples whose **combined** size exceeds `MAX_VALUE_SIZE` (`(merge ta tb)`) currently behaves incorrectly:

- If the result is sized (e.g. `(ok (merge …))`), analysis fails with an `InvariantViolation` surfaced as `Unreachable` cause **invalid block**.
- If the result is bound but never sized (`(let ((m (merge …))) …)`), the oversized type slips past the static checker, the contract **deploys**, and calling it later block-invalidates during cost calculation (`Expect` / "Interpreter failure during cost calculation").

This PR adds a clean, checked `ValueTooLarge` rejection at the `merge` site, **gated at Epoch 4.0** so behavior for all currently-active epochs (≤ 3.4) remains unchanged.

> Note: This is a standalone consensus fix carved out of #6946 so that `Value::size()` caching optimization can land as a separate, consensus-neutral change.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
