### PR TITLE
fix: makes max_analysis_time behave like max_execution_time

### DIFF
--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -3349,6 +3349,7 @@ fn block_proposal_api_endpoint() {
             tx_len,
             &BlockLimitFunction::NO_LIMIT_HIT,
             None,
+            None,
             &mut 0,
         );
         assert!(

--- a/stacks-node/src/tests/signer/v0/tenure_extend.rs
+++ b/stacks-node/src/tests/signer/v0/tenure_extend.rs
@@ -1126,6 +1126,7 @@ fn sip034_tenure_extend_proposal(allow: bool, extend_types: &[TenureChangeCause]
                     tenure_change.serialize_to_vec().len() as u64,
                     &BlockLimitFunction::NO_LIMIT_HIT,
                     None,
+                    None,
                     &mut 0,
                 )
                 .unwrap();

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -654,7 +654,7 @@ fn make_genesis_block_with_recipients(
         .0;
 
     builder
-        .try_mine_tx(&mut epoch_tx, &coinbase_op, None, &mut 0)
+        .try_mine_tx(&mut epoch_tx, &coinbase_op, None, None, &mut 0)
         .unwrap();
 
     let block = builder.mine_anchored_block(&mut epoch_tx);
@@ -924,12 +924,12 @@ fn make_stacks_block_with_input(
         .0;
 
     builder
-        .try_mine_tx(&mut epoch_tx, &coinbase_op, None, &mut 0)
+        .try_mine_tx(&mut epoch_tx, &coinbase_op, None, None, &mut 0)
         .unwrap();
 
     for tx in txs {
         builder
-            .try_mine_tx(&mut epoch_tx, tx, None, &mut 0)
+            .try_mine_tx(&mut epoch_tx, tx, None, None, &mut 0)
             .unwrap();
     }
 

--- a/stackslib/src/chainstate/nakamoto/miner.rs
+++ b/stackslib/src/chainstate/nakamoto/miner.rs
@@ -129,9 +129,6 @@ pub struct NakamotoBlockBuilder {
     contract_limit_percentage: Option<u8>,
     /// Maximum size of the whole tenure
     pub max_tenure_bytes: u64,
-    /// Wall-clock deadline for the contract-analysis phase of each
-    /// transaction mined by this builder. `None` means no analysis deadline.
-    pub max_analysis_time: Option<std::time::Duration>,
 }
 
 /// NB: No PartialEq implementation is deliberate in order to ensure that we use the appropriate
@@ -272,7 +269,6 @@ impl NakamotoBlockBuilder {
             soft_limit: None,
             contract_limit_percentage: None,
             max_tenure_bytes: u64::from(DEFAULT_MAX_TENURE_BYTES),
-            max_analysis_time: None,
         }
     }
 
@@ -348,7 +344,6 @@ impl NakamotoBlockBuilder {
             soft_limit,
             contract_limit_percentage,
             max_tenure_bytes,
-            max_analysis_time: None,
         })
     }
 
@@ -756,9 +751,6 @@ impl NakamotoBlockBuilder {
         }
 
         builder.soft_limit = soft_limit;
