### PR TITLE
fix: preserve squash annotations during re-squash

### DIFF
--- a/changelog.d/resquash-inline-annotation.fixed
+++ b/changelog.d/resquash-inline-annotation.fixed
@@ -1,0 +1,1 @@
+Fix `MARF::squash_to_path` dropping the squash annotation on inline child pointers when the source MARF is itself a squashed (PCS) MARF.

--- a/stackslib/src/chainstate/stacks/index/squash.rs
+++ b/stackslib/src/chainstate/stacks/index/squash.rs
@@ -47,10 +47,10 @@ pub(crate) use stream::compute_node_hash;
 use stream::recompute_content_hashes;
 pub(crate) use stream::stream_squash_blob;
 
-/// Classify a child pointer: resolve the `(block_id, byte_offset)` pair that
-/// locates the child in blob storage. Backpointers carry the target block_id
-/// directly; inline pointers belong to `origin_block_id`.
-/// Returns `None` for empty pointers.
+/// Resolve a child pointer to the `(block_id, byte_offset)` locating it in
+/// blob storage; `None` for empty pointers. Backpointers and squash-annotated
+/// inline pointers (non-zero `back_block`) name the child's block directly;
+/// plain inline pointers inherit `origin_block_id`.
 #[inline]
 fn resolve_child_ptr(ptr: &TriePtr, origin_block_id: u32) -> Option<(u32, u64)> {
     if ptr.id() == TrieNodeID::Empty as u8 {
@@ -58,6 +58,8 @@ fn resolve_child_ptr(ptr: &TriePtr, origin_block_id: u32) -> Option<(u32, u64)> 
     }
     if is_backptr(ptr.id()) {
         Some((ptr.back_block(), ptr.from_backptr().ptr()))
+    } else if ptr.back_block() != 0 {
+        Some((ptr.back_block(), ptr.ptr()))
     } else {
         Some((origin_block_id, ptr.ptr()))
     }
@@ -625,13 +627,13 @@ impl<T: MarfTrieId> MARF<T> {
     /// that `get_block_hash_caching(local_id)` returns the correct original
     /// `StacksBlockId`.
     ///
-    /// Backpointer identity is preserved via `TriePtr.back_block` annotations.
-    /// Children that were backpointers in the archival MARF are stored inline in
-    /// the blob but with `back_block` set to the squashed DB's local_id for the
-    /// original block.  When the squashed MARF is extended to height H+1,
-    /// `node_copy_update_ptrs` preserves these annotations, ensuring
-    /// that `inner_write_children_hashes` uses the same `StacksBlockId` values
-    /// as the archival MARF.  This guarantees identical per-block root hashes.
+    /// Block identity is preserved via `TriePtr.back_block` annotations: every
+    /// non-empty child pointer in the blob is stored inline, annotated with the
+    /// local_id of the block the child came from (its backpointer target in the
+    /// archival MARF, or its containing block). When the squashed MARF is later
+    /// extended, `node_copy_update_ptrs` turns the annotation back into a
+    /// backpointer, so `inner_write_children_hashes` hashes the same
+    /// `StacksBlockId`s as archival state - identical per-block root hashes.
     ///
     /// `tip` is used to identify the canonical fork the squash height
     /// lives on: it must be at or above `height`.
@@ -1024,24 +1026,20 @@ impl<T: MarfTrieId> MARF<T> {
                     .expect("BUG: next_child within bounds");
                 frame.next_child += 1;
 
-                if ptr.id() == TrieNodeID::Empty as u8 {
+                let Some(source_key) = resolve_child_ptr(&ptr, frame.origin_block_id) else {
                     continue;
-                }
-
-                let (child_block_id, read_ptr) = if is_backptr(ptr.id()) {
-                    (ptr.back_block(), ptr.from_backptr())
-                } else {
-                    (frame.origin_block_id, ptr)
                 };
-
-                let source_key = (child_block_id, read_ptr.ptr());
+                let (child_block_id, _) = source_key;
                 if source_to_idx.contains_key(&source_key) {
                     continue;
                 }
 
                 let child_bh = source.get_block_from_local_id(child_block_id)?.clone();
                 source.open_block_maybe_id(&child_bh, Some(child_block_id))?;
-                let (child_node, child_hash) = source.read_nodetype(&read_ptr)?;
+                // The block to read was chosen by `open_block_maybe_id` above;
+                // `from_backptr` strips the pointer's location metadata (backptr
+                // bit, annotation), leaving the offset to read there.
+                let (child_node, child_hash) = source.read_nodetype(&ptr.from_backptr())?;
 
                 let child_is_leaf = child_node.is_leaf();
                 let child_ptrs_vec: Vec<TriePtr> = if child_is_leaf {
@@ -1071,13 +1069,11 @@ impl<T: MarfTrieId> MARF<T> {
                     // Already-collected nodes are skipped: the DFS never
                     // reads them again, so their readahead would be wasted.
                     for ptr in child_ptrs_vec.iter() {
-                        if ptr.id() == TrieNodeID::Empty as u8 {
+                        // Resolve exactly as the DFS will so readahead hits the right page.
+                        let Some((target_block_id, target_in_block_ptr)) =
+                            resolve_child_ptr(ptr, child_block_id)
+                        else {
                             continue;
-                        }
-                        let (target_block_id, target_in_block_ptr) = if is_backptr(ptr.id()) {
-                            (ptr.back_block(), ptr.from_backptr().ptr())
-                        } else {
-                            (child_block_id, ptr.ptr())
                         };
                         if source_to_idx.contains_key(&(target_block_id, target_in_block_ptr)) {
                             continue;

--- a/stackslib/src/chainstate/stacks/index/test/squash.rs
+++ b/stackslib/src/chainstate/stacks/index/test/squash.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashSet;
 use std::io::{Cursor, Seek};
 use std::path::PathBuf;
 
@@ -28,13 +29,14 @@ use crate::chainstate::stacks::index::marf::{
     OWN_BLOCK_HEIGHT_KEY,
 };
 use crate::chainstate::stacks::index::node::{
-    is_u64_ptr, set_backptr, TrieNode as _, TrieNode16, TrieNode256, TrieNode4, TrieNode48,
-    TrieNodeID, TrieNodeType, TriePtr,
+    is_backptr, is_u64_ptr, set_backptr, TrieNode as _, TrieNode16, TrieNode256, TrieNode4,
+    TrieNode48, TrieNodeID, TrieNodeType, TriePtr,
 };
 use crate::chainstate::stacks::index::squash::{
     compute_node_hash, deserialize_node, serialize_node, stream_squash_blob, NodeStore,
 };
 use crate::chainstate::stacks::index::storage::TrieHashCalculationMode;
+use crate::chainstate::stacks::index::trie::Trie;
 use crate::chainstate::stacks::index::{
     blob_layout, trie_sql, ClarityMarfTrieId, Error, MARFValue, TrieLeaf, TrieMerkleProof,
 };
@@ -89,6 +91,52 @@ fn build_archival_and_squashed_marfs(
     let squashed = MARF::from_path(squashed_path.to_str().unwrap(), open_opts).unwrap();
 
     (archival, squashed, blocks)
+}
+
+/// The original blocks named by squash annotations in a squashed MARF's trie
+/// at `tip`.
+///
+/// Pass the squash boundary block: the squash stores every child inline, so
+/// walking inline pointers covers the whole trie, and every one of them
+/// carries an annotation.
+fn annotated_source_blocks(
+    marf: &mut MARF<StacksBlockId>,
+    tip: &StacksBlockId,
+) -> HashSet<StacksBlockId> {
+    marf.with_conn(|conn| {
+        conn.open_block(tip)?;
+        let (root, _) = Trie::read_root(conn)?;
+
+        let mut blocks = HashSet::new();
+        let mut seen_offsets = HashSet::new();
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            for ptr in node.ptrs() {
+                if ptr.id() == TrieNodeID::Empty as u8 {
+                    continue;
+                }
+                assert!(
+                    !is_backptr(ptr.id()),
+                    "not a squashed trie at {tip}: {ptr:?} is a backpointer"
+                );
+                assert_ne!(
+                    ptr.back_block(),
+                    0,
+                    "unannotated inline pointer in squashed trie: {ptr:?}"
+                );
+                blocks.insert(conn.get_block_from_local_id(ptr.back_block())?.clone());
+                if !seen_offsets.insert(ptr.ptr()) {
+                    continue;
+                }
+                let (child, _) = conn.read_nodetype(ptr)?;
+                if !child.is_leaf() {
+                    stack.push(child);
+                }
+            }
+        }
+        Ok::<_, Error>(blocks)
+    })
+    .unwrap()
 }
 
 /// Assert that the archival and squashed MARFs report identical root hashes
@@ -1764,12 +1812,55 @@ fn test_squash_handles_commit_to_renamed_blocks_at_tip() {
     assert_eq!(stats.squash_height, 2);
 }
 
-/// Re-squash walks new blocks and reads old heights from the side table.
+/// Re-squash walks new blocks and reads old heights from the side table, and
+/// extending the result still reproduces archival root hashes.
+///
+/// Pre-squash nodes are stored inline with a squash annotation naming the
+/// block they came from. A second squash must carry those annotations over:
+/// they are absent from every hash the snapshot records, so losing them is
+/// invisible until a later write copies the branch and turns the annotation
+/// back into a backpointer.
 #[test]
 fn test_resquash_after_squash_succeeds() {
+    let commit_block = |marf: &mut MARF<StacksBlockId>,
+                        parent: &StacksBlockId,
+                        next: &StacksBlockId,
+                        writes: &[(String, String)]| {
+        marf.begin(parent, next).unwrap();
+        for (key, val) in writes {
+            marf.insert(key, MARFValue::from_value(val)).unwrap();
+        }
+        marf.commit().unwrap();
+    };
+    // One fresh key plus one overwrite, so most of the squashed trie stays
+    // untouched and is still reached through squash annotations when the MARF
+    // is squashed a second time.
+    let post_squash_writes = |i: usize| -> Vec<(String, String)> {
+        vec![
+            (format!("k_post{i}"), format!("v_post{i}")),
+            (format!("common_all_{i}"), format!("common_all_{i}_post{i}")),
+        ]
+    };
+    // Writes for a block past the re-squash boundary: fresh keys that split
+    // pre-squash branch nodes, plus overwrites of pre-squash keys no earlier
+    // post-squash block touched. Both force COW copies of nodes the re-squash
+    // reached through squash annotations.
+    let extension_writes = |i: usize| -> Vec<(String, String)> {
+        let mut writes: Vec<(String, String)> = (0..32)
+            .map(|j| (format!("resq{i}_k{j}"), format!("resq{i}_v{j}")))
+            .collect();
+        writes.extend((0..8).map(|j| {
+            // Stride 32 so the overwrites span keys introduced by both
+            // pre-squash blocks, not just the first one.
+            let key_index = 2 + 32 * i + j;
+            (format!("k{key_index}"), format!("k{key_index}_resq{i}"))
+        }));
+        writes
+    };
+
     let dir = tempdir().unwrap();
     let archival_path = dir.path().join("archival.sqlite");
-    let (mut archival, blocks, _) = setup_marf(archival_path.to_str().unwrap(), 3, 1);
+    let (mut archival, blocks, _) = setup_marf(archival_path.to_str().unwrap(), 3, 64);
 
     let squashed_dir = dir.path().join("squashed");
     let (squashed_path, _) = squash_helper(
@@ -1781,43 +1872,31 @@ fn test_resquash_after_squash_succeeds() {
 
     let open_opts = MARFOpenOpts::new(TrieHashCalculationMode::Deferred, true);
     let mut squashed = MARF::from_path(squashed_path.to_str().unwrap(), open_opts).unwrap();
+
+    // Premise of the root-hash assertions below: annotations name the blocks
+    // whose keys the extension overwrites, so the re-squash has identity to
+    // preserve and the overwrites exercise it. A flatter fixture would pass
+    // without exercising any annotation.
+    let annotated = annotated_source_blocks(&mut squashed, &blocks[2]);
+    assert!(
+        annotated.contains(&blocks[1]) && annotated.contains(&blocks[2]),
+        "fixture too flat to exercise re-squash: annotations name only {annotated:?}"
+    );
+
     let post: Vec<StacksBlockId> = (0u8..3)
         .map(|i| StacksBlockId::from_bytes(&[0x80 + i; 32]).unwrap())
         .collect();
 
-    squashed.begin(&blocks[2], &post[0]).unwrap();
-    squashed
-        .insert("k_post0", MARFValue::from_value("v_post0"))
-        .unwrap();
-    squashed.commit().unwrap();
-    squashed.begin(&post[0], &post[1]).unwrap();
-    squashed
-        .insert("k_post1", MARFValue::from_value("v_post1"))
-        .unwrap();
-    squashed.commit().unwrap();
-    squashed.begin(&post[1], &post[2]).unwrap();
-    squashed
-        .insert("k_post2", MARFValue::from_value("v_post2"))
-        .unwrap();
-    squashed.commit().unwrap();
+    // Extend both stores identically past the squash height.
+    let mut parent = blocks[2].clone();
+    for (i, next) in post.iter().enumerate() {
+        let writes = post_squash_writes(i);
+        commit_block(&mut squashed, &parent, next, &writes);
+        commit_block(&mut archival, &parent, next, &writes);
+        parent = next.clone();
+    }
+    assert_roots_match_at(&mut archival, &mut squashed, &post, "post-squash extension");
     drop(squashed);
-
-    archival.begin(&blocks[2], &post[0]).unwrap();
-    archival
-        .insert("k_post0", MARFValue::from_value("v_post0"))
-        .unwrap();
-    archival.commit().unwrap();
-    archival.begin(&post[0], &post[1]).unwrap();
-    archival
-        .insert("k_post1", MARFValue::from_value("v_post1"))
-        .unwrap();
-    archival.commit().unwrap();
-    archival.begin(&post[1], &post[2]).unwrap();
-    archival
-        .insert("k_post2", MARFValue::from_value("v_post2"))
-        .unwrap();
-    archival.commit().unwrap();
-    drop(archival);
 
     let resquashed_dir = dir.path().join("resquashed");
     let (resquashed_path, resquash_stats) = squash_helper(
@@ -1848,6 +1927,29 @@ fn test_resquash_after_squash_succeeds() {
             .unwrap()
             .unwrap_or_else(|| panic!("missing block at height {h}"));
         assert_eq!(bh, expected[h as usize], "height {h} mismatch");
+    }
+
+    // The re-squash boundary is post[1], so post[2] onward is state the
+    // re-squashed MARF has to build itself. Every root must match archival.
+    commit_block(&mut resquashed, &post[1], &post[2], &post_squash_writes(2));
+    assert_eq!(
+        archival.get_root_hash_at(&post[2]).unwrap(),
+        resquashed.get_root_hash_at(&post[2]).unwrap(),
+        "re-squashed extension diverged from archival at post[2]"
+    );
+
+    let mut parent = post[2].clone();
+    for i in 0..4usize {
+        let next = StacksBlockId::from_bytes(&[0x90 + i as u8; 32]).unwrap();
+        let writes = extension_writes(i);
+        commit_block(&mut archival, &parent, &next, &writes);
+        commit_block(&mut resquashed, &parent, &next, &writes);
+        assert_eq!(
+            archival.get_root_hash_at(&next).unwrap(),
+            resquashed.get_root_hash_at(&next).unwrap(),
+            "re-squashed extension diverged from archival at extension block {i}"
+        );
+        parent = next;
     }
 }
 


### PR DESCRIPTION
### Description

fixes a bug in `MARF::squash_to_path` that caused re-squashing an already squashed chainstate to generate an invalid snapshot. The problem was that we are not preserving the back_pointers annotations and were always treating the input of `MARF::squash_to_path` as an archival chainstate. 

A node booted from such a snapshot fails the `state_index_root` check on the first block and gets stuck immediately.


### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
