### PR TITLE
chore: deprecate fork_info rpc field

### DIFF
--- a/changelog.d/fork-info-deprecate-nakamoto-blocks.changed
+++ b/changelog.d/fork-info-deprecate-nakamoto-blocks.changed
@@ -1,0 +1,1 @@
+`/v3/tenures/fork_info` no longer returns the Nakamoto blocks of each tenure: `nakamoto_blocks` is now always `null`. The field is deprecated and will be removed in a future release.

--- a/docs/rpc/components/schemas/tenure-fork-info.schema.yaml
+++ b/docs/rpc/components/schemas/tenure-fork-info.schema.yaml
@@ -35,6 +35,9 @@ properties:
     description: 0x-prefixed index-block ID of the first Stacks block in the tenure (if any)
     pattern: '^0x[0-9a-fA-F]{64}$'
   nakamoto_blocks:
-    type: [string, "null"]
-    description: 0x-prefixed SIP-003 binary encoding of all Nakamoto blocks mined in this tenure
+    type: "null"
+    deprecated: true
+    description: >-
+      Deprecated and always null. Retained for compatibility with signers
+      released before it stopped being populated, and will be removed in a future release.
 additionalProperties: false

--- a/stacks-signer/src/tests/tx_replay_removal_compat.rs
+++ b/stacks-signer/src/tests/tx_replay_removal_compat.rs
@@ -22,9 +22,12 @@ use blockstack_lib::chainstate::stacks::{
     StacksTransaction, TokenTransferMemo, TransactionAnchorMode, TransactionAuth,
     TransactionPayload, TransactionPostConditionMode, TransactionVersion,
 };
+use blockstack_lib::net::api::get_tenures_fork_info::TenureForkingInfo;
 use blockstack_lib::net::api::postblock_proposal::{BlockValidateOk, ValidateRejectCode};
 use clarity::codec::StacksMessageCodec;
-use clarity::types::chainstate::{StacksAddress, StacksPrivateKey};
+use clarity::types::chainstate::{
+    BurnchainHeaderHash, ConsensusHash, SortitionId, StacksAddress, StacksPrivateKey,
+};
 use clarity::vm::types::PrincipalData;
 use libsigner::v0::messages::StateMachineUpdate;
 use serde_json::json;
@@ -214,4 +217,52 @@ fn validate_reject_code_seven_stays_reserved() {
         Some(ValidateRejectCode::InvalidTransactionReplay),
         "code 7 must remain decodable and must never be reassigned"
     );
+}
+
+/// Tripwire 5 — `/v3/tenures/fork_info` responses still carry a `nakamoto_blocks` key.
+///
+/// The field is no longer populated (always `null`), but the **key must still be emitted**. A
+/// signer released before that change declares it as `#[serde(with = ...)]` with no
+/// `#[serde(default)]`, which makes it *required*: serde's `Option`-defaults-to-`None` shortcut
+/// does not apply once `deserialize_with` is set. Omitting the key makes such a signer fail to
+/// parse the entire fork-info response.
+///
+/// The assertion is deliberately on the *serialized JSON*, not on the Rust type: what old signers
+/// depend on is the key being on the wire, and that is what must survive the field's eventual
+/// deletion being staged over two releases.
+#[test]
+fn tenure_forking_info_still_emits_nakamoto_blocks_key() {
+    let info = TenureForkingInfo {
+        burn_block_hash: BurnchainHeaderHash([0x11; 32]),
+        burn_block_height: 100,
+        sortition_id: SortitionId([0x22; 32]),
+        parent_sortition_id: SortitionId([0x33; 32]),
+        consensus_hash: ConsensusHash([0x44; 20]),
+        was_sortition: true,
+        first_block_mined: None,
+        nakamoto_blocks: None,
+    };
+
+    let value = serde_json::to_value(&info).expect("TenureForkingInfo must serialize");
+    assert_eq!(
+        value.get("nakamoto_blocks"),
+        Some(&serde_json::Value::Null),
+        "the key must still be emitted (as null); dropping it makes every pre-removal signer \
+         reject block proposals on the reorg-validation path"
+    );
+
+    // From json with omitted `nakamoto_blocks` field should deserialize properly thanks to `#[serde(default)]`
+    let without_key = json!({
+        "burn_block_hash": format!("0x{}", "11".repeat(32)),
+        "burn_block_height": 100,
+        "sortition_id": format!("0x{}", "22".repeat(32)),
+        "parent_sortition_id": format!("0x{}", "33".repeat(32)),
+        "consensus_hash": format!("0x{}", "44".repeat(20)),
+        "was_sortition": true,
+        "first_block_mined": null,
+    });
+    let parsed = serde_json::from_value::<TenureForkingInfo>(without_key).expect(
+        "a response omitting nakamoto_blocks must deserialize, so the field can be dropped later",
+    );
+    assert!(parsed.nakamoto_blocks.is_none());
 }

