### PR TITLE
Move from grcov (deprecated) to cargo-llvm-cov for code coverage

### DIFF
--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -53,7 +53,7 @@ runs:
         components: llvm-tools-preview
 
     #  Install nextest and cargo-llvm-cov
-    #    cargo-llvm-cov is not needed to build the archive, but it is bundled into the
+    #    cargo-llvm-cov is used to build the archive and then bundled into the
     #    artifact for the test jobs (see the staging step below)
     - name: Install nextest and cargo-llvm-cov
       if: |

--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -10,11 +10,6 @@ inputs:
     description: "The nextest archive file"
     required: true
 
-env:
-  # Location of where to place all `cargo llvm-cov` generated artifacts, relative to the current working directory.
-  # See: https://github.com/taiki-e/cargo-llvm-cov#environment-variables
-  CARGO_LLVM_COV_TARGET_DIR: "./target/nextest-archive"
-
 runs:
   using: "composite"
   steps:
@@ -92,6 +87,15 @@ runs:
       with:
         action: restore
 
+    # Set llvm-cov target dir
+    - name: Set llvm-cov Target Dir
+      if: inputs.action == 'create'
+      shell: bash
+      run: |
+        # Location of where to place all `cargo llvm-cov` generated artifacts, relative to the current working directory.
+        # See: https://github.com/taiki-e/cargo-llvm-cov#environment-variables
+        echo "CARGO_LLVM_COV_TARGET_DIR=./target/nextest-archive" >> $GITHUB_ENV
+
     # Build the nextest archive
     - name: Build Nextest Archive
       if: |
@@ -122,14 +126,14 @@ runs:
         path: |
           ${{ inputs.archive-file }}
           ci-tools/
