### PR TITLE
feat: add epoch 4.1 boilerplate

### DIFF
--- a/clarity-types/src/types/mod.rs
+++ b/clarity-types/src/types/mod.rs
@@ -642,7 +642,7 @@ impl SequenceData {
     /// `String(UTF8)`, and elements for `List`.
     ///
     /// This is intended for variadic builders (e.g. Clarity 6's
-    /// `special_concat_v600`) that know the final size up front and want
+    /// `special_concat_v400`) that know the final size up front and want
     /// to do a single allocation.
     pub fn reserve(&mut self, additional: usize) {
         match self {

--- a/clarity-types/src/version.rs
+++ b/clarity-types/src/version.rs
@@ -110,6 +110,7 @@ impl ClarityVersion {
             StacksEpochId::Epoch33 => ClarityVersion::Clarity4,
             StacksEpochId::Epoch34 => ClarityVersion::Clarity5,
             StacksEpochId::Epoch40 => ClarityVersion::Clarity6,
+            StacksEpochId::Epoch41 => ClarityVersion::Clarity6,
         }
     }
 

--- a/clarity/benches/variadic_concat.rs
+++ b/clarity/benches/variadic_concat.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //! End-to-end benchmarks for Clarity 6's variadic `concat` runtime
-//! (`special_concat_v600`).
+//! (`special_concat_v400`).
 //!
 //! `concat` reuses the existing `ClarityCostFunction::Concat` cost
 //! function with `linear(total_len, 37, 220)` — i.e., 37 cost units per
@@ -25,7 +25,7 @@
 //!
 //! These benchmarks measure actual runtime cost so that the calibration
 //! of `linear(n, 37, 220)` can be validated against real execution time,
-//! and so regressions in `special_concat_v600` (the two-pass evaluate /
+//! and so regressions in `special_concat_v400` (the two-pass evaluate /
 //! reserve / append path) get caught.
 //!
 //! Three groups:

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -878,7 +878,7 @@ impl LimitedCostTracker {
             | StacksEpochId::Epoch31
             | StacksEpochId::Epoch32 => COSTS_3_NAME.to_string(),
             StacksEpochId::Epoch33 | StacksEpochId::Epoch34 => COSTS_4_NAME.to_string(),
-            StacksEpochId::Epoch40 => COSTS_5_NAME.to_string(),
+            StacksEpochId::Epoch40 | StacksEpochId::Epoch41 => COSTS_5_NAME.to_string(),
         };
         Ok(result)
     }

--- a/clarity/src/vm/functions/sequences.rs
+++ b/clarity/src/vm/functions/sequences.rs
@@ -405,7 +405,7 @@ pub fn special_append(
 ///
 /// - [`special_concat_v200`]: Epoch 2.0 (legacy size-based cost)
 /// - [`special_concat_v205`]: Epoch 2.05 .. 3.4 (per-element cost, exactly 2 args)
-/// - [`special_concat_v600`]: Epoch 4.0+ (Clarity 6 variadic `concat`)
+/// - [`special_concat_v400`]: Epoch 4.0+ (Clarity 6 variadic `concat`)
 pub fn special_concat(
     args: &[SymbolicExpression],
     exec_state: &mut ExecutionState,
@@ -428,7 +428,9 @@ pub fn special_concat(
         | StacksEpochId::Epoch32
         | StacksEpochId::Epoch33
         | StacksEpochId::Epoch34 => special_concat_v205(args, exec_state, invoke_ctx, context),
-        StacksEpochId::Epoch40 => special_concat_v600(args, exec_state, invoke_ctx, context),
+        StacksEpochId::Epoch40 | StacksEpochId::Epoch41 => {
+            special_concat_v400(args, exec_state, invoke_ctx, context)
+        }
     }
 }
 
@@ -546,7 +548,7 @@ pub fn special_concat_v205(
 /// length. Phase 2 charges cost once, takes the first arg as the accumulator,
 /// pre-reserves capacity to fit the final result, and appends the remaining
 /// args. Pre-reservation means the underlying `Vec` does not reallocate as
-/// we concat — exactly one allocation per `special_concat_v600` call.
+/// we concat — exactly one allocation per `special_concat_v400` call.
 ///
 /// Peak memory during phase 1 is bounded by the type checker's sequence-
 /// length limits: every arg is ≤ `MAX_VALUE_SIZE`, and the type checker
@@ -558,7 +560,7 @@ pub fn special_concat_v205(
 /// contract only ever reaches this function with exactly two arguments —
 /// in which case the two-pass form collapses to the same work and cost as
 /// v205.
-pub fn special_concat_v600(
+pub fn special_concat_v400(
     args: &[SymbolicExpression],
     exec_state: &mut ExecutionState,
     invoke_ctx: &InvocationContext,

--- a/clarity/src/vm/tests/mod.rs
+++ b/clarity/src/vm/tests/mod.rs
@@ -187,6 +187,7 @@ epochs_template! {
     Epoch33,
     Epoch34,
     Epoch40,
+    Epoch41,
 }
 #[cfg(any(test, feature = "testing"))]
 clarity_template! {
@@ -226,6 +227,12 @@ clarity_template! {
     Epoch40_Clarity4: (Epoch40, Clarity4),
     Epoch40_Clarity5: (Epoch40, Clarity5),
     Epoch40_Clarity6: (Epoch40, Clarity6),
+    Epoch41_Clarity1: (Epoch41, Clarity1),
+    Epoch41_Clarity2: (Epoch41, Clarity2),
+    Epoch41_Clarity3: (Epoch41, Clarity3),
+    Epoch41_Clarity4: (Epoch41, Clarity4),
+    Epoch41_Clarity5: (Epoch41, Clarity5),
+    Epoch41_Clarity6: (Epoch41, Clarity6),
 }
 
 #[fixture]

--- a/clarity/src/vm/tests/sequences.rs
+++ b/clarity/src/vm/tests/sequences.rs
@@ -947,7 +947,7 @@ fn test_variadic_concat_string_ascii() {
 #[test]
 fn test_variadic_concat_string_utf8() {
     // Existing test_string_utf8_concat builds the same emoji from 5 binary
-    // concats — here we do it in one variadic call to verify the v600 path
+    // concats — here we do it in one variadic call to verify the v400 path
     // preserves UTF-8 semantics.
     let variadic =
         "(concat u\"\\u{1F926}\" u\"\\u{1F3FC}\" u\"\\u{200D}\" u\"\\u{2642}\" u\"\\u{FE0F}\")";
@@ -1798,7 +1798,7 @@ fn test_filter_with_special_functions() {
 // with random data, builds the variadic `(concat a1 a2 ... aN)` snippet, and
 // verifies the result equals the byte/char/element-wise concatenation of all
 // args computed in Rust. This exercises both the two-pass evaluation in
-// `special_concat_v600` (phase 1 sum, phase 2 reserve+concat) and the
+// `special_concat_v400` (phase 1 sum, phase 2 reserve+concat) and the
 // type-checker fold in `check_special_concat`.
 //
 // Per-arg lengths are kept small so that the combined result fits comfortably

--- a/stacks-common/src/libcommon.rs
+++ b/stacks-common/src/libcommon.rs
@@ -92,6 +92,7 @@ pub mod consts {
     pub const PEER_VERSION_EPOCH_3_3: u8 = 0x0e;
     pub const PEER_VERSION_EPOCH_3_4: u8 = 0x0f;
     pub const PEER_VERSION_EPOCH_4_0: u8 = 0x10;
+    pub const PEER_VERSION_EPOCH_4_1: u8 = 0x11;
 
     /// this should be updated to the latest network epoch version supported by
     ///  this node. this will be checked by the `validate_epochs()` method.

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -38,7 +38,7 @@ use crate::consts::{
     PEER_VERSION_EPOCH_2_05, PEER_VERSION_EPOCH_2_1, PEER_VERSION_EPOCH_2_2,
     PEER_VERSION_EPOCH_2_3, PEER_VERSION_EPOCH_2_4, PEER_VERSION_EPOCH_2_5, PEER_VERSION_EPOCH_3_0,
     PEER_VERSION_EPOCH_3_1, PEER_VERSION_EPOCH_3_2, PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4,
-    PEER_VERSION_EPOCH_4_0, STACKS_EPOCH_MAX,
+    PEER_VERSION_EPOCH_4_0, PEER_VERSION_EPOCH_4_1, STACKS_EPOCH_MAX,
 };
 use crate::types::chainstate::{StacksAddress, StacksPublicKey};
 use crate::util::hash::Hash160;
@@ -167,6 +167,7 @@ define_stacks_epochs! {
     Epoch33 = 0x03003 => "3.3",
     Epoch34 = 0x03004 => "3.4",
     Epoch40 = 0x04000 => "4.0",
+    Epoch41 = 0x04001 => "4.1",
 }
 
 #[derive(Debug)]
@@ -506,7 +507,7 @@ impl StacksEpochId {
 
     #[cfg(any(test, feature = "testing"))]
     pub const fn latest() -> StacksEpochId {
-        StacksEpochId::Epoch40
+        StacksEpochId::Epoch41
     }
 
     #[cfg(not(any(test, feature = "testing")))]
@@ -888,6 +889,7 @@ impl StacksEpochId {
             StacksEpochId::Epoch33 => PEER_VERSION_EPOCH_3_3,
             StacksEpochId::Epoch34 => PEER_VERSION_EPOCH_3_4,
             StacksEpochId::Epoch40 => PEER_VERSION_EPOCH_4_0,
+            StacksEpochId::Epoch41 => PEER_VERSION_EPOCH_4_1,
         }
     }
 }

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -81,7 +81,8 @@ use stacks::core::{
     PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05,
     PEER_VERSION_EPOCH_2_1, PEER_VERSION_EPOCH_2_2, PEER_VERSION_EPOCH_2_3, PEER_VERSION_EPOCH_2_4,
     PEER_VERSION_EPOCH_2_5, PEER_VERSION_EPOCH_3_0, PEER_VERSION_EPOCH_3_1, PEER_VERSION_EPOCH_3_2,
-    PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4, PEER_VERSION_EPOCH_4_1, PEER_VERSION_TESTNET,
+    PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4, PEER_VERSION_EPOCH_4_0, PEER_VERSION_EPOCH_4_1,
+    PEER_VERSION_TESTNET,
 };
 use stacks::libstackerdb::{SlotMetadata, StackerDBChunkData};
 use stacks::net::api::callreadonly::CallReadOnlyRequestBody;
@@ -258,7 +259,7 @@ lazy_static! {
             start_height: 1_002,
             end_height: STACKS_EPOCH_MAX,
             block_limit: HELIUM_BLOCK_LIMIT_20,
-            network_epoch: PEER_VERSION_EPOCH_3_4
+            network_epoch: PEER_VERSION_EPOCH_4_0
         },
         // Epoch 4.1 is present but disabled: zero-width at STACKS_EPOCH_MAX, so
         // `find_epoch` never resolves to it and Epoch 4.0 stays open-ended.

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -81,7 +81,7 @@ use stacks::core::{
     PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05,
     PEER_VERSION_EPOCH_2_1, PEER_VERSION_EPOCH_2_2, PEER_VERSION_EPOCH_2_3, PEER_VERSION_EPOCH_2_4,
     PEER_VERSION_EPOCH_2_5, PEER_VERSION_EPOCH_3_0, PEER_VERSION_EPOCH_3_1, PEER_VERSION_EPOCH_3_2,
-    PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4, PEER_VERSION_TESTNET,
+    PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4, PEER_VERSION_EPOCH_4_1, PEER_VERSION_TESTNET,
 };
 use stacks::libstackerdb::{SlotMetadata, StackerDBChunkData};
 use stacks::net::api::callreadonly::CallReadOnlyRequestBody;
@@ -151,7 +151,7 @@ use stacks::config::DEFAULT_MAX_TENURE_BYTES;
 use crate::clarity::vm::clarity::ClarityConnection;
 
 lazy_static! {
-    pub static ref NAKAMOTO_INTEGRATION_EPOCHS: [StacksEpoch; 14] = [
+    pub static ref NAKAMOTO_INTEGRATION_EPOCHS: [StacksEpoch; 15] = [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -259,6 +259,15 @@ lazy_static! {
             end_height: STACKS_EPOCH_MAX,
             block_limit: HELIUM_BLOCK_LIMIT_20,
             network_epoch: PEER_VERSION_EPOCH_3_4
+        },
+        // Epoch 4.1 is present but disabled: zero-width at STACKS_EPOCH_MAX, so
+        // `find_epoch` never resolves to it and Epoch 4.0 stays open-ended.
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch41,
+            start_height: STACKS_EPOCH_MAX,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: HELIUM_BLOCK_LIMIT_20,
+            network_epoch: PEER_VERSION_EPOCH_4_1
         },
     ];
 }

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -699,6 +699,22 @@ impl StacksChainState {
     // TODO: add tests from mutation testing results #4854
     #[cfg_attr(test, mutants::skip)]
     /// Do all the necessary Clarity operations at the start of a PoX reward cycle.
+    ///
+    /// This should only be called for PoX v5 cycles. Like PoX v4, there is no
+    /// cycle-start work (missed-slot auto-unlocks ended in Epoch 2.5), so this is
+    /// intentionally a no-op.
+    pub fn handle_pox_cycle_start_pox_5(
+        _clarity: &mut ClarityTransactionConnection,
+        _cycle_number: u64,
+        _cycle_info: Option<PoxStartCycleInfo>,
+    ) -> Result<Vec<StacksTransactionEvent>, Error> {
+        // PASS
+        Ok(vec![])
+    }
+
+    // TODO: add tests from mutation testing results #4854
+    #[cfg_attr(test, mutants::skip)]
+    /// Do all the necessary Clarity operations at the start of a PoX reward cycle.
     /// Currently, this just means applying any auto-unlocks to Stackers who qualified.
     ///
     fn handle_pox_cycle_missed_unlocks(

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -4039,7 +4039,11 @@ impl StacksChainState {
                         current_epoch = StacksEpochId::Epoch40;
                     }
                     StacksEpochId::Epoch40 => {
-                        panic!("No defined transition from Epoch40 forward")
+                        receipts.append(&mut clarity_tx.block.initialize_epoch_4_1()?);
+                        current_epoch = StacksEpochId::Epoch41;
+                    }
+                    StacksEpochId::Epoch41 => {
+                        panic!("No defined transition from Epoch41 forward")
                     }
                 }
 
@@ -4982,7 +4986,8 @@ impl StacksChainState {
                 | StacksEpochId::Epoch32
                 | StacksEpochId::Epoch33
                 | StacksEpochId::Epoch34
-                | StacksEpochId::Epoch40 => Self::handle_pox_cycle_start_pox_4(
+                | StacksEpochId::Epoch40
+                | StacksEpochId::Epoch41 => Self::handle_pox_cycle_start_pox_4(
                     clarity_tx,
                     pox_reward_cycle,
                     pox_start_cycle_info,

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -4985,13 +4985,18 @@ impl StacksChainState {
                 | StacksEpochId::Epoch31
                 | StacksEpochId::Epoch32
                 | StacksEpochId::Epoch33
-                | StacksEpochId::Epoch34
-                | StacksEpochId::Epoch40
-                | StacksEpochId::Epoch41 => Self::handle_pox_cycle_start_pox_4(
+                | StacksEpochId::Epoch34 => Self::handle_pox_cycle_start_pox_4(
                     clarity_tx,
                     pox_reward_cycle,
                     pox_start_cycle_info,
                 ),
+                StacksEpochId::Epoch40 | StacksEpochId::Epoch41 => {
+                    Self::handle_pox_cycle_start_pox_5(
+                        clarity_tx,
+                        pox_reward_cycle,
+                        pox_start_cycle_info,
+                    )
+                }
             }
         })?;
         debug!("check_and_handle_reward_start: handled pox cycle start");

--- a/stackslib/src/chainstate/stacks/db/transactions.rs
+++ b/stackslib/src/chainstate/stacks/db/transactions.rs
@@ -2087,6 +2087,9 @@ pub mod test {
     pub const TestBurnStateDB_40: UnitTestBurnStateDB = UnitTestBurnStateDB {
         epoch_id: StacksEpochId::Epoch40,
     };
+    pub const TestBurnStateDB_41: UnitTestBurnStateDB = UnitTestBurnStateDB {
+        epoch_id: StacksEpochId::Epoch41,
+    };
 
     pub const ALL_BURN_DBS: &[&dyn BurnStateDB] = &[
         &TestBurnStateDB_20 as &dyn BurnStateDB,
@@ -2098,6 +2101,7 @@ pub mod test {
         &TestBurnStateDB_33 as &dyn BurnStateDB,
         &TestBurnStateDB_34 as &dyn BurnStateDB,
         &TestBurnStateDB_40 as &dyn BurnStateDB,
+        &TestBurnStateDB_41 as &dyn BurnStateDB,
     ];
 
     pub const PRE_33_DBS: &[&dyn BurnStateDB] = &[
@@ -2121,6 +2125,7 @@ pub mod test {
         &TestBurnStateDB_33 as &dyn BurnStateDB,
         &TestBurnStateDB_34 as &dyn BurnStateDB,
         &TestBurnStateDB_40 as &dyn BurnStateDB,
+        &TestBurnStateDB_41 as &dyn BurnStateDB,
     ];
 
     #[test]
@@ -2228,6 +2233,9 @@ pub mod test {
         if epoch_id >= StacksEpochId::Epoch40 {
             genesis.initialize_epoch_4_0().unwrap();
         }
+        if epoch_id >= StacksEpochId::Epoch41 {
+            genesis.initialize_epoch_4_1().unwrap();
+        }
         genesis.commit_block();
 
         let burn_db = match epoch_id {
@@ -2237,6 +2245,7 @@ pub mod test {
             StacksEpochId::Epoch33 => &TestBurnStateDB_33 as &dyn BurnStateDB,
             StacksEpochId::Epoch34 => &TestBurnStateDB_34 as &dyn BurnStateDB,
             StacksEpochId::Epoch40 => &TestBurnStateDB_40 as &dyn BurnStateDB,
+            StacksEpochId::Epoch41 => &TestBurnStateDB_41 as &dyn BurnStateDB,
             _ => panic!("Unsupported epoch in test helper: {epoch_id}"),
         };
 
@@ -9864,6 +9873,7 @@ pub mod test {
                     StacksEpochId::Epoch33 => self.get_stacks_epoch(10),
                     StacksEpochId::Epoch34 => self.get_stacks_epoch(11),
                     StacksEpochId::Epoch40 => self.get_stacks_epoch(12),
+                    StacksEpochId::Epoch41 => self.get_stacks_epoch(13),
                 }
             }
             fn get_pox_payout_addrs(

--- a/stackslib/src/chainstate/tests/consensus.rs
+++ b/stackslib/src/chainstate/tests/consensus.rs
@@ -56,6 +56,11 @@ use crate::net::tests::NakamotoBootPlan;
 /// The epochs to test for consensus are the current and upcoming epochs.
 /// This constant must be changed when new epochs are introduced.
 /// Note that contract deploys MUST be done in each epoch >= 2.0.
+///
+/// TODO: Epoch 4.1 is defined but deliberately excluded. It is a placeholder for
+/// future consensus-breaking changes with no activation height -- so today it
+/// would only duplicate Epoch 4.0's results across every snapshot. Add it
+/// when 4.1 stabilizes.
 pub const EPOCHS_TO_TEST: &[StacksEpochId] = &[StacksEpochId::Epoch34, StacksEpochId::Epoch40];
 
 /// The latest epoch exercised by the consensus snapshot tests, i.e. the maximum
@@ -125,7 +130,7 @@ pub const fn clarity_versions_for_epoch(epoch: StacksEpochId) -> &'static [Clari
             ClarityVersion::Clarity4,
             ClarityVersion::Clarity5,
         ],
-        StacksEpochId::Epoch40 => &[
+        StacksEpochId::Epoch40 | StacksEpochId::Epoch41 => &[
             ClarityVersion::Clarity1,
             ClarityVersion::Clarity2,
             ClarityVersion::Clarity3,
@@ -463,7 +468,8 @@ impl ConsensusChain<'_> {
                     | StacksEpochId::Epoch32
                     | StacksEpochId::Epoch33
                     | StacksEpochId::Epoch34
-                    | StacksEpochId::Epoch40 => {
+                    | StacksEpochId::Epoch40
+                    | StacksEpochId::Epoch41 => {
                         if num_blocks_per_epoch.contains_key(epoch_id) {
                             start_height + 1
                         } else {

--- a/stackslib/src/chainstate/tests/mod.rs
+++ b/stackslib/src/chainstate/tests/mod.rs
@@ -27,12 +27,14 @@ use clarity::consts::{
     PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05,
     PEER_VERSION_EPOCH_2_1, PEER_VERSION_EPOCH_2_2, PEER_VERSION_EPOCH_2_3, PEER_VERSION_EPOCH_2_4,
     PEER_VERSION_EPOCH_2_5, PEER_VERSION_EPOCH_3_0, PEER_VERSION_EPOCH_3_1, PEER_VERSION_EPOCH_3_2,
-    PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4, PEER_VERSION_EPOCH_4_0, STACKS_EPOCH_MAX,
+    PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4, PEER_VERSION_EPOCH_4_0, PEER_VERSION_EPOCH_4_1,
+    STACKS_EPOCH_MAX,
 };
 use clarity::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, StacksAddress, StacksBlockId,
 };
 use clarity::vm::ast::parser::v1::CONTRACT_MAX_NAME_LENGTH;
+use clarity::vm::clarity::ClarityConnection as _;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::database::STXBalance;
 use clarity::vm::types::*;
@@ -1881,9 +1883,16 @@ impl<'a> TestChainstate<'a> {
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch40,
                 start_height: first_burnchain_height + 5,
-                end_height: STACKS_EPOCH_MAX,
+                end_height: first_burnchain_height + 6,
                 block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
                 network_epoch: PEER_VERSION_EPOCH_4_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch41,
+                start_height: first_burnchain_height + 6,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
+                network_epoch: PEER_VERSION_EPOCH_4_1,
             },
         ])
     }
@@ -1990,9 +1999,16 @@ impl<'a> TestChainstate<'a> {
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch40,
                 start_height: first_burnchain_height + 33,
-                end_height: STACKS_EPOCH_MAX,
+                end_height: first_burnchain_height + 34,
                 block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
                 network_epoch: PEER_VERSION_EPOCH_4_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch41,
+                start_height: first_burnchain_height + 34,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
+                network_epoch: PEER_VERSION_EPOCH_4_1,
             },
         ])
     }
@@ -2034,6 +2050,7 @@ fn advance_through_all_epochs() {
         StacksEpochId::Epoch33,
         StacksEpochId::Epoch34,
         StacksEpochId::Epoch40,
+        StacksEpochId::Epoch41,
     ] {
         chainstate.advance_to_epoch_boundary(&privk, target_epoch);
         let burn_block_height = chainstate.get_burn_block_height();
@@ -2050,6 +2067,53 @@ fn advance_through_all_epochs() {
                 .epoch_id;
         assert_eq!(next_epoch, target_epoch);
     }
+}
+
+#[test]
+/// Cross the Epoch 4.0 -> 4.1 boundary for real.
+///
+/// `advance_through_all_epochs` stops one block *short* of each activation
+/// height, so nothing else executes the 4.0 -> 4.1 transition arm.
+fn advance_into_epoch_41_runs_the_epoch_transition() {
+    let privk = StacksPrivateKey::random();
+    let mut boot_plan = NakamotoBootPlan::new(function_name!())
+        .with_pox_constants(7, 3)
+        .with_private_key(privk.clone());
+    let first_burnchain_height = (boot_plan.pox_constants.pox_4_activation_height
+        + boot_plan.pox_constants.reward_cycle_length
+        + 1) as u64;
+    let epochs = TestChainstate::all_epochs(first_burnchain_height);
+    boot_plan = boot_plan.with_epochs(epochs);
+    let mut chainstate = boot_plan.to_chainstate(None, Some(first_burnchain_height));
+
+    chainstate.advance_into_epoch(&privk, StacksEpochId::Epoch41);
+
+    let burn_block_height = chainstate.get_burn_block_height();
+    let current_epoch =
+        SortitionDB::get_stacks_epoch(chainstate.sortdb().conn(), burn_block_height)
+            .unwrap()
+            .unwrap()
+            .epoch_id;
+    assert_eq!(current_epoch, StacksEpochId::Epoch41);
+
+    // `initialize_epoch_4_1` deploys nothing, so the persisted Clarity epoch is
+    // its only observable effect.
+    let sortdb = chainstate.sortdb.take().unwrap();
+    let (consensus_hash, block_bhh) =
+        SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
+    let stacks_block_id = StacksBlockId::new(&consensus_hash, &block_bhh);
+    let iconn = sortdb.index_handle_at_tip();
+    let clarity_epoch = chainstate
+        .chainstate()
+        .with_read_only_clarity_tx(&iconn, &stacks_block_id, |conn| conn.get_epoch())
+        .expect("failed to open a read-only Clarity connection at the tip");
+    chainstate.sortdb = Some(sortdb);
+
+    assert_eq!(
+        clarity_epoch,
+        StacksEpochId::Epoch41,
+        "initialize_epoch_4_1 must bump the Clarity DB epoch version"
+    );
 }
 
 #[test]

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -2236,6 +2236,32 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
         })
     }
 
+    pub fn initialize_epoch_4_1(&mut self) -> Result<Vec<StacksTransactionReceipt>, ClarityError> {
+        // use the `using!` statement to ensure that the old cost_tracker is placed
+        //  back in all branches after initialization
+        using!(self.cost_track, "cost tracker", |old_cost_tracker| {
+            // epoch initialization is *free*.
+            // NOTE: this also means that cost functions won't be evaluated.
+            self.cost_track.replace(LimitedCostTracker::new_free());
+            self.epoch = StacksEpochId::Epoch41;
+            self.as_transaction(|tx_conn| {
+                // bump the epoch in the Clarity DB
+                tx_conn
+                    .with_clarity_db(|db| {
+                        db.set_clarity_epoch_version(StacksEpochId::Epoch41)?;
+                        Ok(())
+                    })
+                    .unwrap();
+
+                // require 4.1 rules henceforth in this connection as well
+                tx_conn.epoch = StacksEpochId::Epoch41;
+            });
+
+            info!("Epoch 4.1 initialized");
+            (old_cost_tracker, Ok(vec![]))
+        })
+    }
+
     pub fn start_transaction_processing(&mut self) -> ClarityTransactionConnection<'_, '_> {
         ClarityTransactionConnection::new(
             &mut self.datastore,

--- a/stackslib/src/clarity_vm/tests/large_contract.rs
+++ b/stackslib/src/clarity_vm/tests/large_contract.rs
@@ -217,8 +217,8 @@ fn test_simple_token_system(#[case] version: ClarityVersion, #[case] epoch: Stac
             )
             .unwrap();
         }
-        StacksEpochId::Epoch40 => {
-            // Epoch 4.0 no longer deploys a costs boot contract
+        StacksEpochId::Epoch40 | StacksEpochId::Epoch41 => {
+            // Epoch 4.0 onwards no longer deploy a costs boot contract
         }
         _ => panic!("Epoch {} not covered.", &epoch),
     });

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -754,6 +754,8 @@ impl Config {
                 Ok(StacksEpochId::Epoch34)
             } else if epoch_name == EPOCH_CONFIG_4_0_0 {
                 Ok(StacksEpochId::Epoch40)
+            } else if epoch_name == EPOCH_CONFIG_4_1_0 {
+                Ok(StacksEpochId::Epoch41)
             } else {
                 Err(format!("Unknown epoch name specified: {epoch_name}"))
             }?;
@@ -1785,6 +1787,7 @@ pub const EPOCH_CONFIG_3_2_0: &str = "3.2";
 pub const EPOCH_CONFIG_3_3_0: &str = "3.3";
 pub const EPOCH_CONFIG_3_4_0: &str = "3.4";
 pub const EPOCH_CONFIG_4_0_0: &str = "4.0";
+pub const EPOCH_CONFIG_4_1_0: &str = "4.1";
 
 #[derive(Clone, Deserialize, Default, Debug)]
 #[serde(deny_unknown_fields)]

--- a/stackslib/src/core/mod.rs
+++ b/stackslib/src/core/mod.rs
@@ -25,6 +25,8 @@ use lazy_static::lazy_static;
 pub use stacks_common::consts::MICROSTACKS_PER_STACKS;
 use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
 pub use stacks_common::types::StacksEpochId;
+#[cfg(test)]
+use stacks_common::types::StacksEpochRangeTestExt as _;
 use stacks_common::types::{EpochList as GenericEpochList, StacksEpoch as GenericStacksEpoch};
 #[cfg(test)]
 use stacks_common::versions::STACKS_NODE_VERSION;
@@ -55,8 +57,8 @@ pub use stacks_common::consts::{
     PEER_VERSION_EPOCH_2_05, PEER_VERSION_EPOCH_2_1, PEER_VERSION_EPOCH_2_2,
     PEER_VERSION_EPOCH_2_3, PEER_VERSION_EPOCH_2_4, PEER_VERSION_EPOCH_2_5, PEER_VERSION_EPOCH_3_0,
     PEER_VERSION_EPOCH_3_1, PEER_VERSION_EPOCH_3_2, PEER_VERSION_EPOCH_3_3, PEER_VERSION_EPOCH_3_4,
-    PEER_VERSION_EPOCH_4_0, PEER_VERSION_MAINNET, PEER_VERSION_MAINNET_MAJOR, PEER_VERSION_TESTNET,
-    PEER_VERSION_TESTNET_MAJOR, STACKS_EPOCH_MAX,
+    PEER_VERSION_EPOCH_4_0, PEER_VERSION_EPOCH_4_1, PEER_VERSION_MAINNET,
+    PEER_VERSION_MAINNET_MAJOR, PEER_VERSION_TESTNET, PEER_VERSION_TESTNET_MAJOR, STACKS_EPOCH_MAX,
 };
 
 // default port
@@ -139,8 +141,10 @@ pub const BITCOIN_MAINNET_STACKS_32_BURN_HEIGHT: u64 = 907_740;
 pub const BITCOIN_MAINNET_STACKS_33_BURN_HEIGHT: u64 = 923_222;
 /// This is Epoch-3.4, activation timing proposed in SIP-039
 pub const BITCOIN_MAINNET_STACKS_34_BURN_HEIGHT: u64 = 943_333;
-/// This is Epoch-4.0, activation timing TBD. Placeholder until scheduled.
+/// This is Epoch-4.0, activation timing proposed in SIP-045.
 pub use stacks_common::types::BITCOIN_MAINNET_STACKS_40_BURN_HEIGHT;
+/// This is Epoch-4.1, activation timing TBD. Placeholder until scheduled.
+pub const BITCOIN_MAINNET_STACKS_41_BURN_HEIGHT: u64 = STACKS_EPOCH_MAX;
 
 /// Bitcoin mainline testnet3 activation heights.
 /// TODO: No longer used since testnet3 is dead, so remove.
@@ -160,6 +164,7 @@ pub const BITCOIN_TESTNET_STACKS_32_BURN_HEIGHT: u64 = 30_000_002;
 pub const BITCOIN_TESTNET_STACKS_33_BURN_HEIGHT: u64 = 30_000_003;
 pub const BITCOIN_TESTNET_STACKS_34_BURN_HEIGHT: u64 = 30_000_004;
 pub const BITCOIN_TESTNET_STACKS_40_BURN_HEIGHT: u64 = 40_000_000;
+pub const BITCOIN_TESTNET_STACKS_41_BURN_HEIGHT: u64 = 40_000_001;
 
 pub const BITCOIN_REGTEST_FIRST_BLOCK_HEIGHT: u64 = 0;
 pub const BITCOIN_REGTEST_FIRST_BLOCK_TIMESTAMP: u32 = 0;
@@ -381,9 +386,16 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch40,
             start_height: BITCOIN_MAINNET_STACKS_40_BURN_HEIGHT,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: BITCOIN_MAINNET_STACKS_41_BURN_HEIGHT,
             block_limit: BLOCK_LIMIT_MAINNET_40,
             network_epoch: PEER_VERSION_EPOCH_4_0
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch41,
+            start_height: BITCOIN_MAINNET_STACKS_41_BURN_HEIGHT,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: BLOCK_LIMIT_MAINNET_40,
+            network_epoch: PEER_VERSION_EPOCH_4_1
         },
     ]);
 }
@@ -484,9 +496,16 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch40,
             start_height: BITCOIN_TESTNET_STACKS_40_BURN_HEIGHT,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: BITCOIN_TESTNET_STACKS_41_BURN_HEIGHT,
             block_limit: BLOCK_LIMIT_MAINNET_40,
             network_epoch: PEER_VERSION_EPOCH_4_0
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch41,
+            start_height: BITCOIN_TESTNET_STACKS_41_BURN_HEIGHT,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: BLOCK_LIMIT_MAINNET_40,
+            network_epoch: PEER_VERSION_EPOCH_4_1
         },
     ]);
 }
@@ -587,9 +606,16 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch40,
             start_height: 12001,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: 13001,
             block_limit: BLOCK_LIMIT_MAINNET_40,
             network_epoch: PEER_VERSION_EPOCH_4_0
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch41,
+            start_height: 13001,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: BLOCK_LIMIT_MAINNET_40,
+            network_epoch: PEER_VERSION_EPOCH_4_1
         },
     ]);
 }
