### PR TITLE
fix: match interpreter's checks for `contract-call?`

### DIFF
--- a/clarity/src/vm/clarity_wasm.rs
+++ b/clarity/src/vm/clarity_wasm.rs
@@ -7427,19 +7427,167 @@ fn link_contract_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
                     function_length,
                 )?;
 
+                // For dynamic dispatch, read the trait identifier from the
+                // Wasm memory
+                let trait_id = if trait_id_length == 0 {
+                    None
+                } else {
+                    let bytes = read_bytes_from_wasm(
+                        memory,
+                        &mut caller,
+                        trait_id_offset,
+                        trait_id_length,
+                    )?;
+                    Some(trait_identifier_from_bytes(&bytes)?)
+                };
+
+                // Ensure that a trait reference is used for inter-contract
+                // calls only, as in the interpreter's `special_contract_call`.
+                if trait_id.is_some()
+                    && *contract_id == caller.data().contract_context().contract_identifier
+                {
+                    return Err(
+                        VmExecutionError::from(RuntimeCheckErrorKind::CircularReference(vec![
+                            contract_id.name.to_string(),
+                        ]))
+                        .into(),
+                    );
+                }
+
                 // Retrieve the contract context for the contract we're calling
-                let mut contract = caller
+                let contract = caller
                     .data_mut()
                     .global_context
                     .database
-                    .get_contract(contract_id)?;
+                    .get_contract(contract_id)
+                    .map_err(|e| {
+                        if trait_id.is_some() {
+                            RuntimeCheckErrorKind::NoSuchContract(contract_id.to_string()).into()
+                        } else {
+                            e
+                        }
+                    })?;
 
-                // Retrieve the function we're calling
-                let function = &contract.functions.get(function_name.as_str()).ok_or(
-                    VmExecutionError::Wasm(WasmError::Expect(format!(
-                        "Contract {contract_id} does not contain public function {function_name}"
-                    ))),
-                )?;
+                // Retrieve the function we're calling and determine the return
+                // type used to write the result back into Wasm memory. For
+                // dynamic dispatch, first validate the call against the trait
+                // definition, exactly as the interpreter does in
+                // `special_contract_call`; `type_returns_constraint` holds the
+                // trait's declared return type when those runtime checks apply.
+                let (function, return_ty, type_returns_constraint) = match &trait_id {
+                    None => {
+                        // Static dispatch
+                        let function = contract.functions.get(function_name.as_str()).ok_or(
+                            VmExecutionError::from(RuntimeCheckErrorKind::UndefinedFunction(
+                                function_name.to_string(),
+                            )),
+                        )?;
+                        let return_ty = function
+                            .get_return_type()
+                            .as_ref()
+                            .ok_or(VmExecutionError::Wasm(WasmError::Expect(
+                                "Function should be typed".into(),
+                            )))?
+                            .clone();
+                        (function, return_ty, None)
+                    }
+                    Some(trait_id) => {
+                        // Dynamic dispatch: if the contract explicitly
+                        // implements the trait with `impl-trait`, we can rely
+                        // on the analysis performed at publish time and skip
+                        // the runtime checks.
+                        let short_circuit_checks =
+                            contract.is_explicitly_implementing_trait(trait_id);
+
+                        // Retrieve the contract context defining the trait
+                        let defining_contract;
+                        let defining_context: &ContractContext = if trait_id.contract_identifier
+                            == *contract_id
+                        {
+                            &contract
+                        } else {
+                            defining_contract = caller
+                                .data_mut()
+                                .global_context
+                                .database
+                                .get_contract(&trait_id.contract_identifier)
+                                .map_err(|_| {
+                                    VmExecutionError::from(RuntimeCheckErrorKind::NoSuchContract(
+                                        trait_id.contract_identifier.to_string(),
+                                    ))
+                                })?;
+                            &defining_contract
+                        };
+
+                        // Retrieve the function that will be invoked
+                        let function =
+                            contract
+                                .functions
+                                .get(function_name.as_str())
+                                .ok_or_else(|| {
+                                    VmExecutionError::from(if short_circuit_checks {
+                                        RuntimeCheckErrorKind::UndefinedFunction(
+                                            function_name.to_string(),
+                                        )
+                                    } else {
+                                        RuntimeCheckErrorKind::BadTraitImplementation(
+                                            trait_id.name.to_string(),
+                                            function_name.to_string(),
+                                        )
+                                    })
+                                })?;
+
+                        if !short_circuit_checks {
+                            // Check read/write compatibility
+                            if caller.data().global_context.is_read_only() {
+                                return Err(VmExecutionError::from(
+                                    RuntimeCheckErrorKind::Unreachable(
+                                        "Trait based contract call in read-only".to_string(),
+                                    ),
+                                )
+                                .into());
+                            }
+
+                            // Check visibility
+                            if function.define_type == DefineType::Private {
+                                return Err(VmExecutionError::from(
+                                    RuntimeCheckErrorKind::NoSuchPublicFunction(
+                                        contract_id.to_string(),
+                                        function_name.to_string(),
+                                    ),
+                                )
+                                .into());
+                            }
+
+                            function.check_trait_expectations(
+                                &epoch,
+                                defining_context,
+                                trait_id,
+                            )?;
+                        }
+
+                        // Retrieve the expected method signature from the
+                        // trait definition
+                        let trait_name = trait_id.name.to_string();
+                        let expected_returns = defining_context
+                            .lookup_trait_definition(&trait_name)
+                            .ok_or_else(|| {
+                                VmExecutionError::from(RuntimeCheckErrorKind::Unreachable(format!(
+                                    "Trait reference unknown: {trait_name}"
+                                )))
+                            })?
+                            .get(function_name.as_str())
+                            .map(|f_ty| f_ty.returns.clone())
+                            .ok_or_else(|| {
+                                VmExecutionError::from(RuntimeCheckErrorKind::Unreachable(format!(
+                                    "Trait method unknown: {trait_name}.{function_name}"
+                                )))
+                            })?;
+
+                        let constraint = (!short_circuit_checks).then(|| expected_returns.clone());
+                        (function, expected_returns, constraint)
+                    }
+                };
 
                 let mut args = Vec::new();
                 let mut args_sizes = Vec::new();
