### PR TITLE
chore: update pr-review instructions to clarify what constitutes a breaking change

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,13 +12,13 @@ Path-specific guidance under `.github/instructions/` adds language- and subsyste
 
 - Determine the intended behavior from the PR description, changed code, tests, and documentation; comment only when the implementation does not safely establish that behavior.
 - Prioritize defects with a concrete triggering condition and user, protocol, data, security, or operational impact.
-- Treat consensus behavior, persistent data, wire formats, configuration, RPCs, events, public APIs, and smart-contract interfaces as compatibility-sensitive.
+- Treat consensus behavior, persistent data, wire formats, configuration, RPCs, events, and smart-contract interfaces as compatibility-sensitive. We ship binaries; our crates carry no Rust API backwards-compatibility guarantees. Do not flag a public Rust API change solely because downstream Rust code would need updating.
 - Check compatibility for external consumers such as Clarinet and RPC clients, in-repository tooling such as `stacks-inspect`, and node operators.
 - Trace error paths for incomplete cleanup, rollback, partial writes, leaked resources, or state that can affect later work.
 - Verify that changed tests prove the intended invariant through the affected production path and cover material boundary, negative, and regression cases.
 - Check whether behavior changes require matching configuration, RPC, event, operator, contract, or other user-facing documentation.
 - When documentation changes, verify factual claims, commands, paths, examples, links, and sample output against the implementation.
-- Validate changelog handling that CI cannot establish: whether a no-changelog decision is justified and whether the fragment(s) cover the PR's impact on each affected component.
+- Validate changelog handling against `changelog.d/README.md`: whether a no-changelog decision is justified and whether the fragment(s) cover the PR's impact on each affected component.
 - Raise maintainability concerns only when the PR introduces duplication, coupling, misleading structure, or complexity that creates a specific correctness or future-change risk.
 
 ## Review comment threshold

--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -9,7 +9,9 @@ Treat `changelog.d/README.md` as the canonical source for the fragment rules. Ap
 - Verify the fragment is placed in `changelog.d/`; all components (node, stackslib, signer) share a single changelog.
 - Verify the filename follows `<short-description>.<category>` and uses one of the supported categories: `breaking`, `added`, `changed`, `fixed`, or `removed`.
 - Verify the category matches the nature of the change described by the fragment.
-- For `breaking` fragments, verify the change is likely to require user or operator action during an upgrade and that the entry explains both what breaks and the required action.
+- Reserve `.breaking` for node or signer upgrades that require operator action to keep functioning correctly.
+  - Before requesting `.breaking`, identify the concrete operational failure and required upgrade action; verify the fragment explains both. 
+  - Public Rust API changes alone do not warrant `.breaking`; the crates in this repository carry no API backwards-compatibility guarantees unless explicitly documented otherwise.
 - Verify each non-empty line stands alone as a complete sentence, because it becomes a separate bullet in the assembled `CHANGELOG.md`.
-- Verify the fragment accurately describes the PR's impact and identifies the affected component precisely enough for release readers. Describe user, operator, API, protocol, or developer impact when applicable; do not reject an accurate fragment merely because the change is internal.
+- If present, verify the fragment accurately describes the PR's impact and identifies the affected component precisely enough for release readers. Describe user, operator, API, protocol, or developer impact when applicable; do not reject an accurate fragment merely because the change is internal.
 - Check Markdown syntax and references that will be copied into the assembled changelog.

--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -10,7 +10,7 @@ Treat `changelog.d/README.md` as the canonical source for the fragment rules. Ap
 - Verify the filename follows `<short-description>.<category>` and uses one of the supported categories: `breaking`, `added`, `changed`, `fixed`, or `removed`.
 - Verify the category matches the nature of the change described by the fragment.
 - Reserve `.breaking` for node or signer upgrades that require operator action to keep functioning correctly.
-  - Before requesting `.breaking`, identify the concrete operational failure and required upgrade action; verify the fragment explains both. 
+  - Before requesting `.breaking`, identify the concrete operational failure and required upgrade action; verify the fragment explains both.
   - Public Rust API changes alone do not warrant `.breaking`; the crates in this repository carry no API backwards-compatibility guarantees unless explicitly documented otherwise.
 - Verify each non-empty line stands alone as a complete sentence, because it becomes a separate bullet in the assembled `CHANGELOG.md`.
 - If present, verify the fragment accurately describes the PR's impact and identifies the affected component precisely enough for release readers. Describe user, operator, API, protocol, or developer impact when applicable; do not reject an accurate fragment merely because the change is internal.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -45,8 +45,8 @@ for example:
 - changed defaults that alter node or signer behavior in a way operators must
   notice
 
-Breaking changes in public Rust APIs do not constitute breaking changes in the
-context of the changelog.
+Public Rust API changes alone do not warrant `breaking` entries in the context
+of this changelog.
 
 `breaking` entries are assembled into a dedicated **⚠️ Breaking Changes**
 section placed _first_ in the release's changelog section, ahead of Added /

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -25,7 +25,7 @@ CHANGELOG.md.
 
 2. Write the changelog entry text in the file (one or more lines of markdown):
 
-   ```
+   ```text
    Added `marf_compress` as a node configuration parameter to enable MARF compression feature ([#6811](https://github.com/stacks-network/stacks-core/pull/6811))
    ```
 
@@ -34,8 +34,9 @@ CHANGELOG.md.
 
 ## Breaking changes
 
-Use the `breaking` category for anything that is likely to break users if they
-upgrade without taking action, for example:
+Use the `breaking` category for changes that require node or signer operators to
+take action during an upgrade to keep their deployment functioning correctly,
+for example:
 
 - renamed, removed, or newly-required configuration options
 - removed or incompatibly-changed RPC endpoints, event payloads, or CLI flags
@@ -43,6 +44,9 @@ upgrade without taking action, for example:
   upgrade
 - changed defaults that alter node or signer behavior in a way operators must
   notice
+
+Breaking changes in public Rust APIs do not constitute breaking changes in the
+context of the changelog.
 
 `breaking` entries are assembled into a dedicated **⚠️ Breaking Changes**
 section placed _first_ in the release's changelog section, ahead of Added /


### PR DESCRIPTION
Update the `changelog.d/README.md` and Copilot/agentic PR/code-review instructions to clarity what constitutes a breaking change in relation to `changelog.d` `.breaking` fragments and the repo's core `CHANGELOG.md`.