### PR TITLE
fix: exit cleanly when clarity-cli cannot read a file

### DIFF
--- a/changelog.d/clarity-cli-file-read-exit.fixed
+++ b/changelog.d/clarity-cli-file-read-exit.fixed
@@ -1,0 +1,1 @@
+`clarity-cli` and `stacks-inspect` now print an error and exit with status 1 when a file they were asked to read is missing or unreadable, instead of panicking with a backtrace. This covers `stacks-inspect` commands such as `decode-block` and `post-stackerdb`, which share the same read helpers.

--- a/contrib/clarity-cli/src/lib.rs
+++ b/contrib/clarity-cli/src/lib.rs
@@ -119,27 +119,45 @@ pub fn friendly_expect_opt<A>(input: Option<A>, msg: &str) -> A {
 
 /// Read text content from a file path or stdin if path is "-"
 pub fn read_file_or_stdin(path: &str) -> String {
-    if path == "-" {
-        let mut buffer = String::new();
-        io::stdin()
-            .read_to_string(&mut buffer)
-            .expect("Error reading from stdin");
-        buffer
-    } else {
-        fs::read_to_string(path).unwrap_or_else(|e| panic!("Error reading file {path}: {e}"))
-    }
+    friendly_expect(try_read_file_or_stdin(path), &read_error_message(path))
 }
 
 /// Read binary content from a file path or stdin if path is "-"
 pub fn read_file_or_stdin_bytes(path: &str) -> Vec<u8> {
+    friendly_expect(
+        try_read_file_or_stdin_bytes(path),
+        &read_error_message(path),
+    )
+}
+
+/// Build the error message shown when a read of `path` fails.
+fn read_error_message(path: &str) -> String {
+    if path == "-" {
+        "Error reading from stdin".to_string()
+    } else {
+        format!("Error reading file {path}")
+    }
+}
+
+/// Read UTF-8 content from `path`, or from stdin if `path` is "-".
+fn try_read_file_or_stdin(path: &str) -> io::Result<String> {
+    if path == "-" {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+        Ok(buffer)
+    } else {
+        fs::read_to_string(path)
+    }
+}
+
+/// Read raw bytes from `path`, or from stdin if `path` is "-".
+fn try_read_file_or_stdin_bytes(path: &str) -> io::Result<Vec<u8>> {
     if path == "-" {
         let mut buffer = vec![];
-        io::stdin()
-            .read_to_end(&mut buffer)
-            .expect("Error reading from stdin");
-        buffer
+        io::stdin().read_to_end(&mut buffer)?;
+        Ok(buffer)
     } else {
-        fs::read(path).unwrap_or_else(|e| panic!("Error reading file {path}: {e}"))
+        fs::read(path)
     }
 }
 
@@ -2491,5 +2509,33 @@ mod test {
             result_json
         );
         assert!(result_json["error"]["runtime"] != json!(null));
+    }
+
+    #[test]
+    fn test_read_missing_file_is_an_error() {
+        let missing = "path/to/unexistent_contract.clar";
+
+        assert_eq!(
+            try_read_file_or_stdin(missing).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            try_read_file_or_stdin_bytes(missing).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn test_read_file_returns_its_contents() {
+        let path = format!(
+            "/tmp/clarity_cli_read_file_{}.clar",
+            rand::thread_rng().r#gen::<i32>()
+        );
+        fs::write(&path, "(ok u1)").unwrap();
+
+        assert_eq!(try_read_file_or_stdin(&path).unwrap(), "(ok u1)");
+        assert_eq!(try_read_file_or_stdin_bytes(&path).unwrap(), b"(ok u1)");
+
+        fs::remove_file(&path).unwrap();
     }
 }


### PR DESCRIPTION
### Description

Follow-up to #7011, which fixed #7005 for the parsing sites but left the file-reading helpers panicking.

`friendly_expect` / `friendly_expect_opt` are this crate's convention for user-input failures: print to stderr and `std::process::exit(1)` (panicking only under `cfg(test)`, via `panic_test!`). #7011 converted the epoch, Clarity-version, contract-identifier and allocations-parsing sites, but `read_file_or_stdin`, `read_file_or_stdin_bytes` and `read_optional_file_or_stdin` still panic directly:

```rust
fs::read_to_string(path).unwrap_or_else(|e| panic!("Error reading file {path}: {e}"))
```

Those helpers take user-supplied paths on `launch`, `check`, `eval`, `eval_at_chaintip`, `eval_at_block` and `initialize`, so a mistyped contract or allocations path still produces a backtrace and exit status 101 rather than the clean message and `exit(1)` that #7005 asks for.

Before, on current `main`:

```
$ clarity-cli check /tmp/does-not-exist.clar
thread 'main' panicked at contrib/clarity-cli/src/lib.rs:129:
Error reading file /tmp/does-not-exist.clar: No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
$ echo $?
101
```

After:

```
$ clarity-cli check /tmp/does-not-exist.clar
Error reading file /tmp/does-not-exist.clar
Caused by: No such file or directory (os error 2)
$ echo $?
1
```

### Applicable issues

- fixes #7005 (remaining case)

### Additional info (benefits, drawbacks, caveats)

The fallible part is split into `try_read_file_or_stdin` / `try_read_file_or_stdin_bytes` returning `io::Result`, so the error path is unit-testable directly rather than through panic or exit semantics, and the public helpers stay the one-line `friendly_expect` wrappers the rest of the crate already uses.

Scoped deliberately to the read helpers. `main.rs` has six further `db_path.to_str().expect(...)` sites, but a non-UTF-8 path is a different and much rarer failure mode than a mistyped filename, and folding it in would widen an otherwise narrow fix. Happy to convert those in a follow-up if you'd like.

Behaviour change for anyone scripting against the CLI: a failed read now exits `1` instead of `101`. That is the point of #7005, but it is a visible change if a wrapper script keys on the exit status.

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
