### PR TITLE
refactor: simplify complex result and callback types (clippy `type_complexity` lint)

### DIFF
--- a/changelog.d/type-complexity-chainstate.changed
+++ b/changelog.d/type-complexity-chainstate.changed
@@ -1,0 +1,1 @@
+Replace complex chainstate results and callbacks with documented named types and aliases, updating node and inspection-tool callers without changing consensus rules or database schemas.

--- a/contrib/marf-squash/src/manifest.rs
+++ b/contrib/marf-squash/src/manifest.rs
@@ -251,7 +251,6 @@ fn assert_squash_tip<T: MarfTrieId + std::fmt::Display>(label: &str, actual: &T,
 /// and sortition tips equal the resolved anchor tips (`expected_stacks_tip`,
 /// `expected_sortition_tip`). Returns `(clarity, index, sortition)`. Exits on any
 /// mismatch.
-#[allow(clippy::type_complexity)]
 fn read_all_marf_metadata(
     inputs: &ManifestInputs,
 ) -> (

--- a/contrib/stacks-inspect/src/main.rs
+++ b/contrib/stacks-inspect/src/main.rs
@@ -74,7 +74,7 @@ use stackslib::burnchains::bitcoin::{BitcoinNetworkType, spv};
 use stackslib::burnchains::db::BurnchainDB;
 use stackslib::burnchains::{Address, Burnchain, PoxConstants};
 use stackslib::chainstate::burn::db::sortdb::{
-    SortitionDB, SortitionHandle, get_block_commit_by_txid,
+    PoxAnchorSelection, SortitionDB, SortitionHandle, get_block_commit_by_txid,
 };
 use stackslib::chainstate::burn::operations::BlockstackOperationType;
 use stackslib::chainstate::burn::{BlockSnapshot, ConsensusHash};
@@ -1230,8 +1230,12 @@ fn main() {
                     .expect("Failed to compute PoX cycle");
 
                 match result {
-                    Ok((_, _, _, confirmed_by)) => results.push((eval_height, true, confirmed_by)),
-                    Err(confirmed_by) => results.push((eval_height, false, confirmed_by)),
+                    PoxAnchorSelection::Selected { confirmations, .. } => {
+                        results.push((eval_height, true, confirmations))
+                    }
+                    PoxAnchorSelection::NotSelected { max_confirmations } => {
+                        results.push((eval_height, false, max_confirmations))
+                    }
                 };
             }
 

--- a/stacks-node/src/event_dispatcher.rs
+++ b/stacks-node/src/event_dispatcher.rs
@@ -499,7 +499,6 @@ impl EventDispatcher {
     /// - dispatch_matrix: a vector where each index corresponds to the hashset of event indexes
     ///   that each respective event observer is subscribed to
     /// - events: a vector of all events from all the tx receipts
-    #[allow(clippy::type_complexity)]
     fn create_dispatch_matrix_and_event_vector<'a>(
         &self,
         receipts: &'a [StacksTransactionReceipt],

--- a/stacks-node/src/neon_node.rs
+++ b/stacks-node/src/neon_node.rs
@@ -1810,7 +1810,10 @@ impl BlockMinerThread {
                 u16::MAX,
             ) {
                 Ok(x) => {
-                    let num_mblocks = x.as_ref().map(|(mblocks, ..)| mblocks.len()).unwrap_or(0);
+                    let num_mblocks = x
+                        .as_ref()
+                        .map(|stream| stream.microblocks.len())
+                        .unwrap_or(0);
                     debug!(
                         "Loaded {num_mblocks} microblocks descending from {parent_consensus_hash}/{} (data: {})",
                         &stacks_parent_header.anchored_header.block_hash(),
@@ -1827,7 +1830,9 @@ impl BlockMinerThread {
                 }
             };
 
-        if let Some((ref microblocks, ref poison_opt)) = &microblock_info_opt {
+        if let Some(stream) = &microblock_info_opt {
+            let microblocks = &stream.microblocks;
+            let poison_opt = &stream.poison_payload;
             if let Some(tail) = microblocks.last() {
                 debug!(
                     "Confirm microblock stream tailed at {} (seq {})",
@@ -1871,7 +1876,7 @@ impl BlockMinerThread {
             }
         }
 
-        microblock_info_opt.map(|(stream, _)| stream)
+        microblock_info_opt.map(|stream| stream.microblocks)
     }
 
     /// Get the list of possible burn addresses this miner is using

--- a/stacks-node/src/node.rs
+++ b/stacks-node/src/node.rs
@@ -874,7 +874,7 @@ impl Node {
                         break;
                     } else {
                         for block in blocks.iter() {
-                            if let (Some(epoch_receipt), _) = block {
+                            if let Some(epoch_receipt) = &block.receipt {
                                 let attachments_instances =
                                     self.get_attachment_instances(epoch_receipt, &atlas_config);
                                 if !attachments_instances.is_empty() {
@@ -903,7 +903,7 @@ impl Node {
 
         // todo(ludo): yikes but good enough in the context of helium:
         // we only expect 1 block.
-        let processed_block = processed_blocks[0].clone().0.unwrap();
+        let processed_block = processed_blocks[0].clone().receipt.unwrap();
 
         let mut cost_estimator = self.config.make_cost_estimator();
         let mut fee_estimator = self.config.make_fee_estimator();

--- a/stacks-node/src/run_loop/mod.rs
+++ b/stacks-node/src/run_loop/mod.rs
@@ -37,12 +37,14 @@ macro_rules! info_green {
     })
 }
 
-#[allow(clippy::type_complexity)]
+/// Invoked when the run loop observes a new Stacks chain state.
+type NewStacksChainStateCallback =
+    fn(u64, &BurnchainTip, &ChainTip, &mut StacksChainState, &dyn BurnStateDB);
+
 pub struct RunLoopCallbacks {
     on_burn_chain_initialized: Option<fn(&mut Box<dyn BurnchainController>)>,
     on_new_burn_chain_state: Option<fn(u64, &BurnchainTip, &ChainTip)>,
-    on_new_stacks_chain_state:
-        Option<fn(u64, &BurnchainTip, &ChainTip, &mut StacksChainState, &dyn BurnStateDB)>,
+    on_new_stacks_chain_state: Option<NewStacksChainStateCallback>,
     on_new_tenure: Option<fn(u64, &BurnchainTip, &ChainTip, &mut Tenure)>,
 }
 

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -75,8 +75,47 @@ pub const STACKS_TIPS_BY_BURN_VIEW_SEARCH_DEPTH: usize = 4200;
 pub type BlockHeaderCache = HashMap<ConsensusHash, (Option<BlockHeaderHash>, ConsensusHash)>;
 
 const DESCENDANCY_CACHE_SIZE: usize = 2000;
-static DESCENDANCY_CACHE: LazyLock<Arc<Mutex<LruCache<(SortitionId, BlockHeaderHash), bool>>>> =
+
+/// Cached ancestry checks keyed by the winning sortition and potential ancestor block.
+pub type DescendancyCache = LruCache<(SortitionId, BlockHeaderHash), bool>;
+
+static DESCENDANCY_CACHE: LazyLock<Arc<Mutex<DescendancyCache>>> =
     LazyLock::new(|| Arc::new(Mutex::new(LruCache::new(DESCENDANCY_CACHE_SIZE))));
+
+/// Anchor selection and the confirmation count used to decide the reward cycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PoxAnchorSelection {
+    /// A candidate reached the anchor threshold.
+    Selected {
+        /// Consensus hash of the sortition that elected the anchor.
+        consensus_hash: ConsensusHash,
+        /// Elected Stacks block.
+        block_hash: BlockHeaderHash,
+        /// Winning block-commit transaction.
+        txid: Txid,
+        /// Number of prepare-phase confirmations for the anchor.
+        confirmations: u32,
+    },
+    /// No candidate reached the anchor threshold.
+    NotSelected {
+        /// Largest candidate confirmation count, or zero if no candidate exists.
+        max_confirmations: u32,
+    },
+}
+
+/// Newly arrived blocks and the best Stacks tip they establish for a sortition.
+struct NewBlockArrivals {
+    /// Consensus hash of the best tip's sortition.
+    best_tip_consensus_hash: ConsensusHash,
+    /// Best Stacks tip discovered among the arrivals and current tip.
+    best_tip_block_bhh: BlockHeaderHash,
+    /// Height of the best Stacks tip.
+    best_tip_height: u64,
+    /// Highest arrival index examined.
+    max_arrival_index: u64,
+    /// Arriving Stacks blocks paired with their heights.
+    arrivals: Vec<(BlockHeaderHash, u64)>,
+}
 
 pub enum FindIter<R> {
     Found(R),
@@ -1082,7 +1121,7 @@ pub trait SortitionHandle {
     ///
     /// If it does, return the cached entry
     fn descendancy_cache_get(
-        cache: &mut MutexGuard<'_, LruCache<(SortitionId, BlockHeaderHash), bool>>,
+        cache: &mut MutexGuard<'_, DescendancyCache>,
         key: &(SortitionId, BlockHeaderHash),
     ) -> Option<bool> {
         match cache.get(key) {
@@ -1099,7 +1138,7 @@ pub trait SortitionHandle {
     /// Cache the result of the descendancy check on whether or not the winning block in `key.0`
     ///  descends from `key.1`
     fn descendancy_cache_put(
-        cache: &mut MutexGuard<'_, LruCache<(SortitionId, BlockHeaderHash), bool>>,
+        cache: &mut MutexGuard<'_, DescendancyCache>,
         key: (SortitionId, BlockHeaderHash),
         is_descended: bool,
     ) {
@@ -2513,20 +2552,25 @@ impl<'a> SortitionHandleConn<'a> {
         pox_consts: &PoxConstants,
     ) -> Result<Option<(ConsensusHash, BlockHeaderHash, Txid)>, CoordinatorError> {
         match self.get_chosen_pox_anchor_check_position(prepare_end_bhh, pox_consts, true) {
-            Ok(Ok((c_hash, bh_hash, txid, _))) => Ok(Some((c_hash, bh_hash, txid))),
-            Ok(Err(_)) => Ok(None),
+            Ok(PoxAnchorSelection::Selected {
+                consensus_hash,
+                block_hash,
+                txid,
+                ..
+            }) => Ok(Some((consensus_hash, block_hash, txid))),
+            Ok(PoxAnchorSelection::NotSelected { .. }) => Ok(None),
             Err(e) => Err(e),
         }
     }
 
     /// This is the method for calculating the PoX anchor block for a reward cycle
-    /// If no PoX anchor block is found, it returns Ok(Err(maximum confirmations of all candidates))
+    /// If no anchor is selected, returns the maximum confirmation count among candidates.
     pub fn get_chosen_pox_anchor_check_position(
         &self,
         prepare_end_bhh: &BurnchainHeaderHash,
         pox_consts: &PoxConstants,
         check_position: bool,
-    ) -> Result<Result<(ConsensusHash, BlockHeaderHash, Txid, u32), u32>, CoordinatorError> {
+    ) -> Result<PoxAnchorSelection, CoordinatorError> {
         let (effective_height, block_height) = match self.get_heights_for_prepare_phase_end_block(
             prepare_end_bhh,
             pox_consts,
@@ -2535,7 +2579,9 @@ impl<'a> SortitionHandleConn<'a> {
             Some(x) => x,
             None => {
                 // effective height was 0
-                return Ok(Err(0));
+                return Ok(PoxAnchorSelection::NotSelected {
+                    max_confirmations: 0,
+                });
             }
         };
 
@@ -2632,11 +2678,18 @@ impl<'a> SortitionHandleConn<'a> {
                 info!(
                     "Reward cycle #{reward_cycle_id} ({block_height}): (F*w) not reached, expecting consensus over proof of burn"
                 );
-                Ok(Err(max_confirmed_by))
+                Ok(PoxAnchorSelection::NotSelected {
+                    max_confirmations: max_confirmed_by,
+                })
             }
             Some(response) => {
                 info!("Reward cycle #{reward_cycle_id} ({block_height}): {result:?} reached (F*w), expecting consensus over proof of transfer");
-                Ok(Ok(response.clone()))
+                Ok(PoxAnchorSelection::Selected {
+                    consensus_hash: response.0.clone(),
+                    block_hash: response.1.clone(),
+                    txid: response.2.clone(),
+                    confirmations: response.3,
+                })
             }
         }
     }
@@ -6540,26 +6593,10 @@ impl SortitionHandleTx<'_> {
     /// the highest Stacks chain tip and maximum arrival index.
     /// Used for both discovering the new arrivals and processing them with new snapshots.
     ///
-    /// Returns Ok((
-    ///     stacks tip consensus hash,
-    ///     stacks tip block header hash,
-    ///     stacks tip height,
-    ///     max arrival index,
-    ///     list of all blocks that have arrived since this parent_tip
-    /// ))
     fn inner_find_new_block_arrivals(
         &mut self,
         parent_tip: &BlockSnapshot,
-    ) -> Result<
-        (
-            ConsensusHash,
-            BlockHeaderHash,
-            u64,
-            u64,
-            Vec<(BlockHeaderHash, u64)>,
-        ),
-        db_error,
-    > {
+    ) -> Result<NewBlockArrivals, db_error> {
         let mut new_block_arrivals = vec![];
 
         let old_max_arrival_index = self
@@ -6665,13 +6702,13 @@ impl SortitionHandleTx<'_> {
             "Max arrival for child of {best_tip_consensus_hash} is {max_arrival_index} (hash {best_tip_block_bhh} height {best_tip_height})"
         );
 
-        Ok((
+        Ok(NewBlockArrivals {
             best_tip_consensus_hash,
             best_tip_block_bhh,
             best_tip_height,
             max_arrival_index,
-            ret,
-        ))
+            arrivals: ret,
+        })
     }
 
     /// Find the new Stacks block arrivals as of the given tip `tip`, and return the highest chain
@@ -6688,8 +6725,13 @@ impl SortitionHandleTx<'_> {
         &mut self,
         tip: &BlockSnapshot,
     ) -> Result<(ConsensusHash, BlockHeaderHash, u64), db_error> {
-        self.inner_find_new_block_arrivals(tip)
-            .map(|(ch, bhh, height, _, _)| (ch, bhh, height))
+        self.inner_find_new_block_arrivals(tip).map(|arrivals| {
+            (
+                arrivals.best_tip_consensus_hash,
+                arrivals.best_tip_block_bhh,
+                arrivals.best_tip_height,
+            )
+        })
     }
 
     /// Update the given tip's canonical Stacks block pointer.
@@ -6730,13 +6772,13 @@ impl SortitionHandleTx<'_> {
         let mut keys = vec![];
         let mut values = vec![];
 
-        let (
+        let NewBlockArrivals {
             best_tip_consensus_hash,
             best_tip_block_bhh,
             best_tip_height,
             max_arrival_index,
-            new_arrivals,
-        ) = self.inner_find_new_block_arrivals(parent_tip)?;
+            arrivals: new_arrivals,
+        } = self.inner_find_new_block_arrivals(parent_tip)?;
 
         // generate MARF key/value pairs for new arrivals
         for (block_bhh, height) in new_arrivals.into_iter() {
@@ -11231,6 +11273,34 @@ pub mod tests {
                 .get_chosen_pox_anchor(&tip.burn_header_hash, &pox_consts)
                 .unwrap()
                 .unwrap();
+
+            assert_eq!(
+                ic.get_chosen_pox_anchor_check_position(&tip.burn_header_hash, &pox_consts, true)
+                    .unwrap(),
+                PoxAnchorSelection::Selected {
+                    consensus_hash: anchor.0.clone(),
+                    block_hash: anchor.1.clone(),
+                    txid: anchor.2.clone(),
+                    confirmations: 3,
+                }
+            );
+            let mut higher_threshold = pox_consts.clone();
+            higher_threshold.anchor_threshold = 4;
+            assert_eq!(
+                ic.get_chosen_pox_anchor_check_position(
+                    &tip.burn_header_hash,
+                    &higher_threshold,
+                    true
+                )
+                .unwrap(),
+                PoxAnchorSelection::NotSelected {
+                    max_confirmations: 3
+                }
+            );
+            assert!(ic
+                .get_chosen_pox_anchor(&tip.burn_header_hash, &higher_threshold)
+                .unwrap()
+                .is_none());
 
             let ic = db.index_conn();
             let expected_anchor_ch = SortitionDB::get_ancestor_snapshot(&ic, 7, &tip.sortition_id)

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -1658,12 +1658,12 @@ impl<
                 .process_blocks(sortdb_handle, 1, self.dispatcher)?;
 
         while let Some(block_result) = processed_blocks.pop() {
-            if block_result.0.is_none() && block_result.1.is_none() {
+            if block_result.receipt.is_none() && block_result.poison_payload.is_none() {
                 // this block was invalid
                 debug!("Bump blocks processed (invalid)");
                 self.notifier.notify_stacks_block_processed();
                 increment_stx_blocks_processed_counter();
-            } else if let (Some(block_receipt), _) = block_result {
+            } else if let Some(block_receipt) = block_result.receipt {
                 // only bump the coordinator's state if the processed block
                 //   is in our sortition fork
                 //  TODO: we should update the staging block logic to prevent

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -57,7 +57,7 @@ use super::stacks::boot::{
 use super::stacks::db::accounts::MinerReward;
 use super::stacks::db::{
     ChainstateTx, ClarityTx, MinerPaymentSchedule, MinerRewardInfo, StacksBlockHeaderTypes,
-    StacksEpochReceipt, StacksHeaderInfo,
+    StacksEpochReceipt, StacksHeaderInfo, StacksOnBurnchainOperations,
 };
 use super::stacks::events::StacksTransactionReceipt;
 use super::stacks::{
@@ -4234,21 +4234,13 @@ impl NakamotoChainState {
         sortdb_conn: &Connection,
         burn_tip: &BurnchainHeaderHash,
         burn_tip_height: u64,
-    ) -> Result<
-        (
-            Vec<StackStxOp>,
-            Vec<TransferStxOp>,
-            Vec<DelegateStxOp>,
-            Vec<VoteForAggregateKeyOp>,
-        ),
-        ChainstateError,
-    > {
+    ) -> Result<StacksOnBurnchainOperations, ChainstateError> {
         let cur_epoch = SortitionDB::get_stacks_epoch(sortdb_conn, burn_tip_height)?
             .expect("FATAL: no epoch defined for current burnchain tip height");
 
         // only consider transactions in Stacks 3.0
         if cur_epoch.epoch_id < StacksEpochId::Epoch30 {
-            return Ok((vec![], vec![], vec![], vec![]));
+            return Ok(StacksOnBurnchainOperations::default());
         }
 
         let epoch_start_height = cur_epoch.start_height;
@@ -4326,12 +4318,12 @@ impl NakamotoChainState {
                 }
             }
         }
-        Ok((
-            all_stacking_burn_ops,
-            all_transfer_burn_ops,
-            all_delegate_burn_ops,
-            all_vote_for_aggregate_key_ops,
-        ))
+        Ok(StacksOnBurnchainOperations {
+            stack: all_stacking_burn_ops,
+            transfer: all_transfer_burn_ops,
+            delegate: all_delegate_burn_ops,
+            vote_for_aggregate_key: all_vote_for_aggregate_key_ops,
+        })
     }
 
     /// Begin block-processing for a normal block and return all of the pre-processed state within a
@@ -4578,19 +4570,23 @@ impl NakamotoChainState {
             None
         };
 
-        let (stacking_burn_ops, transfer_burn_ops, delegate_burn_ops, vote_for_agg_key_ops) =
-            if tenure_cause.is_new_tenure() {
-                NakamotoChainState::get_stacks_on_burnchain_operations(
-                    chainstate_tx.as_tx(),
-                    parent_consensus_hash,
-                    parent_header_hash,
-                    sortition_dbconn.sqlite_conn(),
-                    burn_header_hash,
-                    burn_header_height.into(),
-                )?
-            } else {
-                (vec![], vec![], vec![], vec![])
-            };
+        let StacksOnBurnchainOperations {
+            stack: stacking_burn_ops,
+            transfer: transfer_burn_ops,
+            delegate: delegate_burn_ops,
+            vote_for_aggregate_key: vote_for_agg_key_ops,
+        } = if tenure_cause.is_new_tenure() {
+            NakamotoChainState::get_stacks_on_burnchain_operations(
+                chainstate_tx.as_tx(),
+                parent_consensus_hash,
+                parent_header_hash,
+                sortition_dbconn.sqlite_conn(),
+                burn_header_hash,
+                burn_header_height.into(),
+            )?
+        } else {
+            StacksOnBurnchainOperations::default()
+        };
 
         // Nakamoto must load block cost from parent if this block isn't a tenure change.
         // If this is a tenure-extend, then the execution cost is reset.

--- a/stackslib/src/chainstate/nakamoto/tenure.rs
+++ b/stackslib/src/chainstate/nakamoto/tenure.rs
@@ -72,6 +72,7 @@ use crate::chainstate::nakamoto::{
     MaturedMinerPaymentSchedules, MaturedMinerRewards, NakamotoBlock, NakamotoBlockHeader,
     NakamotoChainState, StacksDBIndexed,
 };
+use crate::chainstate::stacks::db::accounts::MaturedMinerPayouts;
 use crate::chainstate::stacks::db::{
     ChainstateTx, ClarityTx, MinerPaymentSchedule, MinerPaymentTxFees, StacksChainState,
     StacksDBTx, StacksHeaderInfo,
@@ -395,7 +396,12 @@ impl NakamotoChainState {
             matured_miner_schedule.latest_miners,
             matured_miner_schedule.parent_miner,
         ) {
-            Ok(Some((recipient, _user_burns, parent, reward_info))) => Some(MaturedMinerRewards {
+            Ok(Some(MaturedMinerPayouts {
+                miner: recipient,
+                parent,
+                info: reward_info,
+                ..
+            })) => Some(MaturedMinerRewards {
                 recipient,
                 parent_reward: parent,
                 reward_info,

--- a/stackslib/src/chainstate/nakamoto/tests/node.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/node.rs
@@ -57,6 +57,9 @@ use crate::net::relay::{BlockAcceptResponse, Relayer};
 use crate::net::test::{TestPeer, *};
 use crate::util_lib::db::query_row;
 
+/// A mined test block, its byte size and execution cost, and its malleablized variants.
+pub type MinedTenureBlock = (NakamotoBlock, u64, ExecutionCost, Vec<NakamotoBlock>);
+
 #[derive(Debug, Clone)]
 pub struct TestStacker {
     /// Key used to send stacking transactions
@@ -726,7 +729,7 @@ impl TestStacksNode {
         malleablize: bool,
         mined_canonical: bool,
         timestamp: Option<u64>,
-    ) -> Result<Vec<(NakamotoBlock, u64, ExecutionCost, Vec<NakamotoBlock>)>, ChainstateError>
+    ) -> Result<Vec<MinedTenureBlock>, ChainstateError>
     where
         S: FnMut(&mut NakamotoBlockBuilder),
         F: FnMut(
@@ -1179,7 +1182,7 @@ impl TestStacksNode {
         let res = stacks_node
             .chainstate
             .process_next_staging_block(&mut sort_tx, coord.dispatcher)
-            .map(|(epoch_receipt, _)| epoch_receipt)?;
+            .map(|outcome| outcome.receipt)?;
         sort_tx.commit()?;
         if let Some(block_receipt) = res.as_ref() {
             let in_sortition_set = coord

--- a/stackslib/src/chainstate/stacks/db/accounts.rs
+++ b/stackslib/src/chainstate/stacks/db/accounts.rs
@@ -25,6 +25,19 @@ use crate::clarity_vm::clarity::{ClarityConnection, ClarityTransactionConnection
 use crate::core::StacksEpochId;
 use crate::util_lib::db::{Error as db_error, *};
 
+/// Mature rewards for a block, its supporting burners, and its parent.
+#[derive(Debug, Clone)]
+pub struct MaturedMinerPayouts {
+    /// Child miner reward, possibly redirected to a poison reporter.
+    pub miner: MinerReward,
+    /// Rewards for user-support burns, in payment order.
+    pub users: Vec<MinerReward>,
+    /// Parent miner's reward for produced microblocks.
+    pub parent: MinerReward,
+    /// Chain locations of the rewarded child and parent blocks.
+    pub info: MinerRewardInfo,
+}
+
 /// A record of a coin reward for a miner.  There will be at most two of these for a miner: one for
 /// the coinbase + block-txs + confirmed-mblock-txs, and one for the produced-mblock-txs.  The
 /// latter reward only stores the produced-mblock-txs, and is only ever stored if the microblocks
@@ -988,7 +1001,7 @@ impl StacksChainState {
         tip_stacks_height: u64,
         mut latest_matured_miners: Vec<MinerPaymentSchedule>,
         parent_miner: MinerPaymentSchedule,
-    ) -> Result<Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>, Error> {
+    ) -> Result<Option<MaturedMinerPayouts>, Error> {
         let mainnet = clarity_tx.config.mainnet;
         if tip_stacks_height <= MINER_REWARD_MATURITY {
             // no mature rewards exist
@@ -1067,12 +1080,12 @@ impl StacksChainState {
             user_rewards.push(reward);
         }
 
-        Ok(Some((
-            miner_reward,
-            user_rewards,
-            parent_miner_reward,
-            reward_info,
-        )))
+        Ok(Some(MaturedMinerPayouts {
+            miner: miner_reward,
+            users: user_rewards,
+            parent: parent_miner_reward,
+            info: reward_info,
+        }))
     }
 }
 

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -49,7 +49,7 @@ use crate::chainstate::coordinator::BlockEventDispatcher;
 use crate::chainstate::nakamoto::signer_set::{NakamotoSigners, SignerCalculation};
 use crate::chainstate::nakamoto::{NakamotoChainState, TxToProcess};
 use crate::chainstate::stacks::address::PoxAddress;
-use crate::chainstate::stacks::db::accounts::MinerReward;
+use crate::chainstate::stacks::db::accounts::{MaturedMinerPayouts, MinerReward};
 use crate::chainstate::stacks::db::transactions::TransactionNonceMismatch;
 use crate::chainstate::stacks::db::*;
 use crate::chainstate::stacks::events::StacksBlockEventData;
@@ -136,6 +136,23 @@ pub enum MemPoolRejection {
     Other(String),
 }
 
+/// A loaded descendant microblock stream and evidence of a fork, if found.
+pub struct StagingMicroblockStream {
+    /// Non-forked prefix of the descendant stream.
+    pub microblocks: Vec<StacksMicroblock>,
+    /// Poison transaction payload identifying conflicting microblocks.
+    pub poison_payload: Option<TransactionPayload>,
+}
+
+/// Receipt and optional fork evidence from processing one staging block.
+#[derive(Debug, Clone, Default)]
+pub struct StagingBlockOutcome {
+    /// Processed block receipt; absent for invalid blocks or when no block was processed.
+    pub receipt: Option<StacksEpochReceipt>,
+    /// Poison transaction payload for a discovered microblock fork.
+    pub poison_payload: Option<TransactionPayload>,
+}
+
 pub struct SetupBlockResult<'a, 'b> {
     pub clarity_tx: ClarityTx<'a, 'b>,
     pub tx_receipts: Vec<StacksTransactionReceipt>,
@@ -143,8 +160,7 @@ pub struct SetupBlockResult<'a, 'b> {
     pub microblock_fees: u128,
     pub microblock_burns: u128,
     pub microblock_txs_receipts: Vec<StacksTransactionReceipt>,
-    pub matured_miner_rewards_opt:
-        Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>,
+    pub matured_miner_rewards_opt: Option<MaturedMinerPayouts>,
     pub evaluated_epoch: StacksEpochId,
     pub applied_epoch_transition: bool,
     pub burn_stack_stx_ops: Vec<StackStxOp>,
@@ -1297,7 +1313,7 @@ impl StacksChainState {
             start_seq,
             last_seq,
         )?;
-        Ok(res.map(|(microblocks, _)| microblocks))
+        Ok(res.map(|stream| stream.microblocks))
     }
 
     /// Load up a block's longest non-forked descendant microblock stream, given its block hash and burn header hash.
@@ -1310,7 +1326,7 @@ impl StacksChainState {
         parent_index_block_hash: &StacksBlockId,
         start_seq: u16,
         last_seq: u16,
-    ) -> Result<Option<(Vec<StacksMicroblock>, Option<TransactionPayload>)>, Error> {
+    ) -> Result<Option<StagingMicroblockStream>, Error> {
         assert!(last_seq >= start_seq);
 
         let sql = if start_seq == last_seq {
@@ -1422,7 +1438,10 @@ impl StacksChainState {
             // just as if there were no blocks loaded
             Ok(None)
         } else {
-            Ok(Some((ret, fork_poison)))
+            Ok(Some(StagingMicroblockStream {
+                microblocks: ret,
+                poison_payload: fork_poison,
+            }))
         }
     }
 
@@ -4743,15 +4762,7 @@ impl StacksChainState {
         burn_tip: &BurnchainHeaderHash,
         burn_tip_height: u64,
         epoch_start_height: u64,
-    ) -> Result<
-        (
-            Vec<StackStxOp>,
-            Vec<TransferStxOp>,
-            Vec<DelegateStxOp>,
-            Vec<VoteForAggregateKeyOp>,
-        ),
-        Error,
-    > {
+    ) -> Result<StacksOnBurnchainOperations, Error> {
         // only consider transactions in Stacks 2.1
         let search_window: u8 =
             if epoch_start_height + u64::from(BURNCHAIN_TX_SEARCH_WINDOW) > burn_tip_height {
@@ -4824,12 +4835,12 @@ impl StacksChainState {
                 }
             }
         }
-        Ok((
-            all_stacking_burn_ops,
-            all_transfer_burn_ops,
-            all_delegate_burn_ops,
-            all_vote_for_aggregate_key_ops,
-        ))
+        Ok(StacksOnBurnchainOperations {
+            stack: all_stacking_burn_ops,
+            transfer: all_transfer_burn_ops,
+            delegate: all_delegate_burn_ops,
+            vote_for_aggregate_key: all_vote_for_aggregate_key_ops,
+        })
     }
 
     /// Get the list of burnchain-hosted stacking and transfer operations to apply when evaluating
@@ -4864,15 +4875,7 @@ impl StacksChainState {
         sortdb_conn: &Connection,
         burn_tip: &BurnchainHeaderHash,
         burn_tip_height: u64,
-    ) -> Result<
-        (
-            Vec<StackStxOp>,
-            Vec<TransferStxOp>,
-            Vec<DelegateStxOp>,
-            Vec<VoteForAggregateKeyOp>,
-        ),
-        Error,
-    > {
+    ) -> Result<StacksOnBurnchainOperations, Error> {
         let cur_epoch = SortitionDB::get_stacks_epoch(sortdb_conn, burn_tip_height)?
             .expect("FATAL: no epoch defined for current burnchain tip height");
 
@@ -4886,21 +4889,34 @@ impl StacksChainState {
                 cur_epoch.start_height,
             )
         } else if cur_epoch.epoch_id >= StacksEpochId::Epoch21 {
-            let (stack_ops, transfer_ops, delegate_ops, _) =
-                StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
-                    chainstate_tx,
-                    parent_index_hash,
-                    sortdb_conn,
-                    burn_tip,
-                    burn_tip_height,
-                    cur_epoch.start_height,
-                )?;
-            Ok((stack_ops, transfer_ops, delegate_ops, vec![]))
+            let StacksOnBurnchainOperations {
+                stack: stack_ops,
+                transfer: transfer_ops,
+                delegate: delegate_ops,
+                ..
+            } = StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
+                chainstate_tx,
+                parent_index_hash,
+                sortdb_conn,
+                burn_tip,
+                burn_tip_height,
+                cur_epoch.start_height,
+            )?;
+            Ok(StacksOnBurnchainOperations {
+                stack: stack_ops,
+                transfer: transfer_ops,
+                delegate: delegate_ops,
+                vote_for_aggregate_key: vec![],
+            })
         } else {
             let (stack_ops, transfer_ops) =
                 StacksChainState::get_stacking_and_transfer_burn_ops_v205(sortdb_conn, burn_tip)?;
             // The DelegateStx bitcoin wire format does not exist before Epoch 2.1.
-            Ok((stack_ops, transfer_ops, vec![], vec![]))
+            Ok(StacksOnBurnchainOperations {
+                stack: stack_ops,
+                transfer: transfer_ops,
+                ..StacksOnBurnchainOperations::default()
+            })
         }
     }
 
@@ -5053,14 +5069,18 @@ impl StacksChainState {
             (latest_miners, parent_miner)
         };
 
-        let (stacking_burn_ops, transfer_burn_ops, delegate_burn_ops, vote_for_agg_key_burn_ops) =
-            StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops(
-                chainstate_tx,
-                &parent_index_hash,
-                conn,
-                burn_tip,
-                burn_tip_height.into(),
-            )?;
+        let StacksOnBurnchainOperations {
+            stack: stacking_burn_ops,
+            transfer: transfer_burn_ops,
+            delegate: delegate_burn_ops,
+            vote_for_aggregate_key: vote_for_agg_key_burn_ops,
+        } = StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops(
+            chainstate_tx,
+            &parent_index_hash,
+            conn,
+            burn_tip,
+            burn_tip_height.into(),
+        )?;
 
         // load the execution cost of the parent block if the executor is the follower.
         // otherwise, if the executor is the miner, only load the parent cost if the parent
@@ -5298,12 +5318,18 @@ impl StacksChainState {
     /// Returns stx lockup events.
     pub fn finish_block(
         clarity_tx: &mut ClarityTx,
-        miner_payouts: Option<&(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>,
+        miner_payouts: Option<&MaturedMinerPayouts>,
         block_height: u32,
         mblock_pubkey_hash: &Hash160,
     ) -> Result<Vec<StacksTransactionEvent>, Error> {
         // add miner payments
-        if let Some((ref miner_reward, ref user_rewards, ref parent_reward, _)) = miner_payouts {
+        if let Some(MaturedMinerPayouts {
+            miner: miner_reward,
+            users: user_rewards,
+            parent: parent_reward,
+            ..
+        }) = miner_payouts
+        {
             // grant in order by miner, then users
             let matured_ustx = StacksChainState::process_matured_miner_rewards(
                 clarity_tx,
@@ -5616,22 +5642,30 @@ impl StacksChainState {
             let block_cost = clarity_tx.cost_so_far();
 
             // obtain reward info for receipt -- consolidate miner, user, and parent rewards into a
-            // single list, but keep the miner/user/parent/info tuple for advancing the chain tip
-            let (matured_rewards, miner_payouts_opt) =
-                if let Some((miner_reward, mut user_rewards, parent_reward, reward_ptr)) =
-                    matured_miner_rewards_opt
-                {
-                    let mut ret = vec![];
-                    ret.push(miner_reward.clone());
-                    ret.append(&mut user_rewards);
-                    ret.push(parent_reward.clone());
-                    (
-                        ret,
-                        Some((miner_reward, user_rewards, parent_reward, reward_ptr)),
-                    )
-                } else {
-                    (vec![], None)
-                };
+            // single list, but keep the separate reward components for advancing the chain tip
+            let (matured_rewards, miner_payouts_opt) = if let Some(MaturedMinerPayouts {
+                miner: miner_reward,
+                users: mut user_rewards,
+                parent: parent_reward,
+                info: reward_ptr,
+            }) = matured_miner_rewards_opt
+            {
+                let mut ret = vec![];
+                ret.push(miner_reward.clone());
+                ret.append(&mut user_rewards);
+                ret.push(parent_reward.clone());
+                (
+                    ret,
+                    Some(MaturedMinerPayouts {
+                        miner: miner_reward,
+                        users: user_rewards,
+                        parent: parent_reward,
+                        info: reward_ptr,
+                    }),
+                )
+            } else {
+                (vec![], None)
+            };
 
             // total burns
             let total_burnt = block_burns
@@ -5757,7 +5791,7 @@ impl StacksChainState {
 
         let matured_rewards_info = miner_payouts_opt
             .as_ref()
-            .map(|(_, _, _, info)| info.clone());
+            .map(|rewards| rewards.info.clone());
 
         if do_not_advance {
             let regtest_genesis_header = StacksHeaderInfo::regtest_genesis();
@@ -6017,7 +6051,7 @@ impl StacksChainState {
         &mut self,
         sort_tx: &mut SortitionHandleTx,
         dispatcher_opt: Option<&T>,
-    ) -> Result<(Option<StacksEpochReceipt>, Option<TransactionPayload>), Error> {
+    ) -> Result<StagingBlockOutcome, Error> {
         let blocks_path = self.blocks_path.clone();
         let (mut chainstate_tx, clarity_instance) = self.chainstate_tx_begin();
 
@@ -6037,7 +6071,7 @@ impl StacksChainState {
 
                     // save any orphaning we did
                     chainstate_tx.commit().map_err(Error::DBError)?;
-                    return Ok((None, None));
+                    return Ok(StagingBlockOutcome::default());
                 }
             };
 
@@ -6105,7 +6139,7 @@ impl StacksChainState {
         let parent_header_info =
             match StacksChainState::get_parent_header_info(&chainstate_tx, &next_staging_block)? {
                 Some(hinfo) => hinfo,
-                None => return Ok((None, None)),
+                None => return Ok(StagingBlockOutcome::default()),
             };
 
         let block = StacksChainState::extract_stacks_block(&next_staging_block)?;
@@ -6141,7 +6175,7 @@ impl StacksChainState {
             )?;
             chainstate_tx.commit().map_err(Error::DBError)?;
 
-            return Ok((None, None));
+            return Ok(StagingBlockOutcome::default());
         }
 
         // validation check -- the block must attach to its accepted parent
@@ -6364,7 +6398,10 @@ impl StacksChainState {
                 panic!()
             });
 
-        Ok((Some(epoch_receipt), None))
+        Ok(StagingBlockOutcome {
+            receipt: Some(epoch_receipt),
+            poison_payload: None,
+        })
     }
 
     /// Process staging blocks at the canonical chain tip,
@@ -6377,7 +6414,7 @@ impl StacksChainState {
         &mut self,
         sort_db: &mut SortitionDB,
         max_blocks: usize,
-    ) -> Result<Vec<(Option<StacksEpochReceipt>, Option<TransactionPayload>)>, Error> {
+    ) -> Result<Vec<StagingBlockOutcome>, Error> {
         let tx = sort_db.tx_begin_at_tip();
         let null_event_dispatcher: Option<&DummyEventDispatcher> = None;
         self.process_blocks(tx, max_blocks, null_event_dispatcher)
@@ -6393,7 +6430,7 @@ impl StacksChainState {
         mut sort_tx: SortitionHandleTx,
         max_blocks: usize,
         dispatcher_opt: Option<&T>,
-    ) -> Result<Vec<(Option<StacksEpochReceipt>, Option<TransactionPayload>)>, Error> {
+    ) -> Result<Vec<StagingBlockOutcome>, Error> {
         // first, clear out orphans
         let blocks_path = self.blocks_path.clone();
         let mut block_tx = self.db_tx_begin()?;
@@ -6423,13 +6460,22 @@ impl StacksChainState {
         for i in 0..max_blocks {
             // process up to max_blocks pending blocks
             match self.process_next_staging_block(&mut sort_tx, dispatcher_opt) {
-                Ok((next_tip_opt, next_microblock_poison_opt)) => match next_tip_opt {
+                Ok(StagingBlockOutcome {
+                    receipt: next_tip_opt,
+                    poison_payload: next_microblock_poison_opt,
+                }) => match next_tip_opt {
                     Some(next_tip) => {
-                        ret.push((Some(next_tip), next_microblock_poison_opt));
+                        ret.push(StagingBlockOutcome {
+                            receipt: Some(next_tip),
+                            poison_payload: next_microblock_poison_opt,
+                        });
                     }
                     None => match next_microblock_poison_opt {
                         Some(poison) => {
-                            ret.push((None, Some(poison)));
+                            ret.push(StagingBlockOutcome {
+                                receipt: None,
+                                poison_payload: Some(poison),
+                            });
                         }
                         None => {
                             debug!("No more staging blocks -- processed {} in total", i);
@@ -6439,18 +6485,18 @@ impl StacksChainState {
                 },
                 Err(Error::InvalidStacksBlock(msg)) => {
                     warn!("Encountered invalid block: {}", &msg);
-                    ret.push((None, None));
+                    ret.push(StagingBlockOutcome::default());
                     continue;
                 }
                 Err(Error::InvalidStacksMicroblock(msg, hash)) => {
                     warn!("Encountered invalid microblock {}: {}", hash, &msg);
-                    ret.push((None, None));
+                    ret.push(StagingBlockOutcome::default());
                     continue;
                 }
                 Err(Error::NetError(net_error::DeserializeError(msg))) => {
                     // happens if we load a zero-sized block (i.e. an invalid block)
                     warn!("Encountered invalid block: {}", &msg);
-                    ret.push((None, None));
+                    ret.push(StagingBlockOutcome::default());
                     continue;
                 }
                 Err(e) => {
@@ -11146,16 +11192,20 @@ pub mod test {
             {
                 let chainstate = peer.chainstate();
                 let (mut chainstate_tx, clarity_instance) = chainstate.chainstate_tx_begin();
-                let (stack_stx_ops, transfer_stx_ops, delegate_stx_ops, vote_for_aggregate_key_ops) =
-                    StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
-                        &mut chainstate_tx,
-                        &last_block_id,
-                        sortdb.conn(),
-                        &tip.burn_header_hash,
-                        tip.block_height,
-                        0,
-                    )
-                    .unwrap();
+                let StacksOnBurnchainOperations {
+                    stack: stack_stx_ops,
+                    transfer: transfer_stx_ops,
+                    delegate: delegate_stx_ops,
+                    vote_for_aggregate_key: vote_for_aggregate_key_ops,
+                } = StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
+                    &mut chainstate_tx,
+                    &last_block_id,
+                    sortdb.conn(),
+                    &tip.burn_header_hash,
+                    tip.block_height,
+                    0,
+                )
+                .unwrap();
 
                 assert_eq!(transfer_stx_ops.len(), expected_transfer_ops.len());
                 assert_eq!(delegate_stx_ops.len(), expected_del_ops.len());
@@ -11832,16 +11882,20 @@ pub mod test {
             {
                 let chainstate = peer.chainstate();
                 let (mut chainstate_tx, clarity_instance) = chainstate.chainstate_tx_begin();
-                let (stack_stx_ops, transfer_stx_ops, delegate_stx_ops, _) =
-                    StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
-                        &mut chainstate_tx,
-                        &last_block_id,
-                        sortdb.conn(),
-                        &tip.burn_header_hash,
-                        tip.block_height,
-                        0,
-                    )
-                    .unwrap();
+                let StacksOnBurnchainOperations {
+                    stack: stack_stx_ops,
+                    transfer: transfer_stx_ops,
+                    delegate: delegate_stx_ops,
+                    ..
+                } = StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
+                    &mut chainstate_tx,
+                    &last_block_id,
+                    sortdb.conn(),
+                    &tip.burn_header_hash,
+                    tip.block_height,
+                    0,
+                )
+                .unwrap();
 
                 assert_eq!(transfer_stx_ops.len(), expected_transfer_ops.len());
                 assert_eq!(delegate_stx_ops.len(), expected_delegate_ops.len());

--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -980,28 +980,43 @@ impl ChainstateAccountLockup {
     }
 }
 
+/// Unprocessed Stacks operations from the burnchain, ordered within each operation kind.
+#[derive(Default)]
+pub struct StacksOnBurnchainOperations {
+    /// STX stacking operations enabled for the current epoch.
+    pub stack: Vec<StackStxOp>,
+    /// STX transfer operations.
+    pub transfer: Vec<TransferStxOp>,
+    /// Delegation operations enabled for the current epoch.
+    pub delegate: Vec<DelegateStxOp>,
+    /// Aggregate-key votes enabled for the current epoch.
+    pub vote_for_aggregate_key: Vec<VoteForAggregateKeyOp>,
+}
+
+/// One-shot callback invoked after chainstate boot initialization.
+pub type PostFlightCallback = Box<dyn FnOnce(&mut ClarityTx)>;
+
+/// One-shot factory for lazily streamed genesis records.
+pub type BulkInitialData<T> = Box<dyn FnOnce() -> Box<dyn Iterator<Item = T>>>;
+
 pub struct ChainStateBootData {
     pub first_burnchain_block_hash: BurnchainHeaderHash,
     pub first_burnchain_block_height: u32,
     pub first_burnchain_block_timestamp: u32,
     pub initial_balances: Vec<(PrincipalData, u64)>,
     pub pox_constants: PoxConstants,
-    pub post_flight_callback: Option<Box<dyn FnOnce(&mut ClarityTx)>>,
-    pub get_bulk_initial_lockups:
-        Option<Box<dyn FnOnce() -> Box<dyn Iterator<Item = ChainstateAccountLockup>>>>,
-    pub get_bulk_initial_balances:
-        Option<Box<dyn FnOnce() -> Box<dyn Iterator<Item = ChainstateAccountBalance>>>>,
-    pub get_bulk_initial_namespaces:
-        Option<Box<dyn FnOnce() -> Box<dyn Iterator<Item = ChainstateBNSNamespace>>>>,
-    pub get_bulk_initial_names:
-        Option<Box<dyn FnOnce() -> Box<dyn Iterator<Item = ChainstateBNSName>>>>,
+    pub post_flight_callback: Option<PostFlightCallback>,
+    pub get_bulk_initial_lockups: Option<BulkInitialData<ChainstateAccountLockup>>,
+    pub get_bulk_initial_balances: Option<BulkInitialData<ChainstateAccountBalance>>,
+    pub get_bulk_initial_namespaces: Option<BulkInitialData<ChainstateBNSNamespace>>,
+    pub get_bulk_initial_names: Option<BulkInitialData<ChainstateBNSName>>,
 }
 
 impl ChainStateBootData {
     pub fn new(
         burnchain: &Burnchain,
         initial_balances: Vec<(PrincipalData, u64)>,
-        post_flight_callback: Option<Box<dyn FnOnce(&mut ClarityTx)>>,
+        post_flight_callback: Option<PostFlightCallback>,
     ) -> ChainStateBootData {
         ChainStateBootData {
             first_burnchain_block_hash: burnchain.first_block_hash.clone(),
@@ -2833,7 +2848,7 @@ impl StacksChainState {
         new_burnchain_timestamp: u64,
         microblock_tail_opt: Option<StacksMicroblockHeader>,
         block_reward: &MinerPaymentSchedule,
-        mature_miner_payouts: Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>, // (miner, [users], parent, matured rewards)
+        mature_miner_payouts: Option<MaturedMinerPayouts>,
         anchor_block_cost: &ExecutionCost,
         anchor_block_size: u64,
         applied_epoch_transition: bool,
@@ -2908,7 +2923,12 @@ impl StacksChainState {
             burn_vote_for_aggregate_key_ops,
         )?;
 
-        if let Some((miner_payout, user_payouts, parent_payout, reward_info)) = mature_miner_payouts
+        if let Some(MaturedMinerPayouts {
+            miner: miner_payout,
+            users: user_payouts,
+            parent: parent_payout,
+            info: reward_info,
+        }) = mature_miner_payouts
         {
             let rewarded_miner_block_id = StacksBlockHeader::make_index_block_hash(
                 &reward_info.from_block_consensus_hash,

--- a/stackslib/src/chainstate/stacks/index/squash.rs
+++ b/stackslib/src/chainstate/stacks/index/squash.rs
@@ -47,6 +47,9 @@ pub(crate) use stream::compute_node_hash;
 use stream::recompute_content_hashes;
 pub(crate) use stream::stream_squash_blob;
 
+/// Maps a source block ID and byte offset to its collected node index.
+type SourceNodeIndex = HashMap<(u32, u64), usize>;
+
 /// Resolve a child pointer to the `(block_id, byte_offset)` locating it in
 /// blob storage; `None` for empty pointers. Backpointers and squash-annotated
 /// inline pointers (non-zero `back_block`) name the child's block directly;
@@ -112,7 +115,7 @@ fn restore_default_squash_pragmas(conn: &rusqlite::Connection) -> Result<(), Err
 /// identity when the squashed MARF is extended later.
 fn remap_child_ptrs(
     store: &mut NodeStore,
-    source_to_idx: &HashMap<(u32, u64), usize>,
+    source_to_idx: &SourceNodeIndex,
     block_id_map: &[u32],
     label: &str,
 ) -> Result<(), Error> {
@@ -973,13 +976,13 @@ impl<T: MarfTrieId> MARF<T> {
         source: &mut TrieStorageConnection<T>,
         block_hash: &T,
         tmp_dir: &str,
-    ) -> Result<(NodeStore, HashMap<(u32, u64), usize>), Error> {
+    ) -> Result<(NodeStore, SourceNodeIndex), Error> {
         source.open_block(block_hash)?;
         let (root_node, root_hash) = Trie::read_root(source)?;
         let root_block_id = source.get_cur_block_identifier()?;
 
         let mut store = NodeStore::new(tmp_dir)?;
-        let mut source_to_idx: HashMap<(u32, u64), usize> = HashMap::new();
+        let mut source_to_idx: SourceNodeIndex = HashMap::new();
 
         let root_is_leaf = root_node.is_leaf();
         let root_ptrs: Vec<TriePtr> = if root_is_leaf {

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -39,6 +39,7 @@ use crate::burnchains::{Burnchain, Txid};
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandleConn};
 use crate::chainstate::burn::*;
 use crate::chainstate::stacks::address::StacksAddressExtensions;
+use crate::chainstate::stacks::db::accounts::MaturedMinerPayouts;
 use crate::chainstate::stacks::db::blocks::SetupBlockResult;
 use crate::chainstate::stacks::db::transactions::{
     finalize_failed_transaction, handle_clarity_runtime_error, ClarityRuntimeTxError,
@@ -1874,15 +1875,15 @@ impl StacksBlockBuilder {
                 &self.parent_consensus_hash,
                 &self.parent_header_hash,
             );
-            let (parent_microblocks, _) =
+            let parent_microblocks =
                 match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
                     chainstate.db(),
                     &parent_index_hash,
                     0,
                     u16::MAX,
                 )? {
-                    Some(x) => x,
-                    None => (vec![], None),
+                    Some(stream) => stream.microblocks,
+                    None => vec![],
                 };
 
             debug!(
@@ -1917,8 +1918,12 @@ impl StacksBlockBuilder {
                                     self.header.parent_block)
         );
 
-        if let Some((ref _miner_payout, ref _user_payouts, ref _parent_reward, ref _reward_info)) =
-            self.miner_payouts
+        if let Some(MaturedMinerPayouts {
+            miner: ref _miner_payout,
+            users: ref _user_payouts,
+            parent: ref _parent_reward,
+            ..
+        }) = self.miner_payouts
         {
             test_debug!(
                 "Miner payout to process: {_miner_payout:?}; user payouts: {_user_payouts:?}; parent payout: {_parent_reward:?}"

--- a/stackslib/src/chainstate/stacks/mod.rs
+++ b/stackslib/src/chainstate/stacks/mod.rs
@@ -47,8 +47,8 @@ use stacks_common::util::vrf::VRFProof;
 
 use crate::burnchains::Txid;
 use crate::chainstate::burn::ConsensusHash;
-use crate::chainstate::stacks::db::accounts::MinerReward;
-use crate::chainstate::stacks::db::{MinerRewardInfo, StacksHeaderInfo};
+use crate::chainstate::stacks::db::accounts::MaturedMinerPayouts;
+use crate::chainstate::stacks::db::StacksHeaderInfo;
 use crate::chainstate::stacks::index::Error as marf_error;
 use crate::clarity_vm::clarity::ClarityError;
 use crate::net::Error as net_error;
@@ -484,7 +484,7 @@ pub struct StacksBlockBuilder {
     bytes_so_far: u64,
     prev_microblock_header: StacksMicroblockHeader,
     miner_privkey: StacksPrivateKey,
-    miner_payouts: Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>,
+    miner_payouts: Option<MaturedMinerPayouts>,
     parent_consensus_hash: ConsensusHash,
     parent_header_hash: BlockHeaderHash,
     parent_microblock_hash: Option<BlockHeaderHash>,

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -2650,14 +2650,14 @@ fn test_build_microblock_stream_forks() {
                         }
 
                         // find the poison-microblock at seq 2
-                        let (_, poison_opt) = match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
+                        let poison_opt = match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
                             chainstate.db(),
                             &parent_index_hash,
                             0,
                             u16::MAX
                         ).unwrap() {
-                            Some(x) => x,
-                            None => (vec![], None)
+                            Some(stream) => stream.poison_payload,
+                            None => None
                         };
 
                         if let Some(poison_payload) = poison_opt {
@@ -2977,14 +2977,14 @@ fn test_build_microblock_stream_forks_with_descendants() {
                         }
 
                         // find the poison-microblock at seq 2
-                        let (_, poison_opt) = match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
+                        let poison_opt = match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
                             chainstate.db(),
                             &parent_index_hash,
                             0,
                             u16::MAX
                         ).unwrap() {
-                            Some(x) => x,
-                            None => (vec![], None)
+                            Some(stream) => stream.poison_payload,
+                            None => None
                         };
 
                         if let Some(poison_payload) = poison_opt {

--- a/stackslib/src/chainstate/stacks/tests/chain_histories.rs
+++ b/stackslib/src/chainstate/stacks/tests/chain_histories.rs
@@ -31,6 +31,7 @@ use stacks_common::types::chainstate::SortitionId;
 use crate::burnchains::db::BurnchainDB;
 use crate::burnchains::tests::*;
 use crate::chainstate::burn::db::sortdb::*;
+use crate::chainstate::stacks::db::blocks::StagingBlockOutcome;
 use crate::chainstate::stacks::db::testing::*;
 use crate::chainstate::stacks::db::*;
 use crate::chainstate::stacks::miner::*;
@@ -187,7 +188,10 @@ where
         if expect_success {
             // processed _this_ block
             assert_eq!(tip_info_list.len(), 1);
-            let (chain_tip_opt, poison_opt) = tip_info_list[0].clone();
+            let StagingBlockOutcome {
+                receipt: chain_tip_opt,
+                poison_payload: poison_opt,
+            } = tip_info_list[0].clone();
 
             assert!(chain_tip_opt.is_some());
             assert!(poison_opt.is_none());
@@ -373,7 +377,10 @@ where
 
         // processed _this_ block
         assert_eq!(tip_info_list.len(), 1);
-        let (chain_tip_opt, poison_opt) = tip_info_list[0].clone();
+        let StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } = tip_info_list[0].clone();
 
         assert!(chain_tip_opt.is_some());
         assert!(poison_opt.is_none());
@@ -579,7 +586,10 @@ where
 
         // processed exactly one block, but got back two tip-infos
         assert_eq!(tip_info_list.len(), 1);
-        let (chain_tip_opt, poison_opt) = tip_info_list[0].clone();
+        let StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } = tip_info_list[0].clone();
 
         assert!(chain_tip_opt.is_some());
         assert!(poison_opt.is_none());
@@ -915,7 +925,10 @@ where
 
         // processed _one_ block
         assert_eq!(tip_info_list.len(), 1);
-        let (chain_tip_opt, poison_opt) = tip_info_list[0].clone();
+        let StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } = tip_info_list[0].clone();
 
         assert!(chain_tip_opt.is_some());
         assert!(poison_opt.is_none());
@@ -1183,7 +1196,10 @@ where
 
         // processed exactly one block, but got back two tip-infos
         assert_eq!(tip_info_list.len(), 1);
-        let (chain_tip_opt, poison_opt) = tip_info_list[0].clone();
+        let StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } = tip_info_list[0].clone();
 
         assert!(chain_tip_opt.is_some());
         assert!(poison_opt.is_none());
@@ -1510,7 +1526,10 @@ where
 
         // processed _one_ block
         assert_eq!(tip_info_list.len(), 1);
-        let (chain_tip_opt, poison_opt) = tip_info_list[0].clone();
+        let StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } = tip_info_list[0].clone();
 
         assert!(chain_tip_opt.is_some());
         assert!(poison_opt.is_none());
@@ -1760,14 +1779,22 @@ where
         // processed all stacks blocks -- one on each burn chain fork
         assert_eq!(tip_info_list.len(), 2);
 
-        for (ref chain_tip_opt, ref poison_opt) in tip_info_list.iter() {
+        for StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } in tip_info_list.iter()
+        {
             assert!(chain_tip_opt.is_some());
             assert!(poison_opt.is_none());
         }
 
         // fork 1?
         let mut found_fork_1 = false;
-        for (ref chain_tip_opt, ref poison_opt) in tip_info_list.iter() {
+        for StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } in tip_info_list.iter()
+        {
             let chain_tip = chain_tip_opt.clone().unwrap().header;
             if chain_tip.consensus_hash == fork_snapshot_1.consensus_hash {
                 found_fork_1 = true;
@@ -1788,7 +1815,11 @@ where
         assert!(found_fork_1);
 
         let mut found_fork_2 = false;
-        for (ref chain_tip_opt, ref poison_opt) in tip_info_list.iter() {
+        for StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } in tip_info_list.iter()
+        {
             let chain_tip = chain_tip_opt.clone().unwrap().header;
             if chain_tip.consensus_hash == fork_snapshot_2.consensus_hash {
                 found_fork_2 = true;
@@ -2065,7 +2096,10 @@ where
 
         // processed _one_ block
         assert_eq!(tip_info_list.len(), 1);
-        let (chain_tip_opt, poison_opt) = tip_info_list[0].clone();
+        let StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } = tip_info_list[0].clone();
 
         assert!(chain_tip_opt.is_some());
         assert!(poison_opt.is_none());
@@ -2315,14 +2349,22 @@ where
         // processed all stacks blocks -- one on each burn chain fork
         assert_eq!(tip_info_list.len(), 2);
 
-        for (ref chain_tip_opt, ref poison_opt) in tip_info_list.iter() {
+        for StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } in tip_info_list.iter()
+        {
             assert!(chain_tip_opt.is_some());
             assert!(poison_opt.is_none());
         }
 
         // fork 1?
         let mut found_fork_1 = false;
-        for (ref chain_tip_opt, ref poison_opt) in tip_info_list.iter() {
+        for StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } in tip_info_list.iter()
+        {
             let chain_tip = chain_tip_opt.clone().unwrap().header;
             if chain_tip.consensus_hash == fork_snapshot_1.consensus_hash {
                 found_fork_1 = true;
@@ -2343,7 +2385,11 @@ where
         assert!(found_fork_1);
 
         let mut found_fork_2 = false;
-        for (ref chain_tip_opt, ref poison_opt) in tip_info_list.iter() {
+        for StagingBlockOutcome {
+            receipt: chain_tip_opt,
+            poison_payload: poison_opt,
+        } in tip_info_list.iter()
+        {
             let chain_tip = chain_tip_opt.clone().unwrap().header;
             if chain_tip.consensus_hash == fork_snapshot_2.consensus_hash {
                 found_fork_2 = true;

--- a/stackslib/src/chainstate/stacks/tests/mod.rs
+++ b/stackslib/src/chainstate/stacks/tests/mod.rs
@@ -1412,7 +1412,7 @@ pub fn instantiate_and_exec(
     chain_id: u32,
     test_name: &str,
     balances: Vec<(StacksAddress, u64)>,
-    post_flight_callback: Option<Box<dyn FnOnce(&mut ClarityTx)>>,
+    post_flight_callback: Option<PostFlightCallback>,
 ) -> StacksChainState {
     let path = chainstate_path(test_name);
     if fs::metadata(&path).is_ok() {


### PR DESCRIPTION
### Description

This PR introduces documented named results and callback/container aliases for PoX anchor selection, block arrivals, mature miner payouts, burnchain operations, and staging results. It updates coordinator, mining, Nakamoto, node, inspection-tool, and test callers, and removes two obsolete lint suppressions.

It extends the PoX anchor test to cover selection counts and insufficient confirmations, and includes the chainstate-specific changelog fragment and Rust type documentation.

### Applicable issues

Part of the `clippy::type_complexity` cleanup; no linked issue.

### Additional info (benefits, drawbacks, caveats)

Rust callers use named fields and explicit anchor-selection variants. Reward ordering, block processing behavior, consensus rules, and database schemas were not changed.

### Checklist

- [x] Test coverage for affected behavior; focused tests pass.
- [x] Changelog fragment: `changelog.d/type-complexity-chainstate.changed`.
- [x] Required Rust type documentation updated.
- Property tests and Clarity benchmarking: not applicable; no new Clarity features or consensus changes.
- RPC and event documentation: not applicable; payloads and endpoints are unchanged.
