### PR TITLE
Add CRON schedule to _ci.yml to run nightly so that code coverage for main branch is uploaded and PR code coverage reports are more accurate (never more than 24 hour drift)

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -1,5 +1,5 @@
 ############################################################################
-### The main GitHub Actions workflow for CI/CD
+### Our primary CI/CD workflow
 ############################################################################
 
 name: CI
@@ -9,7 +9,12 @@ on:
   merge_group:
     types:
       - checks_requested
-  workflow_dispatch:
+  schedule:
+    # Run at 00:00 UTC daily
+    # This runs on `main` and is done to have `main` generate and upload 
+    # code coverage information for more accurate PR code coverage reports.
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allows manual triggering
   pull_request:
     types:
       - opened

--- a/.github/workflows/_seed-caches.yml
+++ b/.github/workflows/_seed-caches.yml
@@ -1,4 +1,5 @@
 name: Seed Caches
+run-name: "Seed Caches: [${{ github.ref_name }}]"
 
 ################################################################################################################################
 # GitHub caches are scoped to branches, with a fallback mechanism:

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -22,7 +22,8 @@
 # tests, with a link to the workflow run and the proptest-regression files
 # downloadable as a workflow artifact.
 
-name: Tests::Proptest Extra
+name: "Tests: Proptest Extra"
+run-name: "Tests: Proptest Extra [${{ github.ref_name }}]"
 
 on:
   pull_request_review:


### PR DESCRIPTION
### Description

Add CRON schedule to _ci.yml to run nightly so that code coverage for main branch is uploaded and PR code coverage reports are more accurate (never more than 24 hour drift)

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

Coveralls compares a PR to the base (`main` branch). Currently, `main` merges never trigger CI and thus the code coverage deltas remain insanely out of date (currently comparing PRs against a report from March 2026). This runs the workflow against `main` nightly in order to create a more accurate baseline by uploading a `main` coverage report every 24 hours to Coveralls.

### Checklist

N/A