### PR TITLE
chore: address clippy `new_without_default` lints

### DIFF
--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -291,6 +291,12 @@ impl TestMiner {
 }
 
 // creates miners deterministically
+impl Default for TestMinerFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TestMinerFactory {
     pub fn new() -> TestMinerFactory {
         TestMinerFactory {
@@ -792,6 +798,8 @@ impl TestBurnchainFork {
     }
 }
 
+// A default would hide test database initialization and a possible panic.
+#[allow(clippy::new_without_default)]
 impl TestBurnchainNode {
     pub fn new() -> TestBurnchainNode {
         let first_block_height = 100;

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -184,6 +184,7 @@ pub trait BlockEventDispatcher {
     );
 }
 
+#[derive(Default)]
 pub struct ChainsCoordinatorConfig {
     /// true: enable transactions indexing
     /// false: no transactions indexing
@@ -292,6 +293,12 @@ pub trait RewardSetProvider {
 }
 
 pub struct OnChainRewardSetProvider<'a, T: BlockEventDispatcher>(pub Option<&'a T>);
+
+impl Default for OnChainRewardSetProvider<'static, DummyEventDispatcher> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl OnChainRewardSetProvider<'static, DummyEventDispatcher> {
     pub fn new() -> Self {

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -118,6 +118,8 @@ pub struct TestSimBurnStateDB {
     height: u32,
 }
 
+// A default would hide temporary MARF setup, database writes, and a commit.
+#[allow(clippy::new_without_default)]
 impl ClarityTestSim {
     pub fn new() -> ClarityTestSim {
         let mut marf = MarfedKV::temporary();

--- a/stackslib/src/chainstate/stacks/index/profile.rs
+++ b/stackslib/src/chainstate/stacks/index/profile.rs
@@ -92,6 +92,8 @@ pub struct TrieBenchmark {
     time_errors: u64,
 }
 
+// A default would misleadingly capture the current time for each benchmark timer.
+#[allow(clippy::new_without_default)]
 #[cfg(test)]
 impl TrieBenchmark {
     pub fn new() -> TrieBenchmark {
@@ -410,6 +412,8 @@ impl TrieBenchmark {
     }
 }
 
+// A default would misleadingly capture the current time for each benchmark timer.
+#[allow(clippy::new_without_default)]
 #[cfg(not(test))]
 impl TrieBenchmark {
     pub fn new() -> TrieBenchmark {

--- a/stackslib/src/chainstate/stacks/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/tests/mod.rs
@@ -98,6 +98,7 @@ pub fn copy_dir(src_dir: &str, dest_dir: &str) -> Result<(), io::Error> {
 }
 
 // one point per round
+#[derive(Default)]
 pub struct TestMinerTracePoint {
     pub fork_snapshots: HashMap<usize, BlockSnapshot>, // map miner ID to snapshot
     pub stacks_blocks: HashMap<usize, StacksBlock>,    // map miner ID to stacks block

--- a/stackslib/src/clarity_vm/database/mod.rs
+++ b/stackslib/src/clarity_vm/database/mod.rs
@@ -1206,6 +1206,8 @@ pub struct MemoryBackingStore {
     side_store: Connection,
 }
 
+// A default would hide SQLite connection and schema initialization that can panic.
+#[allow(clippy::new_without_default)]
 impl MemoryBackingStore {
     pub fn new() -> MemoryBackingStore {
         let side_store = SqliteConnection::memory().unwrap();

--- a/stackslib/src/net/api/get_tenure_tip_meta.rs
+++ b/stackslib/src/net/api/get_tenure_tip_meta.rs
@@ -25,7 +25,7 @@ use crate::net::http::{
 use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct NakamotoTenureTipMetadataRequestHandler {
     pub(crate) consensus_hash: Option<ConsensusHash>,
 }

--- a/stackslib/src/net/api/getaccount.rs
+++ b/stackslib/src/net/api/getaccount.rs
@@ -45,7 +45,7 @@ pub struct AccountEntryResponse {
     pub nonce_proof: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetAccountRequestHandler {
     pub account: Option<PrincipalData>,
 }

--- a/stackslib/src/net/api/getattachment.rs
+++ b/stackslib/src/net/api/getattachment.rs
@@ -26,7 +26,7 @@ use crate::net::http::{
 use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetAttachmentRequestHandler {
     pub attachment_hash: Option<Hash160>,
 }

--- a/stackslib/src/net/api/getattachmentsinv.rs
+++ b/stackslib/src/net/api/getattachmentsinv.rs
@@ -32,7 +32,7 @@ use crate::net::http::{
 use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetAttachmentsInvRequestHandler {
     pub index_block_hash: Option<StacksBlockId>,
     pub page_indexes: Option<Vec<u32>>,

--- a/stackslib/src/net/api/getblock.rs
+++ b/stackslib/src/net/api/getblock.rs
@@ -32,7 +32,7 @@ use crate::net::http::{
 use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCBlocksRequestHandler {
     pub block_id: Option<StacksBlockId>,
 }

--- a/stackslib/src/net/api/getblock_v3.rs
+++ b/stackslib/src/net/api/getblock_v3.rs
@@ -32,7 +32,7 @@ use crate::net::http::{
 use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoBlockRequestHandler {
     pub block_id: Option<StacksBlockId>,
 }

--- a/stackslib/src/net/api/getblockbyheight.rs
+++ b/stackslib/src/net/api/getblockbyheight.rs
@@ -31,7 +31,7 @@ use crate::net::httpcore::{
 use crate::net::{Error as NetError, StacksNodeState, TipRequest};
 use crate::util_lib::db::Error as DBError;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoBlockByHeightRequestHandler {
     pub block_height: Option<u64>,
 }

--- a/stackslib/src/net/api/getclaritymarfvalue.rs
+++ b/stackslib/src/net/api/getclaritymarfvalue.rs
@@ -37,7 +37,7 @@ pub struct ClarityMarfResponse {
     pub marf_proof: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetClarityMarfRequestHandler {
     pub marf_key_hash: Option<TrieHash>,
 }

--- a/stackslib/src/net/api/getclaritymetadata.rs
+++ b/stackslib/src/net/api/getclaritymetadata.rs
@@ -52,7 +52,7 @@ pub struct ClarityMetadataResponse {
     pub data: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetClarityMetadataRequestHandler {
     pub clarity_metadata_key: Option<String>,
     pub contract_identifier: Option<QualifiedContractIdentifier>,

--- a/stackslib/src/net/api/getconstantval.rs
+++ b/stackslib/src/net/api/getconstantval.rs
@@ -38,7 +38,7 @@ pub struct ConstantValResponse {
     pub data: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetConstantValRequestHandler {
     pub constname: Option<ClarityName>,
     pub contract_identifier: Option<QualifiedContractIdentifier>,

--- a/stackslib/src/net/api/getcontractabi.rs
+++ b/stackslib/src/net/api/getcontractabi.rs
@@ -33,7 +33,7 @@ use crate::net::httpcore::{
 };
 use crate::net::{Error as NetError, StacksNodeState, TipRequest};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetContractAbiRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
 }

--- a/stackslib/src/net/api/getcontractsrc.rs
+++ b/stackslib/src/net/api/getcontractsrc.rs
@@ -44,7 +44,7 @@ pub struct ContractSrcResponse {
     pub marf_proof: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetContractSrcRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
 }

--- a/stackslib/src/net/api/getdatavar.rs
+++ b/stackslib/src/net/api/getdatavar.rs
@@ -44,7 +44,7 @@ pub struct DataVarResponse {
     pub marf_proof: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetDataVarRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
     pub varname: Option<ClarityName>,

--- a/stackslib/src/net/api/getheaders.rs
+++ b/stackslib/src/net/api/getheaders.rs
@@ -33,7 +33,7 @@ use crate::net::httpcore::{
 use crate::net::{Error as NetError, StacksNodeState, TipRequest, MAX_HEADERS};
 use crate::util_lib::db::{DBConn, Error as DBError};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCHeadersRequestHandler {
     pub quantity: Option<u32>,
 }

--- a/stackslib/src/net/api/gethealth.rs
+++ b/stackslib/src/net/api/gethealth.rs
@@ -41,7 +41,7 @@ pub struct RPCGetHealthResponse {
     pub node_stacks_tip_height: u64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 /// Empty request handler for the GET /v3/health endpoint
 pub struct RPCGetHealthRequestHandler {}
 

--- a/stackslib/src/net/api/getinfo.rs
+++ b/stackslib/src/net/api/getinfo.rs
@@ -36,7 +36,7 @@ use crate::net::{Error as NetError, StacksNodeState};
 use crate::version_string;
 
 /// The request to GET /v2/info
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCPeerInfoRequestHandler {}
 impl RPCPeerInfoRequestHandler {
     pub fn new() -> Self {

--- a/stackslib/src/net/api/getistraitimplemented.rs
+++ b/stackslib/src/net/api/getistraitimplemented.rs
@@ -38,7 +38,7 @@ pub struct GetIsTraitImplementedResponse {
     pub is_implemented: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetIsTraitImplementedRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
     pub trait_contract_identifier: Option<QualifiedContractIdentifier>,

--- a/stackslib/src/net/api/getmicroblocks_confirmed.rs
+++ b/stackslib/src/net/api/getmicroblocks_confirmed.rs
@@ -30,7 +30,7 @@ use crate::net::http::{
 use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCMicroblocksConfirmedRequestHandler {
     pub block_id: Option<StacksBlockId>,
 }

--- a/stackslib/src/net/api/getmicroblocks_indexed.rs
+++ b/stackslib/src/net/api/getmicroblocks_indexed.rs
@@ -30,7 +30,7 @@ use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpRequest, Stacks
 use crate::net::{Error as NetError, StacksNodeState};
 use crate::util_lib::db::DBConn;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCMicroblocksIndexedRequestHandler {
     pub tail_microblock_id: Option<StacksBlockId>,
 }

--- a/stackslib/src/net/api/getmicroblocks_unconfirmed.rs
+++ b/stackslib/src/net/api/getmicroblocks_unconfirmed.rs
@@ -33,7 +33,7 @@ use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpRequest, Stacks
 use crate::net::{Error as NetError, StacksNodeState, MAX_MICROBLOCKS_UNCONFIRMED};
 use crate::util_lib::db::DBConn;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCMicroblocksUnconfirmedRequestHandler {
     pub parent_block_id: Option<StacksBlockId>,
     pub start_sequence: Option<u16>,

--- a/stackslib/src/net/api/getneighbors.rs
+++ b/stackslib/src/net/api/getneighbors.rs
@@ -29,7 +29,7 @@ use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpRespo
 use crate::net::p2p::PeerNetwork;
 use crate::net::{Error as NetError, NeighborKey, StacksNodeState, MAX_NEIGHBORS_DATA_LEN};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNeighborsRequestHandler {}
 impl RPCNeighborsRequestHandler {
     pub fn new() -> Self {

--- a/stackslib/src/net/api/getpoxinfo.rs
+++ b/stackslib/src/net/api/getpoxinfo.rs
@@ -47,7 +47,7 @@ use crate::net::{Error as NetError, StacksNodeState, TipRequest};
 use crate::util_lib::boot::boot_code_id;
 use crate::util_lib::db::Error as DBError;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCPoxInfoRequestHandler {}
 impl RPCPoxInfoRequestHandler {
     pub fn new() -> Self {

--- a/stackslib/src/net/api/getsortition.rs
+++ b/stackslib/src/net/api/getsortition.rs
@@ -140,6 +140,12 @@ pub struct GetSortitionHandler {
     pub query: QuerySpecifier,
 }
 
+impl Default for GetSortitionHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GetSortitionHandler {
     pub fn new() -> Self {
         Self {

--- a/stackslib/src/net/api/getstackerdbchunk.rs
+++ b/stackslib/src/net/api/getstackerdbchunk.rs
@@ -28,7 +28,7 @@ use crate::net::http::{
 use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetStackerDBChunkRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
     pub slot_id: Option<u32>,

--- a/stackslib/src/net/api/getstackerdbmetadata.rs
+++ b/stackslib/src/net/api/getstackerdbmetadata.rs
@@ -28,7 +28,7 @@ use crate::net::http::{
 use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetStackerDBMetadataRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
 }

--- a/stackslib/src/net/api/getstxtransfercost.rs
+++ b/stackslib/src/net/api/getstxtransfercost.rs
@@ -29,7 +29,7 @@ use crate::net::{Error as NetError, HttpServerError, StacksNodeState};
 
 pub(crate) const SINGLESIG_TX_TRANSFER_LEN: u64 = 180;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetStxTransferCostRequestHandler {}
 
 impl RPCGetStxTransferCostRequestHandler {

--- a/stackslib/src/net/api/gettenure.rs
+++ b/stackslib/src/net/api/gettenure.rs
@@ -32,7 +32,7 @@ use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpRespo
 use crate::net::{Error as NetError, StacksNodeState};
 use crate::util_lib::db::DBConn;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoTenureRequestHandler {
     /// Block to start streaming from. It and its ancestors will be incrementally streamed until one of
     /// hte following happens:

--- a/stackslib/src/net/api/gettenureblocks.rs
+++ b/stackslib/src/net/api/gettenureblocks.rs
@@ -254,7 +254,7 @@ pub fn encode_tenure_reply(
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoTenureBlocksRequestHandler {
     pub(crate) consensus_hash: Option<ConsensusHash>,
 }

--- a/stackslib/src/net/api/gettenureblocksbyhash.rs
+++ b/stackslib/src/net/api/gettenureblocksbyhash.rs
@@ -52,7 +52,7 @@ pub fn get_block_snapshot_by_burnchain_block_hash(
     )
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoTenureBlocksByHashRequestHandler {
     pub(crate) burnchain_block_hash: Option<BurnchainHeaderHash>,
 }

--- a/stackslib/src/net/api/gettenureblocksbyheight.rs
+++ b/stackslib/src/net/api/gettenureblocksbyheight.rs
@@ -45,7 +45,7 @@ pub fn get_block_snapshot_by_burnchain_block_height(
         )
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoTenureBlocksByHeightRequestHandler {
     pub(crate) burnchain_block_height: Option<u64>,
 }

--- a/stackslib/src/net/api/gettenureinfo.rs
+++ b/stackslib/src/net/api/gettenureinfo.rs
@@ -26,7 +26,7 @@ use crate::net::http::{
 use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoTenureInfoRequestHandler {}
 
 impl RPCNakamotoTenureInfoRequestHandler {

--- a/stackslib/src/net/api/gettenuretip.rs
+++ b/stackslib/src/net/api/gettenuretip.rs
@@ -27,7 +27,7 @@ use crate::net::http::{
 use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCNakamotoTenureTipRequestHandler {
     pub(crate) consensus_hash: Option<ConsensusHash>,
 }

--- a/stackslib/src/net/api/gettransaction.rs
+++ b/stackslib/src/net/api/gettransaction.rs
@@ -37,7 +37,7 @@ pub struct TransactionResponse {
     pub is_canonical: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetTransactionRequestHandler {
     pub txid: Option<Txid>,
 }

--- a/stackslib/src/net/api/gettransaction_unconfirmed.rs
+++ b/stackslib/src/net/api/gettransaction_unconfirmed.rs
@@ -44,7 +44,7 @@ pub struct UnconfirmedTransactionResponse {
     pub status: UnconfirmedTransactionStatus,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCGetTransactionUnconfirmedRequestHandler {
     pub txid: Option<Txid>,
 }

--- a/stackslib/src/net/api/liststackerdbreplicas.rs
+++ b/stackslib/src/net/api/liststackerdbreplicas.rs
@@ -32,7 +32,7 @@ use crate::net::{Error as NetError, NeighborAddress, StacksNodeState};
 /// Largest number of replicas returned
 pub const MAX_LIST_REPLICAS: usize = 64;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCListStackerDBReplicasRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
 }

--- a/stackslib/src/net/api/postblock.rs
+++ b/stackslib/src/net/api/postblock.rs
@@ -36,7 +36,7 @@ pub struct StacksBlockAcceptedData {
     pub accepted: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCPostBlockRequestHandler {
     pub block: Option<StacksBlock>,
     pub consensus_hash: Option<ConsensusHash>,

--- a/stackslib/src/net/api/postfeerate.rs
+++ b/stackslib/src/net/api/postfeerate.rs
@@ -75,7 +75,7 @@ pub struct RPCFeeEstimateResponse {
     pub cost_scalar_change_by_byte: f64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCPostFeeRateRequestHandler {
     pub estimated_len: Option<u64>,
     pub transaction_payload: Option<TransactionPayload>,

--- a/stackslib/src/net/api/postmempoolquery.rs
+++ b/stackslib/src/net/api/postmempoolquery.rs
@@ -32,7 +32,7 @@ use crate::net::httpcore::{RPCRequestHandler, StacksHttpRequest, StacksHttpRespo
 use crate::net::{Error as NetError, StacksNodeState};
 use crate::util_lib::db::DBConn;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCMempoolQueryRequestHandler {
     pub page_id: Option<Txid>,
     pub mempool_query: Option<MemPoolSyncData>,

--- a/stackslib/src/net/api/postmicroblock.rs
+++ b/stackslib/src/net/api/postmicroblock.rs
@@ -36,7 +36,7 @@ use crate::net::{
     Error as NetError, MicroblocksData, StacksMessageType, StacksNodeState, TipRequest,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCPostMicroblockRequestHandler {
     pub microblock: Option<StacksMicroblock>,
 }

--- a/stackslib/src/net/api/poststackerdbchunk.rs
+++ b/stackslib/src/net/api/poststackerdbchunk.rs
@@ -30,7 +30,7 @@ use crate::net::http::{
 use crate::net::httpcore::{request, RPCRequestHandler, StacksHttpRequest, StacksHttpResponse};
 use crate::net::{Error as NetError, StackerDBPushChunkData, StacksMessageType, StacksNodeState};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCPostStackerDBChunkRequestHandler {
     pub contract_identifier: Option<QualifiedContractIdentifier>,
     pub chunk: Option<StackerDBChunkData>,

--- a/stackslib/src/net/api/posttransaction.rs
+++ b/stackslib/src/net/api/posttransaction.rs
@@ -36,7 +36,7 @@ pub struct PostTransactionRequestBody {
     pub attachment: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RPCPostTransactionRequestHandler {
     pub tx: Option<StacksTransaction>,
     pub attachment: Option<Attachment>,

--- a/stackslib/src/net/atlas/download.rs
+++ b/stackslib/src/net/atlas/download.rs
@@ -1135,6 +1135,12 @@ pub struct AttachmentsBatch {
     pub retry_deadline: u64,
 }
 
+impl Default for AttachmentsBatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AttachmentsBatch {
     pub fn new() -> AttachmentsBatch {
         AttachmentsBatch {

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -65,7 +65,7 @@ pub const BANDWIDTH_POINT_LIFETIME: u64 = 600;
 pub const MAX_PEER_HEARTBEAT_INTERVAL: usize = 3600 * 6; // 6 hours
 
 /// Statistics on relayer hints in Stacks messages.  Used to deduce network choke points.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RelayStats {
     pub num_messages: u64, // how many messages a relayer has pushed to this neighbor
     pub num_bytes: u64,    // how many bytes a relayer has pushed to this neighbor

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -714,6 +714,8 @@ impl StacksMessageCodec for NackData {
     }
 }
 
+// A default would misleadingly consume randomness to generate a fresh nonce.
+#[allow(clippy::new_without_default)]
 impl PingData {
     pub fn new() -> PingData {
         let mut rng = rand::thread_rng();

--- a/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
+++ b/stackslib/src/net/download/nakamoto/tenure_downloader_set.rs
@@ -66,6 +66,7 @@ pub const PEER_DEPRIORITIZATION_TIME_SECS: u64 = 60;
 /// can make progress even if there is only one available peer (in which case, that peer will get
 /// scheduled across multiple machines to drive their progress in the right sequence such that
 /// tenures will be incrementally fetched and yielded by the p2p state machine to the relayer).
+#[derive(Default)]
 pub struct NakamotoTenureDownloaderSet {
     /// A list of instantiated downloaders that are in progress
     pub(crate) downloaders: Vec<Option<NakamotoTenureDownloader>>,

--- a/stackslib/src/net/http/request.rs
+++ b/stackslib/src/net/http/request.rs
@@ -514,6 +514,12 @@ pub struct HttpRequestContents {
     parsed_data: HashMap<String, serde_json::Value>,
 }
 
+impl Default for HttpRequestContents {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HttpRequestContents {
     pub fn new() -> Self {
         Self {

--- a/stackslib/src/net/inv/nakamoto.rs
+++ b/stackslib/src/net/inv/nakamoto.rs
@@ -118,6 +118,12 @@ pub struct InvGenerator {
     no_cache: bool,
 }
 
+impl Default for InvGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InvGenerator {
     pub fn new() -> Self {
         Self {

--- a/stackslib/src/net/mempool/mod.rs
+++ b/stackslib/src/net/mempool/mod.rs
@@ -64,6 +64,12 @@ pub struct MempoolSync {
     api_endpoint: String,
 }
 
+impl Default for MempoolSync {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MempoolSync {
     pub fn new() -> Self {
         Self {

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -949,7 +949,7 @@ pub struct PoxInvData {
 pub struct BlocksDatum(pub ConsensusHash, pub StacksBlock);
 
 /// Stacks epoch 2.x blocks pushed
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct BlocksData {
     pub blocks: Vec<BlocksDatum>,
 }
@@ -970,7 +970,7 @@ pub struct MicroblocksData {
 }
 
 /// Block available hint
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct BlocksAvailableData {
     pub available: Vec<(ConsensusHash, BurnchainHeaderHash)>,
 }
@@ -1311,7 +1311,7 @@ pub trait ProtocolFamily {
 }
 
 // these implement the ProtocolFamily trait
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct StacksP2P {}
 
 // an array in our protocol can't exceed this many items

--- a/stackslib/src/net/neighbors/comms.rs
+++ b/stackslib/src/net/neighbors/comms.rs
@@ -446,6 +446,7 @@ pub trait NeighborComms {
 
 /// Transport-level API for peer network state machines.
 /// Prod implementation of NeighborComms.
+#[derive(Default)]
 pub struct PeerNetworkComms {
     /// Set of PeerNetwork event IDs that this walk is tracking (so they won't get pruned)
     events: HashSet<usize>,
@@ -687,7 +688,7 @@ impl ToNeighborKey for NeighborAddress {
 
 /// This struct represents a batch of in-flight requests to a set of peers, identified by a
 /// neighbor key (or something that converts to it)
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NeighborCommsRequest {
     state: HashMap<NeighborAddress, ReplyHandleP2P>,
 }

--- a/stackslib/src/net/neighbors/db.rs
+++ b/stackslib/src/net/neighbors/db.rs
@@ -30,7 +30,7 @@ use crate::net::{
 use crate::util_lib::db::DBConn;
 
 /// Capture replacement state
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct NeighborReplacements {
     /// neighbors to be replaced
     replacements: HashMap<NeighborAddress, Neighbor>,
@@ -274,6 +274,7 @@ pub trait NeighborWalkDB {
 }
 
 /// Production database I/O implementation that uses PeerDB
+#[derive(Default)]
 pub struct PeerDBNeighborWalk {}
 
 /// Database I/O helpers for the NeighborWalkDB implementation

--- a/stackslib/src/net/neighbors/rpc.rs
+++ b/stackslib/src/net/neighbors/rpc.rs
@@ -28,7 +28,7 @@ use crate::net::{
 
 /// This struct represents a batch of in-flight RPCs to a set of peers, identified by a
 /// neighbor key (or something that converts to it)
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NeighborRPC {
     state: HashMap<NeighborAddress, (usize, Option<StacksHttpRequest>)>,
     dead: HashSet<DropNeighbor>,

--- a/stackslib/src/net/poll.rs
+++ b/stackslib/src/net/poll.rs
@@ -28,6 +28,7 @@ use crate::net::Error as net_error;
 
 const SERVER: Token = mio::Token(0);
 
+#[derive(Default)]
 pub struct NetworkPollState {
     pub new: HashMap<usize, mio_net::TcpStream>,
     pub ready: Vec<usize>,

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -119,7 +119,7 @@ pub struct Relayer {
     recently_sent_nakamoto_blocks: HashMap<StacksBlockId, (ConsensusHash, u128)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct RelayerStats {
     /// Relayer statistics for the p2p network's ongoing conversations.
     /// Note that we key on (addr, port), not the full NeighborAddress.


### PR DESCRIPTION
This PR implements `Default` for 61 types that already expose `pub fn new() -> Self` and have a meaningful default value.

54 types are simple empty values (`None` fields, empty collections, zero-counters, or empty structs) and now derive `Default`. The remaining 7 have deliberate field values, so their explicit implementations delegate to `new()`. Existing constructors remain available and their behavior is unchanged.

Five constructors retain a documented `new_without_default` allow instead: `TestBurnchainNode`, `ClarityTestSim`, `TrieBenchmark`, `MemoryBackingStore`, and `PingData`. Their constructors initialize databases, write test state, capture timestamps, or consume randomness, which typically should not be hidden behind `Default`.

Four implementations remain in a separate API-surface PR (coming after this merges) because they overlap with other changes in the same files.