### PR TITLE
Stop creating duplicate Bitcoin binary cache entries, we only need one

### DIFF
--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -42,17 +42,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ##############################################################################
+  #######################################################################################################################
   ### Create Reusable Caches for Tests
   ###
-  ### Caches can only be created from `main` (OR if SEED_CACHES GitHub Actions 
-  ### variable is 'true'). This workflow runs only from `main` and therefore 
-  ### will successfully create canonical re-usable caches.
-  ##############################################################################
+  ### Caches can only be created from `main` (or via manual seeding when the SEED_CACHES Actions variable is 'true').
+  ### When run on `main`, this workflow creates canonical re-usable caches for future CI runs.
+  ### When manually dispatched from another branch, any created caches will be scoped to that branch.
+  #######################################################################################################################
   cache-bitcoin-binary:
     name: "Create: Bitcoin Binary Cache"
     runs-on: ubuntu-latest
-    # Execute if running in our core repo on `main` OR if SEED_CACHES GitHub Actions variable is 'true'
+    # Execute if running in our core repo on `main` OR manually if SEED_CACHES GitHub Actions variable is 'true'
     if: |
       (github.repository == 'stacks-network/stacks-core' && github.ref_name == 'main') ||
       vars.SEED_CACHES == 'true'
@@ -83,7 +83,7 @@ jobs:
   cache-cargo:
     name: "Create: Cargo Cache"
     runs-on: ubuntu-latest
-    # Execute if running in our core repo on `main` OR if SEED_CACHES GitHub Actions variable is 'true'
+    # Execute if running in our core repo on `main` OR manually if SEED_CACHES GitHub Actions variable is 'true'
     if: |
       (github.repository == 'stacks-network/stacks-core' && github.ref_name == 'main') ||
       vars.SEED_CACHES == 'true'

--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -38,15 +38,16 @@ permissions:
 #   - when multiple pushes to `main` happen in a short time, cancel 
 #     the current run and start the new one with the most recent code.
 concurrency:
-  group: seed-caches
+  group: create-caches
   cancel-in-progress: true
 
 jobs:
   ##############################################################################
   ### Create Reusable Caches for Tests
   ###
-  ### Caches can only be created from `main`. This workflow runs only from 
-  ### `main` and therefore will successfully create canonical re-usable caches.
+  ### Caches can only be created from `main` (OR if SEED_CACHES GitHub Actions 
+  ### variable is 'true'). This workflow runs only from `main` and therefore 
+  ### will successfully create canonical re-usable caches.
   ##############################################################################
   cache-bitcoin-binary:
     name: "Create: Bitcoin Binary Cache"
@@ -65,7 +66,16 @@ jobs:
           sparse-checkout: |
             .github
 
+      # Check cache for bitcoin binary
+      # We don't need multiple caches of the same Bitcoin binary, so skip create if one already exists
+      - name: Check Bitcoin Cache
+        id: bitcoin
+        uses: ./.github/actions/cache/bitcoin
+
+      # Only create when a binary doesn't already exist
       - name: Create Bitcoin Cache
+        if: >-
+          !steps.bitcoin.outputs.cache-matched-key
         uses: ./.github/actions/cache/bitcoin
         with:
           action: create


### PR DESCRIPTION
### Description

Stop creating duplicate Bitcoin binary cache entries, we only need one. When we merge to `main` we create caches for future CI runs. Right now we create another Bitcoin binary cache every single time we merge, but the Bitcoin binary does not change between runs (we do not modify its code). So be smarter and skip creation when a binary already exists in cache.

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

Saves cache space.

### Checklist

N/A