### PR TITLE
chore: drop variant `CostErrors::ExecutionTimeExpired`

### DIFF
--- a/clarity/src/vm/analysis/errors.rs
+++ b/clarity/src/vm/analysis/errors.rs
@@ -235,9 +235,6 @@ pub enum StaticCheckErrorKind {
     /// Failure in cost-tracking due to an unexpected condition or invalid state.
     /// The `String` wraps the specific reason for the failure.
     CostComputationFailed(String),
-    // Time checker errors
-    /// Type-checking time exceeds the allowed budget, halting analysis to ensure responsiveness.
-    ExecutionTimeExpired,
     /// Contract-analysis time exceeds the allowed budget, halting analysis to ensure responsiveness.
     /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable end-to-end.
     AnalysisTimeExpired,
@@ -555,7 +552,7 @@ pub enum RuntimeCheckErrorKind {
     /// The `String` wraps the specific reason for the failure.
     CostComputationFailed(String),
     // Time checker errors
-    /// Type-checking time exceeds the allowed budget, halting analysis to ensure responsiveness.
+    /// Runtime (eval) execution time exceeds the allowed budget, halting execution to ensure responsiveness.
     ExecutionTimeExpired,
 
     /// Value exceeds the maximum allowed size for type-checking or serialization.
@@ -925,7 +922,6 @@ impl From<CostErrors> for StaticCheckErrorKind {
                 "Unexpected interpreter failure in cost computation".into(),
             ),
             CostErrors::Expect(s) => StaticCheckErrorKind::Unreachable(s),
-            CostErrors::ExecutionTimeExpired => StaticCheckErrorKind::ExecutionTimeExpired,
         }
     }
 }
@@ -948,7 +944,6 @@ impl From<CostErrors> for RuntimeCheckErrorKind {
                 "Unexpected interpreter failure in cost computation".into(),
             ),
             CostErrors::Expect(s) => RuntimeCheckErrorKind::Unreachable(s),
-            CostErrors::ExecutionTimeExpired => RuntimeCheckErrorKind::ExecutionTimeExpired,
         }
     }
 }
@@ -1160,7 +1155,6 @@ impl DiagnosableError for StaticCheckErrorKind {
             StaticCheckErrorKind::CostBalanceExceeded(a, b) => format!("contract execution cost exceeded budget: {a:?} > {b:?}"),
             StaticCheckErrorKind::MemoryBalanceExceeded(a, b) => format!("contract execution cost exceeded memory budget: {a:?} > {b:?}"),
             StaticCheckErrorKind::CostComputationFailed(s) => format!("contract cost computation failed: {s}"),
-            StaticCheckErrorKind::ExecutionTimeExpired => "execution time expired".into(),
             StaticCheckErrorKind::AnalysisTimeExpired => "analysis time expired".into(),
             StaticCheckErrorKind::InvalidTypeDescription => "supplied type description is invalid".into(),
             StaticCheckErrorKind::EmptyTuplesNotAllowed => "tuple types may not be empty".into(),

--- a/clarity/src/vm/analysis/errors.rs
+++ b/clarity/src/vm/analysis/errors.rs
@@ -236,7 +236,6 @@ pub enum StaticCheckErrorKind {
     /// The `String` wraps the specific reason for the failure.
     CostComputationFailed(String),
     /// Contract-analysis time exceeds the allowed budget, halting analysis to ensure responsiveness.
-    /// Distinct from `ExecutionTimeExpired` so an analysis-phase timeout is separable end-to-end.
     AnalysisTimeExpired,
 
     /// Value exceeds the maximum allowed size for type-checking or serialization.

--- a/clarity/src/vm/ast/errors.rs
+++ b/clarity/src/vm/ast/errors.rs
@@ -41,8 +41,6 @@ pub enum ParseErrorKind {
     /// Failure in cost-tracking due to an unexpected condition or invalid state.
     /// The `String` represents the specific reason for the failure.
     CostComputationFailed(String),
-    /// Parsing time exceeds the allowed budget, halting AST construction to ensure responsiveness.
-    ExecutionTimeExpired,
 
     // Structural errors
     /// Number of expressions exceeds the maximum allowed limit.
@@ -282,9 +280,6 @@ impl From<CostErrors> for ParseError {
             CostErrors::InterpreterFailure | CostErrors::Expect(_) => {
                 ParseError::new(ParseErrorKind::InterpreterFailure)
             }
-            CostErrors::ExecutionTimeExpired => {
-                ParseError::new(ParseErrorKind::ExecutionTimeExpired)
-            }
         }
     }
 }
@@ -410,7 +405,6 @@ impl DiagnosableError for ParseErrorKind {
                 "unexpected failure while parsing".to_string()
             }
             ParseErrorKind::InterpreterFailure => "unexpected failure while parsing".to_string(),
-            ParseErrorKind::ExecutionTimeExpired => "max execution time expired".to_string(),
         }
     }
 

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -114,7 +114,6 @@ impl From<StaticCheckError> for ClarityError {
             StaticCheckErrorKind::MemoryBalanceExceeded(_a, _b) => {
                 ClarityError::CostError(ExecutionCost::max_value(), ExecutionCost::max_value())
             }
-            StaticCheckErrorKind::ExecutionTimeExpired => ClarityError::ExecutionTimeExpired,
             StaticCheckErrorKind::AnalysisTimeExpired => ClarityError::AnalysisTimeExpired,
             _ => ClarityError::StaticCheck(e),
         }
