### PR TITLE
fix: don't timeout a miner when the fallback can't produce blocks

### DIFF
--- a/stacks-node/src/tests/signer/v0/reorg.rs
+++ b/stacks-node/src/tests/signer/v0/reorg.rs
@@ -20,6 +20,7 @@ use std::{env, thread};
 
 use clarity::vm::types::PrincipalData;
 use libsigner::v0::messages::{BlockResponse, RejectReason};
+use libsigner::v0::signer_state::MinerState;
 use stacks::burnchains::Txid;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::LeaderBlockCommitOp;
@@ -30,12 +31,13 @@ use stacks::codec::StacksMessageCodec;
 use stacks::core::test_util::{make_stacks_transfer_serialized, to_addr};
 use stacks::core::StacksEpochId;
 use stacks::net::relay::fault_injection::set_ignore_block;
-use stacks::types::chainstate::{StacksAddress, StacksPublicKey};
+use stacks::types::chainstate::{ConsensusHash, StacksAddress, StacksPublicKey};
 use stacks::types::PublicKey;
 use stacks::util::hash::{Hash160, Sha512Trunc256Sum};
 use stacks::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use stacks_common::types::chainstate::TrieHash;
 use stacks_common::util::sleep_ms;
+use stacks_signer::v0::signer_state::LocalStateMachine;
 use stacks_signer::v0::tests::{
     TEST_PIN_SUPPORTED_SIGNER_PROTOCOL_VERSION, TEST_REJECT_ALL_BLOCK_PROPOSAL,
     TEST_SIGNERS_SKIP_BLOCK_RESPONSE_BROADCAST, TEST_SKIP_BLOCK_BROADCAST,
@@ -54,8 +56,8 @@ use crate::neon::Counters;
 use crate::run_loop::boot_nakamoto;
 use crate::tests::nakamoto_integrations::{next_block_and, next_block_and_controller, wait_for};
 use crate::tests::neon_integrations::{
-    get_account, get_chain_info, get_chain_info_opt, get_sortition_info, submit_tx, test_observer,
-    TestProxy,
+    get_account, get_chain_info, get_chain_info_opt, get_sortition_info, get_sortition_info_ch,
+    submit_tx, test_observer, TestProxy,
 };
 use crate::tests::{self, gen_random_port};
 use crate::{BitcoinRegtestController, Keychain};
@@ -2210,6 +2212,251 @@ fn bitcoind_forking_test() {
         "New chain info: {:?}",
         get_chain_info(&signer_test.running_nodes.conf)
     );
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Test that the miner inactivity timeout does not revert signers to a miner
+/// that cannot continue its tenure after a Bitcoin reorg.
+///
+/// After a 1-block Bitcoin fork orphans the latest tenure, the replacement
+/// burn block's sortition is won by the re-included block commit. Its parent
+/// (the post-reorg canonical tip) makes it a valid fallback tenure from the
+/// signers' point of view, but no blocks are ever mined in it: the canonical
+/// Stacks tip stays in an older tenure, so its miner will never issue a tenure
+/// extend for it. If the next sortition's winner is then slow to propose,
+/// signers used to revert their active miner view to the replacement
+/// sortition's miner and reject all of the actual winner's proposals until the
+/// next burn block. Signers must only revert to a prior miner whose tenure
+/// contains the canonical Stacks tip.
+///
+/// Test Setup:
+/// The test spins up five stacks signers, one miner Nakamoto node, and a
+/// corresponding bitcoind. The block proposal timeout is set to 60 seconds.
+///
+/// Test Execution:
+/// - Mine several normal tenures.
+/// - Stall the miner, then trigger a 1-block Bitcoin fork, orphaning the
+///   latest tenure. The replacement burn block's sortition is won by the
+///   re-included block commit, but no blocks are mined in its tenure.
+/// - Mine empty burn blocks until the miner submits a fresh commit, then mine
+///   a burn block whose sortition the miner wins, keeping the miner stalled
+///   past the block proposal timeout.
+/// - Verify that every signer still reports the new sortition's winner as the
+///   active miner rather than reverting to the replacement sortition's miner.
+/// - Unstall the miner.
+///
+/// Test Assertion:
+/// The stacks tip advances into the new sortition's tenure.
+fn no_revert_to_prior_miner_after_bitcoin_fork() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let block_proposal_timeout = Duration::from_secs(60);
+    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
+        num_signers,
+        vec![],
+        |signer_config| {
+            signer_config.block_proposal_timeout = block_proposal_timeout;
+        },
+        |node_config| {
+            node_config.miner.block_commit_delay = Duration::from_secs(1);
+        },
+        None,
+        None,
+    );
+    let conf = signer_test.running_nodes.conf.clone();
+    // The BTC key funds the block commits; the Stacks mining key is the one a
+    // sortition's `miner_pk_hash160` refers to.
+    let btc_miner_pk = signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .get_mining_pubkey()
+        .as_deref()
+        .map(Secp256k1PublicKey::from_hex)
+        .unwrap()
+        .unwrap();
+    let miner_sk = conf.miner.mining_key.clone().unwrap();
+    let miner_pkh = Hash160::from_node_public_key(&StacksPublicKey::from_private(&miner_sk));
+
+    let get_unconfirmed_commit_data = |btc_controller: &BitcoinRegtestController| {
+        let unconfirmed_utxo = btc_controller
+            .get_all_utxos(&btc_miner_pk)
+            .into_iter()
+            .find(|utxo| utxo.confirmations == 0)?;
+        let unconfirmed_txid = Txid::from_bitcoin_tx_hash(&unconfirmed_utxo.txid);
+        let unconfirmed_tx = btc_controller.get_raw_transaction(&unconfirmed_txid);
+        let unconfirmed_tx_opreturn_bytes = unconfirmed_tx.output[0].script_pubkey.as_bytes();
+        let data = LeaderBlockCommitOp::parse_data(
+            &unconfirmed_tx_opreturn_bytes[unconfirmed_tx_opreturn_bytes.len() - 77..],
+        )
+        .unwrap();
+        Some(data)
+    };
+
+    let assert_all_signers_active_tenure =
+        |state_machines: Vec<LocalStateMachine>, expected_tenure: &ConsensusHash| {
+            for (ix, state_machine) in state_machines.into_iter().enumerate() {
+                let LocalStateMachine::Initialized(state_machine) = state_machine else {
+                    panic!("Local state machine for signer #{ix} was not initialized");
+                };
+                let MinerState::ActiveMiner { tenure_id, .. } = state_machine.current_miner else {
+                    panic!("State machine for signer #{ix} did not have an active miner");
+                };
+                assert_eq!(
+                    tenure_id, *expected_tenure,
+                    "Signer #{ix} does not view the expected tenure's miner as active"
+                );
+            }
+        };
+
+    signer_test.boot_to_epoch_3();
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+
+    let pre_fork_tenures = 10;
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+        signer_test.check_signer_states_normal();
+    }
+
+    // Stall the miner BEFORE the fork so that no blocks are ever mined in the
+    // replacement burn block's tenure.
+    fault_injection_stall_miner();
+
+    info!("------------------------- Triggering Bitcoin Fork -------------------------");
+
+    let burn_block_height = get_chain_info(&conf).burn_block_height;
+    let burn_header_hash_to_fork = signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .get_block_hash(burn_block_height);
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .invalidate_block(&burn_header_hash_to_fork);
+    signer_test
+        .running_nodes
+        .btc_regtest_controller
+        .build_next_block(1);
+
+    // The replacement burn block's sortition is won by the re-included commit.
+    // Its tenure is valid (its parent is the canonical tip), so signer states
+    // are still "normal" -- but no blocks will ever be mined in it.
+    signer_test.check_signer_states_normal();
+    let replacement_tenure = get_chain_info(&conf).pox_consensus;
+    let replacement_sortition = get_sortition_info_ch(&conf, &replacement_tenure);
+    assert!(replacement_sortition.was_sortition);
+
+    let submitted_commits = signer_test
+        .running_nodes
+        .counters
+        .naka_submitted_commits
+        .clone();
+
+    // We need to mine some blocks for the miner to be considered a frequent
+    // miner again. These burn blocks have no sortition. Note: we deliberately
+    // do NOT check signer states in this loop; the stalled miner may exceed
+    // the block proposal timeout while these blocks are mined, and the states
+    // are recomputed at each burn block arrival anyway.
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and_controller(
+            &signer_test.running_nodes.btc_regtest_controller,
+            60,
+            |btc_controller| {
+                let commits_submitted = submitted_commits.load(Ordering::SeqCst);
+                if commits_submitted <= commits_count {
+                    // wait until a commit was submitted
+                    return Ok(false);
+                }
+                let Some(payload) = get_unconfirmed_commit_data(btc_controller) else {
+                    warn!("Commit submitted, but bitcoin doesn't see it in the unconfirmed UTXO set, will try to wait.");
+                    return Ok(false);
+                };
+                let burn_parent_modulus = payload.burn_parent_modulus;
+                let current_modulus = u8::try_from((current_burn_height + 1) % 5).unwrap();
+                Ok(burn_parent_modulus == current_modulus)
+            },
+        )
+        .unwrap();
+    }
+
+    info!(
+        "------------------------- Mining Sortition With Stalled Winner -------------------------"
+    );
+
+    let current_burn_height = get_chain_info(&conf).burn_block_height;
+    let commits_count = submitted_commits.load(Ordering::SeqCst);
+    next_block_and_controller(
+        &signer_test.running_nodes.btc_regtest_controller,
+        60,
+        |btc_controller| {
+            let commits_submitted = submitted_commits.load(Ordering::SeqCst);
+            if commits_submitted <= commits_count {
+                return Ok(false);
+            }
+            let Some(payload) = get_unconfirmed_commit_data(btc_controller) else {
+                return Ok(false);
+            };
+            let burn_parent_modulus = payload.burn_parent_modulus;
+            let current_modulus = u8::try_from((current_burn_height + 1) % 5).unwrap();
+            Ok(burn_parent_modulus == current_modulus)
+        },
+    )
+    .unwrap();
+
+    let stalled_winner_tenure = get_chain_info(&conf).pox_consensus;
+    let stalled_winner_sortition = get_sortition_info_ch(&conf, &stalled_winner_tenure);
+    assert!(
+        stalled_winner_sortition.was_sortition,
+        "The new burn block must have a sortition winner"
+    );
+    assert_eq!(
+        stalled_winner_sortition.miner_pk_hash160,
+        Some(miner_pkh.clone())
+    );
+    assert_ne!(stalled_winner_tenure, replacement_tenure);
+
+    // All signers view the new sortition's winner as the active miner.
+    let (state_machines, _) = signer_test.get_burn_updated_states();
+    assert_all_signers_active_tenure(state_machines, &stalled_winner_tenure);
+
+    info!(
+        "------------------------- Waiting Out The Block Proposal Timeout -------------------------"
+    );
+
+    // Keep the miner stalled past the block proposal timeout: the inactivity
+    // check must NOT revert the signers to the replacement sortition's miner,
+    // because the canonical stacks tip is not in that miner's tenure (its node
+    // will never mine in it).
+    sleep_ms(block_proposal_timeout.as_millis() as u64 + 15_000);
+
+    let (state_machines, _) = signer_test.get_burn_updated_states();
+    assert_all_signers_active_tenure(state_machines, &stalled_winner_tenure);
+
+    info!("------------------------- Unstalling The Miner -------------------------");
+
+    let info_before = get_chain_info(&conf);
+    fault_injection_unstall_miner();
+
+    // The (very late) proposals from the sortition winner must be accepted:
+    // the stacks tip advances into its tenure.
+    wait_for(120, || {
+        let info = get_chain_info(&conf);
+        Ok(info.stacks_tip_consensus_hash == stalled_winner_tenure
+            && info.stacks_tip_height > info_before.stacks_tip_height)
+    })
+    .expect("Timed out waiting for the stalled sortition winner's blocks to be accepted");
+
     signer_test.shutdown();
 }
 

