### PR TITLE
test: adapt tests to require analysis for deployment

### DIFF
--- a/clarity/src/vm/tests/contracts.rs
+++ b/clarity/src/vm/tests/contracts.rs
@@ -239,17 +239,19 @@ fn test_contract_caller(epoch: StacksEpochId, mut env_factory: MemoryEnvironment
         let (mut exec_state, invoke_ctx) =
             owned_env.get_exec_environment(None, None, &placeholder_context);
         exec_state
-            .initialize_contract(
+            .initialize_contract_with_db(
                 &invoke_ctx,
                 QualifiedContractIdentifier::local("contract-a").unwrap(),
                 contract_a,
+                &mut analysis_db,
             )
             .unwrap();
         exec_state
-            .initialize_contract(
+            .initialize_contract_with_db(
                 &invoke_ctx,
                 QualifiedContractIdentifier::local("contract-b").unwrap(),
                 contract_b,
+                &mut analysis_db,
             )
             .unwrap();
     }
@@ -1194,12 +1196,12 @@ fn test_at_unknown_block(
             e => panic!("Unexpected error: {e}"),
         }
     } else {
-        match err {
-            ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(x)) => {
-                assert_eq!(x, RuntimeCheckErrorKind::AtBlockUnavailable)
-            }
-            e => panic!("Unexpected error: {e}"),
-        }
+        // From Epoch 3.4 on, `at-block` no longer exists, so the contract is
+        // rejected by analysis during initialization rather than at runtime.
+        assert!(
+            err.to_string().contains("AtBlockUnavailable"),
+            "expected analysis to reject `at-block`, got: {err}"
+        );
     }
 }
 
@@ -1290,18 +1292,33 @@ fn test_cc_stack_depth(
     let contract_two = "(unwrap-panic (contract-call? .c-foo foo))";
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
+
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
+
     let (mut exec_state, invoke_ctx) =
         owned_env.get_exec_environment(None, None, &placeholder_context);
 
     let contract_identifier = QualifiedContractIdentifier::local("c-foo").unwrap();
     exec_state
-        .initialize_contract(&invoke_ctx, contract_identifier, &contract_one)
+        .initialize_contract_with_db(
+            &invoke_ctx,
+            contract_identifier,
+            &contract_one,
+            &mut analysis_db,
+        )
         .unwrap();
 
     let contract_identifier = QualifiedContractIdentifier::local("c-bar").unwrap();
     assert_eq!(
         exec_state
-            .initialize_contract(&invoke_ctx, contract_identifier, contract_two)
+            .initialize_contract_with_db(
+                &invoke_ctx,
+                contract_identifier,
+                contract_two,
+                &mut analysis_db
+            )
             .unwrap_err(),
         RuntimeError::MaxStackDepthReached.into()
     );
@@ -1581,27 +1598,34 @@ fn test_contract_hash_type_check(
     let mut owned_env = env_factory.get_env(epoch);
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
+
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
     let (mut exec_state, invoke_ctx) =
         owned_env.get_exec_environment(None, None, &placeholder_context);
 
-    // Deploy a contract with a type-check error in the `contract-hash?` expression
-    // Note that this would usually fail in analysis, but we've skipped it here.
+    // Deploy a contract with a type-check error in the `contract-hash?`
+    // expression. Analysis now runs as part of contract initialization, so the
+    // type error is caught there and the contract is never deployed; the
+    // equivalent runtime check (`ExpectedContractPrincipalValue`) is
+    // unreachable from here.
     let test_contract = QualifiedContractIdentifier::local("test-contract").unwrap();
     let test_program = "(define-read-only (get-hash) (contract-hash? u123))";
 
-    exec_state
-        .initialize_contract(&invoke_ctx, test_contract.clone(), test_program)
-        .unwrap();
-
-    // Attempt to execute the contract, expecting a type-check error
     let err = exec_state
-        .execute_contract(&invoke_ctx, &test_contract, "get-hash", &[], true)
+        .initialize_contract_with_db(
+            &invoke_ctx,
+            test_contract.clone(),
+            test_program,
+            &mut analysis_db,
+        )
         .unwrap_err();
-    assert_eq!(
-        err,
-        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::ExpectedContractPrincipalValue(
-            Value::UInt(123).to_error_string()
-        ))
+
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("TypeError") && err_msg.contains("PrincipalType"),
+        "expected analysis to reject a uint argument to `contract-hash?`, got: {err}"
     );
 }
 
