### PR TITLE
Initial scaffolding for 4.0.0 release

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -19,7 +19,7 @@ runs:
     steps:
         # Checkout the code
         - name: Checkout the latest code
-          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with:
             ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/actions/release/create-github-release/action.yml
+++ b/.github/actions/release/create-github-release/action.yml
@@ -62,7 +62,7 @@ runs:
         # Upload the release archives with the checksums file
         #   - pre-populate the release body text
         - name: Upload Release
-          uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+          uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
           with:
               name: "Release ${{ inputs.tag }}"
               tag_name: ${{ inputs.tag }}

--- a/.github/scripts/check_release.sh
+++ b/.github/scripts/check_release.sh
@@ -4,7 +4,7 @@
 # derives the release tags and validates them against versions.toml.
 #
 # Required env vars:
-#   BRANCH  - branch name from github.ref_name (e.g. release/1.0.0.0.0)
+#   BRANCH  - branch name from github.ref_name (e.g. release/4.0.0)
 #
 # Exit behaviour:
 #   - Branch matches a release pattern  → validates versions.toml, writes outputs, exits 0
@@ -12,8 +12,8 @@
 #                                         jobs guard themselves with is_node/signer_release checks)
 # Outputs:
 #   GITHUB_OUTPUT  - Path to the GitHub Actions output file (set by runner); prints to stderr if unset (via logging.sh)
-#   node_tag          - node release tag       (e.g. 1.0.0.0.0)         empty for signer-only releases
-#   signer_tag        - signer release tag     (e.g. signer-1.0.0.0.0.0)
+#   node_tag          - node release tag    (e.g. 4.0.0, empty for signer-only releases)
+#   signer_tag        - signer release tag  (e.g. signer-4.0.0)
 #   is_node_release   - "true" if this is a node release branch
 #   is_signer_release - "true" if this is a signer release branch
 set -euo pipefail
@@ -26,14 +26,14 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/logging.sh"
 : "${BRANCH:?BRANCH is required}"
 
 ## ── Release branch patterns ─────────────────────────────────────────────────
-# Node release:   release/x.x.x.x.x   (5-part version, optional -rcN suffix)
-# Signer release: release/signer-x.x.x.x.x.x  (6-part version, optional -rcN suffix)
+# Node release:   release/x.x.x         (3-part version, major.minor.revision, optional -rcN suffix)
+# Signer release: release/signer-x.x.x  (3-part version, major.minor.revision, optional -rcN suffix)
 versions_file="versions.toml"
 node_key="stacks_node_version"
 signer_key="stacks_signer_version"
 
-node_version_regex="([0-9]+\.){4}[0-9]+(-rc[0-9]+)?"
-signer_version_regex="([0-9]+\.){5}[0-9]+(-rc[0-9]+)?"
+node_version_regex="([0-9]+\.){2}[0-9]+(-rc[0-9]+)?"
+signer_version_regex="([0-9]+\.){2}[0-9]+(-rc[0-9]+)?"
 
 release_prefix="release/"
 signer_prefix="release/signer-"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,4 +1,5 @@
-# Github workflow to create reusable caches
+# Github workflow to create release binaries (and attest them)
+
 name: Build Release Binaries
 
 on:
@@ -91,7 +92,7 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
@@ -141,7 +142,7 @@ jobs:
       - name: Attest Artifact (stacks-core)
         if: |
           inputs.node_tag != ''
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ steps.build-binaries.outputs.zipfile_name }}.zip
 
@@ -172,6 +173,6 @@ jobs:
       - name: Attest Artifact (stacks-signer)
         if: |
           inputs.signer_tag != ''
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ steps.build-binaries.outputs.zipfile_name }}.zip

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -118,7 +118,7 @@ jobs:
       # Checkout the code
       #   - only .github is required for this job
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           sparse-checkout: |
@@ -144,7 +144,7 @@ jobs:
       # Set docker metatdata
       - name: Docker Metadata ( ${{ matrix.dist }} )
         id: docker-metadata
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf #v6.0.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
@@ -178,7 +178,7 @@ jobs:
       # Build docker image for release
       - name: Build and Push ( ${{matrix.dist}} )
         id: docker-build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           sbom: false
           provenance: ${{ env.PROVENANCE }}
@@ -195,7 +195,7 @@ jobs:
       - name: Attest Image (${{ github.event.repository.name }})
         if: |
           env.PROVENANCE != true
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/${{ inputs.release_type }}
           subject-digest: ${{ steps.docker-build.outputs.digest }}
@@ -204,7 +204,7 @@ jobs:
       # Sign the images with GitHub OIDC Token
       #   - https://github.blog/security/supply-chain-security/safeguard-container-signing-capability-actions/
       - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # Sign the images with Github OIDC token
       - name: Sign the images with OIDC Token

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -93,8 +93,8 @@ jobs:
     # Build the docker images
     uses: ./.github/workflows/release-docker.yml
     with:
-      node_tag: ${{ inputs.node_tag }} # node_tag will contains the 5 char node version, i.e. 3.3.0.0.0
-      signer_tag: ${{ inputs.signer_tag }} # signer_tag contains 6 char signer version, i.e. 3.3.0.0.0.1
+      node_tag: ${{ inputs.node_tag }} # node_tag will contains the 3 char node version, i.e. 4.0.0
+      signer_tag: ${{ inputs.signer_tag }} # signer_tag contains 3 char signer version, i.e. 4.0.0
       release_type: ${{ matrix.type }} # one of stacks-signer or stacks-core
 
   # Consolidate all digest artifacts from docker-images matrix into a single manifest
@@ -180,7 +180,7 @@ jobs:
       # Checkout the code
       #   - only .github is required for this job
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           sparse-checkout: |

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update these values when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with these values.
-stacks_node_version = "3.4.0.0.4"
-stacks_signer_version = "3.4.0.0.4.0"
+stacks_node_version = "4.0.0"
+stacks_signer_version = "4.0.0"


### PR DESCRIPTION
### Description

Initial scaffolding for 4.0.0 release

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

We're moving from a 5 and 6 decimal release versioning (ex: `3.4.0.0.4` and `3.4.0.0.4.0` signer) to a classic `major.minor.revision` syntax for both, starting with major release `4.0.0`. This is the initial scaffolding for that release.

### Checklist

N/A