### PR TITLE
CI: enable debug logs

### DIFF
--- a/.github/workflows/_tests-bitcoin-rpc.yml
+++ b/.github/workflows/_tests-bitcoin-rpc.yml
@@ -21,6 +21,8 @@ permissions:
 # Set default env vars
 env:
   RUST_BACKTRACE: full
+  # Emit DEBUG-level logs; nextest only prints captured output for failing tests
+  STACKS_LOG_DEBUG: 1
   TEST_TIMEOUT_MINS: 5
   DISCOVER_TIMEOUT_MINS: 5
   # Minimum Bitcoin Core major version to start discovering Docker tags from.

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -33,6 +33,8 @@ env:
   # Docker tag for the Bitcoin Core image used when spinning up container with `testcontainers` crate.
   BITCOIN_IMAGE_TAG: "25"
   RUST_BACKTRACE: full
+  # Emit DEBUG-level logs; nextest only prints captured output for failing tests
+  STACKS_LOG_DEBUG: 1
   TEST_TIMEOUT: 30
   TEST_TAG_CI_SKIP: ci_skip
   # This should match the number of jobs we use below

--- a/.github/workflows/_tests-epoch.yml
+++ b/.github/workflows/_tests-epoch.yml
@@ -32,6 +32,8 @@ env:
   BITCOIND_TEST: 1
   RUST_BACKTRACE: full
   TEST_TIMEOUT: 30
+  # Emit DEBUG-level logs; nextest only prints captured output for failing tests
+  STACKS_LOG_DEBUG: 1
 
 # Configure concurrency
 concurrency:


### PR DESCRIPTION
This enables debug logs in the CI integration tests.

These are only actually output when a test fails (otherwise, nextest just captures them and doesn't output them).