### PR TITLE
refactor: remove crate-global `dead_code` allow from `stacks-common`

### DIFF
--- a/changelog.d/stacks-common-dead-code.changed
+++ b/changelog.d/stacks-common-dead-code.changed
@@ -1,0 +1,1 @@
+Remove the crate-wide dead-code allowance from stacks-common, retain C32 decoding coverage through a test-only helper, and expand named-enum macro tests to cover variant and name enumeration.

--- a/changelog.d/stacks-common-dead-code.changed
+++ b/changelog.d/stacks-common-dead-code.changed
@@ -1,1 +1,1 @@
-Remove the crate-wide dead-code allowance from stacks-common, retain C32 decoding coverage through a test-only helper, and expand named-enum macro tests to cover variant and name enumeration.
+Remove the crate-wide dead-code allowance and unused Windows signal alias from stacks-common, retain C32 decoding coverage through a test-only helper, and expand named-enum macro tests to cover variant and name enumeration.

--- a/stacks-common/src/address/c32.rs
+++ b/stacks-common/src/address/c32.rs
@@ -226,6 +226,8 @@ fn c32_encode(input_bytes: &[u8]) -> String {
     String::from_utf8(result).unwrap()
 }
 
+/// Decode raw C32 text for encoder round-trip tests.
+#[cfg(test)]
 fn c32_decode(input_str: &str) -> Result<Vec<u8>, Error> {
     // must be ASCII
     if !input_str.is_ascii() {

--- a/stacks-common/src/deps_common/ctrlc/platform/windows/mod.rs
+++ b/stacks-common/src/deps_common/ctrlc/platform/windows/mod.rs
@@ -22,9 +22,6 @@ use crate::deps_common::ctrlc::SignalId;
 /// Platform specific error type
 pub type Error = io::Error;
 
-/// Platform specific signal type
-pub type Signal = DWORD;
-
 const MAX_SEM_COUNT: c_long = 255;
 static mut SEMAPHORE: HANDLE = 0 as HANDLE;
 

--- a/stacks-common/src/libcommon.rs
+++ b/stacks-common/src/libcommon.rs
@@ -1,5 +1,4 @@
 #![allow(unused_macros)]
-#![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/stacks-common/src/util/macros.rs
+++ b/stacks-common/src/util/macros.rs
@@ -820,6 +820,9 @@ mod tests {
             Variant2("variant2"),
         });
 
+        assert_eq!(MyEnum::ALL, &[MyEnum::Variant1, MyEnum::Variant2]);
+        assert_eq!(MyEnum::ALL_NAMES, &["variant1", "variant2"]);
+
         assert_eq!("variant1", MyEnum::Variant1.get_name());
         assert_eq!("variant2", MyEnum::Variant2.get_name());
 
@@ -841,6 +844,9 @@ mod tests {
             /// Variant2 doc
             Variant2("variant2"),
         });
+
+        assert_eq!(MyEnum::ALL, &[MyEnum::Variant1, MyEnum::Variant2]);
+        assert_eq!(MyEnum::ALL_NAMES, &["variant1", "variant2"]);
 
         assert_eq!("variant1", MyEnum::Variant1.get_name());
         assert_eq!("variant2", MyEnum::Variant2.get_name());

--- a/stacks-common/src/util/vrf.rs
+++ b/stacks-common/src/util/vrf.rs
@@ -554,14 +554,6 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct VRF_Verify_Fixture {
-        pubkey: Vec<u8>,
-        proof: Vec<u8>,
-        message: &'static str,
-        result: bool,
-    }
-
-    #[derive(Debug)]
     struct VRF_Proof_Codec_Fixture {
         proof: Vec<u8>,
         result: bool,


### PR DESCRIPTION
### Description

Removes the crate-wide `dead_code` allowance, gates the private C32 test helper with `cfg(test)`, and deletes an unused VRF fixture. It also extends both named-enum macro tests to verify generated variant and name lists.

Existing functionality and test coverage are preserved. Default and all-feature tests pass, along with scoped lint checks, repository Clippy commands, workspace compilation, and formatting.

### Applicable issues

- Part of general code cleanup/tech debt work; no specific ticket referenced.

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [x] Test coverage for new or modified code paths
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks anything for node operators or users, or requires them to manually do anything (such as adjust a setting), use the breaking category.
