### PR TITLE
feat: add `.breaking` changelog fragment type

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,6 @@
 
 - [ ] Test coverage for new or modified code paths
 - [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
-- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md))
+- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks anything for node operators or users, use the `breaking` category.
 - [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
 - [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,13 @@
 ### Checklist
 
 - [ ] Test coverage for new or modified code paths
-- [ ] For new Clarity features or consensus changes, add property tests (see [`docs/property-testing.md`](/docs/property-testing.md))
-- [ ] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks anything for node operators or users, use the `breaking` category.
-- [ ] Required documentation changes (e.g., [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints, [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
+- [ ] For new Clarity features or consensus changes, add property tests (see
+      [`docs/property-testing.md`](/docs/property-testing.md))
+- [ ] Changelog fragment(s) or "no changelog" label added (see
+      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
+      anything for node operators or users, or requires them to manually do
+      anything (such as adjust a setting), use the breaking category.
+- [ ] Required documentation changes (e.g.,
+      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
+      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
 - [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo

--- a/.github/scripts/changelog.js
+++ b/.github/scripts/changelog.js
@@ -42,7 +42,13 @@ module.exports = async ({ github, context, core }) => {
     return;
   }
 
-  const validExtensions = ["added", "changed", "fixed", "removed"];
+  const validExtensions = [
+    "breaking",
+    "added",
+    "changed",
+    "fixed",
+    "removed",
+  ];
   const fragments = files.filter(
     (f) =>
       (f.filename.startsWith("changelog.d/") ||

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -15,12 +15,13 @@ CHANGELOG.md.
 
 1. Create a file in this directory named: `<short-description>.<category>`
 
-   **Categories:** `added`, `changed`, `fixed`, `removed`
+   **Categories:** `breaking`, `added`, `changed`, `fixed`, `removed`
 
    **Examples:**
    - `marf-compress.added`
    - `tenure-mining-fix.fixed`
    - `remove-deprecated-rpc.removed`
+   - `rename-miner-config-field.breaking`
 
 2. Write the changelog entry text in the file (one or more lines of markdown):
 
@@ -30,6 +31,27 @@ CHANGELOG.md.
 
 3. That's it. The fragment will be assembled into `CHANGELOG.md` at release time
    using `contrib/tools/assemble-changelog.sh`.
+
+## Breaking changes
+
+Use the `breaking` category for anything that is likely to break users if they
+upgrade without taking action, for example:
+
+- renamed, removed, or newly-required configuration options
+- removed or incompatibly-changed RPC endpoints, event payloads, or CLI flags
+- changes to on-disk formats that require a resync, migration, or one-way
+  upgrade
+- changed defaults that alter node behavior in a way operators must notice
+
+`breaking` entries are assembled into a dedicated **⚠️ Breaking Changes**
+section placed _first_ in the release's changelog section, ahead of Added /
+Changed / Fixed / Removed, and that section is carried into the GitHub release
+notes. Write the entry so it says both **what breaks** and **what the reader
+must do about it**.
+
+If a PR has both a breaking aspect and ordinary changes worth listing, add two
+fragments (e.g. `foo.breaking` and `foo.changed`) rather than duplicating the
+whole entry.
 
 ## Notes
 

--- a/contrib/tools/assemble-changelog.sh
+++ b/contrib/tools/assemble-changelog.sh
@@ -15,6 +15,13 @@
 # header in each CHANGELOG.md. Fragment files are deleted after assembly.
 # If a changelog directory has no fragments, it is skipped.
 #
+# Fragments are grouped by their file extension into sections, in this order:
+#   .breaking -> "### ⚠️ Breaking Changes"  (first, so it can't be missed)
+#   .added    -> "### Added"
+#   .changed  -> "### Changed"
+#   .fixed    -> "### Fixed"
+#   .removed  -> "### Removed"
+#
 # Examples:
 #   ./contrib/tools/assemble-changelog.sh 3.3.0.0.7           # node [3.3.0.0.7] + signer [3.3.0.0.7.0]
 #   ./contrib/tools/assemble-changelog.sh 3.3.0.0.7.1 --signer  # signer [3.3.0.0.7.1] only
@@ -41,6 +48,11 @@ done
 
 shopt -s nullglob
 
+# Fragment file extensions, in the order their sections are emitted.
+# `breaking` is emitted first so that breaking changes are the first thing a
+# reader (or release-notes reader) sees for a version.
+CATEGORIES=(breaking added changed fixed removed)
+
 # assemble_changelog <fragment_dir> <changelog_file> <version>
 assemble_changelog() {
     local fragment_dir="$1"
@@ -48,13 +60,14 @@ assemble_changelog() {
     local version="$3"
 
     # --- Collect fragments by category ---
+    local -a BREAKING=()
     local -a ADDED=()
     local -a CHANGED=()
     local -a FIXED=()
     local -a REMOVED=()
     local found_any=false
 
-    for ext in added changed fixed removed; do
+    for ext in "${CATEGORIES[@]}"; do
         for f in "$fragment_dir"/*."$ext"; do
             [ -f "$f" ] || continue
             found_any=true
@@ -67,10 +80,11 @@ assemble_changelog() {
                     line="* $line"
                 fi
                 case "$ext" in
-                    added)   ADDED+=("$line") ;;
-                    changed) CHANGED+=("$line") ;;
-                    fixed)   FIXED+=("$line") ;;
-                    removed) REMOVED+=("$line") ;;
+                    breaking) BREAKING+=("$line") ;;
+                    added)    ADDED+=("$line") ;;
+                    changed)  CHANGED+=("$line") ;;
+                    fixed)    FIXED+=("$line") ;;
+                    removed)  REMOVED+=("$line") ;;
                 esac
             done < "$f"
         done
@@ -84,17 +98,19 @@ assemble_changelog() {
     # --- Build the new section ---
     local new_section="## [$version]"
 
-    for category_name in Added Changed Fixed Removed; do
+    for category in "${CATEGORIES[@]}"; do
         local -a entries=()
-        case "$category_name" in
-            Added)   entries=("${ADDED[@]+"${ADDED[@]}"}") ;;
-            Changed) entries=("${CHANGED[@]+"${CHANGED[@]}"}") ;;
-            Fixed)   entries=("${FIXED[@]+"${FIXED[@]}"}") ;;
-            Removed) entries=("${REMOVED[@]+"${REMOVED[@]}"}") ;;
+        local heading=""
+        case "$category" in
+            breaking) entries=("${BREAKING[@]+"${BREAKING[@]}"}"); heading="⚠️ Breaking Changes" ;;
+            added)    entries=("${ADDED[@]+"${ADDED[@]}"}");    heading="Added" ;;
+            changed)  entries=("${CHANGED[@]+"${CHANGED[@]}"}");  heading="Changed" ;;
+            fixed)    entries=("${FIXED[@]+"${FIXED[@]}"}");    heading="Fixed" ;;
+            removed)  entries=("${REMOVED[@]+"${REMOVED[@]}"}");  heading="Removed" ;;
         esac
 
         if [ ${#entries[@]} -gt 0 ] && [ -n "${entries[0]}" ]; then
-            new_section+=$'\n\n'"### $category_name"$'\n'
+            new_section+=$'\n\n'"### $heading"$'\n'
             for entry in "${entries[@]}"; do
                 new_section+=$'\n'"$entry"
             done
@@ -123,7 +139,7 @@ assemble_changelog() {
     rm -f "$section_file"
 
     # --- Delete assembled fragments ---
-    for ext in added changed fixed removed; do
+    for ext in "${CATEGORIES[@]}"; do
         for f in "$fragment_dir"/*."$ext"; do
             [ -f "$f" ] || continue
             rm "$f"

--- a/contrib/tools/create-changelog-fragment.sh
+++ b/contrib/tools/create-changelog-fragment.sh
@@ -38,19 +38,29 @@ echo "  1) added"
 echo "  2) changed"
 echo "  3) fixed"
 echo "  4) removed"
+echo "  5) breaking  (⚠️  likely to break users)"
 echo ""
-read -rp "Category [1/2/3/4]: " cat_choice
+read -rp "Category [1/2/3/4/5]: " cat_choice
 
 case "$cat_choice" in
   1) CATEGORY="added" ;;
   2) CATEGORY="changed" ;;
   3) CATEGORY="fixed" ;;
   4) CATEGORY="removed" ;;
+  5) CATEGORY="breaking" ;;
   *)
     echo "Invalid choice. Aborting."
     exit 1
     ;;
 esac
+
+if [[ "$CATEGORY" == "breaking" ]]; then
+  echo ""
+  echo "⚠️  Breaking changes are highlighted at the top of the release's changelog"
+  echo "   section. Describe what breaks and what operators/users must do about it."
+  echo "   If the change also has a non-breaking aspect worth listing, add a second"
+  echo "   fragment in the matching category."
+fi
 
 # --- Filename ---
 DEFAULT_DESC=""

--- a/contrib/tools/create-changelog-fragment.sh
+++ b/contrib/tools/create-changelog-fragment.sh
@@ -34,20 +34,20 @@ esac
 # --- Category ---
 echo ""
 echo "Category:"
-echo "  1) added"
-echo "  2) changed"
-echo "  3) fixed"
-echo "  4) removed"
-echo "  5) breaking  (⚠️  likely to break users)"
+echo "  1) breaking  (⚠️  likely to break users)"
+echo "  2) added"
+echo "  3) changed"
+echo "  4) fixed"
+echo "  5) removed"
 echo ""
 read -rp "Category [1/2/3/4/5]: " cat_choice
 
 case "$cat_choice" in
-  1) CATEGORY="added" ;;
-  2) CATEGORY="changed" ;;
-  3) CATEGORY="fixed" ;;
-  4) CATEGORY="removed" ;;
-  5) CATEGORY="breaking" ;;
+  1) CATEGORY="breaking" ;;
+  2) CATEGORY="added" ;;
+  3) CATEGORY="changed" ;;
+  4) CATEGORY="fixed" ;;
+  5) CATEGORY="removed" ;;
   *)
     echo "Invalid choice. Aborting."
     exit 1

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -79,12 +79,17 @@ The timing of the next Stacking cycle can be found [here](https://stx.eco/dao/to
      ```
 
      This will collect all fragment files from `changelog.d/` and `stacks-signer/changelog.d/`,
-     group them by category (Added/Changed/Fixed/Removed), insert them as a new version section
-     in the respective `CHANGELOG.md`, and delete the assembled fragments. For a signer-only
-     release, the flag `--signer` can be passed to only process the signer fragments and upate
-     `stacks-signer/CHANGELOG.md`.
+     group them by category (⚠️ Breaking Changes/Added/Changed/Fixed/Removed), insert them as a
+     new version section in the respective `CHANGELOG.md`, and delete the assembled fragments.
+     For a signer-only release, the flag `--signer` can be passed to only process the signer
+     fragments and upate `stacks-signer/CHANGELOG.md`.
 
      Review the assembled changelog for accuracy and make any manual adjustments if needed.
+
+     If the release has a **⚠️ Breaking Changes** section, it is emitted first in the version
+     section and is carried verbatim into the drafted GitHub release notes. Give it extra
+     scrutiny: every entry should state what breaks and what the operator must do, and the
+     release announcement should call the section out explicitly.
 
    - This PR must be merged before continuing to the next steps
 

--- a/stacks-signer/changelog.d/README.md
+++ b/stacks-signer/changelog.d/README.md
@@ -15,11 +15,12 @@ CHANGELOG.md.
 
 1. Create a file in this directory named: `<short-description>.<category>`
 
-   **Categories:** `added`, `changed`, `fixed`, `removed`
+   **Categories:** `breaking`, `added`, `changed`, `fixed`, `removed`
 
    **Examples:**
    - `track-pending-blocks.added`
    - `db-schema-v19.changed`
+   - `require-auth-password.breaking`
 
 2. Write the changelog entry text in the file (one or more lines of markdown):
 
@@ -29,6 +30,26 @@ CHANGELOG.md.
 
 3. That's it. The fragment will be assembled into `stacks-signer/CHANGELOG.md`
    at release time using `contrib/tools/assemble-changelog.sh`.
+
+## Breaking changes
+
+Use the `breaking` category for anything that is likely to break signer
+operators if they upgrade without taking action, for example:
+
+- renamed, removed, or newly-required configuration options
+- changed or removed CLI subcommands and flags
+- signer database or state changes that require a migration or manual step
+- changed defaults that alter signing behavior in a way operators must notice
+
+`breaking` entries are assembled into a dedicated **⚠️ Breaking Changes**
+section placed *first* in the release's changelog section, ahead of Added /
+Changed / Fixed / Removed, and that section is carried into the GitHub release
+notes. Write the entry so it says both **what breaks** and **what the operator
+must do about it**.
+
+If a PR has both a breaking aspect and ordinary changes worth listing, add two
+fragments (e.g. `foo.breaking` and `foo.changed`) rather than duplicating the
+whole entry.
 
 ## Notes
 


### PR DESCRIPTION
Compile these fragments into a new section at the top of the changelog, to also be copied into any release announcements to ensure they get attention from node operators and signers.