### PR TITLE
fix: comments, var-name in pox-5

### DIFF
--- a/changelog.d/pox-5-comments.fixed
+++ b/changelog.d/pox-5-comments.fixed
@@ -1,0 +1,1 @@
+Clarify PoX-5 naming and comments: add `BOND_LENGTH_PERIODS`, rename `stake-update`'s `prev-unlock-height` response field to `prev-unlock-cycle`, and fix outdated comments around signer grants, prepare-phase callers, and `stake-update` lock handling

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -5708,7 +5708,7 @@ export const contracts = {
                   { name: 'cycles-to-extend', type: 'uint128' },
                   { name: 'num-cycles', type: 'uint128' },
                   { name: 'old-signer', type: 'principal' },
-                  { name: 'prev-unlock-height', type: 'uint128' },
+                  { name: 'prev-unlock-cycle', type: 'uint128' },
                   { name: 'signer', type: 'principal' },
                   { name: 'staker', type: 'principal' },
                   { name: 'unlock-burn-height', type: 'uint128' },
@@ -5734,7 +5734,7 @@ export const contracts = {
             cyclesToExtend: bigint;
             numCycles: bigint;
             oldSigner: string;
-            prevUnlockHeight: bigint;
+            prevUnlockCycle: bigint;
             signer: string;
             staker: string;
             unlockBurnHeight: bigint;
@@ -7380,6 +7380,11 @@ export const contracts = {
         type: 'uint128',
         access: 'constant',
       } as TypedAbiVariable<bigint>,
+      BOND_LENGTH_PERIODS: {
+        name: 'BOND_LENGTH_PERIODS',
+        type: 'uint128',
+        access: 'constant',
+      } as TypedAbiVariable<bigint>,
       ERR_ACTIVE_BOND_NOT_INCLUDED: {
         name: 'ERR_ACTIVE_BOND_NOT_INCLUDED',
         type: {
@@ -7994,6 +7999,7 @@ export const contracts = {
       BITCOIN_LOCKTIME_THRESHOLD: 500_000_000n,
       BOND_GAP_CYCLES: 2n,
       BOND_LENGTH_CYCLES: 12n,
+      BOND_LENGTH_PERIODS: 6n,
       ERR_ACTIVE_BOND_NOT_INCLUDED: {
         isOk: false,
         value: 33n,
@@ -8452,7 +8458,7 @@ export const contracts = {
                   { name: 'cycles-to-extend', type: 'uint128' },
                   { name: 'num-cycles', type: 'uint128' },
                   { name: 'old-signer', type: 'principal' },
-                  { name: 'prev-unlock-height', type: 'uint128' },
+                  { name: 'prev-unlock-cycle', type: 'uint128' },
                   { name: 'signer', type: 'principal' },
                   { name: 'staker', type: 'principal' },
                   { name: 'unlock-burn-height', type: 'uint128' },
@@ -8478,7 +8484,7 @@ export const contracts = {
             cyclesToExtend: bigint;
             numCycles: bigint;
             oldSigner: string;
-            prevUnlockHeight: bigint;
+            prevUnlockCycle: bigint;
             signer: string;
             staker: string;
             unlockBurnHeight: bigint;

--- a/contrib/core-contract-tests/tests/pox-5/commands/StakeExtend.ts
+++ b/contrib/core-contract-tests/tests/pox-5/commands/StakeExtend.ts
@@ -136,7 +136,7 @@ export const StakeExtend = (accounts: Real['accounts']) =>
           // Receipt reflects the new unlock cycle; amount and signer unchanged.
           expect(receipt.value.unlockCycle).toBe(expectedUnlockCycle);
           expect(receipt.value.unlockBurnHeight).toBe(expectedUnlockBurnHeight);
-          expect(receipt.value.prevUnlockHeight).toBe(prevUnlockCycle);
+          expect(receipt.value.prevUnlockCycle).toBe(prevUnlockCycle);
           expect(receipt.value.amountUstx).toBe(expectedAmountUstx);
           expect(receipt.value.signer).toBe(signer);
           expect(receipt.value.staker).toBe(r.sender);

--- a/contrib/core-contract-tests/tests/pox-5/commands/StakeUpdate.ts
+++ b/contrib/core-contract-tests/tests/pox-5/commands/StakeUpdate.ts
@@ -132,7 +132,7 @@ export const StakeUpdate = (accounts: Real['accounts']) =>
           // Receipt reflects the recomputed unlock cycle and new amount/signer.
           expect(receipt.value.unlockCycle).toBe(expectedUnlockCycle);
           expect(receipt.value.unlockBurnHeight).toBe(expectedUnlockBurnHeight);
-          expect(receipt.value.prevUnlockHeight).toBe(prevUnlockCycle);
+          expect(receipt.value.prevUnlockCycle).toBe(prevUnlockCycle);
           expect(receipt.value.amountUstx).toBe(expectedAmountUstx);
           expect(receipt.value.signer).toBe(newSigner);
           expect(receipt.value.staker).toBe(r.sender);

--- a/pox-locking/src/pox_5.rs
+++ b/pox-locking/src/pox_5.rs
@@ -440,8 +440,8 @@ fn handle_lockup_pox_v5(
     }
 }
 
-/// Handle responses from stake-extend and stake-extend-pooled in pox-5 -- functions that
-/// *extend already-locked* STX.
+/// Handle responses from `stake-update` in pox-5 -- the function that
+/// *extends or increases already-locked* STX.
 fn handle_stake_lockup_update_pox_v5(
     global_context: &mut GlobalContext,
     function_name: &str,
@@ -677,7 +677,7 @@ mod tests {
                 ),
                 (ClarityName::from_literal("num-cycle"), Value::UInt(1)),
                 (
-                    ClarityName::from_literal("prev-unlock-height"),
+                    ClarityName::from_literal("prev-unlock-cycle"),
                     Value::UInt(2),
                 ),
                 (

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -74,6 +74,11 @@
 (define-constant BOND_LENGTH_CYCLES u12)
 ;; The gap between the start of different bond periods
 (define-constant BOND_GAP_CYCLES u2)
+;; Bond length measured in bond-period indices
+;; (`BOND_LENGTH_CYCLES / BOND_GAP_CYCLES`). Also the maximum number of
+;; concurrently active bond periods (and the `(list 6 ...)` bound used for
+;; bond-period arguments).
+(define-constant BOND_LENGTH_PERIODS u6)
 ;; The maximum amount of time that a user can stake for
 (define-constant MAX_NUM_CYCLES u96)
 
@@ -860,7 +865,7 @@
             (bond-index (get bond-index current-membership))
             (current-cycle (current-pox-reward-cycle))
             (bond-start-cycle (bond-period-to-reward-cycle bond-index))
-            (bond-end-cycle (bond-period-to-reward-cycle (+ bond-index u6)))
+            (bond-end-cycle (bond-period-to-reward-cycle (+ bond-index BOND_LENGTH_PERIODS)))
             (next-cycle (+ current-cycle u1))
             ;; If the bond hasn't started yet, then the first cycle where
             ;; this new signer is active is the start cycle. Otherwise, it's the next reward
@@ -1159,7 +1164,7 @@
                 staker: tx-sender,
                 signer: signer,
                 old-signer: old-signer,
-                prev-unlock-height: prev-unlock-cycle,
+                prev-unlock-cycle: prev-unlock-cycle,
                 unlock-cycle: unlock-cycle,
                 num-cycles: num-cycles,
                 amount-ustx: new-lock-amount,
@@ -1204,7 +1209,7 @@
             (signer (get signer membership))
             (current-cycle (current-pox-reward-cycle))
             (bond-start-cycle (bond-period-to-reward-cycle bond-index))
-            (bond-end-cycle (bond-period-to-reward-cycle (+ bond-index u6)))
+            (bond-end-cycle (bond-period-to-reward-cycle (+ bond-index BOND_LENGTH_PERIODS)))
             (current-total-staked (get-total-sbtc-staked-for-bond bond-index))
             (first-changed-reward-cycle (clamp current-cycle bond-start-cycle bond-end-cycle))
             (amount-sats (get amount-sats membership))
@@ -1271,7 +1276,7 @@
             (signer (get signer membership))
             (current-cycle (current-pox-reward-cycle))
             (bond-start-cycle (bond-period-to-reward-cycle bond-index))
-            (bond-end-cycle (bond-period-to-reward-cycle (+ bond-index u6)))
+            (bond-end-cycle (bond-period-to-reward-cycle (+ bond-index BOND_LENGTH_PERIODS)))
             (first-changed-reward-cycle (clamp current-cycle bond-start-cycle bond-end-cycle))
             (num-cycles (- bond-end-cycle first-changed-reward-cycle))
             (current-amount-sats (get amount-sats membership))
@@ -2279,7 +2284,7 @@
             ))
             (calculation-height (get calculation-height accumulator))
             (bond-start-height (bond-period-to-burn-height bond-index))
-            (bond-end-height (bond-period-to-burn-height (+ bond-index u6)))
+            (bond-end-height (bond-period-to-burn-height (+ bond-index BOND_LENGTH_PERIODS)))
         )
         ;; Verify that we're paying out bonds in the right order
         (match (get last-bond-stx-value-ratio accumulator)
@@ -2859,9 +2864,9 @@
     )
 )
 
-;; Construct the message hash for validating a signer key grant. Unlike [get-signer-key-message-hash],
-;; this message hash does not include `max-amount`, `period`, or `reward-cycle`. The topic is always `"grant-authorization"`.
-;; The `pox-addr` field is optional. When `none`, it means the signer key can be used for any PoX address.
+;; Construct the message hash for validating a signer key grant.
+;; Unlike [get-signer-key-message-hash], this hash covers only
+;; `signer-manager` and `auth-id`. The topic is always `"grant-authorization"`.
 (define-read-only (get-signer-grant-message-hash
         (signer-manager principal)
         (auth-id uint)
@@ -2951,8 +2956,9 @@
 
 ;; Reject calls that would modify the next reward cycle's signer / staker
 ;; set during the current cycle's prepare phase, when that set is frozen.
-;; Used by `stake`, `stake-update`, `register-for-bond`, and
-;; `update-bond-registration` as `(try! (verify-not-prepare-phase))`.
+;; Used by `stake`, `stake-update`, `register-for-bond`,
+;; `update-bond-registration`, `announce-l1-early-exit`, and `unstake-sbtc`
+;; as `(try! (verify-not-prepare-phase))`.
 (define-private (verify-not-prepare-phase)
     (ok (asserts! (not (is-in-prepare-phase (current-pox-reward-cycle)))
         ERR_STAKE_IN_PREPARE_PHASE
@@ -3030,7 +3036,7 @@
     )
     (let (
             (bond-start-height (bond-period-to-burn-height bond-index))
-            (bond-end-height (bond-period-to-burn-height (+ bond-index u6)))
+            (bond-end-height (bond-period-to-burn-height (+ bond-index BOND_LENGTH_PERIODS)))
         )
         (and
             (is-some (map-get? protocol-bonds bond-index))
@@ -3340,7 +3346,7 @@
 ;; Returns the expected L1 unlock height for a given bond index.
 ;; This is equal to 1/2 of a reward cycle before the end of the bond period.
 (define-read-only (get-bond-l1-unlock-height (bond-index uint))
-    (- (bond-period-to-burn-height (+ bond-index u6))
+    (- (bond-period-to-burn-height (+ bond-index BOND_LENGTH_PERIODS))
         (/ (var-get pox-reward-cycle-length) u2)
     )
 )

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_exceeds_max_value_size_cdeploy.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_exceeds_max_value_size_cdeploy.snap
@@ -1,8 +1,6 @@
 ---
 source: stackslib/src/chainstate/tests/static_analysis_tests.rs
-assertion_line: 1453
 expression: result.get_expected_results()
-snapshot_kind: text
 ---
 [
   Failure(ExpectedFailureOutput(
@@ -26,7 +24,7 @@ snapshot_kind: text
     error: "Invalid Stacks block 3ccc7959909eb66e4071780c595ac12e8236872140cd9898fd3b3ddf4ddd118e: ClarityError(StaticCheck(StaticCheckError { err: Unreachable(\"Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\"), expressions: Some([SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"ok\")), id: 172 }, SymbolicExpression { expr: List([SymbolicExpression { expr: Atom(ClarityName(\"merge\")), id: 174 }, SymbolicExpression { expr: Atom(ClarityName(\"ta\")), id: 175 }, SymbolicExpression { expr: Atom(ClarityName(\"tb\")), id: 176 }]), id: 173 }]), id: 171 }]), diagnostic: Diagnostic { level: Error, message: \"unexpected and unacceptable interpreter behavior: Unexpected error type during static analysis: InvariantViolation(\\\"FAIL: .size() overflowed on too large of a type. Construction should have failed!\\\")\", spans: [Span { start_line: 0, start_column: 0, end_line: 0, end_column: 0 }], suggestion: None } }))",
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "4307de3ba401cf8b0b249c3c14145052e474e176e0a4b17ccebdb16006d3f884",
+    marf_hash: "c3cb6ffa4b392cac63da6cf938ca01098875febd46b39efc067810280c080aae",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -56,7 +54,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "96f223ffc56a0c83b9fce945840bda9861f0d7335e3b108fa0f1cc0cdbb032d2",
+    marf_hash: "411bce021acf12a5dcd67d012a1545c96676910b327c3c3dae1f9e1cb1869a50",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -86,7 +84,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "0c0565210c0967c5b58775318b5f942c1e916b5ea814645ffc29b6ea01fcef47",
+    marf_hash: "db7415eaa975289668950b202d9a6160f8e6f94077aba49b2c5cb0c12508f851",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -116,7 +114,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "fc6b30082e15893859ac7d27713c9da144c9021c7ef5019f5685c2849513b97b",
+    marf_hash: "ac9b94d79f0ed7a4806dc47191d9adeef9ca27b2df277e4381d17151c5dc3b16",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -146,7 +144,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "4930824fd0b20fd53fe6459416c4b50a8431f0034c5e7e91cb907a29ceed52a2",
+    marf_hash: "dafd367ffe49a2fff9ff44943379581af0ab0f9100699af4154077eb209fab30",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -176,7 +174,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "3298dfbaaa0e99f41329fe74ed732d87cc19a92110803e63c8998a1ac6ddbf16",
+    marf_hash: "004bedff0046a7d214bde0afe817287397de87ee37205378ea5c0f785e0446f2",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(

--- a/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_overflow_unused_runtime_ccall.snap
+++ b/stackslib/src/chainstate/tests/snapshots/blockstack_lib__chainstate__tests__static_analysis_tests__tuple_merge_overflow_unused_runtime_ccall.snap
@@ -1,8 +1,6 @@
 ---
 source: stackslib/src/chainstate/tests/static_analysis_tests.rs
-assertion_line: 1518
 expression: result.get_expected_results()
-snapshot_kind: text
 ---
 [
   Success(ExpectedBlockOutput(
@@ -166,7 +164,7 @@ snapshot_kind: text
     error: "Invalid Stacks block dcb41433e1bf6af548bfda3aacb6c787e7834df448bbca12306ce4591f63d6ba: ClarityError(Interpreter(Internal(Expect(\"Interpreter failure during cost calculation\"))))",
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "dd650c4d97811651067ec8467292d94fe3414654e117787bf05dd77d7032d249",
+    marf_hash: "ab7064517573c0d2d6c002498120f5badac4fe0df1779a76e29b0ce5bbb3286a",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -196,7 +194,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "6ba89b4763ddfa8e1f48d31612a061250360712275cdb476f9c19fd067ae6508",
+    marf_hash: "768a553b8a0cb57c66075fdb0f401a6d3674caec1e3dee5f2776c799fbc38bd4",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -226,7 +224,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "011d1f9490ad10bc21e84b496269b0222f834fb10801f3f27d9e01c9423c6001",
+    marf_hash: "96a180ea8c5277d37e8906bfd23f07a223ba6114b6e87eb9cf00ae08d2735167",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -256,7 +254,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "2cefeef0d67024fea0654c4afb7261832a682577ef8bd4345b61ed31b2cceba5",
+    marf_hash: "bcef7efbb49713504f85056efa69c78542be175ec2cb5cd70da453e6d67e74c8",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -286,7 +284,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "a1b2c0ccda1cad84694a673a8dd9005ca49e2238cfd04eab30e8b2a788049eb7",
+    marf_hash: "17d3ea23020b79bdf833bf7cdb7c0cba62cacba4d65c9d916548dd96f1e5614a",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -316,7 +314,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "cdbe90154a50006148226e98b618c9c2b3964723a4043b9141c23b54bf20cddb",
+    marf_hash: "1eb95ea07004ce6e18b5974e4fc569adbe4b02de1c6a919bd3b87fb3289f46b7",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -346,7 +344,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "503c6b689523b56b2869b8b43e036ebd694cb6c702b12c90626994d1325bd3a3",
+    marf_hash: "c12642705714b241a5f0a1940a81c2ac341f930275bcb5445775293d3d80faeb",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -376,7 +374,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "9b6a2b112638e2fac4e5dac4ccc18896f7e2d2806d9287628488f9cb27dcf57a",
+    marf_hash: "c39df91aa585a4fbeefa0ef2f4b62d640ae28c766a7656d4b531d0cf848ffacb",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -406,7 +404,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "f7b01b1f8427c23a512039c032567d0ac0c09319cca2b0fc51cf7048b509b57f",
+    marf_hash: "ed2f29b4abb4e62ad1e455ab4b5e3b8389d93198cd4075364cbeaedac351082a",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -436,7 +434,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "83d1fc62d186b258109545946009d5811d62225ea6cdcadb429b3a59aabc2ae4",
+    marf_hash: "5be28754fa4eba1cbe51fc85a20e8459d23a0a931918a4e2d69c1c44c350c255",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -466,7 +464,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "b134d2232bde8f5ee305288a010a89e95ff0b91716854115025f32dcdb533fb5",
+    marf_hash: "a999f8d609ee27c096dba347e8760ae4024310e216bda0afa0954d6c38ebeb01",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -496,7 +494,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "02fd9184ec8d0c6ff23f93c22779b7d5054e7f619cf37ee2fef3767da71628a6",
+    marf_hash: "3d63f43c97a2c2968de5f236d485a119a77c4a75a1fda1cc87745b55d68699a7",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -526,7 +524,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "e4fd84bfae2002f7dfb2a08c446aa049a2aa85016599416905113d0a333a7cff",
+    marf_hash: "13c3d29997309eb235b89ebaedca7ffdd5ab18816061019e047e57b31aad9ba0",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -556,7 +554,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "4045d6184e8475873dc87138b69391262736b70277d0dd83cb021ea68466d812",
+    marf_hash: "4646ca08b2f9e4a08b95a914a616f94d9c4a3fc69364820a7e890b657cf0d44a",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -586,7 +584,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "de56dc98945860da5347b32e101bd378b3a37d3b21d9c679f1b5f2c37d4bbf04",
+    marf_hash: "64ba630b475cdd225d8b59e3b7463f541440a574041d8df7b5a69e0833cb4bc2",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -616,7 +614,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "9b07f99d1342a719a79a78e4f6708ba9e4ded172e910eddfaaec7c4c18972359",
+    marf_hash: "febcd10a8e5c094af20c87b2bd22f599b94e7a359c146a29ff05349b94c1ab20",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(
@@ -646,7 +644,7 @@ snapshot_kind: text
     ),
   )),
   Success(ExpectedBlockOutput(
-    marf_hash: "02bc8d5701ea118432e7ac02ac67432229972f01c1061ecdf84faef68df39de1",
+    marf_hash: "902ed6356accdffc3dde259e790517b62c03c5ed13029ac89a58dc7d0e5f0e49",
     evaluated_epoch: Epoch40,
     transactions: [
       ExpectedTransactionOutput(


### PR DESCRIPTION
Fixes a few incorrect comments in `pox-5.clar`. Additionally, one of the fields in the result of `stake-update` was `prev-unlock-height`, which was incorrectly named. It has been renamed to `prev-unlock-cycle`.
