### PR TITLE
Experimenting with rust nightly toolchain for parallel front-end builds to see if it speeds up CI pipeline

### DIFF
--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -15,7 +15,7 @@ inputs:
 
 # Set default env vars
 env:
-  RUSTFLAGS: "-C instrument-coverage -A warnings"
+  RUSTFLAGS: "-C instrument-coverage -A warnings -Z threads=8"
   LLVM_PROFILE_FILE: "stacks-core-%p-%m.profraw"
 
 runs:
@@ -36,12 +36,13 @@ runs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-    # Setup rust toolchain
+    # Setup rust toolchain (with nightly, so we can use parallel front-end experimental feature)
     - name: Setup Rust Toolchain
       if: |
         inputs.action == 'create'
       uses: ./.github/actions/setup-rust-toolchain
       with:
+        toolchain: nightly
         components: llvm-tools-preview
 
     #  Install nextest
@@ -75,7 +76,7 @@ runs:
         inputs.action == 'create'
       shell: bash
       env:
-        RUSTFLAGS: "-C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
+        RUSTFLAGS: "-C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=mold -A warnings -Z threads=8"
         CARGO_INCREMENTAL: 0
       # This command should be kept in sync with the same command in cache/cargo action
       run: |

--- a/.github/actions/cache/cargo/action.yml
+++ b/.github/actions/cache/cargo/action.yml
@@ -68,12 +68,13 @@ runs:
       with:
         ref: ${{ github.ref }}
   
-    # Setup rust toolchain
+    # Setup rust toolchain (with nightly, so we can use parallel front-end experimental feature)
     - name: Setup Rust Toolchain
       if: |
         inputs.action == 'create'
       uses: ./.github/actions/setup-rust-toolchain
       with:
+        toolchain: nightly
         components: llvm-tools-preview
     
     #  Install nextest
@@ -99,7 +100,7 @@ runs:
         inputs.action == 'create'
       shell: bash
       env:
-        RUSTFLAGS: "-C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
+        RUSTFLAGS: "-C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=mold -A warnings -Z threads=8"
         CARGO_INCREMENTAL: 0
       # This command should be kept in sync with the same command in artifacts/nextest-archive action
       run: |

--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     # Setup the rust toolchain with any requested components and targets.
     - name: Install Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}


### PR DESCRIPTION
### Description

Experimenting with rust nightly toolchain for parallel front-end builds to see if it speeds up CI pipeline

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

The parallel front-end compilation feature is gated behind nightly toolchain builds, but has been in use for over 2 years now. Testing it out to see what impact it has on compilation times for CI.

### Checklist

N/A