-          ${{ CARGO_LLVM_COV_TARGET_DIR }}
-          !${{ CARGO_LLVM_COV_TARGET_DIR }}/examples/**
-          !${{ CARGO_LLVM_COV_TARGET_DIR }}/incremental/**
-          !${{ CARGO_LLVM_COV_TARGET_DIR }}/.fingerprint/**
-          !${{ CARGO_LLVM_COV_TARGET_DIR }}/build/**
-          !${{ CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.d
-          !${{ CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rlib
-          !${{ CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rmeta
+          ${{ env.CARGO_LLVM_COV_TARGET_DIR }}
+          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/examples/**
+          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/incremental/**
+          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/.fingerprint/**
+          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/build/**
+          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.d
+          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rlib
+          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rmeta
         if-no-files-found: error
         retention-days: 1
         compression-level: 9 # 0 (none) - 9 (most)

--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -96,7 +96,7 @@ runs:
         inputs.action == 'create'
       shell: bash
       env:
-        RUSTFLAGS: "-C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
+        RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
         CARGO_INCREMENTAL: 0
       # This command should be kept in sync with the same command in cache/cargo action
       run: |
@@ -104,7 +104,7 @@ runs:
         INPUT_FILE="${{ inputs.archive-file }}"
         ARCHIVE_FILE="${INPUT_FILE/#\~/$HOME}"
 
-        cargo nextest archive \
+        cargo llvm-cov nextest-archive \
           --workspace \
           --tests \
           --locked \

--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -52,15 +52,15 @@ runs:
       with:
         components: llvm-tools-preview
 
-    #  Install nextest and grcov
-    #    grcov is not needed to build the archive, but it is bundled into the
+    #  Install nextest and cargo-llvm-cov
+    #    cargo-llvm-cov is not needed to build the archive, but it is bundled into the
     #    artifact for the test jobs (see the staging step below)
-    - name: Install nextest and grcov
+    - name: Install nextest and cargo-llvm-cov
       if: |
         inputs.action == 'create'
       uses: ./.github/actions/install-tool
       with:
-        tools: nextest, grcov
+        tools: nextest, cargo-llvm-cov
 
     # Stage the tool binaries so they are uploaded with the artifact. The many
     # parallel test jobs restore them from there instead of each downloading
@@ -71,7 +71,7 @@ runs:
       shell: bash
       run: |
         mkdir -p ci-tools
-        cp "$(command -v cargo-nextest)" "$(command -v grcov)" ci-tools/
+        cp "$(command -v cargo-nextest)" "$(command -v cargo-llvm-cov)" ci-tools/
 
     # Install mold linker and clang (faster than default)      
     - name: Install mold Linker (and clang)

--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -9,9 +9,11 @@ inputs:
   archive-file:
     description: "The nextest archive file"
     required: true
-  debug-binary-path:
-    description: "Debug binary path"
-    required: true
+
+env:
+  # Location of where to place all `cargo llvm-cov` generated artifacts, relative to the current working directory.
+  # See: https://github.com/taiki-e/cargo-llvm-cov#environment-variables
+  CARGO_LLVM_COV_TARGET_DIR: "./target/nextest-archive"
 
 runs:
   using: "composite"
@@ -120,14 +122,14 @@ runs:
         path: |
           ${{ inputs.archive-file }}
           ci-tools/
-          ${{ inputs.debug-binary-path }}
-          !${{ inputs.debug-binary-path }}/examples/**
-          !${{ inputs.debug-binary-path }}/incremental/**
-          !${{ inputs.debug-binary-path }}/.fingerprint/**
-          !${{ inputs.debug-binary-path }}/build/**
-          !${{ inputs.debug-binary-path }}/deps/**/*.d
-          !${{ inputs.debug-binary-path }}/deps/**/*.rlib
-          !${{ inputs.debug-binary-path }}/deps/**/*.rmeta
+          ${{ CARGO_LLVM_COV_TARGET_DIR }}
+          !${{ CARGO_LLVM_COV_TARGET_DIR }}/examples/**
+          !${{ CARGO_LLVM_COV_TARGET_DIR }}/incremental/**
+          !${{ CARGO_LLVM_COV_TARGET_DIR }}/.fingerprint/**
+          !${{ CARGO_LLVM_COV_TARGET_DIR }}/build/**
+          !${{ CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.d
+          !${{ CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rlib
+          !${{ CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rmeta
         if-no-files-found: error
         retention-days: 1
         compression-level: 9 # 0 (none) - 9 (most)

--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -106,7 +106,7 @@ runs:
 
         cargo llvm-cov nextest-archive \
           --workspace \
-          --tests \
+          --all-targets \
           --locked \
           --features monitoring_prom \
           --archive-file "$ARCHIVE_FILE"

--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -106,7 +106,7 @@ runs:
 
         cargo llvm-cov nextest-archive \
           --workspace \
-          --all-targets \
+          --tests \
           --locked \
           --features monitoring_prom \
           --archive-file "$ARCHIVE_FILE"

--- a/.github/actions/artifacts/nextest-archive/action.yml
+++ b/.github/actions/artifacts/nextest-archive/action.yml
@@ -87,15 +87,6 @@ runs:
       with:
         action: restore
 
-    # Set llvm-cov target dir
-    - name: Set llvm-cov Target Dir
-      if: inputs.action == 'create'
-      shell: bash
-      run: |
-        # Location of where to place all `cargo llvm-cov` generated artifacts, relative to the current working directory.
-        # See: https://github.com/taiki-e/cargo-llvm-cov#environment-variables
-        echo "CARGO_LLVM_COV_TARGET_DIR=./target/nextest-archive" >> $GITHUB_ENV
-
     # Build the nextest archive
     - name: Build Nextest Archive
       if: |
@@ -126,14 +117,6 @@ runs:
         path: |
           ${{ inputs.archive-file }}
           ci-tools/
-          ${{ env.CARGO_LLVM_COV_TARGET_DIR }}
-          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/examples/**
-          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/incremental/**
-          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/.fingerprint/**
-          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/build/**
-          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.d
-          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rlib
-          !${{ env.CARGO_LLVM_COV_TARGET_DIR }}/deps/**/*.rmeta
         if-no-files-found: error
         retention-days: 1
         compression-level: 9 # 0 (none) - 9 (most)

--- a/.github/actions/cache/cargo/action.yml
+++ b/.github/actions/cache/cargo/action.yml
@@ -101,19 +101,33 @@ runs:
       env:
         RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
         CARGO_INCREMENTAL: 0
-      # This command should be kept in sync with the same command in artifacts/nextest-archive action OTHER than the excludes
-      # We exclude workspace crates because we only want to cache cargo dependencies
+      # This command should be kept in sync with the same command in artifacts/nextest-archive action
       run: |
-        # Dynamically generate --exclude flags for all local workspace crates
-        EXCLUDES=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name | "--exclude " + .')
-        
         cargo llvm-cov nextest archive \
           --workspace \
-          $EXCLUDES \
           --tests \
           --locked \
           --features monitoring_prom \
           --archive-file "not_used.tar.zst"