@@ -179,7 +178,6 @@ impl From<ParseError> for ClarityError {
             ParseErrorKind::MemoryBalanceExceeded(_a, _b) => {
                 ClarityError::CostError(ExecutionCost::max_value(), ExecutionCost::max_value())
             }
-            ParseErrorKind::ExecutionTimeExpired => ClarityError::ExecutionTimeExpired,
             _ => ClarityError::Parse(e),
         }
     }

--- a/clarity/src/vm/costs/errors.rs
+++ b/clarity/src/vm/costs/errors.rs
@@ -43,10 +43,6 @@ pub enum CostErrors {
     /// The `String` wraps the specific reason for the failure.
     /// Invalidates Block: false.
     CostComputationFailed(String),
-    // Time checker errors
-    /// Runtime (eval) execution time exceeds the allowed budget, halting execution to ensure responsiveness.
-    /// Invalidates Block: false (soft, node-local limit applied only on the mining / block-proposal paths).
-    ExecutionTimeExpired,
     /// Unexpected condition or failure, indicating a bug or invalid state.
     /// Invalidates Block: true.
     InterpreterFailure,
@@ -69,7 +65,6 @@ impl fmt::Display for CostErrors {
             CostErrors::CostContractLoadFailure => write!(f, "Failed to load cost contract"),
             CostErrors::InterpreterFailure => write!(f, "Interpreter failure"),
             CostErrors::Expect(s) => write!(f, "Expectation failed: {s}"),
-            CostErrors::ExecutionTimeExpired => write!(f, "Execution time expired"),
         }
     }
 }

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -494,7 +494,6 @@ fn check_interpreter_abort_condition(
     if global_context.execution_time_tracker.is_expired() {
         return Err(RuntimeCheckErrorKind::ExecutionTimeExpired.into());
     }
-    
     if let Err(reason) = global_context.abort_callback.check() {
         return Err(RuntimeCheckErrorKind::AbortedByExecutionHook(reason).into());
     }

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -494,10 +494,9 @@ fn check_interpreter_abort_condition(
     if global_context.execution_time_tracker.is_expired() {
         return Err(RuntimeCheckErrorKind::ExecutionTimeExpired.into());
     }
+    
     if let Err(reason) = global_context.abort_callback.check() {
-        return Err(VmExecutionError::RuntimeCheck(
-            RuntimeCheckErrorKind::AbortedByExecutionHook(reason),
-        ));
+        return Err(RuntimeCheckErrorKind::AbortedByExecutionHook(reason).into());
     }
 
     Ok(())

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -64,7 +64,7 @@ pub use crate::vm::contexts::{CallStack, ContractContext, LocalContext, MAX_CONT
 use crate::vm::contexts::{ExecutionState, GlobalContext, InvocationContext};
 use crate::vm::costs::cost_functions::ClarityCostFunction;
 use crate::vm::costs::{
-    CostErrors, CostOverflowingMath, CostTracker, LimitedCostTracker, MemoryConsumer, runtime_cost,
+    CostOverflowingMath, CostTracker, LimitedCostTracker, MemoryConsumer, runtime_cost,
 };
 // publish the non-generic StacksEpoch form for use throughout module
 pub use crate::vm::database::clarity_db::StacksEpoch;
@@ -492,7 +492,7 @@ fn check_interpreter_abort_condition(
     global_context: &GlobalContext,
 ) -> Result<(), VmExecutionError> {
     if global_context.execution_time_tracker.is_expired() {
-        return Err(CostErrors::ExecutionTimeExpired.into());
+        return Err(RuntimeCheckErrorKind::ExecutionTimeExpired.into());
     }
     if let Err(reason) = global_context.abort_callback.check() {
         return Err(VmExecutionError::RuntimeCheck(

--- a/clarity/src/vm/tests/simple_apply_eval.rs
+++ b/clarity/src/vm/tests/simple_apply_eval.rs
@@ -42,8 +42,8 @@ use crate::vm::types::{
     TypeSignature,
 };
 use crate::vm::{
-    CallStack, ClarityVersion, ContractContext, CostErrors, GlobalContext, LocalContext, Value,
-    ValueRef, eval, execute as vm_execute, execute_v2 as vm_execute_v2,
+    CallStack, ClarityVersion, ContractContext, GlobalContext, LocalContext, Value, ValueRef, eval,
+    execute as vm_execute, execute_v2 as vm_execute_v2,
     execute_with_limited_execution_time as vm_execute_with_limited_execution_time,
     execute_with_parameters,
 };
@@ -1866,7 +1866,7 @@ fn test_execution_time_expiration() {
         vm_execute_with_limited_execution_time("(+ 1 1)", Duration::from_secs(0))
             .err()
             .unwrap(),
-        ClarityEvalError::Vm(CostErrors::ExecutionTimeExpired.into())
+        ClarityEvalError::Vm(RuntimeCheckErrorKind::ExecutionTimeExpired.into())
     );
 }
 

--- a/stackslib/src/chainstate/tests/parse_tests.rs
+++ b/stackslib/src/chainstate/tests/parse_tests.rs
@@ -61,8 +61,8 @@ fn variant_coverage_report(variant: ParseErrorKind) {
         CostBalanceExceeded(_, _) => Tested(vec![test_cost_balance_exceeded]),
         MemoryBalanceExceeded(_, _) => Unreachable_NotUsed,
         CostComputationFailed(_) => Unreachable_ExpectLike,
-        ExecutionTimeExpired => Unreachable_NotUsed,
 
+        // Parse
         TooManyExpressions => Unreachable_ExpectLike,
         ExpressionStackDepthTooDeep { .. } => Tested(vec![
             test_stack_depth_too_deep_case_1_tuple_only_parsing,

--- a/stackslib/src/chainstate/tests/static_analysis_tests.rs
+++ b/stackslib/src/chainstate/tests/static_analysis_tests.rs
@@ -62,7 +62,6 @@ fn variant_coverage_report(variant: StaticCheckErrorKind) {
         CostBalanceExceeded(execution_cost, execution_cost1) => Tested(vec![static_check_error_cost_balance_exceeded]),
         MemoryBalanceExceeded(_, _) => Tested(vec![static_check_error_memory_balance_exceeded]),
         CostComputationFailed(_) => Unreachable_ExpectLike,
-        ExecutionTimeExpired => Unreachable_Functionally("Can only be triggered at runtime."),
         AnalysisTimeExpired => Unreachable_Functionally(
             "All consensus-critical code paths (block validation and transaction processing) pass
              `None` for max_execution_time, so the analysis-phase time tracking stays


### PR DESCRIPTION
### Description

This PR removes the `CostErrors::ExecutionTimeExpired` variant and instead raises `RuntimeCheckErrorKind::ExecutionTimeExpired` directly from `check_interpreter_abort_condition`.

As a result, we can simplify the error hierarchy by removing the corresponding variants from `ParseErrorKind` and `StaticCheckAnalysis`, along with the associated error remapping logic. This also keeps the concept of "execution time expired" scoped to runtime execution, where it belongs.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