@@ -7506,46 +7654,35 @@ fn link_contract_call_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), 
                     )
                 }?;
 
-                // Write the result to the return buffer
-                let return_ty = if trait_id_length == 0 {
-                    // This is a direct call
-                    function
-                        .get_return_type()
-                        .as_ref()
-                        .ok_or(VmExecutionError::Wasm(WasmError::Expect(
-                            "Function should be typed".into(),
-                        )))?
-                } else {
-                    // This is a dynamic call
-                    let trait_id =
-                        read_bytes_from_wasm(memory, &mut caller, trait_id_offset, trait_id_length)
-                            .and_then(|bs| trait_identifier_from_bytes(&bs))?;
-                    contract = if &trait_id.contract_identifier == contract_id {
-                        contract
-                    } else {
-                        caller
-                            .data_mut()
-                            .global_context
-                            .database
-                            .get_contract(&trait_id.contract_identifier)?
-                    };
-                    contract
-                        .defined_traits
-                        .get(trait_id.name.as_str())
-                        .and_then(|trait_functions| trait_functions.get(function_name.as_str()))
-                        .map(|f_ty| &f_ty.returns)
-                        .ok_or(VmExecutionError::Wasm(WasmError::NotInDatabase(format!(
-                            "Trait: {}",
-                            trait_id.name
-                        ))))?
-                };
+                // sanitize contract-call outputs in epochs >= 2.4, as the
+                // interpreter does in `special_contract_call`
+                let result_type = TypeSignature::type_of(&result)?;
+                let (result, _) = Value::sanitize_value(&epoch, &result_type, result).ok_or(
+                    VmExecutionError::from(RuntimeCheckErrorKind::CouldNotDetermineType),
+                )?;
 
+                // Ensure that the expected type from the trait spec admits
+                // the type of the value returned by the dynamic dispatch.
+                if let Some(returns_type_signature) = type_returns_constraint {
+                    let actual_returns = TypeSignature::type_of(&result)?;
+                    if !returns_type_signature.admits_type(&epoch, &actual_returns)? {
+                        return Err(VmExecutionError::from(
+                            RuntimeCheckErrorKind::ReturnTypesMustMatch(
+                                Box::new(returns_type_signature),
+                                Box::new(actual_returns),
+                            ),
+                        )
+                        .into());
+                    }
+                }
+
+                // Write the result to the return buffer
                 write_to_wasm(
                     &mut caller,
                     memory,
-                    return_ty,
+                    &return_ty,
                     return_offset,
-                    return_offset + get_type_size(return_ty),
+                    return_offset + get_type_size(&return_ty),
                     &result,
                     true,
                 )?;

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1469,13 +1469,34 @@ impl<'a, 'b> ExecutionState<'a, 'b> {
                 return Err(VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::NoSuchPublicFunction(contract_identifier.to_string(), tx_name.to_string())));
             }
 