+  
+    # Dynamic cleanup of local workspace crates right after building. We never want them to exist in the produced cache.
+    # These are things like stacks-signer, stacks-inspect, etc. built locally from our codebase.
+    # We must always compile them on-the-fly from current code, as they aren't bumped in version when they are changed.
+    - name: Clean Local Workspace Crates
+      if: |
+        inputs.action == 'create'
+      shell: bash
+      run: |
+        if [ -f Cargo.toml ]; then
+          echo "Identifying local workspace crates to exclude from restored cache..."
+          cargo metadata --format-version 1 --no-deps | jq -r '.packages[].name' | while read -r crate; do
+            echo "Wiping build artifacts for local crate: $crate"
+            cargo clean -p "$crate"
+          done
+        else
+          echo "ERROR: No Cargo.toml found in the current working directory."
+          exit 1
+        fi
   
     # Save cache data
     - name: Save Cache

--- a/.github/actions/cache/cargo/action.yml
+++ b/.github/actions/cache/cargo/action.yml
@@ -103,7 +103,7 @@ runs:
         CARGO_INCREMENTAL: 0
       # This command should be kept in sync with the same command in artifacts/nextest-archive action
       run: |
-        cargo llvm-cov nextest archive \
+        cargo llvm-cov nextest-archive \
           --workspace \
           --tests \
           --locked \

--- a/.github/actions/cache/cargo/action.yml
+++ b/.github/actions/cache/cargo/action.yml
@@ -94,6 +94,8 @@ runs:
         sudo apt-get install -y mold clang
   
     # Build the cargo crates
+    # This will include local workspace crates, which will be automatically recompiled by future `cargo build`
+    # commands if they differ from the source code being built.
     - name: Build Cargo Crates
       if: |
         inputs.action == 'create'
@@ -109,25 +111,6 @@ runs:
           --locked \
           --features monitoring_prom \
           --archive-file "not_used.tar.zst"
-  
-    # Dynamic cleanup of local workspace crates right after building. We never want them to exist in the produced cache.
-    # These are things like stacks-signer, stacks-inspect, etc. built locally from our codebase.
-    # We must always compile them on-the-fly from current code, as they aren't bumped in version when they are changed.
-    - name: Clean Local Workspace Crates
-      if: |
-        inputs.action == 'create'
-      shell: bash
-      run: |
-        if [ -f Cargo.toml ]; then
-          echo "Identifying local workspace crates to exclude from restored cache..."
-          cargo metadata --format-version 1 --no-deps | jq -r '.packages[].name' | while read -r crate; do
-            echo "Wiping build artifacts for local crate: $crate"
-            cargo clean -p "$crate"
-          done
-        else
-          echo "ERROR: No Cargo.toml found in the current working directory."
-          exit 1
-        fi
   
     # Save cache data
     - name: Save Cache

--- a/.github/actions/cache/cargo/action.yml
+++ b/.github/actions/cache/cargo/action.yml
@@ -104,27 +104,12 @@ runs:
       # This command should be kept in sync with the same command in artifacts/nextest-archive action OTHER than the excludes
       # We exclude workspace crates because we only want to cache cargo dependencies
       run: |
+        # Dynamically generate --exclude flags for all local workspace crates
+        EXCLUDES=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name | "--exclude " + .')
+        
         cargo llvm-cov nextest archive \
           --workspace \
-          --exclude clarity \
-          --exclude clarity-cli \
-          --exclude clarity-types \
-          --exclude libsigner \
-          --exclude libstackerdb \
-          --exclude madhouse \
-          --exclude marf-squash \
-          --exclude pox-locking \
-          --exclude stacks-cli \
-          --exclude stacks-codec \
-          --exclude stacks-common \
-          --exclude stacks-inspect \
-          --exclude stacks-node \
-          --exclude stacks-profiler \
-          --exclude stacks-profiler-macros \
-          --exclude stacks-signer \
-          --exclude stacks-transactions \
-          --exclude stackslib \
-          --exclude stx-genesis \
+          $EXCLUDES \
           --tests \
           --locked \
           --features monitoring_prom \

--- a/.github/actions/cache/cargo/action.yml
+++ b/.github/actions/cache/cargo/action.yml
@@ -101,33 +101,34 @@ runs:
       env:
         RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
         CARGO_INCREMENTAL: 0
