### PR TITLE
ci: run tests refactor to support next flaky workflow

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -24,6 +24,14 @@ inputs:
   codecov-test-name:
     description: "Code coverage test name"
     required: true
+  nextest-profile:
+    description: |
+      Name of the nextest profile to run with, from
+      `.github/nextest/ci-nextest.toml`. Empty (the default) keeps the profile
+      each mode use: `ci-sequential` for named tests, `ci-parallel`
+      for partitioned runs.
+    required: false
+    default: ""
   upload-junit-xml:
     description: "Whether or not to upload the nextest JUnit XML artifact"
     required: true
@@ -155,6 +163,10 @@ runs:
         FILTERSET=$(echo "${{ inputs.test-names }}" | sed -E 's/[[:space:]]*,[[:space:]]*/)|test(=/g')
         FILTERSET="test(=${FILTERSET})"
 
+        # Profile override, defaulting to the profile this mode has always used
+        PROFILE="${{ inputs.nextest-profile }}"
+        PROFILE="${PROFILE:-ci-sequential}"
+
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
@@ -162,27 +174,28 @@ runs:
             --ignore-filename-regex='[/\\]test[/\\]|[/\\](test\.rs|[0-9a-zA-Z_-]+[_-]test\.rs)$' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
-            --profile ci-sequential \
+            --profile "$PROFILE" \
             --run-ignored all \
             --archive-file ${{ inputs.archive-file }} \
             -E "$FILTERSET"
         else
           cargo nextest run \
             --config-file ./.github/nextest/ci-nextest.toml \
-            --profile ci-sequential \
+            --profile "$PROFILE" \
             --run-ignored all \
             --archive-file ${{ inputs.archive-file }} \
             -E "$FILTERSET"
         fi
-          
-        # rename the resulting junit file from the toml config
-        mv junit.xml junit_${{ steps.generate-sanitized-file-name.outputs.file-name }}.xml
 
     # Mode 2: Run Partitioned Tests (If partition IS specified)
     - name: Run Partitioned Tests
       if: inputs.partition != '' && inputs.total-partitions != ''
       shell: bash
       run: |
+        # Profile override, defaulting to the profile this mode has always used
+        PROFILE="${{ inputs.nextest-profile }}"
+        PROFILE="${PROFILE:-ci-parallel}"
+
         if [ "${{ inputs.upload-code-coverage }}" = "true" ]; then
           cargo llvm-cov nextest \
             --lcov \
@@ -190,20 +203,31 @@ runs:
             --ignore-filename-regex='[/\\]test[/\\]|[/\\](test\.rs|[0-9a-zA-Z_-]+[_-]test\.rs)$' \
             --output-path lcov_${{ steps.generate-sanitized-file-name.outputs.file-name }}.info \
             --config-file ./.github/nextest/ci-nextest.toml \
-            --profile ci-parallel \
+            --profile "$PROFILE" \
             --partition count:${{ inputs.partition }}/${{ inputs.total-partitions }} \
             --archive-file ${{ inputs.archive-file }}
         else
           cargo nextest run \
             --config-file ./.github/nextest/ci-nextest.toml \
-            --profile ci-parallel \
+            --profile "$PROFILE" \
             --partition count:${{ inputs.partition }}/${{ inputs.total-partitions }} \
             --archive-file ${{ inputs.archive-file }}
         fi
-          
-        # rename the resulting junit file from the toml config
-        mv junit.xml junit_${{ steps.generate-sanitized-file-name.outputs.file-name }}.xml
-          
+
+    # Rename the JUnit report away from the fixed path set in the nextest
+    # config, so each test job's report gets a distinct artifact name.
+    #
+    # Execute 'always' so that this step is applied for passed and failed tests.
+    - name: Rename JUnit Report
+      if: always()
+      shell: bash
+      run: |
+        if [ -f junit.xml ]; then
+          mv junit.xml junit_${{ steps.generate-sanitized-file-name.outputs.file-name }}.xml
+        else
+          echo "::warning title=No JUnit report::nextest wrote no junit.xml; the test binary may have failed to start"
+        fi
+
     ############################################################################
     ### Upload the nextest JUnit XML
     ############################################################################

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -28,8 +28,8 @@ inputs:
     description: |
       Name of the nextest profile to run with, from
       `.github/nextest/ci-nextest.toml`. Empty (the default) keeps the profile
