### PR TITLE
refactor: remove unused code and `dead_code` lint allowances in `libsigner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,6 @@ version = "0.0.1"
 dependencies = [
  "clarity 0.0.1",
  "hashbrown 0.15.2",
- "libc",
  "libstackerdb 0.0.1",
  "mutants",
  "rand 0.8.5",

--- a/changelog.d/libsigner-dead-code.changed
+++ b/changelog.d/libsigner-dead-code.changed
@@ -1,0 +1,1 @@
+Remove obsolete private HTTP request decoding and signal-handler code from libsigner, including its direct libc dependency, broad dead-code allowances, and redundant crate imports, while preserving block-event deserialization validation.

--- a/libsigner/Cargo.toml
+++ b/libsigner/Cargo.toml
@@ -17,7 +17,6 @@ path = "./src/libsigner.rs"
 [dependencies]
 clarity = { path = "../clarity" }
 hashbrown = { workspace = true }
-libc = "0.2"
 libstackerdb = { path = "../libstackerdb" }
 serde = "1"
 slog = { version = "2.5.2", features = [ "max_level_trace" ] }

--- a/libsigner/src/events.rs
+++ b/libsigner/src/events.rs
@@ -697,8 +697,9 @@ pub struct StacksBlockEvent {
     signer_signature_hash: Option<Sha512Trunc256Sum>,
     #[serde(with = "prefix_hex")]
     consensus_hash: ConsensusHash,
-    #[serde(with = "prefix_hex")]
-    block_hash: BlockHeaderHash,
+    /// Validates the required node-supplied hash; signer events use the index block hash.
+    #[serde(rename = "block_hash", with = "prefix_hex")]
+    _block_hash: BlockHeaderHash,
     block_height: u64,
     /// The transactions included in the block
     #[serde(deserialize_with = "deserialize_raw_tx_hex")]
@@ -752,9 +753,78 @@ fn signer_message_payload_matches_lane(
 mod tests {
     use blockstack_lib::chainstate::nakamoto::NakamotoBlockHeader;
     use clarity::types::MiningReason;
+    use serde_json::{json, Value};
 
     use super::*;
-    use crate::v0::messages::MessageSlotID;
+    use crate::v0::messages::{MessageSlotID, SignerMessage};
+
+    /// A minimal node block event with distinct hashes to check field mapping.
+    fn new_block_event_json() -> Value {
+        json!({
+            "index_block_hash": format!("0x{}", "11".repeat(32)),
+            "consensus_hash": format!("0x{}", "22".repeat(20)),
+            "block_hash": format!("0x{}", "33".repeat(32)),
+            "block_height": 42,
+            "transactions": [],
+        })
+    }
+
+    /// Block events retain their field mapping with or without a signer signature hash.
+    #[test]
+    fn test_stacks_block_event_conversion() {
+        for signer_sighash in [None, Some(Sha512Trunc256Sum([0x44; 32]))] {
+            let mut value = new_block_event_json();
+            if let Some(hash) = &signer_sighash {
+                value["signer_signature_hash"] = json!(format!("0x{hash:x}"));
+            }
+            let block_event: StacksBlockEvent = serde_json::from_value(value).unwrap();
+            let event = SignerEvent::<SignerMessage>::try_from(block_event).unwrap();
+            assert_eq!(
+                event,
+                SignerEvent::NewBlock {
+                    block_id: StacksBlockId([0x11; 32]),
+                    consensus_hash: ConsensusHash([0x22; 20]),
+                    signer_sighash,
+                    block_height: 42,
+                    transactions: vec![],
+                }
+            );
+        }
+    }
+
+    /// The unused block hash remains a required, validated field of incoming block events.
+    #[test]
+    fn test_stacks_block_event_requires_valid_block_hash() {
+        let invalid_hashes = [
+            None,
+            Some(Value::Null),
+            Some(json!(0)),
+            Some(json!("")),
+            Some(json!("0x")),
+            Some(json!("33".repeat(32))),
+            Some(json!(format!("0X{}", "33".repeat(32)))),
+            Some(json!(format!("0x{}", "gg".repeat(32)))),
+            Some(json!(format!("0x{}", "33".repeat(31)))),
+            Some(json!(format!("0x{}", "33".repeat(33)))),
+        ];
+        for hash in invalid_hashes {
+            let mut value = new_block_event_json();
+            if let Some(hash) = hash {
+                value["block_hash"] = hash;
+            } else {
+                value.as_object_mut().unwrap().remove("block_hash");
+            }
+            assert!(
+                serde_json::from_value::<StacksBlockEvent>(value.clone()).is_err(),
+                "invalid block hash accepted: {value}"
+            );
+        }
+
+        let mut value = new_block_event_json();
+        let hash = value.as_object_mut().unwrap().remove("block_hash").unwrap();
+        value["_block_hash"] = hash;
+        assert!(serde_json::from_value::<StacksBlockEvent>(value).is_err());
+    }
 
     #[test]
     fn test_get_signers_db_signer_set_message_id() {

--- a/libsigner/src/http.rs
+++ b/libsigner/src/http.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//! HTTP response decoding and synchronous requests for signer RPC clients.
+
 use std::io;
 use std::io::{Read, Write};
 
@@ -22,110 +24,15 @@ use stacks_common::codec::MAX_MESSAGE_LEN;
 use stacks_common::deps_common::httparse;
 use stacks_common::util::chunked_encoding::*;
 
-use crate::error::{EventError, RPCError};
+use crate::error::RPCError;
 
 pub const MAX_HTTP_HEADERS: usize = 32;
 pub const MAX_HTTP_HEADER_LEN: usize = 4096;
 
-/// Decoding of the relevant parts of a signer-directed HTTP request from the Stacks node
-#[derive(Debug)]
-pub struct SignerHttpRequest {
-    pub verb: String,
-    pub path: String,
-    pub headers: HashMap<String, String>,
-    pub body_offset: usize,
-}
-
-impl SignerHttpRequest {
-    pub fn new(
-        verb: String,
-        path: String,
-        headers: HashMap<String, String>,
-        body_offset: usize,
-    ) -> SignerHttpRequest {
-        SignerHttpRequest {
-            verb,
-            path,
-            headers,
-            body_offset,
-        }
-    }
-
-    /// Decompose into (verb, path, headers, body-offset)
-    pub fn destruct(self) -> (String, String, HashMap<String, String>, usize) {
-        (self.verb, self.path, self.headers, self.body_offset)
-    }
-}
-
-/// Decode the HTTP request payload into its headers and body.
-/// Returns (verb, path, table of headers, body_offset) on success
-pub fn decode_http_request(payload: &[u8]) -> Result<SignerHttpRequest, EventError> {
-    // realistically, there won't be more than 32 headers
-    let mut headers_buf = [httparse::EMPTY_HEADER; MAX_HTTP_HEADERS];
-    let mut req = httparse::Request::new(&mut headers_buf);
-    let (verb, path, headers, body_offset) =
-        if let Ok(httparse::Status::Complete(body_offset)) = req.parse(payload) {
-            // version must be valid
-            match req
-                .version
-                .ok_or(EventError::MalformedRequest("No HTTP version".to_string()))?
-            {
-                0 => {}
-                1 => {}
-                _ => {
-                    return Err(EventError::MalformedRequest(
-                        "Invalid HTTP version".to_string(),
-                    ));
-                }
-            };
-
-            let verb = req
-                .method
-                .ok_or(EventError::MalformedRequest("No HTTP method".to_string()))?
-                .to_string();
-            let path = req
-                .path
-                .ok_or(EventError::MalformedRequest("No HTTP path".to_string()))?
-                .to_string();
-
-            let mut headers: HashMap<String, String> = HashMap::new();
-            for i in 0..req.headers.len() {
-                let value = String::from_utf8(req.headers[i].value.to_vec()).map_err(|_e| {
-                    EventError::MalformedRequest("Invalid HTTP header value: not utf-8".to_string())
-                })?;
-                if !value.is_ascii() {
-                    return Err(EventError::MalformedRequest(
-                        "Invalid HTTP request: header value is not ASCII-US".to_string(),
-                    ));
-                }
-                if value.len() > MAX_HTTP_HEADER_LEN {
-                    return Err(EventError::MalformedRequest(
-                        "Invalid HTTP request: header value is too big".to_string(),
-                    ));
-                }
-
-                let key = req.headers[i].name.to_string().to_lowercase();
-                if headers.get(&key).is_some() {
-                    return Err(EventError::MalformedRequest(format!(
-                        "Invalid HTTP request: duplicate header \"{key}\""
-                    )));
-                }
-                headers.insert(key, value);
-            }
-            (verb, path, headers, body_offset)
-        } else {
-            return Err(EventError::Deserialize(
-                "Failed to decode HTTP headers".to_string(),
-            ));
-        };
-
-    Ok(SignerHttpRequest::new(verb, path, headers, body_offset))
-}
-
 /// Decode the HTTP response payload into its headers and body.
 /// Return the offset into payload where the body starts, and a table of headers.
 ///
-/// If the payload contains a status code other than 200, then RPCERror::HttpError(..) will be
+/// If the payload contains a status code other than 200, then RPCError::HttpError(..) will be
 /// returned with the status code.
 /// If the payload is missing necessary data, then RPCError::MalformedResponse(..) will be
 /// returned, with a human-readable reason string.

--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -21,17 +21,8 @@
 Usage documentation can be found in the [README](https://github.com/stacks-network/stacks-blockchain/libsigner/README.md).
 */
 
-#![allow(dead_code)]
-#[allow(unused_imports)]
-#[macro_use(o, slog_log, slog_trace, slog_debug, slog_info, slog_warn, slog_error)]
-extern crate slog;
-
-extern crate serde;
-extern crate serde_json;
 #[macro_use]
 extern crate stacks_common;
-extern crate clarity;
-extern crate libc;
 
 #[cfg(test)]
 mod tests;

--- a/libsigner/src/runloop.rs
+++ b/libsigner/src/runloop.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
-
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
@@ -23,18 +21,12 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use stacks_common::deps_common::ctrlc as termination;
-use stacks_common::deps_common::ctrlc::SignalId;
-
 use crate::error::EventError;
 use crate::events::{EventReceiver, EventStopSignaler, SignerEvent, SignerEventTrait};
 
 /// Some libcs, like musl, have a very small stack size.
 /// Make sure it's big enough.
 const THREAD_STACK_SIZE: usize = 128 * 1024 * 1024; // 128 MB
-
-/// stderr fileno
-const STDERR: i32 = 2;
 
 /// Trait describing the needful components of a top-level runloop.
 /// This is where the signer business logic would go.
@@ -51,9 +43,9 @@ pub trait SignerRunLoop<R: Send, T: SignerEventTrait> {
 
     /// This is the main loop body for the signer. It continuously receives events from
     /// `event_recv`, polling for up to `self.get_event_timeout()` units of time.  Once it has
-    /// polled for events, they are fed into `run_one_pass()`.  This continues until either
-    /// `run_one_pass()` returns `false`, or the event receiver hangs up.  At this point, this
-    /// method calls the `event_stop_signaler.send()` to terminate the receiver.
+    /// polled for events, they are fed into `run_one_pass()`. A `Some` result signals the event
+    /// receiver to stop and is returned to the caller. If the event channel disconnects, this
+    /// method returns `None`.
     ///
     /// This would run in a separate thread from the event receiver.
     fn main_loop<EVST: EventStopSignaler>(
@@ -136,45 +128,6 @@ impl<EV: EventReceiver<T>, R, T: SignerEventTrait> RunningSigner<EV, R, T> {
         info!("Signer thread joined");
         result_opt
     }
-}
-
-/// Write to stderr in an async-safe manner.
-/// See signal-safety(7)
-#[warn(unused)]
-fn async_safe_write_stderr(msg: &str) {
-    #[cfg(windows)]
-    unsafe {
-        // write(2) inexplicably has a different ABI only on Windows.
-        libc::write(
-            STDERR,
-            msg.as_ptr() as *const libc::c_void,
-            msg.len() as u32,
-        );
-    }
-    #[cfg(not(windows))]
-    unsafe {
-        libc::write(STDERR, msg.as_ptr() as *const libc::c_void, msg.len());
-    }
-}
-
-/// This is a termination handler for handling receipt of a terminating UNIX signal, like SIGINT,
-/// SIGQUIT, SIGTERM, or SIGBUS.  You'd call this as part of the startup code for the signer daemon.
-/// DO NOT call this from within the library!
-pub fn set_runloop_signal_handler<ST: EventStopSignaler + Send + 'static>(mut stop_signaler: ST) {
-    termination::set_handler(move |sig_id| match sig_id {
-        SignalId::Bus => {
-            let msg = "Caught SIGBUS; crashing immediately and dumping core\n";
-            async_safe_write_stderr(msg);
-            unsafe {
-                libc::abort();
-            }
-        }
-        _ => {
-            let msg = format!("Graceful termination request received (signal `{sig_id}`), will complete the ongoing runloop cycles and terminate\n");
-            async_safe_write_stderr(&msg);
-            stop_signaler.send();
-        }
-    }).expect("FATAL: failed to set signal handler");
 }
 
 impl<R, SL, EV, T> Signer<R, SL, EV, T> {

--- a/libsigner/src/tests/http.rs
+++ b/libsigner/src/tests/http.rs
@@ -20,81 +20,8 @@ use std::{io, str};
 use hashbrown::HashMap;
 use stacks_common::util::chunked_encoding::*;
 
-use crate::error::{EventError, RPCError};
-use crate::http::{decode_http_body, decode_http_request, decode_http_response, run_http_request};
-
-#[test]
-fn test_decode_http_request_ok() {
-    let tests = [
-        ("GET /foo HTTP/1.1\r\nHost: localhost:6270\r\n\r\n",
-        ("GET", "/foo", vec![("host", "localhost:6270")])),
-        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nFoo: Bar\r\n\r\n",
-        ("POST", "asdf", vec![("host", "core.blockstack.org"), ("foo", "Bar")])),
-        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nFoo: Bar\r\n\r\n",
-        ("POST", "asdf", vec![("host", "core.blockstack.org"), ("foo", "Bar")])),
-        ("GET /foo HTTP/1.1\r\nConnection: close\r\nHost: localhost:6270\r\n\r\n",
-        ("GET", "/foo", vec![("connection", "close"), ("host", "localhost:6270")])),
-        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nConnection: close\r\nFoo: Bar\r\n\r\n",
-        ("POST", "asdf", vec![("host", "core.blockstack.org"), ("connection", "close"), ("foo", "Bar")])),
-        ("POST asdf HTTP/1.1\r\nHost: core.blockstack.org\r\nFoo: Bar\r\nConnection: close\r\n\r\n",
-        ("POST", "asdf", vec![("host", "core.blockstack.org"), ("foo", "Bar"), ("connection", "close")])),
-        ("GET /foo HTTP/1.1\r\nhOsT: localhost:6270\r\n\r\n",
-        ("GET", "/foo", vec![("host", "localhost:6270")])),
-        ("GET /foo HTTP/1.1\r\ncOnNeCtIoN: cLoSe\r\nhOsT: localhost:6270\r\n\r\n",
-        ("GET", "/foo", vec![("connection", "cLoSe"), ("host", "localhost:6270")])),
-        ("POST asdf HTTP/1.1\r\nhOsT: core.blockstack.org\r\nCOnNeCtIoN: kEeP-aLiVE\r\nFoo: Bar\r\n\r\n",
-        ("POST", "asdf", vec![("host", "core.blockstack.org"), ("connection", "kEeP-aLiVE"), ("foo", "Bar")]))
-    ];
-
-    for (data, (expected_verb, expected_path, headers_list)) in tests.iter() {
-        let mut expected_headers = HashMap::new();
-        for (key, val) in headers_list.iter() {
-            expected_headers.insert(key.to_string(), val.to_string());
-        }
-
-        let (verb, path, headers, _) = decode_http_request(data.as_bytes()).unwrap().destruct();
-        assert_eq!(verb, expected_verb.to_string());
-        assert_eq!(path, expected_path.to_string());
-        assert_eq!(headers, expected_headers);
-    }
-}
-
-#[test]
-fn test_decode_http_request_err() {
-    let tests = [
-        (
-            "GET /foo HTTP/1.1\r\n",
-            EventError::Deserialize("".to_string()),
-        ),
-        (
-            "GET /foo HTTP/\r\n\r\n",
-            EventError::Deserialize("".to_string()),
-        ),
-        (
-            "GET /foo HTTP/1.1\r\nHost:",
-            EventError::Deserialize("".to_string()),
-        ),
-        (
-            "GET /foo HTTP/1.1\r\nHost: foo:80\r\nHost: bar:80\r\n\r\n",
-            EventError::MalformedRequest("".to_string()),
-        ),
-        (
-            "GET /foo HTTP/1.1\r\nHost: localhost:6270\r\nfoo: \u{2764}\r\n\r\n",
-            EventError::MalformedRequest("".to_string()),
-        ),
-    ];
-
-    for (data, expected_err_type) in tests.iter() {
-        let err = decode_http_request(data.as_bytes()).unwrap_err();
-        match (err, expected_err_type) {
-            (EventError::Deserialize(..), EventError::Deserialize(..))
-            | (EventError::MalformedRequest(..), EventError::MalformedRequest(..)) => {}
-            (x, y) => {
-                panic!("expected error mismatch: {x:?} != {y:?}");
-            }
-        }
-    }
-}
+use crate::error::RPCError;
+use crate::http::{decode_http_body, decode_http_response, run_http_request};
 
 #[test]
 fn test_decode_http_response_ok() {

--- a/libsigner/src/tests/mod.rs
+++ b/libsigner/src/tests/mod.rs
@@ -55,10 +55,6 @@ impl<T: SignerEventTrait> SimpleRunLoop<T> {
     }
 }
 
-enum Command {
-    Empty,
-}
-
 impl<T: SignerEventTrait> SignerRunLoop<Vec<SignerEvent<T>>, T> for SimpleRunLoop<T> {
     fn set_event_timeout(&mut self, timeout: Duration) {
         self.poll_timeout = timeout;


### PR DESCRIPTION
### Description

This PR removes obsolete private HTTP request decoding, unused signal-handler code, and the direct `libc` dependency from the `libsigner` crate. 

It removes both broad dead-code allowances, unused macro imports and their suppression, and redundant crate declarations while preserving block-event deserialization validation and adding regression tests for field validation and event conversion.

### Checklist

- [x] Test coverage for new or modified code paths
- [x] Changelog fragment(s) or "no changelog" label added (see [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks anything for node operators or users, or requires them to manually do anything (such as adjust a setting), use the breaking category.
