### PR TITLE
CI: Only run GitHub Actions when Environment var ENABLE_CI_WORKFLOWS is set to true or we're on the official branch

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -189,8 +189,8 @@ runs:
     # Store JUnit file in GitHub CI artifacts (with SHA and "nextest" prefix)
     # always() is needed to execute this step for test failures
     - name: Store JUnit Report as Artifact
-      if: >-
-        always()
+      # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository AND we're not in the merge queue
+      if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && always() && github.event_name != 'merge_group'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
       with:
         name: nextest-${{ steps.generate-sanitized-file-name.outputs.file-name }}
@@ -207,8 +207,8 @@ runs:
     # Generate code coverage using grcov
     # Resulting coverage filenames must be unique, so use test-name input to name the file
     - name: Run grcov
-      if: >-
-        github.event.repository.visibility == 'public'
+      # Only execute if we're on the official repository
+      if: github.repository == 'stacks-network/stacks-core'
       shell: bash
       run: |
         grcov . \
@@ -241,8 +241,8 @@ runs:
 
     # Store coverage file in GitHub CI artifacts (with SHA and "lcov" prefix)
     - name: Store Code Coverage as Artifact
-      if: >-
-        github.event.repository.visibility == 'public'
+      # Only execute if we're on the official repository
+      if: github.repository == 'stacks-network/stacks-core'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
       with:
         name: codecov-${{ steps.generate-sanitized-file-name.outputs.file-name }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -194,7 +194,7 @@ runs:
 
     # Store JUnit file in GitHub CI artifacts (with SHA and "nextest" prefix)
     - name: Store JUnit Report as Artifact
-      if: inputs.upload-junit-xml == 'true'
+      if: always() && inputs.upload-junit-xml == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
       with:
         name: nextest-${{ steps.generate-sanitized-file-name.outputs.file-name }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -27,6 +27,12 @@ inputs:
   codecov-test-name:
     description: "Code coverage test name"
     required: true
+  upload-junit-xml:
+    description: "Whether or not to upload the nextest JUnit XML artifact"
+    required: true
+  upload-code-coverage:
+    description: "Whether or not to upload the code coverage artifact"
+    required: true
 
 runs:
   using: "composite"
@@ -186,18 +192,9 @@ runs:
     ### Upload the nextest JUnit XML
     ############################################################################
 
-    # TODO: delete this after testing
-    - name: Debug Variable
-      run: |
-        echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-        echo "Repository: '${{ github.repository }}'"
-        echo "Event Name: '${{ github.event_name }}'"
-
     # Store JUnit file in GitHub CI artifacts (with SHA and "nextest" prefix)
-    # always() is needed to execute this step for test failures
     - name: Store JUnit Report as Artifact
-      # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository AND we're not in the merge queue
-      if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && always() && github.event_name != 'merge_group'
+      if: inputs.upload-junit-xml == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
       with:
         name: nextest-${{ steps.generate-sanitized-file-name.outputs.file-name }}
@@ -214,8 +211,7 @@ runs:
     # Generate code coverage using grcov
     # Resulting coverage filenames must be unique, so use test-name input to name the file
     - name: Run grcov
-      # Only execute if we're on the official repository
-      if: github.repository == 'stacks-network/stacks-core'
+      if: inputs.upload-code-coverage == 'true'
       shell: bash
       run: |
         grcov . \
@@ -248,8 +244,7 @@ runs:
 
     # Store coverage file in GitHub CI artifacts (with SHA and "lcov" prefix)
     - name: Store Code Coverage as Artifact
-      # Only execute if we're on the official repository
-      if: github.repository == 'stacks-network/stacks-core'
+      if: inputs.upload-code-coverage == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
       with:
         name: codecov-${{ steps.generate-sanitized-file-name.outputs.file-name }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -186,6 +186,13 @@ runs:
     ### Upload the nextest JUnit XML
     ############################################################################
 
+    # TODO: delete this after testing
+    - name: Debug Variable
+      run: |
+        echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+        echo "Repository: '${{ github.repository }}'"
+        echo "Event Name: '${{ github.event_name }}'"
+
     # Store JUnit file in GitHub CI artifacts (with SHA and "nextest" prefix)
     # always() is needed to execute this step for test failures
     - name: Store JUnit Report as Artifact

--- a/.github/workflows/__README.md
+++ b/.github/workflows/__README.md
@@ -1,6 +1,8 @@
 ## Enabling CI
 
-To **enable** CI workflows within your fork or repository, add a GitHub Actions Variable:
+The CI will always run on `stacks-network/stacks-core` with other forks and cloned repos able to opt-in.
+
+To **enable** CI workflows within your fork or cloned repository, add a GitHub Actions Variable:
 
 - Name: `ENABLE_CI_WORKFLOWS`
 - Value: `true`
@@ -8,8 +10,8 @@ To **enable** CI workflows within your fork or repository, add a GitHub Actions 
 This will enable CI functionality within your repo or fork, as our CI workflow files check for it as follows:
 
 ```
-# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-if: vars.ENABLE_CI_WORKFLOWS == 'true'
+# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
 ```
 
 ## Folder Structure

--- a/.github/workflows/__README.md
+++ b/.github/workflows/__README.md
@@ -7,12 +7,7 @@ To **enable** CI workflows within your fork or cloned repository, add a GitHub A
 - Name: `ENABLE_CI_WORKFLOWS`
 - Value: `true`
 
-This will enable CI functionality within your repo or fork, as our CI workflow files check for it as follows:
-
-```
-# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
-```
+This will enable CI functionality within your repo or fork.
 
 ## Folder Structure
 

--- a/.github/workflows/__README.md
+++ b/.github/workflows/__README.md
@@ -1,3 +1,19 @@
+## Enabling CI
+
+To **enable** CI workflows within your fork or repository, add a GitHub Actions Variable:
+
+- Name: `ENABLE_CI_WORKFLOWS`
+- Value: `true`
+
+This will enable CI functionality within your repo or fork, as our CI workflow files check for it as follows:
+
+```
+# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+if: vars.ENABLE_CI_WORKFLOWS == 'true'
+```
+
+## Folder Structure
+
 ALL runnable workflows must be in the root of the .github/workflows folder. Subfolders are not allowed.
 
 When adding or changing files, follow this file naming guidance:

--- a/.github/workflows/_check-test-caches.yml
+++ b/.github/workflows/_check-test-caches.yml
@@ -64,6 +64,6 @@ jobs:
           if [ -z "$BITCOIN_MATCHED_KEY" ] || [ -z "$CARGO_MATCHED_KEY" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "❌ **Required Cache Missing:** A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/${{ github.repository }}/actions/workflows/create-test-caches.yml)" >> $GITHUB_STEP_SUMMARY
-            echo "::error title=Required Cache Missing::A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/${{ github.repository }}/actions/workflows/create-test-caches.yml)"
+            echo "::error title=Required Cache Missing::A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/create-test-caches.yml"
             exit 1
           fi

--- a/.github/workflows/_check-test-caches.yml
+++ b/.github/workflows/_check-test-caches.yml
@@ -63,7 +63,7 @@ jobs:
           # Fail the build gracefully if any cache is missing
           if [ -z "$BITCOIN_MATCHED_KEY" ] || [ -z "$CARGO_MATCHED_KEY" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "❌ **Required Cache Missing:** A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/actions/workflows/create-test-caches.yml)" >> $GITHUB_STEP_SUMMARY
-            echo "::error title=Required Cache Missing::A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/actions/workflows/create-test-caches.yml)"
+            echo "❌ **Required Cache Missing:** A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/${{ github.repository }}/actions/workflows/create-test-caches.yml)" >> $GITHUB_STEP_SUMMARY
+            echo "::error title=Required Cache Missing::A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/${{ github.repository }}/actions/workflows/create-test-caches.yml)"
             exit 1
           fi

--- a/.github/workflows/_check-test-caches.yml
+++ b/.github/workflows/_check-test-caches.yml
@@ -63,7 +63,7 @@ jobs:
           # Fail the build gracefully if any cache is missing
           if [ -z "$BITCOIN_MATCHED_KEY" ] || [ -z "$CARGO_MATCHED_KEY" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "❌ **Required Cache Missing:** A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: https://github.com/stacks-network/stacks-core/actions/workflows/create-test-caches.yml" >> $GITHUB_STEP_SUMMARY
-            echo "::error title=Required Cache Missing::A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: https://github.com/stacks-network/stacks-core/actions/workflows/create-test-caches.yml"
+            echo "❌ **Required Cache Missing:** A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/actions/workflows/create-test-caches.yml)" >> $GITHUB_STEP_SUMMARY
+            echo "::error title=Required Cache Missing::A required cache (Bitcoin or Cargo) was not found. This state should be rare. Re-run this action AFTER manually creating the caches from main branch: [actions/workflows/create-test-caches.yml](/actions/workflows/create-test-caches.yml)"
             exit 1
           fi

--- a/.github/workflows/_release-github.yml
+++ b/.github/workflows/_release-github.yml
@@ -194,9 +194,8 @@ jobs:
       - build-binaries
       - docker-images
       - consolidate-digests
-    if: >-
-      github.event.repository.visibility == 'public' &&
-      inputs.tag != ''
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository AND tag is not empty
+    if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && inputs.tag != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -13,6 +13,14 @@ on:
         description: "Debug binary path"
         required: true
         type: string
+      upload-junit-xml:
+        description: "Whether or not to upload the nextest JUnit XML artifact"
+        required: true
+        type: boolean
+      upload-code-coverage:
+        description: "Whether or not to upload the code coverage artifact"
+        required: true
+        type: boolean
 
 # Set default permissions
 permissions:
@@ -96,6 +104,8 @@ jobs:
           archive-file: ${{ inputs.archive-file }}
           debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: batched-integration-tests-${{ matrix.batch.index }}
+          upload-junit-xml: ${{ inputs.upload-junit-xml }}
+          upload-code-coverage: ${{ inputs.upload-code-coverage }}
 
   # Check that all jobs in this workflow have succeeded.
   check-tests:

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -35,8 +35,8 @@ env:
   RUST_BACKTRACE: full
   TEST_TIMEOUT: 30
   TEST_TAG_CI_SKIP: ci_skip
-  # Configure batch size and archive file for bitcoin_tests.sh invocation
-  BATCH_SIZE: 2
+  # Configure batch size for bitcoin_tests.sh invocation
+  BATCH_SIZE: 1
 
 # Configure concurrency
 concurrency:

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -16,11 +16,11 @@ on:
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
-        type: boolean
+        type: string
       upload-code-coverage:
         description: "Whether or not to upload the code coverage artifact"
         required: true
-        type: boolean
+        type: string
 
 # Set default permissions
 permissions:

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -35,8 +35,8 @@ env:
   RUST_BACKTRACE: full
   TEST_TIMEOUT: 30
   TEST_TAG_CI_SKIP: ci_skip
-  # Configure batch size for bitcoin_tests.sh invocation
-  BATCH_SIZE: 1
+  # Configure batch size and archive file for bitcoin_tests.sh invocation
+  BATCH_SIZE: 2
 
 # Configure concurrency
 concurrency:

--- a/.github/workflows/_tests-epoch.yml
+++ b/.github/workflows/_tests-epoch.yml
@@ -13,6 +13,14 @@ on:
         description: "Debug binary path"
         required: true
         type: string
+      upload-junit-xml:
+        description: "Whether or not to upload the nextest JUnit XML artifact"
+        required: true
+        type: boolean
+      upload-code-coverage:
+        description: "Whether or not to upload the code coverage artifact"
+        required: true
+        type: boolean
 
 # Set default permissions
 permissions:
@@ -79,6 +87,8 @@ jobs:
           archive-file: ${{ inputs.archive-file }}
           debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: ${{ matrix.test-name }}
+          upload-junit-xml: ${{ inputs.upload-junit-xml }}
+          upload-code-coverage: ${{ inputs.upload-code-coverage }}
 
   # Check that all jobs in this workflow have succeeded.
   #   - will not run if the job is cancelled

--- a/.github/workflows/_tests-epoch.yml
+++ b/.github/workflows/_tests-epoch.yml
@@ -16,11 +16,11 @@ on:
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
-        type: boolean
+        type: string
       upload-code-coverage:
         description: "Whether or not to upload the code coverage artifact"
         required: true
-        type: boolean
+        type: string
 
 # Set default permissions
 permissions:

--- a/.github/workflows/_tests-p2p.yml
+++ b/.github/workflows/_tests-p2p.yml
@@ -13,6 +13,14 @@ on:
         description: "Debug binary path"
         required: true
         type: string
+      upload-junit-xml:
+        description: "Whether or not to upload the nextest JUnit XML artifact"
+        required: true
+        type: boolean
+      upload-code-coverage:
+        description: "Whether or not to upload the code coverage artifact"
+        required: true
+        type: boolean
 
 # Set default permissions
 permissions:
@@ -77,6 +85,8 @@ jobs:
           archive-file: ${{ inputs.archive-file }}
           debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: ${{ matrix.test-name }}
+          upload-junit-xml: ${{ inputs.upload-junit-xml }}
+          upload-code-coverage: ${{ inputs.upload-code-coverage }}
 
   # Check that all jobs in this workflow have succeeded.
   #   - will not run if the job is cancelled

--- a/.github/workflows/_tests-p2p.yml
+++ b/.github/workflows/_tests-p2p.yml
@@ -16,11 +16,11 @@ on:
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
-        type: boolean
+        type: string
       upload-code-coverage:
         description: "Whether or not to upload the code coverage artifact"
         required: true
-        type: boolean
+        type: string
 
 # Set default permissions
 permissions:

--- a/.github/workflows/_tests-stacks-core.yml
+++ b/.github/workflows/_tests-stacks-core.yml
@@ -16,11 +16,11 @@ on:
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
-        type: boolean
+        type: string
       upload-code-coverage:
         description: "Whether or not to upload the code coverage artifact"
         required: true
-        type: boolean
+        type: string
 
 # Set default permissions
 permissions:

--- a/.github/workflows/_tests-stacks-core.yml
+++ b/.github/workflows/_tests-stacks-core.yml
@@ -13,6 +13,14 @@ on:
         description: "Debug binary path"
         required: true
         type: string
+      upload-junit-xml:
+        description: "Whether or not to upload the nextest JUnit XML artifact"
+        required: true
+        type: boolean
+      upload-code-coverage:
+        description: "Whether or not to upload the code coverage artifact"
+        required: true
+        type: boolean
 
 # Set default permissions
 permissions:
@@ -80,6 +88,8 @@ jobs:
           archive-file: ${{ inputs.archive-file }}
           debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: ${{ github.job }}-${{ matrix.partition }}
+          upload-junit-xml: ${{ inputs.upload-junit-xml }}
+          upload-code-coverage: ${{ inputs.upload-code-coverage }}
 
   # Generate and upload openapi html artifact
   open-api-validation:

--- a/.github/workflows/check-clippy.yml
+++ b/.github/workflows/check-clippy.yml
@@ -33,8 +33,8 @@ concurrency:
 jobs:
   clippy-stacks:
     name: Clippy Check (stacks)
-    # Only run this if it's the official repo
-    if: github.repository == 'stacks-network/stacks-core'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -55,8 +55,8 @@ jobs:
 
   clippy-stacks-lib:
     name: Clippy Check (stackslib)
-    # Only run this if it's the official repo
-    if: github.repository == 'stacks-network/stacks-core'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-clippy.yml
+++ b/.github/workflows/check-clippy.yml
@@ -32,16 +32,30 @@ concurrency:
 
 jobs:
   check-ci-enabled:
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    name: "Check: CI Enabled"
     runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
     steps:
-      - run: echo "CI enabled"
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+          echo "github.repository:   '${{ github.repository }}'"
+    
+          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
   clippy-stacks:
-    name: Clippy Check (stacks)
+    name: "Check: Clippy (stacks)"
     needs:
       - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -61,9 +75,10 @@ jobs:
         run: cargo clippy-stacks
 
   clippy-stacks-lib:
-    name: Clippy Check (stackslib)
+    name: "Check: Clippy (stackslib)"
     needs:
       - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-clippy.yml
+++ b/.github/workflows/check-clippy.yml
@@ -33,8 +33,8 @@ concurrency:
 jobs:
   clippy-stacks:
     name: Clippy Check (stacks)
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -55,8 +55,8 @@ jobs:
 
   clippy-stacks-lib:
     name: Clippy Check (stackslib)
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-clippy.yml
+++ b/.github/workflows/check-clippy.yml
@@ -31,10 +31,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  clippy-stacks:
-    name: Clippy Check (stacks)
+  check-ci-enabled:
     # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
     if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI enabled"
+
+  clippy-stacks:
+    name: Clippy Check (stacks)
+    needs:
+      - check-ci-enabled
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -55,8 +62,8 @@ jobs:
 
   clippy-stacks-lib:
     name: Clippy Check (stackslib)
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    needs:
+      - check-ci-enabled
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-clippy.yml
+++ b/.github/workflows/check-clippy.yml
@@ -33,6 +33,8 @@ concurrency:
 jobs:
   clippy-stacks:
     name: Clippy Check (stacks)
+    # Only run this if it's the official repo
+    if: github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -53,6 +55,8 @@ jobs:
 
   clippy-stacks-lib:
     name: Clippy Check (stackslib)
+    # Only run this if it's the official repo
+    if: github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-nix.yml
+++ b/.github/workflows/check-nix.yml
@@ -29,10 +29,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-pkg:
-    name: Check Nix package
+  check-ci-enabled:
     # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
     if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI enabled"
+
+  build-pkg:
+    name: Check Nix package
+    needs:
+      - check-ci-enabled
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-nix.yml
+++ b/.github/workflows/check-nix.yml
@@ -31,8 +31,8 @@ concurrency:
 jobs:
   build-pkg:
     name: Check Nix package
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-nix.yml
+++ b/.github/workflows/check-nix.yml
@@ -31,6 +31,8 @@ concurrency:
 jobs:
   build-pkg:
     name: Check Nix package
+    # Only run this if it's the official repo
+    if: github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-nix.yml
+++ b/.github/workflows/check-nix.yml
@@ -31,8 +31,8 @@ concurrency:
 jobs:
   build-pkg:
     name: Check Nix package
-    # Only run this if it's the official repo
-    if: github.repository == 'stacks-network/stacks-core'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/check-nix.yml
+++ b/.github/workflows/check-nix.yml
@@ -30,16 +30,30 @@ concurrency:
 
 jobs:
   check-ci-enabled:
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    name: "Check: CI Enabled"
     runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
     steps:
-      - run: echo "CI enabled"
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+          echo "github.repository:   '${{ github.repository }}'"
+    
+          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
   build-pkg:
-    name: Check Nix package
+    name: "Check: Nix package"
     needs:
       - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
   ############################################################################
   check-changelog:
     name: "Check: Changelog"
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    needs:
+      - setup-env
     runs-on: *shared_config
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
   ############################################################################
   setup-env:
     name: "Setup: Global Variables"
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: &shared_config ubuntu-latest
     outputs:
       test-archive-file: ${{ steps.set-env.outputs.test_archive_file }}
@@ -71,8 +71,8 @@ jobs:
   ############################################################################
   check-changelog:
     name: "Check: Changelog"
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: *shared_config
     permissions:
       contents: read
@@ -344,8 +344,8 @@ jobs:
   ### Create Job Summary: Slow & Failed Tests
   ############################################################################
   create-slow-failed-tests-summary:
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' && always() && github.event_name != 'merge_group'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && always() && github.event_name != 'merge_group'
     name: "Create: Slow & Failed Tests Report"
     runs-on: *shared_config
     needs:
@@ -498,8 +498,8 @@ jobs:
   ### Create Code Coverage Report
   ############################################################################
   create-code-coverage-report:
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and the repository is public
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' && always() && github.event.repository.visibility == 'public'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository and the repository is public
+    if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && always() && github.event.repository.visibility == 'public'
     name: "Create: Code Coverage Report"
     runs-on: *shared_config
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,8 @@ jobs:
     needs:
       - check-changelog
       - check-rustfmt
-    if: >-
-      github.event.repository.visibility == 'public'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: *shared_config
     outputs:
       tag: ${{ steps.check-release.outputs.tag }}
@@ -328,7 +328,6 @@ jobs:
       - check-release
       - check-rustfmt
     if: >-
-      github.event.repository.visibility == 'public' &&
       needs.check-release.outputs.is_release == 'true' &&
       github.event_name != 'merge_group'
     permissions:
@@ -344,7 +343,7 @@ jobs:
   ### Create Job Summary: Slow & Failed Tests
   ############################################################################
   create-slow-failed-tests-summary:
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository AND we're not in the merge queue
     if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && always() && github.event_name != 'merge_group'
     name: "Create: Slow & Failed Tests Report"
     runs-on: *shared_config
@@ -498,8 +497,8 @@ jobs:
   ### Create Code Coverage Report
   ############################################################################
   create-code-coverage-report:
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository and the repository is public
-    if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && always() && github.event.repository.visibility == 'public'
+    # Only execute if we're on the official repository
+    if: github.repository == 'stacks-network/stacks-core' && always()
     name: "Create: Code Coverage Report"
     runs-on: *shared_config
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ concurrency:
 env:
   TEST_ARCHIVE_FILE: "./test_archive.tar.zst"
   DEBUG_BINARY_PATH: "./target/debug/"
+  # Whether or not to create the slow and failed tests summary
+  CREATE_SLOW_FAILED_TESTS_SUMMARY: ${{ (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && github.event_name != 'merge_group' }}
+  # Whether or not to create the code coverage report
+  CREATE_CODE_COVERAGE_REPORT: ${{ github.repository == 'stacks-network/stacks-core' }}
 
 jobs:
   ############################################################################
@@ -52,6 +56,8 @@ jobs:
     outputs:
       test-archive-file: ${{ steps.set-env.outputs.test_archive_file }}
       debug-binary-path: ${{ steps.set-env.outputs.debug_binary_path }}
+      create-slow-failed-tests-summary: ${{ steps.set-env.outputs.create_slow_failed_tests_summary }}
+      create-code-coverage-report: ${{ steps.set-env.outputs.create_code_coverage_report }}
     steps:
       - name: Export Env Variables
         id: set-env
@@ -62,6 +68,8 @@ jobs:
 
           echo "test_archive_file=$ARCHIVE_FILE" >> $GITHUB_OUTPUT
           echo "debug_binary_path=${{ env.DEBUG_BINARY_PATH }}" >> $GITHUB_OUTPUT
+          echo "create_slow_failed_tests_summary=$CREATE_SLOW_FAILED_TESTS_SUMMARY" >> $GITHUB_OUTPUT
+          echo "create_code_coverage_report=$CREATE_CODE_COVERAGE_REPORT" >> $GITHUB_OUTPUT
 
   ############################################################################
   ### Changelog Check
@@ -245,6 +253,8 @@ jobs:
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
       debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
+      upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
+      upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 
   ############################################################################
   ### Run Bitcoin Tests
@@ -261,6 +271,8 @@ jobs:
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
       debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
+      upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
+      upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 
   ############################################################################
   ### Run Bitcoin RPC Tests
@@ -293,6 +305,8 @@ jobs:
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
       debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
+      upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
+      upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 
   ############################################################################
   ### Run Epoch Tests (Release Only)
@@ -313,6 +327,8 @@ jobs:
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
       debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
+      upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
+      upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 
   ############################################################################
   ### Create Release
@@ -343,8 +359,7 @@ jobs:
   ### Create Job Summary: Slow & Failed Tests
   ############################################################################
   create-slow-failed-tests-summary:
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository AND we're not in the merge queue
-    if: (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && always() && github.event_name != 'merge_group'
+    if: always() && needs.setup-env.outputs.create-slow-failed-tests-summary == 'true'
     name: "Create: Slow & Failed Tests Report"
     runs-on: *shared_config
     needs:
@@ -497,8 +512,7 @@ jobs:
   ### Create Code Coverage Report
   ############################################################################
   create-code-coverage-report:
-    # Only execute if we're on the official repository
-    if: github.repository == 'stacks-network/stacks-core' && always()
+    if: always() && needs.setup-env.outputs.create-code-coverage-report == 'true'
     name: "Create: Code Coverage Report"
     runs-on: *shared_config
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,26 @@ env:
   CREATE_CODE_COVERAGE_REPORT: ${{ github.repository == 'stacks-network/stacks-core' }}
 
 jobs:
+  check-ci-enabled:
+    name: "Check: CI Enabled"
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+          echo "github.repository:   '${{ github.repository }}'"
+    
+          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
   ############################################################################
   ### Global Variables Setup
   ###
@@ -50,8 +70,9 @@ jobs:
   ############################################################################
   setup-env:
     name: "Setup: Global Variables"
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    needs:
+      - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: &shared_config ubuntu-latest
     outputs:
       test-archive-file: ${{ steps.set-env.outputs.test_archive_file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,7 @@ jobs:
       - check-rustfmt
       - check-release
       - check-test-caches
+      - setup-env
       - tests-bitcoin
       - tests-epoch
       - tests-p2p
@@ -520,6 +521,7 @@ jobs:
       - check-rustfmt
       - check-release
       - check-test-caches
+      - setup-env
       - tests-bitcoin
       - tests-epoch
       - tests-p2p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
   ############################################################################
   setup-env:
     name: "Setup: Global Variables"
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true'
     runs-on: &shared_config ubuntu-latest
     outputs:
       test-archive-file: ${{ steps.set-env.outputs.test_archive_file }}
@@ -69,6 +71,8 @@ jobs:
   ############################################################################
   check-changelog:
     name: "Check: Changelog"
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true'
     runs-on: *shared_config
     permissions:
       contents: read
@@ -340,9 +344,8 @@ jobs:
   ### Create Job Summary: Slow & Failed Tests
   ############################################################################
   create-slow-failed-tests-summary:
-    if: >-
-      always() &&
-      github.event_name != 'merge_group'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' && always() && github.event_name != 'merge_group'
     name: "Create: Slow & Failed Tests Report"
     runs-on: *shared_config
     needs:
@@ -495,9 +498,8 @@ jobs:
   ### Create Code Coverage Report
   ############################################################################
   create-code-coverage-report:
-    if: >-
-      always() &&
-      github.event.repository.visibility == 'public'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and the repository is public
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' && always() && github.event.repository.visibility == 'public'
     name: "Create: Code Coverage Report"
     runs-on: *shared_config
     needs:

--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -19,9 +19,7 @@ run-name: "Create: Test Caches [${{ github.ref_name }}]"
 # and build them on-the-fly. This allows slightly stale caches to still be very useful.
 #
 # NOTE: 
-#   This job ONLY runs if EITHER of the following is true:
-#     1. We're on the `main` branch of `stacks-network/stacks-core`, OR
-#     2. A GitHub Action variable is set: SEED_CACHES = true
+#   This job ONLY runs if a GitHub Action variable is set: ENABLE_CI_WORKFLOWS = true
 ################################################################################################################################
 
 on:
@@ -45,15 +43,15 @@ jobs:
   #######################################################################################################################
   ### Create Reusable Caches for Tests
   ###
-  ### Caches can only be created from `main` (or via manual seeding when the SEED_CACHES Actions variable is 'true').
+  ### Caches are created from `main` branch when a GitHub Action variable is set: ENABLE_CI_WORKFLOWS = true
   ### When run on `main`, this workflow creates canonical re-usable caches for future CI runs.
   ### When manually dispatched from another branch, any created caches will be scoped to that branch.
   #######################################################################################################################
   cache-bitcoin-binary:
     name: "Create: Bitcoin Binary Cache"
     runs-on: ubuntu-latest
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches
@@ -81,8 +79,8 @@ jobs:
   cache-cargo:
     name: "Create: Cargo Cache"
     runs-on: ubuntu-latest
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches

--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -40,6 +40,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-ci-enabled:
+    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI enabled"
+
   #######################################################################################################################
   ### Create Reusable Caches for Tests
   ###
@@ -49,9 +56,9 @@ jobs:
   #######################################################################################################################
   cache-bitcoin-binary:
     name: "Create: Bitcoin Binary Cache"
+    needs:
+      - check-ci-enabled
     runs-on: ubuntu-latest
-    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches
@@ -78,9 +85,9 @@ jobs:
 
   cache-cargo:
     name: "Create: Cargo Cache"
+    needs:
+      - check-ci-enabled
     runs-on: ubuntu-latest
-    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches

--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -50,8 +50,8 @@ jobs:
   cache-bitcoin-binary:
     name: "Create: Bitcoin Binary Cache"
     runs-on: ubuntu-latest
-    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches
@@ -79,8 +79,8 @@ jobs:
   cache-cargo:
     name: "Create: Cargo Cache"
     runs-on: ubuntu-latest
-    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches

--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -52,10 +52,8 @@ jobs:
   cache-bitcoin-binary:
     name: "Create: Bitcoin Binary Cache"
     runs-on: ubuntu-latest
-    # Execute if running in our core repo on `main` OR manually if SEED_CACHES GitHub Actions variable is 'true'
-    if: |
-      (github.repository == 'stacks-network/stacks-core' && github.ref_name == 'main') ||
-      vars.SEED_CACHES == 'true'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches
@@ -83,10 +81,8 @@ jobs:
   cache-cargo:
     name: "Create: Cargo Cache"
     runs-on: ubuntu-latest
-    # Execute if running in our core repo on `main` OR manually if SEED_CACHES GitHub Actions variable is 'true'
-    if: |
-      (github.repository == 'stacks-network/stacks-core' && github.ref_name == 'main') ||
-      vars.SEED_CACHES == 'true'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: vars.ENABLE_CI_WORKFLOWS == 'true'
     steps:
       # Checkout the code
       #   - only .github is required for checking caches

--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -41,11 +41,25 @@ concurrency:
 
 jobs:
   check-ci-enabled:
-    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    name: "Check: CI Enabled"
     runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
     steps:
-      - run: echo "CI enabled"
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+          echo "github.repository:   '${{ github.repository }}'"
+          echo "github.event_name:   '${{ github.event_name }}'"
+    
+          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
   #######################################################################################################################
   ### Create Reusable Caches for Tests
@@ -58,6 +72,7 @@ jobs:
     name: "Create: Bitcoin Binary Cache"
     needs:
       - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -87,6 +102,7 @@ jobs:
     name: "Create: Cargo Cache"
     needs:
       - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,8 +44,8 @@ jobs:
   # Build arch dependent binaries from source
   build-binaries:
     name: Build Binaries
-    # Only run this if it's the public repo or manually triggered
-    if: github.event_name == 'workflow_dispatch' || github.event.repository.visibility == 'public'
+    # Only run this if it's the official repo or manually triggered
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'stacks-network/stacks-core'
     runs-on: ${{ vars.BUILD_RUNNER_LABEL || 'ubuntu-latest' }}
     strategy:
       max-parallel: 2
@@ -131,9 +131,8 @@ jobs:
     name: Build Image
     needs:
       - build-binaries
-    # Only run this if it's the public repo or manually triggered, and skip it
-    # entirely for blanked builds (binaries only, no image).
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event.repository.visibility == 'public') && !inputs.blank_version_build }}
+    # Only run this if it's the official repo or manually triggered, and skip it entirely for blanked builds (binaries only, no image).
+    if: (github.event_name == 'workflow_dispatch' || github.repository == 'stacks-network/stacks-core') && !inputs.blank_version_build
     runs-on: ubuntu-latest
     permissions:
       contents: read       # required for checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,8 +44,8 @@ jobs:
   # Build arch dependent binaries from source
   build-binaries:
     name: Build Binaries
-    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: ${{ vars.BUILD_RUNNER_LABEL || 'ubuntu-latest' }}
     strategy:
       max-parallel: 2
@@ -131,8 +131,8 @@ jobs:
     name: Build Image
     needs:
       - build-binaries
-    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true', and skip it entirely for blanked builds (binaries only, no image)
-    if: (github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true') && !inputs.blank_version_build
+    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository, and skip it entirely for blanked builds (binaries only, no image)
+    if: (github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && !inputs.blank_version_build
     runs-on: ubuntu-latest
     permissions:
       contents: read       # required for checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,8 +44,8 @@ jobs:
   # Build arch dependent binaries from source
   build-binaries:
     name: Build Binaries
-    # Only run this if it's the official repo or manually triggered
-    if: github.event_name == 'workflow_dispatch' || github.repository == 'stacks-network/stacks-core'
+    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
     runs-on: ${{ vars.BUILD_RUNNER_LABEL || 'ubuntu-latest' }}
     strategy:
       max-parallel: 2
@@ -131,8 +131,8 @@ jobs:
     name: Build Image
     needs:
       - build-binaries
-    # Only run this if it's the official repo or manually triggered, and skip it entirely for blanked builds (binaries only, no image).
-    if: (github.event_name == 'workflow_dispatch' || github.repository == 'stacks-network/stacks-core') && !inputs.blank_version_build
+    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true', and skip it entirely for blanked builds (binaries only, no image)
+    if: (github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true') && !inputs.blank_version_build
     runs-on: ubuntu-latest
     permissions:
       contents: read       # required for checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,11 +41,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-ci-enabled:
+    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI enabled"
+
   # Build arch dependent binaries from source
   build-binaries:
     name: Build Binaries
-    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    needs:
+      - check-ci-enabled
     runs-on: ${{ vars.BUILD_RUNNER_LABEL || 'ubuntu-latest' }}
     strategy:
       max-parallel: 2
@@ -130,9 +137,10 @@ jobs:
   image:
     name: Build Image
     needs:
+      - check-ci-enabled
       - build-binaries
-    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository, and skip it entirely for blanked builds (binaries only, no image)
-    if: (github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && !inputs.blank_version_build
+    # Only run this for versioned builds (skip for blanked builds)
+    if: ${{ !inputs.blank_version_build }}
     runs-on: ubuntu-latest
     permissions:
       contents: read       # required for checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,17 +42,32 @@ concurrency:
 
 jobs:
   check-ci-enabled:
-    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    name: "Check: CI Enabled"
     runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
     steps:
-      - run: echo "CI enabled"
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+          echo "github.repository:   '${{ github.repository }}'"
+          echo "github.event_name:   '${{ github.event_name }}'"
+    
+          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
   # Build arch dependent binaries from source
   build-binaries:
-    name: Build Binaries
+    name: "Build: Binaries"
     needs:
       - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ${{ vars.BUILD_RUNNER_LABEL || 'ubuntu-latest' }}
     strategy:
       max-parallel: 2
@@ -135,12 +150,12 @@ jobs:
 
   # Build and publish the docker images using the binary archives
   image:
-    name: Build Image
+    name: "Build: Image"
     needs:
       - check-ci-enabled
       - build-binaries
     # Only run this for versioned builds (skip for blanked builds)
-    if: ${{ !inputs.blank_version_build }}
+    if: needs.check-ci-enabled.outputs.enabled == 'true' && !inputs.blank_version_build
     runs-on: ubuntu-latest
     permissions:
       contents: read       # required for checkout

--- a/.github/workflows/lock-closed-threads.yml
+++ b/.github/workflows/lock-closed-threads.yml
@@ -20,10 +20,9 @@ concurrency:
 jobs:
   lock:
     name: Lock Closed Issues, PRs, & Discussions
-    # Only execute if running in our core repo. The CRON schedule will run against `main` which is intended
-    if: |
-      github.repository == 'stacks-network/stacks-core' &&
-      github.ref_name == 'main'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and we're on `stacks-network/stacks-core`
+    # We only want this to run on our official repo, because it manages Issues discussions
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' && github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       - name: Lock Threads

--- a/.github/workflows/lock-closed-threads.yml
+++ b/.github/workflows/lock-closed-threads.yml
@@ -18,10 +18,31 @@ concurrency:
   group: lock-threads
 
 jobs:
-  lock:
-    name: Lock Closed Issues, PRs, & Discussions
-    # Execute only on our official repo, because it manages Issues discussions
-    if: github.repository == 'stacks-network/stacks-core'
+  # Execute only on our official repo, because it manages Issues discussions for our official repo
+  check-ci-enabled:
+    name: "Check: CI Enabled"
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "github.repository:   '${{ github.repository }}'"
+    
+          if [[ "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  lock-closed-threads:
+    name: "Lock: Closed Issues, PRs, & Discussions"
+    needs:
+      - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Lock Threads

--- a/.github/workflows/lock-closed-threads.yml
+++ b/.github/workflows/lock-closed-threads.yml
@@ -20,9 +20,8 @@ concurrency:
 jobs:
   lock:
     name: Lock Closed Issues, PRs, & Discussions
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and we're on `stacks-network/stacks-core`
-    # We only want this to run on our official repo, because it manages Issues discussions
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' && github.repository == 'stacks-network/stacks-core'
+    # Execute only on our official repo, because it manages Issues discussions
+    if: github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       - name: Lock Threads

--- a/.github/workflows/slack-pr-nag.yml
+++ b/.github/workflows/slack-pr-nag.yml
@@ -11,10 +11,32 @@ permissions:
   pull-requests: read
 
 jobs:
-  nag-slack:
+  # Execute only on our official repo, because it manages Slack PR nags for us
+  check-ci-enabled:
+    name: "Check: CI Enabled"
     runs-on: ubuntu-latest
-    # Execute only on our official repo, because it manages Slack PR nags for us
-    if: github.repository == 'stacks-network/stacks-core'
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "github.repository:   '${{ github.repository }}'"
+    
+          if [[ "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  nag-slack:
+    name: "Slack: Nag Team"
+    needs:
+      - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch PRs and Post Nags to Slack
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/slack-pr-nag.yml
+++ b/.github/workflows/slack-pr-nag.yml
@@ -13,8 +13,9 @@ permissions:
 jobs:
   nag-slack:
     runs-on: ubuntu-latest
-    # Only execute if running in our core repo
-    if: github.repository == 'stacks-network/stacks-core'
+    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and we're on `stacks-network/stacks-core`
+    # We only want this to run on our official repo, because it manages our open PRs for us
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' && github.repository == 'stacks-network/stacks-core'
     steps:
       - name: Fetch PRs and Post Nags to Slack
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/slack-pr-nag.yml
+++ b/.github/workflows/slack-pr-nag.yml
@@ -13,9 +13,8 @@ permissions:
 jobs:
   nag-slack:
     runs-on: ubuntu-latest
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and we're on `stacks-network/stacks-core`
-    # We only want this to run on our official repo, because it manages our open PRs for us
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' && github.repository == 'stacks-network/stacks-core'
+    # Execute only on our official repo, because it manages Slack PR nags for us
+    if: github.repository == 'stacks-network/stacks-core'
     steps:
       - name: Fetch PRs and Post Nags to Slack
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -62,14 +62,23 @@ env:
   BTC_VERSION: "25.0"
 
 jobs:
+  check-ci-enabled:
+    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI enabled"
+
   # Gate 1: on manual dispatch, always proceed.
   # On pull_request_review, proceed only when the triggering review is an
   # approval targeting the `main` base branch and check approvals
   # from users with write+ permission to be at least `REQUIRED_APPROVALS`.
   check-approvals:
     name: Check Approval Count
-    # Only run this if it's manually triggered OR ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository AND a PR review is approved targeting the main branch
-    if: github.event_name == 'workflow_dispatch' || ((vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main')
+    needs:
+      - check-ci-enabled
+    # Only run this if a PR review is approved targeting the main branch
+    if: github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.count.outputs.ready }}
@@ -129,7 +138,9 @@ jobs:
   # introduce any new proptest tests.
   check-changes:
     name: Detect New Proptest Tests
-    needs: check-approvals
+    needs:
+      - check-ci-enabled
+      - check-approvals
     if: needs.check-approvals.outputs.ready == 'true'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -78,7 +78,7 @@ jobs:
     needs:
       - check-ci-enabled
     # Only run this if a PR review is approved targeting the main branch
-    if: github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main')
+    if: github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.count.outputs.ready }}

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -68,8 +68,8 @@ jobs:
   # from users with write+ permission to be at least `REQUIRED_APPROVALS`.
   check-approvals:
     name: Check Approval Count
-    # Only run this if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and EITHER: it's manually triggered OR a PR review is approved targeted the main branch
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' && ((github.event_name == 'workflow_dispatch') || (github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main'))
+    # Only run this if it's manually triggered OR ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository AND a PR review is approved targeting the main branch
+    if: github.event_name == 'workflow_dispatch' || ((vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.count.outputs.ready }}

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -68,9 +68,8 @@ jobs:
   # from users with write+ permission to be at least `REQUIRED_APPROVALS`.
   check-approvals:
     name: Check Approval Count
-    if: >
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main')
+    # Only run this if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' and EITHER: it's manually triggered OR a PR review is approved targeted the main branch
+    if: vars.ENABLE_CI_WORKFLOWS == 'true' && ((github.event_name == 'workflow_dispatch') || (github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main'))
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.count.outputs.ready }}

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -63,22 +63,36 @@ env:
 
 jobs:
   check-ci-enabled:
-    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    name: "Check: CI Enabled"
     runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
     steps:
-      - run: echo "CI enabled"
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+          echo "github.repository:   '${{ github.repository }}'"
+          echo "github.event_name:   '${{ github.event_name }}'"
+    
+          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
   # Gate 1: on manual dispatch, always proceed.
   # On pull_request_review, proceed only when the triggering review is an
   # approval targeting the `main` base branch and check approvals
   # from users with write+ permission to be at least `REQUIRED_APPROVALS`.
   check-approvals:
-    name: Check Approval Count
+    name: "Check: Approval Count"
     needs:
       - check-ci-enabled
     # Only run this if a PR review is approved targeting the main branch
-    if: github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main'
+    if: needs.check-ci-enabled.outputs.enabled == 'true' && github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.count.outputs.ready }}
@@ -137,7 +151,7 @@ jobs:
   # Skips the expensive test listing/filtering job when a PR does not
   # introduce any new proptest tests.
   check-changes:
-    name: Detect New Proptest Tests
+    name: "Detect: New Proptest Tests"
     needs:
       - check-ci-enabled
       - check-approvals

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -60,10 +60,17 @@ env:
   MADHOUSE: 1
 
 jobs:
-  proptests-nightly:
-    name: Run All Proptest Tests
+  check-ci-enabled:
     # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
     if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI enabled"
+
+  proptests-nightly:
+    name: Run All Proptest Tests
+    needs:
+      - check-ci-enabled
     runs-on: ubuntu-latest
     steps:
       # Compute env variables depending on the workflow trigger (schedule vs dispatch)

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -62,8 +62,8 @@ env:
 jobs:
   proptests-nightly:
     name: Run All Proptest Tests
-    # Only run this if it's the official repo or manually triggered
-    if: github.event_name == 'workflow_dispatch' || github.repository == 'stacks-network/stacks-core'
+    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     steps:
       # Compute env variables depending on the workflow trigger (schedule vs dispatch)

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -62,7 +62,8 @@ env:
 jobs:
   proptests-nightly:
     name: Run All Proptest Tests
-    if: github.event_name == 'workflow_dispatch' || github.event.repository.visibility == 'public'
+    # Only run this if it's the official repo or manually triggered
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Compute env variables depending on the workflow trigger (schedule vs dispatch)

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -62,8 +62,8 @@ env:
 jobs:
   proptests-nightly:
     name: Run All Proptest Tests
-    # Only run this if it's manually triggered or if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true'
+    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
     runs-on: ubuntu-latest
     steps:
       # Compute env variables depending on the workflow trigger (schedule vs dispatch)

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -61,16 +61,31 @@ env:
 
 jobs:
   check-ci-enabled:
-    # Only run this if it's manually triggered or ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    name: "Check: CI Enabled"
     runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
     steps:
-      - run: echo "CI enabled"
+      - id: check
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
+          echo "github.repository:   '${{ github.repository }}'"
+          echo "github.event_name:   '${{ github.event_name }}'"
+    
+          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Result: CI is ENABLED"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: CI is DISABLED"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
   proptests-nightly:
-    name: Run All Proptest Tests
+    name: "Tests: All Proptest Tests"
     needs:
       - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
       # Compute env variables depending on the workflow trigger (schedule vs dispatch)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ See the branching document in [branching.md](./docs/branching.md).
 
 ### Enabling CI on Forks
 
-By default, CI workflows will be disabled on forks. You generally won't need to enable them, but there may be cases where you want to test the workflows.
+The CI will always run on `stacks-network/stacks-core` with other forks and cloned repos able to opt-in.
 
-To **enable** CI workflows within your fork or repository, add a GitHub Actions Variable:
+To **enable** CI workflows within your fork or cloned repository, add a GitHub Actions Variable:
 
 - Name: `ENABLE_CI_WORKFLOWS`
 - Value: `true`
@@ -39,8 +39,8 @@ To **enable** CI workflows within your fork or repository, add a GitHub Actions 
 This will enable CI functionality within your repo or fork, as our CI workflow files check for it as follows:
 
 ```
-# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
-if: vars.ENABLE_CI_WORKFLOWS == 'true'
+# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
+if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
 ```
 
 ### Merging PRs from Forks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,22 @@ This project and everyone participating in it is governed by this [Code of Condu
 
 See the branching document in [branching.md](./docs/branching.md).
 
+### Enabling CI on Forks
+
+By default, CI workflows will be disabled on forks. You generally won't need to enable them, but there may be cases where you want to test the workflows.
+
+To **enable** CI workflows within your fork or repository, add a GitHub Actions Variable:
+
+- Name: `ENABLE_CI_WORKFLOWS`
+- Value: `true`
+
+This will enable CI functionality within your repo or fork, as our CI workflow files check for it as follows:
+
+```
+# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true'
+if: vars.ENABLE_CI_WORKFLOWS == 'true'
+```
+
 ### Merging PRs from Forks
 
 PRs from forks or opened by contributors without commit access require

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,12 +36,7 @@ To **enable** CI workflows within your fork or cloned repository, add a GitHub A
 - Name: `ENABLE_CI_WORKFLOWS`
 - Value: `true`
 
-This will enable CI functionality within your repo or fork, as our CI workflow files check for it as follows:
-
-```
-# Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
-```
+This will enable CI functionality within your repo or fork.
 
 ### Merging PRs from Forks
 


### PR DESCRIPTION
### Description

CI: Only run GitHub Actions when Environment var ENABLE_CI_WORKFLOWS is set to true or we're on the official branch

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

NOTE: I've already added this variable to `stacks-network/stacks-core`:

<img width="456" height="135" alt="image" src="https://github.com/user-attachments/assets/95ccda0c-bef0-4785-b5f4-aa04b0d0df64" />

I noticed recently in my fork that a lot of Actions jobs run automatically on CRON, 1x per day. Not everyone wants to run CI, while developers probably want to run CI for testing purposes on their forks. To that end, this PR changes CI to only run GitHub Actions when Environment var `ENABLE_CI_WORKFLOWS` is set to `true` or we're on the official branch.

This dual check is necessary because forked PRs do not have access to GitHub Actions secrets or vars, so the variable cannot be read.

Any fork can add their own Environment var `ENABLE_CI_WORKFLOWS` and set it to `true` to enable CI.

Some CI actions will still only work against `stacks-network/stacks-core` such as the PR Nag Bot and Scheduled Thread Lock.

### Checklist

N/A