### PR TITLE
feat: rebroadcast `.miners` chunks

### DIFF
--- a/changelog.d/stackerdb-failed-push.fixed
+++ b/changelog.d/stackerdb-failed-push.fixed
@@ -1,0 +1,1 @@
+Remove a receiver from the StackerDB chunk push list when the send fails. This prevents an unavailable receiver from blocking other receivers or the end of the push round.

--- a/changelog.d/stackerdb-relay-hints-rebroadcast.fixed
+++ b/changelog.d/stackerdb-relay-hints-rebroadcast.fixed
@@ -1,0 +1,1 @@
+Keep relay hints when the node receives a StackerDB chunk and use them when it sends the chunk to other peers. The node now sends each locally uploaded `.miners` chunk once more after five seconds, which gives miner proposals another chance to reach peers without creating repeated retries at relay nodes.

--- a/changelog.d/stackerdb-upload-relay.fixed
+++ b/changelog.d/stackerdb-upload-relay.fixed
@@ -1,0 +1,1 @@
+Broadcast HTTP-uploaded StackerDB chunks even when no event observer is attached. This allows uploaded chunks to reach peers in configurations that do not use an event observer.

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -1535,8 +1535,8 @@ pub struct NetworkResult {
     pub uploaded_microblocks: Vec<MicroblocksData>,
     /// chunks we received from the HTTP server
     pub uploaded_stackerdb_chunks: Vec<StackerDBPushChunkData>,
-    /// chunks we received from p2p push
-    pub pushed_stackerdb_chunks: Vec<StackerDBPushChunkData>,
+    /// chunks we received from p2p push and their message relay hints
+    pub pushed_stackerdb_chunks: Vec<(Vec<RelayData>, StackerDBPushChunkData)>,
     /// Atlas attachments we obtained
     pub attachments: Vec<(AttachmentInstance, Attachment)>,
     /// transactions we downloaded via a mempool sync
@@ -1991,7 +1991,7 @@ impl NetworkResult {
         let newer_stackerdb_chunk_versions: HashMap<_, _> = newer
             .uploaded_stackerdb_chunks
             .iter()
-            .chain(newer.pushed_stackerdb_chunks.iter())
+            .chain(newer.pushed_stackerdb_chunks.iter().map(|(_, chunk)| chunk))
             .map(|chunk| {
                 (
                     (
@@ -2033,7 +2033,7 @@ impl NetworkResult {
             }
         });
 
-        self.pushed_stackerdb_chunks.retain(|push_chunk| {
+        self.pushed_stackerdb_chunks.retain(|(_, push_chunk)| {
             if push_chunk.rc_consensus_hash != newer.rc_consensus_hash {
                 debug!(
                     "Drop uploaded StackerDB chunk for {} due to stale view ({} != {}): {:?}",
@@ -2187,9 +2187,9 @@ impl NetworkResult {
                                 .insert(neighbor_key.clone(), vec![(message.relayers, block_data)]);
                         }
                     }
-                    StacksMessageType::StackerDBPushChunk(chunk_data) => {
-                        self.pushed_stackerdb_chunks.push(chunk_data)
-                    }
+                    StacksMessageType::StackerDBPushChunk(chunk_data) => self
+                        .pushed_stackerdb_chunks
+                        .push((message.relayers, chunk_data)),
                     _ => {
                         // forward along
                         if let Some(messages) = self.unhandled_messages.get_mut(&neighbor_key) {

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -95,6 +95,12 @@ impl NetworkHandle {
         NetworkHandle { chan_in }
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_channel(bufsz: usize) -> (Receiver<NetworkRequest>, NetworkHandle) {
+        let (msg_send, msg_recv) = sync_channel(bufsz);
+        (msg_recv, NetworkHandle::new(msg_send))
+    }
+
     /// Send out a command to the p2p thread.  Do not bother waiting for the response.
     /// Error out if the channel buffer is out of space
     fn send_request(&mut self, req: NetworkRequest) -> Result<(), net_error> {

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -2342,34 +2342,36 @@ impl Relayer {
         uploaded_chunks: Vec<StackerDBPushChunkData>,
         event_observer: Option<&dyn StackerDBEventDispatcher>,
     ) {
-        if let Some(observer) = event_observer {
-            let mut all_events: HashMap<QualifiedContractIdentifier, Vec<StackerDBChunkData>> =
-                HashMap::new();
-            for chunk in uploaded_chunks.into_iter() {
-                // forward if not stale
-                if chunk.rc_consensus_hash != *rc_consensus_hash {
-                    debug!("Drop stale uploaded StackerDB chunk";
+        let mut all_events: HashMap<QualifiedContractIdentifier, Vec<StackerDBChunkData>> =
+            HashMap::new();
+        for chunk in uploaded_chunks.into_iter() {
+            // forward if not stale
+            if chunk.rc_consensus_hash != *rc_consensus_hash {
+                debug!("Drop stale uploaded StackerDB chunk";
                            "stackerdb_contract_id" => %chunk.contract_id,
                            "slot_id" => chunk.chunk_data.slot_id,
                            "slot_version" => chunk.chunk_data.slot_version,
                            "chunk.rc_consensus_hash" => %chunk.rc_consensus_hash,
                            "network.rc_consensus_hash" => %rc_consensus_hash);
-                    continue;
-                }
+                continue;
+            }
 
+            if event_observer.is_some() {
                 if let Some(events) = all_events.get_mut(&chunk.contract_id) {
                     events.push(chunk.chunk_data.clone());
                 } else {
                     all_events.insert(chunk.contract_id.clone(), vec![chunk.chunk_data.clone()]);
                 }
-
-                debug!("Got uploaded StackerDB chunk"; "stackerdb_contract_id" => %chunk.contract_id, "slot_id" => chunk.chunk_data.slot_id, "slot_version" => chunk.chunk_data.slot_version);
-
-                let msg = StacksMessageType::StackerDBPushChunk(chunk);
-                if let Err(e) = self.p2p.broadcast_message(vec![], msg) {
-                    warn!("Failed to broadcast Nakamoto blocks: {e:?}");
-                }
             }
+
+            debug!("Got uploaded StackerDB chunk"; "stackerdb_contract_id" => %chunk.contract_id, "slot_id" => chunk.chunk_data.slot_id, "slot_version" => chunk.chunk_data.slot_version);
+
+            let msg = StacksMessageType::StackerDBPushChunk(chunk);
+            if let Err(e) = self.p2p.broadcast_message(vec![], msg) {
+                warn!("Failed to broadcast StackerDB chunk: {e:?}");
+            }
+        }
+        if let Some(observer) = event_observer {
             for (contract_id, new_chunks) in all_events.into_iter() {
                 observer.new_stackerdb_chunks(contract_id, new_chunks);
             }
@@ -3364,5 +3366,48 @@ impl PeerNetwork {
                 self.relayer_stats.add_relayed_message((*nk).clone(), tx);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::TryRecvError;
+
+    use stacks_common::util::secp256k1::MessageSignature;
+
+    use super::*;
+    use crate::net::p2p::{NetworkHandle, NetworkRequest};
+
+    /// An HTTP-uploaded StackerDB chunk is broadcast to peers whether or not an event observer
+    /// is attached.
+    #[test]
+    fn uploaded_chunk_is_broadcast_without_event_observer() {
+        let (requests, handle) = NetworkHandle::test_channel(4);
+        let mut relayer = Relayer::new(
+            handle,
+            ConnectionOptions::default(),
+            StackerDBs::connect_memory(),
+        );
+        let rc_consensus_hash = ConsensusHash([0x11; 20]);
+        let chunk = StackerDBPushChunkData {
+            contract_id: QualifiedContractIdentifier::transient(),
+            rc_consensus_hash: rc_consensus_hash.clone(),
+            chunk_data: StackerDBChunkData {
+                slot_id: 1,
+                slot_version: 2,
+                sig: MessageSignature::empty(),
+                data: vec![3],
+            },
+        };
+
+        relayer.process_uploaded_stackerdb_chunks(&rc_consensus_hash, vec![chunk.clone()], None);
+        match requests.try_recv().unwrap() {
+            NetworkRequest::Broadcast(relay_hints, StacksMessageType::StackerDBPushChunk(sent)) => {
+                assert!(relay_hints.is_empty());
+                assert_eq!(sent, chunk);
+            }
+            request => panic!("unexpected network request: {request:?}"),
+        }
+        assert!(matches!(requests.try_recv(), Err(TryRecvError::Empty)));
     }
 }

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -2367,29 +2367,6 @@ impl Relayer {
         event_observer: Option<&dyn StackerDBEventDispatcher>,
     ) {
         let mut pending = mem::take(&mut self.pending_miners_stackerdb_rebroadcasts);
-        pending.retain(|(retry_at, chunk)| {
-            if *retry_at > now {
-                return true;
-            }
-            if chunk.rc_consensus_hash != *rc_consensus_hash {
-                debug!("Drop stale delayed StackerDB rebroadcast";
-                    "stackerdb_contract_id" => %chunk.contract_id,
-                    "slot_id" => chunk.chunk_data.slot_id,
-                    "slot_version" => chunk.chunk_data.slot_version);
-                return false;
-            }
-            info!("Rebroadcast locally-uploaded .miners StackerDB chunk";
-                "slot_id" => chunk.chunk_data.slot_id,
-                "slot_version" => chunk.chunk_data.slot_version);
-            if let Err(e) = self
-                .p2p
-                .broadcast_message(vec![], StacksMessageType::StackerDBPushChunk(chunk.clone()))
-            {
-                warn!("Failed to rebroadcast .miners StackerDB chunk: {e:?}");
-            }
-            false
-        });
-        self.pending_miners_stackerdb_rebroadcasts = pending;
 
         let mut all_events: HashMap<QualifiedContractIdentifier, Vec<StackerDBChunkData>> =
             HashMap::new();
@@ -2422,15 +2399,74 @@ impl Relayer {
                 warn!("Failed to broadcast StackerDB chunk: {e:?}");
             }
             if schedule_retry {
-                self.pending_miners_stackerdb_rebroadcasts
-                    .push((now + MINERS_STACKERDB_REBROADCAST_DELAY_MS, chunk));
+                let previous = pending.iter_mut().find(|(_, pending_chunk)| {
+                    pending_chunk.contract_id == chunk.contract_id
+                        && pending_chunk.chunk_data.slot_id == chunk.chunk_data.slot_id
+                });
+                if let Some((retry_at, pending_chunk)) = previous {
+                    if pending_chunk.rc_consensus_hash != chunk.rc_consensus_hash
+                        || pending_chunk.chunk_data.slot_version <= chunk.chunk_data.slot_version
+                    {
+                        *retry_at = now + MINERS_STACKERDB_REBROADCAST_DELAY_MS;
+                        *pending_chunk = chunk;
+                    }
+                } else {
+                    pending.push((now + MINERS_STACKERDB_REBROADCAST_DELAY_MS, chunk));
+                }
             }
         }
+
+        pending.retain(|(retry_at, chunk)| {
+            if chunk.rc_consensus_hash != *rc_consensus_hash {
+                debug!("Drop stale delayed StackerDB rebroadcast";
+                    "stackerdb_contract_id" => %chunk.contract_id,
+                    "slot_id" => chunk.chunk_data.slot_id,
+                    "slot_version" => chunk.chunk_data.slot_version);
+                return false;
+            }
+            if *retry_at > now {
+                return true;
+            }
+
+            match self
+                .stacker_dbs
+                .get_slot_metadata(&chunk.contract_id, chunk.chunk_data.slot_id)
+            {
+                Ok(Some(metadata)) if metadata.slot_version > chunk.chunk_data.slot_version => {
+                    debug!("Drop locally superseded delayed StackerDB rebroadcast";
+                        "stackerdb_contract_id" => %chunk.contract_id,
+                        "slot_id" => chunk.chunk_data.slot_id,
+                        "slot_version" => chunk.chunk_data.slot_version,
+                        "local_slot_version" => metadata.slot_version);
+                    return false;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    warn!("Failed to inspect local StackerDB slot before delayed rebroadcast";
+                        "stackerdb_contract_id" => %chunk.contract_id,
+                        "slot_id" => chunk.chunk_data.slot_id,
+                        "error" => ?e);
+                }
+            }
+
+            debug!("Rebroadcast locally-uploaded .miners StackerDB chunk";
+                "slot_id" => chunk.chunk_data.slot_id,
+                "slot_version" => chunk.chunk_data.slot_version);
+            if let Err(e) = self
+                .p2p
+                .broadcast_message(vec![], StacksMessageType::StackerDBPushChunk(chunk.clone()))
+            {
+                warn!("Failed to rebroadcast .miners StackerDB chunk: {e:?}");
+            }
+            false
+        });
+
         if let Some(observer) = event_observer {
             for (contract_id, new_chunks) in all_events.into_iter() {
                 observer.new_stackerdb_chunks(contract_id, new_chunks);
             }
         }
+        self.pending_miners_stackerdb_rebroadcasts = pending;
     }
 
     /// Process newly-arrived chunks obtained from a peer stackerdb replica.
@@ -3441,6 +3477,7 @@ impl PeerNetwork {
 mod tests {
     use std::sync::mpsc::TryRecvError;
 
+    use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
     use stacks_common::util::secp256k1::MessageSignature;
 
     use super::*;
@@ -3536,6 +3573,121 @@ mod tests {
 
         relayer.process_uploaded_stackerdb_chunks_at(
             100 + 2 * MINERS_STACKERDB_REBROADCAST_DELAY_MS,
+            &rc_consensus_hash,
+            vec![],
+            None,
+        );
+        assert!(matches!(requests.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn newer_uploaded_miners_chunk_supersedes_pending_retry() {
+        let (requests, handle) = NetworkHandle::test_channel(4);
+        let mut relayer = Relayer::new(
+            handle,
+            ConnectionOptions::default(),
+            StackerDBs::connect_memory(),
+        );
+        let rc_consensus_hash = ConsensusHash([0x11; 20]);
+        let chunk_v1 = StackerDBPushChunkData {
+            contract_id: boot_code_id(MINERS_NAME, false),
+            rc_consensus_hash: rc_consensus_hash.clone(),
+            chunk_data: StackerDBChunkData {
+                slot_id: 1,
+                slot_version: 1,
+                sig: MessageSignature::empty(),
+                data: vec![1],
+            },
+        };
+        let mut chunk_v2 = chunk_v1.clone();
+        chunk_v2.chunk_data.slot_version = 2;
+        chunk_v2.chunk_data.data = vec![2];
+
+        relayer.process_uploaded_stackerdb_chunks_at(100, &rc_consensus_hash, vec![chunk_v1], None);
+        assert!(matches!(
+            requests.try_recv(),
+            Ok(NetworkRequest::Broadcast(
+                _,
+                StacksMessageType::StackerDBPushChunk(_)
+            ))
+        ));
+
+        // The newer upload must suppress the old due retry before it is broadcast.
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100 + MINERS_STACKERDB_REBROADCAST_DELAY_MS,
+            &rc_consensus_hash,
+            vec![chunk_v2.clone()],
+            None,
+        );
+        match requests.try_recv().unwrap() {
+            NetworkRequest::Broadcast(_, StacksMessageType::StackerDBPushChunk(sent)) => {
+                assert_eq!(sent, chunk_v2);
+            }
+            request => panic!("unexpected network request: {request:?}"),
+        }
+
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100 + 2 * MINERS_STACKERDB_REBROADCAST_DELAY_MS,
+            &rc_consensus_hash,
+            vec![],
+            None,
+        );
+        match requests.try_recv().unwrap() {
+            NetworkRequest::Broadcast(_, StacksMessageType::StackerDBPushChunk(sent)) => {
+                assert_eq!(sent, chunk_v2);
+            }
+            request => panic!("unexpected network request: {request:?}"),
+        }
+        assert!(matches!(requests.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn local_newer_miners_chunk_suppresses_pending_retry() {
+        let (requests, handle) = NetworkHandle::test_channel(4);
+        let mut relayer = Relayer::new(
+            handle,
+            ConnectionOptions::default(),
+            StackerDBs::connect_memory(),
+        );
+        let rc_consensus_hash = ConsensusHash([0x11; 20]);
+        let contract_id = boot_code_id(MINERS_NAME, false);
+        let signer_privkey = StacksPrivateKey::from_seed(&[42]);
+        let signer = StacksAddress::p2pkh(false, &StacksPublicKey::from_private(&signer_privkey));
+        let mut config = StackerDBConfig::noop();
+        config.signers = vec![(signer.clone(), 1)];
+        let tx = relayer.stacker_dbs.tx_begin(config).unwrap();
+        tx.create_stackerdb(&contract_id, &[(signer, 1)]).unwrap();
+        let mut local_chunk = StackerDBChunkData::new(0, 2, vec![2]);
+        local_chunk.sign(&signer_privkey).unwrap();
+        tx.try_replace_chunk(
+            &contract_id,
+            &local_chunk.get_slot_metadata(),
+            &local_chunk.data,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let pending_chunk = StackerDBPushChunkData {
+            contract_id,
+            rc_consensus_hash: rc_consensus_hash.clone(),
+            chunk_data: StackerDBChunkData::new(0, 1, vec![1]),
+        };
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100,
+            &rc_consensus_hash,
+            vec![pending_chunk],
+            None,
+        );
+        assert!(matches!(
+            requests.try_recv(),
+            Ok(NetworkRequest::Broadcast(
+                _,
+                StacksMessageType::StackerDBPushChunk(_)
+            ))
+        ));
+
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100 + MINERS_STACKERDB_REBROADCAST_DELAY_MS,
             &rc_consensus_hash,
             vec![],
             None,

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -39,6 +39,7 @@ use crate::chainstate::nakamoto::coordinator::{
 };
 use crate::chainstate::nakamoto::staging_blocks::NakamotoBlockObtainMethod;
 use crate::chainstate::nakamoto::{NakamotoBlock, NakamotoChainState};
+use crate::chainstate::stacks::boot::MINERS_NAME;
 use crate::chainstate::stacks::db::unconfirmed::ProcessedUnconfirmedState;
 use crate::chainstate::stacks::db::StacksChainState;
 use crate::chainstate::stacks::{StacksBlockHeader, TransactionPayload};
@@ -52,6 +53,7 @@ use crate::net::stackerdb::{
     StackerDBConfig, StackerDBEventDispatcher, StackerDBSyncResult, StackerDBs,
 };
 use crate::net::{Error as net_error, *};
+use crate::util_lib::boot::boot_code_id;
 
 pub type BlocksAvailableMap = HashMap<BurnchainHeaderHash, (u64, ConsensusHash)>;
 
@@ -59,6 +61,10 @@ pub const MAX_RELAYER_STATS: usize = 4096;
 pub const MAX_RECENT_MESSAGES: usize = 256;
 pub const MAX_RECENT_MESSAGE_AGE: usize = 600; // seconds; equal to the expected epoch length
 pub const RELAY_DUPLICATE_INFERENCE_WARMUP: usize = 128;
+/// Give a locally-uploaded miner proposal one more bounded fanout opportunity before its
+/// StackerDB slot can be overwritten. Only origin uploads are scheduled, so relays do not
+/// multiply this retry at each hop.
+pub const MINERS_STACKERDB_REBROADCAST_DELAY_MS: u128 = 5_000;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod fault_injection {
@@ -116,6 +122,8 @@ pub struct Relayer {
     /// Maps to tenure ID and timestamp, so we can garbage-collect.
     /// Timestamp is in milliseconds
     recently_sent_nakamoto_blocks: HashMap<StacksBlockId, (ConsensusHash, u128)>,
+    /// One-shot retries for locally HTTP-uploaded `.miners` chunks.
+    pending_miners_stackerdb_rebroadcasts: Vec<(u128, StackerDBPushChunkData)>,
 }
 
 #[derive(Debug)]
@@ -580,6 +588,7 @@ impl Relayer {
             connection_opts,
             stacker_dbs,
             recently_sent_nakamoto_blocks: HashMap::new(),
+            pending_miners_stackerdb_rebroadcasts: vec![],
         }
     }
 
@@ -2342,6 +2351,46 @@ impl Relayer {
         uploaded_chunks: Vec<StackerDBPushChunkData>,
         event_observer: Option<&dyn StackerDBEventDispatcher>,
     ) {
+        self.process_uploaded_stackerdb_chunks_at(
+            get_epoch_time_ms(),
+            rc_consensus_hash,
+            uploaded_chunks,
+            event_observer,
+        );
+    }
+
+    fn process_uploaded_stackerdb_chunks_at(
+        &mut self,
+        now: u128,
+        rc_consensus_hash: &ConsensusHash,
+        uploaded_chunks: Vec<StackerDBPushChunkData>,
+        event_observer: Option<&dyn StackerDBEventDispatcher>,
+    ) {
+        let mut pending = mem::take(&mut self.pending_miners_stackerdb_rebroadcasts);
+        pending.retain(|(retry_at, chunk)| {
+            if *retry_at > now {
+                return true;
+            }
+            if chunk.rc_consensus_hash != *rc_consensus_hash {
+                debug!("Drop stale delayed StackerDB rebroadcast";
+                    "stackerdb_contract_id" => %chunk.contract_id,
+                    "slot_id" => chunk.chunk_data.slot_id,
+                    "slot_version" => chunk.chunk_data.slot_version);
+                return false;
+            }
+            info!("Rebroadcast locally-uploaded .miners StackerDB chunk";
+                "slot_id" => chunk.chunk_data.slot_id,
+                "slot_version" => chunk.chunk_data.slot_version);
+            if let Err(e) = self
+                .p2p
+                .broadcast_message(vec![], StacksMessageType::StackerDBPushChunk(chunk.clone()))
+            {
+                warn!("Failed to rebroadcast .miners StackerDB chunk: {e:?}");
+            }
+            false
+        });
+        self.pending_miners_stackerdb_rebroadcasts = pending;
+
         let mut all_events: HashMap<QualifiedContractIdentifier, Vec<StackerDBChunkData>> =
             HashMap::new();
         for chunk in uploaded_chunks.into_iter() {
@@ -2366,9 +2415,15 @@ impl Relayer {
 
             debug!("Got uploaded StackerDB chunk"; "stackerdb_contract_id" => %chunk.contract_id, "slot_id" => chunk.chunk_data.slot_id, "slot_version" => chunk.chunk_data.slot_version);
 
-            let msg = StacksMessageType::StackerDBPushChunk(chunk);
+            let schedule_retry = chunk.contract_id == boot_code_id(MINERS_NAME, true)
+                || chunk.contract_id == boot_code_id(MINERS_NAME, false);
+            let msg = StacksMessageType::StackerDBPushChunk(chunk.clone());
             if let Err(e) = self.p2p.broadcast_message(vec![], msg) {
                 warn!("Failed to broadcast StackerDB chunk: {e:?}");
+            }
+            if schedule_retry {
+                self.pending_miners_stackerdb_rebroadcasts
+                    .push((now + MINERS_STACKERDB_REBROADCAST_DELAY_MS, chunk));
             }
         }
         if let Some(observer) = event_observer {
@@ -2446,7 +2501,10 @@ impl Relayer {
                             rc_consensus_hash: rc_consensus_hash.clone(),
                             chunk_data: chunk,
                         });
-                        if let Err(e) = self.p2p.broadcast_message(vec![], msg) {
+                        if let Err(e) = self
+                            .p2p
+                            .broadcast_message(sync_result.relay_hints.clone(), msg)
+                        {
                             warn!("Failed to broadcast StackerDB chunk: {e:?}");
                         }
                     }
@@ -2471,15 +2529,25 @@ impl Relayer {
         &mut self,
         rc_consensus_hash: &ConsensusHash,
         stackerdb_configs: &HashMap<QualifiedContractIdentifier, StackerDBConfig>,
-        stackerdb_chunks: Vec<StackerDBPushChunkData>,
+        stackerdb_chunks: Vec<(Vec<RelayData>, StackerDBPushChunkData)>,
         event_observer: Option<&dyn StackerDBEventDispatcher>,
     ) -> Result<(), Error> {
         // synthesize StackerDBSyncResults from each chunk
         let sync_results = stackerdb_chunks
             .into_iter()
-            .map(|chunk_data| {
-                debug!("Received pushed StackerDB chunk {chunk_data:?}");
-                let sync_result = StackerDBSyncResult::from_pushed_chunk(chunk_data);
+            .map(|(relay_hints, chunk_data)| {
+                if chunk_data.contract_id == boot_code_id(MINERS_NAME, true)
+                    || chunk_data.contract_id == boot_code_id(MINERS_NAME, false)
+                {
+                    // A received `.miners` push is rare (one per block proposal), and the time
+                    // at which each node first saw a proposal is the primary diagnostic for
+                    // proposal-propagation stalls, so log it at INFO.
+                    info!("Received pushed .miners StackerDB chunk";
+                        "slot_id" => chunk_data.chunk_data.slot_id,
+                        "slot_version" => chunk_data.chunk_data.slot_version,
+                        "data_hash" => %chunk_data.chunk_data.data_hash());
+                }
+                let sync_result = StackerDBSyncResult::from_pushed_chunk(relay_hints, chunk_data);
                 sync_result
             })
             .collect();
@@ -3377,7 +3445,6 @@ mod tests {
 
     use super::*;
     use crate::net::p2p::{NetworkHandle, NetworkRequest};
-
     /// An HTTP-uploaded StackerDB chunk is broadcast to peers whether or not an event observer
     /// is attached.
     #[test]
@@ -3408,6 +3475,71 @@ mod tests {
             }
             request => panic!("unexpected network request: {request:?}"),
         }
+        assert!(matches!(requests.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn uploaded_miners_chunk_is_broadcast_once_then_retried_once() {
+        let (requests, handle) = NetworkHandle::test_channel(4);
+        let mut relayer = Relayer::new(
+            handle,
+            ConnectionOptions::default(),
+            StackerDBs::connect_memory(),
+        );
+        let rc_consensus_hash = ConsensusHash([0x11; 20]);
+        let chunk = StackerDBPushChunkData {
+            contract_id: boot_code_id(MINERS_NAME, false),
+            rc_consensus_hash: rc_consensus_hash.clone(),
+            chunk_data: StackerDBChunkData {
+                slot_id: 1,
+                slot_version: 2,
+                sig: MessageSignature::empty(),
+                data: vec![3],
+            },
+        };
+
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100,
+            &rc_consensus_hash,
+            vec![chunk.clone()],
+            None,
+        );
+        match requests.try_recv().unwrap() {
+            NetworkRequest::Broadcast(relay_hints, StacksMessageType::StackerDBPushChunk(sent)) => {
+                assert!(relay_hints.is_empty());
+                assert_eq!(sent, chunk);
+            }
+            request => panic!("unexpected network request: {request:?}"),
+        }
+
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100 + MINERS_STACKERDB_REBROADCAST_DELAY_MS - 1,
+            &rc_consensus_hash,
+            vec![],
+            None,
+        );
+        assert!(matches!(requests.try_recv(), Err(TryRecvError::Empty)));
+
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100 + MINERS_STACKERDB_REBROADCAST_DELAY_MS,
+            &rc_consensus_hash,
+            vec![],
+            None,
+        );
+        match requests.try_recv().unwrap() {
+            NetworkRequest::Broadcast(relay_hints, StacksMessageType::StackerDBPushChunk(sent)) => {
+                assert!(relay_hints.is_empty());
+                assert_eq!(sent, chunk);
+            }
+            request => panic!("unexpected network request: {request:?}"),
+        }
+
+        relayer.process_uploaded_stackerdb_chunks_at(
+            100 + 2 * MINERS_STACKERDB_REBROADCAST_DELAY_MS,
+            &rc_consensus_hash,
+            vec![],
+            None,
+        );
         assert!(matches!(requests.try_recv(), Err(TryRecvError::Empty)));
     }
 }

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -132,8 +132,9 @@ use crate::net::connection::ConnectionOptions;
 use crate::net::neighbors::NeighborComms;
 use crate::net::p2p::PeerNetwork;
 use crate::net::{
-    Error as net_error, NackData, NackErrorCodes, NeighborAddress, Preamble, StackerDBChunkData,
-    StackerDBChunkInvData, StackerDBGetChunkData, StackerDBPushChunkData, StacksMessageType,
+    Error as net_error, NackData, NackErrorCodes, NeighborAddress, Preamble, RelayData,
+    StackerDBChunkData, StackerDBChunkInvData, StackerDBGetChunkData, StackerDBPushChunkData,
+    StacksMessageType,
 };
 use crate::util_lib::boot::boot_code_id;
 use crate::util_lib::db::{DBConn, DBTx, Error as db_error};
@@ -158,6 +159,8 @@ pub struct StackerDBSyncResult {
     pub chunk_invs: HashMap<NeighborAddress, StackerDBChunkInvData>,
     /// list of data to store
     pub chunks_to_store: Vec<StackerDBChunkData>,
+    /// relay history supplied with a pushed chunk; empty for inventory/pull synchronization
+    pub relay_hints: Vec<RelayData>,
     /// neighbors that have stale views, but are otherwise online
     pub(crate) stale: HashSet<NeighborAddress>,
     /// number of connections made
@@ -457,11 +460,15 @@ pub struct StackerDBSync<NC: NeighborComms> {
 impl StackerDBSyncResult {
     /// The receipt of a single StackerDBPushChunk message is equivalent to performing a single
     /// sync
-    pub fn from_pushed_chunk(chunk: StackerDBPushChunkData) -> StackerDBSyncResult {
+    pub fn from_pushed_chunk(
+        relay_hints: Vec<RelayData>,
+        chunk: StackerDBPushChunkData,
+    ) -> StackerDBSyncResult {
         StackerDBSyncResult {
             contract_id: chunk.contract_id,
             chunk_invs: HashMap::new(),
             chunks_to_store: vec![chunk.chunk_data],
+            relay_hints,
             stale: HashSet::new(),
             num_attempted_connections: 0,
             num_connections: 0,

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -1231,7 +1231,11 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
 
             let chunk_push = cur_push_priority.0.clone();
             // try the first neighbor in the chunk_push_priorities list
-            let selected_neighbor_opt = cur_push_priority.1.first().map(|neighbor| (0, neighbor));
+            let selected_neighbor_opt = cur_push_priority
+                .1
+                .first()
+                .cloned()
+                .map(|neighbor| (0, neighbor));
 
             let Some((idx, selected_neighbor)) = selected_neighbor_opt else {
                 debug!("{:?}: {}: pushchunks_begin: no available neighbor to send StackerDBChunk(id={},ver={}) to",
@@ -1258,17 +1262,24 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
 
             let slot_id = chunk_push.chunk_data.slot_id;
             let slot_version = chunk_push.chunk_data.slot_version;
-            if let Err(e) = self.comms.neighbor_send(
+            let send_result = self.comms.neighbor_send(
                 network,
-                selected_neighbor,
+                &selected_neighbor,
                 StacksMessageType::StackerDBPushChunk(chunk_push),
-            ) {
+            );
+
+            // Whether the send succeeded or failed, do not try this same neighbor again for this
+            // chunk.
+            cur_push_priority.1.remove(idx);
+            cur_priority = (cur_priority + 1) % self.chunk_push_priorities.len();
+
+            if let Err(e) = send_result {
                 info!(
                     "{:?}: {}: Failed to send chunk {} from {:?}: {:?}",
                     network.get_local_peer(),
                     &self.smart_contract_id,
                     slot_id,
-                    selected_neighbor,
+                    &selected_neighbor,
                     &e
                 );
                 continue;
@@ -1277,12 +1288,6 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             // record what we just sent
             self.chunk_push_receipts
                 .insert(selected_neighbor.clone(), (slot_id, slot_version));
-
-            // don't send to this neighbor again
-            cur_push_priority.1.remove(idx);
-
-            // next-prioritized chunk
-            cur_priority = (cur_priority + 1) % self.chunk_push_priorities.len();
 
             num_sent += 1;
             if num_sent > self.request_capacity {

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -190,6 +190,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             contract_id: self.smart_contract_id.clone(),
             chunk_invs,
             chunks_to_store: chunks,
+            relay_hints: vec![],
             stale: std::mem::replace(&mut self.stale_neighbors, HashSet::new()),
             num_connections: self.num_connections,
             num_attempted_connections: self.num_attempted_connections,

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -22,6 +22,7 @@ use stacks_common::address::C32_ADDRESS_VERSION_MAINNET_SINGLESIG;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, ConsensusHash, StacksAddress, StacksPublicKey,
 };
+use stacks_common::types::net::PeerAddress;
 use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::Secp256k1PrivateKey;
 
@@ -29,7 +30,9 @@ use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::net::p2p::PeerNetwork;
 use crate::net::stackerdb::StackerDBConfig;
 use crate::net::test::{TestPeer, TestPeerConfig};
-use crate::net::{Error as net_error, NetworkResult, StackerDBChunkData};
+use crate::net::{
+    Error as net_error, NeighborAddress, NetworkResult, StackerDBChunkData, StackerDBPushChunkData,
+};
 use crate::util_lib::test::with_timeout;
 
 const BASE_PORT: u16 = 33000;
@@ -1280,4 +1283,82 @@ fn test_validate_received_chunk_accepts_max_size() {
         .validate_received_chunk(&contract_id, &stackerdb_config, &chunk, &expected_versions)
         .unwrap();
     assert!(result, "a chunk within chunk_size must pass the size gate");
+}
+
+/// [`StackerDBSync::pushchunks_begin`] must consume a receiver whose send fails, exactly as it
+/// consumes one whose send succeeds: an unreachable neighbor at the head of a chunk's receiver
+/// list must not starve the chunk's push to the remaining receivers, and the state machine must
+/// still drain its schedule and report the round done.
+#[test]
+fn test_pushchunks_begin_consumes_failed_receiver() {
+    let mut peer_config = TestPeerConfig::from_port(BASE_PORT + 120);
+    peer_config.allowed = -1;
+
+    let idx = add_stackerdb(&mut peer_config, Some(StackerDBConfig::template()));
+    let mut peer = TestPeer::new(peer_config);
+    setup_stackerdb(&mut peer, idx, true, 1);
+
+    let contract_id = peer.config.stacker_dbs[idx].clone();
+    let rc_consensus_hash = peer.network.get_chain_view().rc_consensus_hash.clone();
+
+    // Two receivers that are not connected peers, so `neighbor_send` fails with
+    // PeerNotConnected for each.
+    let dead_receiver_1 = NeighborAddress {
+        addrbytes: PeerAddress([1u8; 16]),
+        port: 1,
+        public_key_hash: Hash160([0x11; 20]),
+    };
+    let dead_receiver_2 = NeighborAddress {
+        addrbytes: PeerAddress([2u8; 16]),
+        port: 2,
+        public_key_hash: Hash160([0x22; 20]),
+    };
+
+    let chunk_push = StackerDBPushChunkData {
+        contract_id: contract_id.clone(),
+        rc_consensus_hash,
+        chunk_data: StackerDBChunkData::new(0, 1, vec![7u8; 32]),
+    };
+
+    let mut stacker_db_syncs = peer
+        .network
+        .stacker_db_syncs
+        .take()
+        .expect("network must hold stacker DB sync machines");
+    let sync = stacker_db_syncs
+        .get_mut(&contract_id)
+        .expect("sync machine must exist for the test stackerdb");
+
+    // Plant a push schedule directly (bypassing make_chunk_push_schedule) with both dead
+    // receivers queued behind one chunk.
+    sync.chunk_push_priorities = vec![(
+        chunk_push,
+        vec![dead_receiver_1.clone(), dead_receiver_2.clone()],
+    )];
+    sync.next_chunk_push_priority = 0;
+
+    // Pass 1: the send to dead_receiver_1 fails; the receiver must be consumed anyway.
+    let done = sync.pushchunks_begin(&mut peer.network).unwrap();
+    assert!(!done, "one receiver must remain after the first pass");
+    assert_eq!(
+        sync.chunk_push_priorities[0].1,
+        vec![dead_receiver_2.clone()],
+        "the failed receiver must be removed, not retried"
+    );
+    assert!(
+        sync.chunk_push_receipts.is_empty(),
+        "a failed send must not record a push receipt"
+    );
+
+    // Pass 2: the send to dead_receiver_2 fails; the schedule must drain and the state
+    // machine must report done instead of spinning on dead receivers forever.
+    let done = sync.pushchunks_begin(&mut peer.network).unwrap();
+    assert!(
+        done,
+        "all receivers consumed: pushchunks_begin must report done"
+    );
+    assert!(sync.chunk_push_priorities[0].1.is_empty());
+    assert!(sync.chunk_push_receipts.is_empty());
+
+    peer.network.stacker_db_syncs = Some(stacker_db_syncs);
 }

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -39,7 +39,7 @@ use stacks_common::types::chainstate::{
 };
 use stacks_common::types::net::PeerAddress;
 use stacks_common::types::Address;
-use stacks_common::util::hash::Sha512Trunc256Sum;
+use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::MessageSignature;
 
 use crate::burnchains::PoxConstants;
@@ -69,8 +69,9 @@ use crate::core::{StacksEpoch, StacksEpochExtension};
 use crate::net::relay::Relayer;
 use crate::net::test::{RPCHandlerArgsType, TestEventObserver, TestPeer, TestPeerConfig};
 use crate::net::{
-    BlocksData, BlocksDatum, MicroblocksData, NakamotoBlocksData, NeighborKey, NetworkResult,
-    PingData, StackerDBPushChunkData, StacksMessage, StacksMessageType, StacksNodeState,
+    BlocksData, BlocksDatum, MicroblocksData, NakamotoBlocksData, NeighborAddress, NeighborKey,
+    NetworkResult, PingData, RelayData, StackerDBPushChunkData, StacksMessage, StacksMessageType,
+    StacksNodeState,
 };
 use crate::util_lib::boot::{boot_code_addr, boot_code_id, boot_code_tx_auth};
 
@@ -1506,7 +1507,7 @@ fn test_network_result_update() {
         .push(uploaded_nblk1);
     network_result_1
         .pushed_stackerdb_chunks
-        .push(pushed_stackerdb_chunk_1);
+        .push((vec![], pushed_stackerdb_chunk_1));
     network_result_1
         .uploaded_stackerdb_chunks
         .push(uploaded_stackerdb_chunk_1);
@@ -1565,7 +1566,7 @@ fn test_network_result_update() {
         .push(uploaded_nblk2);
     network_result_2
         .pushed_stackerdb_chunks
-        .push(pushed_stackerdb_chunk_2);
+        .push((vec![], pushed_stackerdb_chunk_2));
     network_result_2
         .uploaded_stackerdb_chunks
         .push(uploaded_stackerdb_chunk_2);
@@ -1741,15 +1742,17 @@ fn test_network_result_update() {
         },
     };
 
-    old.pushed_stackerdb_chunks.push(old_chunk_1);
+    old.pushed_stackerdb_chunks.push((vec![], old_chunk_1));
     // replaced
-    new.pushed_stackerdb_chunks.push(new_chunk_1.clone());
+    new.pushed_stackerdb_chunks
+        .push((vec![], new_chunk_1.clone()));
     // included
-    new.pushed_stackerdb_chunks.push(new_chunk_2.clone());
+    new.pushed_stackerdb_chunks
+        .push((vec![], new_chunk_2.clone()));
 
     assert_eq!(
         old.update(new).pushed_stackerdb_chunks,
-        vec![new_chunk_1, new_chunk_2]
+        vec![(vec![], new_chunk_1), (vec![], new_chunk_2)]
     );
 
     // nakamoto blocks obtained via download, upload, or pushed get consoldated
@@ -1854,6 +1857,64 @@ fn test_network_result_update() {
     assert!(updated_uploaded.pushed_nakamoto_blocks.is_empty());
     assert_eq!(updated_uploaded.uploaded_nakamoto_blocks.len(), 1);
     assert_eq!(updated_uploaded.uploaded_nakamoto_blocks[0], nblk1);
+}
+
+#[test]
+fn test_network_result_preserves_stackerdb_relay_hints() {
+    let rc_consensus_hash = ConsensusHash([0x11; 20]);
+    let chunk = StackerDBPushChunkData {
+        contract_id: QualifiedContractIdentifier::transient(),
+        rc_consensus_hash: rc_consensus_hash.clone(),
+        chunk_data: StackerDBChunkData {
+            slot_id: 1,
+            slot_version: 2,
+            sig: MessageSignature::empty(),
+            data: vec![3],
+        },
+    };
+    let relay_hint = RelayData {
+        peer: NeighborAddress {
+            addrbytes: PeerAddress([0x22; 16]),
+            port: 20444,
+            public_key_hash: Hash160([0x33; 20]),
+        },
+        seq: 7,
+    };
+    let neighbor = NeighborKey {
+        peer_version: 1,
+        network_id: 1,
+        addrbytes: PeerAddress([0x44; 16]),
+        port: 20444,
+    };
+    let mut message = StacksMessage::new(
+        1,
+        1,
+        1,
+        &BurnchainHeaderHash([0x55; 32]),
+        1,
+        &BurnchainHeaderHash([0x55; 32]),
+        StacksMessageType::StackerDBPushChunk(chunk.clone()),
+    );
+    message.relayers = vec![relay_hint.clone()];
+
+    let mut result = NetworkResult::new(
+        StacksBlockId([0x66; 32]),
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        rc_consensus_hash,
+        HashMap::new(),
+    );
+    result.consume_unsolicited(HashMap::from([((1, neighbor), vec![message])]));
+
+    assert_eq!(
+        result.pushed_stackerdb_chunks,
+        vec![(vec![relay_hint], chunk)]
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
This builds on top of #7532, with additional functionality for rebroadcasting `.miners` chunks after a 5-seconds delay. This should add some "defense in depth" to ensuring that signers receive block proposals from miners.