### PR TITLE
ci: extract ci-enabled in reusable workflow

### DIFF
--- a/.github/workflows/__README.md
+++ b/.github/workflows/__README.md
@@ -1,17 +1,85 @@
 ## Enabling CI
 
-The CI will always run on `stacks-network/stacks-core` with other forks and cloned repos able to opt-in.
+Workflows always run on `stacks-network/stacks-core`, with forks and cloned repos able to
+opt in. Every gated workflow calls the reusable `_check-ci-enabled.yml` and runs its real
+jobs only when that gate says so.
 
-To **enable** CI workflows within your fork or cloned repository, add a GitHub Actions Variable:
+The gate answers two independent questions and ANDs them:
 
-- Name: `ENABLE_CI_WORKFLOWS`
-- Value: `true`
+```
+enabled = (ENABLE_CI_WORKFLOWS || <extra-enable-var> || manual dispatch)
+          && (repo == stacks-network/stacks-core || allow-fork-run)
+```
 
-This will enable CI functionality within your repo or fork.
+To **enable** workflows within your fork or cloned repository, add the GitHub Actions
+Variable `ENABLE_CI_WORKFLOWS` with value `true`. To enable a single workflow instead, set
+only that workflow's own variable — see [Repository variables](#repository-variables).
+
+Pressing **Run workflow** enables that one run without enabling anything persistently. This
+matters for scheduled workflows: setting a variable would also start the cron on that
+repository, whereas a dispatch runs once.
+
+## Documentation
+
+### Repository variables
+
+Actions **Variables** (not secrets). Any value other than `true` — including unset — means
+off.
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `ENABLE_CI_WORKFLOWS` | Master switch for every gated workflow. Authoritative in the official repository too, so setting it to anything but `true` pauses all CI without a code change. Must be `true` on `stacks-network/stacks-core`. | unset |
+| `ENABLE_CI_DOCKER_IMAGE` | Enables `docker-image.yml` on its own | unset |
+| `ENABLE_CI_PROPTEST_EXTRA` | Enables `tests-proptest-extra.yml` on its own | unset |
+| `ENABLE_CI_PROPTEST_NIGHTLY` | Enables `tests-proptest-nightly.yml` on its own | unset |
+
+The per-workflow variables let a fork exercise one workflow — including on its schedule —
+without `ENABLE_CI_WORKFLOWS` turning on all CI for every PR.
+
+### `_check-ci-enabled.yml` inputs
+
+| Input | Description | Required | Default |
+| ----- | ----------- | -------- | ------- |
+| `allow-fork-run` | Whether this workflow may run outside the official repository at all. Set `false` for workflows whose side effects land on upstream; no variable or manual dispatch can then enable them in a fork. | `false` | `true` |
+| `extra-enable-var` | Name of an additional repository variable that enables this one workflow on its own, e.g. `ENABLE_CI_DOCKER_IMAGE`. Empty means no workflow-specific variable. | `false` | `""` |
+
+### `_check-ci-enabled.yml` outputs
+
+| Output | Description |
+| ------ | ----------- |
+| `enabled` | `'true'` when this workflow's jobs should run in this repository |
+
+### Upstream-only workflows
+
+These pass `allow-fork-run: false`, so no variable or manual dispatch can enable them in a
+fork:
+
+| Workflow | Why |
+| -------- | --- |
+| `slack-pr-nag.yml` | reads `stacks-network/stacks-core` PRs and posts to team Slack |
+| `lock-closed-threads.yml` | upstream-only by convention; keeps forks from locking their own stale threads |
+
+## Usage
+
+```yaml
+jobs:
+  check-ci-enabled:
+    name: "Check: CI Enabled"
+    uses: ./.github/workflows/_check-ci-enabled.yml
+    
+  build:
+    name: Job
+    needs:
+      - check-ci-enabled
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "gated work goes here"
+```
 
 ## Folder Structure
 