@@ -645,6 +671,10 @@ pub static STACKS_EPOCH_3_4_MARKER: u8 = 0x10;
 /// *or greater*.
 pub static STACKS_EPOCH_4_0_MARKER: u8 = 0x11;
 
+/// Stacks 4.1 epoch marker.  All block-commits in 4.1 must have a memo bitfield with this value
+/// *or greater*.
+pub static STACKS_EPOCH_4_1_MARKER: u8 = 0x12;
+
 /// Latest Stacks epoch marker. Automatically uses the marker for the highest supported epoch.
 pub static STACKS_EPOCH_LATEST_MARKER: u8 =
     marker_for_epoch(StacksEpochId::latest()).expect("Latest epoch should always have a marker");
@@ -665,6 +695,7 @@ pub const fn marker_for_epoch(epoch_id: StacksEpochId) -> Option<u8> {
         StacksEpochId::Epoch33 => Some(STACKS_EPOCH_3_3_MARKER),
         StacksEpochId::Epoch34 => Some(STACKS_EPOCH_3_4_MARKER),
         StacksEpochId::Epoch40 => Some(STACKS_EPOCH_4_0_MARKER),
+        StacksEpochId::Epoch41 => Some(STACKS_EPOCH_4_1_MARKER),
     }
 }
 
