### PR TITLE
fix: reject unlock heights >500 million

### DIFF
--- a/changelog.d/pox5-cltv-height-limit.fixed
+++ b/changelog.d/pox5-cltv-height-limit.fixed
@@ -1,0 +1,1 @@
+Fixed PoX-5 L1 lockup script construction to reject Bitcoin `CHECKLOCKTIMEVERIFY` values that would be interpreted as Unix timestamps instead of block heights.

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -7365,6 +7365,11 @@ export const contracts = {
       } as TypedAbiMap<number | bigint, bigint>,
     },
     variables: {
+      BITCOIN_LOCKTIME_THRESHOLD: {
+        name: 'BITCOIN_LOCKTIME_THRESHOLD',
+        type: 'uint128',
+        access: 'constant',
+      } as TypedAbiVariable<bigint>,
       BOND_GAP_CYCLES: {
         name: 'BOND_GAP_CYCLES',
         type: 'uint128',
@@ -7986,6 +7991,7 @@ export const contracts = {
       } as TypedAbiVariable<bigint>,
     },
     constants: {
+      BITCOIN_LOCKTIME_THRESHOLD: 500_000_000n,
       BOND_GAP_CYCLES: 2n,
       BOND_LENGTH_CYCLES: 12n,
       ERR_ACTIVE_BOND_NOT_INCLUDED: {

--- a/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5.test.ts
@@ -49,6 +49,7 @@ const emily = accounts.wallet_5.address;
 const REWARD_CYCLE_LENGTH = 100n;
 const HALF_CYCLE_LENGTH = REWARD_CYCLE_LENGTH / 2n;
 const BASIS_POINTS = 10000n;
+const BITCOIN_LOCKTIME_THRESHOLD = 500000000n;
 
 function reserveRewards(rewards: bigint) {
   return (rewards * pox5.constants.RESERVE_RATIO) / BASIS_POINTS;
@@ -2448,6 +2449,36 @@ test('l1 lockup rejects an unlock height below the bond minimum', () => {
             staker: alice,
             sats: aliceSats,
             unlockBurnHeight: minimumUnlockHeight - 1n,
+          }),
+        ],
+        stakerUnlockBytes: new Uint8Array(),
+      }),
+      signerCalldata: null,
+    }),
+    alice,
+  );
+
+  expect(result.value).toBe(errorCodes.ERR_INVALID_UNLOCK_HEIGHT);
+});
+
+test('l1 lockup rejects timestamp-style CLTV unlock heights', () => {
+  const signer = testSigner.identifier;
+  const aliceSats = 480000n;
+
+  registerSigner();
+  setupBondForAllowlist([{ maxSats: aliceSats, staker: alice }]);
+
+  const result = txErr(
+    pox5.registerForBond({
+      bondIndex: 0n,
+      signerManager: signer,
+      amountUstx: stxToUStx(50_000),
+      btcLockup: ok({
+        outputs: [
+          buildL1Lockup({
+            staker: alice,
+            sats: aliceSats,
+            unlockBurnHeight: BITCOIN_LOCKTIME_THRESHOLD,
           }),
         ],
         stakerUnlockBytes: new Uint8Array(),

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -84,6 +84,9 @@
 ;; SIP18 message prefix
 (define-constant SIP018_MSG_PREFIX 0x534950303138)
 
+;; Bitcoin treats locktimes >= 500,000,000 as Unix timestamps, not block heights.
+(define-constant BITCOIN_LOCKTIME_THRESHOLD u500000000)
+
 ;; SIP018 domain
 (define-constant POX_5_SIGNER_DOMAIN {
     name: "pox-5-signer",
@@ -2060,6 +2063,9 @@
             (seen-outpoints (get seen-outpoints accumulator))
         )
         (asserts! (>= unlock-burn-height (get minimum-unlock-height accumulator))
+            ERR_INVALID_UNLOCK_HEIGHT
+        )
+        (asserts! (< unlock-burn-height BITCOIN_LOCKTIME_THRESHOLD)
             ERR_INVALID_UNLOCK_HEIGHT
         )
         (asserts! (is-eq (get script output) expected-script-hash)


### PR DESCRIPTION
When a value >= 500,000,000 is used with `CHECKTIMELOCKVERIFY`, it is interpreted as a unix timestamp. This PR changes that behavior to reject values greater than 500 million.