### PR TITLE
Fix issue where new __check-ci.yml file requests unneeded contents: read permissions

### DIFF
--- a/.github/workflows/__check-ci.yml
+++ b/.github/workflows/__check-ci.yml
@@ -16,8 +16,7 @@ on:
         description: "Returns 'true' if CI is enabled, 'false' otherwise"
         value: ${{ jobs.check-ci.outputs.enabled }}
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check-ci:


### PR DESCRIPTION
### Description

After merging #7604 , the Slack PR nag started failing:

```
[Invalid workflow file: .github/workflows/slack-pr-nag.yml#L15](https://github.com/stacks-network/stacks-core/actions/runs/34588302546/workflow)
The workflow is not valid. .github/workflows/slack-pr-nag.yml (Line: 15, Col: 3): Error calling workflow 'stacks-network/stacks-core/.github/workflows/__check-ci.yml@4deaf81233f3015bd98aabee5621c08d6a84e5a6'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```

Removed unnecessary permissions check to fix this (and probably other workflows too).

### Applicable issues

N/A

### Additional info (benefits, drawbacks, caveats)

N/A

### Checklist

N/A