-ALL runnable workflows must be in the root of the .github/workflows folder. Subfolders are not allowed.
+ALL runnable workflows must be in the root of the `.github/` workflows folder. Subfolders are not allowed.
 
 When adding or changing files, follow this file naming guidance:
 

--- a/.github/workflows/__README.md
+++ b/.github/workflows/__README.md
@@ -7,7 +7,8 @@ jobs only when that gate says so.
 The gate answers two independent questions and ANDs them:
 
 ```
-enabled = (ENABLE_CI_WORKFLOWS || <extra-enable-var> || manual dispatch)
+enabled = (repo == stacks-network/stacks-core || ENABLE_CI_WORKFLOWS
+           || <extra-enable-var> || manual dispatch)
           && (repo == stacks-network/stacks-core || allow-fork-run)
 ```
 
@@ -19,6 +20,12 @@ Pressing **Run workflow** enables that one run without enabling anything persist
 matters for scheduled workflows: setting a variable would also start the cron on that
 repository, whereas a dispatch runs once.
 
+> **Note on fork pull requests.** GitHub does not pass repository variables to
+> `pull_request` runs from a fork, so `vars.*` is always empty there — even though
+> `github.repository` is the base repo. Those runs are enabled by the
+> `repo == stacks-network/stacks-core` arm instead, which is why it must stay first in the
+> expression above.
+
 ## Documentation
 
 ### Repository variables
@@ -28,7 +35,7 @@ off.
 
 | Variable | Description | Default |
 | -------- | ----------- | ------- |
-| `ENABLE_CI_WORKFLOWS` | Master switch for every gated workflow. Authoritative in the official repository too, so setting it to anything but `true` pauses all CI without a code change. Must be `true` on `stacks-network/stacks-core`. | unset |
+| `ENABLE_CI_WORKFLOWS` | Opts a fork or clone in to every gated workflow. Not needed on `stacks-network/stacks-core`, which is always enabled. | unset |
 | `ENABLE_CI_DOCKER_IMAGE` | Enables `docker-image.yml` on its own | unset |
 | `ENABLE_CI_PROPTEST_EXTRA` | Enables `tests-proptest-extra.yml` on its own | unset |
 | `ENABLE_CI_PROPTEST_NIGHTLY` | Enables `tests-proptest-nightly.yml` on its own | unset |

