### PR TITLE
CI: allow manual binary build triggers

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,6 +12,12 @@ on:
         description: "Signer Release Tag"
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release Tag"
+        required: true
+        type: string
 
 # Set default permissions
 permissions:


### PR DESCRIPTION
This allows manually building binaries in CI _without_ triggering a full release -- this just produces the CI artifacts.