### PR TITLE
ci: save tool binaries in nextest archive artifact

### DIFF
--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -13,11 +13,6 @@ inputs:
     description: "Debug binary path"
     required: true
 
-# Set default env vars
-env:
-  RUSTFLAGS: "-C instrument-coverage -A warnings"
-  LLVM_PROFILE_FILE: "stacks-core-%p-%m.profraw"
-
 runs:
   using: "composite"
   steps:
@@ -27,6 +22,19 @@ runs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
       with:
         name: "nextest-archive"
+
+    # Install the tool binaries bundled in the artifact (see the staging step
+    # in the create path below)
+    - name: Install Bundled Tools
+      if: |
+        inputs.action == 'restore'
+      shell: bash
+      run: |
+        # upload-artifact does not preserve file permissions, so restore the
+        # executable bit before putting the tools on $PATH
+        chmod +x ci-tools/*
+        mkdir -p "$HOME/.cargo/bin"
+        mv -f ci-tools/* "$HOME/.cargo/bin/"
 
     # Checkout the code
     - name: Checkout the latest code
@@ -44,14 +52,27 @@ runs:
       with:
         components: llvm-tools-preview
 
-    #  Install nextest
-    - name: Install nextest
+    #  Install nextest and grcov
+    #    grcov is not needed to build the archive, but it is bundled into the
+    #    artifact for the test jobs (see the staging step below)
+    - name: Install nextest and grcov
       if: |
         inputs.action == 'create'
       uses: ./.github/actions/install-tool
       with:
-        tools: nextest
-    
+        tools: nextest, grcov
+
+    # Stage the tool binaries so they are uploaded with the artifact. The many
+    # parallel test jobs restore them from there instead of each downloading
+    # from GitHub Releases, which rate-limits the runners' shared IPs (429)
+    - name: Stage Tool Binaries for Upload
+      if: |
+        inputs.action == 'create'
+      shell: bash
+      run: |
+        mkdir -p ci-tools
+        cp "$(command -v cargo-nextest)" "$(command -v grcov)" ci-tools/
+
     # Install mold linker and clang (faster than default)      
     - name: Install mold Linker (and clang)
       if: |
@@ -98,6 +119,7 @@ runs:
         name: "nextest-archive"
         path: |
           ${{ inputs.archive-file }}
+          ci-tools/
           ${{ inputs.debug-binary-path }}
           !${{ inputs.debug-binary-path }}/examples/**
           !${{ inputs.debug-binary-path }}/incremental/**

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -75,13 +75,6 @@ runs:
         archive-file: ${{ inputs.archive-file }}
         debug-binary-path: ${{ inputs.debug-binary-path }}
 
-    # Install dependencies
-    #   grcov is used in the code coverage workflow in tests, so it's installed here
-    - name: Install Dependencies
-      uses: ./.github/actions/install-tool
-      with:
-        tools: nextest, grcov
-
     ############################################################################
     ### Run the tests
     ############################################################################

--- a/.github/workflows/check-cargo-hack.yml
+++ b/.github/workflows/check-cargo-hack.yml
@@ -39,6 +39,9 @@ jobs:
 
       # Install cargo-hack tool
       - name: Install cargo-hack
+        # Fail fast if GitHub rate-limits the download instead of retrying
+        # until the job times out
+        timeout-minutes: 5
         uses: ./.github/actions/install-tool
         with:
           tools: cargo-hack
@@ -80,6 +83,9 @@ jobs:
 
       # Install cargo-hack tool
       - name: Install cargo-hack
+        # Fail fast if GitHub rate-limits the download instead of retrying
+        # until the job times out
+        timeout-minutes: 5
         uses: ./.github/actions/install-tool
         with:
           tools: cargo-hack

--- a/.github/workflows/tests-bitcoin-rpc.yml
+++ b/.github/workflows/tests-bitcoin-rpc.yml
@@ -81,13 +81,6 @@ jobs:
         with:
           components: llvm-tools-preview
      
-      # Install nextest
-      - name: Install Dependencies
-        id: install_dependencies
-        uses: ./.github/actions/install-tool
-        with:
-          tools: nextest
-        
       # Restore bitcoin cache data
       - name: Restore Bitcoin Binary Cache
         uses: ./.github/actions/cache/bitcoin

--- a/.github/workflows/tests-bitcoin.yml
+++ b/.github/workflows/tests-bitcoin.yml
@@ -51,13 +51,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      # Install nextest
-      - name: Install nextest
-        uses: ./.github/actions/install-tool
-        with:
-          tools: nextest
-          
       # Restore Nextest archive artifact
+      #   - also provides the nextest binary bundled in the artifact
       - name: Restore Nextest Archive Artifact
         uses: ./.github/actions/artifacts/nextest-archive
         with:

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -258,13 +258,6 @@ jobs:
         with:
           components: llvm-tools-preview
      
-      # Install nextest
-      - name: Install Dependencies
-        id: install_dependencies
-        uses: ./.github/actions/install-tool
-        with:
-          tools: nextest
-
       # Restore bitcoin cache data
       - name: Restore Bitcoin Binary Cache
         uses: ./.github/actions/cache/bitcoin

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -107,6 +107,9 @@ jobs:
       # Install dependencies
       - name: Install Dependencies
         id: install_dependencies
+        # Fail fast if GitHub rate-limits the download instead of retrying
+        # until the job times out
+        timeout-minutes: 5
         uses: ./.github/actions/install-tool
         with:
           tools: nextest


### PR DESCRIPTION
With the way our tests fan out, we were occasionally hitting rate-limiting when trying to install nextest and grcov (e.g. https://github.com/stacks-network/stacks-core/actions/runs/30360816784/job/90282455937). This change caches nextest and grcov in the artifact that is already being shared.

Also, fail fast (5 min) during installs instead of wasting 30 minutes.