--- a/.github/workflows/_check-ci-enabled.yml
+++ b/.github/workflows/_check-ci-enabled.yml
@@ -1,0 +1,134 @@
+############################################################################
+### Reusable gate deciding whether a workflow's real jobs should run here.
+###
+### Two independent questions, ANDed together:
+###
+###   1. Is CI switched on?    ENABLE_CI_WORKFLOWS, or this workflow's own
+###                            variable, or a manual dispatch.
+###   2. May it run here?      Always in the official repo; elsewhere only
+###                            when the caller passes allow-fork-run.
+###
+###   enabled = (ENABLE_CI_WORKFLOWS || <extra-enable-var> || dispatch)
+###             && (repo == stacks-network/stacks-core || allow-fork-run)
+###
+### The variable is authoritative in the official repo too, so clearing it
+### (or setting it to anything but "true") pauses CI everywhere without a
+### code change. See __README.md for the variable reference.
+###
+### A manual dispatch enables a single run without enabling anything
+### persistently - the distinction matters for scheduled workflows, where
+### setting a variable would also start the cron on that repository.
+###
+### Callers gate their jobs on the output:
+###   needs:
+###     - check-ci-enabled
+###   if: needs.check-ci-enabled.outputs.enabled == 'true'
+############################################################################
+
+name: "Check: CI Enabled"
+
+on:
+  workflow_call:
+    inputs:
+      allow-fork-run:
+        description: >-
+          Whether this workflow may run outside the official repository at all.
+        required: false
+        default: true
+        type: boolean
+      extra-enable-var:
+        description: >-
+          Name of a repository variable that enables this one workflow on its
+          own. Empty means no workflow-specific variable.
+        required: false
+        default: ""
+        type: string
+    outputs:
+      enabled:
+        description: "'true' when this workflow's jobs should run in this repository."
+        value: ${{ jobs.check.outputs.enabled }}
+
+  # Just for play-testing
+  workflow_dispatch:
+    inputs:
+      allow-fork-run:
+        description: >-
+          Whether this workflow may run outside the official repository at all.
+        required: false
+        default: true
+        type: boolean
+
+      extra-enable-var:
+        description: >-
+          Name of a repository variable that enables this one workflow on its
+          own. Empty means no workflow-specific variable.
+        required: false
+        default: ""
+        type: string
+
+# This job only reads contexts; it needs no access to the repository.
+permissions: {}
+
+jobs:
+  check:
+    name: "Gate"
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          ENABLE_CI_WORKFLOWS: ${{ vars.ENABLE_CI_WORKFLOWS }}
+          ALLOW_FORK_RUN: ${{ inputs.allow-fork-run }}
+          EXTRA_VAR_NAME: ${{ inputs.extra-enable-var }}
+          EXTRA_VAR_VALUE: ${{ inputs.extra-enable-var != '' && vars[inputs.extra-enable-var] || '' }}
+        run: |
+          echo "=== CI Enablement Check ==="
+          echo "github.repository:   '$REPOSITORY'"
+          echo "github.event_name:   '$EVENT_NAME'"
+          echo "ENABLE_CI_WORKFLOWS: '$ENABLE_CI_WORKFLOWS'"
+          echo "${EXTRA_VAR_NAME:-<no workflow-specific variable>}: '$EXTRA_VAR_VALUE'"
+          echo "allow-fork-run:      '$ALLOW_FORK_RUN'"
+          echo
+
+          # 1. Is CI switched on for this repository?
+          switched_on=true
+          if [[ "$ENABLE_CI_WORKFLOWS" == "true" ]]; then
+            switch="ENABLE_CI_WORKFLOWS is set"
+          elif [[ -n "$EXTRA_VAR_NAME" && "$EXTRA_VAR_VALUE" == "true" ]]; then
+            switch="$EXTRA_VAR_NAME is set"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # One run only. Deliberately not persistent, so a fork can exercise
+            # a scheduled workflow by hand without starting its cron.
+            switch="manual dispatch"
+          else
+            switched_on=false
+            switch="no enabling variable is set and this is not a manual dispatch"
+          fi
+
+          # 2. May this workflow run in this repository at all?
+          #    Tested positively, so a malformed allow-fork-run fails closed.
+          allowed_here=true
+          if [[ "$REPOSITORY" == "stacks-network/stacks-core" ]]; then
+            where="official repository"
+          elif [[ "$ALLOW_FORK_RUN" == "true" ]]; then
+            where="fork runs are allowed"
+          else
+            allowed_here=false
+            where="this workflow is restricted to the official repository"
+          fi
+
+          if [[ "$switched_on" == "true" && "$allowed_here" == "true" ]]; then
+            enabled=true
+            echo "Result: CI is ENABLED ($switch; $where)"
+          else
+            enabled=false
+            if [[ "$allowed_here" != "true" ]]; then
+              echo "Result: CI is DISABLED ($where)"
+            else
+              echo "Result: CI is DISABLED ($switch)"
+            fi
+          fi
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_check-ci-enabled.yml
+++ b/.github/workflows/_check-ci-enabled.yml
@@ -3,17 +3,22 @@
 ###
 ### Two independent questions, ANDed together:
 ###
-###   1. Is CI switched on?    ENABLE_CI_WORKFLOWS, or this workflow's own
+###   1. Is CI switched on?    Always in the official repo; elsewhere via
+###                            ENABLE_CI_WORKFLOWS, this workflow's own
 ###                            variable, or a manual dispatch.
 ###   2. May it run here?      Always in the official repo; elsewhere only
 ###                            when the caller passes allow-fork-run.
 ###
-###   enabled = (ENABLE_CI_WORKFLOWS || <extra-enable-var> || dispatch)
+###   enabled = (repo == stacks-network/stacks-core || ENABLE_CI_WORKFLOWS
+###              || <extra-enable-var> || dispatch)
 ###             && (repo == stacks-network/stacks-core || allow-fork-run)
 ###