-      each mode use: `ci-sequential` for named tests, `ci-parallel`
-      for partitioned runs.
+      each mode uses by default: `ci-sequential` for named tests,
+      `ci-parallel` for partitioned runs.
     required: false
     default: ""
   upload-junit-xml:

--- a/.github/nextest/ci-nextest.toml
+++ b/.github/nextest/ci-nextest.toml
@@ -22,6 +22,21 @@ status-level = "pass"
 # Create JUnit output that we can parse
 path = "../../../junit.xml"
 
+# Do not store captured stdout/stderr in the report.
+#
+# Integration test output with RUST_BACKTRACE=full reaches tens of megabytes
+# per test, and every failing test uploads its report as an artifact. Anything
+# reading those reports pays that size again on download, for output it does
+# not read.
+#
+# What survives is nextest's own verdict in the `message` attribute: the panic
+# location and thread, the abort signal, or the timeout. The full output stays
+# in the job log under repo retention policy.
+store-failure-output = false
+# Already the nextest default; set explicitly so a change of default cannot
+# silently start embedding passing tests output.
+store-success-output = false
+
 [profile.ci-sequential]
 inherits = "ci"
 # The number of tests to run simultaneously

--- a/.github/scripts/bitcoin_tests.sh
+++ b/.github/scripts/bitcoin_tests.sh
@@ -9,6 +9,10 @@
 #   MAX_PER_CHUNK    - Max tests per matrix output chunk (default: 256)
 #   NEXTEST_ARCHIVE  - Nextest archive to use (default: ./test_archive.tar.zst)
 #   TEST_TAG_CI_SKIP - Tag name used to exclude tests from CI (default: ci_skip)
+#   ONLY_TESTS       - Comma-separated fully qualified test names. When set, the
+#                      matrix is narrowed to just these tests, for cheap manual
+#                      runs. Empty (default) generates the full matrix, so PR CI
+#                      is unaffected. Names must survive the exclude list below.
 
 set -euo pipefail
 
@@ -20,6 +24,7 @@ max_per_chunk="${MAX_PER_CHUNK:-256}"
 nextest_archive="${NEXTEST_ARCHIVE:-./test_archive.tar.zst}"
 nextest_archive="${nextest_archive/#\~/$HOME}"
 ci_skip_tag="${TEST_TAG_CI_SKIP:-ci_skip}"
+only_tests="${ONLY_TESTS:-}"
 
 ## ── Require bash 5+ ─────────────────────────────────────────────────────────
 if [[ "${BASH_VERSINFO[0]}" -lt 5 ]]; then
@@ -114,6 +119,43 @@ jq -r '.[]' ignored_tests.json | sort > ignored_sorted.txt
 jq -r '.[]' exclude.json        | sort > exclude_sorted.txt
 
 comm -23 ignored_sorted.txt exclude_sorted.txt > filtered.txt