-      # This command should be kept in sync with the same command in artifacts/nextest-archive action
+      # This command should be kept in sync with the same command in artifacts/nextest-archive action OTHER than the excludes
+      # We exclude workspace crates because we only want to cache cargo dependencies
       run: |
         cargo llvm-cov nextest archive \
           --workspace \
+          --exclude clarity \
+          --exclude clarity-cli \
+          --exclude clarity-types \
+          --exclude libsigner \
+          --exclude libstackerdb \
+          --exclude madhouse \
+          --exclude marf-squash \
+          --exclude pox-locking \
+          --exclude stacks-cli \
+          --exclude stacks-codec \
+          --exclude stacks-common \
+          --exclude stacks-inspect \
+          --exclude stacks-node \
+          --exclude stacks-profiler \
+          --exclude stacks-profiler-macros \
+          --exclude stacks-signer \
+          --exclude stacks-transactions \
+          --exclude stackslib \
+          --exclude stx-genesis \
           --tests \
           --locked \
           --features monitoring_prom \
           --archive-file "not_used.tar.zst"
-  
-    # Dynamic cleanup of local workspace crates right after building. We never want them to exist in the produced cache.
-    # These are things like stacks-signer, stacks-inspect, etc. built locally from our codebase.
-    # We must always compile them on-the-fly from current code, as they aren't bumped in version when they are changed.
-    - name: Clean Local Workspace Crates
-      if: |
-        inputs.action == 'create'
-      shell: bash
-      run: |
-        if [ -f Cargo.toml ]; then
-          echo "Identifying local workspace crates to exclude from restored cache..."
-          cargo metadata --format-version 1 --no-deps | jq -r '.packages[].name' | while read -r crate; do
-            echo "Wiping build artifacts for local crate: $crate"
-            cargo clean -p "$crate"
-          done
-        else
-          echo "ERROR: No Cargo.toml found in the current working directory."
-          exit 1
-        fi
   
     # Save cache data
     - name: Save Cache

--- a/.github/actions/cache/cargo/action.yml
+++ b/.github/actions/cache/cargo/action.yml
@@ -76,13 +76,13 @@ runs:
       with:
         components: llvm-tools-preview
     
-    #  Install nextest
-    - name: Install nextest
+    #  Install nextest and cargo-llvm-cov
+    - name: Install nextest and cargo-llvm-cov
       if: |
         inputs.action == 'create'
       uses: ./.github/actions/install-tool
       with:
-        tools: nextest
+        tools: nextest, cargo-llvm-cov
     
     # Install mold linker and clang (faster than default)      
     - name: Install mold Linker (and clang)
@@ -99,11 +99,11 @@ runs:
         inputs.action == 'create'
       shell: bash
       env:
-        RUSTFLAGS: "-C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
+        RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold -A warnings"
         CARGO_INCREMENTAL: 0
       # This command should be kept in sync with the same command in artifacts/nextest-archive action
       run: |
-        cargo nextest archive \
+        cargo llvm-cov nextest archive \
           --workspace \
           --tests \
           --locked \

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,7 +1,7 @@
 name: Run Tests
 description: |
-  1. Sets up the runner with grcov, nextest tooling, etc.
-  2. Runs tests using cargo nextest, either sequentially by name or in parallel via partitions.
+  1. Sets up the runner with cargo-llvm-cov, nextest tooling, etc.
+  2. Runs tests using cargo llvm-cov nextest, either sequentially by name or in parallel via partitions.
   3. Generates and uploads the code coverage artifact
 
 inputs:
@@ -148,25 +148,36 @@ runs:
         SANITIZED_FILE_NAME=$(echo "${{ inputs.codecov-test-name }}" | sed 's/[\\/:\*\?"<>|]/_/g')
         echo "file-name=$SANITIZED_FILE_NAME" >> $GITHUB_OUTPUT
 
+
     # Mode 1: Run specific test names sequentially (If partition is NOT specified)
     - name: Run Tests Sequentially
       if: inputs.partition == '' && inputs.total-partitions == ''
       shell: bash
       run: |
-        export LLVM_PROFILE_FILE="test-results-%p-%m.profraw"
-        
         # Convert CSV string to Nextest exact-match Filterset format
         # e.g., "a, b" becomes "test(=a)|test(=b)"
         FILTERSET=$(echo "${{ inputs.test-names }}" | sed -E 's/[[:space:]]*,[[:space:]]*/)|test(=/g')
         FILTERSET="test(=${FILTERSET})"
 
