### PR TITLE
Fix flakiness in `tx_replay_budget_exceeded_tenure_extend` and `test_shadow_recovery`

### DIFF
--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -10795,7 +10795,6 @@ fn test_shadow_recovery() {
 
     let stacks_height_before = get_chain_info(&naka_conf).stacks_tip_height;
 
-    // TODO: stall block processing; otherwise this test can flake
     // stop block processing on the node
     TEST_COORDINATOR_STALL.lock().unwrap().replace(true);
 
@@ -10818,8 +10817,17 @@ fn test_shadow_recovery() {
     // revive ATC-C by waiting for commits
     next_block_and_commits_only(btc_regtest_controller, 60, &naka_conf, &counters).unwrap();
 
-    // make another tenure
-    next_block_and_mine_commit(btc_regtest_controller, 60, &naka_conf, &counters).unwrap();
+    // make another tenure.
+    //
+    // NOTE: `next_block_and_mine_commit()` can be flaky here because the
+    // shadow-parent commit may be rejected by the PoX output check, and the
+    // miner may tenure-extend instead of winning a new tenure.
+    let stacks_height_before = get_chain_info(&naka_conf).stacks_tip_height;
+    next_block_and_commits_only(btc_regtest_controller, 60, &naka_conf, &counters).unwrap();
+    wait_for(60, || {
+        Ok(get_chain_info(&naka_conf).stacks_tip_height > stacks_height_before)
+    })
+    .unwrap();
 
     // all shadow blocks are present and processed
     let mut shadow_ids = HashSet::new();

--- a/stacks-node/src/tests/signer/v0/tx_replay.rs
+++ b/stacks-node/src/tests/signer/v0/tx_replay.rs
@@ -2387,9 +2387,11 @@ fn tx_replay_budget_exceeded_tenure_extend() {
 
     info!("---- Waiting for replay set to be cleared ----");
 
-    // Now, wait for the tx replay set to be cleared
+    // Now, wait for the tx replay set to be cleared. This requires a BlockFound
+    // block, a budget-full replay block, a tenure extend, a second replay block,
+    // and state convergence across all signers, so give it plenty of time.
     signer_test
-        .wait_for_signer_state_check(60, |state| Ok(state.get_tx_replay_set().is_none()))
+        .wait_for_signer_state_check(120, |state| Ok(state.get_tx_replay_set().is_none()))
         .expect("Timed out waiting for tx replay set to be cleared");
     let mut found_block: Option<StacksBlockEvent> = None;
     wait_for(60, || {


### PR DESCRIPTION
In `tx_replay_budget_exceeded_tenure_extend`, the timeout needed to be extended here because it is waiting for a bunch of work to happen, which is too slow in CI.

In `test_shadow_recovery`, `next_block_and_mine_commit` could be flaky after the shadow block, so replace it with two separate checks, waiting for commits, and then waiting for the tip to advance.