-### The variable is authoritative in the official repo too, so clearing it
-### (or setting it to anything but "true") pauses CI everywhere without a
-### code change. See __README.md for the variable reference.
+### IMPORTANT: the official-repo check in (1) is load-bearing and must not be
+### removed. GitHub does not pass repository variables to `pull_request` runs
+### from a fork, so `vars.ENABLE_CI_WORKFLOWS` is ALWAYS empty there - even
+### though `github.repository` is the base repo and the variable is set on it.
+###
+### See __README.md for the variable reference.
 ###
 ### A manual dispatch enables a single run without enabling anything
 ### persistently - the distinction matters for scheduled workflows, where
@@ -94,8 +99,13 @@ jobs:
           echo
 
           # 1. Is CI switched on for this repository?
+          #    The official-repo arm must come first: repository variables are
+          #    not passed to pull_request runs from a fork, so the variables
+          #    below are always empty there. See the header comment.
           switched_on=true
-          if [[ "$ENABLE_CI_WORKFLOWS" == "true" ]]; then
+          if [[ "$REPOSITORY" == "stacks-network/stacks-core" ]]; then
+            switch="official repository"
+          elif [[ "$ENABLE_CI_WORKFLOWS" == "true" ]]; then
             switch="ENABLE_CI_WORKFLOWS is set"
           elif [[ -n "$EXTRA_VAR_NAME" && "$EXTRA_VAR_VALUE" == "true" ]]; then
             switch="$EXTRA_VAR_NAME is set"
@@ -105,7 +115,7 @@ jobs:
             switch="manual dispatch"
           else
             switched_on=false
-            switch="no enabling variable is set and this is not a manual dispatch"
+            switch="not the official repo, no enabling variable set, not a manual dispatch"
           fi
 
           # 2. May this workflow run in this repository at all?
@@ -122,7 +132,11 @@ jobs:
 
           if [[ "$switched_on" == "true" && "$allowed_here" == "true" ]]; then
             enabled=true
-            echo "Result: CI is ENABLED ($switch; $where)"
+            if [[ "$switch" == "$where" ]]; then
+              echo "Result: CI is ENABLED ($switch)"
+            else
+              echo "Result: CI is ENABLED ($switch; $where)"
+            fi
           else
             enabled=false
             if [[ "$allowed_here" != "true" ]]; then

--- a/.github/workflows/check-clippy.yml
+++ b/.github/workflows/check-clippy.yml
@@ -33,23 +33,7 @@ concurrency:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
 
   clippy-stacks:
     name: "Check: Clippy (stacks)"

--- a/.github/workflows/check-nix.yml
+++ b/.github/workflows/check-nix.yml
@@ -31,23 +31,7 @@ concurrency:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
 
   build-pkg:
     name: "Check: Nix package"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,23 +42,7 @@ env:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
 
   ############################################################################
   ### Global Variables Setup

--- a/.github/workflows/create-test-caches.yml
+++ b/.github/workflows/create-test-caches.yml
@@ -42,24 +42,7 @@ concurrency:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-          echo "github.event_name:   '${{ github.event_name }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
 
   #######################################################################################################################
   ### Create Reusable Caches for Tests

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,24 +43,9 @@ concurrency:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-          echo "github.event_name:   '${{ github.event_name }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
+    with:
+      extra-enable-var: ENABLE_CI_DOCKER_IMAGE
 
   # Build arch dependent binaries from source
   build-binaries:

