### PR TITLE
ci: add extra-enable-var to __check-ci.yml

### DIFF
--- a/.github/workflows/__README.md
+++ b/.github/workflows/__README.md
@@ -29,3 +29,26 @@ Typically, you will want to start your "top level" workflow with a call to the `
 ```
 
 This workflow checks if CI is enabled, providing useful output variables. Using these outputs is a best practice so that forks and clones do not have to run CI unless they choose to opt-in.
+
+### Inputs
+
+| Input | Description | Required | Default |
+| ----- | ----------- | -------- | ------- |
+| `allow-fork-runs` | Whether this workflow may run outside of the official repository at all. Set `false` for workflows whose side effects land on upstream, so no variable can enable them in a fork. | `false` | `true` |
+| `extra-enable-var` | Name of an additional repository variable that enables this one workflow on its own, e.g. `ENABLE_CI_PROPTEST_NIGHTLY`. Lets a fork run a single scheduled workflow — on its schedule, not just by hand — without `ENABLE_CI_WORKFLOWS` turning on all of CI. Empty means no workflow-specific variable. | `false` | `""` |
+
+### Outputs
+
+| Output | Description |
+| ------ | ----------- |
+| `enabled` | `'true'` if CI is enabled in this repository, `'false'` otherwise |
+
+### Per-workflow variables
+
+Workflows that name their own variable via `extra-enable-var`. Set one to `true` to enable
+just that workflow:
+
+| Workflow | Variable |
+| -------- | -------- |
+| `docker-image.yml` | `ENABLE_CI_DOCKER_IMAGE` |
+| `tests-proptest-nightly.yml` | `ENABLE_CI_PROPTEST_NIGHTLY` |

--- a/.github/workflows/__check-ci.yml
+++ b/.github/workflows/__check-ci.yml
@@ -11,6 +11,14 @@ on:
         required: false
         default: true
         type: boolean
+      extra-enable-var:
+        description: >-
+          Name of an additional repository variable that enables this one workflow
+          on its own. Lets a fork run a single scheduled workflow without 
+          ENABLE_CI_WORKFLOWS turning on all of CI.
+        required: false
+        default: ""
+        type: string
     outputs:
       enabled:
         description: "Returns 'true' if CI is enabled, 'false' otherwise"
@@ -35,12 +43,17 @@ jobs:
           echo "github.repository:   '${{ github.repository }}'"
           echo "github.event_name:   '${{ github.event_name }}'"
           echo "allow-fork-runs: '${{ inputs.allow-fork-runs }}'"
+          echo "extra-enable-var: '${{ inputs.extra-enable-var }}'"
+
+          # Value of the workflow-specific variable, when the caller named one.
+          EXTRA_ENABLED="${{ inputs.extra-enable-var != '' && vars[inputs.extra-enable-var] || '' }}"
+          echo "  -> value: '${EXTRA_ENABLED}'"
 
           IS_ENABLED="false"
           if [[ "${{ inputs.allow-fork-runs }}" == "false" && "${{ github.repository }}" != "stacks-network/stacks-core" ]]; then
             echo "Result: CI is DISABLED (run disabled on repos other than \`stacks-network/stacks-core\`)"
             IS_ENABLED="false"
-          elif [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          elif [[ "${{ vars.ENABLE_CI_WORKFLOWS }}" == "true" || "${EXTRA_ENABLED}" == "true" || "${{ github.repository }}" == "stacks-network/stacks-core" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Result: CI is ENABLED"
             IS_ENABLED="true"
           else
@@ -58,6 +71,7 @@ jobs:
           echo "| \`github.repository\` | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| \`github.event_name\` | \`${{ github.event_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| \`allow-fork-runs\` | \`${{ inputs.allow-fork-runs }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`${{ inputs.extra-enable-var || 'extra-enable-var' }}\` | \`${EXTRA_ENABLED}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "${IS_ENABLED}" == "true" ]]; then

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,6 +45,8 @@ jobs:
   check-ci:
     name: "Check: CI Enabled"
     uses: ./.github/workflows/__check-ci.yml
+    with:
+      extra-enable-var: ENABLE_CI_DOCKER_IMAGE
 
   # Build arch dependent binaries from source
   build-binaries:

--- a/.github/workflows/tests-proptest-nightly.yml
+++ b/.github/workflows/tests-proptest-nightly.yml
@@ -64,6 +64,8 @@ jobs:
   check-ci:
     name: "Check: CI Enabled"
     uses: ./.github/workflows/__check-ci.yml
+    with:
+      extra-enable-var: ENABLE_CI_PROPTEST_NIGHTLY
 
   proptests-nightly:
     name: "Tests: All Proptest Tests"


### PR DESCRIPTION
### Description

Add an `extra-enable-var` input parameter to `__check-ci.yml` to allow configuring an additional repository variable that can independently enable a workflow.

This is useful for forks that want to run a scheduled workflow on their own schedule without enabling all workflows through the `ENABLE_CI_WORKFLOWS` variable.

The input is currently configured for the scheduled workflows that are intended to run on forks: `docker-image.yml` and `tests-proptest-nightly.yml`.

### Applicable issues

- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist

- [ ] Test coverage for new or modified code paths
- [ ] For new Clarity features or consensus changes, add property tests (see
      [`docs/property-testing.md`](/docs/property-testing.md))
- [ ] Changelog fragment(s) or "no changelog" label added (see
      [`changelog.d/README.md`](changelog.d/README.md)). If this PR breaks
      anything for node operators or users, or requires them to manually do
      anything (such as adjust a setting), use the breaking category.
- [ ] Required documentation changes (e.g.,
      [`rpc/openapi.yaml`](/docs/rpc/openapi.yaml) for RPC endpoints,
      [`event-dispatcher.md`](/docs/event-dispatcher.md) for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
