### PR TITLE
fix: `Secp256k1PublicKey::recover_to_pubkey()` and `verify()` for WASM target

### DIFF
--- a/.github/workflows/_tests-wasm.yml
+++ b/.github/workflows/_tests-wasm.yml
@@ -1,6 +1,6 @@
-# Execute wasm-specific implementations that cargo-hack only compile-checks.
+# Execute Wasm-specific implementations that cargo-hack only compile-checks.
 
-name: "Tests: WASM"
+name: "Tests: Wasm"
 
 on:
   workflow_call:
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   # No caching needed as it runs in parallel with much longer jobs
   wasm-tests:
-    name: WASM Unit Tests (Node)
+    name: Wasm Unit Tests (Node)
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      # Setup the rust toolchain for the wasm target
+      # Set up the Rust toolchain for the Wasm target.
       - name: Setup Rust Toolchain
         uses: ./.github/actions/setup-rust-toolchain
         with:
@@ -50,7 +50,7 @@ jobs:
         with:
           tools: wasm-pack
 
-      # `wasm-pack test --node` runs the built wasm under Node
+      # `wasm-pack test --node` runs the built Wasm module under Node.
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -58,6 +58,6 @@ jobs:
           package-manager-cache: false # cache is not reusable, do not save anything
 
       # Add crates here once they contain `#[wasm_bindgen_test]` tests.
-      - name: Run wasm tests (stacks-codec)
+      - name: Run Wasm tests (stacks-codec)
         working-directory: stacks-codec
         run: wasm-pack test --node --features wasm-web

--- a/.github/workflows/_tests-wasm.yml
+++ b/.github/workflows/_tests-wasm.yml
@@ -1,16 +1,4 @@
-# Run the unit tests that have to execute on a wasm target.
-#
-# `Check: Cargo Hack` already compiles the wasm targets, but compiling is not
-# running. Several crates carry two implementations of the same API selected by
-# `cfg(target_family = "wasm")` — `stacks_common::util::secp256k1` is the
-# clearest case, with `native.rs` over the C `secp256k1` library and `wasm.rs`
-# over the pure-Rust `libsecp256k1`. A behavioural difference between such a
-# pair is invisible to a type check, so without this workflow the wasm half of
-# consensus-critical code is never executed by CI at all.
-#
-# That is not hypothetical: `Secp256k1PublicKey::recover_to_pubkey` decoded
-# `MessageSignature` with the wrong byte order on wasm and reached `main`,
-# leaving `StacksTransaction::verify` unable to verify any signature there.
+# Execute wasm-specific implementations that cargo-hack only compile-checks.
 
 name: "Tests: WASM"
 
@@ -54,10 +42,6 @@ jobs:
         with:
           target: wasm32-unknown-unknown
 
-      # Install wasm-pack, which resolves and fetches the `wasm-bindgen` CLI
-      # matching the `wasm-bindgen` version in Cargo.lock. Doing that by hand
-      # would mean pinning the CLI version here and breaking this job every
-      # time the lockfile moves.
       - name: Install wasm-pack
         # Fail fast if GitHub rate-limits the download instead of retrying
         # until the job times out
@@ -73,13 +57,7 @@ jobs:
           node-version: 25.x
           package-manager-cache: false # cache is not reusable, do not save anything
 
-      # Only `#[wasm_bindgen_test]` functions run here; a plain `#[test]` is
-      # compiled but skipped by the harness. Add a crate to this list once it
-      # has tests annotated that way.
-      #
-      # `--features wasm-web` is required: it selects the wasm-compatible
-      # `getrandom` and `libsecp256k1` backends, without which the test build
-      # does not compile for wasm32.
+      # Add crates here once they contain `#[wasm_bindgen_test]` tests.
       - name: Run wasm tests (stacks-codec)
         working-directory: stacks-codec
         run: wasm-pack test --node --features wasm-web

--- a/.github/workflows/_tests-wasm.yml
+++ b/.github/workflows/_tests-wasm.yml
@@ -1,0 +1,85 @@
+# Run the unit tests that have to execute on a wasm target.
+#
+# `Check: Cargo Hack` already compiles the wasm targets, but compiling is not
+# running. Several crates carry two implementations of the same API selected by
+# `cfg(target_family = "wasm")` — `stacks_common::util::secp256k1` is the
+# clearest case, with `native.rs` over the C `secp256k1` library and `wasm.rs`
+# over the pure-Rust `libsecp256k1`. A behavioural difference between such a
+# pair is invisible to a type check, so without this workflow the wasm half of
+# consensus-critical code is never executed by CI at all.
+#
+# That is not hypothetical: `Secp256k1PublicKey::recover_to_pubkey` decoded
+# `MessageSignature` with the wrong byte order on wasm and reached `main`,
+# leaving `StacksTransaction::verify` unable to verify any signature there.
+
+name: "Tests: WASM"
+
+on:
+  workflow_call:
+
+# Set default permissions
+permissions:
+  contents: read
+
+# Set default shell
+defaults:
+  run:
+    shell: bash
+
+# Set default env vars
+env:
+  RUST_BACKTRACE: full
+
+# Configure concurrency
+concurrency:
+  group: wasm-tests-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # No caching needed as it runs in parallel with much longer jobs
+  wasm-tests:
+    name: WASM Unit Tests (Node)
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - name: Checkout the latest code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      # Setup the rust toolchain for the wasm target
+      - name: Setup Rust Toolchain
+        uses: ./.github/actions/setup-rust-toolchain
+        with:
+          target: wasm32-unknown-unknown
+
+      # Install wasm-pack, which resolves and fetches the `wasm-bindgen` CLI
+      # matching the `wasm-bindgen` version in Cargo.lock. Doing that by hand
+      # would mean pinning the CLI version here and breaking this job every
+      # time the lockfile moves.
+      - name: Install wasm-pack
+        # Fail fast if GitHub rate-limits the download instead of retrying
+        # until the job times out
+        timeout-minutes: 5
+        uses: ./.github/actions/install-tool
+        with:
+          tools: wasm-pack
+
+      # `wasm-pack test --node` runs the built wasm under Node
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 25.x
+          package-manager-cache: false # cache is not reusable, do not save anything
+
+      # Only `#[wasm_bindgen_test]` functions run here; a plain `#[test]` is
+      # compiled but skipped by the harness. Add a crate to this list once it
+      # has tests annotated that way.
+      #
+      # `--features wasm-web` is required: it selects the wasm-compatible
+      # `getrandom` and `libsecp256k1` backends, without which the test build
+      # does not compile for wasm32.
+      - name: Run wasm tests (stacks-codec)
+        working-directory: stacks-codec
+        run: wasm-pack test --node --features wasm-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,18 @@ jobs:
     uses: ./.github/workflows/_check-cargo-hack.yml
   
   ############################################################################
