### PR TITLE
chore: extract `load_nakamoto_reward_set_for_tenure`

### DIFF
--- a/stacks-node/src/nakamoto_node/miner.rs
+++ b/stacks-node/src/nakamoto_node/miner.rs
@@ -31,7 +31,7 @@ use stacks::burnchains::{Burnchain, Txid};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::{BlockSnapshot, ConsensusHash};
 use stacks::chainstate::coordinator::OnChainRewardSetProvider;
-use stacks::chainstate::nakamoto::coordinator::load_nakamoto_reward_set;
+use stacks::chainstate::nakamoto::coordinator::load_nakamoto_reward_set_for_tenure;
 use stacks::chainstate::nakamoto::miner::{NakamotoBlockBuilder, NakamotoTenureInfo};
 use stacks::chainstate::nakamoto::staging_blocks::NakamotoBlockObtainMethod;
 use stacks::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
@@ -1072,26 +1072,23 @@ impl BlockMinerThread {
                 ))
             })?;
 
-        let burn_election_height = self.burn_election_block.block_height;
-
-        let reward_cycle = self
-            .burnchain
-            .block_height_to_reward_cycle(burn_election_height)
-            .expect("FATAL: no reward cycle for sortition");
-
-        let reward_info = match load_nakamoto_reward_set(
-            reward_cycle,
-            &self.burn_election_block.sortition_id,
+        let reward_set = match load_nakamoto_reward_set_for_tenure(
+            &self.burn_election_block,
             &self.burnchain,
             &mut chain_state,
             &self.parent_tenure_id,
             &sort_db,
             &OnChainRewardSetProvider::new(),
         ) {
-            Ok(Some((reward_info, _))) => reward_info,
+            Ok(Some(reward_set)) => reward_set,
             Ok(None) => {
                 return Err(NakamotoNodeError::SigningCoordinatorFailure(
                     "No reward set stored yet. Cannot mine!".into(),
+                ));
+            }
+            Err(ChainstateError::NoRegisteredSigners(..)) => {
+                return Err(NakamotoNodeError::SigningCoordinatorFailure(
+                    "Current reward cycle did not select a reward set. Cannot mine!".into(),
                 ));
             }
             Err(e) => {
@@ -1099,12 +1096,6 @@ impl BlockMinerThread {
                     "Failure while fetching reward set. Cannot initialize miner coordinator. {e:?}"
                 )));
             }
