### PR TITLE
perf: shrink Value from 128 to 64 bytes

### DIFF
--- a/changelog.d/clarity-value-64-bytes.changed
+++ b/changelog.d/clarity-value-64-bytes.changed
@@ -1,0 +1,1 @@
+Shrunk `size_of::<Value>()` from 128 to 64 bytes by boxing `CallableData::trait_identifier`, halving the memory of every `Vec<Value>`, clone, and stack copy in the Clarity VM and deserializer.

--- a/clarity-types/src/tests/types/mod.rs
+++ b/clarity-types/src/tests/types/mod.rs
@@ -851,7 +851,7 @@ fn test_sequence_try_retain_utf8_keep_none() {
 
 #[test]
 fn test_sequence_try_retain_utf8_multibyte_filter() {
-    let dog = vec![0xF0, 0x9F, 0x90, 0xB6]; // 🐶 
+    let dog = vec![0xF0, 0x9F, 0x90, 0xB6]; // 🐶
     let cat = vec![0xF0, 0x9F, 0x90, 0xB1]; // 🐱
     let seq = SequenceData::String(CharType::UTF8(UTF8Data {
         data: vec![dog.clone(), cat.clone(), dog.clone()],
@@ -907,9 +907,6 @@ fn test_sequence_try_retain_internal_error() {
 /// 64 bytes doubles list memory. Box large payloads instead.
 #[test]
 fn test_value_size_regression() {
-    assert!(
-        size_of::<Value>() <= 64,
-        "size_of::<Value>() grew to {} bytes (must stay <= 64)",
-        size_of::<Value>()
-    );
+    // exact on 64-bit so any layout change must update this test deliberately;
+    assert_eq!(size_of::<Value>(), 64);
 }

--- a/clarity-types/src/tests/types/mod.rs
+++ b/clarity-types/src/tests/types/mod.rs
@@ -902,3 +902,14 @@ fn test_sequence_try_retain_internal_error() {
     let err = seq.try_retain::<(), _>(utils::keep_all).unwrap_err();
     assert!(matches!(err, RetainValuesError::Internal(_)));
 }
+
+/// Every `Vec<Value>` in the VM scales with this size; a variant growing past
+/// 64 bytes doubles list memory. Box large payloads instead.
+#[test]
+fn test_value_size_regression() {
+    assert!(
+        size_of::<Value>() <= 64,
+        "size_of::<Value>() grew to {} bytes (must stay <= 64)",
+        size_of::<Value>()
+    );
+}

--- a/clarity-types/src/tests/types/signatures.rs
+++ b/clarity-types/src/tests/types/signatures.rs
@@ -495,7 +495,7 @@ fn test_type_min_size_callable_trait_matches_minimum_value_kind() {
     let declared_type = TypeSignature::CallableType(CallableSubtype::Trait(trait_id.clone()));
     let min_value = Value::CallableContract(CallableData {
         contract_identifier: QualifiedContractIdentifier::local("a").unwrap(),
-        trait_identifier: Some(trait_id.clone()),
+        trait_identifier: Some(Box::new(trait_id.clone())),
     });
     let min_value_type = TypeSignature::type_of(&min_value).unwrap();
 

--- a/clarity-types/src/types/mod.rs
+++ b/clarity-types/src/types/mod.rs
@@ -244,7 +244,8 @@ pub struct ResponseData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallableData {
     pub contract_identifier: QualifiedContractIdentifier,
-    pub trait_identifier: Option<TraitIdentifier>,
+    /// Boxed to keep `size_of::<Value>()` at 64 bytes.
+    pub trait_identifier: Option<Box<TraitIdentifier>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]

--- a/clarity-types/src/types/mod.rs
+++ b/clarity-types/src/types/mod.rs
@@ -244,7 +244,6 @@ pub struct ResponseData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallableData {
     pub contract_identifier: QualifiedContractIdentifier,
-    /// Boxed to keep `size_of::<Value>()` at 64 bytes.
     pub trait_identifier: Option<Box<TraitIdentifier>>,
 }
 

--- a/clarity-types/src/types/signatures.rs
+++ b/clarity-types/src/types/signatures.rs
@@ -1269,7 +1269,7 @@ impl TypeSignature {
             Value::Response(v) => v.type_signature()?,
             Value::CallableContract(v) => {
                 if let Some(trait_identifier) = &v.trait_identifier {
-                    CallableType(CallableSubtype::Trait(trait_identifier.clone()))
+                    CallableType(CallableSubtype::Trait(trait_identifier.as_ref().clone()))
                 } else {
                     CallableType(CallableSubtype::Principal(v.contract_identifier.clone()))
                 }

--- a/clarity/src/vm/callables.rs
+++ b/clarity/src/vm/callables.rs
@@ -234,7 +234,7 @@ impl DefinedFunction {
                             name.clone(),
                             CallableData {
                                 contract_identifier: callee_contract_id.clone(),
-                                trait_identifier: Some(trait_identifier.clone()),
+                                trait_identifier: Some(Box::new(trait_identifier.clone())),
                             },
                         );
                     }
@@ -250,7 +250,7 @@ impl DefinedFunction {
                             name.clone(),
                             CallableData {
                                 contract_identifier: callee_contract_id.clone(),
-                                trait_identifier: Some(trait_identifier.clone()),
+                                trait_identifier: Some(Box::new(trait_identifier.clone())),
                             },
                         );
                     }
@@ -543,7 +543,7 @@ fn clarity2_implicit_cast(
             Value::CallableContract(callable_data),
         ) => Value::CallableContract(CallableData {
             contract_identifier: callable_data.contract_identifier.clone(),
-            trait_identifier: Some(trait_identifier.clone()),
+            trait_identifier: Some(Box::new(trait_identifier.clone())),
         }),
         // N.B. it seems like this should be illegal, since it is converting a
         // principal to a callable trait, and only principal literals should be
@@ -558,7 +558,7 @@ fn clarity2_implicit_cast(
             Value::Principal(PrincipalData::Contract(contract_identifier)),
         ) => Value::CallableContract(CallableData {
             contract_identifier: contract_identifier.clone(),
-            trait_identifier: Some(trait_identifier.clone()),
+            trait_identifier: Some(Box::new(trait_identifier.clone())),
         }),
         _ => value.clone(),
     })
@@ -601,7 +601,10 @@ mod test {
         let cast_contract = clarity2_implicit_cast(&trait_ty, &contract).unwrap();
         let cast_trait = cast_contract.expect_callable().unwrap();
         assert_eq!(&cast_trait.contract_identifier, &contract_identifier);
-        assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+        assert_eq!(
+            cast_trait.trait_identifier.unwrap().as_ref(),
+            &trait_identifier
+        );
 
         // (optional principal) -> (optional <trait>)
         let optional_ty = TypeSignature::new_option(trait_ty.clone()).unwrap();
@@ -613,7 +616,7 @@ mod test {
                 trait_identifier: trait_id,
             }) => {
                 assert_eq!(contract_id, &contract_identifier);
-                assert_eq!(trait_id.as_ref().unwrap(), &trait_identifier);
+                assert_eq!(trait_id.as_deref().unwrap(), &trait_identifier);
             }
             other => panic!("expected Value::CallableContract, got {other:?}"),
         }
@@ -629,7 +632,10 @@ mod test {
             .expect_callable()
             .unwrap();
         assert_eq!(&cast_trait.contract_identifier, &contract_identifier);
-        assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+        assert_eq!(
+            cast_trait.trait_identifier.unwrap().as_ref(),
+            &trait_identifier
+        );
 
         // (err principal) -> (err <trait>)
         let response_err_ty =
@@ -642,7 +648,10 @@ mod test {
             .expect_callable()
             .unwrap();
         assert_eq!(&cast_trait.contract_identifier, &contract_identifier);
-        assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+        assert_eq!(
+            cast_trait.trait_identifier.unwrap().as_ref(),
+            &trait_identifier
+        );
 
         // (list principal) -> (list <trait>)
         let list_ty = TypeSignature::list_of(trait_ty.clone(), 4).unwrap();
@@ -651,7 +660,10 @@ mod test {
         let items = cast_list.expect_list().unwrap();
         for item in items {
             let cast_trait = item.expect_callable().unwrap();
-            assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+            assert_eq!(
+                cast_trait.trait_identifier.unwrap().as_ref(),
+                &trait_identifier
+            );
         }
 
         // {a: principal} -> {a: <trait>}
@@ -683,7 +695,10 @@ mod test {
             .expect_callable()
             .unwrap();
         assert_eq!(&cast_trait.contract_identifier, &contract_identifier);
-        assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+        assert_eq!(
+            cast_trait.trait_identifier.unwrap().as_ref(),
+            &trait_identifier
+        );
 
         // (list (optional principal)) -> (list (optional <trait>))
         let list_opt_ty = TypeSignature::list_of(optional_ty.clone(), 4).unwrap();
@@ -698,7 +713,10 @@ mod test {
         for item in items {
             if let Some(cast_opt) = item.expect_optional().unwrap() {
                 let cast_trait = cast_opt.expect_callable().unwrap();
-                assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+                assert_eq!(
+                    cast_trait.trait_identifier.unwrap().as_ref(),
+                    &trait_identifier
+                );
             }
         }
 
@@ -714,7 +732,10 @@ mod test {
         let items = cast_list.expect_list().unwrap();
         for item in items {
             let cast_trait = item.expect_result_ok().unwrap().expect_callable().unwrap();
-            assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+            assert_eq!(
+                cast_trait.trait_identifier.unwrap().as_ref(),
+                &trait_identifier
+            );
         }
 
         // (list (response uint principal)) -> (list (response uint <trait>))
@@ -729,7 +750,10 @@ mod test {
         let items = cast_list.expect_list().unwrap();
         for item in items {
             let cast_trait = item.expect_result_err().unwrap().expect_callable().unwrap();
-            assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+            assert_eq!(
+                cast_trait.trait_identifier.unwrap().as_ref(),
+                &trait_identifier
+            );
         }
 
         // (optional (list (response uint principal))) -> (optional (list (response uint <trait>)))
@@ -747,7 +771,10 @@ mod test {
         let items = inner.expect_list().unwrap();
         for item in items {
             let cast_trait = item.expect_result_err().unwrap().expect_callable().unwrap();
-            assert_eq!(&cast_trait.trait_identifier.unwrap(), &trait_identifier);
+            assert_eq!(
+                cast_trait.trait_identifier.unwrap().as_ref(),
+                &trait_identifier
+            );
         }
 
         // (optional (optional principal)) -> (optional (optional <trait>))
@@ -770,7 +797,7 @@ mod test {
                 trait_identifier: trait_id,
             }) => {
                 assert_eq!(contract_id, &contract_identifier);
-                assert_eq!(trait_id.as_ref().unwrap(), &trait_identifier);
+                assert_eq!(trait_id.as_deref().unwrap(), &trait_identifier);
             }
             other => panic!("expected Value::CallableContract, got {other:?}"),
         }


### PR DESCRIPTION
### Description

Reduce `size_of::<Value>()` from 128 to 64 bytes by boxing `CallableData::trait_identifier`, the field that made `CallableContract` the largest variant. Every `Vec<Value>`, clone, and stack copy in the VM halves:
deserializing a 1M-bool list drops from 122 to 61 MiB. 

The diff is very mechanical (`Box::new` at construction sites), a regression test pins the size.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