-        # nextest settings are configured in ~/.github/nextest/ci-nextest.toml, arguments here override those settings
-        cargo nextest run \
-          --config-file ./.github/nextest/ci-nextest.toml \
-          --profile ci-sequential \
-          --run-ignored all \
-          --archive-file ${{ inputs.archive-file }} \
-          -E "$FILTERSET"
+        if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
+          cargo llvm-cov nextest \
+            --lcov \
+            --branch \
+            --ignore-filename-regex '(\.github|\.vscode|changelog\.d|contrib|benches|tests?(\.rs)?|_tests?\.rs)' \
+            --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
+            --config-file ./.github/nextest/ci-nextest.toml \
+            --profile ci-sequential \
+            --run-ignored all \
+            --archive-file ${{ inputs.archive-file }} \
+            -E "$FILTERSET"
+        else
+          cargo nextest run \
+            --config-file ./.github/nextest/ci-nextest.toml \
+            --profile ci-sequential \
+            --run-ignored all \
+            --archive-file ${{ inputs.archive-file }} \
+            -E "$FILTERSET"
+        fi
           
         # rename the resulting junit file from the toml config
         mv junit.xml junit_${{ steps.generate-sanitized-file-name.outputs.file-name }}.xml
@@ -176,14 +187,23 @@ runs:
       if: inputs.partition != '' && inputs.total-partitions != ''
       shell: bash
       run: |
-        export LLVM_PROFILE_FILE="test-results-%p-%m.profraw"
-        
-        # nextest settings are configured in ~/.github/nextest/ci-nextest.toml, arguments here override those settings
-        cargo nextest run \
-          --config-file ./.github/nextest/ci-nextest.toml \
-          --profile ci-parallel \
-          --partition count:${{ inputs.partition }}/${{ inputs.total-partitions }} \
-          --archive-file ${{ inputs.archive-file }}
+        if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
+          cargo llvm-cov nextest \
+            --lcov \
+            --branch \
+            --ignore-filename-regex '(\.github|\.vscode|changelog\.d|contrib|benches|tests?(\.rs)?|_tests?\.rs)' \
+            --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
+            --config-file ./.github/nextest/ci-nextest.toml \
+            --profile ci-parallel \
+            --partition count:${{ inputs.partition }}/${{ inputs.total-partitions }} \
+            --archive-file ${{ inputs.archive-file }}
+        else
+          cargo nextest run \
+            --config-file ./.github/nextest/ci-nextest.toml \
+            --profile ci-parallel \
+            --partition count:${{ inputs.partition }}/${{ inputs.total-partitions }} \
+            --archive-file ${{ inputs.archive-file }}
+        fi
           
         # rename the resulting junit file from the toml config
         mv junit.xml junit_${{ steps.generate-sanitized-file-name.outputs.file-name }}.xml
@@ -205,44 +225,10 @@ runs:
         overwrite: true
           
     ############################################################################
-    ### Generate and upload code coverage artifact
+    ### Upload the code coverage artifact
     ############################################################################
-
-    # Generate code coverage using grcov
-    # Resulting coverage filenames must be unique, so use test-name input to name the file
-    - name: Run grcov
-      if: inputs.upload-code-coverage == 'true'
-      shell: bash
-      run: |
-        grcov . \
-          -b ${{ inputs.debug-binary-path }} \
-          -s . \
-          -t lcov \
-          --branch \
-          --ignore-not-existing \
-          --ignore "../*" \
-          --ignore "/*" \
-          --ignore ".github/**" \
-          --ignore ".vscode/**" \
-          --ignore "changelog.d/**" \
-          --ignore "contrib/**" \
-          --ignore "**/.cargo/**" \
-          --ignore "**/benches/**" \
-          --ignore "**/test{,s}/**" \
-          --ignore "**/test{,s}.rs" \
-          --ignore "**/*_test{,s}.rs" \
-          --ignore "**/*.clar" \
-          --ignore "**/*.json" \
-          --ignore "**/*.md" \
-          --ignore "**/*.sha256" \
-          --ignore "**/*.snap" \
-          --ignore "**/*.toml" \
-          --ignore "**/*.txt" \
-          --ignore "**/*.yml" \
-          -o lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
-        || exit 1
-
-    # Store coverage file in GitHub CI artifacts (with SHA and "lcov" prefix)
+      
+    # Store coverage file in GitHub CI artifacts ("lcov_" prefix)
     - name: Store Code Coverage as Artifact
       if: inputs.upload-code-coverage == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -162,7 +162,6 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --branch \
             --ignore-filename-regex '(\.github|\.vscode|changelog\.d|contrib|benches|tests?(\.rs)?|_tests?\.rs)' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -162,7 +162,7 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]'
