### PR TITLE
Prevent a release if the phrase "DO NOT RELEASE" appears in the codebase anywhere (case sensitive)

### DIFF
--- a/.github/workflows/_release-github.yml
+++ b/.github/workflows/_release-github.yml
@@ -14,9 +14,9 @@ on:
 permissions:
   contents: read
 
-# Configure concurrency
+# Configure concurrency so that we can only have one release at a time
 concurrency:
-  group: release-github-${{ github.head_ref || github.ref }}
+  group: release-github
   # Always cancel duplicate jobs
   cancel-in-progress: true
 
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-           ref: ${{ github.head_ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
            
       - name: 'Check for "DO NOT RELEASE" in codebase'
         shell: bash

--- a/.github/workflows/_release-github.yml
+++ b/.github/workflows/_release-github.yml
@@ -1,6 +1,6 @@
 # Github workflow to create a github release and upload binary artifacts
 
-name: "Release: Github"
+name: "Release: GitHub"
 
 on:
   workflow_call:
@@ -22,15 +22,55 @@ concurrency:
 
 run-name: ${{ inputs.tag }}
 
+# Build arch dependent binaries from source
+#
+# Runs when the following is true:
+#  - a release tag is provided
+#  - workflow approval is provided
 jobs:
+  # If the codebase contains "DO NOT RELEASE", abort the release (and let us know)
+  check-do-not-release:
+    name: 'Check Codebase for "DO NOT RELEASE"'
+    if: >-
+      inputs.tag != ''
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - name: Checkout the latest code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+           ref: ${{ github.head_ref || github.ref }}
+           
+      - name: 'Check for "DO NOT RELEASE" in codebase'
+        shell: bash
+        run: |
+          # Search recursively (-r), with line numbers (-n), skipping binaries (-I) and ignoring .git and .github directories.
+          # This file always has the string "DO NOT RELEASE" in it so the .github folder MUST be skipped or we'll always find this.
+          # '|| true' prevents GitHub Action's default 'set -e' from exiting early when grep finds no matches (exit code 1).
+          
+          FOUND_MATCHES=$(grep -rnI --exclude-dir=.git --exclude-dir=.github "DO NOT RELEASE" . || true)
+          
+          if [ -n "$FOUND_MATCHES" ]; then
+            {
+              echo "### ❌ Release Blocked"
+              echo 'Found phrase `"DO NOT RELEASE"` in the following location(s):'
+              echo '```text'
+              echo "$FOUND_MATCHES"
+              echo '```'
+              echo 'These instances must be removed before a release can be completed.'
+            } >> "$GITHUB_STEP_SUMMARY"
+          
+            echo "::error::Found 'DO NOT RELEASE' in codebase. Aborting release."
+            exit 1
+          fi
+          
+          echo "No 'DO NOT RELEASE' markers found in codebase. Proceeding with release."
 
-  # Build arch dependent binaries from source
-  #
-  # Runs when the following is true:
-  #  - a release tag is provided
-  #  - workflow approval is provided
+  # Wait for someone to pull the andon cord (as configured in the "Builds Release" GitHub Actions environment)
   andon-cord:
     name: Andon Cord
+    needs:
+      - check-do-not-release
     if: >-
       inputs.tag != ''
     runs-on: ubuntu-latest
@@ -86,7 +126,7 @@ jobs:
   consolidate-digests:
     name: Consolidate Digest Artifacts
     needs: docker-images
-    if: always()
+    if: !cancelled() && needs.docker-images.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
       # Download all individual digest artifacts from all matrix jobs

--- a/.github/workflows/_release-github.yml
+++ b/.github/workflows/_release-github.yml
@@ -44,11 +44,11 @@ jobs:
       - name: 'Check for "DO NOT RELEASE" in codebase'
         shell: bash
         run: |
-          # Search recursively (-r), with line numbers (-n), skipping binaries (-I) and ignoring .git and .github directories.
+          # Search recursively (-r), with line numbers (-n), skipping binaries (-I) and ignoring .git and .github directories as well as CONTRIBUTING.md
           # This file always has the string "DO NOT RELEASE" in it so the .github folder MUST be skipped or we'll always find this.
           # '|| true' prevents GitHub Action's default 'set -e' from exiting early when grep finds no matches (exit code 1).
           
-          FOUND_MATCHES=$(grep -rnI --exclude-dir=.git --exclude-dir=.github "DO NOT RELEASE" . || true)
+          FOUND_MATCHES=$(grep -rnI --exclude-dir=.git --exclude-dir=.github --exclude=CONTRIBUTING.md "DO NOT RELEASE" . || true)
           
           if [ -n "$FOUND_MATCHES" ]; then
             {

--- a/.github/workflows/_release-github.yml
+++ b/.github/workflows/_release-github.yml
@@ -126,7 +126,7 @@ jobs:
   consolidate-digests:
     name: Consolidate Digest Artifacts
     needs: docker-images
-    if: !cancelled() && needs.docker-images.result != 'skipped'
+    if: "!cancelled() && needs.docker-images.result != 'skipped'"
     runs-on: ubuntu-latest
     steps:
       # Download all individual digest artifacts from all matrix jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       # Checkout the code
       #   - only .github is required for this job
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           sparse-checkout: |
@@ -104,7 +104,7 @@ jobs:
     runs-on: *shared_config
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
@@ -145,7 +145,7 @@ jobs:
       # Checkout the code
       #   - only .github and versions.toml are required for this job
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           sparse-checkout: |
@@ -212,7 +212,7 @@ jobs:
       # Checkout the code
       #   - only .github is required for this job
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           sparse-checkout: |
@@ -524,7 +524,7 @@ jobs:
 
       # Checkout the code (Coveralls requires source code to be available when action is called)
       - name: Checkout the latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
            ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,14 @@ mask compiler warnings with macros.
 
 Contributions should not contain `unsafe` blocks if at all possible.
 
+### Preventing Accidental Releases ("DO NOT RELEASE" Markers)
+
+To safeguard against accidentally deploying incomplete work, experimental features, or unvetted consensus changes, our release pipeline includes an automated check for release-blocking markers.
+
+- **How to use it:** If a pull request contains code or configuration that must **never** be included in a production release, add the exact string `"DO NOT RELEASE"` in a comment or file within the codebase.
+- **CI Safety Check:** During automated release workflows, the `check-do-not-release` job recursively scans the codebase (excluding `.git` and `.github`). If it detects the string anywhere, it immediately halts the pipeline, logs an inline error annotation, and writes a detailed breakdown to the GitHub Job Summary showing every location where the phrase was found.
+- **Resolving the block:** A release cannot proceed until all instances of `"DO NOT RELEASE"` are removed from the codebase and merged to the target branch.
+
 # Coding Guidelines
 
 ## Documentation


### PR DESCRIPTION
### Description

As a way to avoid foot-gunning ourselves, we can use the phrase "DO NOT RELEASE" anywhere in our codebase to block releases until the phrase is removed from the code. This might be ideal in the comments of new settings or TBD settings that we'll figure out later (perhaps an epoch height, set closer to the actual date for example). This will prevent issues like we had with our 4.0.0 release where we forgot to update some settings.

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

N/A

### Checklist

N/A