### PR TITLE
chore: set default stackerdb timeouts to 10s

### DIFF
--- a/changelog.d/reduce-timeout.changed
+++ b/changelog.d/reduce-timeout.changed
@@ -1,0 +1,1 @@
+Lower the default StackerDB timeouts to retry HTTP RPC sooner.

--- a/sample/conf/mainnet-miner-conf.toml
+++ b/sample/conf/mainnet-miner-conf.toml
@@ -370,7 +370,7 @@ wallet_name = "<YOUR_BITCOIN_WALLET_NAME>"
 # replay_transactions = false
 
 # StackerDB socket timeout for miner operations.
-# Default: 120
+# Default: 10
 # Units: seconds
 # stackerdb_timeout_secs = 10
 

--- a/sample/conf/mainnet-miner-conf.toml
+++ b/sample/conf/mainnet-miner-conf.toml
@@ -372,7 +372,7 @@ wallet_name = "<YOUR_BITCOIN_WALLET_NAME>"
 # StackerDB socket timeout for miner operations.
 # Default: 120
 # Units: seconds
-# stackerdb_timeout_secs = 120
+# stackerdb_timeout_secs = 10
 
 # Log transactions that are skipped during mempool walk.
 # Default: false

--- a/sample/conf/signer/mainnet-signer-conf.toml
+++ b/sample/conf/signer/mainnet-signer-conf.toml
@@ -224,7 +224,7 @@ db_path = "/var/lib/stacks-signer/signerdb.sqlite"
 # reset_replay_set_after_fork_blocks = 2
 
 # HTTP timeout for StackerDB read/write operations.
-# Default: 120
+# Default: 10
 # Units: seconds
 # stackerdb_timeout_secs = 10
 

--- a/sample/conf/signer/mainnet-signer-conf.toml
+++ b/sample/conf/signer/mainnet-signer-conf.toml
@@ -226,7 +226,7 @@ db_path = "/var/lib/stacks-signer/signerdb.sqlite"
 # HTTP timeout for StackerDB read/write operations.
 # Default: 120
 # Units: seconds
-# stackerdb_timeout_secs = 120
+# stackerdb_timeout_secs = 10
 
 # Timeout for receiving events from the stacks-node.
 # Default: 5_000

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -61,7 +61,7 @@ pub const DEFAULT_RESET_REPLAY_SET_AFTER_FORK_BLOCKS: u64 = 2;
 /// machine view point and capitulating to other signers tenure view
 const DEFAULT_CAPITULATE_MINER_VIEW_SECS: u64 = 20;
 /// Default HTTP timeout (in seconds) for read/write operations with StackerDB.
-pub const DEFAULT_STACKERDB_TIMEOUT_SECS: u64 = 120;
+pub const DEFAULT_STACKERDB_TIMEOUT_SECS: u64 = 10;
 
 #[derive(thiserror::Error, Debug)]
 /// An error occurred parsing the provided configuration

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -463,7 +463,7 @@ struct RawConfigFile {
     pub capitulate_miner_view_timeout_secs: Option<u64>,
     /// HTTP timeout for read/write operations with StackerDB.
     /// ---
-    /// @default: `120`
+    /// @default: `10`
     /// @units: seconds
     pub stackerdb_timeout_secs: Option<u64>,
     #[cfg(any(test, feature = "testing"))]

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -144,7 +144,7 @@ const DEFAULT_MAX_EXECUTION_TIME_SECS: u64 = 30;
 /// phase of a transaction before timing out.
 const DEFAULT_MAX_ANALYSIS_TIME_SECS: u64 = 30;
 /// Default number of seconds that a miner should wait before timing out an HTTP request to StackerDB.
-const DEFAULT_STACKERDB_TIMEOUT_SECS: u64 = 120;
+const DEFAULT_STACKERDB_TIMEOUT_SECS: u64 = 10;
 /// Default maximum size for a tenure (note: the counter is reset on tenure extend).
 pub const DEFAULT_MAX_TENURE_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 /// Default maximum memory allocation during miner block assembly


### PR DESCRIPTION
This should trigger the miner and signers to retry faster for stackerdb endpoints.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