+            // sanitize contract-call inputs in epochs >= 2.4, exactly as
+            // `inner_execute_contract` does on the interpreter path
+            let args: Result<Vec<Value>, VmExecutionError> = args.iter()
+                .map(|value| {
+                    let expected_type = TypeSignature::type_of(value)?;
+                    let (sanitized_value, _) = Value::sanitize_value(
+                        self.epoch(),
+                        &expected_type,
+                        value.clone(),
+                    ).ok_or_else(|| RuntimeCheckErrorKind::TypeValueError(
+                            Box::new(expected_type),
+                            value.to_error_string(),
+                        )
+                    )?;
+
+                    Ok(sanitized_value)
+                })
+                .collect();
+
+            let args = args?;
+
             let func_identifier = func.get_identifier();
             if self.call_stack.contains(&func_identifier) {
                 return Err(VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::CircularReference(vec![func_identifier.to_string()])))
             }
             self.call_stack.insert(&func_identifier, true);
 
-            let res = self.execute_function_as_transaction(invoke_ctx,&func, args, Some(&contract), false);
+            let res = self.execute_function_as_transaction(invoke_ctx,&func, &args, Some(&contract), false);
             self.call_stack.remove(&func_identifier, true)?;
 
             match res {
@@ -1487,7 +1508,7 @@ impl<'a, 'b> ExecutionState<'a, 'b> {
                             invoke_ctx.sponsor.as_ref(),
                             contract_identifier,
                             tx_name,
-                            args,
+                            &args,
                             &value
                         )?;
                     }

--- a/stackslib/src/clarity_vm/tests/contracts.rs
+++ b/stackslib/src/clarity_vm/tests/contracts.rs
@@ -303,6 +303,36 @@ fn publish_contract(
     })
 }
 
+/// Publish a contract with a compiled Wasm module, as the transaction deploy
+/// path does, so that the contract executes on the Wasm runtime.
+#[cfg(feature = "clarity-wasm")]
+fn publish_wasm_contract(
+    bc: &mut ClarityBlockConnection,
+    contract_id: &QualifiedContractIdentifier,
+    contract: &str,
+    version: ClarityVersion,
+) {
+    bc.as_transaction(|tx| {
+        let (mut ast, analysis) = tx
+            .analyze_smart_contract(contract_id, version, contract)
+            .unwrap();
+        let mut module = clar2wasm::compile_contract(analysis.clone()).unwrap();
+        ast.wasm_module = Some(module.emit_wasm());
+        tx.initialize_smart_contract(
+            contract_id,
+            version,
+            &mut ast,
+            &analysis,
+            contract,
+            None,
+            |_, _| None,
+            None,
+        )
+        .unwrap();
+        tx.save_analysis(contract_id, &analysis).unwrap();
+    });
+}
+
 /// Test that you cannot invoke a 2.05 contract
 ///  with a trait parameter using a stored principal.
 #[test]
@@ -1760,5 +1790,133 @@ fn test_get_block_info_time() {
             tx.eval_read_only(&contract_identifier3_3, "(get-time)")
                 .unwrap()
         );