--- a/stacks-signer/changelog.d/no-fallback-to-stopped-miner.fixed
+++ b/stacks-signer/changelog.d/no-fallback-to-stopped-miner.fixed
@@ -1,0 +1,1 @@
+Do not revert to the prior sortition's miner on inactivity timeout unless the canonical Stacks tip is in that miner's tenure. A miner only extends a tenure it won, so after a Bitcoin reorg orphaned the prior tenure, signers could demote a slow-but-live sortition winner to a miner that had already stopped mining, rejecting all of the winner's proposals until the next burn block.

--- a/stacks-signer/src/tests/signer_state.rs
+++ b/stacks-signer/src/tests/signer_state.rs
@@ -39,7 +39,9 @@ use stacks_common::bitvec::BitVec;
 use stacks_common::function_name;
 
 use crate::chainstate::{ProposalEvalConfig, SortitionData};
-use crate::client::tests::{build_get_tenure_tip_response, MockServerClient};
+use crate::client::tests::{
+    build_get_peer_info_response, build_get_tenure_tip_response, MockServerClient,
+};
 use crate::client::StacksClient;
 use crate::config::{GlobalConfig, DEFAULT_RESET_REPLAY_SET_AFTER_FORK_BLOCKS};
 use crate::signerdb::tests::{create_block_override, tmp_db_path};
