### PR TITLE
chore: add --ignore-costs to block-validation / stack-inspect

### DIFF
--- a/contrib/stacks-inspect/README.md
+++ b/contrib/stacks-inspect/README.md
@@ -126,9 +126,11 @@ replay-mock-mining <CHAINSTATE_PATH> <MOCK_MINING_OUTPUT_PATH>
 Block validation and integrity checks.
 
 ```
-validate-block <DATABASE_PATH> [--early-exit] [MODE]
+validate-block <DATABASE_PATH> [--early-exit] [--ignore-costs] [MODE]
     Validate Stacks blocks (Epoch2 and Nakamoto) from chainstate database
     --early-exit: Stop on first error (default: collect all errors)
+    --ignore-costs: Don't fail a block whose only mismatch is its execution cost.
+        The mismatch is logged and the block counts as valid.
 
     MODE options:
       prefix <HASH_PREFIX>           Validate blocks matching hash prefix

--- a/contrib/stacks-inspect/src/cli.rs
+++ b/contrib/stacks-inspect/src/cli.rs
@@ -83,6 +83,10 @@ pub struct ValidateBlockArgs {
     #[arg(long, default_value_t = false)]
     pub early_exit: bool,
 
+    /// Don't fail a block whose only mismatch is its execution cost
+    #[arg(long, default_value_t = false)]
+    pub ignore_costs: bool,
+
     /// Block selection mode (if not specified, validates all blocks)
     #[command(subcommand)]
     pub mode: Option<ValidateBlockMode>,
@@ -618,5 +622,50 @@ mod tests {
 
         assert_eq!(cli.config, Some("/path/to/config.toml".to_string()));
         assert!(matches!(cli.command, Command::DumpConsts));
+    }
+
+    #[test]
+    fn test_validate_block_defaults() {
+        let cli = Cli::try_parse_from(["stacks-inspect", "validate-block", "/path/to/chainstate"])
+            .unwrap();
+
+        match cli.command {
+            Command::ValidateBlock(args) => {
+                assert_eq!(args.database_path, "/path/to/chainstate");
+                assert!(!args.early_exit);
+                assert!(!args.ignore_costs);
+                assert!(args.mode.is_none());
+            }
+            _ => panic!("Expected ValidateBlock command"),
+        }
+    }
+
+    #[test]
+    fn test_validate_block_ignore_costs() {
+        let cli = Cli::try_parse_from([
+            "stacks-inspect",
+            "validate-block",
+            "--ignore-costs",
+            "/path/to/chainstate",
+            "naka-index-range",
+            "0",
+            "100",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::ValidateBlock(args) => {
+                assert!(args.ignore_costs);
+                assert!(!args.early_exit);
+                assert!(matches!(
+                    args.mode,
+                    Some(ValidateBlockMode::NakaIndexRange {
+                        start: Some(0),
+                        end: Some(100)
+                    })
+                ));
+            }
+            _ => panic!("Expected ValidateBlock command"),
+        }
     }
 }

--- a/contrib/stacks-inspect/src/lib.rs
+++ b/contrib/stacks-inspect/src/lib.rs
@@ -63,6 +63,13 @@ pub struct CommonOpts {
     pub config: Option<Config>,
 }
 
+/// Options controlling how strict block replay is
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReplayOpts {
+    /// Treat a block whose only failure is a cost mismatch as valid
+    pub ignore_costs: bool,
+}
+
 #[derive(Clone)]
 enum BlockSource {
     Nakamoto,
@@ -306,6 +313,9 @@ pub fn command_validate_block(args: &ValidateBlockArgs, conf: Option<&Config>) {
     let start = Instant::now();
     let db_path = &args.database_path;
     let early_exit = args.early_exit;
+    let opts = ReplayOpts {
+        ignore_costs: args.ignore_costs,
+    };
 
     let selection = convert_args_to_selection(&args.mode).unwrap_or_else(|err| {
         eprintln!("{err}");
@@ -353,8 +363,13 @@ pub fn command_validate_block(args: &ValidateBlockArgs, conf: Option<&Config>) {
     let mut reward_set_cache: HashMap<u64, CachedRewardSet> = HashMap::new();
 
     for entry in work_items {
-        if let Err(e) = validate_entry(&mut chainstate, &mut sortdb, &mut reward_set_cache, &entry)
-        {
+        if let Err(e) = validate_entry(
+            &mut chainstate,
+            &mut sortdb,
+            &mut reward_set_cache,
+            &entry,
+            opts,
+        ) {
             if early_exit {
                 print!("\r");
                 io::stdout().flush().ok();
@@ -442,6 +457,7 @@ fn validate_entry(
     sortdb: &mut SortitionDB,
     reward_set_cache: &mut HashMap<u64, CachedRewardSet>,
     entry: &BlockScanEntry,
+    opts: ReplayOpts,
 ) -> Result<(), String> {
     match entry.source {
         BlockSource::Nakamoto => replay_naka_staging_block(
@@ -449,8 +465,11 @@ fn validate_entry(
             sortdb,
             reward_set_cache,
             &entry.index_block_hash,
+            opts,
         ),
-        BlockSource::Epoch2 => replay_staging_block(chainstate, sortdb, &entry.index_block_hash),
+        BlockSource::Epoch2 => {
+            replay_staging_block(chainstate, sortdb, &entry.index_block_hash, opts)
+        }
     }
 }
 
@@ -724,6 +743,7 @@ fn replay_staging_block(
     chainstate: &mut StacksChainState,
     sortdb: &mut SortitionDB,
     block_id: &StacksBlockId,
+    opts: ReplayOpts,
 ) -> Result<(), String> {
     let sort_tx = sortdb.tx_begin_at_tip();
 
@@ -765,6 +785,7 @@ fn replay_staging_block(
         &next_staging_block.anchored_block_hash,
         next_staging_block.commit_burn,
         next_staging_block.sortition_burn,
+        opts,
     )
 }
 
@@ -836,6 +857,7 @@ fn replay_mock_mined_block(db_path: &str, block: AssembledAnchorBlock, conf: Opt
         // I think the burn is used for miner rewards but not necessary for validation
         0,
         0,
+        ReplayOpts::default(),
     )
     .expect("Failed to replay mock mined block");
 }
@@ -856,6 +878,7 @@ fn replay_block(
     block_hash: &BlockHeaderHash,
     block_commit_burn: u64,
     block_sortition_burn: u64,
+    opts: ReplayOpts,
 ) -> Result<(), String> {
     let parent_block_header = match &parent_header_info.anchored_header {
         StacksBlockHeaderTypes::Epoch2(bh) => bh,
@@ -959,10 +982,16 @@ fn replay_block(
             clarity_commit.rollback();
             if let Some(cost) = cost_opt {
                 if receipt.anchored_block_cost != cost {
-                    return Err(format!(
-                        "Failed processing block! block = {block_id}. Unexpected cost. expected = {cost}, evaluated = {}",
+                    if !opts.ignore_costs {
+                        return Err(format!(
+                            "Failed processing block! block = {block_id}. Unexpected cost. expected = {cost}, evaluated = {}",
+                            receipt.anchored_block_cost
+                        ));
+                    }
+                    warn!(
+                        "Cost mismatch ignored! block = {block_id}. expected = {cost}, evaluated = {}",
                         receipt.anchored_block_cost
-                    ));
+                    );
                 }
             } else {
                 info!("No stored cost for {block_id}; skipping cost check");
@@ -982,6 +1011,7 @@ fn replay_naka_staging_block(
     sortdb: &mut SortitionDB,
     reward_set_cache: &mut HashMap<u64, CachedRewardSet>,
     block_id: &StacksBlockId,
+    opts: ReplayOpts,
 ) -> Result<(), String> {
     let (block, block_size) = chainstate
         .nakamoto_blocks_db()
@@ -989,8 +1019,15 @@ fn replay_naka_staging_block(
         .map_err(|e| format!("Failed to load Nakamoto block: {e:?}"))?
         .ok_or_else(|| "No block data found".to_string())?;
 
-    replay_block_nakamoto(sortdb, chainstate, reward_set_cache, &block, block_size)
-        .map_err(|e| format!("Failed to validate Nakamoto block: {e:?}"))
+    replay_block_nakamoto(
+        sortdb,
+        chainstate,
+        reward_set_cache,
+        &block,
+        block_size,
+        opts,
+    )
+    .map_err(|e| format!("Failed to validate Nakamoto block: {e:?}"))
 }
 
 /// Reward set cached per cycle, tagged with the block that calculated it so
@@ -1080,6 +1117,7 @@ fn replay_block_nakamoto(
     reward_set_cache: &mut HashMap<u64, CachedRewardSet>,
     block: &NakamotoBlock,
     block_size: u64,
+    opts: ReplayOpts,
 ) -> Result<(), ChainstateError> {
     // find corresponding snapshot
     let next_ready_block_snapshot =
@@ -1366,9 +1404,17 @@ fn replay_block_nakamoto(
         // check the cost
         let evaluated_cost = receipt.anchored_block_cost.clone();
         if evaluated_cost != expected_cost {
-            return Err(ChainstateError::InvalidStacksBlock(format!(
-                "Failed processing block! block = {block_id}. Unexpected cost. expected = {expected_cost}, evaluated = {evaluated_cost}"
-            )));
+            if !opts.ignore_costs {
+                return Err(ChainstateError::InvalidStacksBlock(format!(
+                    "Failed processing block! block = {block_id}. Unexpected cost. expected = {expected_cost}, evaluated = {evaluated_cost}"
+                )));
+            }
+            warn!(
+                "Cost mismatch ignored!";
+                "stacks_block_id" => %block_id,
+                "expected" => %expected_cost,
+                "evaluated" => %evaluated_cost
+            );
         }
     }
 

--- a/contrib/tools/block-validation.sh
+++ b/contrib/tools/block-validation.sh
@@ -124,6 +124,7 @@ pre_input_config() {
     CORES=""                                   # cores to use for validation; resolved in post_input_config
     NETWORK="mainnet"                          # network to validate
     RANGE="full"                               # block range to validate: scenario or numeric range
+    IGNORE_COSTS_ARG=""                  # holds "--ignore-costs" when cost-only mismatches must not fail blocks
     LAST_ERROR=""                              # last error_and_exit message; surfaced by on_exit in status.json
 
     if [[ -t 1 ]]; then
@@ -305,6 +306,9 @@ Options:
           $(cyan "<start>:<end>")   - inclusive range; auto-splits at the epoch2/3 boundary
           $(cyan "<start>+<count>") - <count> blocks starting at <start>
         Default: $(cyan "full")
+    $(yellow "--ignore-costs")
+        Don't fail blocks whose only mismatch is their execution cost.
+        Default: $(cyan "disabled")
 
 Example: full block validation, auto-downloading the chainstate using stacks-core public repo at develop
     $(bold "${0} --workdir /data/workdir")
@@ -932,7 +936,7 @@ validate_block_range() {
         slice_progress_files+=("${progress_file}")
         # tmux send-keys re-parses this string as shell source in the target window,
         # so quote the paths so spaces / shell metacharacters survive re-parsing.
-        local inspect_cmd="\"${inspect_bin}\" --config \"${inspect_config}\" validate-block \"${slice_path}\" ${range_command} ${start_block_count} ${end_block_count} 2>/dev/null"
+        local inspect_cmd="\"${inspect_bin}\" --config \"${inspect_config}\" validate-block ${IGNORE_COSTS_ARG} \"${slice_path}\" ${range_command} ${start_block_count} ${end_block_count} 2>/dev/null"
         local cmd="${inspect_cmd} | ${tee_stage}stdbuf -oL tr '\\r' '\\n' | while IFS= read -r line; do if [[ \"\$line\" =~ ^Validating:[[:space:]]+[0-9]+% ]]; then printf '%s\\n' \"\$line\" > '${progress_file}'; elif [[ -n \"\$line\" ]]; then printf '%s\\n' \"\$line\" >> '${log_file}'; fi; done"
         info "  $(highlight "${TMUX_SESSION}:slice${slice_counter}") :: Blocks: $(highlight "${global_slice_start}-${global_slice_end}") :: Logs: ${log_file}"
         echo "Command: ${inspect_cmd}" > "${log_file}"
@@ -1308,6 +1312,10 @@ parse_input() {
                 require_value "${1}" "${2:-}"
                 NETWORK=${2}
                 shift
+                ;;
+            --ignore-costs)
+                # Don't treat a cost-only mismatch as a block validation failure
+                IGNORE_COSTS_ARG="--ignore-costs"
                 ;;
             --rev)
                 # Build from a specific git revision (branch, tag, or commit SHA)

--- a/contrib/tools/block-validation.sh
+++ b/contrib/tools/block-validation.sh
@@ -120,11 +120,11 @@ pre_input_config() {
     REPO="stacks-core"                         # --repo value: known label, git URL, or path to an existing checkout.
     REPO_REV="develop"                         # default git revision (branch, tag, or commit) to build stacks-inspect from
     PR=""                                      # optional pull request to validate: number (repo-relative) or full PR URL
-    GH_TOKEN="${GH_TOKEN:-}"                    # optional token for authenticated PR fetches (env-provided value is preserved)
+    GH_TOKEN="${GH_TOKEN:-}"                   # optional token for authenticated PR fetches (env-provided value is preserved)
     CORES=""                                   # cores to use for validation; resolved in post_input_config
     NETWORK="mainnet"                          # network to validate
     RANGE="full"                               # block range to validate: scenario or numeric range
-    IGNORE_COSTS_ARG=""                  # holds "--ignore-costs" when cost-only mismatches must not fail blocks
+    IGNORE_COSTS_ARG=""                        # holds "--ignore-costs" when cost-only mismatches must not fail blocks
     LAST_ERROR=""                              # last error_and_exit message; surfaced by on_exit in status.json
 
     if [[ -t 1 ]]; then

--- a/contrib/tools/block-validation.sh
+++ b/contrib/tools/block-validation.sh
@@ -179,6 +179,7 @@ post_input_config() {
     #   - commit: the resolved HEAD (set after checkout in build_stacks_inspect)
     #   - range : left empty until the numeric block bounds are resolved
     #             (set per phase in validate_block_range)
+    #   - ignore_costs: whether --ignore-costs was requested ("true"/"false")
     STATUS_REPO="${REPO_URL:-LOCAL}"
     if [ -n "${PR_NUMBER}" ]; then
         STATUS_REF="PR #${PR_NUMBER}"
@@ -187,6 +188,7 @@ post_input_config() {
     fi
     STATUS_COMMIT=""
     STATUS_RANGE=""
+    STATUS_IGNORE_COSTS=$([ -n "${IGNORE_COSTS_ARG}" ] && echo "true" || echo "false")
 }
 
 # Resolve the --repo argument into REPO_URL, REPO_DIR, and TRACK_REV.
@@ -695,12 +697,15 @@ declare -r STATUS_STATE_ERROR="ERROR"       # unexpected abort (see LAST_ERROR /
 #
 #   { "state": <s>, "message": <str>,
 #     "repo": <url|LOCAL>, "commit": <sha>, "ref": <str>, "range": <str>,
+#     "ignore_costs": <"true"|"false">,
 #     "started_at": <iso8601 UTC>, "updated_at": <iso8601 UTC> }
 #
 #   state    ONGOING (preparing/validating) | SUCCESS | FAILURE (validation
 #            failed; per-block detail in results.log) | ERROR (unexpected abort)
 #   message  human-readable current activity
 #   range    empty until the numeric block bounds are resolved
+#   ignore_costs  "true" when --ignore-costs was passed: blocks failing only
+#            their cost check were not counted as failures
 #
 # status_write <state> <message>
 # Builds the JSON with jq (guaranteed valid + correctly escaped) and swaps it in
@@ -713,15 +718,16 @@ status_write() {
     : "${STATUS_STARTED_AT:=$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
     local tmp="${STATUS_FILE}.tmp"
     jq -n \
-        --arg     state      "${state}" \
-        --arg     message    "${message}" \
-        --arg     repo       "${STATUS_REPO:-}" \
-        --arg     commit     "${STATUS_COMMIT:-}" \
-        --arg     ref        "${STATUS_REF:-}" \
-        --arg     range      "${STATUS_RANGE:-}" \
-        --arg     started_at "${STATUS_STARTED_AT}" \
-        --arg     updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-        '{state: $state, message: $message, repo: $repo, commit: $commit, ref: $ref, range: $range, started_at: $started_at, updated_at: $updated_at}' \
+        --arg     state        "${state}" \
+        --arg     message      "${message}" \
+        --arg     repo         "${STATUS_REPO:-}" \
+        --arg     commit       "${STATUS_COMMIT:-}" \
+        --arg     ref          "${STATUS_REF:-}" \
+        --arg     range        "${STATUS_RANGE:-}" \
+        --arg     ignore_costs "${STATUS_IGNORE_COSTS:-}" \
+        --arg     started_at   "${STATUS_STARTED_AT}" \
+        --arg     updated_at   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{state: $state, message: $message, repo: $repo, commit: $commit, ref: $ref, range: $range, ignore_costs: $ignore_costs, started_at: $started_at, updated_at: $updated_at}' \
         > "${tmp}" || {
         error_and_exit "writing status file ${tmp}"
     }


### PR DESCRIPTION
### Description

add `--ignore-costs` flag to run block-validation ignoring execution costs mismatches.

### Applicable issues

- fixes https://github.com/stx-labs/core-epics/issues/432

### Additional info (benefits, drawbacks, caveats)

Block-validation github-app updated to support an `help` command and the `--ignore-costs` flags.

Related execution is shown in this PR running /valid commands

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