-        };
-
-        let Some(reward_set) = reward_info.known_selected_anchor_block_owned() else {
-            return Err(NakamotoNodeError::SigningCoordinatorFailure(
-                "Current reward cycle did not select a reward set. Cannot mine!".into(),
-            ));
         };
 
         self.signer_set_cache = Some(reward_set.clone());

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -393,7 +393,13 @@ pub fn load_nakamoto_reward_set_for_tenure<U: RewardSetProvider>(
         Error::ChainstateError(e) => e,
         Error::DBError(DBError::NotFoundError) => ChainstateError::PoxNoRewardCycle,
         Error::DBError(e) => ChainstateError::DBError(e),
-        _ => ChainstateError::PoxNoRewardCycle,
+        e => {
+            error!(
+                "Failed to load reward set for tenure election at burn height {}: {e:?}",
+                tenure_snapshot.block_height
+            );
+            ChainstateError::PoxNoRewardCycle
+        }
     })?
     else {
         return Ok(None);

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -356,6 +356,55 @@ pub fn get_nakamoto_reward_cycle_info<U: RewardSetProvider>(
     return Ok(Some(rc_info));
 }
 
+/// Load the reward set that was active when a Nakamoto tenure was elected.
+///
+/// `tenure_snapshot` must be the snapshot of the sortition that elected the tenure (the
+/// sortition whose consensus hash the tenure's blocks carry), not the burnchain tip: a tenure
+/// extended across a reward-cycle boundary is still signed by the reward set that was active
+/// at its election. Load errors are folded into `ChainstateError` as block acceptance has
+/// historically classified them.
+pub fn load_nakamoto_reward_set_for_tenure<U: RewardSetProvider>(
+    tenure_snapshot: &BlockSnapshot,
+    burnchain: &Burnchain,
+    chain_state: &mut StacksChainState,
+    stacks_tip: &StacksBlockId,
+    sort_db: &SortitionDB,
+    provider: &U,
+) -> Result<Option<RewardSet>, ChainstateError> {
+    let reward_cycle = burnchain
+        .block_height_to_reward_cycle(tenure_snapshot.block_height)
+        .ok_or_else(|| {
+            ChainstateError::Expects(format!(
+                "Nakamoto tenure election at burn height {} has no reward cycle",
+                tenure_snapshot.block_height
+            ))
+        })?;
+
+    let Some((reward_cycle_info, _)) = load_nakamoto_reward_set(
+        reward_cycle,
+        &tenure_snapshot.sortition_id,
+        burnchain,
+        chain_state,
+        stacks_tip,
+        sort_db,
+        provider,
+    )
+    .map_err(|e| match e {
+        Error::ChainstateError(e) => e,
+        Error::DBError(DBError::NotFoundError) => ChainstateError::PoxNoRewardCycle,
+        Error::DBError(e) => ChainstateError::DBError(e),
+        _ => ChainstateError::PoxNoRewardCycle,
+    })?
+    else {
+        return Ok(None);
+    };
+    let reward_set = reward_cycle_info
+        .known_selected_anchor_block_owned()
+        .ok_or_else(|| ChainstateError::NoRegisteredSigners(reward_cycle))?;
+
+    Ok(Some(reward_set))
+}
+
 /// Helper to get the Nakamoto reward set for a given reward cycle, identified by `reward_cycle`.
 ///
 /// In all but the first Nakamoto reward cycle, this will load up the stored reward set from the

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -34,7 +34,9 @@ use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionDBConn, Sortitio
 use crate::chainstate::burn::{BlockSnapshot, ConsensusHash};
 use crate::chainstate::coordinator::comm::CoordinatorChannels;
 use crate::chainstate::coordinator::{Error as CoordinatorError, OnChainRewardSetProvider};
-use crate::chainstate::nakamoto::coordinator::load_nakamoto_reward_set;
+use crate::chainstate::nakamoto::coordinator::{
+    load_nakamoto_reward_set, load_nakamoto_reward_set_for_tenure,
+};
 use crate::chainstate::nakamoto::staging_blocks::NakamotoBlockObtainMethod;
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
 use crate::chainstate::stacks::db::unconfirmed::ProcessedUnconfirmedState;
@@ -1009,45 +1011,25 @@ impl Relayer {
             &block.header.block_hash()
         );
 
-        let tip = block_sn.sortition_id;
+        let tip = &block_sn.sortition_id;
 
-        let reward_info = match load_nakamoto_reward_set(
-            burnchain
-                .block_height_to_reward_cycle(block_sn.block_height)
-                .expect("FATAL: block snapshot has no reward cycle"),
-            &tip,
+        let reward_set = match load_nakamoto_reward_set_for_tenure(
+            &block_sn,
             burnchain,
             chainstate,
             stacks_tip,
             sortdb,
             &OnChainRewardSetProvider::new(),
         ) {
-            Ok(Some((reward_info, ..))) => reward_info,
+            Ok(Some(reward_set)) => reward_set,
             Ok(None) => {
                 error!("No RewardCycleInfo found for tip {}", tip);
                 return Err(chainstate_error::PoxNoRewardCycle);
             }
-            Err(CoordinatorError::DBError(db_error::NotFoundError)) => {
-                error!("No RewardCycleInfo found for tip {}", tip);
-                return Err(chainstate_error::PoxNoRewardCycle);
-            }
-            Err(CoordinatorError::ChainstateError(e)) => {
+            Err(e) => {
                 error!("No RewardCycleInfo loaded for tip {}: {:?}", tip, &e);
                 return Err(e);
             }
-            Err(CoordinatorError::DBError(e)) => {
-                error!("No RewardCycleInfo loaded for tip {}: {:?}", tip, &e);
-                return Err(chainstate_error::DBError(e));
-            }
-            Err(e) => {
-                error!("Failed to load RewardCycleInfo for tip {}: {:?}", tip, &e);
-                return Err(chainstate_error::PoxNoRewardCycle);
-            }
-        };
-        let reward_cycle = reward_info.reward_cycle;
-
-        let Some(reward_set) = reward_info.known_selected_anchor_block_owned() else {
-            return Err(chainstate_error::NoRegisteredSigners(reward_cycle));
         };
 
         let accepted = NakamotoChainState::accept_block(


### PR DESCRIPTION
### Description

Extracts the reward set lookup that `relay.rs` computed inline into a helper (`load_nakamoto_reward_set_for_tenure`) and reuse it in the miner, which duplicates the same logic.

This is behavior-preserving. All errors at both call sites are unchanged. The only deltas are two unreachable `.expect` that now return errors. 

I had to extract it because I have another upcoming PR for adding PoX-5 to `TestChainstate` that resolves reward sets through this exact production path instead of maintaining its own copy. And this is the only "production" change, that I preferred opening separately.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
