### PR TITLE
test: fix proptest failing for too many local rejects due to prop_filter on high case count

### DIFF
--- a/clarity/src/vm/tests/sequences.rs
+++ b/clarity/src/vm/tests/sequences.rs
@@ -1810,12 +1810,22 @@ fn buff_chunk_strategy() -> impl Strategy<Value = Vec<u8>> {
     prop::collection::vec(any::<u8>(), 0..=32)
 }
 
+/// Printable-ASCII bytes (`0x20..=0x7E`) excluding `"` and `\`, which need
+/// escaping in a Clarity string literal.
+///
+/// Callers sample from this set directly rather than `prop_filter`-ing the full
+/// range: a per-byte filter rejects `"`/`\` ~2% of the time, and with many
+/// bytes per case the cumulative local rejects blow past proptest's cap under
+/// high case counts (aborting the run).
+fn allowed_ascii_bytes() -> Vec<u8> {
+    (0x20u8..=0x7Eu8)
+        .filter(|b| *b != b'"' && *b != b'\\')
+        .collect()
+}
+
 /// Random printable-ASCII bytes (no `"` or `\`) for a string-ascii arg.
 fn ascii_chunk_strategy() -> impl Strategy<Value = Vec<u8>> {
-    prop::collection::vec(
-        (0x20u8..=0x7Eu8).prop_filter("not quote or backslash", |b| *b != b'"' && *b != b'\\'),
-        0..=32,
-    )
+    prop::collection::vec(prop::sample::select(allowed_ascii_bytes()), 0..=32)
 }
 
 /// Random Unicode chars (printable ASCII + BMP + emoji) for a string-utf8 arg.
@@ -1823,9 +1833,7 @@ fn utf8_chunk_strategy() -> impl Strategy<Value = Vec<char>> {
     prop::collection::vec(
         prop_oneof![
             // Printable ASCII excluding `"` and `\`
-            (0x20u8..=0x7Eu8)
-                .prop_filter("not quote or backslash", |b| *b != b'"' && *b != b'\\')
-                .prop_map(|b| b as char),
+            prop::sample::select(allowed_ascii_bytes()).prop_map(|b| b as char),
             // BMP non-control non-surrogate codepoints
             (0xA1u32..=0xD7FF).prop_filter_map("valid bmp char", |n| {
                 char::from_u32(n).filter(|c| !c.is_control())


### PR DESCRIPTION
### Description

The nightly proptest job with `PROPTEST_CASES=2500` failed on `prop_variadic_concat_string_ascii` with:

```
Test aborted: Too many local rejects
successes: 1501
local rejects: 65536
65536 times at not quote or backslash
```
> Job run details: https://github.com/stacks-network/stacks-core/actions/runs/29073625443/job/86300334114


The abort came from the test's generation strategy. `ascii_chunk_strategy` (and the ASCII branch of utf8_chunk_strategy) generated a byte in `0x20..=0x7E` and then used `prop_filter` to reject `"` and `\`. That's a ~2% reject rate per byte; with up to 32 bytes per chunk and a high case count, the cumulative local rejects exceeded proptest's default cap (65536) and aborted the whole run.
> NOTE: It's seed/case-count sensitive, so it surfaces intermittently in the nightly job.

**Fix**

Sample directly from the set of allowed bytes with `prop::sample::select` instead of filtering the full range, so generation produces zero rejects. The allowed-byte logic is extracted into a shared `allowed_ascii_bytes()` helper to be used in the 2 strategies (ascii_chunk_strategy() and  fn utf8_chunk_strategy() ) to fix both tests: `prop_variadic_concat_string_ascii` and` prop_variadic_concat_string_utf8`

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