--- a/stackslib/src/net/api/get_tenures_fork_info.rs
+++ b/stackslib/src/net/api/get_tenures_fork_info.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Stacks Open Internet Foundation
+// Copyright (C) 2024-2026 Stacks Open Internet Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -66,8 +66,16 @@ pub struct TenureForkingInfo {
     /// tenure's first block.
     #[serde(with = "prefix_opt_hex")]
     pub first_block_mined: Option<StacksBlockId>,
-    /// Nakamoto blocks in the tenure
-    #[serde(with = "prefix_opt_hex_codec")]
+    /// Deprecated. Always `null`. It will be removed in a future release.
+    ///
+    /// Existed to support signer's tx-replay feature, which has been removed. The key
+    /// is still emitted — as `null` — because a signer built before this release declares the
+    /// field with `#[serde(with = ...)]` and no `#[serde(default)]`, which makes it *required*.
+    ///
+    /// The `#[serde(default)]` below is what lets this field be deleted outright in a later
+    /// release: it makes signers from this release onward tolerate the key's absence. Do not
+    /// remove it before the field itself goes.
+    #[serde(default, with = "prefix_opt_hex_codec")]
     pub nakamoto_blocks: Option<Vec<NakamotoBlock>>,
 }
 
@@ -143,8 +151,8 @@ impl TenureForkingInfo {
         chainstate: &StacksChainState,
         tip_block_id: &StacksBlockId,
     ) -> Result<Self, ChainError> {
-        let (first_block_mined, nakamoto_blocks) = if !sn.sortition {
-            (None, None)
+        let first_block_mined = if !sn.sortition {
+            None
         } else {
             // is this a nakamoto sortition?
             let epoch = SortitionDB::get_stacks_epoch(sortdb.conn(), sn.block_height)?.ok_or_else(
@@ -157,28 +165,18 @@ impl TenureForkingInfo {
                 },
             )?;
             if epoch.epoch_id < StacksEpochId::Epoch30 {
-                (
-                    StacksChainState::get_stacks_block_header_info_by_consensus_hash(
-                        chainstate.db(),
-                        &sn.consensus_hash,
-                    )?
-                    .map(|header| header.index_block_hash()),
-                    None,
-                )
+                StacksChainState::get_stacks_block_header_info_by_consensus_hash(
+                    chainstate.db(),
+                    &sn.consensus_hash,
+                )?
+                .map(|header| header.index_block_hash())
             } else {
-                (
-                    NakamotoChainState::get_nakamoto_tenure_start_block_header(
-                        &mut chainstate.index_conn(),
-                        tip_block_id,
-                        &sn.consensus_hash,
-                    )?
-                    .map(|header| header.index_block_hash()),
-                    Some(
-                        chainstate
-                            .nakamoto_blocks_db()
-                            .get_nakamoto_blocks_in_tenure(&sn.consensus_hash)?,
-                    ),
-                )
+                NakamotoChainState::get_nakamoto_tenure_start_block_header(
+                    &mut chainstate.index_conn(),
+                    tip_block_id,
+                    &sn.consensus_hash,
+                )?
+                .map(|header| header.index_block_hash())
             }
         };
         Ok(TenureForkingInfo {
@@ -189,7 +187,8 @@ impl TenureForkingInfo {
             consensus_hash: sn.consensus_hash.clone(),
             was_sortition: sn.sortition,
             first_block_mined,
-            nakamoto_blocks,
+            // Deprecated; see the field's documentation.
+            nakamoto_blocks: None,
         })
     }
 }


### PR DESCRIPTION
### Description

This PR is a continuation of tx-replay feature removal. In particular this patch deprecate the `nakamoto_blocks` field for the `/v3/tenures/fork_info` as is was used just from the signer binary during tx-replay logic.

The field is kept and set to `null` for backward compatibility (an old signer binary talking to a new node binary)

> NOTE: This PR is built on top https://github.com/stacks-network/stacks-core/pull/7496. So keeping this on draft until 7496 get merged

### Applicable issues

- fixes #https://github.com/stx-labs/core-epics/issues/398

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