-        // Bound the analysis phase of each mined tx by the miner's
-        // configured analysis deadline (constant for this builder's lifetime).
-        builder.max_analysis_time = settings.max_analysis_time;
 
         let initial_txs: Vec<_> = [
             tenure_info.tenure_change_tx.clone(),
@@ -848,6 +840,7 @@ impl BlockBuilder for NakamotoBlockBuilder {
         tx_len: u64,
         limit_behavior: &BlockLimitFunction,
         max_execution_time: Option<std::time::Duration>,
+        max_analysis_time: Option<std::time::Duration>,
         total_receipts_size: &mut u64,
     ) -> TransactionResult {
         if self.bytes_so_far + tx_len >= u64::from(MAX_EPOCH_SIZE) {
@@ -913,7 +906,7 @@ impl BlockBuilder for NakamotoBlockBuilder {
                 tx,
                 quiet,
                 max_execution_time,
-                self.max_analysis_time,
+                max_analysis_time,
                 |receipt| {
                     if !receipt.post_condition_aborted {
                         let all_events_valid = receipt.events.iter().all(|event| {

--- a/stackslib/src/chainstate/nakamoto/shadow.rs
+++ b/stackslib/src/chainstate/nakamoto/shadow.rs
@@ -538,6 +538,7 @@ impl NakamotoBlockBuilder {
                 tx_len,
                 &BlockLimitFunction::NO_LIMIT_HIT,
                 None,
+                None,
                 &mut receipts_total,
             ) {
                 TransactionResult::Success(..) => {

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -1023,6 +1023,7 @@ impl TestStacksNode {
                 tx_len,
                 &BlockLimitFunction::NO_LIMIT_HIT,
                 None,
+                None,
                 &mut total,
             ) {
                 TransactionResult::Success(..) => {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -765,6 +765,7 @@ pub trait BlockBuilder {
         tx_len: u64,
         limit_behavior: &BlockLimitFunction,
         max_execution_time: Option<std::time::Duration>,
+        max_analysis_time: Option<std::time::Duration>,
         total_receipts_size: &mut u64,
     ) -> TransactionResult;
 
@@ -775,6 +776,7 @@ pub trait BlockBuilder {
         clarity_tx: &mut ClarityTx,
         tx: &StacksTransaction,
         max_execution_time: Option<std::time::Duration>,
+        max_analysis_time: Option<std::time::Duration>,
         total_receipts_size: &mut u64,
     ) -> Result<TransactionResult, Error> {
         let tx_len = tx.tx_len();
@@ -784,6 +786,7 @@ pub trait BlockBuilder {
             tx_len,
             &BlockLimitFunction::NO_LIMIT_HIT,
             max_execution_time,
+            max_analysis_time,
             total_receipts_size,
         ) {
             TransactionResult::Success(s) => Ok(TransactionResult::Success(s)),
@@ -2085,7 +2088,7 @@ impl StacksBlockBuilder {
         let mut miner_epoch_info = builder.pre_epoch_begin(&mut chainstate, burn_dbconn, true)?;
         let (mut epoch_tx, _) = builder.epoch_begin(burn_dbconn, &mut miner_epoch_info)?;
         for tx in txs.into_iter() {
-            match builder.try_mine_tx(&mut epoch_tx, &tx, None, &mut 0) {
+            match builder.try_mine_tx(&mut epoch_tx, &tx, None, None, &mut 0) {
                 Ok(_) => {
                     debug!("Included {}", &tx.txid());
                 }
@@ -2253,6 +2256,7 @@ impl StacksBlockBuilder {
                         epoch_tx,
                         initial_tx,
                         settings.max_execution_time,
+                        settings.max_analysis_time,
                         &mut receipts_total,
                     )?
                     .convert_to_event(),
@@ -2460,6 +2464,7 @@ impl BlockBuilder for StacksBlockBuilder {
         tx_len: u64,
         limit_behavior: &BlockLimitFunction,
         _max_execution_time: Option<std::time::Duration>,
+        _max_analysis_time: Option<std::time::Duration>,
         _total_receipt_size: &mut u64,
     ) -> TransactionResult {
         if self.bytes_so_far + tx_len >= u64::from(MAX_EPOCH_SIZE) {
@@ -2735,6 +2740,7 @@ fn select_and_apply_transactions_from_mempool<B: BlockBuilder>(
                     txinfo.metadata.len,
                     &block_limit_hit,
                     settings.max_execution_time,
+                    settings.max_analysis_time,
                     &mut receipts_total,
                 );
 
@@ -2910,6 +2916,7 @@ fn select_and_apply_transactions_from_vec<B: BlockBuilder>(
             replay_tx,
             replay_tx.tx_len(),
             &BlockLimitFunction::NO_LIMIT_HIT,
+            None,
             None,
             &mut receipts_total,
         );

--- a/stackslib/src/chainstate/stacks/tests/chain_histories.rs
+++ b/stackslib/src/chainstate/stacks/tests/chain_histories.rs
@@ -2695,7 +2695,7 @@ pub fn mine_empty_anchored_block(
     let tx_coinbase_signed = make_coinbase(miner, burnchain_height);
 
     builder
-        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, None, &mut 0)
         .unwrap();
 
     let stacks_block = builder.mine_anchored_block(clarity_tx);
@@ -2730,7 +2730,7 @@ pub fn mine_empty_anchored_block_with_burn_height_pubkh(
     let tx_coinbase_signed = make_coinbase(miner, burnchain_height);
 
     builder
-        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, None, &mut 0)
         .unwrap();
 
     let stacks_block = builder.mine_anchored_block(clarity_tx);
@@ -2765,7 +2765,7 @@ pub fn mine_empty_anchored_block_with_stacks_height_pubkh(
     let tx_coinbase_signed = make_coinbase(miner, burnchain_height);
 
     builder
-        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, None, &mut 0)
         .unwrap();
 
     let stacks_block = builder.mine_anchored_block(clarity_tx);
@@ -2796,7 +2796,7 @@ pub fn mine_invalid_token_transfers_block(
     // make a coinbase for this miner
     let tx_coinbase_signed = make_coinbase(miner, burnchain_height);
     builder
-        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, None, &mut 0)
         .unwrap();
 
     let recipient =
@@ -2870,7 +2870,7 @@ pub fn mine_smart_contract_contract_call_block(
     // make a coinbase for this miner
     let tx_coinbase_signed = make_coinbase(miner, burnchain_height);
     builder
-        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, None, &mut 0)
         .unwrap();
 
     // make a smart contract
@@ -2880,7 +2880,7 @@ pub fn mine_smart_contract_contract_call_block(
         builder.header.total_work.work as usize,
     );
     builder
-        .try_mine_tx(clarity_tx, &tx_contract_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_contract_signed, None, None, &mut 0)
         .unwrap();
 
     // make a contract call
@@ -2892,7 +2892,7 @@ pub fn mine_smart_contract_contract_call_block(
         2,
     );
     builder
-        .try_mine_tx(clarity_tx, &tx_contract_call_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_contract_call_signed, None, None, &mut 0)
         .unwrap();
 
     let stacks_block = builder.mine_anchored_block(clarity_tx);
@@ -2947,7 +2947,7 @@ pub fn mine_smart_contract_block_contract_call_microblock(
     // make a coinbase for this miner
     let tx_coinbase_signed = make_coinbase(miner, burnchain_height);
     builder
-        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, None, &mut 0)
         .unwrap();
 
     // make a smart contract
@@ -2957,7 +2957,7 @@ pub fn mine_smart_contract_block_contract_call_microblock(
         builder.header.total_work.work as usize,
     );
     builder
-        .try_mine_tx(clarity_tx, &tx_contract_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_contract_signed, None, None, &mut 0)
         .unwrap();
 
     let stacks_block = builder.mine_anchored_block(clarity_tx);
@@ -3034,7 +3034,7 @@ pub fn mine_smart_contract_block_contract_call_microblock_exception(
     // make a coinbase for this miner
     let tx_coinbase_signed = make_coinbase(miner, burnchain_height);
     builder
-        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_coinbase_signed, None, None, &mut 0)
         .unwrap();
 
     // make a smart contract
@@ -3044,7 +3044,7 @@ pub fn mine_smart_contract_block_contract_call_microblock_exception(
         builder.header.total_work.work as usize,
     );
     builder
-        .try_mine_tx(clarity_tx, &tx_contract_signed, None, &mut 0)
+        .try_mine_tx(clarity_tx, &tx_contract_signed, None, None, &mut 0)
         .unwrap();
 
     let stacks_block = builder.mine_anchored_block(clarity_tx);

--- a/stackslib/src/chainstate/tests/consensus.rs
+++ b/stackslib/src/chainstate/tests/consensus.rs
@@ -715,13 +715,19 @@ impl ConsensusChain<'_> {
 
             // First mine the coinbase transaction
             builder
-                .try_mine_tx(&mut epoch_tx, &coinbase_tx, None, &mut total_receipt_size)
+                .try_mine_tx(
+                    &mut epoch_tx,
+                    &coinbase_tx,
+                    None,
+                    None,
+                    &mut total_receipt_size,
+                )
                 .unwrap();
 
             // We attempt to mine each transaction to build the hash
             for tx in &test_block.transactions {
                 // NOTE: It is expected to fail when trying computing the marf for invalid block/transactions.
-                let _ = builder.try_mine_tx(&mut epoch_tx, tx, None, &mut total_receipt_size);
+                let _ = builder.try_mine_tx(&mut epoch_tx, tx, None, None, &mut total_receipt_size);
             }
 
             let stacks_block = builder.mine_anchored_block(&mut epoch_tx);

--- a/stackslib/src/clarity_vm/tests/ephemeral.rs
+++ b/stackslib/src/clarity_vm/tests/ephemeral.rs
@@ -370,6 +370,7 @@ fn replay_block(
             tx_len,
             &BlockLimitFunction::NO_LIMIT_HIT,
             None,
+            None,
             &mut total_receipts,
         );
         let err = match &tx_result {

--- a/stackslib/src/net/api/blockreplay.rs
+++ b/stackslib/src/net/api/blockreplay.rs
@@ -303,6 +303,7 @@ where
             tx_len,
             &BlockLimitFunction::NO_LIMIT_HIT,
             None,
+            None,
             &mut total_receipts,
         );
 

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -749,7 +749,7 @@ impl NakamotoBlockProposal {
         let per_tx_max_execution_time = Duration::from_secs(max_tx_execution_time_secs);
         // Bound the analysis phase during proposal validation by the
         // dedicated per-tx analysis budget, independently of the eval budget above.
-        builder.max_analysis_time = Some(Duration::from_secs(max_tx_analysis_time_secs));
+        let per_tx_max_analysis_time = Duration::from_secs(max_tx_analysis_time_secs);
         let mut receipts_total = 0u64;
         for (i, tx) in self.block.txs.iter().enumerate() {
             // Enforce the overall block validation budget between txs. A tx
@@ -798,6 +798,7 @@ impl NakamotoBlockProposal {
                         tx_len,
                         &BlockLimitFunction::NO_LIMIT_HIT,
                         Some(per_tx_max_execution_time),
+                        Some(per_tx_max_analysis_time),
                         &mut receipts_total,
                     ),
                     Err(e) => e,
@@ -1004,6 +1005,7 @@ impl NakamotoBlockProposal {
                     replay_tx.tx_len(),
                     &BlockLimitFunction::NO_LIMIT_HIT,
                     None,
+                    None,
                     &mut total_receipts,
                 );
                 match tx_result {
@@ -1071,6 +1073,7 @@ impl NakamotoBlockProposal {
                 tx_len,
                 &BlockLimitFunction::NO_LIMIT_HIT,
                 None,
+                None,
                 &mut total_receipts,
             );
         }
@@ -1085,6 +1088,7 @@ impl NakamotoBlockProposal {
                     &tx,
                     tx.tx_len(),
                     &BlockLimitFunction::NO_LIMIT_HIT,
+                    None,
                     None,
                     &mut total_receipts,
                 );

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -305,6 +305,7 @@ fn test_try_make_response() {
                         tx.tx_len(),
                         &BlockLimitFunction::NO_LIMIT_HIT,
                         None,
+                        None,
                         &mut 0,
                     );
                     let block = builder.mine_nakamoto_block(&mut tenure_tx, burn_chain_height);
@@ -612,6 +613,7 @@ fn test_block_proposal_validation_timeout_blames_tx() {
                         deploy_tx.tx_len(),
                         &BlockLimitFunction::NO_LIMIT_HIT,
                         None,
+                        None,
                         &mut 0,
                     );
                     assert!(matches!(tx_result, TransactionResult::Success(_)));
@@ -620,6 +622,7 @@ fn test_block_proposal_validation_timeout_blames_tx() {
                         &call_tx,
                         call_tx.tx_len(),
                         &BlockLimitFunction::NO_LIMIT_HIT,
+                        None,
                         None,
                         &mut 0,
                     );
@@ -801,6 +804,7 @@ fn test_block_proposal_validation_analysis_time_expired_blames_tx() {
                         deploy_tx.tx_len(),
                         &BlockLimitFunction::NO_LIMIT_HIT,
                         None,
+                        None,
                         &mut 0,
                     );
                     assert!(matches!(tx_result, TransactionResult::Success(_)));
@@ -947,6 +951,7 @@ fn replay_validation_test(
                             &tx,
                             tx.tx_len(),
                             &BlockLimitFunction::NO_LIMIT_HIT,
+                            None,
                             None,
                             &mut 0,
                         );


### PR DESCRIPTION
### Description

This patch makes `max_analysis_time` behave consistently with `max_execution_time` by passing it as a function argument rather than storing it as part of the `NakamotoBlockBuilder` configuration (introduced by this PR #7349 with explaination in the PR description).

This change is necessary to keep both timeout configurations in sync when a miner creates a block proposal in the case some transactions need to be replayed. In that scenario, `max_execution_time` is not used, so `max_analysis_time` should follow the same behavior.

> Note: not critical, but we could make this PR fit into the same release as the #7349 which introduced the contract analysis guard-rails.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

While working on this, I also noticed a particular behavior on the signer side when validating a block proposal. If the proposal contains replay transactions, validation is performed in two passes:

- Pass 1 (`validate_replay`): replay transactions are validated with `None` as the timeout https://github.com/stacks-network/stacks-core/blob/2ccde7b243cade729b27569271c460e0e5779f6b/stackslib/src/net/api/postblock_proposal.rs#L1065-L1075.
- Pass 2 (`validate`): the main validation loop replays all block transactions, including the replay transactions, using the configured max timeout. https://github.com/stacks-network/stacks-core/blob/2ccde7b243cade729b27569271c460e0e5779f6b/stackslib/src/net/api/postblock_proposal.rs#L795-L802

As a result, the configured timeout is applyied to the replay transactions as well.

Maybe we could avoid this distintion on both miner/signer side and always applying timeout configuration when in block-proposal phase?

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