+            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
             --profile ci-sequential \
@@ -189,7 +189,7 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]'
+            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
             --profile ci-parallel \

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -162,7 +162,7 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --ignore-filename-regex '(\.github|\.vscode|changelog\.d|contrib|benches|tests?(\.rs)?|_tests?\.rs)' \
+            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]'
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
             --profile ci-sequential \
@@ -189,7 +189,7 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --ignore-filename-regex '(\.github|\.vscode|changelog\.d|contrib|benches|tests?(\.rs)?|_tests?\.rs)' \
+            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]'
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
             --profile ci-parallel \

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -208,12 +208,12 @@ runs:
     ### Upload the nextest JUnit XML
     ############################################################################
 
-    # Store JUnit file in GitHub CI artifacts (with SHA and "nextest" prefix)
+    # Store JUnit file in GitHub CI artifacts (with "junit-" prefix)
     - name: Store JUnit Report as Artifact
       if: always() && inputs.upload-junit-xml == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
       with:
-        name: nextest-${{ steps.generate-sanitized-file-name.outputs.file-name }}
+        name: junit-${{ steps.generate-sanitized-file-name.outputs.file-name }}
         path: junit_${{ steps.generate-sanitized-file-name.outputs.file-name }}.xml
         if-no-files-found: error
         retention-days: 1
@@ -224,7 +224,7 @@ runs:
     ### Upload the code coverage artifact
     ############################################################################
       