--- a/.github/workflows/lock-closed-threads.yml
+++ b/.github/workflows/lock-closed-threads.yml
@@ -21,22 +21,9 @@ jobs:
   # Execute only on our official repo, because it manages Issues discussions for our official repo
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "github.repository:   '${{ github.repository }}'"
-    
-          if [[ "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
+    with:
+      allow-fork-run: false
 
   lock-closed-threads:
     name: "Lock: Closed Issues, PRs, & Discussions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,23 +30,7 @@ env:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
 
   ############################################################################
   ### Global Variables Setup
@@ -84,8 +68,7 @@ jobs:
     needs:
       - check-ci-enabled
       - setup-env
-    # Execute if ENABLE_CI_WORKFLOWS GitHub Actions variable is 'true' or we're on the official repository
-    if: vars.ENABLE_CI_WORKFLOWS == 'true' || github.repository == 'stacks-network/stacks-core'
+    if: needs.check-ci-enabled.outputs.enabled == 'true'
     runs-on: *shared_config
     outputs:
       tag: ${{ steps.check-release.outputs.tag }}

--- a/.github/workflows/slack-pr-nag.yml
+++ b/.github/workflows/slack-pr-nag.yml
@@ -14,22 +14,9 @@ jobs:
   # Execute only on our official repo, because it manages Slack PR nags for us
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "github.repository:   '${{ github.repository }}'"
-    
-          if [[ "${{ github.repository }}" == "stacks-network/stacks-core" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
+    with:
+      allow-fork-run: false
 
   nag-slack:
     name: "Slack: Nag Team"

--- a/.github/workflows/tests-proptest-extra.yml
+++ b/.github/workflows/tests-proptest-extra.yml
@@ -63,24 +63,9 @@ env:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-          echo "github.event_name:   '${{ github.event_name }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
+    with:
+      extra-enable-var: ENABLE_CI_PROPTEST_EXTRA
 
   # Gate 1: on manual dispatch, always proceed.
   # On pull_request_review, proceed only when the triggering review is an

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -62,24 +62,9 @@ env:
 jobs:
   check-ci-enabled:
     name: "Check: CI Enabled"
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-    steps:
-      - id: check
-        run: |
-          echo "=== CI Enablement Check ==="
-          echo "ENABLE_CI_WORKFLOWS: '${{ vars.ENABLE_CI_WORKFLOWS }}'"
-          echo "github.repository:   '${{ github.repository }}'"
-          echo "github.event_name:   '${{ github.event_name }}'"
-    
-          if [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Result: CI is ENABLED"
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Result: CI is DISABLED"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_check-ci-enabled.yml
+    with:
+      extra-enable-var: ENABLE_CI_PROPTEST_NIGHTLY
 
   proptests-nightly:
     name: "Tests: All Proptest Tests"


### PR DESCRIPTION
### Description

Consolidates the duplicated `check-ci-enabled` job into a single reusable workflow, `_check-ci-enabled.yml`.

Ten workflows each carried their own inline copy of the gate, which had drifted into three variants that differed only in a bash `if` condition:

| variant | condition | workflows |
|---|---|---|
| A | repo \|\| `ENABLE_CI_WORKFLOWS` | ci, check-clippy, check-nix, release |
| B | A \|\| `workflow_dispatch` | create-test-caches, docker-image, tests-proptest-extra, tests-proptest-nightly |
| C | repo only | lock-closed-threads, slack-pr-nag |

The gate is now one file with two inputs, so each call site states its own policy in a line you can read (see `__README.md` for details):

```yaml
  check-ci-enabled:
    name: "Check: CI Enabled"
    uses: ./.github/workflows/_check-ci-enabled.yml
```

The gate reduces to two clauses — *is it switched on*, and *is it allowed to run here*:

```
enabled = (ENABLE_CI_WORKFLOWS || <extra-enable-var> || manual dispatch)
          && (repo == stacks-network/stacks-core || allow-fork-run)
```

`extra-enable-var` is new: it lets a fork enable one workflow on its own — including on its schedule — without `ENABLE_CI_WORKFLOWS` turning on the full PR matrix. Downstream consumers are untouched; the job id stays `check-ci-enabled`, so every existing `needs:` and `if: needs.check-ci-enabled.outputs.enabled == 'true'` still resolves.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

Also in this PR:

- `release.yml`'s `check-release` already declared `needs: check-ci-enabled` but re-derived the predicate inline; it now reads the output.


### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
