### PR TITLE
refactor: Expose Clarity transaction commit/rollback framing

### DIFF
--- a/changelog.d/clarity-transaction-frame.changed
+++ b/changelog.d/clarity-transaction-frame.changed
@@ -1,0 +1,1 @@
+Moved Clarity transaction commit/rollback framing into `clarity` crate

--- a/changelog.d/clarity-transaction-frame.changed
+++ b/changelog.d/clarity-transaction-frame.changed
@@ -1,1 +1,1 @@
-Moved Clarity transaction commit/rollback framing into `clarity` crate
+Moved Clarity transaction framing into the `clarity` crate for reuse by external consumers with evaluation hooks.

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -29,6 +29,7 @@ use crate::vm::costs::{ExecutionCost, LimitedCostTracker};
 use crate::vm::database::ClarityDatabase;
 use crate::vm::errors::{ClarityEvalError, VmExecutionError};
 use crate::vm::events::StacksTransactionEvent;
+use crate::vm::hooks::EvalHook;
 use crate::vm::resource_limiter::ResourceBudget;
 use crate::vm::types::{BuffData, PrincipalData, QualifiedContractIdentifier};
 use crate::vm::{ClarityVersion, ContractContext, SymbolicExpression, Value, analysis, ast};
@@ -428,6 +429,75 @@ pub trait ClarityConnection {
     }
 }
 