-    # Store coverage file in GitHub CI artifacts ("lcov_" prefix)
+    # Store coverage file in GitHub CI artifacts ("lcov-" prefix)
     - name: Store Code Coverage as Artifact
       if: inputs.upload-code-coverage == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -41,9 +41,17 @@ runs:
     # Checkout the code
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        # Only check out .rs files and related Rust files for testing
+        filter: blob:none
+        sparse-checkout-cone-mode: false
+        sparse-checkout: |
+          **/Cargo.toml
+          **/Cargo.lock
+          **/*.rs
+          
 
     # Setup rust toolchain with llvm-tools-preview
     - name: Setup Rust Toolchain

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -21,9 +21,6 @@ inputs:
   archive-file:
     description: "Archive file to use for tests"
     required: true
-  debug-binary-path:
-    description: "Debug binary path"
-    required: true
   codecov-test-name:
     description: "Code coverage test name"
     required: true
@@ -79,7 +76,6 @@ runs:
       with:
         action: restore
         archive-file: ${{ inputs.archive-file }}
-        debug-binary-path: ${{ inputs.debug-binary-path }}
 
     ############################################################################
     ### Run the tests

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -189,7 +189,6 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --branch \
             --ignore-filename-regex '(\.github|\.vscode|changelog\.d|contrib|benches|tests?(\.rs)?|_tests?\.rs)' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -44,14 +44,6 @@ runs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
-        # Only check out .rs files and related Rust files for testing
-        filter: blob:none
-        sparse-checkout-cone-mode: false
-        sparse-checkout: |
-          **/Cargo.toml
-          **/Cargo.lock
-          **/*.rs
-          
 
     # Setup rust toolchain with llvm-tools-preview
     - name: Setup Rust Toolchain
@@ -166,7 +158,8 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]' \
+            --skip-functions \
+            --ignore-filename-regex='[/\\]test[/\\]|[/\\](test\.rs|[0-9a-zA-Z_-]+[_-]test\.rs)$' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
             --profile ci-sequential \
@@ -193,7 +186,8 @@ runs:
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
-            --ignore-filename-regex='[/\\](\.github|\.vscode|changelog\.d|contrib|benches)[/\\]' \
+            --skip-functions \
+            --ignore-filename-regex='[/\\]test[/\\]|[/\\](test\.rs|[0-9a-zA-Z_-]+[_-]test\.rs)$' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
             --profile ci-parallel \

--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     # Setup the rust toolchain with any requested components and targets.
     - name: Install Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}

--- a/.github/nextest/ci-nextest.toml
+++ b/.github/nextest/ci-nextest.toml
@@ -1,8 +1,8 @@
 [profile.ci]
 # Stop at the first test failure in CI
 fail-fast = true
-# Retry failed tests up to 2 times
-retries = 2
+# Retry failed tests up to 4 times (5 total attempts)
+retries = 4
 # set slow timeout to 5 minutes and test termination to 20 minutes total (4 periods of 5 minutes)
 slow-timeout = { period = "5m", terminate-after = 4, on-timeout = "fail" }
 

--- a/.github/workflows/_check-test-caches.yml
+++ b/.github/workflows/_check-test-caches.yml
@@ -9,11 +9,6 @@ on:
 permissions:
   contents: read
 
-# Set default env vars
-env:
-  RUSTFLAGS: "-C instrument-coverage -A warnings"
-  LLVM_PROFILE_FILE: "stacks-core-%p-%m.profraw"
-
 jobs:
   # Check existing caches
   check-existing-caches:

--- a/.github/workflows/_tests-bitcoin-rpc.yml
+++ b/.github/workflows/_tests-bitcoin-rpc.yml
@@ -9,10 +9,6 @@ on:
         description: "The test archive file"
         required: true
         type: string
-      debug-binary-path:
-        description: "Debug binary path"
-        required: true
-        type: string
 
 # Set default permissions
 permissions:
@@ -105,7 +101,6 @@ jobs:
         with:
           action: restore
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
 
       # Pull bitcoin docker image
       - name: Pull bitcoind image (${{ matrix.bitcoin_version }})

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -9,10 +9,6 @@ on:
         description: "The test archive file"
         required: true
         type: string
-      debug-binary-path:
-        description: "Debug binary path"
-        required: true
-        type: string
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
@@ -71,7 +67,6 @@ jobs:
         with:
           action: restore
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
 
       # Generate the bitcoin test matrices json used for running tests
       - name: Generate Test Matrices
@@ -101,7 +96,6 @@ jobs:
         with:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}
@@ -129,7 +123,6 @@ jobs:
         with:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}
@@ -157,7 +150,6 @@ jobs:
         with:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}
@@ -185,7 +177,6 @@ jobs:
         with:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}

--- a/.github/workflows/_tests-epoch.yml
+++ b/.github/workflows/_tests-epoch.yml
@@ -9,10 +9,6 @@ on:
         description: "The test archive file"
         required: true
         type: string
-      debug-binary-path:
-        description: "Debug binary path"
-        required: true
-        type: string
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
@@ -85,7 +81,6 @@ jobs:
         with:
           test-names: ${{ matrix.test-name }}
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: ${{ matrix.test-name }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}

--- a/.github/workflows/_tests-p2p.yml
+++ b/.github/workflows/_tests-p2p.yml
@@ -9,10 +9,6 @@ on:
         description: "The test archive file"
         required: true
         type: string
-      debug-binary-path:
-        description: "Debug binary path"
-        required: true
-        type: string
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
@@ -83,7 +79,6 @@ jobs:
         with:
           test-names: ${{ matrix.test-name }}
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: ${{ matrix.test-name }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}

--- a/.github/workflows/_tests-stacks-core.yml
+++ b/.github/workflows/_tests-stacks-core.yml
@@ -9,10 +9,6 @@ on:
         description: "The test archive file"
         required: true
         type: string
-      debug-binary-path:
-        description: "Debug binary path"
-        required: true
-        type: string
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
@@ -86,7 +82,6 @@ jobs:
           partition: ${{ matrix.partition }}
           total-partitions: ${{ strategy.job-total }}
           archive-file: ${{ inputs.archive-file }}
-          debug-binary-path: ${{ inputs.debug-binary-path }}
           codecov-test-name: ${{ github.job }}-${{ matrix.partition }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
       - name: Download nextest JUnit artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          pattern: nextest-*
+          pattern: junit-*
           path: ${{ env.NEXTEST_FILES_DIR }}
           merge-multiple: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ concurrency:
 # Env vars
 env:
   TEST_ARCHIVE_FILE: "./test_archive.tar.zst"
-  DEBUG_BINARY_PATH: "./target/debug/"
   # Whether or not to create the slow and failed tests summary
   CREATE_SLOW_FAILED_TESTS_SUMMARY: ${{ (vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core') && github.event_name != 'merge_group' }}
   # Whether or not to create the code coverage report
@@ -76,7 +75,6 @@ jobs:
     runs-on: &shared_config ubuntu-latest
     outputs:
       test-archive-file: ${{ steps.set-env.outputs.test_archive_file }}
-      debug-binary-path: ${{ steps.set-env.outputs.debug_binary_path }}
       create-slow-failed-tests-summary: ${{ steps.set-env.outputs.create_slow_failed_tests_summary }}
       create-code-coverage-report: ${{ steps.set-env.outputs.create_code_coverage_report }}
     steps:
@@ -88,7 +86,6 @@ jobs:
           ARCHIVE_FILE="${INPUT_FILE/#\~/$HOME}"
 
           echo "test_archive_file=$ARCHIVE_FILE" >> $GITHUB_OUTPUT
-          echo "debug_binary_path=${{ env.DEBUG_BINARY_PATH }}" >> $GITHUB_OUTPUT
           echo "create_slow_failed_tests_summary=$CREATE_SLOW_FAILED_TESTS_SUMMARY" >> $GITHUB_OUTPUT
           echo "create_code_coverage_report=$CREATE_CODE_COVERAGE_REPORT" >> $GITHUB_OUTPUT
 
@@ -257,7 +254,6 @@ jobs:
         with:
           action: create
           archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-          debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
 
   ############################################################################
   ### Run Stacks Core Tests
@@ -273,7 +269,6 @@ jobs:
     uses: ./.github/workflows/_tests-stacks-core.yml
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-      debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
       upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
       upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 
@@ -291,7 +286,6 @@ jobs:
     uses: ./.github/workflows/_tests-bitcoin.yml
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-      debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
       upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
       upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 
@@ -309,7 +303,6 @@ jobs:
     uses: ./.github/workflows/_tests-bitcoin-rpc.yml
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-      debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
 
   ############################################################################
   ### Run P2P Tests
@@ -325,7 +318,6 @@ jobs:
     uses: ./.github/workflows/_tests-p2p.yml
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-      debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
       upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
       upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 
@@ -347,7 +339,6 @@ jobs:
     uses: ./.github/workflows/_tests-epoch.yml
     with:
       archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-      debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
       upload-junit-xml: ${{ needs.setup-env.outputs.create-slow-failed-tests-summary }}
       upload-code-coverage: ${{ needs.setup-env.outputs.create-code-coverage-report }}
 

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -58,7 +58,6 @@ env:
   # Number of generated cases to run per selected proptest.
   PROPTEST_CASES: 2500
   TEST_ARCHIVE_FILE: "./test_archive.tar.zst"
-  DEBUG_BINARY_PATH: "./target/debug/"
   BTC_VERSION: "25.0"
 
 jobs:
@@ -209,7 +208,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       test-archive-file: ${{ steps.set-env.outputs.test_archive_file }}
-      debug-binary-path: ${{ steps.set-env.outputs.debug_binary_path }}
       btc-version: ${{ steps.set-env.outputs.btc_version }}
     steps:
       - name: Export Env Variables
@@ -219,7 +217,6 @@ jobs:
           FILE="${{ env.TEST_ARCHIVE_FILE }}"
   
           echo "test_archive_file=${FILE/#\~/$HOME}" >> $GITHUB_OUTPUT
-          echo "debug_binary_path=${{ env.DEBUG_BINARY_PATH }}" >> $GITHUB_OUTPUT
           echo "btc_version=${{ env.BTC_VERSION }}" >> $GITHUB_OUTPUT
 
   ############################################################################
@@ -274,7 +271,6 @@ jobs:
         with:
           action: create
           archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-          debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
      
       # Setup rust toolchain with llvm-tools-preview
       - name: Setup Rust Toolchain
@@ -307,7 +303,6 @@ jobs:
         with:
           action: restore
           archive-file: ${{ needs.setup-env.outputs.test-archive-file }}
-          debug-binary-path: ${{ needs.setup-env.outputs.debug-binary-path }}
 
       ############################################################################
       ### Run proptests

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -337,7 +337,7 @@ jobs:
       # (and its build output) is removed afterwards.
       #
       # This is always a full compile: the Cargo cache was built with 
-      # -C instrument-coverage so its fingerprints never match this list-only build
+      # cargo-llvm-cov so its fingerprints never match this list-only build
       # and there is nothing to reuse. RUSTFLAGS only allows warnings here — the
       # job-wide `-D warnings` would otherwise turn a benign warning into a hard
       # error and leave an empty list.


### PR DESCRIPTION
### Description

We currently use `grcov` for code coverage. It is abandonware that is buggy. The current industry standard for Rust is `cargo-llvm-cov` so let's move to that for more reliable code coverage reports.

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

Should work seamlessly when ready to merge.

### Checklist

N/A