### PR TITLE
fix incorrect stringification of consensus hash mismatch rejection

### DIFF
--- a/changelog.d/7438-consensus-hash-mismatch-string.fixed
+++ b/changelog.d/7438-consensus-hash-mismatch-string.fixed
@@ -1,0 +1,1 @@
+Fix the stringification of block proposal rejections based on a mismatch of the consensus hash between the proposal and the miner's tenure. The error message had the expected and actual values in the wrong order.

--- a/libsigner/src/v0/messages.rs
+++ b/libsigner/src/v0/messages.rs
@@ -2087,7 +2087,7 @@ impl std::fmt::Display for RejectReason {
             RejectReason::ConsensusHashMismatch { expected, actual } => {
                 write!(
                     f,
-                    "The block's consensus hash ({expected}) does not match the active miner's tenure id ({actual})",
+                    "The block's consensus hash ({actual}) does not match the active miner's tenure id ({expected})",
                 )
             }
             RejectReason::ProblematicTransactions => {

--- a/stacks-node/src/tests/signer/v0/mod.rs
+++ b/stacks-node/src/tests/signer/v0/mod.rs
@@ -3754,6 +3754,20 @@ fn empty_tenure_delayed() {
             {
                 assert_eq!(reason_code, RejectCode::SortitionViewMismatch);
                 assert!(matches!(response_data.reject_reason, RejectReason::ConsensusHashMismatch { .. }), "Unexpected reject reason: {}", response_data.reject_reason);
+
+                let proposals = signer_test.get_miner_proposal_messages();
+                let rejected_proposal = proposals.last().expect("proposal must exist since we've found a rejection");
+                let expected_message = format!(
+                    "block's consensus hash ({}) does not match the active miner's tenure id",
+                    rejected_proposal.block.header.consensus_hash
+                );
+                assert!(
+                    response_data.reject_reason.to_string().contains(expected_message.as_str()),
+                    "expected reject reason message to contain \"{}\" but got \"{}\"",
+                    expected_message,
+                    response_data.reject_reason.to_string()
+                );
+
                 assert_eq!(metadata.server_version, VERSION_STRING.to_string());
                 found_rejections.push(*slot_id);
             } else {


### PR DESCRIPTION
Expected and actual hash were reversed. Discovered [here](https://stackslabs.slack.com/archives/C096W1B7N7J/p1784795066544159?thread_ts=1784794840.427149&cid=C096W1B7N7J).
