### PR TITLE
Chore: 4.0.1 prep and set mainnet admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [4.0.0]
+## [4.0.1]
 
-This release includes the activation logic for the 4.0.0 hard-fork. It is compatible with prior chainstates, but after the hard-fork activation height, nodes running 4.0.0 and 3.4.x will diverge. Node operators **must** upgrade before the activation height.
+This release includes the activation logic for the Epoch 4.0 hard-fork. It is compatible with prior chainstates, but after the hard-fork activation height, nodes running 4.0.1 and 3.4.x will diverge. Node operators **must** upgrade before the activation height.
 
 ### Added
 

--- a/contrib/core-contract-tests/tests/pox-5/pox-5-helpers.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5-helpers.ts
@@ -68,7 +68,7 @@ export const RESERVE_RATIO = pox5.constants.RESERVE_RATIO;
 export const deployer = accounts.deployer.address;
 // With `override_boot_contracts_source`, pox-5 starts with the placeholder
 // mainnet admin principal baked into pox-5.clar for both admin roles.
-const POX5_BOOTSTRAP_ADMIN = 'SP000000000000000000002Q6VF78';
+const POX5_BOOTSTRAP_ADMIN = 'SP72DMR3MJKS7RVBY33JVV7EEJSQ1PYDVKDP10FX';
 export const AUTH_PROXY_NAME = 'pox-5-auth-proxy';
 export const AUTH_PROXY_ID = `${deployer}.${AUTH_PROXY_NAME}`;
 

--- a/stackslib/src/chainstate/nakamoto/signer_set.rs
+++ b/stackslib/src/chainstate/nakamoto/signer_set.rs
@@ -139,7 +139,7 @@ pub fn pox_5_sbtc_registry_contract(is_mainnet: bool) -> QualifiedContractIdenti
 }
 
 /// The default mainnet PoX-5 bond admin principal.
-pub const POX_5_BOND_ADMIN_MAINNET: &str = "SP000000000000000000002Q6VF78";
+pub const POX_5_BOND_ADMIN_MAINNET: &str = "SP72DMR3MJKS7RVBY33JVV7EEJSQ1PYDVKDP10FX";
 
 /// The default non-mainnet PoX-5 bond admin principal — the unsignable
 /// testnet boot principal. Used as the substitution target on non-mainnet
@@ -189,7 +189,7 @@ pub fn pox_5_bond_admin(is_mainnet: bool) -> PrincipalData {
     resolve_pox_5_bond_admin(is_mainnet, POX_5_BOND_ADMIN.read().unwrap().clone())
 }
 
-pub const POX_5_PAUSE_ADMIN_MAINNET: &str = "SP000000000000000000002Q6VF78";
+pub const POX_5_PAUSE_ADMIN_MAINNET: &str = "SP72DMR3MJKS7RVBY33JVV7EEJSQ1PYDVKDP10FX";
 pub const POX_5_PAUSE_ADMIN_TESTNET: &str = "ST000000000000000000002AMW42H";
 
 static POX_5_PAUSE_ADMIN: RwLock<Option<PrincipalData>> = RwLock::new(None);

--- a/stackslib/src/chainstate/stacks/boot/pox-5.clar
+++ b/stackslib/src/chainstate/stacks/boot/pox-5.clar
@@ -345,12 +345,12 @@
 ;; On non-mainnet networks `make_pox_5_body` rewrites the literal to the
 ;; configured admin before deploy.
 ;; TODO: this should be set to some predefined multisig for mainnet.
-(define-data-var bond-admin principal 'SP000000000000000000002Q6VF78)
+(define-data-var bond-admin principal 'SP72DMR3MJKS7RVBY33JVV7EEJSQ1PYDVKDP10FX)
 
 ;; The role that can permanently pause signer reward claims.
 ;; On non-mainnet networks `make_pox_5_body` rewrites the literal to the
 ;; configured admin before deploy.
-(define-data-var pause-admin principal 'SP000000000000000000002Q6VF78)
+(define-data-var pause-admin principal 'SP72DMR3MJKS7RVBY33JVV7EEJSQ1PYDVKDP10FX)
 (define-data-var rewards-paused bool false)
 
 ;; Data vars that store a copy of the burnchain configuration.

--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
 # Update this value when a new release is created.
 # `stacks-common/build.rs` will automatically update `versions.rs` with it.
 # The node and signer are released together and share this single version.
-stacks_node_version = "4.0.0"
+stacks_node_version = "4.0.1"


### PR DESCRIPTION
This preps the 4.0.1 release and sets the mainnet bond and pause admins in PoX-5.