### PR TITLE
don't restrict CI cache seeding to the main repo

### DIFF
--- a/.github/workflows/_seed-caches.yml
+++ b/.github/workflows/_seed-caches.yml
@@ -39,8 +39,6 @@ jobs:
   ############################################################################
   setup-test-caches:
     name: "Create: Test Caches"
-    # Only execute if running in our core repo. The CRON schedule will run against `master` which is intended
-    if: |
-      github.repository == 'stacks-network/stacks-core' &&
-      github.ref_name == 'master'
+    # Only execute on the default branch.
+    if: github.ref_name == 'master'
     uses: ./.github/workflows/setup-test-caches.yml


### PR DESCRIPTION
That breaks CI in every other fork

https://stackslabs.slack.com/archives/C09GGBWDKKM/p1784215701200219

> [!WARNING]
> Note that this PR (intentionally) targets `master`.
