### PR TITLE
chore: ignore the pinny macro error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
   "rust-analyzer.runnables.extraEnv": {
     "BITCOIND_TEST": "1"
   },
+  "rust-analyzer.procMacro.ignored": {
+    "pinny": ["tag"]
+  },
   "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
   "files.eol": "\n",
 }


### PR DESCRIPTION
Because of the way VSCode builds, our tags, like `#[tag(bitcoind)]` show as an error, and when the error is there, it doesn't give you the options to run the test, which is annoying.