### PR TITLE
Fix/utf8 length check ordering

### DIFF
--- a/changelog.d/utf8-length-check-order.changed
+++ b/changelog.d/utf8-length-check-order.changed
@@ -1,0 +1,1 @@
+`Value::string_utf8_from_bytes` now validates the UTF-8 codepoint-count limit before encoding the string, so oversized input is rejected without first building one `Vec<u8>` per codepoint. Which inputs are accepted and the error returned for oversized input are unchanged.

--- a/clarity-types/src/tests/types/mod.rs
+++ b/clarity-types/src/tests/types/mod.rs
@@ -21,8 +21,8 @@ use stacks_common::types::StacksEpochId;
 use crate::ClarityName;
 use crate::errors::ClarityTypeError;
 use crate::types::{
-    ASCIIData, BuffData, CharType, ListTypeData, MAX_VALUE_SIZE, PrincipalData,
-    QualifiedContractIdentifier, RetainValuesError, SequenceData, SequenceSubtype,
+    ASCIIData, BuffData, CharType, ListTypeData, MAX_UTF8_VALUE_SIZE, MAX_VALUE_SIZE,
+    PrincipalData, QualifiedContractIdentifier, RetainValuesError, SequenceData, SequenceSubtype,
     SequencedValue as _, StandardPrincipalData, TraitIdentifier, TupleData, TupleFieldsBehavior,
     TupleTypeSignature, TypeSignature, UTF8Data, Value,
 };
@@ -740,6 +740,34 @@ fn invalid_utf8_string_from_bytes() {
     let err = Value::string_utf8_from_bytes(bad_bytes).unwrap_err();
 
     assert!(matches!(err, ClarityTypeError::InvalidUtf8Encoding));
+}
+
+#[test]
+fn string_utf8_from_bytes_at_max_size_is_ok() {
+    // an all-ASCII input has one codepoint per byte, so MAX_UTF8_VALUE_SIZE
+    // bytes is exactly at the codepoint-count limit and must be accepted.
+    let bytes = vec![b'a'; MAX_UTF8_VALUE_SIZE as usize];
+
+    let value = Value::string_utf8_from_bytes(bytes).unwrap();
+
+    assert_eq!(
+        Value::Sequence(SequenceData::String(CharType::UTF8(UTF8Data {
+            data: vec![vec![b'a']; MAX_UTF8_VALUE_SIZE as usize],
+        }))),
+        value
+    );
+}
+
+#[test]
+fn string_utf8_from_bytes_too_large() {
+    // one codepoint over MAX_UTF8_VALUE_SIZE must be rejected. This also
+    // guards against the size check regressing to run only after the
+    // per-codepoint Vec<u8> allocations below it.
+    let bytes = vec![b'a'; MAX_UTF8_VALUE_SIZE as usize + 1];
+
+    let err = Value::string_utf8_from_bytes(bytes).unwrap_err();
+
+    assert_eq!(ClarityTypeError::ValueTooLarge, err);
 }
 
 #[test]

--- a/clarity-types/src/types/mod.rs
+++ b/clarity-types/src/types/mod.rs
@@ -1182,6 +1182,10 @@ impl Value {
     pub fn string_utf8_from_bytes(bytes: Vec<u8>) -> Result<Value, ClarityTypeError> {
         let validated_utf8_str =
             str::from_utf8(&bytes).map_err(|_| ClarityTypeError::InvalidUtf8Encoding)?;
+
+        // check the string size before allocating a Vec<u8> per codepoint below
+        StringUTF8Length::try_from(validated_utf8_str.chars().count())?;
+
         let data = validated_utf8_str
             .chars()
             .map(|char| {
@@ -1190,8 +1194,6 @@ impl Value {
                 encoded_char
             })
             .collect::<Vec<_>>();
-        // check the string size
-        StringUTF8Length::try_from(data.len())?;
 
         Ok(Value::Sequence(SequenceData::String(CharType::UTF8(
             UTF8Data { data },


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/stacksgov/sips/blob/main/sips/sip-000/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This small patch changes the ordering between the allocation and size check of Value::string_utf8_from_bytes by enforcing early fail is the size is bigger than MAX_UTF8_VALUE_SIZE.

A couple of additional unit tests are included

### Applicable issues

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
