### PR TITLE
Fix the definition sorter's handling of `contract-call?`

### DIFF
--- a/changelog.d/7527-definition-sorter-contract-call.fixed
+++ b/changelog.d/7527-definition-sorter-contract-call.fixed
@@ -1,0 +1,1 @@
+Fix a bug that prevented duplicate name detection in some cases during contract analysis. This change applies starting in epoch 4.1.

--- a/clarity/src/vm/analysis/tests/mod.rs
+++ b/clarity/src/vm/analysis/tests/mod.rs
@@ -610,3 +610,130 @@ fn test_order_of_readonly_check_and_type_check() {
         err
     );
 }
+
+/// Checks that the analysis succeeds in 4.0 but fails in 4.1 with an error that
+/// contains the given substring. Helper for [`test_definition_sorting_of_contract_call`]`.
+fn assert_contract_starts_failing_in_epoch_41(snippet: &str, expected_error_41: &str) {
+    let result = mem_run_analysis(snippet, ClarityVersion::latest(), StacksEpochId::Epoch40);
+    assert!(
+        result.is_ok(),
+        "expected to pass in Epoch 4.0 but got {}; contract: {snippet}",
+        result.unwrap_err()
+    );
+
+    let result = mem_run_analysis(snippet, ClarityVersion::latest(), StacksEpochId::Epoch41);
+    match result {
+        Err(e) => assert!(
+            e.to_string().contains(expected_error_41),
+            "expected error to contain \"{expected_error_41}\" in Epoch 4.1 but got {e}; contract: {snippet}"
+        ),
+        Ok(_) => panic!("should not succeed in Epoch 4.1"),
+    };
+}
+
+/// Checks that the analysis fails in both 4.0 and 4.1 with an error that
+/// contains the given substring. Helper for [`test_definition_sorting_of_contract_call`]`.
+fn assert_contract_fails_even_before_epoch_41(snippet: &str, expected_error: &str) {
+    let result = mem_run_analysis(snippet, ClarityVersion::latest(), StacksEpochId::Epoch40);
+    match result {
+        Err(e) => assert!(
+            e.to_string().contains(expected_error),
+            "expected error to contain \"{expected_error}\" in Epoch 4.0 but got {e}; contract: {snippet}"
+        ),
+        Ok(_) => panic!("should not succeed in Epoch 4.0"),
+    };
+
+    let result = mem_run_analysis(snippet, ClarityVersion::latest(), StacksEpochId::Epoch41);
+    match result {
+        Err(e) => assert!(
+            e.to_string().contains(expected_error),
+            "expected error to contain \"{expected_error}\" Epoch 4.1 but got {e}; contract: {snippet}"
+        ),
+        Ok(_) => panic!("should not succeed in Epoch 4.1"),
+    };
+}
+
+#[test]
+/// Until Epoch 4.0, the definition sorter ignored the first argument to `contract-call?`,
+/// which means it didn't prevent a local binding (e.g. function parameter) and a global
+/// object (e.g. a data-var) from having the same name, if the global was defined after
+/// the function. This is inconsistent (this shouldn't depend on the order), and it can
+/// cause cryptic failures at runtime, and was therefore fixed in Epoch 4.1.
+/// Even for non-broken contracts, this fix can change cost, which is why we
+/// have to preserve the legacy behavior for all earlier epochs. That is what this test
+/// ensures: Until 4.0, such contracts pass analysis, but from 4.1 on, they fail. It also
+/// ensures that the cases that have previously been rejected still are.
+fn test_definition_sorting_of_contract_call() {
+    // Function name matches parameter name. Even though that works as expected by
+    // accident, it is invalid.
+    assert_contract_starts_failing_in_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-public (stuff (stuff <my-trait>)) (contract-call? stuff trait-func))",
+        "CircularReference",
+    );
+
+    // These contracts define a global `thing` *after* a function with a parameter
+    // called `thing` that was passed to `contract-call?`. This passed analysis until
+    // epoch 4.0, but should be rejected starting in 4.1
+
+    assert_contract_starts_failing_in_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-public (stuff (thing <my-trait>)) (contract-call? thing trait-func))
+         (define-constant thing (unwrap-panic (as-contract? () tx-sender)))",
+        "NameAlreadyUsed",
+    );
+
+    assert_contract_starts_failing_in_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-public (stuff (thing <my-trait>)) (contract-call? thing trait-func))
+         (define-data-var thing principal (unwrap-panic (as-contract? () tx-sender)))",
+        "NameAlreadyUsed",
+    );
+
+    assert_contract_starts_failing_in_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-public (stuff (thing <my-trait>)) (contract-call? thing trait-func))
+         (define-private (thing) 42)",
+        "NameAlreadyUsed",
+    );
+
+    // same as above, except that the function parameter is fine -- it's the
+    // `let` binding that uses the duplicate name
+    assert_contract_starts_failing_in_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-public (stuff (target <my-trait>)) (let ((thing target)) (contract-call? thing trait-func)))
+         (define-private (thing) 42)",
+        "NameAlreadyUsed",
+    );
+
+    // These contracts are identical to the previous four, except that the global
+    // `thing` is defined *before* the function. This was always prevented.
+
+    assert_contract_fails_even_before_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-constant thing (unwrap-panic (as-contract? () tx-sender)))
+         (define-public (stuff (thing <my-trait>)) (contract-call? thing trait-func))",
+        "NameAlreadyUsed",
+    );
+
+    assert_contract_fails_even_before_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-data-var thing principal (unwrap-panic (as-contract? () tx-sender)))
+         (define-public (stuff (thing <my-trait>)) (contract-call? thing trait-func))",
+        "NameAlreadyUsed",
+    );
+
+    assert_contract_fails_even_before_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+        (define-private (thing) 42)
+         (define-public (stuff (thing <my-trait>)) (contract-call? thing trait-func))",
+        "NameAlreadyUsed",
+    );
+
+    assert_contract_fails_even_before_epoch_41(
+        "(define-trait my-trait ((trait-func () (response uint uint))))
+         (define-private (thing) 42)
+         (define-public (stuff (target <my-trait>)) (let ((thing target)) (contract-call? thing trait-func)))",
+        "NameAlreadyUsed",
+    );
+}