+    });
+}
+
+/// Verify that a dynamic (trait-based) `contract-call?` under the Wasm
+/// runtime enforces the same runtime checks as the interpreter's
+/// `special_contract_call`: a valid implementation dispatches successfully,
+/// dispatching back into the calling contract fails with
+/// `CircularReference`, and dispatching to a contract that does not
+/// implement the trait method fails with `BadTraitImplementation`.
+#[test]
+#[cfg(feature = "clarity-wasm")]
+fn test_wasm_dynamic_dispatch_validation() {
+    use clarity::vm::types::{CallableData, TraitIdentifier};
+
+    let mut sim = ClarityTestSim::new();
+    sim.epoch_bounds = vec![0, 1, 2, 3, 4, 5, 6, 7];
+
+    let trait_def_id = QualifiedContractIdentifier::local("simple-trait").unwrap();
+    let dispatch_id = QualifiedContractIdentifier::local("dispatch").unwrap();
+    let good_impl_id = QualifiedContractIdentifier::local("good-impl").unwrap();
+    let bad_impl_id = QualifiedContractIdentifier::local("bad-impl").unwrap();
+    let sender: PrincipalData = StacksAddress::burn_address(false).into();
+
+    let trait_def_src = "(define-trait simple ((do-it () (response bool uint))))";
+    let dispatch_src = "
+        (use-trait simple-trait .simple-trait.simple)
+        (define-public (call-it (t <simple-trait>))
+          (contract-call? t do-it))
+        (define-public (do-it)
+          (if true (ok true) (err u1)))
+    ";
+    let good_impl_src = "(define-public (do-it) (if true (ok true) (err u1)))";
+    let bad_impl_src = "(define-public (other-fn) (if true (ok true) (err u1)))";
+
+    // Advance to epoch 3.0
+    while sim.block_height <= 7 {
+        sim.execute_next_block(|_env| {});
+    }
+
+    sim.execute_next_block_as_conn(|conn| {
+        let epoch = conn.get_epoch();
+        let clarity_version = ClarityVersion::default_for_epoch(epoch);
+        for (id, src) in [
+            (&trait_def_id, trait_def_src),
+            (&dispatch_id, dispatch_src),
+            (&good_impl_id, good_impl_src),
+            (&bad_impl_id, bad_impl_src),
+        ] {
+            publish_wasm_contract(conn, id, src, clarity_version);
+        }
+    });
+
+    let trait_arg = |impl_id: &QualifiedContractIdentifier| {
+        Value::CallableContract(CallableData {
+            contract_identifier: impl_id.clone(),
+            trait_identifier: Some(TraitIdentifier {
+                name: ClarityName::from_literal("simple"),
+                contract_identifier: trait_def_id.clone(),
+            }),
+        })
+    };
+
+    sim.execute_next_block_as_conn(|conn| {
+        // A valid implementation dispatches successfully.
+        conn.as_transaction(|clarity_db| {
+            let (value, ..) = clarity_db
+                .run_contract_call(
+                    &sender,
+                    None,
+                    &dispatch_id,
+                    "call-it",
+                    &[trait_arg(&good_impl_id)],
+                    |_, _| None,
+                    None,
+                )
+                .unwrap();
+            assert_eq!(Value::okay(Value::Bool(true)).unwrap(), value);
+        });
+
+        // Dispatching back into the calling contract itself is a circular
+        // reference, as in the interpreter.
+        conn.as_transaction(|clarity_db| {
+            let err = clarity_db
+                .run_contract_call(
+                    &sender,
+                    None,
+                    &dispatch_id,
+                    "call-it",
+                    &[trait_arg(&dispatch_id)],
+                    |_, _| None,
+                    None,
+                )
+                .unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    ClarityError::Interpreter(VmExecutionError::RuntimeCheck(
+                        RuntimeCheckErrorKind::CircularReference(_)
+                    ))
+                ),
+                "expected CircularReference, got: {err:?}"
+            );
+        });
+
+        // Dispatching to a contract that does not implement the trait method
+        // fails with BadTraitImplementation, as in the interpreter.
+        conn.as_transaction(|clarity_db| {
+            let err = clarity_db
+                .run_contract_call(
+                    &sender,
+                    None,
+                    &dispatch_id,
+                    "call-it",
+                    &[trait_arg(&bad_impl_id)],
+                    |_, _| None,
+                    None,
+                )
+                .unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    ClarityError::Interpreter(VmExecutionError::RuntimeCheck(
+                        RuntimeCheckErrorKind::BadTraitImplementation(_, _)
+                    ))
+                ),
+                "expected BadTraitImplementation, got: {err:?}"
+            );
+        });
     });
 }


### PR DESCRIPTION
This adds newer checks that the interpreter's implementation includes (in `special_contract_call`).
- validate dynamic dispatch before execution: reject self-calls (CircularReference), missing trait methods (BadTraitImplementation), trait calls in read-only contexts, and private functions; verify trait expectations and the declared return type (ReturnTypesMustMatch)
- sanitize contract-call arguments and results in epochs >= 2.4