+/// Execute a nested Clarity transaction and let a callback decide whether its
+/// database changes should be committed.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn execute_with_abort_callback<'db, 'hooks, F, A, R, E>(
+    mut db: ClarityDatabase<'db>,
+    cost_tracker: LimitedCostTracker,
+    mainnet: bool,
+    chain_id: u32,
+    epoch: StacksEpochId,
+    eval_hooks: Option<Vec<&'hooks mut dyn EvalHook>>,
+    to_do: F,
+    abort_callback: A,
+) -> (
+    ClarityDatabase<'db>,
+    LimitedCostTracker,
+    Result<
+        (
+            R,
+            AssetMap,
+            Vec<StacksTransactionEvent>,
+            Option<BoundedErrorString>,
+        ),
+        E,
+    >,
+)
+where
+    A: FnOnce(&AssetMap, &mut ClarityDatabase) -> Option<BoundedErrorString>,
+    F: FnOnce(
+        &mut OwnedEnvironment<'_, 'hooks>,
+    ) -> Result<(R, AssetMap, Vec<StacksTransactionEvent>), E>,
+    E: From<VmExecutionError>,
+{
+    db.begin();
+    let mut vm_env = OwnedEnvironment::new_cost_limited_with_hooks(
+        mainnet,
+        chain_id,
+        db,
+        cost_tracker,
+        epoch,
+        eval_hooks,
+    );
+
+    let execution_result = to_do(&mut vm_env);
+    let (mut db, cost_tracker) = vm_env
+        .destruct()
+        .expect("Failed to recover database reference after executing transaction");
+
+    let result = match execution_result {
+        Ok((value, asset_map, events)) => {
+            let abort_reason = abort_callback(&asset_map, &mut db);
+            let db_result = if abort_reason.is_some() {
+                db.roll_back()
+            } else {
+                db.commit()
+            };
+            match db_result {
+                Ok(()) => Ok((value, asset_map, events, abort_reason)),
+                Err(error) => Err(error.into()),
+            }
+        }
+        Err(error) => match db.roll_back() {
+            Ok(()) => Err(error),
+            Err(db_error) => Err(db_error.into()),
+        },
+    };
+
+    (db, cost_tracker, result)
+}
+
 pub trait TransactionConnection: ClarityConnection {
     /// Do something with this connection's Clarity environment that can be aborted
     /// with `abort_call_back`.
@@ -693,9 +763,101 @@ mod unit_tests {
     use super::*;
     use crate::vm::analysis::errors::StaticCheckErrorKind;
     use crate::vm::ast::errors::ParseErrorKind;
+    use crate::vm::database::MemoryBackingStore;
     use crate::vm::errors::{EarlyReturnError, RuntimeError};
     use crate::vm::events::{STXBurnEventData, STXEventType};
+    use crate::vm::hooks::testing::ExecutionLifecycleHook;
     use crate::vm::types::StandardPrincipalData;
+
+    #[test]
+    fn shared_transaction_frame_commits_and_runs_hooks() {
+        let mut store = MemoryBackingStore::new();
+        let db = store.as_clarity_db();
+        let mut hook = ExecutionLifecycleHook::default();
+
+        let (mut db, _, result) = execute_with_abort_callback(
+            db,
+            LimitedCostTracker::new_free(),
+            false,
+            stacks_common::consts::CHAIN_ID_TESTNET,
+            StacksEpochId::Epoch33,
+            Some(vec![&mut hook]),
+            |vm_env| {
+                vm_env.execute_in_env(
+                    PrincipalData::Standard(StandardPrincipalData::transient()),
+                    None,
+                    None,
+                    |exec_state, _| {
+                        exec_state
+                            .global_context
+                            .database
+                            .put_data("shared-frame", &1_u64)?;
+                        Ok::<_, VmExecutionError>(())
+                    },
+                )
+            },
+            |_, _| None,
+        );
+
+        assert!(result.is_ok());
+        db.begin();
+        assert_eq!(db.get_data::<u64>("shared-frame").unwrap(), Some(1));
+        db.roll_back().unwrap();
+        assert_eq!(hook.events.len(), 2);
+    }
+
+    #[test]
+    fn shared_transaction_frame_rolls_back_callback_abort() {
+        let mut store = MemoryBackingStore::new();
+        let db = store.as_clarity_db();
+
+        let (mut db, _, result) = execute_with_abort_callback(
+            db,
+            LimitedCostTracker::new_free(),
+            false,
+            stacks_common::consts::CHAIN_ID_TESTNET,
+            StacksEpochId::Epoch33,
+            None,
+            |vm_env| {
+                vm_env.context.database.put_data("shared-frame", &1_u64)?;
+                Ok::<_, VmExecutionError>(((), AssetMap::new(), vec![]))
+            },
+            |_, _| Some("abort".into()),
+        );
+
+        assert!(result.unwrap().3.is_some());
+        db.begin();
+        assert_eq!(db.get_data::<u64>("shared-frame").unwrap(), None);
+        db.roll_back().unwrap();
+    }
+
+    #[test]
+    fn shared_transaction_frame_rolls_back_execution_error() {
+        let mut store = MemoryBackingStore::new();
+        let db = store.as_clarity_db();
+
+        let (mut db, _, result) = execute_with_abort_callback(
+            db,
+            LimitedCostTracker::new_free(),
+            false,
+            stacks_common::consts::CHAIN_ID_TESTNET,
+            StacksEpochId::Epoch33,
+            None,
+            |vm_env| {
+                vm_env.context.database.put_data("shared-frame", &1_u64)?;
+                Err::<((), AssetMap, Vec<StacksTransactionEvent>), _>(VmExecutionError::Runtime(
+                    RuntimeError::ArithmeticOverflow,
+                    None,
+                ))
+            },
+            |_, _| None,
+        );
+
+        assert!(result.is_err());
+        db.begin();
+        assert_eq!(db.get_data::<u64>("shared-frame").unwrap(), None);
+        db.roll_back().unwrap();
+    }
 
     #[test]
     fn runtime_error_disposition_is_authoritative() {

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -479,15 +479,13 @@ where
     let result = match execution_result {
         Ok((value, asset_map, events)) => {
             let abort_reason = abort_callback(&asset_map, &mut db);
-            let db_result = if abort_reason.is_some() {
-                db.roll_back()
-            } else {
-                db.commit()
+            let db_result = match &abort_reason {
+                Some(_) => db.roll_back(),
+                None => db.commit(),
             };
-            match db_result {
-                Ok(()) => Ok((value, asset_map, events, abort_reason)),
-                Err(error) => Err(error.into()),
-            }
+            db_result
+                .map(|()| (value, asset_map, events, abort_reason))
+                .map_err(Into::into)
         }
         Err(error) => match db.roll_back() {
             Ok(()) => Err(error),

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -462,14 +462,10 @@ where
     E: From<VmExecutionError>,
 {
     db.begin();
-    let mut vm_env = OwnedEnvironment::new_cost_limited_with_hooks(
-        mainnet,
-        chain_id,
-        db,
-        cost_tracker,
-        epoch,
-        eval_hooks,
-    );
+    let mut vm_env = OwnedEnvironment::new_cost_limited(mainnet, chain_id, db, cost_tracker, epoch);
+    for hook in eval_hooks.into_iter().flatten() {
+        vm_env.add_eval_hook(hook);
+    }
 
     let execution_result = to_do(&mut vm_env);
     let (mut db, cost_tracker) = vm_env

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -431,6 +431,10 @@ pub trait ClarityConnection {
 
 /// Execute a nested Clarity transaction and let a callback decide whether its
 /// database changes should be committed.
+///
+/// Successful execution commits unless `abort_callback` returns a reason; errors and
+/// callback aborts roll back. The returned cost tracker retains its memory usage for the
+/// surrounding transaction to reset. Evaluation hooks must not run on consensus paths.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn execute_with_abort_callback<'db, 'hooks, F, A, R, E>(
     mut db: ClarityDatabase<'db>,
@@ -760,7 +764,8 @@ mod unit_tests {
     use crate::vm::database::MemoryBackingStore;
     use crate::vm::errors::{EarlyReturnError, RuntimeError};
     use crate::vm::events::{STXBurnEventData, STXEventType};
-    use crate::vm::hooks::testing::ExecutionLifecycleHook;
+    use crate::vm::hooks::ExecutionOutcome;
+    use crate::vm::hooks::testing::{ExecutionLifecycleEvent, ExecutionLifecycleHook};
     use crate::vm::types::StandardPrincipalData;
 
     #[test]
@@ -793,11 +798,18 @@ mod unit_tests {
             |_, _| None,
         );
 
-        assert!(result.is_ok());
+        let (_, _, _, abort_reason) = result.unwrap();
+        assert!(abort_reason.is_none());
         db.begin();
         assert_eq!(db.get_data::<u64>("shared-frame").unwrap(), Some(1));
         db.roll_back().unwrap();
-        assert_eq!(hook.events.len(), 2);
+        assert_eq!(
+            hook.events,
+            vec![
+                ExecutionLifecycleEvent::Begin,
+                ExecutionLifecycleEvent::Finish(ExecutionOutcome::Success),
+            ]
+        );
     }
 
     #[test]
@@ -819,7 +831,8 @@ mod unit_tests {
             |_, _| Some("abort".into()),
         );
 
-        assert!(result.unwrap().3.is_some());
+        let (_, _, _, abort_reason) = result.unwrap();
+        assert_eq!(abort_reason, Some("abort".into()));
         db.begin();
         assert_eq!(db.get_data::<u64>("shared-frame").unwrap(), None);
         db.roll_back().unwrap();

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -379,12 +379,7 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
 
     /// Registers an evaluation hook for this environment.
     pub fn add_eval_hook(&mut self, hook: &'hooks mut dyn EvalHook) {
-        if let Some(mut hooks) = self.context.eval_hooks.take() {
-            hooks.push(hook);
-            self.context.eval_hooks = Some(hooks);
-        } else {
-            self.context.eval_hooks = Some(vec![hook]);
-        }
+        self.context.eval_hooks.get_or_insert_default().push(hook);
     }
 
     pub fn set_execution_resource_limiter(&mut self, resource_limiter: ResourceLimiter) {

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -359,6 +359,24 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
         }
     }
 
+    /// Construct a cost-limited environment with evaluation hooks already installed.
+    pub fn new_cost_limited_with_hooks(
+        mainnet: bool,
+        chain_id: u32,
+        database: ClarityDatabase<'a>,
+        cost_tracker: LimitedCostTracker,
+        epoch_id: StacksEpochId,
+        eval_hooks: Option<Vec<&'hooks mut dyn EvalHook>>,
+    ) -> OwnedEnvironment<'a, 'hooks> {
+        OwnedEnvironment {
+            context: GlobalContext {
+                eval_hooks,
+                ..GlobalContext::new(mainnet, chain_id, database, cost_tracker, epoch_id)
+            },
+            call_stack: CallStack::new(),
+        }
+    }
+
     /// Registers an evaluation hook for this environment.
     pub fn add_eval_hook(&mut self, hook: &'hooks mut dyn EvalHook) {
         if let Some(mut hooks) = self.context.eval_hooks.take() {

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -352,27 +352,9 @@ impl<'a, 'hooks> OwnedEnvironment<'a, 'hooks> {
         database: ClarityDatabase<'a>,
         cost_tracker: LimitedCostTracker,
         epoch_id: StacksEpochId,
-    ) -> OwnedEnvironment<'a, 'a> {
-        OwnedEnvironment {
-            context: GlobalContext::new(mainnet, chain_id, database, cost_tracker, epoch_id),
-            call_stack: CallStack::new(),
-        }
-    }
-
-    /// Construct a cost-limited environment with evaluation hooks already installed.
-    pub fn new_cost_limited_with_hooks(
-        mainnet: bool,
-        chain_id: u32,
-        database: ClarityDatabase<'a>,
-        cost_tracker: LimitedCostTracker,
-        epoch_id: StacksEpochId,
-        eval_hooks: Option<Vec<&'hooks mut dyn EvalHook>>,
     ) -> OwnedEnvironment<'a, 'hooks> {
         OwnedEnvironment {
-            context: GlobalContext {
-                eval_hooks,
-                ..GlobalContext::new(mainnet, chain_id, database, cost_tracker, epoch_id)
-            },
+            context: GlobalContext::new(mainnet, chain_id, database, cost_tracker, epoch_id),
             call_stack: CallStack::new(),
         }
     }

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -2427,7 +2427,7 @@ impl TransactionConnection for ClarityTransactionConnection<'_, '_> {
                     to_do,
                     abort_call_back,
                 );
-                // DO NOT reset memory usage yet -- that should happen only when the TX commits.
+                // Memory is reset when the surrounding transaction commits.
 
                 (cost_track, (db.destroy().into(), result))
             })

--- a/stackslib/src/clarity_vm/clarity.rs
+++ b/stackslib/src/clarity_vm/clarity.rs
@@ -2410,51 +2410,24 @@ impl TransactionConnection for ClarityTransactionConnection<'_, '_> {
         using!(self.log, "log", |log| {
             using!(self.cost_track, "cost tracker", |cost_track| {
                 let rollback_wrapper = RollbackWrapper::from_persisted_log(self.store, log);
-                let mut db = ClarityDatabase::new_with_rollback_wrapper(
+                let db = ClarityDatabase::new_with_rollback_wrapper(
                     rollback_wrapper,
                     self.header_db,
                     self.burn_state_db,
                 )
                 .with_cache(&mut self.cache);
 
-                // wrap the whole contract-call in a claritydb transaction,
-                //   so we can abort on call_back's boolean retun
-                db.begin();
-                let mut vm_env = OwnedEnvironment::new_cost_limited(
-                    self.mainnet,
-                    self.chain_id,
+                let (db, cost_track, result) = clarity::vm::clarity::execute_with_abort_callback(
                     db,
                     cost_track,
+                    self.mainnet,
+                    self.chain_id,
                     self.epoch,
+                    None,
+                    to_do,
+                    abort_call_back,
                 );
-
-                let result = to_do(&mut vm_env);
-                let (mut db, cost_track) = vm_env
-                    .destruct()
-                    .expect("Failed to recover database reference after executing transaction");
                 // DO NOT reset memory usage yet -- that should happen only when the TX commits.
-
-                let result = match result {
-                    Ok((value, asset_map, events)) => {
-                        let aborted = abort_call_back(&asset_map, &mut db);
-                        let db_result = if aborted.is_some() {
-                            db.roll_back()
-                        } else {
-                            db.commit()
-                        };
-                        match db_result {
-                            Ok(_) => Ok((value, asset_map, events, aborted)),
-                            Err(e) => Err(e.into()),
-                        }
-                    }
-                    Err(e) => {
-                        let db_result = db.roll_back();
-                        match db_result {
-                            Ok(_) => Err(e),
-                            Err(db_err) => Err(db_err.into()),
-                        }
-                    }
-                };
 
                 (cost_track, (db.destroy().into(), result))
             })


### PR DESCRIPTION
### Description

This PR extracts Clarity’s transaction commit/rollback framing into a reusable helper in the `clarity` crate. This will allow Clarinet to handle a full Stacks transaction the same way as a Stacks node, without duplicating logic

### Applicable issues
- Required for: stx-labs/clarinet#2489

### Checklist
- [x] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
