### PR TITLE
fix(stacks-inspect): apply config for pox-5 overrides

### DIFF
--- a/changelog.d/testnet-block-replay.fixed
+++ b/changelog.d/testnet-block-replay.fixed
@@ -1,0 +1,1 @@
+Apply the pox-5 overrides from the config in stacks-inspect, ensuring that block replay has the correct settings and can properly match the node's behavior in epoch 4.0+.

--- a/contrib/stacks-inspect/src/main.rs
+++ b/contrib/stacks-inspect/src/main.rs
@@ -320,6 +320,10 @@ fn build_common_opts(cli: &Cli) -> CommonOpts {
         });
         let config = Config::from_config_file(config_file, false)
             .unwrap_or_else(|e| panic!("Failed to convert config file into node config: {e}"));
+        // Install the config-driven process-wide state (the pox-5 sBTC contract and admin
+        // overrides) exactly as the node's run loop does, so that a replay which crosses the
+        // Epoch 4.0 boundary instantiates the same pox-5 body as the chain being replayed.
+        config.apply_runtime_state();
         opts.config.replace(config);
     }
 
@@ -337,6 +341,10 @@ fn build_common_opts(cli: &Cli) -> CommonOpts {
         };
         let config = Config::from_config_file(config_file, false)
             .unwrap_or_else(|e| panic!("Failed to convert config file into node config: {e}"));
+        // Install the config-driven process-wide state (the pox-5 sBTC contract and admin
+        // overrides) exactly as the node's run loop does, so that a replay which crosses the
+        // Epoch 4.0 boundary instantiates the same pox-5 body as the chain being replayed.
+        config.apply_runtime_state();
         opts.config.replace(config);
     }
 


### PR DESCRIPTION
Ensure that the pox-5 overrides in the config (for testnets) are applied in stacks-inspect. This is needed for block replay or else all blocks after epoch 4.0 will fail.

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [x] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
