### PR TITLE
Refactored ClarityBackingStorage trait to be more generic

### DIFF
--- a/changelog.d/clarity_backing_store_trait.changed
+++ b/changelog.d/clarity_backing_store_trait.changed
@@ -1,0 +1,1 @@
+Updated the ClarityBackingStore trait to be no more dependent on sqlite

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -628,7 +628,7 @@ impl<'a> ClarityDatabase<'a> {
     pub fn get_data_with_proof<T>(
         &mut self,
         key: &str,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {
@@ -638,7 +638,7 @@ impl<'a> ClarityDatabase<'a> {
     pub fn get_data_with_proof_by_hash<T>(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {

--- a/clarity/src/vm/database/clarity_store.rs
+++ b/clarity/src/vm/database/clarity_store.rs
@@ -57,16 +57,20 @@ pub trait ClarityBackingStore {
     fn get_data(&mut self, key: &str) -> Result<Option<String>, VmExecutionError>;
     /// fetch Hash(K)-V out of the commmitted datastore
     fn get_data_from_path(&mut self, hash: &TrieHash) -> Result<Option<String>, VmExecutionError>;
-    /// fetch K-V out of the committed datastore, along with the byte representation
-    ///  of the Merkle proof for that key-value pair
+    /// Fetch K-V out of the committed datastore, along with the byte representation of the
+    /// Merkle proof for that key-value pair -- if this backend is able to produce one. The
+    /// outer `Option` is `None` if the key doesn't exist; the inner `Option` is `None` if the
+    /// key exists but this backend has no proof to offer for it (e.g. a non-Merkleized
+    /// backend). Callers that were asked for a proof must treat that as "no proof available",
+    /// not as a valid empty proof.
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError>;
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError>;
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError>;
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError>;
     fn has_entry(&mut self, key: &str) -> Result<bool, VmExecutionError> {
         Ok(self.get_data(key)?.is_some())
     }
@@ -86,9 +90,6 @@ pub trait ClarityBackingStore {
 
     fn get_open_chain_tip_height(&mut self) -> u32;
     fn get_open_chain_tip(&mut self) -> StacksBlockId;
-
-    #[cfg(feature = "rusqlite")]
-    fn get_side_store(&mut self) -> &Connection;
 
     fn get_cc_special_cases_handler(&self) -> Option<SpecialCaseHandler> {
         None
@@ -142,6 +143,18 @@ pub trait ClarityBackingStore {
         }
         Ok(())
     }
+}
+
+/// Opt-in capability for backends that happen to store their data in sqlite.
+///
+/// This is *not* part of [`ClarityBackingStore`]: nothing about the Clarity VM's execution
+/// semantics requires sqlite, and a non-sqlite backend (e.g. a plain hashmap) has no reason to
+/// implement it. It exists only so that sqlite-backed implementations can share the free-function
+/// helpers in [`crate::vm::database::sqlite`], and so that tests/tools with a concrete sqlite-backed
+/// store in hand can still reach the raw connection for inspection.
+#[cfg(feature = "rusqlite")]
+pub trait SqliteBackingStore: ClarityBackingStore {
+    fn get_side_store(&mut self) -> &Connection;
 }
 
 // TODO: Figure out where this belongs
@@ -216,20 +229,15 @@ impl ClarityBackingStore for NullBackingStore {
     fn get_data_with_proof(
         &mut self,
         _key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         panic!("NullBackingStore can't retrieve data")
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         _hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         panic!("NullBackingStore can't retrieve data")
-    }
-
-    #[cfg(feature = "rusqlite")]
-    fn get_side_store(&mut self) -> &Connection {
-        panic!("NullBackingStore has no side store")
     }
 
     fn get_block_at_height(&mut self, _height: u32) -> Option<StacksBlockId> {

--- a/clarity/src/vm/database/key_value_wrapper.rs
+++ b/clarity/src/vm/database/key_value_wrapper.rs
@@ -359,11 +359,13 @@ impl RollbackWrapper<'_> {
     }
 
     /// this function will only return commitment proofs for values _already_ materialized
-    ///  in the underlying store. otherwise it returns None.
+    ///  in the underlying store. otherwise it returns None. The inner `Option<Vec<u8>>` is
+    ///  `None` if the backing store has no proof to offer for this value at all (e.g. a
+    ///  non-Merkleized backend), as distinct from the value simply not existing.
     pub fn get_data_with_proof<T>(
         &mut self,
         key: &str,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {
@@ -374,11 +376,13 @@ impl RollbackWrapper<'_> {
     }
 
     /// this function will only return commitment proofs for values _already_ materialized
-    ///  in the underlying store. otherwise it returns None.
+    ///  in the underlying store. otherwise it returns None. The inner `Option<Vec<u8>>` is
+    ///  `None` if the backing store has no proof to offer for this value at all (e.g. a
+    ///  non-Merkleized backend), as distinct from the value simply not existing.
     pub fn get_data_with_proof_by_hash<T>(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -22,6 +22,9 @@ pub use self::clarity_db::{
     STORE_CONTRACT_SRC_INTERFACE, StoreType,
 };
 pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
+#[cfg(feature = "rusqlite")]
+pub use self::clarity_store::SqliteBackingStore;
+pub use self::hashmap_store::HashMapBackingStore;
 pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 #[cfg(feature = "rusqlite")]
 pub use self::sqlite::{DATA_TABLE_NAME, METADATA_TABLE_NAME, MetadataRow, SqliteConnection};
@@ -33,6 +36,7 @@ pub use self::structures::{
 mod caching;
 pub mod clarity_db;
 pub mod clarity_store;
+pub mod hashmap_store;
 mod key_value_wrapper;
 #[cfg(feature = "rusqlite")]
 pub mod sqlite;

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -21,9 +21,9 @@ pub use self::clarity_db::{
     BurnStateDB, ClarityDatabase, HeadersDB, NULL_BURN_STATE_DB, NULL_HEADER_DB,
     STORE_CONTRACT_SRC_INTERFACE, StoreType,
 };
-pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
 #[cfg(feature = "rusqlite")]
 pub use self::clarity_store::SqliteBackingStore;
+pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
 pub use self::hashmap_store::HashMapBackingStore;
 pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 #[cfg(feature = "rusqlite")]

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -21,7 +21,7 @@ use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::db::tx_busy_handler;
 use stacks_common::util::hash::Sha512Trunc256Sum;
 
-use super::clarity_store::{ContractCommitment, make_contract_hash_key};
+use super::clarity_store::{ContractCommitment, SqliteBackingStore, make_contract_hash_key};
 use super::{
     ClarityBackingStore, ClarityDatabase, ClarityDeserializable, NULL_BURN_STATE_DB,
     NULL_HEADER_DB, SpecialCaseHandler,
@@ -108,7 +108,7 @@ pub fn sqlite_get_contract_hash(
 }
 
 pub fn sqlite_insert_metadata(
-    store: &mut dyn ClarityBackingStore,
+    store: &mut dyn SqliteBackingStore,
     contract: &QualifiedContractIdentifier,
     key: &str,
     value: &str,
@@ -124,7 +124,7 @@ pub fn sqlite_insert_metadata(
 }
 
 pub fn sqlite_get_metadata(
-    store: &mut dyn ClarityBackingStore,
+    store: &mut dyn SqliteBackingStore,
     contract: &QualifiedContractIdentifier,
     key: &str,
 ) -> Result<Option<String>, VmExecutionError> {
@@ -133,7 +133,7 @@ pub fn sqlite_get_metadata(
 }
 
 pub fn sqlite_get_metadata_manual(
-    store: &mut dyn ClarityBackingStore,
+    store: &mut dyn SqliteBackingStore,
     at_height: u32,
     contract: &QualifiedContractIdentifier,
     key: &str,
@@ -408,19 +408,17 @@ impl ClarityBackingStore for MemoryBackingStore {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
-        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, vec![])))
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
+        // This backend has no MARF trie, so it can't produce a real Merkle proof -- report that
+        // honestly instead of fabricating one.
+        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, None)))
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.get_data_with_proof(&hash.to_string())
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        &self.side_store
     }
 
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
@@ -485,6 +483,12 @@ impl ClarityBackingStore for MemoryBackingStore {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for MemoryBackingStore {
+    fn get_side_store(&mut self) -> &Connection {
+        &self.side_store
     }
 }
 

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -2628,7 +2628,9 @@ mod tests {
 
     use clarity::types::chainstate::{BurnchainHeaderHash, SortitionId, StacksAddress};
     use clarity::vm::analysis::errors::RuntimeCheckErrorKind;
-    use clarity::vm::database::{ClarityBackingStore, STXBalance, SqliteConnection};
+    use clarity::vm::database::{
+        ClarityBackingStore, STXBalance, SqliteBackingStore, SqliteConnection,
+    };
     use clarity::vm::test_util::{TEST_BURN_STATE_DB, TEST_HEADER_DB};
     use clarity::vm::types::{StandardPrincipalData, TupleData, Value};
     use clarity::vm::ClarityName;
@@ -2639,6 +2641,7 @@ mod tests {
     use super::*;
     use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MarfConnection as _};
     use crate::chainstate::stacks::index::ClarityMarfTrieId;
+    use crate::clarity_vm::database::hashmap::HashMapWritableStore;
     use crate::clarity_vm::database::marf::MarfedKV;
     use crate::core::PEER_VERSION_EPOCH_2_0;
 
@@ -3850,6 +3853,63 @@ mod tests {
             assert_eq!(conn.chain_id(), CHAIN_ID_TESTNET);
             assert_eq!(conn.get_epoch(), StacksEpochId::Epoch20);
             assert!(conn.block_limit().is_some());
+            conn.commit_block();
+        }
+
+        // Non-MARF injection: `HashMapWritableStore` has no trie and no sqlite underneath, yet
+        // it drives the exact same block-processing path -- deploy a contract, call it, and
+        // commit the block -- proving `WritableMarfStore` doesn't actually require MARF.
+        {
+            let mut store = HashMapWritableStore::new();
+            store.begin(&StacksBlockId::sentinel(), StacksBlockId([0; 32]));
+            let mut conn = ClarityBlockConnection::from_writable_store_genesis(
+                Box::new(store),
+                &TEST_HEADER_DB,
+                &TEST_BURN_STATE_DB,
+                false,
+                CHAIN_ID_TESTNET,
+            );
+
+            let contract_identifier = QualifiedContractIdentifier::local("noop-contract").unwrap();
+            let sender = StandardPrincipalData::transient().into();
+            let contract_src = "(define-public (noop) (ok true))";
+
+            conn.as_transaction(|tx| {
+                let (ct_ast, ct_analysis) = tx
+                    .analyze_smart_contract(
+                        &contract_identifier,
+                        ClarityVersion::Clarity1,
+                        contract_src,
+                        &ResourceBudget::unlimited(),
+                    )
+                    .unwrap();
+                tx.initialize_smart_contract(
+                    &contract_identifier,
+                    ClarityVersion::Clarity1,
+                    &ct_ast,
+                    contract_src,
+                    None,
+                    |_, _| None,
+                    &ResourceBudget::unlimited(),
+                )
+                .unwrap();
+                tx.save_analysis(&contract_identifier, &ct_analysis)
+                    .unwrap();
+
+                let result = tx
+                    .run_contract_call(
+                        &sender,
+                        None,
+                        &contract_identifier,
+                        "noop",
+                        &[],
+                        |_, _| None,
+                        &ResourceBudget::unlimited(),
+                    )
+                    .unwrap();
+                assert_eq!(result.0, Value::okay_true());
+            });
+
             conn.commit_block();
         }
     }

--- a/stackslib/src/clarity_vm/database/ephemeral.rs
+++ b/stackslib/src/clarity_vm/database/ephemeral.rs
@@ -20,7 +20,9 @@ use clarity::vm::database::sqlite::{
     sqlite_get_contract_hash, sqlite_get_metadata, sqlite_get_metadata_manual,
     sqlite_insert_metadata,
 };
-use clarity::vm::database::{ClarityBackingStore, SpecialCaseHandler, SqliteConnection};
+use clarity::vm::database::{
+    ClarityBackingStore, SpecialCaseHandler, SqliteBackingStore, SqliteConnection,
+};
 use clarity::vm::errors::{RuntimeError, VmExecutionError, VmInternalError};
 use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::{self, Connection};
@@ -494,7 +496,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         trace!(
             "Ephemeral MarfedKV get_data_with_proof: '{}' tip={:?}",
             key,
@@ -516,7 +518,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok(Some((data, proof.serialize_to_vec())))
+                Ok(Some((data, Some(proof.serialize_to_vec()))))
             },
             |read_only_marf, key| read_only_marf.get_data_with_proof(key),
         )
@@ -529,7 +531,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         trace!(
             "Ephemeral MarfedKV get_data_with_proof_from_hash: {:?} tip={:?}",
             hash,
@@ -551,17 +553,10 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok(Some((data, proof.serialize_to_vec())))
+                Ok(Some((data, Some(proof.serialize_to_vec()))))
             },
             |read_only_marf, path| read_only_marf.get_data_with_proof_from_path(path),
         )
-    }
-
-    /// Get a sqlite connection to the MARF side-store.
-    /// Note that due to `setup_views()` and `teardown_views()`, the MARF DB will show key/value
-    /// pairs for both the ephemeral MARF and the disk-backed readonly MARF.
-    fn get_side_store(&mut self) -> &Connection {
-        self.ephemeral_marf.sqlite_conn()
     }
 
     /// Get an ancestor block's ID at a given absolute height, off of the open tip.
@@ -770,6 +765,15 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for EphemeralMarfStore<'_> {
+    /// Get a sqlite connection to the MARF side-store.
+    /// Note that due to `setup_views()` and `teardown_views()`, the MARF DB will show key/value
+    /// pairs for both the ephemeral MARF and the disk-backed readonly MARF.
+    fn get_side_store(&mut self) -> &Connection {
+        self.ephemeral_marf.sqlite_conn()
     }
 }
 

--- a/stackslib/src/clarity_vm/database/marf.rs
+++ b/stackslib/src/clarity_vm/database/marf.rs
@@ -23,7 +23,9 @@ use clarity::vm::database::sqlite::{
     sqlite_get_contract_hash, sqlite_get_metadata, sqlite_get_metadata_manual,
     sqlite_insert_metadata,
 };
-use clarity::vm::database::{ClarityBackingStore, SpecialCaseHandler, SqliteConnection};
+use clarity::vm::database::{
+    ClarityBackingStore, SpecialCaseHandler, SqliteBackingStore, SqliteConnection,
+};
 use clarity::vm::errors::{IncomparableError, RuntimeError, VmExecutionError, VmInternalError};
 use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::Connection;
@@ -531,10 +533,6 @@ impl ReadOnlyMarfStore<'_> {
 }
 
 impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
-    fn get_side_store(&mut self) -> &Connection {
-        self.marf.sqlite_conn()
-    }
-
     fn get_cc_special_cases_handler(&self) -> Option<SpecialCaseHandler> {
         Some(&handle_contract_call_special_cases)
     }
@@ -632,7 +630,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof(&self.chain_tip, key)
             .or_else(|e| match e {
@@ -649,7 +647,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
     }
@@ -657,7 +655,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof_from_hash(&self.chain_tip, hash)
             .or_else(|e| match e {
@@ -674,7 +672,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
     }
@@ -785,6 +783,12 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
     }
 }
 
+impl SqliteBackingStore for ReadOnlyMarfStore<'_> {
+    fn get_side_store(&mut self) -> &Connection {
+        self.marf.sqlite_conn()
+    }
+}
+
 impl PersistentWritableMarfStore<'_> {
     #[cfg(test)]
     fn do_test_commit(self) {
@@ -892,7 +896,7 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof(&self.chain_tip, key)
             .or_else(|e| match e {
@@ -909,7 +913,7 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
     }
@@ -917,7 +921,7 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof_from_hash(&self.chain_tip, hash)
             .or_else(|e| match e {
@@ -934,13 +938,9 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        self.marf.sqlite_tx()
     }
 
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
@@ -1047,6 +1047,12 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for PersistentWritableMarfStore<'_> {
+    fn get_side_store(&mut self) -> &Connection {
+        self.marf.sqlite_tx()
     }
 }
 
@@ -1173,14 +1179,14 @@ impl<'a> ClarityBackingStore for Box<dyn WritableMarfStore + 'a> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         ClarityBackingStore::get_data_with_proof(self.deref_mut(), key)
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         ClarityBackingStore::get_data_with_proof_from_path(self.deref_mut(), hash)
     }
 
@@ -1202,10 +1208,6 @@ impl<'a> ClarityBackingStore for Box<dyn WritableMarfStore + 'a> {
 
     fn get_open_chain_tip(&mut self) -> StacksBlockId {
         ClarityBackingStore::get_open_chain_tip(self.deref_mut())
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        ClarityBackingStore::get_side_store(self.deref_mut())
     }
 
     fn get_cc_special_cases_handler(&self) -> Option<SpecialCaseHandler> {

--- a/stackslib/src/clarity_vm/database/mod.rs
+++ b/stackslib/src/clarity_vm/database/mod.rs
@@ -9,7 +9,7 @@ use clarity::vm::database::sqlite::{
 };
 use clarity::vm::database::{
     BurnStateDB, ClarityBackingStore, ClarityDatabase, HeadersDB, SpecialCaseHandler,
-    SqliteConnection, NULL_BURN_STATE_DB, NULL_HEADER_DB,
+    SqliteBackingStore, SqliteConnection, NULL_BURN_STATE_DB, NULL_HEADER_DB,
 };
 use clarity::vm::errors::{RuntimeError, VmExecutionError};
 use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
@@ -36,6 +36,7 @@ use crate::core::{StacksEpoch, StacksEpochId};
 use crate::util_lib::db::{DBConn, Error as DBError, FromColumn, FromRow};
 
 pub mod ephemeral;
+pub mod hashmap;
 pub mod marf;
 
 pub trait GetTenureStartId {
@@ -1252,22 +1253,20 @@ impl ClarityBackingStore for MemoryBackingStore {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
-        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, vec![])))
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
+        // This backend has no MARF trie, so it can't produce a real Merkle proof -- report that
+        // honestly instead of fabricating one.
+        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, None)))
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         key: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         Ok(
             SqliteConnection::get(self.get_side_store(), key.to_string().as_str())?
-                .map(|x| (x, vec![])),
+                .map(|x| (x, None)),
         )
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        &self.side_store
     }
 
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
@@ -1332,5 +1331,11 @@ impl ClarityBackingStore for MemoryBackingStore {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for MemoryBackingStore {
+    fn get_side_store(&mut self) -> &Connection {
+        &self.side_store
     }
 }

--- a/stackslib/src/clarity_vm/tests/mod.rs
+++ b/stackslib/src/clarity_vm/tests/mod.rs
@@ -24,4 +24,5 @@ pub mod events;
 pub mod forking;
 pub mod large_contract;
 pub mod smoke;
+pub mod storage_conformance;
 pub mod utils;

--- a/stackslib/src/net/api/getaccount.rs
+++ b/stackslib/src/net/api/getaccount.rs
@@ -148,7 +148,9 @@ impl RPCRequestHandler for RPCGetAccountRequestHandler {
                                     .get_data_with_proof::<STXBalance>(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })
                                     .unwrap_or_else(|| (STXBalance::zero(), Some("".into())))
                             } else {
                                 clarity_db
@@ -165,7 +167,9 @@ impl RPCRequestHandler for RPCGetAccountRequestHandler {
                                     .get_data_with_proof(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })
                                     .unwrap_or_else(|| (0, Some("".into())))
                             } else {
                                 clarity_db

--- a/stackslib/src/net/api/getclaritymarfvalue.rs
+++ b/stackslib/src/net/api/getclaritymarfvalue.rs
@@ -131,7 +131,7 @@ impl RPCRequestHandler for RPCGetClarityMarfRequestHandler {
                                 .get_data_with_proof_by_hash(&marf_key_hash)
                                 .ok()
                                 .flatten()
-                                .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))?
+                                .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
                         } else {
                             clarity_db
                                 .get_data_by_hash(&marf_key_hash)

--- a/stackslib/src/net/api/getcontractsrc.rs
+++ b/stackslib/src/net/api/getcontractsrc.rs
@@ -136,7 +136,7 @@ impl RPCRequestHandler for RPCGetContractSrcRequestHandler {
                                 db.get_data_with_proof::<ContractCommitment>(&contract_commit_key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))?
+                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
                             } else {
                                 db.get_data::<ContractCommitment>(&contract_commit_key)
                                     .ok()

--- a/stackslib/src/net/api/getcontractsrc.rs
+++ b/stackslib/src/net/api/getcontractsrc.rs
@@ -136,7 +136,9 @@ impl RPCRequestHandler for RPCGetContractSrcRequestHandler {
                                 db.get_data_with_proof::<ContractCommitment>(&contract_commit_key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })?
                             } else {
                                 db.get_data::<ContractCommitment>(&contract_commit_key)
                                     .ok()

--- a/stackslib/src/net/api/getdatavar.rs
+++ b/stackslib/src/net/api/getdatavar.rs
@@ -145,19 +145,18 @@ impl RPCRequestHandler for RPCGetDataVarRequestHandler {
                 &tip,
                 |clarity_tx| {
                     clarity_tx.with_clarity_db_readonly(|clarity_db| {
-                        let (value_hex, marf_proof): (String, _) = if with_proof {
-                            clarity_db
-                                .get_data_with_proof(&key)
-                                .ok()
-                                .flatten()
-                                .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
-                        } else {
-                            clarity_db
-                                .get_data(&key)
-                                .ok()
-                                .flatten()
-                                .map(|a| (a, None))?
-                        };
+                        let (value_hex, marf_proof): (String, _) =
+                            if with_proof {
+                                clarity_db.get_data_with_proof(&key).ok().flatten().map(
+                                    |(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))),
+                                )?
+                            } else {
+                                clarity_db
+                                    .get_data(&key)
+                                    .ok()
+                                    .flatten()
+                                    .map(|a| (a, None))?
+                            };
 
                         let data = format!("0x{}", value_hex);
                         Some(DataVarResponse { data, marf_proof })

--- a/stackslib/src/net/api/getdatavar.rs
+++ b/stackslib/src/net/api/getdatavar.rs
@@ -150,7 +150,7 @@ impl RPCRequestHandler for RPCGetDataVarRequestHandler {
                                 .get_data_with_proof(&key)
                                 .ok()
                                 .flatten()
-                                .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))?
+                                .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
                         } else {
                             clarity_db
                                 .get_data(&key)

--- a/stackslib/src/net/api/getmapentry.rs
+++ b/stackslib/src/net/api/getmapentry.rs
@@ -176,7 +176,7 @@ impl RPCRequestHandler for RPCGetMapEntryRequestHandler {
                                     .get_data_with_proof(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))
+                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))
                                     .unwrap_or_else(|| {
                                         test_debug!("No value for '{}' in {}", &key, tip);
                                         (none_response, Some("".into()))

--- a/stackslib/src/net/api/getmapentry.rs
+++ b/stackslib/src/net/api/getmapentry.rs
@@ -176,7 +176,9 @@ impl RPCRequestHandler for RPCGetMapEntryRequestHandler {
                                     .get_data_with_proof(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })
                                     .unwrap_or_else(|| {
                                         test_debug!("No value for '{}' in {}", &key, tip);
                                         (none_response, Some("".into()))


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

The current ClarityBackingStorage trait is (still) heavily bound to sqlite. This patch makes it more generic without chnging the current logic (an additional abstraction layer for "Backing Stores" based on sqlite has been provided)

In addition to this it addresses the TrieHash/proof mechanism that right now is heavily tied to the MARF specific implementation (by allowing the proof to be invalid instead of empty)

Another patch will follow to take care of the MARF naming convention in some of the trait/structs

Note that an example/proof-of-concept/non-marf implementation (HashMapWritableStore) is provided too in tests

### Applicable issues

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