@@ -1619,6 +1643,10 @@ fn test_contract_hash_pre_clarity4(
     let mut owned_env = env_factory.get_env(epoch);
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
+
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
     let (mut exec_state, invoke_ctx) =
         owned_env.get_exec_environment(None, None, &placeholder_context);
 
@@ -1628,7 +1656,12 @@ fn test_contract_hash_pre_clarity4(
     let expected_hash = Sha512Trunc256Sum::from_data(contract_content.as_bytes());
 
     exec_state
-        .initialize_contract(&invoke_ctx, other_contract.clone(), contract_content)
+        .initialize_contract_with_db(
+            &invoke_ctx,
+            other_contract.clone(),
+            contract_content,
+            &mut analysis_db,
+        )
         .unwrap();
 
     // Test successful contract hash retrieval
@@ -1636,30 +1669,23 @@ fn test_contract_hash_pre_clarity4(
     let test_program =
         "(define-read-only (get-hash (contract principal)) (contract-hash? contract))";
 
-    exec_state
-        .initialize_contract(&invoke_ctx, test_contract.clone(), test_program)
-        .unwrap();
-
-    // Attempt to get the hash of the other contract and expect it to be
-    // successful and for the returned hash to match the expected hash.
-    let standard_principal = QualifiedContractIdentifier::local("standard-principal").unwrap();
+    // Analysis runs as part of contract initialization, so a contract using
+    // `contract-hash?` before Clarity 4 cannot be deployed at all: the function
+    // is rejected by the type checker and the old runtime rejection (an
+    // `UndefinedFunction` runtime check) is unreachable.
     let err = exec_state
-        .execute_contract(
+        .initialize_contract_with_db(
             &invoke_ctx,
-            &test_contract,
-            "get-hash",
-            &symbols_from_values(vec![Value::Principal(PrincipalData::Contract(
-                other_contract.clone(),
-            ))]),
-            true,
+            test_contract.clone(),
+            test_program,
+            &mut analysis_db,
         )
         .unwrap_err();
 
-    assert_eq!(
-        err,
-        VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::UndefinedFunction(
-            "contract-hash?".to_string()
-        ))
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("UnknownFunction") && err_msg.contains("contract-hash?"),
+        "expected analysis to reject `contract-hash?` before Clarity 4, got: {err}"
     );
 }
 
@@ -1682,23 +1708,37 @@ fn test_contract_call_with_constant(
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
 
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
+
     {
         let (mut exec_env, invoke_ctx) =
             owned_env.get_exec_environment(None, None, &placeholder_context);
         exec_env
-            .initialize_contract(
+            .initialize_contract_with_db(
                 &invoke_ctx,
                 QualifiedContractIdentifier::local("contract-a").unwrap(),
                 contract_a,
+                &mut analysis_db,
             )
             .unwrap();
-        exec_env
-            .initialize_contract(
-                &invoke_ctx,
-                QualifiedContractIdentifier::local("contract-b").unwrap(),
-                contract_b,
-            )
-            .unwrap();
+        let deploy_result = exec_env.initialize_contract_with_db(
+            &invoke_ctx,
+            QualifiedContractIdentifier::local("contract-b").unwrap(),
+            contract_b,
+            &mut analysis_db,
+        );
+
+        if !version.supports_callables() {
+            let err = deploy_result.unwrap_err();
+            assert!(
+                err.to_string().contains("TraitReferenceUnknown"),
+                "expected analysis to reject a callable constant in Clarity 1, got: {err}"
+            );
+            return;
+        }
+        deploy_result.unwrap();
     }
 
     let (mut exec_env, invoke_ctx) = owned_env.get_exec_environment(
@@ -1745,27 +1785,45 @@ fn test_contract_call_with_constant_at_deploy(
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
 
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
+
     let (mut exec_env, invoke_ctx) =
         owned_env.get_exec_environment(None, None, &placeholder_context);
     exec_env
-        .initialize_contract(
+        .initialize_contract_with_db(
             &invoke_ctx,
             QualifiedContractIdentifier::local("contract-a").unwrap(),
             contract_a,
+            &mut analysis_db,
         )
         .unwrap();
-    let call_result = exec_env.initialize_contract(
+    let call_result = exec_env.initialize_contract_with_db(
         &invoke_ctx,
         QualifiedContractIdentifier::local("contract-b").unwrap(),
         contract_b,
+        &mut analysis_db,
     );
 
-    assert_eq!(
-        call_result.unwrap_err(),
-        ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-            RuntimeCheckErrorKind::ContractCallExpectName
-        )),
-    );
+    let err = call_result.unwrap_err();
+    if version.supports_callables() {
+        // The constant type-checks from Clarity 2 on, so the contract is
+        // deployed and the call at deploy time is what gets rejected.
+        assert_eq!(
+            err,
+            ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
+                RuntimeCheckErrorKind::ContractCallExpectName
+            )),
+        );
+    } else {
+        // Clarity 1 has no callable constants, so analysis (which now runs as
+        // part of contract initialization) rejects the contract first.
+        assert!(
+            err.to_string().contains("TraitReferenceUnknown"),
+            "expected analysis to reject a callable constant in Clarity 1, got: {err}"
+        );
+    }
 }
 
 /// Calling from a deploying contract into a contract which uses contract-calls via define-constant
@@ -1793,26 +1851,45 @@ fn test_nested_cc_with_constant_at_deploy(
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
 
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
+
     let (mut exec_env, invoke_ctx) =
         owned_env.get_exec_environment(None, None, &placeholder_context);
     exec_env
-        .initialize_contract(
+        .initialize_contract_with_db(
             &invoke_ctx,
             QualifiedContractIdentifier::local("contract-a").unwrap(),
             contract_a,
+            &mut analysis_db,
         )
         .unwrap();
-    exec_env
-        .initialize_contract(
-            &invoke_ctx,
-            QualifiedContractIdentifier::local("contract-b").unwrap(),
-            contract_b,
-        )
-        .unwrap();
-    let call_result = exec_env.initialize_contract(
+    let contract_b_result = exec_env.initialize_contract_with_db(
+        &invoke_ctx,
+        QualifiedContractIdentifier::local("contract-b").unwrap(),
+        contract_b,
+        &mut analysis_db,
+    );
+
+    // Clarity 1 has no callable constants, so `contract-b` itself is rejected
+    // by analysis (which now runs as part of contract initialization) and
+    // `contract-c` never gets a contract to call into.
+    if !version.supports_callables() {
+        let err = contract_b_result.unwrap_err();
+        assert!(
+            err.to_string().contains("TraitReferenceUnknown"),
+            "expected analysis to reject a callable constant in Clarity 1, got: {err}"
+        );
+        return;
+    }
+    contract_b_result.unwrap();
+
+    let call_result = exec_env.initialize_contract_with_db(
         &invoke_ctx,
         QualifiedContractIdentifier::local("contract-c").unwrap(),
         contract_c,
+        &mut analysis_db,
     );
 
     if epoch.supports_call_with_constant() && version.supports_callables() {
@@ -1850,23 +1927,41 @@ fn test_constant_to_trait(
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
 
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
+
     {
         let (mut exec_env, invoke_ctx) =
             owned_env.get_exec_environment(None, None, &placeholder_context);
         exec_env
-            .initialize_contract(
+            .initialize_contract_with_db(
                 &invoke_ctx,
                 QualifiedContractIdentifier::local("contract-a").unwrap(),
                 contract_a,
+                &mut analysis_db,
             )
             .unwrap();
-        exec_env
-            .initialize_contract(
-                &invoke_ctx,
-                QualifiedContractIdentifier::local("contract-b").unwrap(),
-                contract_b,
-            )
-            .unwrap();
+        let deploy_result = exec_env.initialize_contract_with_db(
+            &invoke_ctx,
+            QualifiedContractIdentifier::local("contract-b").unwrap(),
+            contract_b,
+            &mut analysis_db,
+        );
+
+        // Passing a contract principal held in a constant to a trait parameter
+        // requires callable types, which only exist from Clarity 2 on. Before
+        // that, analysis (which now runs as part of contract initialization)
+        // rejects the contract.
+        if !version.supports_callables() {
+            let err = deploy_result.unwrap_err();
+            assert!(
+                err.to_string().contains("TypeError"),
+                "expected analysis to reject a constant used as a trait in Clarity 1, got: {err}"
+            );
+            return;
+        }
+        deploy_result.unwrap();
     }
 
     let (mut exec_env, invoke_ctx) = owned_env.get_exec_environment(
@@ -2028,21 +2123,27 @@ fn test_constant_contract_principal_dual_use(
     let placeholder_context =
         ContractContext::new(QualifiedContractIdentifier::transient(), version);
 
+    let mut store = MemoryBackingStore::new();
+    let mut analysis_db = store.as_analysis_db();
+    analysis_db.begin();
+
     {
         let (mut exec_env, invoke_ctx) =
             owned_env.get_exec_environment(None, None, &placeholder_context);
         exec_env
-            .initialize_contract(
+            .initialize_contract_with_db(
                 &invoke_ctx,
                 QualifiedContractIdentifier::local("contract-a").unwrap(),
                 contract_a,
+                &mut analysis_db,
             )
             .unwrap();
         exec_env
-            .initialize_contract(
+            .initialize_contract_with_db(
                 &invoke_ctx,
                 QualifiedContractIdentifier::local("contract-b").unwrap(),
                 contract_b,
+                &mut analysis_db,
             )
             .unwrap();
     }

--- a/clarity/src/vm/tests/hooks.rs
+++ b/clarity/src/vm/tests/hooks.rs
@@ -69,7 +69,7 @@ fn eval_hook_captures_failed_top_level_execution_lifecycle() {
     let contract_id = QualifiedContractIdentifier::local("trace-lifecycle-failure").unwrap();
     let source = r#"
         (define-public (entry)
-          (/ u1 u0))
+          (ok (/ u1 u0)))
     "#;
 
     env.initialize_versioned_contract(contract_id.clone(), ClarityVersion::Clarity2, source, None)
@@ -383,11 +383,15 @@ fn eval_hook_captures_fold_with_user_step_function() {
 fn eval_hook_captures_trait_dispatched_contract_call_arguments() {
     let mut marf = MemoryBackingStore::new();
     let mut env = OwnedEnvironment::new(marf.as_clarity_db(), StacksEpochId::Epoch21);
+
+    let mut analysis_store = MemoryBackingStore::new();
+    let mut analysis_db = analysis_store.as_analysis_db();
+    analysis_db.begin();
     let trait_contract_id = QualifiedContractIdentifier::local("trace-trait").unwrap();
     let impl_contract_id = QualifiedContractIdentifier::local("trace-impl").unwrap();
     let caller_contract_id = QualifiedContractIdentifier::local("trace-caller").unwrap();
 
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         trait_contract_id,
         ClarityVersion::Clarity2,
         r#"
@@ -395,9 +399,10 @@ fn eval_hook_captures_trait_dispatched_contract_call_arguments() {
               ((do-it (uint uint) (response uint uint))))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         impl_contract_id,
         ClarityVersion::Clarity2,
         r#"
@@ -407,22 +412,23 @@ fn eval_hook_captures_trait_dispatched_contract_call_arguments() {
               (ok (+ x y)))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         caller_contract_id.clone(),
         ClarityVersion::Clarity2,
         r#"
             (use-trait runner .trace-trait.trace-runner)
-            (define-data-var runner-contract principal .trace-impl)
 
-            (define-private (call-runner (runner <runner>) (x uint) (y uint))
-              (contract-call? runner do-it x y))
+            (define-private (call-runner (target <runner>) (x uint) (y uint))
+              (contract-call? target do-it x y))
 
             (define-public (entry (seed uint))
-              (call-runner (var-get runner-contract) seed (+ seed u10)))
+              (call-runner .trace-impl seed (+ seed u10)))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
 
@@ -453,7 +459,7 @@ fn eval_hook_captures_trait_dispatched_contract_call_arguments() {
         "trace-caller",
         "call-runner",
         0,
-        "runner",
+        "target",
         Value::Principal(PrincipalData::Contract(
             QualifiedContractIdentifier::local("trace-impl").unwrap(),
         )),
@@ -505,11 +511,15 @@ fn eval_hook_captures_trait_dispatched_contract_call_arguments() {
 fn eval_hook_balances_trait_dispatched_contract_call_after_failure() {
     let mut marf = MemoryBackingStore::new();
     let mut env = OwnedEnvironment::new(marf.as_clarity_db(), StacksEpochId::Epoch21);
+
+    let mut analysis_store = MemoryBackingStore::new();
+    let mut analysis_db = analysis_store.as_analysis_db();
+    analysis_db.begin();
     let trait_contract_id = QualifiedContractIdentifier::local("trace-failure-trait").unwrap();
     let impl_contract_id = QualifiedContractIdentifier::local("trace-failure-impl").unwrap();
     let caller_contract_id = QualifiedContractIdentifier::local("trace-failure-caller").unwrap();
 
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         trait_contract_id,
         ClarityVersion::Clarity2,
         r#"
@@ -517,9 +527,10 @@ fn eval_hook_balances_trait_dispatched_contract_call_after_failure() {
               ((divide (uint) (response uint uint))))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         impl_contract_id,
         ClarityVersion::Clarity2,
         r#"
@@ -529,22 +540,24 @@ fn eval_hook_balances_trait_dispatched_contract_call_after_failure() {
               (ok (/ u12 divisor)))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         caller_contract_id.clone(),
         ClarityVersion::Clarity2,
         r#"
             (use-trait divider .trace-failure-trait.divider)
-            (define-data-var divider-contract principal .trace-failure-impl)
+            (define-data-var call-count uint u0)
 
             (define-private (call-divider (target <divider>) (divisor uint))
               (contract-call? target divide divisor))
 
             (define-public (entry (divisor uint))
-              (call-divider (var-get divider-contract) divisor))
+              (call-divider .trace-failure-impl (+ divisor (var-get call-count))))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
 
@@ -642,13 +655,17 @@ fn eval_hook_captures_nested_contract_calls_folding_over_contract_calls() {
     let mut marf = MemoryBackingStore::new();
     let mut env = OwnedEnvironment::new(marf.as_clarity_db(), StacksEpochId::Epoch21);
 
+    let mut analysis_store = MemoryBackingStore::new();
+    let mut analysis_db = analysis_store.as_analysis_db();
+    analysis_db.begin();
+
     let math_id = QualifiedContractIdentifier::local("trace-math").unwrap();
     let agg_id = QualifiedContractIdentifier::local("trace-agg").unwrap();
     let top_id = QualifiedContractIdentifier::local("trace-top").unwrap();
 
     // Leaf contract: doubles a value, guarding against overflow with an `if` whose
     // error branch is never taken for our inputs.
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         math_id,
         ClarityVersion::Clarity2,
         r#"
@@ -658,12 +675,13 @@ fn eval_hook_captures_nested_contract_calls_folding_over_contract_calls() {
                   (ok (* n u2))))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
 
     // Middle contract: folds over a list. Each step branches on the item with `if`
     // (skipping zero), and `match`es the contract-call response from `.trace-math`.
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         agg_id,
         ClarityVersion::Clarity2,
         r#"
@@ -678,12 +696,13 @@ fn eval_hook_captures_nested_contract_calls_folding_over_contract_calls() {
               (ok (fold add-doubled items u0)))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
 
     // Top contract: builds a list (with a trailing zero to exercise the skip branch)
     // and contract-calls the middle contract.
-    env.initialize_versioned_contract(
+    env.initialize_versioned_contract_with_db(
         top_id.clone(),
         ClarityVersion::Clarity2,
         r#"
@@ -691,6 +710,7 @@ fn eval_hook_captures_nested_contract_calls_folding_over_contract_calls() {
               (contract-call? .trace-agg sum-doubled (list seed (+ seed u1) u0)))
         "#,
         None,
+        &mut analysis_db,
     )
     .unwrap();
 

--- a/clarity/src/vm/tests/variables.rs
+++ b/clarity/src/vm/tests/variables.rs
@@ -1212,10 +1212,10 @@ fn test_block_time(
         assert!(analysis.is_ok());
     }
 
-    // Initialize the contract
-    // Note that we're ignoring the analysis failure here so that we can test
-    // the runtime behavior. In earlier versions, if this case somehow gets past the
-    // analysis, it should fail at runtime.
+    // Initialize the contract.
+    // Analysis now runs as part of contract initialization, so a contract that
+    // fails analysis can no longer be deployed at all. The old runtime rejection
+    // is therefore unreachable, and we assert on the rejected deployment instead.
     let result = owned_env.initialize_versioned_contract(
         contract_identifier.clone(),
         version,
@@ -1223,27 +1223,23 @@ fn test_block_time(
         None,
     );
 
+    if version < ClarityVersion::Clarity4 {
+        assert!(
+            result.is_err(),
+            "deploying a contract using `stacks-block-time` before Clarity 4 must be rejected"
+        );
+        return;
+    }
+    result.unwrap();
+
     let (mut exec_state, invoke_ctx) =
         owned_env.get_exec_environment(None, None, &placeholder_context);
 
     // Call the function
     let eval_result = exec_state.eval_read_only(&invoke_ctx, &contract_identifier, "(test-func)");
 
-    // In versions before Clarity 4, this should trigger a runtime error
-    if version < ClarityVersion::Clarity4 {
-        let err = eval_result.unwrap_err();
-        assert_eq!(
-            ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-                RuntimeCheckErrorKind::Unreachable(
-                    "Undefined variable: stacks-block-time".to_string()
-                )
-            )),
-            err
-        );
-    } else {
-        // Always 1 in the testing environment
-        assert_eq!(Ok(Value::UInt(1)), eval_result);
-    }
+    // Always 1 in the testing environment
+    assert_eq!(Ok(Value::UInt(1)), eval_result);
 }
 
 #[test]
@@ -1346,10 +1342,10 @@ fn test_current_contract(
         assert!(analysis.is_ok());
     }
 
-    // Initialize the contract
-    // Note that we're ignoring the analysis failure here so that we can test
-    // the runtime behavior. In Clarity 3, if this case somehow gets past the
-    // analysis, it should fail at runtime.
+    // Initialize the contract.
+    // Analysis now runs as part of contract initialization, so a contract that
+    // fails analysis can no longer be deployed at all. The old runtime rejection
+    // is therefore unreachable, and we assert on the rejected deployment instead.
     let result = owned_env.initialize_versioned_contract(
         contract_identifier.clone(),
         version,
@@ -1357,30 +1353,26 @@ fn test_current_contract(
         None,
     );
 
+    if version < ClarityVersion::Clarity4 {
+        assert!(
+            result.is_err(),
+            "deploying a contract using `current-contract` before Clarity 4 must be rejected"
+        );
+        return;
+    }
+    result.unwrap();
+
     let (mut exec_state, invoke_ctx) =
         owned_env.get_exec_environment(None, None, &placeholder_context);
 
     // Call the function
     let eval_result = exec_state.eval_read_only(&invoke_ctx, &contract_identifier, "(test-func)");
-    // In Clarity 3, this should trigger a runtime error
-    if version < ClarityVersion::Clarity4 {
-        let err = eval_result.unwrap_err();
-        assert_eq!(
-            ClarityEvalError::Vm(VmExecutionError::RuntimeCheck(
-                RuntimeCheckErrorKind::Unreachable(
-                    "Undefined variable: current-contract".to_string()
-                )
-            )),
-            err
-        );
-    } else {
-        assert_eq!(
-            Ok(Value::Principal(PrincipalData::Contract(
-                contract_identifier
-            ))),
-            eval_result
-        );
-    }
+    assert_eq!(
+        Ok(Value::Principal(PrincipalData::Contract(
+            contract_identifier
+        ))),
+        eval_result
+    );
 }
 
 /// Test the checks on reuse of the `current-contract` name

--- a/stackslib/src/clarity_vm/tests/forking.rs
+++ b/stackslib/src/clarity_vm/tests/forking.rs
@@ -52,6 +52,15 @@ fn test_forking_simple(#[case] version: ClarityVersion, #[case] epoch: StacksEpo
 
 #[apply(test_clarity_versions)]
 fn test_at_block_mutations(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId) {
+    // `at-block` was removed in Epoch 3.4. Analysis now runs as part of
+    // contract initialization, so the contract this test forks over cannot be
+    // deployed in those epochs at all and the scenarios below are unreachable.
+    // The rejection itself is covered by
+    // `clarity::vm::tests::contracts::test_at_unknown_block`.
+    if !epoch.supports_at_block() {
+        return;
+    }
+
     // test how at-block works when a mutation has occurred
     fn initialize(owned_env: &mut OwnedEnvironment) {
         let c = QualifiedContractIdentifier::local("contract").unwrap();
@@ -147,6 +156,15 @@ fn test_at_block_mutations(#[case] version: ClarityVersion, #[case] epoch: Stack
 
 #[apply(test_clarity_versions)]
 fn test_at_block_good(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId) {
+    // `at-block` was removed in Epoch 3.4. Analysis now runs as part of
+    // contract initialization, so the contract this test forks over cannot be
+    // deployed in those epochs at all and the scenarios below are unreachable.
+    // The rejection itself is covered by
+    // `clarity::vm::tests::contracts::test_at_unknown_block`.
+    if !epoch.supports_at_block() {
+        return;
+    }
+
     fn initialize(owned_env: &mut OwnedEnvironment) {
         let c = QualifiedContractIdentifier::local("contract").unwrap();
         let contract =


### PR DESCRIPTION
The interpreter could deploy contracts without ever analyzing them, allowing it to test runtime errors that are not actually reachable. The Clarity Wasm compiler requires analysis, so we have to adjust the tests, where possible, to be able to pass analysis.