@@ -942,15 +973,17 @@ fn test_ord_for_stacks_epoch_id() {
 // `BLOCK_LIMIT_MAINNET_40` for Epoch 4.0, rather than e.g. `BLOCK_LIMIT_MAINNET_21`.
 #[test]
 fn test_epoch_40_uses_the_doubled_read_budget_block_limit() {
-    for epochs in [
-        &*STACKS_EPOCHS_MAINNET,
-        &*STACKS_EPOCHS_TESTNET,
-        &*STACKS_EPOCHS_REGTEST,
+    for (network_name, epochs) in [
+        ("mainnet", &*STACKS_EPOCHS_MAINNET),
+        ("testnet", &*STACKS_EPOCHS_TESTNET),
+        ("regtest", &*STACKS_EPOCHS_REGTEST),
     ] {
-        assert_eq!(
-            epochs[StacksEpochId::Epoch40].block_limit,
-            BLOCK_LIMIT_MAINNET_40
-        );
+        for epoch_id in (StacksEpochId::Epoch40..).iter() {
+            assert_eq!(
+                epochs[*epoch_id].block_limit, BLOCK_LIMIT_MAINNET_40,
+                "{network_name} epoch {epoch_id} must use BLOCK_LIMIT_MAINNET_40"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Add 4.1 boilerplate code and rename `special_concat_v600` -> `special_concat_v400` to match other clarity functions that matches the epoch in which they were activated.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
