### PR TITLE
Generalize ClarityStore related traits

### DIFF
--- a/changelog.d/clarity_backing_store_trait.changed
+++ b/changelog.d/clarity_backing_store_trait.changed
@@ -1,0 +1,1 @@
+Updated the ClarityBackingStore trait to be no more dependent on sqlite

--- a/changelog.d/clarity_store_trait.changed
+++ b/changelog.d/clarity_store_trait.changed
@@ -1,0 +1,1 @@
+Updated ClarityStore and related traits to be non MARF-centric

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -628,7 +628,7 @@ impl<'a> ClarityDatabase<'a> {
     pub fn get_data_with_proof<T>(
         &mut self,
         key: &str,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {
@@ -638,7 +638,7 @@ impl<'a> ClarityDatabase<'a> {
     pub fn get_data_with_proof_by_hash<T>(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {

--- a/clarity/src/vm/database/clarity_store.rs
+++ b/clarity/src/vm/database/clarity_store.rs
@@ -57,16 +57,20 @@ pub trait ClarityBackingStore {
     fn get_data(&mut self, key: &str) -> Result<Option<String>, VmExecutionError>;
     /// fetch Hash(K)-V out of the commmitted datastore
     fn get_data_from_path(&mut self, hash: &TrieHash) -> Result<Option<String>, VmExecutionError>;
-    /// fetch K-V out of the committed datastore, along with the byte representation
-    ///  of the Merkle proof for that key-value pair
+    /// Fetch K-V out of the committed datastore, along with the byte representation of the
+    /// Merkle proof for that key-value pair -- if this backend is able to produce one. The
+    /// outer `Option` is `None` if the key doesn't exist; the inner `Option` is `None` if the
+    /// key exists but this backend has no proof to offer for it (e.g. a non-Merkleized
+    /// backend). Callers that were asked for a proof must treat that as "no proof available",
+    /// not as a valid empty proof.
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError>;
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError>;
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError>;
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError>;
     fn has_entry(&mut self, key: &str) -> Result<bool, VmExecutionError> {
         Ok(self.get_data(key)?.is_some())
     }
@@ -86,9 +90,6 @@ pub trait ClarityBackingStore {
 
     fn get_open_chain_tip_height(&mut self) -> u32;
     fn get_open_chain_tip(&mut self) -> StacksBlockId;
-
-    #[cfg(feature = "rusqlite")]
-    fn get_side_store(&mut self) -> &Connection;
 
     fn get_cc_special_cases_handler(&self) -> Option<SpecialCaseHandler> {
         None
@@ -142,6 +143,18 @@ pub trait ClarityBackingStore {
         }
         Ok(())
     }
+}
+
+/// Opt-in capability for backends that happen to store their data in sqlite.
+///
+/// This is *not* part of [`ClarityBackingStore`]: nothing about the Clarity VM's execution
+/// semantics requires sqlite, and a non-sqlite backend (e.g. a plain hashmap) has no reason to
+/// implement it. It exists only so that sqlite-backed implementations can share the free-function
+/// helpers in [`crate::vm::database::sqlite`], and so that tests/tools with a concrete sqlite-backed
+/// store in hand can still reach the raw connection for inspection.
+#[cfg(feature = "rusqlite")]
+pub trait SqliteBackingStore: ClarityBackingStore {
+    fn get_side_store(&mut self) -> &Connection;
 }
 
 // TODO: Figure out where this belongs
@@ -216,20 +229,15 @@ impl ClarityBackingStore for NullBackingStore {
     fn get_data_with_proof(
         &mut self,
         _key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         panic!("NullBackingStore can't retrieve data")
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         _hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         panic!("NullBackingStore can't retrieve data")
-    }
-
-    #[cfg(feature = "rusqlite")]
-    fn get_side_store(&mut self) -> &Connection {
-        panic!("NullBackingStore has no side store")
     }
 
     fn get_block_at_height(&mut self, _height: u32) -> Option<StacksBlockId> {

--- a/clarity/src/vm/database/key_value_wrapper.rs
+++ b/clarity/src/vm/database/key_value_wrapper.rs
@@ -359,11 +359,13 @@ impl RollbackWrapper<'_> {
     }
 
     /// this function will only return commitment proofs for values _already_ materialized
-    ///  in the underlying store. otherwise it returns None.
+    ///  in the underlying store. otherwise it returns None. The inner `Option<Vec<u8>>` is
+    ///  `None` if the backing store has no proof to offer for this value at all (e.g. a
+    ///  non-Merkleized backend), as distinct from the value simply not existing.
     pub fn get_data_with_proof<T>(
         &mut self,
         key: &str,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {
@@ -374,11 +376,13 @@ impl RollbackWrapper<'_> {
     }
 
     /// this function will only return commitment proofs for values _already_ materialized
-    ///  in the underlying store. otherwise it returns None.
+    ///  in the underlying store. otherwise it returns None. The inner `Option<Vec<u8>>` is
+    ///  `None` if the backing store has no proof to offer for this value at all (e.g. a
+    ///  non-Merkleized backend), as distinct from the value simply not existing.
     pub fn get_data_with_proof_by_hash<T>(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(T, Vec<u8>)>, VmExecutionError>
+    ) -> Result<Option<(T, Option<Vec<u8>>)>, VmExecutionError>
     where
         T: ClarityDeserializable<T>,
     {

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -22,6 +22,9 @@ pub use self::clarity_db::{
     STORE_CONTRACT_SRC_INTERFACE, StoreType,
 };
 pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
+#[cfg(feature = "rusqlite")]
+pub use self::clarity_store::SqliteBackingStore;
+pub use self::hashmap_store::HashMapBackingStore;
 pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 #[cfg(feature = "rusqlite")]
 pub use self::sqlite::{DATA_TABLE_NAME, METADATA_TABLE_NAME, MetadataRow, SqliteConnection};
@@ -33,6 +36,7 @@ pub use self::structures::{
 mod caching;
 pub mod clarity_db;
 pub mod clarity_store;
+pub mod hashmap_store;
 mod key_value_wrapper;
 #[cfg(feature = "rusqlite")]
 pub mod sqlite;

--- a/clarity/src/vm/database/mod.rs
+++ b/clarity/src/vm/database/mod.rs
@@ -21,9 +21,9 @@ pub use self::clarity_db::{
     BurnStateDB, ClarityDatabase, HeadersDB, NULL_BURN_STATE_DB, NULL_HEADER_DB,
     STORE_CONTRACT_SRC_INTERFACE, StoreType,
 };
-pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
 #[cfg(feature = "rusqlite")]
 pub use self::clarity_store::SqliteBackingStore;
+pub use self::clarity_store::{ClarityBackingStore, SpecialCaseHandler};
 pub use self::hashmap_store::HashMapBackingStore;
 pub use self::key_value_wrapper::{RollbackWrapper, RollbackWrapperPersistedLog};
 #[cfg(feature = "rusqlite")]

--- a/clarity/src/vm/database/sqlite.rs
+++ b/clarity/src/vm/database/sqlite.rs
@@ -21,7 +21,7 @@ use stacks_common::types::sqlite::NO_PARAMS;
 use stacks_common::util::db::tx_busy_handler;
 use stacks_common::util::hash::Sha512Trunc256Sum;
 
-use super::clarity_store::{ContractCommitment, make_contract_hash_key};
+use super::clarity_store::{ContractCommitment, SqliteBackingStore, make_contract_hash_key};
 use super::{
     ClarityBackingStore, ClarityDatabase, ClarityDeserializable, NULL_BURN_STATE_DB,
     NULL_HEADER_DB, SpecialCaseHandler,
@@ -108,7 +108,7 @@ pub fn sqlite_get_contract_hash(
 }
 
 pub fn sqlite_insert_metadata(
-    store: &mut dyn ClarityBackingStore,
+    store: &mut dyn SqliteBackingStore,
     contract: &QualifiedContractIdentifier,
     key: &str,
     value: &str,
@@ -124,7 +124,7 @@ pub fn sqlite_insert_metadata(
 }
 
 pub fn sqlite_get_metadata(
-    store: &mut dyn ClarityBackingStore,
+    store: &mut dyn SqliteBackingStore,
     contract: &QualifiedContractIdentifier,
     key: &str,
 ) -> Result<Option<String>, VmExecutionError> {
@@ -133,7 +133,7 @@ pub fn sqlite_get_metadata(
 }
 
 pub fn sqlite_get_metadata_manual(
-    store: &mut dyn ClarityBackingStore,
+    store: &mut dyn SqliteBackingStore,
     at_height: u32,
     contract: &QualifiedContractIdentifier,
     key: &str,
@@ -408,19 +408,17 @@ impl ClarityBackingStore for MemoryBackingStore {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
-        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, vec![])))
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
+        // This backend has no MARF trie, so it can't produce a real Merkle proof -- report that
+        // honestly instead of fabricating one.
+        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, None)))
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.get_data_with_proof(&hash.to_string())
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        &self.side_store
     }
 
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
@@ -485,6 +483,12 @@ impl ClarityBackingStore for MemoryBackingStore {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for MemoryBackingStore {
+    fn get_side_store(&mut self) -> &Connection {
+        &self.side_store
     }
 }
 

--- a/contrib/clarity-cli/src/lib.rs
+++ b/contrib/clarity-cli/src/lib.rs
@@ -56,7 +56,7 @@ use stackslib::chainstate::stacks::boot::{
     POX_2_MAINNET_CODE, POX_2_TESTNET_CODE,
 };
 use stackslib::chainstate::stacks::index::ClarityMarfTrieId;
-use stackslib::clarity_vm::clarity::{ClarityMarfStore, ClarityMarfStoreTransaction};
+use stackslib::clarity_vm::clarity::{ClarityStore, ClarityStoreTransaction};
 use stackslib::clarity_vm::database::MemoryBackingStore;
 use stackslib::clarity_vm::database::marf::{MarfedKV, PersistentWritableMarfStore};
 use stackslib::core::{BLOCK_LIMIT_MAINNET_205, HELIUM_BLOCK_LIMIT_20, StacksEpochId};
@@ -406,7 +406,7 @@ where
 
     let marf_tx = marf_kv.begin(&from, &to);
     let (marf_return, result) = f(marf_tx);
-    marf_return.drop_current_trie();
+    marf_return.drop_current_block();
     result
 }
 
@@ -421,7 +421,7 @@ where
 
     let marf_tx = marf_kv.begin(&from, &to);
     let (marf_return, result) = f(marf_tx);
-    marf_return.drop_current_trie();
+    marf_return.drop_current_block();
     result
 }
 

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -46,8 +46,8 @@ use crate::chainstate::stacks::boot::{
 use crate::chainstate::stacks::index::ClarityMarfTrieId;
 use crate::chainstate::stacks::{C32_ADDRESS_VERSION_TESTNET_SINGLESIG, *};
 use crate::clarity_vm::clarity::{
-    ClarityBlockConnection, ClarityError, ClarityMarfStore, ClarityMarfStoreTransaction,
-    WritableMarfStore,
+    ClarityBlockConnection, ClarityError, ClarityStore, ClarityStoreTransaction,
+    WritableClarityStore,
 };
 use crate::clarity_vm::database::marf::MarfedKV;
 use crate::core::{
@@ -160,12 +160,12 @@ impl ClarityTestSim {
         &'_ mut self,
         new_tenure: bool,
     ) -> (
-        Box<dyn WritableMarfStore + '_>,
+        Box<dyn WritableClarityStore + '_>,
         TestSimHeadersDB,
         TestSimBurnStateDB,
         StacksEpochId,
     ) {
-        let mut store: Box<dyn WritableMarfStore> = Box::new(self.marf.begin(
+        let mut store: Box<dyn WritableClarityStore> = Box::new(self.marf.begin(
             &StacksBlockId(test_sim_height_to_hash(self.block_height, self.fork)),
             &StacksBlockId(test_sim_height_to_hash(self.block_height + 1, self.fork)),
         ));
@@ -253,7 +253,7 @@ impl ClarityTestSim {
     }
 
     fn check_and_bump_epoch<'a>(
-        store: &mut Box<dyn WritableMarfStore + 'a>,
+        store: &mut Box<dyn WritableClarityStore + 'a>,
         headers_db: &TestSimHeadersDB,
         burn_db: &dyn BurnStateDB,
     ) -> StacksEpochId {
@@ -280,7 +280,7 @@ impl ClarityTestSim {
     where
         F: FnOnce(&mut OwnedEnvironment) -> R,
     {
-        let mut store: Box<dyn WritableMarfStore> = Box::new(self.marf.begin(
+        let mut store: Box<dyn WritableClarityStore> = Box::new(self.marf.begin(
             &StacksBlockId(test_sim_height_to_hash(parent_height, self.fork)),
             &StacksBlockId(test_sim_height_to_hash(parent_height + 1, self.fork + 1)),
         ));

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -520,7 +520,7 @@ impl<'a, 'b> ClarityTx<'a, 'b> {
     /// by `inner_clarity_tx_begin`. Paired with
     /// [`ClarityBlockConnection::from_writable_store`], it lets a caller run the
     /// whole consensus transaction engine (`process_transaction`, `finish_block`,
-    /// `seal`, …) against a custom [`WritableMarfStore`] backend rather than the
+    /// `seal`, …) against a custom [`WritableClarityStore`] backend rather than the
     /// datastore owned by a `ClarityInstance`.
     ///
     /// `DBConfig` is derived from the block connection so mainnet/chain_id cannot
@@ -1364,7 +1364,7 @@ impl StacksChainState {
     /// final `commit_to_block`. Extracted from [`Self::install_boot_code`] (which
     /// now calls it against a `MarfedKV`-backed tx) so the same boot can be run
     /// against *any* [`ClarityTx`] — e.g. one built over a custom
-    /// [`WritableMarfStore`] via [`ClarityBlockConnection::from_writable_store_genesis`]
+    /// [`WritableClarityStore`] via [`ClarityBlockConnection::from_writable_store_genesis`]
     /// — yielding a byte-identical genesis state root regardless of backend.
     ///
     /// Network mode (`mainnet` vs testnet) is taken from `clarity_tx.config` so it

--- a/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
+++ b/stackslib/src/chainstate/stacks/db/snapshot/tests/clarity.rs
@@ -29,7 +29,7 @@ use super::super::copy_clarity_side_tables;
 use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MARF};
 use crate::chainstate::stacks::index::storage::TrieHashCalculationMode;
 use crate::chainstate::stacks::index::{ClarityMarfTrieId as _, Error, MARFValue};
-use crate::clarity_vm::clarity::ClarityMarfStoreTransaction as _;
+use crate::clarity_vm::clarity::ClarityStoreTransaction as _;
 use crate::clarity_vm::database::marf::MarfedKV;
 
 /// Build a Clarity MARF with N blocks of data and a single contract.

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -212,7 +212,8 @@ pub trait ClarityStoreTransaction {
     /// It can later be deleted via `drop_metadata_for_block()` if given the same target.
     /// Returns Ok(()) on success
     /// Returns Err(..) on error
-    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError>;
+    fn commit_metadata_for_block(&mut self, target: &StacksBlockId)
+        -> Result<(), VmExecutionError>;
 
     /// Drop metadata for a particular block that was stored previously via
     /// `commit_metadata_for_block()`. This function is idempotent.

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -2628,7 +2628,9 @@ mod tests {
 
     use clarity::types::chainstate::{BurnchainHeaderHash, SortitionId, StacksAddress};
     use clarity::vm::analysis::errors::RuntimeCheckErrorKind;
-    use clarity::vm::database::{ClarityBackingStore, STXBalance, SqliteConnection};
+    use clarity::vm::database::{
+        ClarityBackingStore, STXBalance, SqliteBackingStore, SqliteConnection,
+    };
     use clarity::vm::test_util::{TEST_BURN_STATE_DB, TEST_HEADER_DB};
     use clarity::vm::types::{StandardPrincipalData, TupleData, Value};
     use clarity::vm::ClarityName;
@@ -2639,6 +2641,7 @@ mod tests {
     use super::*;
     use crate::chainstate::stacks::index::marf::{MARFOpenOpts, MarfConnection as _};
     use crate::chainstate::stacks::index::ClarityMarfTrieId;
+    use crate::clarity_vm::database::hashmap::HashMapWritableStore;
     use crate::clarity_vm::database::marf::MarfedKV;
     use crate::core::PEER_VERSION_EPOCH_2_0;
 
@@ -3850,6 +3853,63 @@ mod tests {
             assert_eq!(conn.chain_id(), CHAIN_ID_TESTNET);
             assert_eq!(conn.get_epoch(), StacksEpochId::Epoch20);
             assert!(conn.block_limit().is_some());
+            conn.commit_block();
+        }
+
+        // Non-MARF injection: `HashMapWritableStore` has no trie and no sqlite underneath, yet
+        // it drives the exact same block-processing path -- deploy a contract, call it, and
+        // commit the block -- proving `WritableMarfStore` doesn't actually require MARF.
+        {
+            let mut store = HashMapWritableStore::new();
+            store.begin(&StacksBlockId::sentinel(), StacksBlockId([0; 32]));
+            let mut conn = ClarityBlockConnection::from_writable_store_genesis(
+                Box::new(store),
+                &TEST_HEADER_DB,
+                &TEST_BURN_STATE_DB,
+                false,
+                CHAIN_ID_TESTNET,
+            );
+
+            let contract_identifier = QualifiedContractIdentifier::local("noop-contract").unwrap();
+            let sender = StandardPrincipalData::transient().into();
+            let contract_src = "(define-public (noop) (ok true))";
+
+            conn.as_transaction(|tx| {
+                let (ct_ast, ct_analysis) = tx
+                    .analyze_smart_contract(
+                        &contract_identifier,
+                        ClarityVersion::Clarity1,
+                        contract_src,
+                        &ResourceBudget::unlimited(),
+                    )
+                    .unwrap();
+                tx.initialize_smart_contract(
+                    &contract_identifier,
+                    ClarityVersion::Clarity1,
+                    &ct_ast,
+                    contract_src,
+                    None,
+                    |_, _| None,
+                    &ResourceBudget::unlimited(),
+                )
+                .unwrap();
+                tx.save_analysis(&contract_identifier, &ct_analysis)
+                    .unwrap();
+
+                let result = tx
+                    .run_contract_call(
+                        &sender,
+                        None,
+                        &contract_identifier,
+                        "noop",
+                        &[],
+                        |_, _| None,
+                        &ResourceBudget::unlimited(),
+                    )
+                    .unwrap();
+                assert_eq!(result.0, Value::okay_true());
+            });
+
             conn.commit_block();
         }
     }

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -56,7 +56,7 @@ use crate::chainstate::stacks::{
     TransactionSmartContract, TransactionVersion,
 };
 use crate::clarity_vm::database::marf::{
-    BoxedClarityMarfStoreTransaction, MarfedKV, ReadOnlyMarfStore,
+    BoxedClarityStoreTransaction, MarfedKV, ReadOnlyMarfStore,
 };
 use crate::core::{StacksEpoch, StacksEpochId, FIRST_STACKS_BLOCK_ID, GENESIS_EPOCH};
 use crate::util_lib::boot::{boot_code_acc, boot_code_addr, boot_code_id, boot_code_tx_auth};
@@ -105,7 +105,7 @@ pub struct ClarityInstance {
 /// issuring event dispatches, before the Clarity database commits.
 ///
 pub struct PreCommitClarityBlock<'a> {
-    datastore: Box<dyn WritableMarfStore + 'a>,
+    datastore: Box<dyn WritableClarityStore + 'a>,
     commit_to: StacksBlockId,
 }
 
@@ -113,7 +113,7 @@ pub struct PreCommitClarityBlock<'a> {
 /// A high-level interface for Clarity VM interactions within a single block.
 ///
 pub struct ClarityBlockConnection<'a, 'b> {
-    datastore: Box<dyn WritableMarfStore + 'a>,
+    datastore: Box<dyn WritableClarityStore + 'a>,
     header_db: &'b dyn HeadersDB,
     burn_state_db: &'b dyn BurnStateDB,
     cost_track: Option<LimitedCostTracker>,
@@ -141,9 +141,16 @@ pub struct ClarityTransactionConnection<'a, 'b> {
     cache: ClarityExecutionCache,
 }
 
-/// Unified API common to all MARF stores
-pub trait ClarityMarfStore: ClarityBackingStore {
-    /// Instantiate a `ClarityDatabase` out of this MARF store.
+/// Convenience factory methods, common to any [`ClarityBackingStore`] implementation, for
+/// building the higher-level `ClarityDatabase`/`AnalysisDatabase` views over it.
+///
+/// This is split out from `ClarityBackingStore` itself (rather than being default methods there)
+/// because both methods pass `self` by value into a constructor that takes a concrete
+/// `&mut dyn ClarityBackingStore` reference -- a coercion that requires `Self: Sized`, which would
+/// make `ClarityBackingStore` itself not object-safe. Nothing here is MARF- or sqlite-specific;
+/// any backing store gets both methods for free via their default implementations.
+pub trait ClarityStore: ClarityBackingStore {
+    /// Instantiate a `ClarityDatabase` out of this store.
     /// Takes a `HeadersDB` and `BurnStateDB` implementation which are both used by
     /// `ClarityDatabase` to access Stacks's chainstate and sortition chainstate, respectively.
     fn as_clarity_db<'b>(
@@ -157,7 +164,7 @@ pub trait ClarityMarfStore: ClarityBackingStore {
         ClarityDatabase::new(self, headers_db, burn_state_db)
     }
 
-    /// Instantiate an `AnalysisDatabase` out of this MARF store.
+    /// Instantiate an `AnalysisDatabase` out of this store.
     fn as_analysis_db(&mut self) -> AnalysisDatabase<'_>
     where
         Self: Sized,
@@ -166,8 +173,8 @@ pub trait ClarityMarfStore: ClarityBackingStore {
     }
 }
 
-/// A MARF store which can be written to is both a ClarityMarfStore and a
-/// ClarityMarfStoreTransaction (and thus also a ClarityBackingStore).
+/// A backing store that can be written to is both a `ClarityStore` and a
+/// `ClarityStoreTransaction` (and thus also a `ClarityBackingStore`).
 ///
 /// This is the storage-backend abstraction for Clarity block processing: any type
 /// implementing it can drive a full block (`process_transaction`, `finish_block`,
@@ -175,51 +182,61 @@ pub trait ClarityMarfStore: ClarityBackingStore {
 /// [`ClarityBlockConnection::from_writable_store`] (or
 /// [`ClarityBlockConnection::from_writable_store_genesis`] for the boot block);
 /// the built-in [`MarfedKV`] backend reaches the same path through
-/// [`ClarityInstance::begin_block`].
-pub trait WritableMarfStore:
-    ClarityMarfStore + ClarityMarfStoreTransaction + BoxedClarityMarfStoreTransaction
+/// [`ClarityInstance::begin_block`]. Nothing about this trait requires a MARF trie --
+/// `crate::clarity_vm::database::hashmap::HashMapWritableStore` is a second, unrelated
+/// implementation with no trie and no sqlite underneath it. The one place MARF specifically is
+/// still required is real chain consensus: [`Self::seal`]'s result becomes the block header's
+/// `state_index_root`, which every node must derive identically, so only a MARF-faithful
+/// implementation may back actual mainnet/testnet block processing. Other implementations are
+/// valid for tests, tooling, and simulation.
+pub trait WritableClarityStore:
+    ClarityStore + ClarityStoreTransaction + BoxedClarityStoreTransaction
 {
 }
 
-/// A MARF store transaction for a chainstate block's trie.
-/// This transaction instantiates a trie which builds atop an already-written trie in the
-/// chainstate.  Once committed, it will persist -- it may be built upon, and a subsequent attempt
-/// to build the same trie will fail.
+/// A write transaction for a chainstate block's storage.
+/// This transaction builds atop an already-written parent block. Once committed, it will
+/// persist -- it may be built upon, and a subsequent attempt to build the same block will fail.
 ///
-/// The Stacks node commits tries for one of three purposes:
-/// * It processed a block, and needs to persist its trie in the chainstate proper.
-/// * It mined a block, and needs to persist its trie outside of the chainstate proper. The miner
+/// The Stacks node commits blocks for one of three purposes:
+/// * It processed a block, and needs to persist it in the chainstate proper.
+/// * It mined a block, and needs to persist it outside of the chainstate proper. The miner
 /// may build on it later.
 /// * It processed an unconfirmed microblock (Stacks 2.x only), and needs to persist the
 /// unconfirmed chainstate outside of the chainstate proper so that the microblock miner can
 /// continue to build on it and the network can service RPC requests on its state.
 ///
 /// These needs are each captured in distinct methods for committing this transaction.
-pub trait ClarityMarfStoreTransaction {
-    /// Commit all inserted metadata and associate it with the block trie identified by `target`.
-    /// It can later be deleted via `drop_metadata_for()` if given the same taret.
+pub trait ClarityStoreTransaction {
+    /// Commit all inserted metadata and associate it with the block identified by `target`.
+    /// It can later be deleted via `drop_metadata_for_block()` if given the same target.
     /// Returns Ok(()) on success
     /// Returns Err(..) on error
-    fn commit_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError>;
+    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError>;
 
-    /// Drop metadata for a particular block trie that was stored previously via `commit_metadata_to()`.
-    /// This function is idempotent.
+    /// Drop metadata for a particular block that was stored previously via
+    /// `commit_metadata_for_block()`. This function is idempotent.
     ///
-    /// Returns Ok(()) if the metadata for the trie identified by `target` was dropped.
+    /// Returns Ok(()) if the metadata for the block identified by `target` was dropped.
     /// It will be possible to insert it again afterwards.
     /// Returns Err(..) if the metadata was not successfully dropped.
-    fn drop_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError>;
+    fn drop_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError>;
 
-    /// Compute the ID of the trie being built.
-    /// In Stacks, this will only be called once all key/value pairs are inserted (and will only be
-    /// called at most once in this transaction's lifetime).
-    fn seal_trie(&mut self) -> TrieHash;
+    /// Compute a commitment (root hash) for the batch of writes in the block being built.
+    /// In Stacks, this will only be called once all key/value pairs are inserted (and will only
+    /// be called at most once in this transaction's lifetime).
+    ///
+    /// For real chainstate blocks, this **must** be the actual MARF trie's root hash: the
+    /// result is embedded as `state_index_root` in the block header and every node re-derives
+    /// it while replaying the block, rejecting the block on mismatch. Implementations not used
+    /// for real chain consensus (tests, tooling, simulation) may return any deterministic value.
+    fn seal(&mut self) -> TrieHash;
 
-    /// Drop the block trie that this transaction was creating.
+    /// Drop the block that this transaction was creating.
     /// Destroys the transaction.
-    fn drop_current_trie(self);
+    fn drop_current_block(self);
 
-    /// Drop the unconfirmed state trie that this transaction was creating.
+    /// Drop the unconfirmed state that this transaction was creating.
     /// Destroys the transaction.
     ///
     /// Returns Ok(()) on successful deletion of the data
@@ -227,22 +244,22 @@ pub trait ClarityMarfStoreTransaction {
     /// to the caller)
     fn drop_unconfirmed(self) -> Result<(), VmExecutionError>;
 
-    /// Store the processed block's trie that this transaction was creating.
-    /// The trie's ID must be `target`, so that subsequent tries can be built on it (and so that
-    /// subsequent queries can read from it).  `target` may not be known until it is time to write
-    /// the trie out, which is why it is provided here.
+    /// Store the processed block that this transaction was creating.
+    /// The block's ID must be `target`, so that subsequent blocks can be built on it (and so
+    /// that subsequent queries can read from it).  `target` may not be known until it is time to
+    /// write the block out, which is why it is provided here.
     ///
-    /// Returns Ok(()) if the block trie was successfully persisted.
-    /// Returns Err(..) if there was an error in trying to persist this block trie.
+    /// Returns Ok(()) if the block was successfully persisted.
+    /// Returns Err(..) if there was an error in trying to persist this block.
     fn commit_to_processed_block(self, target: &StacksBlockId) -> Result<(), VmExecutionError>;
 
-    /// Store a mined block's trie that this transaction was creating.
+    /// Store a mined block that this transaction was creating.
     /// This function is distinct from `commit_to_processed_block()` in that the stored block will
     /// not be added to the chainstate. However, it must be persisted so that the node can later
     /// build on it.
     ///
-    /// Returns Ok(()) if the block trie was successfully persisted.
-    /// Returns Err(..) if there was an error trying to persist this MARF trie.
+    /// Returns Ok(()) if the block was successfully persisted.
+    /// Returns Err(..) if there was an error trying to persist this block.
     fn commit_to_mined_block(self, target: &StacksBlockId) -> Result<(), VmExecutionError>;
 
     /// Persist the unconfirmed state trie so that other parts of the Stacks node can read from it
@@ -320,7 +337,7 @@ macro_rules! using {
 impl ClarityBlockConnection<'_, '_> {
     #[cfg(test)]
     pub fn new_test_conn<'a, 'b>(
-        datastore: Box<dyn WritableMarfStore + 'a>,
+        datastore: Box<dyn WritableClarityStore + 'a>,
         header_db: &'b dyn HeadersDB,
         burn_state_db: &'b dyn BurnStateDB,
         epoch: StacksEpochId,
@@ -340,10 +357,10 @@ impl ClarityBlockConnection<'_, '_> {
     ///
     /// `ClarityBlockConnection` — and therefore the whole consensus block-processing
     /// pipeline built on it (`process_transaction`, `finish_block`, `seal`, …) — is
-    /// generic over the [`WritableMarfStore`] trait: it holds a
-    /// `Box<dyn WritableMarfStore>` and never names a concrete store type. This
+    /// generic over the [`WritableClarityStore`] trait: it holds a
+    /// `Box<dyn WritableClarityStore>` and never names a concrete store type. This
     /// constructor is the public injection point for that abstraction. It lets a
-    /// caller run block processing against any `WritableMarfStore` implementation —
+    /// caller run block processing against any `WritableClarityStore` implementation —
     /// the built-in [`MarfedKV`], an in-memory store, a remote/disaggregated
     /// backend, a snapshotting store, and so on — instead of only the datastore
     /// owned by a [`ClarityInstance`].
@@ -359,7 +376,7 @@ impl ClarityBlockConnection<'_, '_> {
     /// The store must already be positioned on the block being built (its
     /// `begin`/`extend_to_block` equivalent has run).
     pub fn from_writable_store<'a, 'b>(
-        mut datastore: Box<dyn WritableMarfStore + 'a>,
+        mut datastore: Box<dyn WritableClarityStore + 'a>,
         header_db: &'b dyn HeadersDB,
         burn_state_db: &'b dyn BurnStateDB,
         mainnet: bool,
@@ -392,12 +409,12 @@ impl ClarityBlockConnection<'_, '_> {
     }
 
     /// Genesis/boot twin of [`Self::from_writable_store`]: begins the genesis block
-    /// over an externally-supplied [`WritableMarfStore`] using a free (unmetered)
+    /// over an externally-supplied [`WritableClarityStore`] using a free (unmetered)
     /// cost tracker and [`GENESIS_EPOCH`], because the cost-limit contract has not
     /// yet been installed at boot. The injection twin of
     /// [`ClarityInstance::begin_genesis_block`].
     pub fn from_writable_store_genesis<'a, 'b>(
-        datastore: Box<dyn WritableMarfStore + 'a>,
+        datastore: Box<dyn WritableClarityStore + 'a>,
         header_db: &'b dyn HeadersDB,
         burn_state_db: &'b dyn BurnStateDB,
         mainnet: bool,
@@ -522,7 +539,7 @@ impl ClarityInstance {
         header_db: &'b dyn HeadersDB,
         burn_state_db: &'b dyn BurnStateDB,
     ) -> ClarityBlockConnection<'a, 'b> {
-        // The built-in datastore (`MarfedKV`) is just one `WritableMarfStore`; this
+        // The built-in datastore (`MarfedKV`) is just one `WritableClarityStore`; this
         // funnels through the same generic injection point external backends use.
         let datastore = self.datastore.begin(current, next);
         let epoch = Self::get_epoch_of(current, header_db, burn_state_db);
@@ -987,7 +1004,7 @@ impl PreCommitClarityBlock<'_> {
     /// the instance cannot `begin` the next block while a trie is open.
     pub fn rollback(self) {
         debug!("Rolling back pre-commit Clarity block connection"; "index_block" => %self.commit_to);
-        self.datastore.drop_current_trie();
+        self.datastore.drop_current_block();
     }
 }
 
@@ -999,7 +1016,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
         // this is a "lower-level" rollback than the roll backs performed in
         //   ClarityDatabase or AnalysisDatabase -- this is done at the backing store level.
         debug!("Rollback Clarity datastore");
-        self.datastore.drop_current_trie();
+        self.datastore.drop_current_block();
     }
 
     /// Rolls back all unconfirmed state in the current block by
@@ -2313,10 +2330,10 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
     }
 
     pub fn seal(&mut self) -> TrieHash {
-        self.datastore.seal_trie()
+        self.datastore.seal()
     }
 
-    pub fn destruct(self) -> Box<dyn WritableMarfStore + 'a> {
+    pub fn destruct(self) -> Box<dyn WritableClarityStore + 'a> {
         self.datastore
     }
 
@@ -3800,7 +3817,7 @@ mod tests {
         conn.commit_block();
     }
 
-    /// Exercise the public `WritableMarfStore` injection constructors and the
+    /// Exercise the public `WritableClarityStore` injection constructors and the
     /// mainnet/chain_id getters.
     #[test]
     fn test_from_writable_store_constructors() {
@@ -3858,7 +3875,7 @@ mod tests {
 
         // Non-MARF injection: `HashMapWritableStore` has no trie and no sqlite underneath, yet
         // it drives the exact same block-processing path -- deploy a contract, call it, and
-        // commit the block -- proving `WritableMarfStore` doesn't actually require MARF.
+        // commit the block -- proving `WritableClarityStore` doesn't actually require MARF.
         {
             let mut store = HashMapWritableStore::new();
             store.begin(&StacksBlockId::sentinel(), StacksBlockId([0; 32]));

--- a/stackslib/src/clarity_vm/database/ephemeral.rs
+++ b/stackslib/src/clarity_vm/database/ephemeral.rs
@@ -32,9 +32,7 @@ use stacks_common::types::sqlite::NO_PARAMS;
 
 use crate::chainstate::stacks::index::marf::{MarfConnection, MarfTransaction, MARF};
 use crate::chainstate::stacks::index::{Error, MARFValue};
-use crate::clarity_vm::clarity::{
-    ClarityStore, ClarityStoreTransaction, WritableClarityStore,
-};
+use crate::clarity_vm::clarity::{ClarityStore, ClarityStoreTransaction, WritableClarityStore};
 use crate::clarity_vm::database::marf::ReadOnlyMarfStore;
 use crate::clarity_vm::special::handle_contract_call_special_cases;
 use crate::core::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH};
@@ -69,7 +67,10 @@ impl ClarityStoreTransaction for EphemeralMarfStore<'_> {
     ///
     /// Returns Ok(()) on success
     /// Returns Err(VmInternalError(..)) on sqlite failure
-    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+    fn commit_metadata_for_block(
+        &mut self,
+        target: &StacksBlockId,
+    ) -> Result<(), VmExecutionError> {
         if let Some(tip) = self.ephemeral_marf.get_open_chain_tip() {
             self.teardown_views();
             let res =

--- a/stackslib/src/clarity_vm/database/ephemeral.rs
+++ b/stackslib/src/clarity_vm/database/ephemeral.rs
@@ -33,7 +33,7 @@ use stacks_common::types::sqlite::NO_PARAMS;
 use crate::chainstate::stacks::index::marf::{MarfConnection, MarfTransaction, MARF};
 use crate::chainstate::stacks::index::{Error, MARFValue};
 use crate::clarity_vm::clarity::{
-    ClarityMarfStore, ClarityMarfStoreTransaction, WritableMarfStore,
+    ClarityStore, ClarityStoreTransaction, WritableClarityStore,
 };
 use crate::clarity_vm::database::marf::ReadOnlyMarfStore;
 use crate::clarity_vm::special::handle_contract_call_special_cases;
@@ -59,9 +59,9 @@ pub struct EphemeralMarfStore<'a> {
     read_only_marf: ReadOnlyMarfStore<'a>,
 }
 
-impl ClarityMarfStore for EphemeralMarfStore<'_> {}
+impl ClarityStore for EphemeralMarfStore<'_> {}
 
-impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
+impl ClarityStoreTransaction for EphemeralMarfStore<'_> {
     /// Commit metadata for a given `target` trie.  In this MARF store, this just renames all
     /// metadata rows with `self.chain_tip` as their block identifier to have `target` instead,
     /// but only within the ephemeral MARF.  None of the writes will hit disk, and they will
@@ -69,7 +69,7 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
     ///
     /// Returns Ok(()) on success
     /// Returns Err(VmInternalError(..)) on sqlite failure
-    fn commit_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
         if let Some(tip) = self.ephemeral_marf.get_open_chain_tip() {
             self.teardown_views();
             let res =
@@ -87,7 +87,7 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
     ///
     /// Returns Ok(()) on success
     /// Returns Err(VmInternalError(..)) on sqlite failure
-    fn drop_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+    fn drop_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
         self.teardown_views();
         let res = SqliteConnection::drop_metadata(self.ephemeral_marf.sqlite_tx(), target);
         self.setup_views();
@@ -96,7 +96,7 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
 
     /// Seal the trie -- compute the root hash.
     /// NOTE: This is a one-time operation for this implementation -- a subsequent call will panic.
-    fn seal_trie(&mut self) -> TrieHash {
+    fn seal(&mut self) -> TrieHash {
         self.ephemeral_marf
             .seal()
             .expect("FATAL: failed to .seal() MARF")
@@ -104,7 +104,7 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
 
     /// Drop the trie being built. This just drops the data from RAM and aborts the underlying
     /// sqlite transaction.  This MARF store instance is consumed.
-    fn drop_current_trie(self) {
+    fn drop_current_block(self) {
         self.ephemeral_marf.drop_current()
     }
 
@@ -116,7 +116,7 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
     fn drop_unconfirmed(mut self) -> Result<(), VmExecutionError> {
         if let Some(tip) = self.ephemeral_marf.get_open_chain_tip().cloned() {
             debug!("Drop unconfirmed MARF trie {}", tip);
-            self.drop_metadata_for_trie(&tip)?;
+            self.drop_metadata_for_block(&tip)?;
             self.ephemeral_marf.drop_unconfirmed();
         }
         Ok(())
@@ -131,7 +131,7 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
     /// Returns Err(VmInternalError(..)) on sqlite failure
     fn commit_to_processed_block(mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
         if self.ephemeral_marf.get_open_chain_tip().is_some() {
-            self.commit_metadata_for_trie(target)?;
+            self.commit_metadata_for_block(target)?;
             let _ = self.ephemeral_marf.commit_to(target).map_err(|e| {
                 error!("Failed to commit to ephemeral MARF block {target}: {e:?}",);
                 VmInternalError::Expect("Failed to commit to MARF block".into())
@@ -154,7 +154,7 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
             //    included in the processed chainstate (like a block constructed during mining)
             //    _if_ for some reason, we do want to be able to access that mined chain state in the future,
             //    we should probably commit the data to a different table which does not have uniqueness constraints.
-            self.drop_metadata_for_trie(&tip)?;
+            self.drop_metadata_for_block(&tip)?;
             let _ = self.ephemeral_marf.commit_mined(target).map_err(|e| {
                 error!("Failed to commit to mined MARF block {target}: {e:?}",);
                 VmInternalError::Expect("Failed to commit to MARF block".into())
@@ -777,4 +777,4 @@ impl SqliteBackingStore for EphemeralMarfStore<'_> {
     }
 }
 
-impl WritableMarfStore for EphemeralMarfStore<'_> {}
+impl WritableClarityStore for EphemeralMarfStore<'_> {}

--- a/stackslib/src/clarity_vm/database/ephemeral.rs
+++ b/stackslib/src/clarity_vm/database/ephemeral.rs
@@ -20,7 +20,9 @@ use clarity::vm::database::sqlite::{
     sqlite_get_contract_hash, sqlite_get_metadata, sqlite_get_metadata_manual,
     sqlite_insert_metadata,
 };
-use clarity::vm::database::{ClarityBackingStore, SpecialCaseHandler, SqliteConnection};
+use clarity::vm::database::{
+    ClarityBackingStore, SpecialCaseHandler, SqliteBackingStore, SqliteConnection,
+};
 use clarity::vm::errors::{RuntimeError, VmExecutionError, VmInternalError};
 use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::{self, Connection};
@@ -494,7 +496,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         trace!(
             "Ephemeral MarfedKV get_data_with_proof: '{}' tip={:?}",
             key,
@@ -516,7 +518,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok(Some((data, proof.serialize_to_vec())))
+                Ok(Some((data, Some(proof.serialize_to_vec()))))
             },
             |read_only_marf, key| read_only_marf.get_data_with_proof(key),
         )
@@ -529,7 +531,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         trace!(
             "Ephemeral MarfedKV get_data_with_proof_from_hash: {:?} tip={:?}",
             hash,
@@ -551,17 +553,10 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok(Some((data, proof.serialize_to_vec())))
+                Ok(Some((data, Some(proof.serialize_to_vec()))))
             },
             |read_only_marf, path| read_only_marf.get_data_with_proof_from_path(path),
         )
-    }
-
-    /// Get a sqlite connection to the MARF side-store.
-    /// Note that due to `setup_views()` and `teardown_views()`, the MARF DB will show key/value
-    /// pairs for both the ephemeral MARF and the disk-backed readonly MARF.
-    fn get_side_store(&mut self) -> &Connection {
-        self.ephemeral_marf.sqlite_conn()
     }
 
     /// Get an ancestor block's ID at a given absolute height, off of the open tip.
@@ -770,6 +765,15 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for EphemeralMarfStore<'_> {
+    /// Get a sqlite connection to the MARF side-store.
+    /// Note that due to `setup_views()` and `teardown_views()`, the MARF DB will show key/value
+    /// pairs for both the ephemeral MARF and the disk-backed readonly MARF.
+    fn get_side_store(&mut self) -> &Connection {
+        self.ephemeral_marf.sqlite_conn()
     }
 }
 

--- a/stackslib/src/clarity_vm/database/marf.rs
+++ b/stackslib/src/clarity_vm/database/marf.rs
@@ -37,9 +37,7 @@ use crate::chainstate::stacks::index::marf::{
 };
 use crate::chainstate::stacks::index::storage::{TrieFileStorage, TrieHashCalculationMode};
 use crate::chainstate::stacks::index::{ClarityMarfTrieId, Error, MARFValue};
-use crate::clarity_vm::clarity::{
-    ClarityStore, ClarityStoreTransaction, WritableClarityStore,
-};
+use crate::clarity_vm::clarity::{ClarityStore, ClarityStoreTransaction, WritableClarityStore};
 use crate::clarity_vm::database::ephemeral::EphemeralMarfStore;
 use crate::clarity_vm::special::handle_contract_call_special_cases;
 use crate::core::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH};
@@ -409,7 +407,10 @@ impl ClarityStoreTransaction for PersistentWritableMarfStore<'_> {
     ///
     /// Returns Ok(()) on success
     /// Returns Err(VmInternalError(..)) on sqlite failure
-    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+    fn commit_metadata_for_block(
+        &mut self,
+        target: &StacksBlockId,
+    ) -> Result<(), VmExecutionError> {
         SqliteConnection::commit_metadata_to(self.marf.sqlite_tx(), &self.chain_tip, target)
     }
 
@@ -1126,7 +1127,10 @@ impl<T: ClarityStoreTransaction> BoxedClarityStoreTransaction for T {
 }
 
 impl<'a> ClarityStoreTransaction for Box<dyn WritableClarityStore + 'a> {
-    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+    fn commit_metadata_for_block(
+        &mut self,
+        target: &StacksBlockId,
+    ) -> Result<(), VmExecutionError> {
         ClarityStoreTransaction::commit_metadata_for_block(self.deref_mut(), target)
     }
 

--- a/stackslib/src/clarity_vm/database/marf.rs
+++ b/stackslib/src/clarity_vm/database/marf.rs
@@ -38,7 +38,7 @@ use crate::chainstate::stacks::index::marf::{
 use crate::chainstate::stacks::index::storage::{TrieFileStorage, TrieHashCalculationMode};
 use crate::chainstate::stacks::index::{ClarityMarfTrieId, Error, MARFValue};
 use crate::clarity_vm::clarity::{
-    ClarityMarfStore, ClarityMarfStoreTransaction, WritableMarfStore,
+    ClarityStore, ClarityStoreTransaction, WritableClarityStore,
 };
 use crate::clarity_vm::database::ephemeral::EphemeralMarfStore;
 use crate::clarity_vm::special::handle_contract_call_special_cases;
@@ -58,7 +58,7 @@ pub struct MarfedKV {
     /// RAM-backed MARF that will be mutably referenced in an EphemeralMarfStore instance.
     /// Due to limits in Rust's type system, it is necessary for this to be instantiated in
     /// MarfedKV, since it must outlive EphemeralMarfStore, and MarfedKV is the "parent" of
-    /// all data referenced by ClarityMarfStore implementations (including the read-only and
+    /// all data referenced by ClarityStore implementations (including the read-only and
     /// persistent MARF stores).
     ephemeral_marf: Option<MARF<StacksBlockId>>,
 }
@@ -400,16 +400,16 @@ pub struct ReadOnlyMarfStore<'a> {
     marf: &'a mut MARF<StacksBlockId>,
 }
 
-impl ClarityMarfStore for ReadOnlyMarfStore<'_> {}
-impl ClarityMarfStore for PersistentWritableMarfStore<'_> {}
+impl ClarityStore for ReadOnlyMarfStore<'_> {}
+impl ClarityStore for PersistentWritableMarfStore<'_> {}
 
-impl ClarityMarfStoreTransaction for PersistentWritableMarfStore<'_> {
+impl ClarityStoreTransaction for PersistentWritableMarfStore<'_> {
     /// Commit metadata for a given `target` trie.  In this MARF store, this just renames all
     /// metadata rows with `self.chain_tip` as their block identifier to have `target` instead.
     ///
     /// Returns Ok(()) on success
     /// Returns Err(VmInternalError(..)) on sqlite failure
-    fn commit_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
         SqliteConnection::commit_metadata_to(self.marf.sqlite_tx(), &self.chain_tip, target)
     }
 
@@ -418,13 +418,13 @@ impl ClarityMarfStoreTransaction for PersistentWritableMarfStore<'_> {
     ///
     /// Returns Ok(()) on success
     /// Returns Err(VmInternalError(..)) on sqlite failure
-    fn drop_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+    fn drop_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
         SqliteConnection::drop_metadata(self.marf.sqlite_tx(), target)
     }
 
     /// Seal the trie -- compute the root hash.
     /// NOTE: This is a one-time operation for this implementation -- a subsequent call will panic.
-    fn seal_trie(&mut self) -> TrieHash {
+    fn seal(&mut self) -> TrieHash {
         self.marf
             .seal()
             .expect("FATAL: failed to .seal() MARF transaction")
@@ -432,7 +432,7 @@ impl ClarityMarfStoreTransaction for PersistentWritableMarfStore<'_> {
 
     /// Drop the trie being built. This just drops the data from RAM and aborts the underlying
     /// sqlite transaction.  This instance is consumed.
-    fn drop_current_trie(self) {
+    fn drop_current_block(self) {
         self.marf.drop_current();
     }
 
@@ -444,7 +444,7 @@ impl ClarityMarfStoreTransaction for PersistentWritableMarfStore<'_> {
     fn drop_unconfirmed(mut self) -> Result<(), VmExecutionError> {
         let chain_tip = self.chain_tip.clone();
         debug!("Drop unconfirmed MARF trie {}", &chain_tip);
-        self.drop_metadata_for_trie(&chain_tip)?;
+        self.drop_metadata_for_block(&chain_tip)?;
         self.marf.drop_unconfirmed();
         Ok(())
     }
@@ -457,7 +457,7 @@ impl ClarityMarfStoreTransaction for PersistentWritableMarfStore<'_> {
     /// Returns Err(VmInternalError(..)) on sqlite failure
     fn commit_to_processed_block(mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
         debug!("commit_to({})", target);
-        self.commit_metadata_for_trie(target)?;
+        self.commit_metadata_for_block(target)?;
         let _ = self.marf.commit_to(target).map_err(|e| {
             error!("Failed to commit to MARF block {target}: {e:?}");
             VmInternalError::Expect("Failed to commit to MARF block".into())
@@ -479,7 +479,7 @@ impl ClarityMarfStoreTransaction for PersistentWritableMarfStore<'_> {
         //    _if_ for some reason, we do want to be able to access that mined chain state in the future,
         //    we should probably commit the data to a different table which does not have uniqueness constraints.
         let chain_tip = self.chain_tip.clone();
-        self.drop_metadata_for_trie(&chain_tip)?;
+        self.drop_metadata_for_block(&chain_tip)?;
         let _ = self.marf.commit_mined(target).map_err(|e| {
             error!("Failed to commit to mined MARF block {target}: {e:?}",);
             VmInternalError::Expect("Failed to commit to MARF block".into())
@@ -1056,27 +1056,27 @@ impl SqliteBackingStore for PersistentWritableMarfStore<'_> {
     }
 }
 
-impl WritableMarfStore for PersistentWritableMarfStore<'_> {}
+impl WritableClarityStore for PersistentWritableMarfStore<'_> {}
 
-/// This trait exists so we can implement `ClarityMarfStore`, `ClarityMarfStoreTransaction`, and
-/// `WritableMarfStore` for `Box<dyn WritableMarfStore + '_>`.  We need
-/// `Box<dyn WritableMarfStore + '_>` because `dyn WritableMarfStore` doesn't have a size known at
-/// compile time (so it cannot be Sized).  But then we'd need it to implement `WritableMarfStore`,
-/// which is tricky because some of `ClartyMarfStoreTransaction`'s functions take an instance
+/// This trait exists so we can implement `ClarityStore`, `ClarityStoreTransaction`, and
+/// `WritableClarityStore` for `Box<dyn WritableClarityStore + '_>`.  We need
+/// `Box<dyn WritableClarityStore + '_>` because `dyn WritableClarityStore` doesn't have a size known at
+/// compile time (so it cannot be Sized).  But then we'd need it to implement `WritableClarityStore`,
+/// which is tricky because some of `ClarityStoreTransaction`'s functions take an instance
 /// `self` instead of a reference.  Because we don't know the size of `self` at compile-time, we
 /// have to employ a layer of indirection.
 ///
-/// To work around this, `WritableMarfStore` is composed of `BoxedClarityMarfStoreTransaction`
-/// below, and we have a blanket implementation of `BoxedClarityMarfStoreTransaction` for any
-/// `T: ClarityMarfStoreTransaction`.  This in turn allows us to implement
-/// `ClarityMarfStoreTransaction for `Box<dyn WritableMarfStore + 'a>` -- we cast to
-/// `ClarityMarfStoreTransaction` to call functions that take a reference to `self`, and we cast to
-/// `BoxedClarityMarfStoreTransaction` to call functions that take an instance of `self`.  In the
+/// To work around this, `WritableClarityStore` is composed of `BoxedClarityStoreTransaction`
+/// below, and we have a blanket implementation of `BoxedClarityStoreTransaction` for any
+/// `T: ClarityStoreTransaction`.  This in turn allows us to implement
+/// `ClarityStoreTransaction for `Box<dyn WritableClarityStore + 'a>` -- we cast to
+/// `ClarityStoreTransaction` to call functions that take a reference to `self`, and we cast to
+/// `BoxedClarityStoreTransaction` to call functions that take an instance of `self`.  In the
 /// latter case, the instance will have a compile-time size since it will be a Box.  The
-/// implementation of `BoxedClarityMarfStoreTransaction` just forwards the call to the
-/// corresponding function in `ClarityMarfStoreTransaction` with a reference to the boxed instance.
-pub trait BoxedClarityMarfStoreTransaction {
-    fn boxed_drop_current_trie(self: Box<Self>);
+/// implementation of `BoxedClarityStoreTransaction` just forwards the call to the
+/// corresponding function in `ClarityStoreTransaction` with a reference to the boxed instance.
+pub trait BoxedClarityStoreTransaction {
+    fn boxed_drop_current_block(self: Box<Self>);
     fn boxed_drop_unconfirmed(self: Box<Self>) -> Result<(), VmExecutionError>;
     fn boxed_commit_to_processed_block(
         self: Box<Self>,
@@ -1092,78 +1092,78 @@ pub trait BoxedClarityMarfStoreTransaction {
     fn boxed_test_commit(self: Box<Self>);
 }
 
-impl<T: ClarityMarfStoreTransaction> BoxedClarityMarfStoreTransaction for T {
-    fn boxed_drop_current_trie(self: Box<Self>) {
-        <Self as ClarityMarfStoreTransaction>::drop_current_trie(*self)
+impl<T: ClarityStoreTransaction> BoxedClarityStoreTransaction for T {
+    fn boxed_drop_current_block(self: Box<Self>) {
+        <Self as ClarityStoreTransaction>::drop_current_block(*self)
     }
 
     fn boxed_drop_unconfirmed(self: Box<Self>) -> Result<(), VmExecutionError> {
-        <Self as ClarityMarfStoreTransaction>::drop_unconfirmed(*self)
+        <Self as ClarityStoreTransaction>::drop_unconfirmed(*self)
     }
 
     fn boxed_commit_to_processed_block(
         self: Box<Self>,
         target: &StacksBlockId,
     ) -> Result<(), VmExecutionError> {
-        <Self as ClarityMarfStoreTransaction>::commit_to_processed_block(*self, target)
+        <Self as ClarityStoreTransaction>::commit_to_processed_block(*self, target)
     }
 
     fn boxed_commit_to_mined_block(
         self: Box<Self>,
         target: &StacksBlockId,
     ) -> Result<(), VmExecutionError> {
-        <Self as ClarityMarfStoreTransaction>::commit_to_mined_block(*self, target)
+        <Self as ClarityStoreTransaction>::commit_to_mined_block(*self, target)
     }
 
     fn boxed_commit_unconfirmed(self: Box<Self>) {
-        <Self as ClarityMarfStoreTransaction>::commit_unconfirmed(*self)
+        <Self as ClarityStoreTransaction>::commit_unconfirmed(*self)
     }
 
     #[cfg(test)]
     fn boxed_test_commit(self: Box<Self>) {
-        <Self as ClarityMarfStoreTransaction>::test_commit(*self)
+        <Self as ClarityStoreTransaction>::test_commit(*self)
     }
 }
 
-impl<'a> ClarityMarfStoreTransaction for Box<dyn WritableMarfStore + 'a> {
-    fn commit_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
-        ClarityMarfStoreTransaction::commit_metadata_for_trie(self.deref_mut(), target)
+impl<'a> ClarityStoreTransaction for Box<dyn WritableClarityStore + 'a> {
+    fn commit_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+        ClarityStoreTransaction::commit_metadata_for_block(self.deref_mut(), target)
     }
 
-    fn drop_metadata_for_trie(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
-        ClarityMarfStoreTransaction::drop_metadata_for_trie(self.deref_mut(), target)
+    fn drop_metadata_for_block(&mut self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
+        ClarityStoreTransaction::drop_metadata_for_block(self.deref_mut(), target)
     }
 
-    fn seal_trie(&mut self) -> TrieHash {
-        ClarityMarfStoreTransaction::seal_trie(self.deref_mut())
+    fn seal(&mut self) -> TrieHash {
+        ClarityStoreTransaction::seal(self.deref_mut())
     }
 
-    fn drop_current_trie(self) {
-        BoxedClarityMarfStoreTransaction::boxed_drop_current_trie(self)
+    fn drop_current_block(self) {
+        BoxedClarityStoreTransaction::boxed_drop_current_block(self)
     }
 
     fn drop_unconfirmed(self) -> Result<(), VmExecutionError> {
-        BoxedClarityMarfStoreTransaction::boxed_drop_unconfirmed(self)
+        BoxedClarityStoreTransaction::boxed_drop_unconfirmed(self)
     }
     fn commit_to_processed_block(self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
-        BoxedClarityMarfStoreTransaction::boxed_commit_to_processed_block(self, target)
+        BoxedClarityStoreTransaction::boxed_commit_to_processed_block(self, target)
     }
 
     fn commit_to_mined_block(self, target: &StacksBlockId) -> Result<(), VmExecutionError> {
-        BoxedClarityMarfStoreTransaction::boxed_commit_to_mined_block(self, target)
+        BoxedClarityStoreTransaction::boxed_commit_to_mined_block(self, target)
     }
 
     fn commit_unconfirmed(self) {
-        BoxedClarityMarfStoreTransaction::boxed_commit_unconfirmed(self)
+        BoxedClarityStoreTransaction::boxed_commit_unconfirmed(self)
     }
 
     #[cfg(test)]
     fn test_commit(self) {
-        BoxedClarityMarfStoreTransaction::boxed_test_commit(self)
+        BoxedClarityStoreTransaction::boxed_test_commit(self)
     }
 }
 
-impl<'a> ClarityBackingStore for Box<dyn WritableMarfStore + 'a> {
+impl<'a> ClarityBackingStore for Box<dyn WritableClarityStore + 'a> {
     fn put_all_data(&mut self, items: Vec<(String, String)>) -> Result<(), VmExecutionError> {
         ClarityBackingStore::put_all_data(self.deref_mut(), items)
     }
@@ -1248,5 +1248,5 @@ impl<'a> ClarityBackingStore for Box<dyn WritableMarfStore + 'a> {
     }
 }
 
-impl<'a> ClarityMarfStore for Box<dyn WritableMarfStore + 'a> {}
-impl<'a> WritableMarfStore for Box<dyn WritableMarfStore + 'a> {}
+impl<'a> ClarityStore for Box<dyn WritableClarityStore + 'a> {}
+impl<'a> WritableClarityStore for Box<dyn WritableClarityStore + 'a> {}

--- a/stackslib/src/clarity_vm/database/marf.rs
+++ b/stackslib/src/clarity_vm/database/marf.rs
@@ -23,7 +23,9 @@ use clarity::vm::database::sqlite::{
     sqlite_get_contract_hash, sqlite_get_metadata, sqlite_get_metadata_manual,
     sqlite_insert_metadata,
 };
-use clarity::vm::database::{ClarityBackingStore, SpecialCaseHandler, SqliteConnection};
+use clarity::vm::database::{
+    ClarityBackingStore, SpecialCaseHandler, SqliteBackingStore, SqliteConnection,
+};
 use clarity::vm::errors::{IncomparableError, RuntimeError, VmExecutionError, VmInternalError};
 use clarity::vm::types::QualifiedContractIdentifier;
 use rusqlite::Connection;
@@ -531,10 +533,6 @@ impl ReadOnlyMarfStore<'_> {
 }
 
 impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
-    fn get_side_store(&mut self) -> &Connection {
-        self.marf.sqlite_conn()
-    }
-
     fn get_cc_special_cases_handler(&self) -> Option<SpecialCaseHandler> {
         Some(&handle_contract_call_special_cases)
     }
@@ -632,7 +630,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof(&self.chain_tip, key)
             .or_else(|e| match e {
@@ -649,7 +647,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
     }
@@ -657,7 +655,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof_from_hash(&self.chain_tip, hash)
             .or_else(|e| match e {
@@ -674,7 +672,7 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
     }
@@ -785,6 +783,12 @@ impl ClarityBackingStore for ReadOnlyMarfStore<'_> {
     }
 }
 
+impl SqliteBackingStore for ReadOnlyMarfStore<'_> {
+    fn get_side_store(&mut self) -> &Connection {
+        self.marf.sqlite_conn()
+    }
+}
+
 impl PersistentWritableMarfStore<'_> {
     #[cfg(test)]
     fn do_test_commit(self) {
@@ -892,7 +896,7 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof(&self.chain_tip, key)
             .or_else(|e| match e {
@@ -909,7 +913,7 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
     }
@@ -917,7 +921,7 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         self.marf
             .get_with_proof_from_hash(&self.chain_tip, hash)
             .or_else(|e| match e {
@@ -934,13 +938,9 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
                             side_key
                         ))
                     })?;
-                Ok((data, proof.serialize_to_vec()))
+                Ok((data, Some(proof.serialize_to_vec())))
             })
             .transpose()
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        self.marf.sqlite_tx()
     }
 
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
@@ -1047,6 +1047,12 @@ impl ClarityBackingStore for PersistentWritableMarfStore<'_> {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for PersistentWritableMarfStore<'_> {
+    fn get_side_store(&mut self) -> &Connection {
+        self.marf.sqlite_tx()
     }
 }
 
@@ -1173,14 +1179,14 @@ impl<'a> ClarityBackingStore for Box<dyn WritableMarfStore + 'a> {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         ClarityBackingStore::get_data_with_proof(self.deref_mut(), key)
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         hash: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         ClarityBackingStore::get_data_with_proof_from_path(self.deref_mut(), hash)
     }
 
@@ -1202,10 +1208,6 @@ impl<'a> ClarityBackingStore for Box<dyn WritableMarfStore + 'a> {
 
     fn get_open_chain_tip(&mut self) -> StacksBlockId {
         ClarityBackingStore::get_open_chain_tip(self.deref_mut())
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        ClarityBackingStore::get_side_store(self.deref_mut())
     }
 
     fn get_cc_special_cases_handler(&self) -> Option<SpecialCaseHandler> {

--- a/stackslib/src/clarity_vm/database/mod.rs
+++ b/stackslib/src/clarity_vm/database/mod.rs
@@ -9,7 +9,7 @@ use clarity::vm::database::sqlite::{
 };
 use clarity::vm::database::{
     BurnStateDB, ClarityBackingStore, ClarityDatabase, HeadersDB, SpecialCaseHandler,
-    SqliteConnection, NULL_BURN_STATE_DB, NULL_HEADER_DB,
+    SqliteBackingStore, SqliteConnection, NULL_BURN_STATE_DB, NULL_HEADER_DB,
 };
 use clarity::vm::errors::{RuntimeError, VmExecutionError};
 use clarity::vm::types::{QualifiedContractIdentifier, TupleData};
@@ -36,6 +36,7 @@ use crate::core::{StacksEpoch, StacksEpochId};
 use crate::util_lib::db::{DBConn, Error as DBError, FromColumn, FromRow};
 
 pub mod ephemeral;
+pub mod hashmap;
 pub mod marf;
 
 pub trait GetTenureStartId {
@@ -1252,22 +1253,20 @@ impl ClarityBackingStore for MemoryBackingStore {
     fn get_data_with_proof(
         &mut self,
         key: &str,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
-        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, vec![])))
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
+        // This backend has no MARF trie, so it can't produce a real Merkle proof -- report that
+        // honestly instead of fabricating one.
+        Ok(SqliteConnection::get(self.get_side_store(), key)?.map(|x| (x, None)))
     }
 
     fn get_data_with_proof_from_path(
         &mut self,
         key: &TrieHash,
-    ) -> Result<Option<(String, Vec<u8>)>, VmExecutionError> {
+    ) -> Result<Option<(String, Option<Vec<u8>>)>, VmExecutionError> {
         Ok(
             SqliteConnection::get(self.get_side_store(), key.to_string().as_str())?
-                .map(|x| (x, vec![])),
+                .map(|x| (x, None)),
         )
-    }
-
-    fn get_side_store(&mut self) -> &Connection {
-        &self.side_store
     }
 
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
@@ -1332,5 +1331,11 @@ impl ClarityBackingStore for MemoryBackingStore {
         key: &str,
     ) -> Result<Option<String>, VmExecutionError> {
         sqlite_get_metadata_manual(self, at_height, contract, key)
+    }
+}
+
+impl SqliteBackingStore for MemoryBackingStore {
+    fn get_side_store(&mut self) -> &Connection {
+        &self.side_store
     }
 }

--- a/stackslib/src/clarity_vm/tests/costs.rs
+++ b/stackslib/src/clarity_vm/tests/costs.rs
@@ -42,7 +42,7 @@ use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::StacksEpochId;
 
 use crate::chainstate::stacks::index::ClarityMarfTrieId;
-use crate::clarity_vm::clarity::{ClarityInstance, ClarityMarfStore, ClarityMarfStoreTransaction};
+use crate::clarity_vm::clarity::{ClarityInstance, ClarityStore, ClarityStoreTransaction};
 use crate::clarity_vm::database::marf::MarfedKV;
 use crate::clarity_vm::tests::utils::{
     new_cost_test_clarity_instance, next_test_block_id, setup_cost_test_epoch,

--- a/stackslib/src/clarity_vm/tests/ephemeral.rs
+++ b/stackslib/src/clarity_vm/tests/ephemeral.rs
@@ -44,7 +44,7 @@ use crate::chainstate::stacks::{
     TransactionSmartContract, TransactionVersion,
 };
 use crate::clarity::vm::database::ClarityBackingStore;
-use crate::clarity_vm::clarity::ClarityMarfStoreTransaction;
+use crate::clarity_vm::clarity::ClarityStoreTransaction;
 use crate::clarity_vm::database::marf::MarfedKV;
 use crate::config::DEFAULT_MAX_TENURE_BYTES;
 use crate::net::test::TestEventObserver;

--- a/stackslib/src/clarity_vm/tests/events.rs
+++ b/stackslib/src/clarity_vm/tests/events.rs
@@ -26,7 +26,7 @@ use stacks_common::types::StacksEpochId;
 
 use crate::chainstate::stacks::index::ClarityMarfTrieId;
 use crate::chainstate::stacks::StacksBlockHeader;
-use crate::clarity_vm::clarity::{ClarityInstance, ClarityMarfStore};
+use crate::clarity_vm::clarity::{ClarityInstance, ClarityStore};
 use crate::clarity_vm::database::marf::MarfedKV;
 use crate::core::{FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH};
 

--- a/stackslib/src/clarity_vm/tests/forking.rs
+++ b/stackslib/src/clarity_vm/tests/forking.rs
@@ -27,7 +27,7 @@ use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
 use stacks_common::types::StacksEpochId;
 
 use crate::chainstate::stacks::index::ClarityMarfTrieId;
-use crate::clarity_vm::clarity::{ClarityMarfStore, ClarityMarfStoreTransaction};
+use crate::clarity_vm::clarity::{ClarityStore, ClarityStoreTransaction};
 use crate::clarity_vm::database::marf::MarfedKV;
 
 const p1_str: &str = "'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR";

--- a/stackslib/src/clarity_vm/tests/mod.rs
+++ b/stackslib/src/clarity_vm/tests/mod.rs
@@ -24,4 +24,5 @@ pub mod events;
 pub mod forking;
 pub mod large_contract;
 pub mod smoke;
+pub mod storage_conformance;
 pub mod utils;

--- a/stackslib/src/clarity_vm/tests/smoke.rs
+++ b/stackslib/src/clarity_vm/tests/smoke.rs
@@ -21,7 +21,7 @@ use stacks_common::types::chainstate::{BlockHeaderHash, StacksBlockId};
 use stacks_common::types::StacksEpochId;
 
 use crate::chainstate::stacks::index::ClarityMarfTrieId;
-use crate::clarity_vm::clarity::{ClarityMarfStore, ClarityMarfStoreTransaction};
+use crate::clarity_vm::clarity::{ClarityStore, ClarityStoreTransaction};
 use crate::clarity_vm::database::marf::MarfedKV;
 
 pub fn with_marfed_environment<F>(f: F, top_level: bool, epoch: Option<StacksEpochId>)

--- a/stackslib/src/net/api/getaccount.rs
+++ b/stackslib/src/net/api/getaccount.rs
@@ -148,7 +148,9 @@ impl RPCRequestHandler for RPCGetAccountRequestHandler {
                                     .get_data_with_proof::<STXBalance>(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })
                                     .unwrap_or_else(|| (STXBalance::zero(), Some("".into())))
                             } else {
                                 clarity_db
@@ -165,7 +167,9 @@ impl RPCRequestHandler for RPCGetAccountRequestHandler {
                                     .get_data_with_proof(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })
                                     .unwrap_or_else(|| (0, Some("".into())))
                             } else {
                                 clarity_db

--- a/stackslib/src/net/api/getclaritymarfvalue.rs
+++ b/stackslib/src/net/api/getclaritymarfvalue.rs
@@ -131,7 +131,7 @@ impl RPCRequestHandler for RPCGetClarityMarfRequestHandler {
                                 .get_data_with_proof_by_hash(&marf_key_hash)
                                 .ok()
                                 .flatten()
-                                .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))?
+                                .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
                         } else {
                             clarity_db
                                 .get_data_by_hash(&marf_key_hash)

--- a/stackslib/src/net/api/getcontractsrc.rs
+++ b/stackslib/src/net/api/getcontractsrc.rs
@@ -136,7 +136,7 @@ impl RPCRequestHandler for RPCGetContractSrcRequestHandler {
                                 db.get_data_with_proof::<ContractCommitment>(&contract_commit_key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))?
+                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
                             } else {
                                 db.get_data::<ContractCommitment>(&contract_commit_key)
                                     .ok()

--- a/stackslib/src/net/api/getcontractsrc.rs
+++ b/stackslib/src/net/api/getcontractsrc.rs
@@ -136,7 +136,9 @@ impl RPCRequestHandler for RPCGetContractSrcRequestHandler {
                                 db.get_data_with_proof::<ContractCommitment>(&contract_commit_key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })?
                             } else {
                                 db.get_data::<ContractCommitment>(&contract_commit_key)
                                     .ok()

--- a/stackslib/src/net/api/getdatavar.rs
+++ b/stackslib/src/net/api/getdatavar.rs
@@ -145,19 +145,18 @@ impl RPCRequestHandler for RPCGetDataVarRequestHandler {
                 &tip,
                 |clarity_tx| {
                     clarity_tx.with_clarity_db_readonly(|clarity_db| {
-                        let (value_hex, marf_proof): (String, _) = if with_proof {
-                            clarity_db
-                                .get_data_with_proof(&key)
-                                .ok()
-                                .flatten()
-                                .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
-                        } else {
-                            clarity_db
-                                .get_data(&key)
-                                .ok()
-                                .flatten()
-                                .map(|a| (a, None))?
-                        };
+                        let (value_hex, marf_proof): (String, _) =
+                            if with_proof {
+                                clarity_db.get_data_with_proof(&key).ok().flatten().map(
+                                    |(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))),
+                                )?
+                            } else {
+                                clarity_db
+                                    .get_data(&key)
+                                    .ok()
+                                    .flatten()
+                                    .map(|a| (a, None))?
+                            };
 
                         let data = format!("0x{}", value_hex);
                         Some(DataVarResponse { data, marf_proof })

--- a/stackslib/src/net/api/getdatavar.rs
+++ b/stackslib/src/net/api/getdatavar.rs
@@ -150,7 +150,7 @@ impl RPCRequestHandler for RPCGetDataVarRequestHandler {
                                 .get_data_with_proof(&key)
                                 .ok()
                                 .flatten()
-                                .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))?
+                                .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))?
                         } else {
                             clarity_db
                                 .get_data(&key)

--- a/stackslib/src/net/api/getmapentry.rs
+++ b/stackslib/src/net/api/getmapentry.rs
@@ -176,7 +176,7 @@ impl RPCRequestHandler for RPCGetMapEntryRequestHandler {
                                     .get_data_with_proof(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, Some(format!("0x{}", to_hex(&b)))))
+                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))
                                     .unwrap_or_else(|| {
                                         test_debug!("No value for '{}' in {}", &key, tip);
                                         (none_response, Some("".into()))

--- a/stackslib/src/net/api/getmapentry.rs
+++ b/stackslib/src/net/api/getmapentry.rs
@@ -176,7 +176,9 @@ impl RPCRequestHandler for RPCGetMapEntryRequestHandler {
                                     .get_data_with_proof(&key)
                                     .ok()
                                     .flatten()
-                                    .map(|(a, b)| (a, b.map(|bytes| format!("0x{}", to_hex(&bytes)))))
+                                    .map(|(a, b)| {
+                                        (a, b.map(|bytes| format!("0x{}", to_hex(&bytes))))
+                                    })
                                     .unwrap_or_else(|| {
                                         test_debug!("No value for '{}' in {}", &key, tip);
                                         (none_response, Some("".into()))


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This patch builds on top of https://github.com/stacks-network/stacks-core/pull/7480

It renames the ClarityStore related traits to rename the MARF word as a signal of being independent by the MARF-specific implementation.

### Applicable issues

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