--- a/clarity/src/vm/ast/definition_sorter/mod.rs
+++ b/clarity/src/vm/ast/definition_sorter/mod.rs
@@ -17,6 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use clarity_types::representations::ClarityName;
+use stacks_common::types::StacksEpochId;
 
 use crate::vm::ClarityVersion;
 use crate::vm::ast::errors::{ParseError, ParseErrorKind, ParseResult};
@@ -37,13 +38,15 @@ mod tests;
 pub struct DefinitionSorter {
     graph: Graph,
     top_level_expressions_map: HashMap<ClarityName, TopLevelExpressionIndex>,
+    epoch: StacksEpochId,
 }
 
 impl DefinitionSorter {
-    fn new() -> Self {
+    fn new(epoch: StacksEpochId) -> Self {
         Self {
             top_level_expressions_map: HashMap::new(),
             graph: Graph::new(),
+            epoch,
         }
     }
 
@@ -51,8 +54,9 @@ impl DefinitionSorter {
         contract_ast: &mut ContractAST,
         accounting: &mut T,
         version: ClarityVersion,
+        epoch: StacksEpochId,
     ) -> ParseResult<()> {
-        let mut pass = DefinitionSorter::new();
+        let mut pass = DefinitionSorter::new(epoch);
         pass.run(contract_ast, accounting, version)?;
         Ok(())
     }
@@ -237,11 +241,14 @@ impl DefinitionSorter {
                         {
                             match native_function {
                                 NativeFunctions::ContractCall => {
-                                    // Args: [contract-name, function-name, ...]: ignore contract-name, function-name, handle rest
-                                    if function_args.len() > 2 {
-                                        for expr in function_args[2..].iter() {
-                                            self.probe_for_dependencies(expr, tle_index, version)?;
+                                    // Args: [contract-name, function-name, ...]: Always ignore function-name because it's not
+                                    // a dependency *in this contract*. Handle contract-name beginning in Epoch 4.1, see
+                                    // `should_skip_contract_call_argument` for details. Always handle the rest.
+                                    for (index, expr) in function_args.iter().enumerate() {
+                                        if self.should_skip_contract_call_argument(index) {
+                                            continue;
                                         }
+                                        self.probe_for_dependencies(expr, tle_index, version)?;
                                     }
                                     return Ok(());
                                 }
@@ -393,6 +400,24 @@ impl DefinitionSorter {
         };
         let tle_name = defined_name.match_atom()?;
         Some((tle_name.clone(), defined_name.id, defined_name))
+    }
+
+    /// When probing dependencies of a `contract-call?` invocation, should
+    /// the argument with the given index be ignored? The signature is
+    /// `(contract-call? contract-principal function-name other-args...)`,
+    /// so `contract-principal` is index 0 and `function-name` is index 1.
+    fn should_skip_contract_call_argument(&self, argument_index: usize) -> bool {
+        if self.epoch.checks_dependency_of_contract_call_target() {
+            // only skip argument 1, the function name (because it doesn't
+            // refer to a name in the current contract, but in the called contract)
+            argument_index == 1
+        } else {
+            // also skip argument 0, the target contract, because that is
+            // the legacy behavior that we have to support, even though it
+            // was incorrect starting with Clarity 2 when this argument no
+            // longer had to be a principal literal
+            argument_index <= 1
+        }
     }
 }
 

--- a/clarity/src/vm/ast/definition_sorter/tests.rs
+++ b/clarity/src/vm/ast/definition_sorter/tests.rs
@@ -38,13 +38,11 @@ fn test_clarity_versions_definition_sorter(#[case] version: ClarityVersion) {}
 
 fn run_scoped_parsing_helper(contract: &str, version: ClarityVersion) -> ParseResult<ContractAST> {
     let contract_identifier = QualifiedContractIdentifier::transient();
-    let pre_expressions = parser::v1::parse(
-        contract,
-        StackDepthLimits::for_epoch(StacksEpochId::Epoch2_05),
-    )?;
+    let epoch = StacksEpochId::Epoch2_05;
+    let pre_expressions = parser::v1::parse(contract, StackDepthLimits::for_epoch(epoch))?;
     let mut contract_ast = ContractAST::new(contract_identifier, pre_expressions);
     ExpressionIdentifier::run_pre_expression_pass(&mut contract_ast, version)?;
-    DefinitionSorter::run_pass(&mut contract_ast, &mut (), version)?;
+    DefinitionSorter::run_pass(&mut contract_ast, &mut (), version, epoch)?;
     Ok(contract_ast)
 }
 

--- a/clarity/src/vm/ast/mod.rs
+++ b/clarity/src/vm/ast/mod.rs
@@ -121,8 +121,7 @@ fn inner_build_ast<T: CostTracker>(
     source_code: &str,
     cost_track: &mut T,
     clarity_version: ClarityVersion,
-    // the epoch_id argument can be removed as part of #3662 (removing parser v1)
-    #[allow(unused_variables)] epoch: StacksEpochId,
+    epoch: StacksEpochId,
     error_early: bool,
 ) -> ParseResult<(ContractAST, Vec<Diagnostic>, bool)> {
     let cost_err = match runtime_cost(
@@ -202,7 +201,7 @@ fn inner_build_ast<T: CostTracker>(
         }
         _ => (),
     }
-    match DefinitionSorter::run_pass(&mut contract_ast, cost_track, clarity_version) {
+    match DefinitionSorter::run_pass(&mut contract_ast, cost_track, clarity_version, epoch) {
         Err(e) if error_early => return Err(e),
         Err(e) => {
             diagnostics.push(e.diagnostic);

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -888,6 +888,16 @@ impl StacksEpochId {
         self < &StacksEpochId::Epoch41
     }
 
+    /// Whether the analysis engine's definition sorter should track the `contract-call?`
+    /// function's `contract-name` argument as a dependency. That behavior would be
+    /// correct (starting in Epoch 2, when that argument no longer had to be a literal;
+    /// before that, it was not necessary), but it was broken before Epoch 4.1, and
+    /// because the change is consensus-breaking (even for non-broken contracts, because
+    /// it can change cost), we have to preserve the legacy behavior.
+    pub fn checks_dependency_of_contract_call_target(&self) -> bool {
+        self >= &StacksEpochId::Epoch41
+    }
+
     /// Return the network epoch associated with the StacksEpochId
     pub fn network_epoch(epoch: StacksEpochId) -> u8 {
         match epoch {


### PR DESCRIPTION
When said handling was added in #1301, we were still on Clarity 1, where the `contract-name` argument had to be a literal. Starting in Clarity 2, it was allowed to be a variable (although until #6924 that didn't actually work), but the definition sorter was never updated to no longer ignore that argument.