+
+## ── Optionally narrow to specific tests -------------------------------------
+# For manual runs: restrict the matrix to the named tests instead of generating
+# a job per test. Names must be present in the runnable set above; a name that
+# is misspelled, not marked #[ignore], or on the exclude list is an error rather
+# than a silently empty matrix, which would otherwise report a green run that
+# tested nothing.
+if [[ -n "${only_tests}" ]]; then
+    tr ',' '\n' <<< "${only_tests}" \
+        | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+        | grep -v '^$' \
+        | sort -u > only_tests.txt || true
+
+    if [[ ! -s only_tests.txt ]]; then
+        error "$(hl "ONLY_TESTS") is set but contains no test names"
+        exit 1
+    fi
+
+    # Sort explicitly rather than relying on how filtered.txt was produced:
+    # comm only warns on unsorted input and still exits 0, so a mismatch here
+    # would silently yield the wrong matrix.
+    sort -u filtered.txt > filtered_sorted.txt
+
+    comm -23 only_tests.txt filtered_sorted.txt > only_missing.txt
+    if [[ -s only_missing.txt ]]; then
+        error "$(hl "ONLY_TESTS") names tests that are not in the runnable set:"
+        while read -r missing_test; do
+            error "  - $(hl "${missing_test}")"
+        done < only_missing.txt
+        error "Each name must be fully qualified, marked #[ignore], and not excluded."
+        exit 1
+    fi
+
+    comm -12 only_tests.txt filtered_sorted.txt > filtered_only.txt
+    mv filtered_only.txt filtered.txt
+    info "$(hl "ONLY_TESTS") applied: matrix narrowed to $(hl "$(wc -l < filtered.txt)") test(s)"
+fi
 
 mapfile -t tests < filtered.txt
 total=${#tests[@]}

--- a/.github/scripts/bitcoin_tests.sh
+++ b/.github/scripts/bitcoin_tests.sh
@@ -121,8 +121,8 @@ jq -r '.[]' exclude.json        | sort > exclude_sorted.txt
 comm -23 ignored_sorted.txt exclude_sorted.txt > filtered.txt
 
 ## ── Optionally narrow to specific tests -------------------------------------
-# For manual runs: restrict the matrix to the named tests instead of generating
-# a job per test. Names must be present in the runnable set above; a name that
+# For manual runs: restrict the matrix to the named tests, still one job per
+# test. Names must be present in the runnable set above; a name that
 # is misspelled, not marked #[ignore], or on the exclude list is an error rather
 # than a silently empty matrix, which would otherwise report a green run that
 # tested nothing.

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -9,6 +9,21 @@ on:
         description: "The test archive file"
         required: true
         type: string
+      nextest-profile:
+        description: |
+          Nextest profile override forwarded to the run-tests action. Empty (the
+          default) keeps the profile used by PR CI.
+        required: false
+        default: ""
+        type: string
+      only-tests:
+        description: |
+          Comma-separated fully qualified test names. When set, the matrix is
+          narrowed to just these tests instead of one job per test. Empty (the
+          default) generates the full matrix.
+        required: false
+        default: ""
+        type: string
       upload-junit-xml:
         description: "Whether or not to upload the nextest JUnit XML artifact"
         required: true
@@ -38,7 +53,7 @@ env:
 
 # Configure concurrency
 concurrency:
-  group: bitcoin-tests-${{ github.head_ref || github.ref || github.run_id }}
+  group: bitcoin-tests-${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -71,6 +86,8 @@ jobs:
       # Generate the bitcoin test matrices json used for running tests
       - name: Generate Test Matrices
         id: set-matrix
+        env:
+          ONLY_TESTS: ${{ inputs.only-tests }}
         run: bash ./.github/scripts/bitcoin_tests.sh
 
   integration-tests-1:
@@ -97,6 +114,7 @@ jobs:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
+          nextest-profile: ${{ inputs.nextest-profile }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}
 
@@ -124,6 +142,7 @@ jobs:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
+          nextest-profile: ${{ inputs.nextest-profile }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}
 
@@ -151,6 +170,7 @@ jobs:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
+          nextest-profile: ${{ inputs.nextest-profile }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}
           
@@ -178,6 +198,7 @@ jobs:
           test-names: ${{ matrix.batch.csv }}
           archive-file: ${{ inputs.archive-file }}
           codecov-test-name: isolated-test-${{ matrix.batch.index }}
+          nextest-profile: ${{ inputs.nextest-profile }}
           upload-junit-xml: ${{ inputs.upload-junit-xml }}
           upload-code-coverage: ${{ inputs.upload-code-coverage }}
  

--- a/.github/workflows/_tests-bitcoin.yml
+++ b/.github/workflows/_tests-bitcoin.yml
@@ -19,8 +19,7 @@ on:
       only-tests:
         description: |
           Comma-separated fully qualified test names. When set, the matrix is
-          narrowed to just these tests instead of one job per test. Empty (the
-          default) generates the full matrix.
+          narrowed to just these tests. Empty (the default) generates the full matrix.
         required: false
         default: ""
         type: string


### PR DESCRIPTION
### Description

This is a pre-flight PR that refactors some CI components so they can be reused by the flaky scan workflow.

Changes:

* Add an optional `nextest-profile` input to `.github/actions/run-tests/action.yml`.
* Configure `.github/actions/run-tests/action.yml` to always produce JUnit reports for both passed and failed tests. As part of this, configure the nextest JUnit profile to omit potentially large failed-test output.
* Add optional `nextest-profile` and `only-tests` inputs to `.github/workflows/_tests-bitcoin.yml`. The `only-tests` input allows running a specific subset of tests, primarily for manual testing.


### Applicable issues

- fixes https://github.com/stx-labs/core-epics/issues/427

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
