### PR TITLE
chore: update to clarity-wasm branch `fix/match-bind-used`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 [[package]]
 name = "clar2wasm"
 version = "0.1.0"
-source = "git+https://github.com/stx-labs/clarity-wasm.git#02bf6737d4a4bed0f42a0b557f50ebaba19f5f3f"
+source = "git+https://github.com/stx-labs/clarity-wasm.git#ca141c9770edc2812890773ad462319956dc1754"
 dependencies = [
  "chrono",
  "clap",


### PR DESCRIPTION
This is not yet merged, but in PR 844. It includes a bunch of fixes that I'd like to run a block replay on.