@@ -1194,6 +1196,41 @@ fn check_miner_inactivity_timeout() {
     let json_payload = serde_json::to_string(&expected_result).unwrap();
     let to_send_1 = format!("HTTP/1.1 200 OK\n\n{json_payload}");
 
+    // If the canonical stacks tip is NOT in the prior sortition's tenure (e.g. a
+    // Bitcoin reorg orphaned it), the prior miner's node has already stopped mining,
+    // so the current miner must NOT be demoted.
+    let (_, mut peer_info) = build_get_peer_info_response(None, None);
+    peer_info.stacks_tip_consensus_hash = ConsensusHash([0x77; 20]);
+    let json_payload = serde_json::to_string(&peer_info).unwrap();
+    let to_send_tip_mismatch = format!("HTTP/1.1 200 OK\n\n{json_payload}");
+
+    let MockServerClient {
+        mut server,
+        client,
+        config,
+    } = MockServerClient::new();
+    let expected_state = local_state_machine.clone();
+    let h = std::thread::spawn(move || {
+        local_state_machine
+            .check_miner_inactivity(&mut signer_db, &client, &proposal_config, &eval)
+            .unwrap();
+        // The timed out miner must remain the current miner: the prior miner cannot
+        // continue a tenure it does not own.
+        assert_eq!(local_state_machine, expected_state);
+        (local_state_machine, signer_db, proposal_config, eval)
+    });
+    crate::client::tests::write_response(server, to_send_1.as_bytes());
+    server = crate::client::tests::mock_server_from_config(&config);
+    crate::client::tests::write_response(server, to_send_tip_mismatch.as_bytes());
+    let (mut local_state_machine, mut signer_db, proposal_config, eval) = h.join().unwrap();
+
+    // Now the canonical stacks tip IS in the prior sortition's tenure, so the prior
+    // miner can continue it and the demotion should proceed.
+    let (_, mut peer_info) = build_get_peer_info_response(None, None);
+    peer_info.stacks_tip_consensus_hash = last_sortition.consensus_hash.clone();
+    let json_payload = serde_json::to_string(&peer_info).unwrap();
+    let to_send_tip_match = format!("HTTP/1.1 200 OK\n\n{json_payload}");
+
     // Next it will check if the prior sortition is both valid
     // and that it has chosen a good parent
     let expected_result = vec![
@@ -1246,6 +1283,9 @@ fn check_miner_inactivity_timeout() {
     });
 
     crate::client::tests::write_response(server, to_send_1.as_bytes());
+
+    server = crate::client::tests::mock_server_from_config(&config);
+    crate::client::tests::write_response(server, to_send_tip_match.as_bytes());
 
     server = crate::client::tests::mock_server_from_config(&config);
     crate::client::tests::write_response(server, to_send_2.as_bytes());

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -333,6 +333,21 @@ impl LocalStateMachine {
             return Ok(());
         }
 
+        // Only revert to the prior miner if its tenure is the canonical Stacks tip's
+        // tenure. A miner only continues (extends) a tenure it won, so if the canonical
+        // tip is in some other tenure due to a Bitcoin reorg orphaning the prior
+        // sortition's tenure, the prior miner's node has already stopped mining and
+        // will never propose again.
+        let stacks_tip_ch = client.get_peer_info()?.stacks_tip_consensus_hash;
+        if sortition_data.consensus_hash != stacks_tip_ch {
+            warn!(
+                "Signer State: Current miner timed out due to inactivity, but the canonical stacks tip is not in the prior miner's tenure, so the prior miner cannot continue it. Allowing current miner to continue";
+                "stacks_tip_consensus_hash" => %stacks_tip_ch,
+                "prior_sortition_consensus_hash" => %sortition_data.consensus_hash,
+            );
+            return Ok(());
+        }
+
         if !last_sortition.is_tenure_valid(db, client, proposal_config, eval)? {
             warn!("Signer State: Current miner timed out due to inactivity, but prior miner is not valid. Allowing current miner to continue");
             return Ok(());


### PR DESCRIPTION
We saw this in one of the Bitcoin reorgs last month. In this case, there's no point in timing out the latest miner if the previous miner could not possibly mine any blocks. A followup could select the actual previous miner that could take over, but that will be a more complicated change and so can be done in a separate PR.

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