+  ### WASM Tests
+  ############################################################################
+  tests-wasm:
+    name: "Tests: WASM"
+    needs:
+      - check-changelog
+      - check-rustfmt
+      - setup-env
+      - check-test-caches
+    uses: ./.github/workflows/_tests-wasm.yml
+
+  ############################################################################
   ### Constant Check (stacks-inspect)
   ############################################################################
   check-constants:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,6 +4432,7 @@ dependencies = [
  "serde",
  "stacks-common 0.0.1",
  "variant_count",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -5643,6 +5654,31 @@ name = "wasm-bindgen-shared"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143ddeb4f833e2ed0d252e618986e18bfc7b0e52f2d28d77d05b2f045dd8eb61"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5211b7550606857312bba1d978a8ec75692eae187becc5e680444fffc5e6f89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "web-sys"

--- a/changelog.d/wasm-signature-recovery-byte-order.fixed
+++ b/changelog.d/wasm-signature-recovery-byte-order.fixed
@@ -1,2 +1,2 @@
-Fixed `Secp256k1PublicKey::recover_to_pubkey` on wasm targets, where a `MessageSignature` was decoded as RSV instead of VRS. Every field was read one byte out of position, so `StacksTransaction::verify`, `PublicKey::verify`, and block signature verification could not verify any signature under `wasm32`. Clarity's `secp256k1-recover?` and `secp256k1-verify` builtins were unaffected.
-Added a `Tests: WASM` CI workflow that executes wasm unit tests under Node, so the wasm implementations of `cfg(target_family = "wasm")` code are run rather than only compile-checked.
+Fixed wasm signature recovery to decode `MessageSignature` in VRS order, restoring transaction, public-key, and block-signature verification.
+Added a CI workflow that executes wasm unit tests under Node.

--- a/changelog.d/wasm-signature-recovery-byte-order.fixed
+++ b/changelog.d/wasm-signature-recovery-byte-order.fixed
@@ -1,2 +1,2 @@
 Fixed Wasm signature recovery to decode `MessageSignature` in VRS order, restoring transaction, public-key, and block-signature verification.
-Added a CI workflow that executes Wasm unit tests under Node.
+Fixed `Secp256k1PublicKey::verify()` on Wasm rejecting every valid signature for an uncompressed public key.

--- a/changelog.d/wasm-signature-recovery-byte-order.fixed
+++ b/changelog.d/wasm-signature-recovery-byte-order.fixed
@@ -1,2 +1,2 @@
-Fixed wasm signature recovery to decode `MessageSignature` in VRS order, restoring transaction, public-key, and block-signature verification.
-Added a CI workflow that executes wasm unit tests under Node.
+Fixed Wasm signature recovery to decode `MessageSignature` in VRS order, restoring transaction, public-key, and block-signature verification.
+Added a CI workflow that executes Wasm unit tests under Node.

--- a/changelog.d/wasm-signature-recovery-byte-order.fixed
+++ b/changelog.d/wasm-signature-recovery-byte-order.fixed
@@ -1,0 +1,2 @@
+Fixed `Secp256k1PublicKey::recover_to_pubkey` on wasm targets, where a `MessageSignature` was decoded as RSV instead of VRS. Every field was read one byte out of position, so `StacksTransaction::verify`, `PublicKey::verify`, and block signature verification could not verify any signature under `wasm32`. Clarity's `secp256k1-recover?` and `secp256k1-verify` builtins were unaffected.
+Added a `Tests: WASM` CI workflow that executes wasm unit tests under Node, so the wasm implementations of `cfg(target_family = "wasm")` code are run rather than only compile-checked.

--- a/changelog.d/wasm-unit-tests-ci.added
+++ b/changelog.d/wasm-unit-tests-ci.added
@@ -1,0 +1,1 @@
+Added a CI workflow that executes the Wasm unit tests under Node.

--- a/stacks-codec/Cargo.toml
+++ b/stacks-codec/Cargo.toml
@@ -24,7 +24,7 @@ variant_count = { workspace = true }
 stacks-common = { path = "../stacks-common", default-features = false, features = ["testing"] }
 clarity-types = { path = "../clarity-types", default-features = false, features = ["testing"] }
 
-# Run signature-verification tests against the wasm backend.
+# Run signature-verification tests against the Wasm backend.
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 

--- a/stacks-codec/Cargo.toml
+++ b/stacks-codec/Cargo.toml
@@ -24,10 +24,7 @@ variant_count = { workspace = true }
 stacks-common = { path = "../stacks-common", default-features = false, features = ["testing"] }
 clarity-types = { path = "../clarity-types", default-features = false, features = ["testing"] }
 
-# Lets the signature-verification tests actually execute under wasm32, instead
-# of only being compile-checked there. The `native.rs` / `wasm.rs` split in
-# `stacks-common`'s secp256k1 module means a bug can live in one backend while
-# the other is green, so these tests run on both.
+# Run signature-verification tests against the wasm backend.
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 

--- a/stacks-codec/Cargo.toml
+++ b/stacks-codec/Cargo.toml
@@ -24,6 +24,13 @@ variant_count = { workspace = true }
 stacks-common = { path = "../stacks-common", default-features = false, features = ["testing"] }
 clarity-types = { path = "../clarity-types", default-features = false, features = ["testing"] }
 
+# Lets the signature-verification tests actually execute under wasm32, instead
+# of only being compile-checked there. The `native.rs` / `wasm.rs` split in
+# `stacks-common`'s secp256k1 module means a bug can live in one backend while
+# the other is green, so these tests run on both.
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [features]
 default = []
 testing = ["stacks-common/testing", "clarity-types/testing"]

--- a/stacks-codec/src/lib.rs
+++ b/stacks-codec/src/lib.rs
@@ -24,6 +24,9 @@
 pub mod strings;
 pub mod transaction;
 
+#[cfg(test)]
+mod signature_verification_tests;
+
 pub use stacks_common::codec::*;
 pub use stacks_common::{
     impl_byte_array_message_codec, impl_stacks_message_codec_for_int, BITVEC_LEN,

--- a/stacks-codec/src/signature_verification_tests.rs
+++ b/stacks-codec/src/signature_verification_tests.rs
@@ -1,0 +1,459 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2026 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Cross-backend tests for [`StacksTransaction::verify`].
+//!
+//! `stacks_common::util::secp256k1` has two independent implementations —
+//! `native.rs` over the C `secp256k1` library, `wasm.rs` over the pure-Rust
+//! `libsecp256k1` — selected by `cfg(target_family = "wasm")`. Signature
+//! verification is consensus-critical and the two backends must agree, but CI
+//! only ever *compile-checks* the wasm one, so a behavioural difference between
+//! them can sit undetected indefinitely.
+//!
+//! Every test here therefore runs on both: as a plain `#[test]` natively, and
+//! as a `#[wasm_bindgen_test]` under `wasm32-unknown-unknown`. Run the wasm
+//! side with:
+//!
+//! ```text
+//! cd stacks-codec && wasm-pack test --node --features wasm-web
+//! ```
+//!
+//! The vectors are deliberately deterministic. A byte-order bug can be
+//! invisible for one signature and fatal for the next, so a random suite would
+//! be both flaky and impossible to bisect.
+
+#![cfg(test)]
+
+use clarity_types::representations::{ClarityName, ContractName};
+use clarity_types::types::{PrincipalData, StandardPrincipalData, Value};
+use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
+use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
+use stacks_common::util::secp256k1::MessageSignature;
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+use crate::strings::StacksString;
+use crate::transaction::{
+    StacksTransaction, TokenTransferMemo, TransactionAuth, TransactionAuthVerificationMode,
+    TransactionContractCall, TransactionPayload, TransactionSmartContract,
+    TransactionSpendingCondition, TransactionVersion,
+};
+
+/// How many distinct signing keys the suite sweeps.
+///
+/// The recovery id is the single byte the two backends can disagree about, and
+/// its value is effectively unpredictable per (key, sighash) pair. Sweeping
+/// many keys is what makes the suite exercise more than one recovery id — see
+/// [`vectors_cover_multiple_recovery_ids`], which asserts that it actually does
+/// rather than trusting it to.
+const KEY_COUNT: u8 = 12;
+
+/// Deterministic signing key `i`.
+///
+/// Hashing the index spreads the key bytes across the field, so the resulting
+/// signatures have well-distributed `r`/`s` values instead of the near-adjacent
+/// ones that `[i; 32]` would produce.
+fn key(i: u8) -> StacksPrivateKey {
+    let bytes = Sha512Trunc256Sum::from_data(&[b'v', b'e', b'r', b'i', b'f', b'y', i]);
+    StacksPrivateKey::from_slice(bytes.as_bytes())
+        .expect("BUG: hashed key material is not a valid secp256k1 scalar")
+}
+
+fn compressed_key(i: u8) -> StacksPrivateKey {
+    let mut k = key(i);
+    k.set_compress_public(true);
+    k
+}
+
+fn uncompressed_key(i: u8) -> StacksPrivateKey {
+    let mut k = key(i);
+    k.set_compress_public(false);
+    k
+}
+
+/// The payload shapes a transaction can carry. The payload feeds the initial
+/// sighash, so varying it varies every signature in the suite.
+fn payloads() -> Vec<(&'static str, TransactionPayload)> {
+    vec![
+        (
+            "token-transfer",
+            TransactionPayload::TokenTransfer(
+                PrincipalData::Standard(StandardPrincipalData::transient()),
+                12_345,
+                TokenTransferMemo([0x42; 34]),
+            ),
+        ),
+        (
+            "contract-call",
+            TransactionPayload::ContractCall(TransactionContractCall {
+                address: StacksAddress::new(1, Hash160([0xab; 20])).unwrap(),
+                contract_name: ContractName::try_from("verify-target").unwrap(),
+                function_name: ClarityName::try_from("do-thing").unwrap(),
+                function_args: vec![Value::Int(-7), Value::UInt(7)],
+            }),
+        ),
+        (
+            "smart-contract",
+            TransactionPayload::SmartContract(
+                TransactionSmartContract {
+                    name: ContractName::try_from("verify-deploy").unwrap(),
+                    code_body: StacksString::from_str("(define-read-only (f) u1)").unwrap(),
+                },
+                None,
+            ),
+        ),
+    ]
+}
+
+/// Build and fully sign a single-signature transaction.
+fn signed_singlesig(
+    auth: TransactionAuth,
+    privk: &StacksPrivateKey,
+    version: TransactionVersion,
+    payload: TransactionPayload,
+    nonce: u64,
+) -> StacksTransaction {
+    let mut tx = StacksTransaction::new(version, auth, payload);
+    tx.set_tx_fee(180 + nonce);
+    tx.set_origin_nonce(nonce);
+    tx.sign_next_origin(&tx.sign_begin(), privk)
+        .expect("BUG: failed to sign the origin");
+    tx
+}
+
+/// Every single-signature transaction shape this suite knows how to build,
+/// labelled so a failure names the case rather than an index.
+fn singlesig_vectors() -> Vec<(String, StacksTransaction)> {
+    let mut out = vec![];
+
+    for i in 0..KEY_COUNT {
+        for (payload_name, payload) in payloads() {
+            let version = if i % 2 == 0 {
+                TransactionVersion::Testnet
+            } else {
+                TransactionVersion::Mainnet
+            };
+
+            // p2pkh, compressed — the shape real clients emit.
+            let privk = compressed_key(i);
+            out.push((
+                format!("p2pkh-compressed/{payload_name}/key{i}"),
+                signed_singlesig(
+                    TransactionAuth::from_p2pkh(&privk).unwrap(),
+                    &privk,
+                    version,
+                    payload.clone(),
+                    i as u64,
+                ),
+            ));
+
+            // p2pkh, uncompressed — a different `key_encoding` branch in
+            // `next_verification`, so it must be covered separately.
+            let privk = uncompressed_key(i);
+            out.push((
+                format!("p2pkh-uncompressed/{payload_name}/key{i}"),
+                signed_singlesig(
+                    TransactionAuth::from_p2pkh(&privk).unwrap(),
+                    &privk,
+                    version,
+                    payload.clone(),
+                    i as u64,
+                ),
+            ));
+
+            // p2wpkh — segwit-style singlesig hash mode.
+            let privk = compressed_key(i);
+            out.push((
+                format!("p2wpkh/{payload_name}/key{i}"),
+                signed_singlesig(
+                    TransactionAuth::from_p2wpkh(&privk).unwrap(),
+                    &privk,
+                    version,
+                    payload.clone(),
+                    i as u64,
+                ),
+            ));
+        }
+    }
+
+    out
+}
+
+/// Ordered 2-of-3 multisig, signed sequentially: each signature commits to the
+/// sighash the previous one produced, so this exercises the rolling-hash path
+/// in `next_verification` rather than a single recovery.
+fn multisig_vectors() -> Vec<(String, StacksTransaction)> {
+    let mut out = vec![];
+
+    for i in 0..KEY_COUNT {
+        let signers = [compressed_key(i), compressed_key(i + 40)];
+        let spectator = compressed_key(i + 80);
+        let all = [signers[0].clone(), signers[1].clone(), spectator.clone()];
+
+        for (payload_name, payload) in payloads() {
+            for (shape, auth) in [
+                ("p2sh", TransactionAuth::from_p2sh(&all, 2).unwrap()),
+                ("p2wsh", TransactionAuth::from_p2wsh(&all, 2).unwrap()),
+            ] {
+                let mut tx =
+                    StacksTransaction::new(TransactionVersion::Testnet, auth, payload.clone());
+                tx.set_tx_fee(300);
+                tx.set_origin_nonce(i as u64);
+
+                let mut sighash = tx.sign_begin();
+                for privk in &signers {
+                    sighash = tx
+                        .sign_next_origin(&sighash, privk)
+                        .expect("BUG: failed to add a multisig signature");
+                }
+                // The third participant contributes only its public key.
+                tx.append_next_origin(&StacksPublicKey::from_private(&spectator))
+                    .expect("BUG: failed to append the trailing public key");
+
+                out.push((format!("multisig-{shape}-2of3/{payload_name}/key{i}"), tx));
+            }
+        }
+    }
+
+    out
+}
+
+/// Sponsored transactions: the origin signature is verified first and its
+/// resulting sighash is what the sponsor signs, so a recovery failure on the
+/// origin half would be masked without covering this shape.
+fn sponsored_vectors() -> Vec<(String, StacksTransaction)> {
+    let mut out = vec![];
+
+    for i in 0..KEY_COUNT {
+        let origin = compressed_key(i);
+        let sponsor = compressed_key(i + 120);
+
+        for (payload_name, payload) in payloads() {
+            let auth = TransactionAuth::from_p2pkh(&origin)
+                .unwrap()
+                .into_sponsored(TransactionAuth::from_p2pkh(&sponsor).unwrap())
+                .unwrap();
+
+            let mut tx = StacksTransaction::new(TransactionVersion::Mainnet, auth, payload);
+            tx.set_tx_fee(240);
+            tx.set_origin_nonce(i as u64);
+            tx.set_sponsor_nonce(u64::from(i) + 1).unwrap();
+
+            let origin_sighash = tx
+                .sign_next_origin(&tx.sign_begin(), &origin)
+                .expect("BUG: failed to sign the origin");
+            tx.sign_next_sponsor(&origin_sighash, &sponsor)
+                .expect("BUG: failed to sign the sponsor");
+
+            out.push((format!("sponsored-p2pkh/{payload_name}/key{i}"), tx));
+        }
+    }
+
+    out
+}
+
+fn all_vectors() -> Vec<(String, StacksTransaction)> {
+    let mut out = singlesig_vectors();
+    out.extend(multisig_vectors());
+    out.extend(sponsored_vectors());
+    out
+}
+
+// -- The tests ----------------------------------------------------------------
+
+/// The headline property: a correctly signed transaction verifies. This is what
+/// fails wholesale on the wasm backend.
+#[test]
+fn correctly_signed_transactions_verify() {
+    let vectors = all_vectors();
+    assert!(
+        vectors.len() >= 100,
+        "the vector set collapsed to {} cases; a shrinking suite silently \
+         stops covering recovery ids",
+        vectors.len()
+    );
+
+    let mut failures = vec![];
+    for (name, tx) in &vectors {
+        if let Err(e) = tx.verify(TransactionAuthVerificationMode::EnforceLowS) {
+            failures.push(format!("{name}: {e}"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} correctly signed transactions failed to verify.\nFirst 5:\n  {}",
+        failures.len(),
+        vectors.len(),
+        failures
+            .iter()
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}
+
+/// `AllowHighS` takes a different recovery entry point
+/// (`recover_to_pubkey_without_validating_low_s`), so it needs its own sweep —
+/// a fix applied to only one of the two would otherwise look complete.
+#[test]
+fn correctly_signed_transactions_verify_allowing_high_s() {
+    let vectors = all_vectors();
+    let mut failures = vec![];
+    for (name, tx) in &vectors {
+        if let Err(e) = tx.verify(TransactionAuthVerificationMode::AllowHighS) {
+            failures.push(format!("{name}: {e}"));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} transactions failed to verify under AllowHighS.\nFirst 5:\n  {}",
+        failures.len(),
+        vectors.len(),
+        failures
+            .iter()
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}
+
+/// The suite must actually exercise more than one recovery id, or it would not
+/// distinguish a correct implementation from one that hardcodes the common case.
+#[test]
+fn vectors_cover_multiple_recovery_ids() {
+    let mut seen = [0usize; 256];
+    for (_, tx) in singlesig_vectors() {
+        if let TransactionAuth::Standard(TransactionSpendingCondition::Singlesig(ref data)) =
+            tx.auth
+        {
+            // Byte 0 of a `MessageSignature` is the recovery id.
+            seen[data.signature.as_bytes()[0] as usize] += 1;
+        }
+    }
+
+    let distinct = seen.iter().filter(|c| **c > 0).count();
+    assert!(
+        distinct >= 2,
+        "the vectors only produced {distinct} distinct recovery id(s): {:?}. \
+         A byte-order bug can pass for one and fail for another, so the suite \
+         must span at least two.",
+        seen.iter()
+            .enumerate()
+            .filter(|(_, c)| **c > 0)
+            .map(|(id, c)| (id, *c))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Guards against the opposite failure: a `verify` that returns `Ok`
+/// unconditionally would satisfy every test above.
+#[test]
+fn tampered_transactions_do_not_verify() {
+    for (name, tx) in all_vectors() {
+        for (what, mut tampered) in [
+            ("nonce", tx.clone()),
+            ("fee", tx.clone()),
+            ("version", tx.clone()),
+        ] {
+            match what {
+                "nonce" => tampered.set_origin_nonce(tx.get_origin_nonce() ^ 0xff),
+                "fee" => tampered.set_tx_fee(tx.get_tx_fee() + 1),
+                _ => {
+                    tampered.version = match tx.version {
+                        TransactionVersion::Mainnet => TransactionVersion::Testnet,
+                        TransactionVersion::Testnet => TransactionVersion::Mainnet,
+                    }
+                }
+            }
+
+            // Changing the version does not change the sighash, so it is only
+            // the nonce and fee that must break verification.
+            if what == "version" {
+                continue;
+            }
+
+            assert!(
+                tampered
+                    .verify(TransactionAuthVerificationMode::EnforceLowS)
+                    .is_err(),
+                "{name}: verification accepted a transaction with a tampered {what}"
+            );
+        }
+    }
+}
+
+/// A high-S signature must be rejected under `EnforceLowS` and accepted under
+/// `AllowHighS`. This is the pair of behaviours that the low-S pre-check inside
+/// the recovery path is responsible for, so it is exactly the code a byte-order
+/// bug would also corrupt.
+#[test]
+fn high_s_signatures_are_rejected_only_when_enforcing_low_s() {
+    for (name, tx) in singlesig_vectors() {
+        let high_s = tx.with_negated_s_in_signature();
+
+        assert!(
+            high_s
+                .verify(TransactionAuthVerificationMode::EnforceLowS)
+                .is_err(),
+            "{name}: a high-S signature was accepted under EnforceLowS"
+        );
+        assert!(
+            high_s
+                .verify(TransactionAuthVerificationMode::AllowHighS)
+                .is_ok(),
+            "{name}: a high-S signature was rejected under AllowHighS"
+        );
+    }
+}
+
+/// The narrowest reproduction, kept separate so a failure points straight at
+/// `recover_to_pubkey` rather than at transaction assembly: sign a hash, then
+/// recover the signer's public key from it.
+#[test]
+fn recovering_a_public_key_round_trips() {
+    use stacks_common::types::PrivateKey;
+
+    let mut failures = vec![];
+    for i in 0..KEY_COUNT {
+        let privk = compressed_key(i);
+        let expected = StacksPublicKey::from_private(&privk);
+        let sighash = Sha512Trunc256Sum::from_data(&[b'm', b's', b'g', i]);
+
+        let sig: MessageSignature = privk
+            .sign(sighash.as_bytes())
+            .expect("BUG: failed to sign a 32-byte hash");
+
+        match StacksPublicKey::recover_to_pubkey(sighash.as_bytes(), &sig) {
+            Ok(recovered) if recovered.to_hex() == expected.to_hex() => {}
+            Ok(recovered) => failures.push(format!(
+                "key{i}: recovered {} instead of {}",
+                recovered.to_hex(),
+                expected.to_hex()
+            )),
+            Err(e) => failures.push(format!("key{i}: {e}")),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{}/{KEY_COUNT} keys failed to round-trip through recover_to_pubkey:\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}

--- a/stacks-codec/src/signature_verification_tests.rs
+++ b/stacks-codec/src/signature_verification_tests.rs
@@ -27,17 +27,21 @@
 
 use clarity_types::representations::{ClarityName, ContractName};
 use clarity_types::types::{PrincipalData, StandardPrincipalData, Value};
-use stacks_common::types::chainstate::{StacksAddress, StacksPrivateKey, StacksPublicKey};
-use stacks_common::util::hash::{Hash160, Sha512Trunc256Sum};
+use stacks_common::codec::StacksMessageCodec;
+use stacks_common::types::chainstate::{
+    BlockHeaderHash, StacksAddress, StacksPrivateKey, StacksPublicKey,
+};
+use stacks_common::types::{PrivateKey, PublicKey};
+use stacks_common::util::hash::{hex_bytes, Hash160, Sha512Trunc256Sum};
 use stacks_common::util::secp256k1::MessageSignature;
 #[cfg(target_family = "wasm")]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use crate::strings::StacksString;
 use crate::transaction::{
-    StacksTransaction, TokenTransferMemo, TransactionAuth, TransactionAuthVerificationMode,
-    TransactionContractCall, TransactionPayload, TransactionSmartContract,
-    TransactionSpendingCondition, TransactionVersion,
+    StacksMicroblockHeader, StacksTransaction, TokenTransferMemo, TransactionAuth,
+    TransactionAuthVerificationMode, TransactionContractCall, TransactionPayload,
+    TransactionSmartContract, TransactionSpendingCondition, TransactionVersion,
 };
 
 /// Enough keys to exercise multiple recovery IDs.
@@ -204,6 +208,55 @@ fn multisig_vectors() -> Vec<(String, StacksTransaction)> {
     out
 }
 
+/// Order-independent 2-of-3 multisig vectors. Unlike the ordered form, every
+/// signature is checked against the *initial* sighash rather than a rolling one,
+/// so this is a separate path into `recover_to_pubkey()`.
+fn order_independent_multisig_vectors() -> Vec<(String, StacksTransaction)> {
+    let mut out = vec![];
+
+    for i in 0..KEY_COUNT {
+        let signers = [compressed_key(i), compressed_key(i + 40)];
+        let spectator = compressed_key(i + 80);
+        let all = [signers[0].clone(), signers[1].clone(), spectator.clone()];
+
+        for (payload_name, payload) in payloads() {
+            for (shape, auth) in [
+                (
+                    "p2sh",
+                    TransactionAuth::from_order_independent_p2sh(&all, 2).unwrap(),
+                ),
+                (
+                    "p2wsh",
+                    TransactionAuth::from_order_independent_p2wsh(&all, 2).unwrap(),
+                ),
+            ] {
+                let mut tx =
+                    StacksTransaction::new(TransactionVersion::Testnet, auth, payload.clone());
+                tx.set_tx_fee(300);
+                tx.set_origin_nonce(i as u64);
+
+                // Every signer signs the same initial sighash, which is what makes
+                // the field order irrelevant.
+                let sighash = tx.sign_begin();
+                for privk in &signers {
+                    tx.sign_next_origin(&sighash, privk)
+                        .expect("BUG: failed to add an order-independent signature");
+                }
+                // The third participant contributes only its public key.
+                tx.append_next_origin(&StacksPublicKey::from_private(&spectator))
+                    .expect("BUG: failed to append the trailing public key");
+
+                out.push((
+                    format!("order-independent-{shape}-2of3/{payload_name}/key{i}"),
+                    tx,
+                ));
+            }
+        }
+    }
+
+    out
+}
+
 /// Sponsored vectors exercise origin and sponsor verification.
 fn sponsored_vectors() -> Vec<(String, StacksTransaction)> {
     let mut out = vec![];
@@ -239,6 +292,7 @@ fn sponsored_vectors() -> Vec<(String, StacksTransaction)> {
 fn all_vectors() -> Vec<(String, StacksTransaction)> {
     let mut out = singlesig_vectors();
     out.extend(multisig_vectors());
+    out.extend(order_independent_multisig_vectors());
     out.extend(sponsored_vectors());
     out
 }
@@ -349,7 +403,7 @@ fn tampered_transactions_do_not_verify() {
 /// High-S signatures are accepted only when explicitly allowed.
 #[test]
 fn high_s_signatures_are_rejected_only_when_enforcing_low_s() {
-    for (name, tx) in singlesig_vectors() {
+    for (name, tx) in all_vectors() {
         let high_s = tx.with_negated_s_in_signature();
 
         assert!(
@@ -370,8 +424,6 @@ fn high_s_signatures_are_rejected_only_when_enforcing_low_s() {
 /// Directly exercise the recovery function fixed by this change.
 #[test]
 fn recovering_a_public_key_round_trips() {
-    use stacks_common::types::PrivateKey;
-
     let mut failures = vec![];
     for i in 0..KEY_COUNT {
         let privk = compressed_key(i);
@@ -399,4 +451,229 @@ fn recovering_a_public_key_round_trips() {
         failures.len(),
         failures.join("\n  ")
     );
+}
+
+/// Reference signatures produced by the native backend, as
+/// `(message hash, signature, public key)`.
+///
+/// These ensure that both backends accept the same signature bytes.
+const REFERENCE_SIGNATURES: &[(&str, &str, &str)] = &[
+    (
+        "4a2944a5d0ea8e79f5845f6e053aa7ff030707ce2a543041bec5d1e79fc3e406",
+        "00badd6360ac3aea39c1ef69f215623861306b9285c9ebbba4309b5c475f2d6b5873999c350f8fced1fafdcf2163a69ee6209a72788eea92b15bc53f1ad515f2c6",
+        "03487a92ff8ab40f9394d08bd77802abdee2d356f3b7ab3c1dfb56c50eae4f67dc",
+    ),
+    (
+        "b1f660b68b4c927e89ea6de8f6d7872de9c1022033da7cce59f141e0750ac55a",
+        "0027cd6a55705de1a83cad8e92bb28b4d808cc256020e08aa5ac65932a2b24ed331f4432e5dbc7215ca762bbbb48eac2ccdf01efd0082a2130ad3331d74eab5d29",
+        "0369707efb096923bd8d21d4fd9003403c9c124ff3d8f2203218f07e8f8732b824",
+    ),
+    (
+        "df1193b90d202b715788f9eea12fb35569cc3db3e3b66c34859fcaf093f1a739",
+        "0190ccee424514ebd2e7fdab36ed00bf9f2545e3327d16a6be14259df3df7d32bc75e8913d57bdb1090e6a3362ac01a4d00f2473f2aa593ab50fb6a224cf7848c0",
+        "028f88ca7be209a0c45fe7da3242e9983257aff9c3a9c144b796c84c05c061e126",
+    ),
+    (
+        "77d094338f2caa17f8531a9405db2469e307324691bda3959f2df4445c885547",
+        "0008f11e809c32f9abd9d7299c16fa23fa2598d0e3faf4f964979624eaa587f45d4bae7b9c7983bcaf61c6251d9615cd1a320141436ac8bc4ae476dc567857a669",
+        "035369282f28dbc0ae9a4f02dded5eccc20115e8d91635d369e1ae15a896c8abd1",
+    ),
+];
+
+/// One fully signed, natively serialized transaction per auth shape.
+const REFERENCE_TRANSACTIONS: &[(&str, &str)] = &[
+    ("p2pkh-compressed/token-transfer/key0", "800000000004001bcb71024dc180cd823e7d9c7fb2832dce430e8c000000000000000000000000000000b40000eb1ec09783fcfe64886e2bf3c6d47c3f910384b08116c259be319bd938f5fe217c6d5213c1bad7bbe00fef81b16421d2b914065bccd1a76c892645c1cb882aff0302000000000005010101010101010101010101010101010101010101000000000000303942424242424242424242424242424242424242424242424242424242424242424242"),
+    ("p2pkh-uncompressed/token-transfer/key0", "80000000000400832ddef530dc5c3da0ce87e2ec8d0e04555cb453000000000000000000000000000000b40100f576a06afdf2418e047a2d741e89c909ee47e1b4fcbe6fa5b4b5bb26900d860904c561e5fe4f3a7f3abd4bf9d49bc5b928c3978bb432726071250cd6b89424e30302000000000005010101010101010101010101010101010101010101000000000000303942424242424242424242424242424242424242424242424242424242424242424242"),
+    ("p2wpkh/contract-call/key1", "0000000000040213b8083c5d82453b338feafa754b2452ff9e19cf000000000000000100000000000000b50000e02cd617cc8c176f7a08fec4b31f270839c5a09b9f15800e15d1a79773930a4c119becf7d66098ca1d1d842418ee510958e6139dcbc62b09c312249130e95fe50302000000000201abababababababababababababababababababab0d7665726966792d74617267657408646f2d7468696e670000000200fffffffffffffffffffffffffffffff90100000000000000000000000000000007"),
+    ("multisig-p2sh-2of3/token-transfer/key0", "800000000004016d19203ede791c0ab9e2959e01cec910b784d53e0000000000000000000000000000012c000000030200c57bf5ee3557ec14414a1849e6ae4328ce88e4b98227fc116944fdf3ec15019f178414fe4e783cd8729a77137dd1b16ab916f74e5369c47cfc5481b76a01fac6020176af8397ebf61795e490fe61bc743841a696dd96b1524fa243dfc47162ffe4eb44bb953f6ef160cbf340469b23f39854382b41f681f635fb4844482c9c0aa5510002f9e2e210e7706dc8dc35f7c8d45585a41767c10096889474830f7eeb8b94a51300020302000000000005010101010101010101010101010101010101010101000000000000303942424242424242424242424242424242424242424242424242424242424242424242"),
+    ("multisig-p2wsh-2of3/contract-call/key3", "800000000004036dae79777a210821fc234c33a1ad277e85cab7f60000000000000003000000000000012c000000030201f4ad601e3604b0193aba16cb60464653ea0908b2c3c9ced93649a84c593436ad4eba8efbfab0fe33f63f142b365df35401f85c97d2115eceaba62176436dba36020108252de92dd8a9d67101e2ed535b4992c5cdd48b91ecd531918a970cd2c189d341e43bd72dd558c6ad5155db39943c3f215f23d1b82a17dbbdb573b413b5c91b00034f128bc856f15a8ce111498549cdada39a22cc5639c8697f5de5c4e7a5d2ec7300020302000000000201abababababababababababababababababababab0d7665726966792d74617267657408646f2d7468696e670000000200fffffffffffffffffffffffffffffff90100000000000000000000000000000007"),
+    ("order-independent-p2sh-2of3/token-transfer/key0", "800000000004056d19203ede791c0ab9e2959e01cec910b784d53e0000000000000000000000000000012c0000000302013b2f96897a152a9edc228d762167f04a068b76c976038bf37a31db9c5ec47cba173217b75bb562c89936ffe0a9a9ff4c042cdd691e459700462b5fd80f5440a90201bb4ca34565e553ae07b2ce96d99df8587e8184fc0116947258cc1029295362956cff0469c133df81e2148eb54deafdae52b5f01b2ec6741e44fd1b758579a1c20002f9e2e210e7706dc8dc35f7c8d45585a41767c10096889474830f7eeb8b94a51300020302000000000005010101010101010101010101010101010101010101000000000000303942424242424242424242424242424242424242424242424242424242424242424242"),
+    ("order-independent-p2wsh-2of3/smart-contract/key5", "800000000004077169787ececfc855c04c8b55c9176016819de0550000000000000005000000000000012c000000030201b915a06f9dc46822b620f5c61e8f89fd00893d42ab9fd1c1236896eb888756a71ed372c1d71fe14cedc47c1eef71c7a609d8e658aeac70be0eaf3fdca47056450201fc87be9d8e9f1df15e0fbcaa80b4e21a5b52ee71cf0d439ff614d5a098eb8b711d984d1873284f621f75aa8ff05bc8121296307b00d97e6a3fb4d7153a235c9900037da48101551591fede0d2b28629573ca1268ba155d2b1883b46e070118a1d3e80002030200000000010d7665726966792d6465706c6f790000001928646566696e652d726561642d6f6e6c792028662920753129"),
+    ("sponsored-p2pkh/smart-contract/key2", "00000000000500a83d3582e571d4381ca9024ab45db4642f35ddfa0000000000000002000000000000000000000935acb8ff83fc7116727fa38b2f1a0cc5d9fd2989fa26aef46552ce437a41ce3277d81e87f7874bbd68b72edb3d2774e47136cafba6a64506a5df136a5dbf1a009d2585f991265316113e5a1ac864b56d41180188000000000000000300000000000000f00001dd888bb9ead98f681d25afa59539f01449715b5c05e9fb08611c1bfa8d06174967f148a5d694accf691cdcd2d4b3c622abc4288cc083017131ec6c6ce4e936fc030200000000010d7665726966792d6465706c6f790000001928646566696e652d726561642d6f6e6c792028662920753129"),
+];
+
+/// Recovery and verification accept signatures produced by the native backend.
+#[test]
+fn native_reference_signatures_verify() {
+    for (i, (hash_hex, sig_hex, pubkey_hex)) in REFERENCE_SIGNATURES.iter().enumerate() {
+        let hash = hex_bytes(hash_hex).expect("BUG: bad reference hash hex");
+        let sig = MessageSignature::from_hex(sig_hex).expect("BUG: bad reference signature hex");
+
+        assert_eq!(
+            StacksPublicKey::recover_to_pubkey(&hash, &sig)
+                .unwrap_or_else(|e| panic!("reference {i}: {e}"))
+                .to_hex(),
+            *pubkey_hex,
+            "reference {i}: recovery from the native signature returned the wrong key"
+        );
+        assert!(
+            StacksPublicKey::from_hex(pubkey_hex)
+                .unwrap()
+                .verify(&hash, &sig)
+                .unwrap_or_else(|e| panic!("reference {i}: {e}")),
+            "reference {i}: verification rejected the native signature"
+        );
+    }
+}
+
+/// Transactions serialized and signed by the native backend verify.
+#[test]
+fn native_reference_transactions_verify() {
+    for (name, tx_hex) in REFERENCE_TRANSACTIONS {
+        let bytes = hex_bytes(tx_hex).expect("BUG: bad reference transaction hex");
+        let tx = StacksTransaction::consensus_deserialize(&mut &bytes[..])
+            .unwrap_or_else(|e| panic!("{name}: failed to decode: {e:?}"));
+
+        tx.verify(TransactionAuthVerificationMode::EnforceLowS)
+            .unwrap_or_else(|e| panic!("{name}: reference transaction failed to verify: {e}"));
+    }
+}
+
+/// `PublicKey::verify()` is a separate entry point from `tx.verify()`, which
+/// compares address hashes after forcing the recovered key's encoding.
+#[test]
+fn public_key_verify_accepts_both_key_encodings() {
+    for i in 0..KEY_COUNT {
+        let privk = compressed_key(i);
+        let hash = Sha512Trunc256Sum::from_data(&[b'v', b'r', b'f', i]);
+        let sig = privk
+            .sign(hash.as_bytes())
+            .expect("BUG: failed to sign a 32-byte hash");
+
+        // `recover_to_pubkey()` always returns a compressed key, so a `verify()`
+        // that compares whole `Secp256k1PublicKey` values -- `compressed` flag
+        // included -- would reject every uncompressed key.
+        for compressed in [true, false] {
+            let mut pubk = StacksPublicKey::from_private(&privk);
+            pubk.set_compressed(compressed);
+            assert!(
+                pubk.verify(hash.as_bytes(), &sig)
+                    .unwrap_or_else(|e| panic!("key{i}: {e}")),
+                "key{i}: verify() rejected a valid signature for a {} key",
+                if compressed {
+                    "compressed"
+                } else {
+                    "uncompressed"
+                }
+            );
+        }
+
+        let other = StacksPublicKey::from_private(&compressed_key(i + 40));
+        assert!(
+            !other
+                .verify(hash.as_bytes(), &sig)
+                .unwrap_or_else(|e| panic!("key{i}: {e}")),
+            "key{i}: verify() accepted a signature made by a different key"
+        );
+
+        assert!(
+            StacksPublicKey::from_private(&privk)
+                .verify(hash.as_bytes(), &sig.with_negated_s())
+                .is_err(),
+            "key{i}: verify() accepted a high-S signature"
+        );
+    }
+}
+
+/// The recovery path rejects each kind of malformed input with the same error on
+/// both backends. None of these branches are reachable from a signed
+/// transaction.
+#[test]
+fn recover_to_pubkey_rejects_malformed_input() {
+    let privk = compressed_key(0);
+    let hash = Sha512Trunc256Sum::from_data(b"reject");
+    let sig = privk
+        .sign(hash.as_bytes())
+        .expect("BUG: failed to sign a 32-byte hash");
+
+    // The message must be exactly 32 bytes.
+    for len in [0usize, 31, 33, 64] {
+        assert_eq!(
+            StacksPublicKey::recover_to_pubkey(&vec![0u8; len], &sig),
+            Err("Invalid message: failed to decode data hash: must be a 32-byte hash"),
+            "a {len}-byte message hash was not rejected"
+        );
+    }
+
+    // When the message and the signature are both malformed, both backends
+    // report the message first.
+    assert_eq!(
+        StacksPublicKey::recover_to_pubkey(&[], &MessageSignature([0xff; 65])),
+        Err("Invalid message: failed to decode data hash: must be a 32-byte hash"),
+        "a malformed message and signature did not report the message error"
+    );
+
+    // The recovery id occupies byte 0 and must be in 0..=3.
+    let mut bytes = [0u8; 65];
+    bytes.copy_from_slice(sig.as_bytes());
+    for recovery_id in [4u8, 0x80, 0xff] {
+        bytes[0] = recovery_id;
+        assert_eq!(
+            StacksPublicKey::recover_to_pubkey(hash.as_bytes(), &MessageSignature(bytes)),
+            Err("Invalid signature: failed to decode recoverable signature"),
+            "recovery id {recovery_id} was not rejected"
+        );
+    }
+
+    // A valid recovery id over a point that is not on the curve.
+    let mut unrecoverable = [0u8; 65];
+    unrecoverable[0] = 1;
+    assert_eq!(
+        StacksPublicKey::recover_to_pubkey(hash.as_bytes(), &MessageSignature(unrecoverable)),
+        Err("Invalid signature: failed to recover public key"),
+        "an all-zero signature was not rejected"
+    );
+
+    // High-S is rejected only by the low-S entry point.
+    let high_s = sig.with_negated_s();
+    assert_eq!(
+        StacksPublicKey::recover_to_pubkey(hash.as_bytes(), &high_s),
+        Err("Invalid signature: high-S"),
+        "a high-S signature was not rejected by recover_to_pubkey()"
+    );
+    assert!(
+        StacksPublicKey::recover_to_pubkey_without_validating_low_s(hash.as_bytes(), &high_s)
+            .is_ok(),
+        "a high-S signature was rejected by the entry point that allows it"
+    );
+}
+
+/// `StacksMicroblockHeader` recovers its signer through
+/// `recover_to_pubkey_without_validating_low_s()`, which no transaction vector
+/// above reaches under `EnforceLowS`.
+#[test]
+fn microblock_header_signatures_verify() {
+    for i in 0..KEY_COUNT {
+        let privk = compressed_key(i);
+        let signer = Hash160::from_node_public_key(&StacksPublicKey::from_private(&privk));
+
+        let mut header = StacksMicroblockHeader {
+            version: 0x12,
+            sequence: u16::from(i),
+            prev_block: BlockHeaderHash([0x33; 32]),
+            tx_merkle_root: Sha512Trunc256Sum([0x44; 32]),
+            signature: MessageSignature::empty(),
+        };
+        header
+            .sign(&privk)
+            .expect("BUG: failed to sign the microblock header");
+
+        header
+            .verify(&signer)
+            .unwrap_or_else(|e| panic!("key{i}: a correctly signed header failed to verify: {e}"));
+
+        let other =
+            Hash160::from_node_public_key(&StacksPublicKey::from_private(&compressed_key(i + 40)));
+        assert!(
+            header.verify(&other).is_err(),
+            "key{i}: verification accepted the wrong signer"
+        );
+
+        let mut tampered = header.clone();
+        tampered.sequence ^= 0xff;
+        assert!(
+            tampered.verify(&signer).is_err(),
+            "key{i}: verification accepted a header with a tampered sequence"
+        );
+    }
 }

--- a/stacks-codec/src/signature_verification_tests.rs
+++ b/stacks-codec/src/signature_verification_tests.rs
@@ -1,5 +1,4 @@
-// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
-// Copyright (C) 2020-2026 Stacks Open Internet Foundation
+// Copyright (C) 2026 Stacks Open Internet Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,26 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Cross-backend tests for [`StacksTransaction::verify`].
+//! Signature-verification tests shared by the native and wasm backends.
 //!
-//! `stacks_common::util::secp256k1` has two independent implementations —
-//! `native.rs` over the C `secp256k1` library, `wasm.rs` over the pure-Rust
-//! `libsecp256k1` — selected by `cfg(target_family = "wasm")`. Signature
-//! verification is consensus-critical and the two backends must agree, but CI
-//! only ever *compile-checks* the wasm one, so a behavioural difference between
-//! them can sit undetected indefinitely.
-//!
-//! Every test here therefore runs on both: as a plain `#[test]` natively, and
-//! as a `#[wasm_bindgen_test]` under `wasm32-unknown-unknown`. Run the wasm
-//! side with:
+//! Run the wasm tests with:
 //!
 //! ```text
 //! cd stacks-codec && wasm-pack test --node --features wasm-web
 //! ```
 //!
-//! The vectors are deliberately deterministic. A byte-order bug can be
-//! invisible for one signature and fatal for the next, so a random suite would
-//! be both flaky and impossible to bisect.
+//! The vectors are deterministic so failures are reproducible.
 
 #![cfg(test)]
 
@@ -52,20 +40,10 @@ use crate::transaction::{
     TransactionSpendingCondition, TransactionVersion,
 };
 
-/// How many distinct signing keys the suite sweeps.
-///
-/// The recovery id is the single byte the two backends can disagree about, and
-/// its value is effectively unpredictable per (key, sighash) pair. Sweeping
-/// many keys is what makes the suite exercise more than one recovery id — see
-/// [`vectors_cover_multiple_recovery_ids`], which asserts that it actually does
-/// rather than trusting it to.
+/// Enough keys to exercise multiple recovery IDs.
 const KEY_COUNT: u8 = 12;
 
 /// Deterministic signing key `i`.
-///
-/// Hashing the index spreads the key bytes across the field, so the resulting
-/// signatures have well-distributed `r`/`s` values instead of the near-adjacent
-/// ones that `[i; 32]` would produce.
 fn key(i: u8) -> StacksPrivateKey {
     let bytes = Sha512Trunc256Sum::from_data(&[b'v', b'e', b'r', b'i', b'f', b'y', i]);
     StacksPrivateKey::from_slice(bytes.as_bytes())
@@ -84,8 +62,7 @@ fn uncompressed_key(i: u8) -> StacksPrivateKey {
     k
 }
 
-/// The payload shapes a transaction can carry. The payload feeds the initial
-/// sighash, so varying it varies every signature in the suite.
+/// Payloads that produce distinct initial sighashes.
 fn payloads() -> Vec<(&'static str, TransactionPayload)> {
     vec![
         (
@@ -134,8 +111,7 @@ fn signed_singlesig(
     tx
 }
 
-/// Every single-signature transaction shape this suite knows how to build,
-/// labelled so a failure names the case rather than an index.
+/// Single-signature transaction vectors.
 fn singlesig_vectors() -> Vec<(String, StacksTransaction)> {
     let mut out = vec![];
 
@@ -147,7 +123,7 @@ fn singlesig_vectors() -> Vec<(String, StacksTransaction)> {
                 TransactionVersion::Mainnet
             };
 
-            // p2pkh, compressed — the shape real clients emit.
+            // The common client-generated shape.
             let privk = compressed_key(i);
             out.push((
                 format!("p2pkh-compressed/{payload_name}/key{i}"),
@@ -160,8 +136,7 @@ fn singlesig_vectors() -> Vec<(String, StacksTransaction)> {
                 ),
             ));
 
-            // p2pkh, uncompressed — a different `key_encoding` branch in
-            // `next_verification`, so it must be covered separately.
+            // Exercise the uncompressed-key branch.
             let privk = uncompressed_key(i);
             out.push((
                 format!("p2pkh-uncompressed/{payload_name}/key{i}"),
@@ -174,7 +149,7 @@ fn singlesig_vectors() -> Vec<(String, StacksTransaction)> {
                 ),
             ));
 
-            // p2wpkh — segwit-style singlesig hash mode.
+            // Exercise the segwit-style hash mode.
             let privk = compressed_key(i);
             out.push((
                 format!("p2wpkh/{payload_name}/key{i}"),
@@ -192,9 +167,7 @@ fn singlesig_vectors() -> Vec<(String, StacksTransaction)> {
     out
 }
 
-/// Ordered 2-of-3 multisig, signed sequentially: each signature commits to the
-/// sighash the previous one produced, so this exercises the rolling-hash path
-/// in `next_verification` rather than a single recovery.
+/// Ordered 2-of-3 multisig vectors exercise rolling signature hashes.
 fn multisig_vectors() -> Vec<(String, StacksTransaction)> {
     let mut out = vec![];
 
@@ -231,9 +204,7 @@ fn multisig_vectors() -> Vec<(String, StacksTransaction)> {
     out
 }
 
-/// Sponsored transactions: the origin signature is verified first and its
-/// resulting sighash is what the sponsor signs, so a recovery failure on the
-/// origin half would be masked without covering this shape.
+/// Sponsored vectors exercise origin and sponsor verification.
 fn sponsored_vectors() -> Vec<(String, StacksTransaction)> {
     let mut out = vec![];
 
@@ -272,10 +243,7 @@ fn all_vectors() -> Vec<(String, StacksTransaction)> {
     out
 }
 
-// -- The tests ----------------------------------------------------------------
-
-/// The headline property: a correctly signed transaction verifies. This is what
-/// fails wholesale on the wasm backend.
+/// Correctly signed transactions verify.
 #[test]
 fn correctly_signed_transactions_verify() {
     let vectors = all_vectors();
@@ -307,9 +275,7 @@ fn correctly_signed_transactions_verify() {
     );
 }
 
-/// `AllowHighS` takes a different recovery entry point
-/// (`recover_to_pubkey_without_validating_low_s`), so it needs its own sweep —
-/// a fix applied to only one of the two would otherwise look complete.
+/// `AllowHighS` uses a separate recovery entry point.
 #[test]
 fn correctly_signed_transactions_verify_allowing_high_s() {
     let vectors = all_vectors();
@@ -333,8 +299,7 @@ fn correctly_signed_transactions_verify_allowing_high_s() {
     );
 }
 
-/// The suite must actually exercise more than one recovery id, or it would not
-/// distinguish a correct implementation from one that hardcodes the common case.
+/// Ensure the deterministic vectors cover multiple recovery IDs.
 #[test]
 fn vectors_cover_multiple_recovery_ids() {
     let mut seen = [0usize; 256];
@@ -361,31 +326,14 @@ fn vectors_cover_multiple_recovery_ids() {
     );
 }
 
-/// Guards against the opposite failure: a `verify` that returns `Ok`
-/// unconditionally would satisfy every test above.
+/// Verification rejects changes to signed fields.
 #[test]
 fn tampered_transactions_do_not_verify() {
     for (name, tx) in all_vectors() {
-        for (what, mut tampered) in [
-            ("nonce", tx.clone()),
-            ("fee", tx.clone()),
-            ("version", tx.clone()),
-        ] {
+        for (what, mut tampered) in [("nonce", tx.clone()), ("fee", tx.clone())] {
             match what {
                 "nonce" => tampered.set_origin_nonce(tx.get_origin_nonce() ^ 0xff),
-                "fee" => tampered.set_tx_fee(tx.get_tx_fee() + 1),
-                _ => {
-                    tampered.version = match tx.version {
-                        TransactionVersion::Mainnet => TransactionVersion::Testnet,
-                        TransactionVersion::Testnet => TransactionVersion::Mainnet,
-                    }
-                }
-            }
-
-            // Changing the version does not change the sighash, so it is only
-            // the nonce and fee that must break verification.
-            if what == "version" {
-                continue;
+                _ => tampered.set_tx_fee(tx.get_tx_fee() + 1),
             }
 
             assert!(
@@ -398,10 +346,7 @@ fn tampered_transactions_do_not_verify() {
     }
 }
 
-/// A high-S signature must be rejected under `EnforceLowS` and accepted under
-/// `AllowHighS`. This is the pair of behaviours that the low-S pre-check inside
-/// the recovery path is responsible for, so it is exactly the code a byte-order
-/// bug would also corrupt.
+/// High-S signatures are accepted only when explicitly allowed.
 #[test]
 fn high_s_signatures_are_rejected_only_when_enforcing_low_s() {
     for (name, tx) in singlesig_vectors() {
@@ -422,9 +367,7 @@ fn high_s_signatures_are_rejected_only_when_enforcing_low_s() {
     }
 }
 
-/// The narrowest reproduction, kept separate so a failure points straight at
-/// `recover_to_pubkey` rather than at transaction assembly: sign a hash, then
-/// recover the signer's public key from it.
+/// Directly exercise the recovery function fixed by this change.
 #[test]
 fn recovering_a_public_key_round_trips() {
     use stacks_common::types::PrivateKey;

--- a/stacks-codec/src/signature_verification_tests.rs
+++ b/stacks-codec/src/signature_verification_tests.rs
@@ -13,9 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Signature-verification tests shared by the native and wasm backends.
+//! Signature-verification tests shared by the native and Wasm backends.
 //!
-//! Run the wasm tests with:
+//! Run the Wasm tests with:
 //!
 //! ```text
 //! cd stacks-codec && wasm-pack test --node --features wasm-web

--- a/stacks-common/src/util/secp256k1/native.rs
+++ b/stacks-common/src/util/secp256k1/native.rs
@@ -462,6 +462,7 @@ fn secp256k1_privkey_deserialize<'de, D: serde::Deserializer<'de>>(
     LibSecp256k1PrivateKey::from_slice(&key_bytes[..]).map_err(de_Error::custom)
 }
 
+/// Recover a public key from a 32-byte message hash and a 65-byte RSV signature.
 pub fn secp256k1_recover(
     message_arr: &[u8],
     serialized_signature_arr: &[u8],

--- a/stacks-common/src/util/secp256k1/wasm.rs
+++ b/stacks-common/src/util/secp256k1/wasm.rs
@@ -139,19 +139,31 @@ impl Secp256k1PublicKey {
         sig: &MessageSignature,
         verify_low_s: bool,
     ) -> Result<Secp256k1PublicKey, &'static str> {
+        // A `MessageSignature` is VRS: the recovery id is byte 0 and `r || s`
+        // follows in bytes 1..=64. `secp256k1_recover` below is RSV instead,
+        // because its callers are Clarity's `secp256k1-recover?` and
+        // `secp256k1-verify` builtins and RSV is Clarity's wire order. Decode
+        // through the helper that knows the difference rather than handing it
+        // the raw bytes, which would shift `r`, `s` and the recovery id each by
+        // one position and fail to recover any real signature.
+        let (signature, recovery_id) = sig
+            .to_secp256k1_recoverable()
+            .ok_or("Invalid signature: failed to decode recoverable signature")?;
+
         if verify_low_s {
-            let signature = LibSecp256k1Signature::parse_standard_slice(&sig[..64])
-                .map_err(|_| "Invalid signature: incorrect length")?;
             let mut sig_low_s = signature;
             sig_low_s.normalize_s();
             if signature != sig_low_s {
                 return Err("Invalid signature: high-S");
             }
         }
-        let secp256k1_sig = secp256k1_recover(msg, sig.as_bytes())
-            .map_err(|_e| "Invalid signature: failed to recover public key")?;
 
-        Secp256k1PublicKey::from_slice(&secp256k1_sig)
+        let message = LibSecp256k1Message::parse_slice(msg)
+            .map_err(|_| "Invalid message: failed to decode data hash: must be a 32-byte hash")?;
+        let recovered = libsecp256k1::recover(&message, &signature, &recovery_id)
+            .map_err(|_| "Invalid signature: failed to recover public key")?;
+
+        Secp256k1PublicKey::from_slice(&recovered.serialize_compressed())
     }
 }
 

--- a/stacks-common/src/util/secp256k1/wasm.rs
+++ b/stacks-common/src/util/secp256k1/wasm.rs
@@ -139,13 +139,8 @@ impl Secp256k1PublicKey {
         sig: &MessageSignature,
         verify_low_s: bool,
     ) -> Result<Secp256k1PublicKey, &'static str> {
-        // A `MessageSignature` is VRS: the recovery id is byte 0 and `r || s`
-        // follows in bytes 1..=64. `secp256k1_recover` below is RSV instead,
-        // because its callers are Clarity's `secp256k1-recover?` and
-        // `secp256k1-verify` builtins and RSV is Clarity's wire order. Decode
-        // through the helper that knows the difference rather than handing it
-        // the raw bytes, which would shift `r`, `s` and the recovery id each by
-        // one position and fail to recover any real signature.
+        // `MessageSignature` uses VRS, while the Clarity-facing recovery helper
+        // uses RSV. Decode VRS directly instead of passing it to that helper.
         let (signature, recovery_id) = sig
             .to_secp256k1_recoverable()
             .ok_or("Invalid signature: failed to decode recoverable signature")?;
@@ -340,10 +335,7 @@ impl MessageSignature {
         MessageSignature(ret_bytes)
     }
 
-    // Returns the version of this message signature in which s has
-    // the opposite sign (mod n). This is only used in tests, to
-    // create invalid (or let's call them semi-valid) transaction
-    // signatures to test how the code handles them.
+    /// Return the equivalent signature with `s` negated modulo the curve order.
     #[cfg(any(test, feature = "testing"))]
     pub fn with_negated_s(&self) -> Self {
         let mut bytes = [0u8; 65];

--- a/stacks-common/src/util/secp256k1/wasm.rs
+++ b/stacks-common/src/util/secp256k1/wasm.rs
@@ -139,8 +139,8 @@ impl Secp256k1PublicKey {
         sig: &MessageSignature,
         verify_low_s: bool,
     ) -> Result<Secp256k1PublicKey, &'static str> {
-        // `MessageSignature` uses VRS, while `secp256k1_recover()` expects RSV.
-        // Decode the `MessageSignature` directly to preserve its byte order.
+        // `MessageSignature` stores the recovery ID before the compact signature
+        // (VRS), so decode it into separate recovery ID and signature values.
         let (signature, recovery_id) = sig
             .to_secp256k1_recoverable()
             .ok_or("Invalid signature: failed to decode recoverable signature")?;
@@ -233,6 +233,7 @@ impl Secp256k1PrivateKey {
 }
 
 #[cfg(not(feature = "wasm-deterministic"))]
+/// Recover a public key from a 32-byte message hash and a 65-byte RSV signature.
 pub fn secp256k1_recover(
     message_arr: &[u8],
     serialized_signature: &[u8],
@@ -354,11 +355,8 @@ impl MessageSignature {
     pub fn to_secp256k1_recoverable(
         &self,
     ) -> Option<(LibSecp256k1Signature, LibSecp256k1RecoveryId)> {
-        let recovery_id = match LibSecp256k1RecoveryId::parse(self.0[0]) {
-            Ok(rid) => rid,
-            Err(_) => {
-                return None;
-            }
+        let Ok(recovery_id) = LibSecp256k1RecoveryId::parse(self.0[0]) else {
+            return None;
         };
         let signature = LibSecp256k1Signature::parse_standard_slice(&self.0[1..65]).ok()?;
         Some((signature, recovery_id))

--- a/stacks-common/src/util/secp256k1/wasm.rs
+++ b/stacks-common/src/util/secp256k1/wasm.rs
@@ -139,6 +139,11 @@ impl Secp256k1PublicKey {
         sig: &MessageSignature,
         verify_low_s: bool,
     ) -> Result<Secp256k1PublicKey, &'static str> {
+        // Validate in the same order as `native.rs`, so that both backends return
+        // the same error for the same input.
+        let message = LibSecp256k1Message::parse_slice(msg)
+            .map_err(|_| "Invalid message: failed to decode data hash: must be a 32-byte hash")?;
+
         // `MessageSignature` stores the recovery ID before the compact signature
         // (VRS), so decode it into separate recovery ID and signature values.
         let (signature, recovery_id) = sig
@@ -153,8 +158,6 @@ impl Secp256k1PublicKey {
             }
         }
 
-        let message = LibSecp256k1Message::parse_slice(msg)
-            .map_err(|_| "Invalid message: failed to decode data hash: must be a 32-byte hash")?;
         let recovered = libsecp256k1::recover(&message, &signature, &recovery_id)
             .map_err(|_| "Invalid signature: failed to recover public key")?;
 
@@ -377,8 +380,14 @@ impl PublicKey for Secp256k1PublicKey {
     fn verify(&self, data_hash: &[u8], sig: &MessageSignature) -> Result<bool, &'static str> {
         // `recover_to_pubkey` also ensures that the signature has low-S. That matches the
         // corresponding implementation in `native.rs`.
-        let pub_key = Secp256k1PublicKey::recover_to_pubkey(data_hash, sig)?;
-        Ok(self.eq(&pub_key))
+        let recovered = Secp256k1PublicKey::recover_to_pubkey(data_hash, sig)?;
+
+        // Compare the curve points only. `recover_to_pubkey()` always returns a
+        // compressed key, while `self` may use either encoding, and `compressed`
+        // takes part in the derived `PartialEq` for `Secp256k1PublicKey`. Comparing
+        // whole values would reject every uncompressed key. `native.rs` compares
+        // the underlying keys for the same reason.
+        Ok(self.key == recovered.key)
     }
 }
 

--- a/stacks-common/src/util/secp256k1/wasm.rs
+++ b/stacks-common/src/util/secp256k1/wasm.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#[cfg(all(any(test, feature = "testing"), not(feature = "wasm-deterministic")))]
+#[cfg(any(test, feature = "testing"))]
 use ::libsecp256k1::curve::Scalar;
 pub use ::libsecp256k1::Error;
 use ::libsecp256k1::{
@@ -156,6 +156,11 @@ impl Secp256k1PublicKey {
 }
 
 impl Secp256k1PrivateKey {
+    #[cfg(feature = "rand")]
+    pub fn random() -> Secp256k1PrivateKey {
+        Self::new()
+    }
+
     #[cfg(feature = "rand")]
     pub fn new() -> Secp256k1PrivateKey {
         use rand::RngCore as _;
@@ -321,6 +326,25 @@ impl MessageSignature {
         ret_bytes[0] = recovery_id_byte;
         ret_bytes[1..=64].copy_from_slice(&bytes[..64]);
         MessageSignature(ret_bytes)
+    }
+
+    // Returns the version of this message signature in which s has
+    // the opposite sign (mod n). This is only used in tests, to
+    // create invalid (or let's call them semi-valid) transaction
+    // signatures to test how the code handles them.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn with_negated_s(&self) -> Self {
+        let mut bytes = [0u8; 65];
+        bytes.copy_from_slice(self.as_bytes());
+
+        // `s` occupies bytes 33..65, since byte 0 is the recovery id.
+        let mut s = Scalar::default();
+        let mut s_bytes = [0u8; 32];
+        s_bytes.copy_from_slice(&bytes[33..]);
+        let _ = s.set_b32(&s_bytes);
+        bytes[33..].copy_from_slice(&(-s).b32());
+        bytes[0] ^= 1; // invert the parity of the recovery id
+        Self(bytes)
     }
 
     pub fn to_secp256k1_recoverable(

--- a/stacks-common/src/util/secp256k1/wasm.rs
+++ b/stacks-common/src/util/secp256k1/wasm.rs
@@ -139,8 +139,8 @@ impl Secp256k1PublicKey {
         sig: &MessageSignature,
         verify_low_s: bool,
     ) -> Result<Secp256k1PublicKey, &'static str> {
-        // `MessageSignature` uses VRS, while the Clarity-facing recovery helper
-        // uses RSV. Decode VRS directly instead of passing it to that helper.
+        // `MessageSignature` uses VRS, while `secp256k1_recover()` expects RSV.
+        // Decode the `MessageSignature` directly to preserve its byte order.
         let (signature, recovery_id) = sig
             .to_secp256k1_recoverable()
             .ok_or("Invalid signature: failed to decode recoverable signature")?;


### PR DESCRIPTION
### Description

Two fixes related to Secp256k1 on Wasm targets:

- `Secp256k1PublicKey::recover_to_pubkey()`: We use signatures in VRS order in Stacks. The Wasm variant of this function was parsing the signature byes in RSV order, so verification would always fail. Fix it by using `to_secp256k1_recoverable()` which parses the signature in VRS order 

- `Secp256k1PublicKey::verify()`: This was comparing the entire struct, which includes the compression flag, meaning the check would always fail for uncompressed keys. Fix it by the pubkeys directly instead of the wrapper struct

### Applicable issues

- Required for: #stx-labs/clarinet#2489

### Checklist

- [x] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
