### PR TITLE
feat: initial implementation of signer-manager-core and module v1

### DIFF
--- a/contrib/core-contract-tests/Clarinet.toml
+++ b/contrib/core-contract-tests/Clarinet.toml
@@ -75,6 +75,21 @@ path = "./contracts/signer-manager.clar"
 clarity_version = 6
 epoch = 4.0
 
+[contracts.signer-manager-core]
+path = "./contracts/signer-manager-core.clar"
+clarity_version = 6
+epoch = 4.0
+
+[contracts.signer-manager-v1]
+path = "./contracts/signer-manager-v1.clar"
+clarity_version = 6
+epoch = 4.0
+
+[contracts.test-signer-manager-v2]
+path = "./contracts/test-signer-manager-v2.clar"
+clarity_version = 6
+epoch = 4.0
+
 [contracts.pox-5-auth-proxy]
 path = "./contracts/pox-5-auth-proxy.clar"
 clarity_version = 6

--- a/contrib/core-contract-tests/contracts/signer-manager-core.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager-core.clar
@@ -1,0 +1,649 @@
+;; Core of an upgradable signer manager for pox-5.
+;;
+;; This contract is the signer's identity with pox-5 (the principal passed to
+;; `register-signer`) and the vault for the sBTC it earns. It holds the stable
+;; per-staker state and enforces the invariants around it, but has no user
+;; facing policy of its own. All policy, including governance, lives in a
+;; separate module contract that stakers and operators call directly.
+
+(impl-trait 'ST000000000000000000002AMW42H.pox-5.signer-manager-trait)
+(use-trait signer-manager-trait 'ST000000000000000000002AMW42H.pox-5.signer-manager-trait)
+
+;; A pox-5 callback (validate-stake!) was invoked by a
+;; principal other than the pox-5 contract.
+(define-constant ERR_UNAUTHORIZED_CALLER (err u1001))
+;; A module function was invoked by a principal other than the current module.
+(define-constant ERR_UNAUTHORIZED_MODULE (err u1002))
+;; The calldata provided when staking was invalid
+(define-constant ERR_INVALID_CALLDATA (err u1003))
+;; The pox-addr provided isn't a valid sBTC withdrawal recipient
+(define-constant ERR_INVALID_POX_ADDR (err u1004))
+;; A staker tried to settle rewards, but they had none available
+(define-constant ERR_NO_CLAIMABLE_REWARDS (err u1005))
+;; The amount exceeds the staker's pending payout balance
+(define-constant ERR_INSUFFICIENT_PENDING (err u1006))
+;; A third party tried to pay out less than the staker's `min-claim`
+(define-constant ERR_BELOW_MIN_CLAIM (err u1007))
+;; An L1 payout would not clear `max-fee` plus the sBTC dust limit
+(define-constant ERR_BELOW_DUST_LIMIT (err u1008))
+;; Attempted to withdraw more fees than have accrued.
+(define-constant ERR_INSUFFICIENT_FEES (err u1009))
+;; The given withdrawal-request id is not tracked by this contract.
+(define-constant ERR_UNKNOWN_WITHDRAWAL_REQUEST (err u1010))
+;; The withdrawal request has not been rejected, so its full
+;; `amount + max-fee` is not reclaimable for the staker.
+(define-constant ERR_WITHDRAWAL_NOT_REJECTED (err u1011))
+;; The withdrawal request has not been accepted, so it cannot be
+;; settled via `settle-accepted-withdrawal`.
+(define-constant ERR_WITHDRAWAL_NOT_ACCEPTED (err u1012))
+;; No refunds available to sweep.
+(define-constant ERR_NO_REFUNDS (err u1013))
+;; `set-module` was given a principal that is not a deployed contract.
+(define-constant ERR_INVALID_MODULE (err u1014))
+
+;; sBTC rejects withdrawals of `DUST_LIMIT` sats or less (`sbtc-withdrawal`).
+(define-constant DUST_LIMIT u546)
+
+;; The module contract allowed to drive this contract's privileged functions.
+(define-data-var current-module principal tx-sender)
+
+;; How each staker wants rewards paid out. `min-claim` is the smallest payout
+;; a third party may trigger on the staker's behalf.
+(define-map payout-configs
+    principal
+    {
+        l1-withdrawal: (optional {
+            pox-addr: {
+                version: (buff 1),
+                hashbytes: (buff 32),
+            },
+            max-fee: uint,
+            min-claim: uint,
+        }),
+        sbtc-recipient: (optional principal),
+    }
+)
+
+;; sBTC settled for a staker but not yet paid out. Credited by
+;; `settle-staker-rewards` and by reclaiming a rejected L1 withdrawal,
+;; debited by `charge-fee` and `payout`.
+(define-map pending-payouts
+    principal
+    uint
+)
+(define-data-var total-pending uint u0)
+
+;; sBTC pulled in by `claim-rewards` that no staker has settled yet, per
+;; `(reward-cycle, bond-index)` so one cycle's settlements can never draw on
+;; another's. Every settlement debits its bucket by the staker's gross.
+(define-map reward-reserves
+    {
+        reward-cycle: uint,
+        bond-index: (optional uint),
+    }
+    uint
+)
+(define-data-var total-reserved uint u0)
+
+;; Fees charged by the module, withdrawable via `withdraw-fees`.
+(define-data-var earned-fees uint u0)
+
+;; Withdrawal request ID -> the staker whose payout created it.
+(define-map withdrawal-requests
+    uint
+    principal
+)
+
+;; Sum of `amount + max-fee` over every live entry in `withdrawal-requests`.
+;; That sBTC has either left for the sBTC withdrawal system (pending) or come
+;; back (rejected) without being credited yet, so it stays owed to stakers.
+(define-data-var withdrawal-liability uint u0)
+
+;; Callback function from a `stake` transaction.
+;;
+;; If `signer-calldata` is provided, it must decode to a payout config, which
+;; is saved for the staker. Without calldata the staker's existing config (if
+;; any) is left untouched; use the module's `clear-payout-config` to remove it.
+(define-public (validate-stake!
+        (staker principal)
+        ;; #[allow(unused_binding)]
+        (first-index uint)
+        ;; #[allow(unused_binding)]
+        (num-indexes uint)
+        ;; #[allow(unused_binding)]
+        (amount-ustx uint)
+        ;; #[allow(unused_binding)]
+        (amount-sats uint)
+        ;; #[allow(unused_binding)]
+        (is-bond bool)
+        (signer-calldata (optional (buff 500)))
+    )
+    (begin
+        (try! (authorize-pox-5))
+        (match signer-calldata
+            calldata (let ((config (try! (parse-payout-config calldata))))
+                (try! (check-payout-config config))
+                (ok (map-set payout-configs staker config))
+            )
+            (ok true)
+        )
+    )
+)
+
+;;; Module functions
+
+;; Store a payout config for `staker`.
+(define-public (set-payout-config
+        (staker principal)
+        (config {
+            l1-withdrawal: (optional {
+                pox-addr: {
+                    version: (buff 1),
+                    hashbytes: (buff 32),
+                },
+                max-fee: uint,
+                min-claim: uint,
+            }),
+            sbtc-recipient: (optional principal),
+        })
+    )
+    (begin
+        (try! (authorize-module))
+        (try! (check-payout-config config))
+        (print {
+            topic: "set-payout-config",
+            staker: staker,
+            config: config,
+        })
+        (ok (map-set payout-configs staker config))
+    )
+)
+
+;; Remove `staker`'s payout config so rewards are paid to them as sBTC.
+(define-public (clear-payout-config (staker principal))
+    (begin
+        (try! (authorize-module))
+        (print {
+            topic: "clear-payout-config",
+            staker: staker,
+        })
+        (ok (map-delete payout-configs staker))
+    )
+)
+
+;; Pull this signer's rewards for `reward-cycle` out of pox-5 and reserve
+;; them for its stakers.
+(define-public (claim-rewards
+        (bond-periods (list 6 uint))
+        (reward-cycle uint)
+    )
+    (begin
+        (try! (authorize-module))
+        (let ((result (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 claim-rewards
+                bond-periods reward-cycle
+            ))))
+            (reserve-rewards reward-cycle none
+                (get earned (get stx-rewards result))
+            )
+            (fold reserve-bond-rewards (get bond-rewards result) reward-cycle)
+            (ok result)
+        )
+    )
+)
+
+;; Settle `staker`'s rewards for one `(reward-cycle, bond-index)` with pox-5
+;; and credit the gross amount to their pending payout. Returns the gross.
+(define-public (settle-staker-rewards
+        (staker principal)
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (begin
+        (try! (authorize-module))
+        (let (
+                (key {
+                    reward-cycle: reward-cycle,
+                    bond-index: bond-index,
+                })
+                ;; `unwrap-panic` is ok here: there is no `err` type returnable
+                (gross (get earned
+                    (unwrap-panic (contract-call? 'ST000000000000000000002AMW42H.pox-5
+                        claim-staker-rewards-for-signer staker reward-cycle
+                        bond-index
+                    ))
+                ))
+                (reserve (default-to u0 (map-get? reward-reserves key)))
+            )
+            (asserts! (> gross u0) ERR_NO_CLAIMABLE_REWARDS)
+            (asserts! (>= reserve gross) ERR_NO_CLAIMABLE_REWARDS)
+            (map-set reward-reserves key (- reserve gross))
+            (var-set total-reserved (- (var-get total-reserved) gross))
+            (credit-pending staker gross)
+            (print {
+                topic: "settle-staker-rewards",
+                staker: staker,
+                reward-cycle: reward-cycle,
+                bond-index: bond-index,
+                amount-sats: gross,
+            })
+            (ok gross)
+        )
+    )
+)
+
+;; Move `amount` of `staker`'s pending payout into the signer's earned fees.
+(define-public (charge-fee
+        (staker principal)
+        (amount uint)
+    )
+    (begin
+        (try! (authorize-module))
+        (try! (debit-pending staker amount))
+        (var-set earned-fees (+ (var-get earned-fees) amount))
+        (print {
+            topic: "charge-fee",
+            staker: staker,
+            amount-sats: amount,
+        })
+        (ok amount)
+    )
+)
+
+;; Pay `amount` of `staker`'s pending payout to their configured destination:
+;; an sBTC withdrawal to their L1 address, or an sBTC transfer to their
+;; `sbtc-recipient` (or themselves). Anyone but the staker must clear their
+;; `min-claim`. Returns the withdrawal request id when routed to L1.
+(define-public (payout
+        (staker principal)
+        (amount uint)
+    )
+    (let ((config (default-to {
+            l1-withdrawal: none,
+            sbtc-recipient: none,
+        }
+            (map-get? payout-configs staker)
+        )))
+        (try! (authorize-module))
+        (try! (debit-pending staker amount))
+        (let ((withdrawal-request (match (get l1-withdrawal config)
+                l1 (some (try! (initiate-withdrawal staker amount l1)))
+                (begin
+                    (try! (transfer-sbtc amount
+                        (default-to staker (get sbtc-recipient config))
+                    ))
+                    none
+                )
+            )))
+            (print {
+                topic: "payout",
+                staker: staker,
+                amount-sats: amount,
+                withdrawal-request: withdrawal-request,
+            })
+            (ok withdrawal-request)
+        )
+    )
+)
+
+;; Credit a REJECTED L1 withdrawal's full `amount + max-fee` back to the
+;; staker's pending payout, so their next `payout` retries it.
+(define-public (reclaim-failed-withdrawal (request-id uint))
+    (begin
+        (try! (authorize-module))
+        (let (
+                (staker (unwrap! (map-get? withdrawal-requests request-id)
+                    ERR_UNKNOWN_WITHDRAWAL_REQUEST
+                ))
+                (request (unwrap!
+                    (contract-call?
+                        'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
+                        get-withdrawal-request request-id
+                    )
+                    ERR_UNKNOWN_WITHDRAWAL_REQUEST
+                ))
+                (refund (+ (get amount request) (get max-fee request)))
+            )
+            ;; `status` is `none` while pending and `(some true)` once accepted;
+            ;; only `(some false)` (rejected) unlocks the full amount back here.
+            (asserts! (is-eq (get status request) (some false))
+                ERR_WITHDRAWAL_NOT_REJECTED
+            )
+            (map-delete withdrawal-requests request-id)
+            (var-set withdrawal-liability
+                (- (var-get withdrawal-liability) refund)
+            )
+            (credit-pending staker refund)
+            (print {
+                topic: "reclaim-failed-withdrawal",
+                request-id: request-id,
+                staker: staker,
+                amount-sats: refund,
+            })
+            (ok refund)
+        )
+    )
+)
+
+;; Retire an ACCEPTED L1 withdrawal. The staker was paid on L1 and only the
+;; unused fee budget came back as dust, which this makes sweepable.
+(define-public (settle-accepted-withdrawal (request-id uint))
+    (begin
+        (try! (authorize-module))
+        (let (
+                (staker (unwrap! (map-get? withdrawal-requests request-id)
+                    ERR_UNKNOWN_WITHDRAWAL_REQUEST
+                ))
+                (request (unwrap!
+                    (contract-call?
+                        'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
+                        get-withdrawal-request request-id
+                    )
+                    ERR_UNKNOWN_WITHDRAWAL_REQUEST
+                ))
+                (liability (+ (get amount request) (get max-fee request)))
+            )
+            (asserts! (is-eq (get status request) (some true))
+                ERR_WITHDRAWAL_NOT_ACCEPTED
+            )
+            (map-delete withdrawal-requests request-id)
+            (var-set withdrawal-liability
+                (- (var-get withdrawal-liability) liability)
+            )
+            (print {
+                topic: "settle-accepted-withdrawal",
+                request-id: request-id,
+                staker: staker,
+                liability-released: liability,
+            })
+            (ok true)
+        )
+    )
+)
+
+;; Withdraw earned fees.
+(define-public (withdraw-fees
+        (amount uint)
+        (recipient principal)
+    )
+    (let ((fees (var-get earned-fees)))
+        (try! (authorize-module))
+        (asserts! (<= amount fees) ERR_INSUFFICIENT_FEES)
+        (var-set earned-fees (- fees amount))
+        (try! (transfer-sbtc amount recipient))
+        (ok amount)
+    )
+)
+
+;; Sweep sBTC that is owed to nobody: the balance net of earned fees,
+;; unsettled reserves, pending payouts and live withdrawal liability. In
+;; practice this is the unused fee budget minted back by accepted L1
+;; withdrawals.
+(define-public (sweep-fee-refunds (recipient principal))
+    (let (
+            (balance (unwrap-panic (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token
+                get-balance current-contract
+            )))
+            (reserved (get-reserved-balance))
+            (sweepable (if (>= balance reserved)
+                (- balance reserved)
+                u0
+            ))
+        )
+        (try! (authorize-module))
+        (asserts! (> sweepable u0) ERR_NO_REFUNDS)
+        (print {
+            topic: "sweep-fee-refunds",
+            amount-sats: sweepable,
+            recipient: recipient,
+        })
+        (try! (transfer-sbtc sweepable recipient))
+        (ok sweepable)
+    )
+)
+
+;; Hand control of this contract to a new module. The module must be a
+;; deployed contract: nothing but the current module can ever call this, so
+;; a typo here would strand the vault.
+(define-public (set-module (module principal))
+    (begin
+        (try! (authorize-module))
+        (asserts! (is-ok (contract-hash? module)) ERR_INVALID_MODULE)
+        (print {
+            topic: "set-module",
+            old-module: (var-get current-module),
+            new-module: module,
+        })
+        (var-set current-module module)
+        (ok module)
+    )
+)
+
+;; Register this contract with a specific signer key. The signer key grant
+;; must not have been used yet.
+(define-public (register-self
+        (signer-manager <signer-manager-trait>)
+        (signer-key (buff 33))
+        (auth-id uint)
+        (signer-sig (buff 65))
+    )
+    (begin
+        (try! (authorize-module))
+        (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 grant-signer-key
+            signer-key current-contract auth-id signer-sig
+        ))
+        (contract-call? 'ST000000000000000000002AMW42H.pox-5 register-signer
+            signer-manager signer-key
+        )
+    )
+)
+
+(define-private (authorize-module)
+    (ok (asserts! (is-eq contract-caller (var-get current-module))
+        ERR_UNAUTHORIZED_MODULE
+    ))
+)
+
+;; Ensure that the immediate caller is the pox-5 contract. The trait callbacks
+;; (validate-stake!) write per-staker state keyed by the
+;; `staker` argument; they must only ever be driven by pox-5, never invoked
+;; directly by an external principal.
+(define-private (authorize-pox-5)
+    (ok (asserts! (is-eq contract-caller 'ST000000000000000000002AMW42H.pox-5)
+        ERR_UNAUTHORIZED_CALLER
+    ))
+)
+
+(define-private (reserve-rewards
+        (reward-cycle uint)
+        (bond-index (optional uint))
+        (amount uint)
+    )
+    (let ((key {
+            reward-cycle: reward-cycle,
+            bond-index: bond-index,
+        }))
+        (map-set reward-reserves key
+            (+ (default-to u0 (map-get? reward-reserves key)) amount)
+        )
+        (var-set total-reserved (+ (var-get total-reserved) amount))
+    )
+)
+
+(define-private (reserve-bond-rewards
+        (bond-info {
+            bond-index: uint,
+            earned: uint,
+            rewards-per-token: uint,
+        })
+        (reward-cycle uint)
+    )
+    (begin
+        (reserve-rewards reward-cycle (some (get bond-index bond-info))
+            (get earned bond-info)
+        )
+        reward-cycle
+    )
+)
+
+(define-private (credit-pending
+        (staker principal)
+        (amount uint)
+    )
+    (begin
+        (map-set pending-payouts staker (+ (get-pending-payout staker) amount))
+        (var-set total-pending (+ (var-get total-pending) amount))
+    )
+)
+
+(define-private (debit-pending
+        (staker principal)
+        (amount uint)
+    )
+    (let ((pending (get-pending-payout staker)))
+        (asserts! (and (> amount u0) (<= amount pending))
+            ERR_INSUFFICIENT_PENDING
+        )
+        (map-set pending-payouts staker (- pending amount))
+        (ok (var-set total-pending (- (var-get total-pending) amount)))
+    )
+)
+
+;; Withdraw `amount - max-fee` to the staker's L1 address with this contract
+;; as the requester, and record the request so its outcome can be settled.
+(define-private (initiate-withdrawal
+        (staker principal)
+        (amount uint)
+        (l1 {
+            pox-addr: {
+                version: (buff 1),
+                hashbytes: (buff 32),
+            },
+            max-fee: uint,
+            min-claim: uint,
+        })
+    )
+    (let ((max-fee (get max-fee l1)))
+        (asserts! (> amount (+ max-fee DUST_LIMIT)) ERR_BELOW_DUST_LIMIT)
+        (asserts! (or (is-eq tx-sender staker) (>= amount (get min-claim l1)))
+            ERR_BELOW_MIN_CLAIM
+        )
+        (let ((request-id (try! (as-contract?
+                ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token
+                    "sbtc-token" amount
+                ))
+                (try! (contract-call?
+                    'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-withdrawal
+                    initiate-withdrawal-request (- amount max-fee)
+                    (get pox-addr l1) max-fee
+                ))
+            ))))
+            (map-set withdrawal-requests request-id staker)
+            (var-set withdrawal-liability
+                (+ (var-get withdrawal-liability) amount)
+            )
+            (ok request-id)
+        )
+    )
+)
+
+(define-private (transfer-sbtc
+        (amount uint)
+        (recipient principal)
+    )
+    (as-contract?
+        ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token
+            "sbtc-token" amount
+        ))
+        (try! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token
+            transfer amount tx-sender recipient none
+        ))
+    )
+)
+
+;; Decode a payout config from calldata.
+(define-read-only (parse-payout-config (calldata (buff 500)))
+    (ok (unwrap!
+        (from-consensus-buff? {
+            l1-withdrawal: (optional {
+                pox-addr: {
+                    version: (buff 1),
+                    hashbytes: (buff 32),
+                },
+                max-fee: uint,
+                min-claim: uint,
+            }),
+            sbtc-recipient: (optional principal),
+        }
+            calldata
+        )
+        ERR_INVALID_CALLDATA
+    ))
+)
+
+;; Delegate to the sBTC withdrawal contract so the accepted recipient
+;; shapes can't drift from what `initiate-withdrawal-request` allows.
+(define-read-only (check-payout-config (config {
+    l1-withdrawal: (optional {
+        pox-addr: {
+            version: (buff 1),
+            hashbytes: (buff 32),
+        },
+        max-fee: uint,
+        min-claim: uint,
+    }),
+    sbtc-recipient: (optional principal),
+}))
+    (match (get l1-withdrawal config)
+        l1 (ok (asserts!
+            (is-ok (contract-call?
+                'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-withdrawal
+                validate-recipient (get pox-addr l1)
+            ))
+            ERR_INVALID_POX_ADDR
+        ))
+        (ok true)
+    )
+)
+
+(define-read-only (get-current-module)
+    (var-get current-module)
+)
+
+(define-read-only (get-payout-config (staker principal))
+    (map-get? payout-configs staker)
+)
+
+(define-read-only (get-pending-payout (staker principal))
+    (default-to u0 (map-get? pending-payouts staker))
+)
+
+(define-read-only (get-reward-reserve
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (default-to u0
+        (map-get? reward-reserves {
+            reward-cycle: reward-cycle,
+            bond-index: bond-index,
+        })
+    )
+)
+
+(define-read-only (get-earned-fees)
+    (var-get earned-fees)
+)
+
+(define-read-only (get-withdrawal-liability)
+    (var-get withdrawal-liability)
+)
+
+(define-read-only (get-withdrawal-request-staker (request-id uint))
+    (map-get? withdrawal-requests request-id)
+)
+
+;; sBTC in this contract that is spoken for.
+(define-read-only (get-reserved-balance)
+    (+ (var-get earned-fees) (var-get total-reserved) (var-get total-pending)
+        (var-get withdrawal-liability)
+    )
+)

--- a/contrib/core-contract-tests/contracts/signer-manager-v1.clar
+++ b/contrib/core-contract-tests/contracts/signer-manager-v1.clar
@@ -1,0 +1,311 @@
+;; Signer manager module, v1.
+;;
+;; This is the contract stakers and operators interact with. It holds the
+;; signer's policies and governance and drives `signer-manager-core`, which is
+;; the signer's identity with pox-5 and the vault for its sBTC.
+;;
+;; This module can only interact with core while this contract is set as the
+;; current module. Upgrading the module is handled by calling `set-module` on core from
+;; this contract.
+
+(use-trait signer-manager-trait 'ST000000000000000000002AMW42H.pox-5.signer-manager-trait)
+
+;; Staker functions must be called directly by the staker.
+(define-constant ERR_UNAUTHORIZED_CALLER (err u2001))
+;; Attempted to call an admin function
+(define-constant ERR_UNAUTHORIZED_ADMIN (err u2002))
+;; The fees provided when updating fees is invalid
+(define-constant ERR_INVALID_FEES_BIPS (err u2003))
+;; The given withdrawal-request id is not tracked by core.
+(define-constant ERR_UNKNOWN_WITHDRAWAL_REQUEST (err u2004))
+
+(define-constant MAX_BIPS u10000)
+
+(define-map admins
+    principal
+    bool
+)
+(map-set admins tx-sender true)
+
+;; Fees taken, in basis points, from rewards. The rate is snapshotted per
+;; `(reward-cycle, bond-index)` when `claim-rewards` pulls that cycle in, so
+;; later fee changes never touch rewards already pulled from pox-5.
+(define-data-var fees-bips uint u0)
+(define-map fee-bips-for-cycle
+    {
+        reward-cycle: uint,
+        bond-index: (optional uint),
+    }
+    uint
+)
+
+;;; Rewards
+
+;; Pull this signer's rewards for `reward-cycle` into core. Callable by
+;; anyone; must happen before stakers can settle that cycle.
+(define-public (claim-rewards
+        (bond-periods (list 6 uint))
+        (reward-cycle uint)
+    )
+    (let ((result (try! (contract-call? .signer-manager-core claim-rewards bond-periods
+            reward-cycle
+        ))))
+        (map-insert fee-bips-for-cycle {
+            reward-cycle: reward-cycle,
+            bond-index: none,
+        }
+            (var-get fees-bips)
+        )
+        (fold snapshot-bond-fee (get bond-rewards result) reward-cycle)
+        (ok result)
+    )
+)
+
+;; Settle a staker's rewards for one `(reward-cycle, bond-index)` into their
+;; pending payout, charging the fee snapshotted for that cycle. Callable by
+;; anyone. Returns `{ gross, fee }`.
+(define-public (settle-staker-rewards
+        (staker principal)
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (let (
+            (gross (try! (contract-call? .signer-manager-core settle-staker-rewards staker
+                reward-cycle bond-index
+            )))
+            (fee (/ (* gross (get-fee-bips-for-cycle reward-cycle bond-index))
+                MAX_BIPS
+            ))
+        )
+        (if (> fee u0)
+            (try! (contract-call? .signer-manager-core charge-fee staker fee))
+            u0
+        )
+        (ok {
+            gross: gross,
+            fee: fee,
+        })
+    )
+)
+
+;; Pay out a staker's whole pending balance to their configured destination.
+;; Callable by anyone, but third parties must clear the staker's `min-claim`.
+;; Returns `{ amount, withdrawal-request }`.
+(define-public (payout (staker principal))
+    (let ((amount (contract-call? .signer-manager-core get-pending-payout staker)))
+        (ok {
+            amount: amount,
+            withdrawal-request: (try! (contract-call? .signer-manager-core payout staker amount)),
+        })
+    )
+)
+
+;; Settle one `(reward-cycle, bond-index)` and pay out in a single call.
+;; Returns `{ earned, withdrawal-request }` where `earned` is the whole
+;; pending balance paid, including anything settled earlier.
+(define-public (claim-staker-rewards
+        (staker principal)
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (begin
+        (try! (settle-staker-rewards staker reward-cycle bond-index))
+        (let ((paid (try! (payout staker))))
+            (ok {
+                earned: (get amount paid),
+                withdrawal-request: (get withdrawal-request paid),
+            })
+        )
+    )
+)
+
+;;; L1 withdrawal outcomes
+
+;; Credit a REJECTED L1 withdrawal back to the staker's pending payout.
+(define-public (reclaim-failed-withdrawal (request-id uint))
+    (contract-call? .signer-manager-core reclaim-failed-withdrawal request-id)
+)
+
+;; Reclaim a REJECTED L1 withdrawal and immediately pay out again using the
+;; staker's current payout config.
+(define-public (retry-failed-withdrawal (request-id uint))
+    (let ((staker (unwrap!
+            (contract-call? .signer-manager-core get-withdrawal-request-staker
+                request-id
+            )
+            ERR_UNKNOWN_WITHDRAWAL_REQUEST
+        )))
+        (try! (reclaim-failed-withdrawal request-id))
+        (payout staker)
+    )
+)
+
+;; Retire an ACCEPTED L1 withdrawal so its unused fee budget is sweepable.
+(define-public (settle-accepted-withdrawal (request-id uint))
+    (contract-call? .signer-manager-core settle-accepted-withdrawal request-id)
+)
+
+;;; Staker functions
+
+;; Set your own payout config. With `l1-withdrawal` set, rewards are withdrawn
+;; to BTC at `pox-addr` with an sBTC withdrawal fee budget of `max-fee`, and
+;; a minimum withdrawal amount of `min-claim`.
+;; Otherwise they are paid as sBTC to `sbtc-recipient`, or to you if none.
+(define-public (set-payout-config
+        (l1-withdrawal (optional {
+            pox-addr: {
+                version: (buff 1),
+                hashbytes: (buff 32),
+            },
+            max-fee: uint,
+            min-claim: uint,
+        }))
+        (sbtc-recipient (optional principal))
+    )
+    (begin
+        (try! (authorize-staker))
+        (contract-call? .signer-manager-core set-payout-config tx-sender {
+            l1-withdrawal: l1-withdrawal,
+            sbtc-recipient: sbtc-recipient,
+        })
+    )
+)
+
+;; Remove your payout config so rewards are paid to you as sBTC.
+(define-public (clear-payout-config)
+    (begin
+        (try! (authorize-staker))
+        (contract-call? .signer-manager-core clear-payout-config tx-sender)
+    )
+)
+
+;;; Admin functions
+
+;; Update the allowed admin principal
+(define-public (update-admin
+        (admin principal)
+        (enabled bool)
+    )
+    (begin
+        (try! (authorize-admin))
+        (print {
+            topic: "update-admin",
+            admin: admin,
+            enabled: enabled,
+        })
+        (map-set admins admin enabled)
+        (ok admin)
+    )
+)
+
+;; Update the fees taken from rewards
+(define-public (update-fees (new-fees uint))
+    (begin
+        (try! (authorize-admin))
+        (asserts! (< new-fees MAX_BIPS) ERR_INVALID_FEES_BIPS)
+        (print {
+            topic: "update-fees",
+            old-fees: (var-get fees-bips),
+            new-fees: new-fees,
+        })
+        (var-set fees-bips new-fees)
+        (ok true)
+    )
+)
+
+;; Withdraw accrued fees from staker rewards.
+(define-public (withdraw-fees
+        (amount uint)
+        (recipient principal)
+    )
+    (begin
+        (try! (authorize-admin))
+        (contract-call? .signer-manager-core withdraw-fees amount recipient)
+    )
+)
+
+;; Sweep sBTC owed to nobody (unused L1 fee budgets) to a recipient.
+(define-public (sweep-fee-refunds (recipient principal))
+    (begin
+        (try! (authorize-admin))
+        (contract-call? .signer-manager-core sweep-fee-refunds recipient)
+    )
+)
+
+;; Upgrade: hand control of core to a new module. This contract stops
+;; working once core no longer recognizes it.
+(define-public (set-module (module principal))
+    (begin
+        (try! (authorize-admin))
+        (contract-call? .signer-manager-core set-module module)
+    )
+)
+
+;; Register core with pox-5 under a specific signer key. The signer key grant
+;; must not have been used yet.
+(define-public (register-self
+        (signer-manager <signer-manager-trait>)
+        (signer-key (buff 33))
+        (auth-id uint)
+        (signer-sig (buff 65))
+    )
+    (begin
+        (try! (authorize-admin))
+        (contract-call? .signer-manager-core register-self signer-manager
+            signer-key auth-id signer-sig
+        )
+    )
+)
+
+(define-private (authorize-staker)
+    (ok (asserts! (is-eq contract-caller tx-sender) ERR_UNAUTHORIZED_CALLER))
+)
+
+;; Admins are checked on `contract-caller` so a contract (multisig, DAO) can
+;; be an admin, while a non-admin contract can never act for an admin wallet.
+(define-private (authorize-admin)
+    (ok (asserts! (is-admin contract-caller) ERR_UNAUTHORIZED_ADMIN))
+)
+
+(define-private (snapshot-bond-fee
+        (bond-info {
+            bond-index: uint,
+            earned: uint,
+            rewards-per-token: uint,
+        })
+        (reward-cycle uint)
+    )
+    (begin
+        (map-insert fee-bips-for-cycle {
+            reward-cycle: reward-cycle,
+            bond-index: (some (get bond-index bond-info)),
+        }
+            (var-get fees-bips)
+        )
+        reward-cycle
+    )
+)
+
+(define-read-only (get-fees-bips)
+    (var-get fees-bips)
+)
+
+(define-read-only (get-fee-bips-for-cycle
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (default-to u0
+        (map-get? fee-bips-for-cycle {
+            reward-cycle: reward-cycle,
+            bond-index: bond-index,
+        })
+    )
+)
+
+(define-read-only (is-admin (caller principal))
+    (default-to false (map-get? admins caller))
+)
+
+(define-read-only (get-payout-config (staker principal))
+    (contract-call? .signer-manager-core get-payout-config staker)
+)

--- a/contrib/core-contract-tests/contracts/test-signer-manager-v2.clar
+++ b/contrib/core-contract-tests/contracts/test-signer-manager-v2.clar
@@ -1,0 +1,66 @@
+;; A minimal successor to `signer-manager-v1`, used by the upgrade tests.
+
+(define-constant MAX_BIPS u10000)
+(define-constant FEE_BIPS u1000)
+
+(define-map claimed-cycles
+    uint
+    bool
+)
+
+(define-public (claim-rewards
+        (bond-periods (list 6 uint))
+        (reward-cycle uint)
+    )
+    (begin
+        (map-set claimed-cycles reward-cycle true)
+        (contract-call? .signer-manager-core claim-rewards bond-periods
+            reward-cycle
+        )
+    )
+)
+
+(define-public (settle-staker-rewards
+        (staker principal)
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (let (
+            (gross (try! (contract-call? .signer-manager-core settle-staker-rewards staker
+                reward-cycle bond-index
+            )))
+            (fee (/ (* gross (fee-bips-for-cycle reward-cycle bond-index)) MAX_BIPS))
+        )
+        (if (> fee u0)
+            (try! (contract-call? .signer-manager-core charge-fee staker fee))
+            u0
+        )
+        (ok {
+            gross: gross,
+            fee: fee,
+        })
+    )
+)
+
+(define-public (payout (staker principal))
+    (contract-call? .signer-manager-core payout staker
+        (contract-call? .signer-manager-core get-pending-payout staker)
+    )
+)
+
+(define-public (reclaim-failed-withdrawal (request-id uint))
+    (contract-call? .signer-manager-core reclaim-failed-withdrawal request-id)
+)
+
+;; Cycles v1 pulled in keep v1's snapshotted fee.
+(define-read-only (fee-bips-for-cycle
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (if (default-to false (map-get? claimed-cycles reward-cycle))
+        FEE_BIPS
+        (contract-call? .signer-manager-v1 get-fee-bips-for-cycle reward-cycle
+            bond-index
+        )
+    )
+)

--- a/contrib/core-contract-tests/deployments/default.simnet-plan.yaml
+++ b/contrib/core-contract-tests/deployments/default.simnet-plan.yaml
@@ -158,8 +158,23 @@ plan:
       path: contracts/signer-manager.clar
       clarity-version: 6
     - transaction-type: emulated-contract-publish
+      contract-name: signer-manager-core
+      emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      path: contracts/signer-manager-core.clar
+      clarity-version: 6
+    - transaction-type: emulated-contract-publish
+      contract-name: signer-manager-v1
+      emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      path: contracts/signer-manager-v1.clar
+      clarity-version: 6
+    - transaction-type: emulated-contract-publish
       contract-name: test-pox-5-signer
       emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
       path: contracts/test-pox-5-signer.clar
+      clarity-version: 6
+    - transaction-type: emulated-contract-publish
+      contract-name: test-signer-manager-v2
+      emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      path: contracts/test-signer-manager-v2.clar
       clarity-version: 6
     epoch: '4.0'

--- a/contrib/core-contract-tests/tests/clarigen-types.ts
+++ b/contrib/core-contract-tests/tests/clarigen-types.ts
@@ -10995,6 +10995,1584 @@ export const contracts = {
     clarity_version: 'Clarity6',
     contractName: 'signer-manager',
   },
+  signerManagerCore: {
+    functions: {
+      authorizeModule: {
+        name: 'authorize-module',
+        access: 'private',
+        args: [],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<[], Response<boolean, bigint>>,
+      authorizePox5: {
+        name: 'authorize-pox-5',
+        access: 'private',
+        args: [],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<[], Response<boolean, bigint>>,
+      creditPending: {
+        name: 'credit-pending',
+        access: 'private',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'amount', type: 'uint128' },
+        ],
+        outputs: { type: 'bool' },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+        ],
+        boolean
+      >,
+      debitPending: {
+        name: 'debit-pending',
+        access: 'private',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'amount', type: 'uint128' },
+        ],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+        ],
+        Response<boolean, bigint>
+      >,
+      initiateWithdrawal: {
+        name: 'initiate-withdrawal',
+        access: 'private',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'amount', type: 'uint128' },
+          {
+            name: 'l1',
+            type: {
+              tuple: [
+                { name: 'max-fee', type: 'uint128' },
+                { name: 'min-claim', type: 'uint128' },
+                {
+                  name: 'pox-addr',
+                  type: {
+                    tuple: [
+                      { name: 'hashbytes', type: { buffer: { length: 32 } } },
+                      { name: 'version', type: { buffer: { length: 1 } } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+          l1: TypedAbiArg<
+            {
+              maxFee: number | bigint;
+              minClaim: number | bigint;
+              poxAddr: {
+                hashbytes: Uint8Array;
+                version: Uint8Array;
+              };
+            },
+            'l1'
+          >,
+        ],
+        Response<bigint, bigint>
+      >,
+      reserveBondRewards: {
+        name: 'reserve-bond-rewards',
+        access: 'private',
+        args: [
+          {
+            name: 'bond-info',
+            type: {
+              tuple: [
+                { name: 'bond-index', type: 'uint128' },
+                { name: 'earned', type: 'uint128' },
+                { name: 'rewards-per-token', type: 'uint128' },
+              ],
+            },
+          },
+          { name: 'reward-cycle', type: 'uint128' },
+        ],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<
+        [
+          bondInfo: TypedAbiArg<
+            {
+              bondIndex: number | bigint;
+              earned: number | bigint;
+              rewardsPerToken: number | bigint;
+            },
+            'bondInfo'
+          >,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+        ],
+        bigint
+      >,
+      reserveRewards: {
+        name: 'reserve-rewards',
+        access: 'private',
+        args: [
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+          { name: 'amount', type: 'uint128' },
+        ],
+        outputs: { type: 'bool' },
+      } as TypedAbiFunction<
+        [
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+        ],
+        boolean
+      >,
+      transferSbtc: {
+        name: 'transfer-sbtc',
+        access: 'private',
+        args: [
+          { name: 'amount', type: 'uint128' },
+          { name: 'recipient', type: 'principal' },
+        ],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+          recipient: TypedAbiArg<string, 'recipient'>,
+        ],
+        Response<boolean, bigint>
+      >,
+      chargeFee: {
+        name: 'charge-fee',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'amount', type: 'uint128' },
+        ],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+        ],
+        Response<bigint, bigint>
+      >,
+      claimRewards: {
+        name: 'claim-rewards',
+        access: 'public',
+        args: [
+          {
+            name: 'bond-periods',
+            type: { list: { type: 'uint128', length: 6 } },
+          },
+          { name: 'reward-cycle', type: 'uint128' },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  {
+                    name: 'bond-rewards',
+                    type: {
+                      list: {
+                        type: {
+                          tuple: [
+                            { name: 'bond-index', type: 'uint128' },
+                            { name: 'earned', type: 'uint128' },
+                            { name: 'rewards-per-token', type: 'uint128' },
+                          ],
+                        },
+                        length: 6,
+                      },
+                    },
+                  },
+                  { name: 'bond-totals', type: 'uint128' },
+                  {
+                    name: 'stx-rewards',
+                    type: {
+                      tuple: [
+                        { name: 'earned', type: 'uint128' },
+                        { name: 'rewards-per-token', type: 'uint128' },
+                      ],
+                    },
+                  },
+                  { name: 'total-rewards', type: 'uint128' },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          bondPeriods: TypedAbiArg<number | bigint[], 'bondPeriods'>,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+        ],
+        Response<
+          {
+            bondRewards: {
+              bondIndex: bigint;
+              earned: bigint;
+              rewardsPerToken: bigint;
+            }[];
+            bondTotals: bigint;
+            stxRewards: {
+              earned: bigint;
+              rewardsPerToken: bigint;
+            };
+            totalRewards: bigint;
+          },
+          bigint
+        >
+      >,
+      clearPayoutConfig: {
+        name: 'clear-payout-config',
+        access: 'public',
+        args: [{ name: 'staker', type: 'principal' }],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [staker: TypedAbiArg<string, 'staker'>],
+        Response<boolean, bigint>
+      >,
+      payout: {
+        name: 'payout',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'amount', type: 'uint128' },
+        ],
+        outputs: {
+          type: { response: { ok: { optional: 'uint128' }, error: 'uint128' } },
+        },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+        ],
+        Response<bigint | null, bigint>
+      >,
+      reclaimFailedWithdrawal: {
+        name: 'reclaim-failed-withdrawal',
+        access: 'public',
+        args: [{ name: 'request-id', type: 'uint128' }],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [requestId: TypedAbiArg<number | bigint, 'requestId'>],
+        Response<bigint, bigint>
+      >,
+      registerSelf: {
+        name: 'register-self',
+        access: 'public',
+        args: [
+          { name: 'signer-manager', type: 'trait_reference' },
+          { name: 'signer-key', type: { buffer: { length: 33 } } },
+          { name: 'auth-id', type: 'uint128' },
+          { name: 'signer-sig', type: { buffer: { length: 65 } } },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'signer', type: 'principal' },
+                  { name: 'signer-key', type: { buffer: { length: 33 } } },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          signerManager: TypedAbiArg<string, 'signerManager'>,
+          signerKey: TypedAbiArg<Uint8Array, 'signerKey'>,
+          authId: TypedAbiArg<number | bigint, 'authId'>,
+          signerSig: TypedAbiArg<Uint8Array, 'signerSig'>,
+        ],
+        Response<
+          {
+            signer: string;
+            signerKey: Uint8Array;
+          },
+          bigint
+        >
+      >,
+      setModule: {
+        name: 'set-module',
+        access: 'public',
+        args: [{ name: 'module', type: 'principal' }],
+        outputs: { type: { response: { ok: 'principal', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [module: TypedAbiArg<string, 'module'>],
+        Response<string, bigint>
+      >,
+      setPayoutConfig: {
+        name: 'set-payout-config',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          {
+            name: 'config',
+            type: {
+              tuple: [
+                {
+                  name: 'l1-withdrawal',
+                  type: {
+                    optional: {
+                      tuple: [
+                        { name: 'max-fee', type: 'uint128' },
+                        { name: 'min-claim', type: 'uint128' },
+                        {
+                          name: 'pox-addr',
+                          type: {
+                            tuple: [
+                              {
+                                name: 'hashbytes',
+                                type: { buffer: { length: 32 } },
+                              },
+                              {
+                                name: 'version',
+                                type: { buffer: { length: 1 } },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                { name: 'sbtc-recipient', type: { optional: 'principal' } },
+              ],
+            },
+          },
+        ],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          config: TypedAbiArg<
+            {
+              l1Withdrawal: {
+                maxFee: number | bigint;
+                minClaim: number | bigint;
+                poxAddr: {
+                  hashbytes: Uint8Array;
+                  version: Uint8Array;
+                };
+              } | null;
+              sbtcRecipient: string | null;
+            },
+            'config'
+          >,
+        ],
+        Response<boolean, bigint>
+      >,
+      settleAcceptedWithdrawal: {
+        name: 'settle-accepted-withdrawal',
+        access: 'public',
+        args: [{ name: 'request-id', type: 'uint128' }],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [requestId: TypedAbiArg<number | bigint, 'requestId'>],
+        Response<boolean, bigint>
+      >,
+      settleStakerRewards: {
+        name: 'settle-staker-rewards',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+        ],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+        ],
+        Response<bigint, bigint>
+      >,
+      sweepFeeRefunds: {
+        name: 'sweep-fee-refunds',
+        access: 'public',
+        args: [{ name: 'recipient', type: 'principal' }],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [recipient: TypedAbiArg<string, 'recipient'>],
+        Response<bigint, bigint>
+      >,
+      validateStake_x: {
+        name: 'validate-stake!',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'first-index', type: 'uint128' },
+          { name: 'num-indexes', type: 'uint128' },
+          { name: 'amount-ustx', type: 'uint128' },
+          { name: 'amount-sats', type: 'uint128' },
+          { name: 'is-bond', type: 'bool' },
+          {
+            name: 'signer-calldata',
+            type: { optional: { buffer: { length: 500 } } },
+          },
+        ],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          firstIndex: TypedAbiArg<number | bigint, 'firstIndex'>,
+          numIndexes: TypedAbiArg<number | bigint, 'numIndexes'>,
+          amountUstx: TypedAbiArg<number | bigint, 'amountUstx'>,
+          amountSats: TypedAbiArg<number | bigint, 'amountSats'>,
+          isBond: TypedAbiArg<boolean, 'isBond'>,
+          signerCalldata: TypedAbiArg<Uint8Array | null, 'signerCalldata'>,
+        ],
+        Response<boolean, bigint>
+      >,
+      withdrawFees: {
+        name: 'withdraw-fees',
+        access: 'public',
+        args: [
+          { name: 'amount', type: 'uint128' },
+          { name: 'recipient', type: 'principal' },
+        ],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+          recipient: TypedAbiArg<string, 'recipient'>,
+        ],
+        Response<bigint, bigint>
+      >,
+      checkPayoutConfig: {
+        name: 'check-payout-config',
+        access: 'read_only',
+        args: [
+          {
+            name: 'config',
+            type: {
+              tuple: [
+                {
+                  name: 'l1-withdrawal',
+                  type: {
+                    optional: {
+                      tuple: [
+                        { name: 'max-fee', type: 'uint128' },
+                        { name: 'min-claim', type: 'uint128' },
+                        {
+                          name: 'pox-addr',
+                          type: {
+                            tuple: [
+                              {
+                                name: 'hashbytes',
+                                type: { buffer: { length: 32 } },
+                              },
+                              {
+                                name: 'version',
+                                type: { buffer: { length: 1 } },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                { name: 'sbtc-recipient', type: { optional: 'principal' } },
+              ],
+            },
+          },
+        ],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          config: TypedAbiArg<
+            {
+              l1Withdrawal: {
+                maxFee: number | bigint;
+                minClaim: number | bigint;
+                poxAddr: {
+                  hashbytes: Uint8Array;
+                  version: Uint8Array;
+                };
+              } | null;
+              sbtcRecipient: string | null;
+            },
+            'config'
+          >,
+        ],
+        Response<boolean, bigint>
+      >,
+      getCurrentModule: {
+        name: 'get-current-module',
+        access: 'read_only',
+        args: [],
+        outputs: { type: 'principal' },
+      } as TypedAbiFunction<[], string>,
+      getEarnedFees: {
+        name: 'get-earned-fees',
+        access: 'read_only',
+        args: [],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<[], bigint>,
+      getPayoutConfig: {
+        name: 'get-payout-config',
+        access: 'read_only',
+        args: [{ name: 'staker', type: 'principal' }],
+        outputs: {
+          type: {
+            optional: {
+              tuple: [
+                {
+                  name: 'l1-withdrawal',
+                  type: {
+                    optional: {
+                      tuple: [
+                        { name: 'max-fee', type: 'uint128' },
+                        { name: 'min-claim', type: 'uint128' },
+                        {
+                          name: 'pox-addr',
+                          type: {
+                            tuple: [
+                              {
+                                name: 'hashbytes',
+                                type: { buffer: { length: 32 } },
+                              },
+                              {
+                                name: 'version',
+                                type: { buffer: { length: 1 } },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                { name: 'sbtc-recipient', type: { optional: 'principal' } },
+              ],
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [staker: TypedAbiArg<string, 'staker'>],
+        {
+          l1Withdrawal: {
+            maxFee: bigint;
+            minClaim: bigint;
+            poxAddr: {
+              hashbytes: Uint8Array;
+              version: Uint8Array;
+            };
+          } | null;
+          sbtcRecipient: string | null;
+        } | null
+      >,
+      getPendingPayout: {
+        name: 'get-pending-payout',
+        access: 'read_only',
+        args: [{ name: 'staker', type: 'principal' }],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<[staker: TypedAbiArg<string, 'staker'>], bigint>,
+      getReservedBalance: {
+        name: 'get-reserved-balance',
+        access: 'read_only',
+        args: [],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<[], bigint>,
+      getRewardReserve: {
+        name: 'get-reward-reserve',
+        access: 'read_only',
+        args: [
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+        ],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<
+        [
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+        ],
+        bigint
+      >,
+      getWithdrawalLiability: {
+        name: 'get-withdrawal-liability',
+        access: 'read_only',
+        args: [],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<[], bigint>,
+      getWithdrawalRequestStaker: {
+        name: 'get-withdrawal-request-staker',
+        access: 'read_only',
+        args: [{ name: 'request-id', type: 'uint128' }],
+        outputs: { type: { optional: 'principal' } },
+      } as TypedAbiFunction<
+        [requestId: TypedAbiArg<number | bigint, 'requestId'>],
+        string | null
+      >,
+      parsePayoutConfig: {
+        name: 'parse-payout-config',
+        access: 'read_only',
+        args: [{ name: 'calldata', type: { buffer: { length: 500 } } }],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  {
+                    name: 'l1-withdrawal',
+                    type: {
+                      optional: {
+                        tuple: [
+                          { name: 'max-fee', type: 'uint128' },
+                          { name: 'min-claim', type: 'uint128' },
+                          {
+                            name: 'pox-addr',
+                            type: {
+                              tuple: [
+                                {
+                                  name: 'hashbytes',
+                                  type: { buffer: { length: 32 } },
+                                },
+                                {
+                                  name: 'version',
+                                  type: { buffer: { length: 1 } },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  { name: 'sbtc-recipient', type: { optional: 'principal' } },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [calldata: TypedAbiArg<Uint8Array, 'calldata'>],
+        Response<
+          {
+            l1Withdrawal: {
+              maxFee: bigint;
+              minClaim: bigint;
+              poxAddr: {
+                hashbytes: Uint8Array;
+                version: Uint8Array;
+              };
+            } | null;
+            sbtcRecipient: string | null;
+          },
+          bigint
+        >
+      >,
+    },
+    maps: {
+      payoutConfigs: {
+        name: 'payout-configs',
+        key: 'principal',
+        value: {
+          tuple: [
+            {
+              name: 'l1-withdrawal',
+              type: {
+                optional: {
+                  tuple: [
+                    { name: 'max-fee', type: 'uint128' },
+                    { name: 'min-claim', type: 'uint128' },
+                    {
+                      name: 'pox-addr',
+                      type: {
+                        tuple: [
+                          {
+                            name: 'hashbytes',
+                            type: { buffer: { length: 32 } },
+                          },
+                          { name: 'version', type: { buffer: { length: 1 } } },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            { name: 'sbtc-recipient', type: { optional: 'principal' } },
+          ],
+        },
+      } as TypedAbiMap<
+        string,
+        {
+          l1Withdrawal: {
+            maxFee: bigint;
+            minClaim: bigint;
+            poxAddr: {
+              hashbytes: Uint8Array;
+              version: Uint8Array;
+            };
+          } | null;
+          sbtcRecipient: string | null;
+        }
+      >,
+      pendingPayouts: {
+        name: 'pending-payouts',
+        key: 'principal',
+        value: 'uint128',
+      } as TypedAbiMap<string, bigint>,
+      rewardReserves: {
+        name: 'reward-reserves',
+        key: {
+          tuple: [
+            { name: 'bond-index', type: { optional: 'uint128' } },
+            { name: 'reward-cycle', type: 'uint128' },
+          ],
+        },
+        value: 'uint128',
+      } as TypedAbiMap<
+        {
+          bondIndex: number | bigint | null;
+          rewardCycle: number | bigint;
+        },
+        bigint
+      >,
+      withdrawalRequests: {
+        name: 'withdrawal-requests',
+        key: 'uint128',
+        value: 'principal',
+      } as TypedAbiMap<number | bigint, string>,
+    },
+    variables: {
+      DUST_LIMIT: {
+        name: 'DUST_LIMIT',
+        type: 'uint128',
+        access: 'constant',
+      } as TypedAbiVariable<bigint>,
+      ERR_BELOW_DUST_LIMIT: {
+        name: 'ERR_BELOW_DUST_LIMIT',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_BELOW_MIN_CLAIM: {
+        name: 'ERR_BELOW_MIN_CLAIM',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INSUFFICIENT_FEES: {
+        name: 'ERR_INSUFFICIENT_FEES',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INSUFFICIENT_PENDING: {
+        name: 'ERR_INSUFFICIENT_PENDING',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_CALLDATA: {
+        name: 'ERR_INVALID_CALLDATA',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_MODULE: {
+        name: 'ERR_INVALID_MODULE',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_POX_ADDR: {
+        name: 'ERR_INVALID_POX_ADDR',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_NO_CLAIMABLE_REWARDS: {
+        name: 'ERR_NO_CLAIMABLE_REWARDS',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_NO_REFUNDS: {
+        name: 'ERR_NO_REFUNDS',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_UNAUTHORIZED_CALLER: {
+        name: 'ERR_UNAUTHORIZED_CALLER',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_UNAUTHORIZED_MODULE: {
+        name: 'ERR_UNAUTHORIZED_MODULE',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_UNKNOWN_WITHDRAWAL_REQUEST: {
+        name: 'ERR_UNKNOWN_WITHDRAWAL_REQUEST',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_WITHDRAWAL_NOT_ACCEPTED: {
+        name: 'ERR_WITHDRAWAL_NOT_ACCEPTED',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_WITHDRAWAL_NOT_REJECTED: {
+        name: 'ERR_WITHDRAWAL_NOT_REJECTED',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      currentModule: {
+        name: 'current-module',
+        type: 'principal',
+        access: 'variable',
+      } as TypedAbiVariable<string>,
+      earnedFees: {
+        name: 'earned-fees',
+        type: 'uint128',
+        access: 'variable',
+      } as TypedAbiVariable<bigint>,
+      totalPending: {
+        name: 'total-pending',
+        type: 'uint128',
+        access: 'variable',
+      } as TypedAbiVariable<bigint>,
+      totalReserved: {
+        name: 'total-reserved',
+        type: 'uint128',
+        access: 'variable',
+      } as TypedAbiVariable<bigint>,
+      withdrawalLiability: {
+        name: 'withdrawal-liability',
+        type: 'uint128',
+        access: 'variable',
+      } as TypedAbiVariable<bigint>,
+    },
+    constants: {
+      DUST_LIMIT: 546n,
+      ERR_BELOW_DUST_LIMIT: {
+        isOk: false,
+        value: 1_008n,
+      },
+      ERR_BELOW_MIN_CLAIM: {
+        isOk: false,
+        value: 1_007n,
+      },
+      ERR_INSUFFICIENT_FEES: {
+        isOk: false,
+        value: 1_009n,
+      },
+      ERR_INSUFFICIENT_PENDING: {
+        isOk: false,
+        value: 1_006n,
+      },
+      ERR_INVALID_CALLDATA: {
+        isOk: false,
+        value: 1_003n,
+      },
+      ERR_INVALID_MODULE: {
+        isOk: false,
+        value: 1_014n,
+      },
+      ERR_INVALID_POX_ADDR: {
+        isOk: false,
+        value: 1_004n,
+      },
+      ERR_NO_CLAIMABLE_REWARDS: {
+        isOk: false,
+        value: 1_005n,
+      },
+      ERR_NO_REFUNDS: {
+        isOk: false,
+        value: 1_013n,
+      },
+      ERR_UNAUTHORIZED_CALLER: {
+        isOk: false,
+        value: 1_001n,
+      },
+      ERR_UNAUTHORIZED_MODULE: {
+        isOk: false,
+        value: 1_002n,
+      },
+      ERR_UNKNOWN_WITHDRAWAL_REQUEST: {
+        isOk: false,
+        value: 1_010n,
+      },
+      ERR_WITHDRAWAL_NOT_ACCEPTED: {
+        isOk: false,
+        value: 1_012n,
+      },
+      ERR_WITHDRAWAL_NOT_REJECTED: {
+        isOk: false,
+        value: 1_011n,
+      },
+      currentModule: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+      earnedFees: 0n,
+      totalPending: 0n,
+      totalReserved: 0n,
+      withdrawalLiability: 0n,
+    },
+    non_fungible_tokens: [],
+    fungible_tokens: [],
+    epoch: 'Epoch40',
+    clarity_version: 'Clarity6',
+    contractName: 'signer-manager-core',
+  },
+  signerManagerV1: {
+    functions: {
+      authorizeAdmin: {
+        name: 'authorize-admin',
+        access: 'private',
+        args: [],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<[], Response<boolean, bigint>>,
+      authorizeStaker: {
+        name: 'authorize-staker',
+        access: 'private',
+        args: [],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<[], Response<boolean, bigint>>,
+      snapshotBondFee: {
+        name: 'snapshot-bond-fee',
+        access: 'private',
+        args: [
+          {
+            name: 'bond-info',
+            type: {
+              tuple: [
+                { name: 'bond-index', type: 'uint128' },
+                { name: 'earned', type: 'uint128' },
+                { name: 'rewards-per-token', type: 'uint128' },
+              ],
+            },
+          },
+          { name: 'reward-cycle', type: 'uint128' },
+        ],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<
+        [
+          bondInfo: TypedAbiArg<
+            {
+              bondIndex: number | bigint;
+              earned: number | bigint;
+              rewardsPerToken: number | bigint;
+            },
+            'bondInfo'
+          >,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+        ],
+        bigint
+      >,
+      claimRewards: {
+        name: 'claim-rewards',
+        access: 'public',
+        args: [
+          {
+            name: 'bond-periods',
+            type: { list: { type: 'uint128', length: 6 } },
+          },
+          { name: 'reward-cycle', type: 'uint128' },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  {
+                    name: 'bond-rewards',
+                    type: {
+                      list: {
+                        type: {
+                          tuple: [
+                            { name: 'bond-index', type: 'uint128' },
+                            { name: 'earned', type: 'uint128' },
+                            { name: 'rewards-per-token', type: 'uint128' },
+                          ],
+                        },
+                        length: 6,
+                      },
+                    },
+                  },
+                  { name: 'bond-totals', type: 'uint128' },
+                  {
+                    name: 'stx-rewards',
+                    type: {
+                      tuple: [
+                        { name: 'earned', type: 'uint128' },
+                        { name: 'rewards-per-token', type: 'uint128' },
+                      ],
+                    },
+                  },
+                  { name: 'total-rewards', type: 'uint128' },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          bondPeriods: TypedAbiArg<number | bigint[], 'bondPeriods'>,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+        ],
+        Response<
+          {
+            bondRewards: {
+              bondIndex: bigint;
+              earned: bigint;
+              rewardsPerToken: bigint;
+            }[];
+            bondTotals: bigint;
+            stxRewards: {
+              earned: bigint;
+              rewardsPerToken: bigint;
+            };
+            totalRewards: bigint;
+          },
+          bigint
+        >
+      >,
+      claimStakerRewards: {
+        name: 'claim-staker-rewards',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'earned', type: 'uint128' },
+                  { name: 'withdrawal-request', type: { optional: 'uint128' } },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+        ],
+        Response<
+          {
+            earned: bigint;
+            withdrawalRequest: bigint | null;
+          },
+          bigint
+        >
+      >,
+      clearPayoutConfig: {
+        name: 'clear-payout-config',
+        access: 'public',
+        args: [],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<[], Response<boolean, bigint>>,
+      payout: {
+        name: 'payout',
+        access: 'public',
+        args: [{ name: 'staker', type: 'principal' }],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'amount', type: 'uint128' },
+                  { name: 'withdrawal-request', type: { optional: 'uint128' } },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [staker: TypedAbiArg<string, 'staker'>],
+        Response<
+          {
+            amount: bigint;
+            withdrawalRequest: bigint | null;
+          },
+          bigint
+        >
+      >,
+      reclaimFailedWithdrawal: {
+        name: 'reclaim-failed-withdrawal',
+        access: 'public',
+        args: [{ name: 'request-id', type: 'uint128' }],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [requestId: TypedAbiArg<number | bigint, 'requestId'>],
+        Response<bigint, bigint>
+      >,
+      registerSelf: {
+        name: 'register-self',
+        access: 'public',
+        args: [
+          { name: 'signer-manager', type: 'trait_reference' },
+          { name: 'signer-key', type: { buffer: { length: 33 } } },
+          { name: 'auth-id', type: 'uint128' },
+          { name: 'signer-sig', type: { buffer: { length: 65 } } },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'signer', type: 'principal' },
+                  { name: 'signer-key', type: { buffer: { length: 33 } } },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          signerManager: TypedAbiArg<string, 'signerManager'>,
+          signerKey: TypedAbiArg<Uint8Array, 'signerKey'>,
+          authId: TypedAbiArg<number | bigint, 'authId'>,
+          signerSig: TypedAbiArg<Uint8Array, 'signerSig'>,
+        ],
+        Response<
+          {
+            signer: string;
+            signerKey: Uint8Array;
+          },
+          bigint
+        >
+      >,
+      retryFailedWithdrawal: {
+        name: 'retry-failed-withdrawal',
+        access: 'public',
+        args: [{ name: 'request-id', type: 'uint128' }],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'amount', type: 'uint128' },
+                  { name: 'withdrawal-request', type: { optional: 'uint128' } },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [requestId: TypedAbiArg<number | bigint, 'requestId'>],
+        Response<
+          {
+            amount: bigint;
+            withdrawalRequest: bigint | null;
+          },
+          bigint
+        >
+      >,
+      setModule: {
+        name: 'set-module',
+        access: 'public',
+        args: [{ name: 'module', type: 'principal' }],
+        outputs: { type: { response: { ok: 'principal', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [module: TypedAbiArg<string, 'module'>],
+        Response<string, bigint>
+      >,
+      setPayoutConfig: {
+        name: 'set-payout-config',
+        access: 'public',
+        args: [
+          {
+            name: 'l1-withdrawal',
+            type: {
+              optional: {
+                tuple: [
+                  { name: 'max-fee', type: 'uint128' },
+                  { name: 'min-claim', type: 'uint128' },
+                  {
+                    name: 'pox-addr',
+                    type: {
+                      tuple: [
+                        { name: 'hashbytes', type: { buffer: { length: 32 } } },
+                        { name: 'version', type: { buffer: { length: 1 } } },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          { name: 'sbtc-recipient', type: { optional: 'principal' } },
+        ],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          l1Withdrawal: TypedAbiArg<
+            {
+              maxFee: number | bigint;
+              minClaim: number | bigint;
+              poxAddr: {
+                hashbytes: Uint8Array;
+                version: Uint8Array;
+              };
+            } | null,
+            'l1Withdrawal'
+          >,
+          sbtcRecipient: TypedAbiArg<string | null, 'sbtcRecipient'>,
+        ],
+        Response<boolean, bigint>
+      >,
+      settleAcceptedWithdrawal: {
+        name: 'settle-accepted-withdrawal',
+        access: 'public',
+        args: [{ name: 'request-id', type: 'uint128' }],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [requestId: TypedAbiArg<number | bigint, 'requestId'>],
+        Response<boolean, bigint>
+      >,
+      settleStakerRewards: {
+        name: 'settle-staker-rewards',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'fee', type: 'uint128' },
+                  { name: 'gross', type: 'uint128' },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+        ],
+        Response<
+          {
+            fee: bigint;
+            gross: bigint;
+          },
+          bigint
+        >
+      >,
+      sweepFeeRefunds: {
+        name: 'sweep-fee-refunds',
+        access: 'public',
+        args: [{ name: 'recipient', type: 'principal' }],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [recipient: TypedAbiArg<string, 'recipient'>],
+        Response<bigint, bigint>
+      >,
+      updateAdmin: {
+        name: 'update-admin',
+        access: 'public',
+        args: [
+          { name: 'admin', type: 'principal' },
+          { name: 'enabled', type: 'bool' },
+        ],
+        outputs: { type: { response: { ok: 'principal', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          admin: TypedAbiArg<string, 'admin'>,
+          enabled: TypedAbiArg<boolean, 'enabled'>,
+        ],
+        Response<string, bigint>
+      >,
+      updateFees: {
+        name: 'update-fees',
+        access: 'public',
+        args: [{ name: 'new-fees', type: 'uint128' }],
+        outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [newFees: TypedAbiArg<number | bigint, 'newFees'>],
+        Response<boolean, bigint>
+      >,
+      withdrawFees: {
+        name: 'withdraw-fees',
+        access: 'public',
+        args: [
+          { name: 'amount', type: 'uint128' },
+          { name: 'recipient', type: 'principal' },
+        ],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [
+          amount: TypedAbiArg<number | bigint, 'amount'>,
+          recipient: TypedAbiArg<string, 'recipient'>,
+        ],
+        Response<bigint, bigint>
+      >,
+      getFeeBipsForCycle: {
+        name: 'get-fee-bips-for-cycle',
+        access: 'read_only',
+        args: [
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+        ],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<
+        [
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+        ],
+        bigint
+      >,
+      getFeesBips: {
+        name: 'get-fees-bips',
+        access: 'read_only',
+        args: [],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<[], bigint>,
+      getPayoutConfig: {
+        name: 'get-payout-config',
+        access: 'read_only',
+        args: [{ name: 'staker', type: 'principal' }],
+        outputs: {
+          type: {
+            optional: {
+              tuple: [
+                {
+                  name: 'l1-withdrawal',
+                  type: {
+                    optional: {
+                      tuple: [
+                        { name: 'max-fee', type: 'uint128' },
+                        { name: 'min-claim', type: 'uint128' },
+                        {
+                          name: 'pox-addr',
+                          type: {
+                            tuple: [
+                              {
+                                name: 'hashbytes',
+                                type: { buffer: { length: 32 } },
+                              },
+                              {
+                                name: 'version',
+                                type: { buffer: { length: 1 } },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                { name: 'sbtc-recipient', type: { optional: 'principal' } },
+              ],
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [staker: TypedAbiArg<string, 'staker'>],
+        {
+          l1Withdrawal: {
+            maxFee: bigint;
+            minClaim: bigint;
+            poxAddr: {
+              hashbytes: Uint8Array;
+              version: Uint8Array;
+            };
+          } | null;
+          sbtcRecipient: string | null;
+        } | null
+      >,
+      isAdmin: {
+        name: 'is-admin',
+        access: 'read_only',
+        args: [{ name: 'caller', type: 'principal' }],
+        outputs: { type: 'bool' },
+      } as TypedAbiFunction<[caller: TypedAbiArg<string, 'caller'>], boolean>,
+    },
+    maps: {
+      admins: {
+        name: 'admins',
+        key: 'principal',
+        value: 'bool',
+      } as TypedAbiMap<string, boolean>,
+      feeBipsForCycle: {
+        name: 'fee-bips-for-cycle',
+        key: {
+          tuple: [
+            { name: 'bond-index', type: { optional: 'uint128' } },
+            { name: 'reward-cycle', type: 'uint128' },
+          ],
+        },
+        value: 'uint128',
+      } as TypedAbiMap<
+        {
+          bondIndex: number | bigint | null;
+          rewardCycle: number | bigint;
+        },
+        bigint
+      >,
+    },
+    variables: {
+      ERR_INVALID_FEES_BIPS: {
+        name: 'ERR_INVALID_FEES_BIPS',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_UNAUTHORIZED_ADMIN: {
+        name: 'ERR_UNAUTHORIZED_ADMIN',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_UNAUTHORIZED_CALLER: {
+        name: 'ERR_UNAUTHORIZED_CALLER',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_UNKNOWN_WITHDRAWAL_REQUEST: {
+        name: 'ERR_UNKNOWN_WITHDRAWAL_REQUEST',
+        type: {
+          response: {
+            ok: 'none',
+            error: 'uint128',
+          },
+        },
+        access: 'constant',
+      } as TypedAbiVariable<Response<null, bigint>>,
+      MAX_BIPS: {
+        name: 'MAX_BIPS',
+        type: 'uint128',
+        access: 'constant',
+      } as TypedAbiVariable<bigint>,
+      feesBips: {
+        name: 'fees-bips',
+        type: 'uint128',
+        access: 'variable',
+      } as TypedAbiVariable<bigint>,
+    },
+    constants: {
+      ERR_INVALID_FEES_BIPS: {
+        isOk: false,
+        value: 2_003n,
+      },
+      ERR_UNAUTHORIZED_ADMIN: {
+        isOk: false,
+        value: 2_002n,
+      },
+      ERR_UNAUTHORIZED_CALLER: {
+        isOk: false,
+        value: 2_001n,
+      },
+      ERR_UNKNOWN_WITHDRAWAL_REQUEST: {
+        isOk: false,
+        value: 2_004n,
+      },
+      MAX_BIPS: 10_000n,
+      feesBips: 0n,
+    },
+    non_fungible_tokens: [],
+    fungible_tokens: [],
+    epoch: 'Epoch40',
+    clarity_version: 'Clarity6',
+    contractName: 'signer-manager-v1',
+  },
   signers: {
     functions: {
       setSigners: {
@@ -12184,6 +13762,177 @@ export const contracts = {
     clarity_version: 'Clarity6',
     contractName: 'test-pox-5-signer',
   },
+  testSignerManagerV2: {
+    functions: {
+      claimRewards: {
+        name: 'claim-rewards',
+        access: 'public',
+        args: [
+          {
+            name: 'bond-periods',
+            type: { list: { type: 'uint128', length: 6 } },
+          },
+          { name: 'reward-cycle', type: 'uint128' },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  {
+                    name: 'bond-rewards',
+                    type: {
+                      list: {
+                        type: {
+                          tuple: [
+                            { name: 'bond-index', type: 'uint128' },
+                            { name: 'earned', type: 'uint128' },
+                            { name: 'rewards-per-token', type: 'uint128' },
+                          ],
+                        },
+                        length: 6,
+                      },
+                    },
+                  },
+                  { name: 'bond-totals', type: 'uint128' },
+                  {
+                    name: 'stx-rewards',
+                    type: {
+                      tuple: [
+                        { name: 'earned', type: 'uint128' },
+                        { name: 'rewards-per-token', type: 'uint128' },
+                      ],
+                    },
+                  },
+                  { name: 'total-rewards', type: 'uint128' },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          bondPeriods: TypedAbiArg<number | bigint[], 'bondPeriods'>,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+        ],
+        Response<
+          {
+            bondRewards: {
+              bondIndex: bigint;
+              earned: bigint;
+              rewardsPerToken: bigint;
+            }[];
+            bondTotals: bigint;
+            stxRewards: {
+              earned: bigint;
+              rewardsPerToken: bigint;
+            };
+            totalRewards: bigint;
+          },
+          bigint
+        >
+      >,
+      payout: {
+        name: 'payout',
+        access: 'public',
+        args: [{ name: 'staker', type: 'principal' }],
+        outputs: {
+          type: { response: { ok: { optional: 'uint128' }, error: 'uint128' } },
+        },
+      } as TypedAbiFunction<
+        [staker: TypedAbiArg<string, 'staker'>],
+        Response<bigint | null, bigint>
+      >,
+      reclaimFailedWithdrawal: {
+        name: 'reclaim-failed-withdrawal',
+        access: 'public',
+        args: [{ name: 'request-id', type: 'uint128' }],
+        outputs: { type: { response: { ok: 'uint128', error: 'uint128' } } },
+      } as TypedAbiFunction<
+        [requestId: TypedAbiArg<number | bigint, 'requestId'>],
+        Response<bigint, bigint>
+      >,
+      settleStakerRewards: {
+        name: 'settle-staker-rewards',
+        access: 'public',
+        args: [
+          { name: 'staker', type: 'principal' },
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: 'fee', type: 'uint128' },
+                  { name: 'gross', type: 'uint128' },
+                ],
+              },
+              error: 'uint128',
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          staker: TypedAbiArg<string, 'staker'>,
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+        ],
+        Response<
+          {
+            fee: bigint;
+            gross: bigint;
+          },
+          bigint
+        >
+      >,
+      feeBipsForCycle: {
+        name: 'fee-bips-for-cycle',
+        access: 'read_only',
+        args: [
+          { name: 'reward-cycle', type: 'uint128' },
+          { name: 'bond-index', type: { optional: 'uint128' } },
+        ],
+        outputs: { type: 'uint128' },
+      } as TypedAbiFunction<
+        [
+          rewardCycle: TypedAbiArg<number | bigint, 'rewardCycle'>,
+          bondIndex: TypedAbiArg<number | bigint | null, 'bondIndex'>,
+        ],
+        bigint
+      >,
+    },
+    maps: {
+      claimedCycles: {
+        name: 'claimed-cycles',
+        key: 'uint128',
+        value: 'bool',
+      } as TypedAbiMap<number | bigint, boolean>,
+    },
+    variables: {
+      FEE_BIPS: {
+        name: 'FEE_BIPS',
+        type: 'uint128',
+        access: 'constant',
+      } as TypedAbiVariable<bigint>,
+      MAX_BIPS: {
+        name: 'MAX_BIPS',
+        type: 'uint128',
+        access: 'constant',
+      } as TypedAbiVariable<bigint>,
+    },
+    constants: {
+      FEE_BIPS: 1_000n,
+      MAX_BIPS: 10_000n,
+    },
+    non_fungible_tokens: [],
+    fungible_tokens: [],
+    epoch: 'Epoch40',
+    clarity_version: 'Clarity6',
+    contractName: 'test-signer-manager-v2',
+  },
 } as const;
 
 export const accounts = {
@@ -12245,11 +13994,17 @@ export const identifiers = {
   sbtcToken: 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token',
   sbtcWithdrawal: 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-withdrawal',
   signerManager: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signer-manager',
+  signerManagerCore:
+    'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signer-manager-core',
+  signerManagerV1:
+    'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signer-manager-v1',
   signers: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signers',
   signersVoting: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signers-voting',
   sip031: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sip-031',
   sip031Indirect: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sip-031-indirect',
   testPox5Signer: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test-pox-5-signer',
+  testSignerManagerV2:
+    'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test-signer-manager-v2',
 } as const;
 
 export const simnet = {
@@ -12325,6 +14080,18 @@ export const deployments = {
     testnet: null,
     mainnet: null,
   },
+  signerManagerCore: {
+    devnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signer-manager-core',
+    simnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signer-manager-core',
+    testnet: null,
+    mainnet: null,
+  },
+  signerManagerV1: {
+    devnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signer-manager-v1',
+    simnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signer-manager-v1',
+    testnet: null,
+    mainnet: null,
+  },
   signers: {
     devnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signers',
     simnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.signers',
@@ -12352,6 +14119,12 @@ export const deployments = {
   testPox5Signer: {
     devnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test-pox-5-signer',
     simnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test-pox-5-signer',
+    testnet: null,
+    mainnet: null,
+  },
+  testSignerManagerV2: {
+    devnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test-signer-manager-v2',
+    simnet: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test-signer-manager-v2',
     testnet: null,
     mainnet: null,
   },

--- a/contrib/core-contract-tests/tests/pox-5/pox-5-helpers.ts
+++ b/contrib/core-contract-tests/tests/pox-5/pox-5-helpers.ts
@@ -1,3 +1,15 @@
+import {
+  contractFactory,
+  err,
+  extractErrors,
+  projectErrors,
+  projectFactory,
+} from '@clarigen/core';
+import { rov, rovOk, tx, txOk } from '@clarigen/test';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { concatBytes } from '@noble/hashes/utils.js';
+import { hex } from '@scure/base';
 import * as BTC from '@scure/btc-signer';
 import {
   Cl,
@@ -7,20 +19,8 @@ import {
   serializeCV,
   signWithKey,
 } from '@stacks/transactions';
-import { hex } from '@scure/base';
-import {
-  err,
-  extractErrors,
-  projectErrors,
-  projectFactory,
-  contractFactory,
-} from '@clarigen/core';
-import { accounts, project } from '../clarigen-types';
-import { rov, rovOk, tx, txOk } from '@clarigen/test';
-import { sha256 } from '@noble/hashes/sha2.js';
-import { concatBytes } from '@noble/hashes/utils.js';
-import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { expect } from 'vitest';
+import { accounts, project } from '../clarigen-types';
 import { randomPoxAddress } from '../test-helpers';
 
 const contracts = projectFactory(project, 'simnet');
@@ -43,6 +43,11 @@ export const testSigner = contracts.testPox5Signer;
 export const testSignerErrors = extractErrors(testSigner);
 export const signerManager = contracts.signerManager;
 export const signerManagerErrors = extractErrors(signerManager);
+export const signerManagerCore = contracts.signerManagerCore;
+export const signerManagerCoreErrors = extractErrors(signerManagerCore);
+export const signerManagerV1 = contracts.signerManagerV1;
+export const signerManagerV1Errors = extractErrors(signerManagerV1);
+export const testSignerManagerV2 = contracts.testSignerManagerV2;
 export const sbtc = contracts.sbtcToken;
 
 export const REWARD_CYCLE_LENGTH = 100n;
@@ -429,7 +434,7 @@ export function deployTestSignerContract(name: string) {
   simnet.deployContract(
     name,
     signerSource,
-    // @ts-ignore
+    // @ts-expect-error
     { clarityVersion: 6 },
     accounts.deployer.address,
   );
@@ -460,6 +465,30 @@ export function registerSignerManager() {
       signerKey: secp256k1.getPublicKey(signerSk, true),
       signerManager: signerManager.identifier,
       authId: 1n,
+      signerSig: signature,
+    }),
+    deployer,
+  );
+}
+
+/**
+ * Bootstrap a signer-manager-core contract to set
+ * `signer-manager-v1` as the current module.
+ */
+export function registerSignerManagerCore() {
+  txOk(signerManagerCore.setModule(signerManagerV1.identifier), deployer);
+  const signerSk = secp256k1.utils.randomSecretKey();
+  const authId = grantAuthIdCounter++;
+  const signature = signSignerKeyGrant({
+    signerManager: signerManagerCore.identifier,
+    authId,
+    signerSk,
+  });
+  txOk(
+    signerManagerV1.registerSelf({
+      signerKey: secp256k1.getPublicKey(signerSk, true),
+      signerManager: signerManagerCore.identifier,
+      authId,
       signerSig: signature,
     }),
     deployer,
@@ -524,7 +553,7 @@ export function getAllStakers(): string[] {
 /** Get all stakers for a given reward cycle */
 function getAllStakersForCycle(cycle: bigint): string[] {
   const first = rov(pox5.getSignerSetFirstItemForCycle(cycle));
-  let signers: string[] = [];
+  const signers: string[] = [];
   let cur: string | null = first;
   if (cur) signers.push(cur);
   while (cur) {
@@ -615,4 +644,53 @@ export function makePoxAddrCalldata(
       ),
     ),
   };
+}
+
+export type PayoutConfig = {
+  l1Withdrawal: {
+    poxAddr: { version: Uint8Array; hashbytes: Uint8Array };
+    maxFee: bigint;
+    minClaim: bigint;
+  } | null;
+  sbtcRecipient: string | null;
+};
+
+/** A payout config withdrawing to a random L1 address. */
+export function randomPayoutConfig({
+  maxFee,
+  minClaim,
+}: {
+  maxFee: bigint;
+  minClaim: bigint;
+}): PayoutConfig {
+  return {
+    l1Withdrawal: { poxAddr: randomPoxAddress(), maxFee, minClaim },
+    sbtcRecipient: null,
+  };
+}
+
+/** Encode a payout config as `signer-manager-core` calldata. */
+export function payoutConfigCalldata(config: PayoutConfig) {
+  const l1 = config.l1Withdrawal;
+  return hex.decode(
+    serializeCV(
+      Cl.tuple({
+        'l1-withdrawal': l1
+          ? Cl.some(
+              Cl.tuple({
+                'pox-addr': Cl.tuple({
+                  version: Cl.buffer(l1.poxAddr.version),
+                  hashbytes: Cl.buffer(l1.poxAddr.hashbytes),
+                }),
+                'max-fee': Cl.uint(l1.maxFee),
+                'min-claim': Cl.uint(l1.minClaim),
+              }),
+            )
+          : Cl.none(),
+        'sbtc-recipient': config.sbtcRecipient
+          ? Cl.some(Cl.principal(config.sbtcRecipient))
+          : Cl.none(),
+      }),
+    ),
+  );
 }

--- a/contrib/core-contract-tests/tests/pox-5/signer-manager-core.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/signer-manager-core.test.ts
@@ -1,0 +1,187 @@
+import { rov, txErr, txOk } from '@clarigen/test';
+import { beforeEach, expect, test } from 'vitest';
+import { accounts } from '../clarigen-types';
+import { randomPoxAddress, stxToUStx } from '../test-helpers';
+import {
+  initPox5,
+  payoutConfigCalldata,
+  pox5,
+  randomPayoutConfig,
+  registerSignerManagerCore,
+  signerManagerCore,
+  signerManagerCoreErrors,
+  signerManagerV1,
+  signerManagerV1Errors,
+  testSignerManagerV2,
+} from './pox-5-helpers';
+
+const deployer = accounts.deployer.address;
+const alice = accounts.wallet_1.address;
+const bob = accounts.wallet_2.address;
+
+beforeEach(() => {
+  initPox5();
+  registerSignerManagerCore();
+});
+
+function stake(signerCalldata: Uint8Array | null = null) {
+  return pox5.stake({
+    signerManager: signerManagerCore.identifier,
+    amountUstx: stxToUStx(50_000),
+    numCycles: 2n,
+    startBurnHt: simnet.burnBlockHeight,
+    signerCalldata,
+  });
+}
+
+test('core is registered with pox-5 and controlled by the v1 module', () => {
+  expect(rov(pox5.getSignerInfo(signerManagerCore.identifier))).not.toBeNull();
+  expect(rov(signerManagerCore.getCurrentModule())).toBe(
+    signerManagerV1.identifier,
+  );
+});
+
+test('staking with payout-config calldata stores the config', () => {
+  const config = randomPayoutConfig({ maxFee: 100n, minClaim: 5000n });
+  txOk(stake(payoutConfigCalldata(config)), alice);
+  expect(rov(signerManagerCore.getPayoutConfig(alice))).toEqual(config);
+  // The module exposes the same view.
+  expect(rov(signerManagerV1.getPayoutConfig(alice))).toEqual(config);
+});
+
+test('staking without calldata leaves an existing config untouched', () => {
+  const config = randomPayoutConfig({ maxFee: 100n, minClaim: 0n });
+  txOk(stake(payoutConfigCalldata(config)), alice);
+  txOk(
+    pox5.stakeUpdate({
+      signerManager: signerManagerCore.identifier,
+      oldSignerManager: signerManagerCore.identifier,
+      cyclesToExtend: 1n,
+      amountIncrease: 0n,
+      signerCalldata: null,
+    }),
+    alice,
+  );
+  expect(rov(signerManagerCore.getPayoutConfig(alice))).toEqual(config);
+  txOk(stake(), bob);
+  expect(rov(signerManagerCore.getPayoutConfig(bob))).toBeNull();
+});
+
+test('malformed calldata and pox-addrs are rejected', () => {
+  expect(txErr(stake(new Uint8Array([1, 2, 3])), alice).value).toBe(
+    signerManagerCoreErrors.ERR_INVALID_CALLDATA,
+  );
+  // Version 0x06 is above the highest sBTC address version.
+  const config = randomPayoutConfig({ maxFee: 100n, minClaim: 0n });
+  config.l1Withdrawal!.poxAddr.version = new Uint8Array([0x06]);
+  expect(txErr(stake(payoutConfigCalldata(config)), alice).value).toBe(
+    signerManagerCoreErrors.ERR_INVALID_POX_ADDR,
+  );
+  expect(
+    txErr(
+      signerManagerV1.setPayoutConfig({
+        l1Withdrawal: config.l1Withdrawal,
+        sbtcRecipient: null,
+      }),
+      alice,
+    ).value,
+  ).toBe(signerManagerCoreErrors.ERR_INVALID_POX_ADDR);
+  expect(rov(signerManagerCore.getPayoutConfig(alice))).toBeNull();
+});
+
+test('validate-stake! errors when not called by the pox-5 contract', () => {
+  const config = randomPayoutConfig({ maxFee: 100n, minClaim: 0n });
+  expect(
+    txErr(
+      signerManagerCore.validateStake_x({
+        staker: alice,
+        firstIndex: 0n,
+        numIndexes: 1n,
+        amountUstx: stxToUStx(50_000),
+        amountSats: 0n,
+        isBond: false,
+        signerCalldata: payoutConfigCalldata(config),
+      }),
+      alice,
+    ).value,
+  ).toBe(signerManagerCoreErrors.ERR_UNAUTHORIZED_CALLER);
+  expect(rov(signerManagerCore.getPayoutConfig(alice))).toBeNull();
+});
+
+test('stakers set and clear their payout config through the module', () => {
+  txOk(stake(), alice);
+  const l1Withdrawal = {
+    poxAddr: randomPoxAddress(),
+    maxFee: 200n,
+    minClaim: 1000n,
+  };
+  txOk(
+    signerManagerV1.setPayoutConfig({ l1Withdrawal, sbtcRecipient: null }),
+    alice,
+  );
+  expect(rov(signerManagerCore.getPayoutConfig(alice))).toEqual({
+    l1Withdrawal,
+    sbtcRecipient: null,
+  });
+  // Switch to sBTC paid to another address.
+  txOk(
+    signerManagerV1.setPayoutConfig({ l1Withdrawal: null, sbtcRecipient: bob }),
+    alice,
+  );
+  expect(rov(signerManagerCore.getPayoutConfig(alice))).toEqual({
+    l1Withdrawal: null,
+    sbtcRecipient: bob,
+  });
+  txOk(signerManagerV1.clearPayoutConfig(), alice);
+  expect(rov(signerManagerCore.getPayoutConfig(alice))).toBeNull();
+});
+
+test('core functions reject callers other than the module', () => {
+  const config = randomPayoutConfig({ maxFee: 100n, minClaim: 0n });
+  expect(
+    txErr(signerManagerCore.setPayoutConfig({ staker: alice, config }), alice)
+      .value,
+  ).toBe(signerManagerCoreErrors.ERR_UNAUTHORIZED_MODULE);
+  expect(
+    txErr(signerManagerCore.clearPayoutConfig(alice), deployer).value,
+  ).toBe(signerManagerCoreErrors.ERR_UNAUTHORIZED_MODULE);
+  // The deployer was only the bootstrap module; it lost control at hand-off.
+  expect(txErr(signerManagerCore.setModule(alice), deployer).value).toBe(
+    signerManagerCoreErrors.ERR_UNAUTHORIZED_MODULE,
+  );
+});
+
+test('admins upgrade by pointing core at a new module', () => {
+  expect(
+    txErr(signerManagerV1.setModule(testSignerManagerV2.identifier), alice)
+      .value,
+  ).toBe(signerManagerV1Errors.ERR_UNAUTHORIZED_ADMIN);
+  // A principal with no contract behind it would strand core forever.
+  expect(txErr(signerManagerV1.setModule(alice), deployer).value).toBe(
+    signerManagerCoreErrors.ERR_INVALID_MODULE,
+  );
+  txOk(signerManagerV1.setModule(testSignerManagerV2.identifier), deployer);
+  expect(rov(signerManagerCore.getCurrentModule())).toBe(
+    testSignerManagerV2.identifier,
+  );
+  // The old module is cut off.
+  expect(
+    txErr(
+      signerManagerV1.setPayoutConfig({
+        l1Withdrawal: null,
+        sbtcRecipient: null,
+      }),
+      bob,
+    ).value,
+  ).toBe(signerManagerCoreErrors.ERR_UNAUTHORIZED_MODULE);
+});
+
+test('only admins can update admins', () => {
+  expect(
+    txErr(signerManagerV1.updateAdmin({ admin: alice, enabled: true }), alice)
+      .value,
+  ).toBe(signerManagerV1Errors.ERR_UNAUTHORIZED_ADMIN);
+  txOk(signerManagerV1.updateAdmin({ admin: alice, enabled: true }), deployer);
+  expect(rov(signerManagerV1.isAdmin(alice))).toBe(true);
+  txOk(signerManagerV1.setModule(testSignerManagerV2.identifier), alice);
+});

--- a/contrib/core-contract-tests/tests/pox-5/signer-manager-upgrade.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/signer-manager-upgrade.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, expect, test } from 'vitest';
+import {
+  signerManagerCore,
+  signerManagerCoreErrors,
+  signerManagerV1,
+  testSignerManagerV2,
+  pox5,
+  sbtc,
+  sbtcBalance,
+  initPox5,
+  registerSignerManagerCore,
+  randomPayoutConfig,
+  payoutConfigCalldata,
+  PayoutConfig,
+  BASIS_POINTS,
+  HALF_CYCLE_LENGTH,
+} from './pox-5-helpers';
+import { rov, txErr, txOk } from '@clarigen/test';
+import { ContractCallTyped, Response, projectFactory } from '@clarigen/core';
+import { accounts, project } from '../clarigen-types';
+import { mineUntil, stxToUStx } from '../test-helpers';
+
+// What an upgrade must preserve. Core keeps all accounting, so pending
+// payouts, unsettled reserves and live withdrawals carry over to the new
+// module untouched. Policy state the old module kept for itself (v1's fee
+// snapshots) stays readable through a literal call, so cycles pulled in
+// before the upgrade still settle at the fee they were pulled in with.
+
+const contracts = projectFactory(project, 'simnet');
+const sbtcWithdrawal = contracts.sbtcWithdrawal;
+const SBTC_SIGNER = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4';
+
+const deployer = accounts.deployer.address;
+const alice = accounts.wallet_1.address;
+const bob = accounts.wallet_2.address;
+
+beforeEach(() => {
+  initPox5();
+  registerSignerManagerCore();
+});
+
+function stake(staker: string, config: PayoutConfig | null = null) {
+  txOk(
+    pox5.stake({
+      signerManager: signerManagerCore.identifier,
+      amountUstx: stxToUStx(50_000),
+      numCycles: 3n,
+      startBurnHt: simnet.burnBlockHeight,
+      signerCalldata: config && payoutConfigCalldata(config),
+    }),
+    staker,
+  );
+}
+
+function fundAndCrystallize(cycle: bigint, rewards: bigint): bigint {
+  txOk(
+    sbtc.transfer({
+      recipient: pox5.identifier,
+      amount: rewards,
+      sender: deployer,
+      memo: null,
+    }),
+    deployer,
+  );
+  mineUntil(rov(pox5.rewardCycleToBurnHeight(cycle)) + HALF_CYCLE_LENGTH);
+  txOk(pox5.calculateRewards([]), deployer);
+  return rewards - (rewards * pox5.constants.RESERVE_RATIO) / BASIS_POINTS;
+}
+
+function upgradeToV2() {
+  txOk(signerManagerV1.setModule(testSignerManagerV2.identifier), deployer);
+  expect(rov(signerManagerCore.getCurrentModule())).toBe(
+    testSignerManagerV2.identifier,
+  );
+}
+
+test('the old module is fully cut off after hand-off', () => {
+  stake(alice);
+  fundAndCrystallize(1n, 2000n);
+  upgradeToV2();
+  const calls: ContractCallTyped<any, Response<any, bigint>>[] = [
+    signerManagerV1.claimRewards([], 1n),
+    signerManagerV1.settleStakerRewards(alice, 1n, null),
+    signerManagerV1.payout(alice),
+    signerManagerV1.reclaimFailedWithdrawal(1n),
+    signerManagerV1.withdrawFees(1n, deployer),
+    signerManagerV1.sweepFeeRefunds(deployer),
+    signerManagerV1.setModule(signerManagerV1.identifier),
+    signerManagerV1.setPayoutConfig({
+      l1Withdrawal: null,
+      sbtcRecipient: null,
+    }),
+  ];
+  for (const call of calls) {
+    expect(txErr(call, deployer).value).toBe(
+      signerManagerCoreErrors.ERR_UNAUTHORIZED_MODULE,
+    );
+  }
+});
+
+test('a cycle pulled in under v1 settles at the v1 fee after upgrade', () => {
+  stake(alice);
+  txOk(signerManagerV1.updateFees(500n), deployer);
+  const gross1 = fundAndCrystallize(1n, 2000n);
+  txOk(signerManagerV1.claimRewards([], 1n), deployer);
+  upgradeToV2();
+
+  // v2 reads v1's snapshot for cycle 1: 5%, not its own flat 10%.
+  expect(
+    txOk(testSignerManagerV2.settleStakerRewards(alice, 1n, null), bob).value,
+  ).toEqual({ gross: gross1, fee: (gross1 * 500n) / BASIS_POINTS });
+
+  // A cycle v2 pulls in itself uses v2's fee.
+  const gross2 = fundAndCrystallize(2n, 2000n);
+  txOk(testSignerManagerV2.claimRewards([], 2n), deployer);
+  expect(
+    txOk(testSignerManagerV2.settleStakerRewards(alice, 2n, null), bob).value,
+  ).toEqual({ gross: gross2, fee: (gross2 * 1000n) / BASIS_POINTS });
+
+  const net =
+    gross1 -
+    (gross1 * 500n) / BASIS_POINTS +
+    gross2 -
+    (gross2 * 1000n) / BASIS_POINTS;
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(net);
+  const before = sbtcBalance(alice);
+  txOk(testSignerManagerV2.payout(alice), alice);
+  expect(sbtcBalance(alice)).toBe(before + net);
+});
+
+test('pending payouts and unsettled reserves survive the upgrade', () => {
+  stake(alice);
+  stake(bob);
+  const total = fundAndCrystallize(1n, 2000n);
+  txOk(signerManagerV1.claimRewards([], 1n), deployer);
+  txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), alice);
+  const alicePending = rov(signerManagerCore.getPendingPayout(alice));
+  upgradeToV2();
+
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(alicePending);
+  expect(rov(signerManagerCore.getRewardReserve(1n, null))).toBe(
+    total - alicePending,
+  );
+  txOk(testSignerManagerV2.settleStakerRewards(bob, 1n, null), bob);
+  expect(rov(signerManagerCore.getRewardReserve(1n, null))).toBe(0n);
+  txOk(testSignerManagerV2.payout(alice), alice);
+  txOk(testSignerManagerV2.payout(bob), bob);
+  expect(sbtcBalance(signerManagerCore.identifier)).toBe(0n);
+});
+
+test('a withdrawal initiated under v1 and rejected later is retried by v2', () => {
+  stake(alice, randomPayoutConfig({ maxFee: 100n, minClaim: 0n }));
+  const total = fundAndCrystallize(1n, 2000n);
+  txOk(signerManagerV1.claimRewards([], 1n), deployer);
+  txOk(signerManagerV1.claimStakerRewards(alice, 1n, null), bob);
+  expect(rov(signerManagerCore.getWithdrawalLiability())).toBe(total);
+  upgradeToV2();
+
+  txOk(sbtcWithdrawal.rejectWithdrawalRequest(1n, 0n), SBTC_SIGNER);
+  expect(txOk(testSignerManagerV2.reclaimFailedWithdrawal(1n), bob).value).toBe(
+    total,
+  );
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(total);
+  expect(rov(signerManagerCore.getWithdrawalLiability())).toBe(0n);
+  // Retry through v2 using the config alice set under v1.
+  expect(txOk(testSignerManagerV2.payout(alice), bob).value).toBe(2n);
+  expect(rov(signerManagerCore.getWithdrawalRequestStaker(2n))).toBe(alice);
+});

--- a/contrib/core-contract-tests/tests/pox-5/signer-manager-v1.test.ts
+++ b/contrib/core-contract-tests/tests/pox-5/signer-manager-v1.test.ts
@@ -1,0 +1,381 @@
+import {
+  type ContractCallTyped,
+  projectFactory,
+  type Response,
+} from '@clarigen/core';
+import { rov, txErr, txOk } from '@clarigen/test';
+import { hex } from '@scure/base';
+import { beforeEach, expect, test } from 'vitest';
+import { accounts, project } from '../clarigen-types';
+import { mineUntil, stxToUStx } from '../test-helpers';
+import {
+  BASIS_POINTS,
+  HALF_CYCLE_LENGTH,
+  initPox5,
+  type PayoutConfig,
+  payoutConfigCalldata,
+  pox5,
+  randomPayoutConfig,
+  registerSignerManagerCore,
+  sbtc,
+  sbtcBalance,
+  signerManagerCore,
+  signerManagerCoreErrors,
+  signerManagerV1,
+  signerManagerV1Errors,
+} from './pox-5-helpers';
+
+const contracts = projectFactory(project, 'simnet');
+const sbtcWithdrawal = contracts.sbtcWithdrawal;
+
+// The principal allowed to accept/reject sBTC withdrawals: the sBTC registry's
+// `current-signer-principal`, which defaults to the sBTC deployer.
+const SBTC_SIGNER = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4';
+const DUST_LIMIT = 546n;
+
+const deployer = accounts.deployer.address;
+const alice = accounts.wallet_1.address;
+const bob = accounts.wallet_2.address;
+const charlie = accounts.wallet_3.address;
+
+beforeEach(() => {
+  initPox5();
+  registerSignerManagerCore();
+});
+
+function stake(staker: string, config: PayoutConfig | null = null) {
+  txOk(
+    pox5.stake({
+      signerManager: signerManagerCore.identifier,
+      amountUstx: stxToUStx(50_000),
+      numCycles: 3n,
+      startBurnHt: simnet.burnBlockHeight,
+      signerCalldata: config && payoutConfigCalldata(config),
+    }),
+    staker,
+  );
+}
+
+// Fund pox-5 with `rewards`, roll into `cycle`, crystallize and pull the
+// signer's share into core. Returns the STX-staker portion (after pox-5's
+// reserve skim), which is the whole cycle when there is one staker.
+function claimCycle(cycle: bigint, rewards: bigint): bigint {
+  txOk(
+    sbtc.transfer({
+      recipient: pox5.identifier,
+      amount: rewards,
+      sender: deployer,
+      memo: null,
+    }),
+    deployer,
+  );
+  mineUntil(rov(pox5.rewardCycleToBurnHeight(cycle)) + HALF_CYCLE_LENGTH);
+  txOk(pox5.calculateRewards([]), deployer);
+  txOk(signerManagerV1.claimRewards([], cycle), deployer);
+  return rewards - (rewards * pox5.constants.RESERVE_RATIO) / BASIS_POINTS;
+}
+
+// The bitcoin header hash at `height`. The sBTC `accept-withdrawal-request`
+// fork check requires it to equal the burn header at the same height.
+function burnHeader(height: bigint): Uint8Array {
+  const result = simnet.execute(
+    `(get-burn-block-info? header-hash u${height})`,
+  );
+  return hex.decode((result.result as any).value.value);
+}
+
+function acceptWithdrawal(requestId: bigint, fee: bigint) {
+  const height = BigInt(simnet.burnBlockHeight - 1);
+  txOk(
+    sbtcWithdrawal.acceptWithdrawalRequest(
+      requestId,
+      new Uint8Array(32),
+      0n,
+      0n,
+      fee,
+      burnHeader(height),
+      height,
+      new Uint8Array(32),
+    ),
+    SBTC_SIGNER,
+  );
+}
+
+function expectSolvent() {
+  expect(sbtcBalance(signerManagerCore.identifier)).toBeGreaterThanOrEqual(
+    rov(signerManagerCore.getReservedBalance()),
+  );
+}
+
+test('claim-rewards reserves the cycle in core and snapshots the fee', () => {
+  stake(alice);
+  txOk(signerManagerV1.updateFees(500n), deployer);
+  const total = claimCycle(1n, 2000n);
+  expect(sbtcBalance(signerManagerCore.identifier)).toBe(total);
+  expect(rov(signerManagerCore.getRewardReserve(1n, null))).toBe(total);
+  expect(rov(signerManagerV1.getFeeBipsForCycle(1n, null))).toBe(500n);
+  // Everything in the vault is spoken for.
+  expect(txErr(signerManagerV1.sweepFeeRefunds(deployer), deployer).value).toBe(
+    signerManagerCoreErrors.ERR_NO_REFUNDS,
+  );
+  expectSolvent();
+});
+
+test('settling credits pending net of the snapshotted fee', () => {
+  stake(alice);
+  txOk(signerManagerV1.updateFees(500n), deployer);
+  const gross = claimCycle(1n, 2000n);
+  const fee = (gross * 500n) / BASIS_POINTS;
+  // A later fee change does not touch the already-pulled cycle.
+  txOk(signerManagerV1.updateFees(9000n), deployer);
+
+  expect(
+    txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), bob).value,
+  ).toEqual({ gross, fee });
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(gross - fee);
+  expect(rov(signerManagerCore.getEarnedFees())).toBe(fee);
+  expect(rov(signerManagerCore.getRewardReserve(1n, null))).toBe(0n);
+
+  // Nothing left to settle for this cycle.
+  expect(
+    txErr(signerManagerV1.settleStakerRewards(alice, 1n, null), bob).value,
+  ).toBe(signerManagerCoreErrors.ERR_NO_CLAIMABLE_REWARDS);
+  expectSolvent();
+});
+
+test('settling before the signer pulls the cycle has nothing to claim', () => {
+  stake(alice);
+  mineUntil(rov(pox5.rewardCycleToBurnHeight(1n)) + HALF_CYCLE_LENGTH);
+  expect(
+    txErr(signerManagerV1.settleStakerRewards(alice, 1n, null), bob).value,
+  ).toBe(signerManagerCoreErrors.ERR_NO_CLAIMABLE_REWARDS);
+});
+
+test('payout pays sBTC to the staker, or to their sbtc-recipient', () => {
+  stake(alice);
+  stake(bob, { l1Withdrawal: null, sbtcRecipient: charlie });
+  const total = claimCycle(1n, 2000n);
+  const each = total / 2n;
+
+  txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), alice);
+  const aliceBefore = sbtcBalance(alice);
+  expect(txOk(signerManagerV1.payout(alice), alice).value).toEqual({
+    amount: each,
+    withdrawalRequest: null,
+  });
+  expect(sbtcBalance(alice)).toBe(aliceBefore + each);
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(0n);
+
+  const charlieBefore = sbtcBalance(charlie);
+  txOk(signerManagerV1.claimStakerRewards(bob, 1n, null), bob);
+  expect(sbtcBalance(charlie)).toBe(charlieBefore + each);
+  expectSolvent();
+});
+
+test('payout with nothing pending fails', () => {
+  stake(alice);
+  expect(txErr(signerManagerV1.payout(alice), alice).value).toBe(
+    signerManagerCoreErrors.ERR_INSUFFICIENT_PENDING,
+  );
+});
+
+test('third parties must clear min-claim on L1 payouts, the staker need not', () => {
+  stake(alice, randomPayoutConfig({ maxFee: 100n, minClaim: 5000n }));
+  const total = claimCycle(1n, 2000n);
+  txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), bob);
+  expect(total).toBeLessThan(5000n);
+  expect(txErr(signerManagerV1.payout(alice), bob).value).toBe(
+    signerManagerCoreErrors.ERR_BELOW_MIN_CLAIM,
+  );
+  // `tx-sender` survives the module hop, so core knows it is the staker.
+  expect(txOk(signerManagerV1.payout(alice), alice).value).toEqual({
+    amount: total,
+    withdrawalRequest: 1n,
+  });
+});
+
+test('claim-staker-rewards with an L1 config initiates a withdrawal', () => {
+  const config = randomPayoutConfig({ maxFee: 100n, minClaim: 0n });
+  stake(alice, config);
+  const total = claimCycle(1n, 2000n);
+
+  const result = txOk(
+    signerManagerV1.claimStakerRewards(alice, 1n, null),
+    bob,
+  ).value;
+  expect(result).toEqual({ earned: total, withdrawalRequest: 1n });
+  expect(rov(signerManagerCore.getWithdrawalRequestStaker(1n))).toBe(alice);
+  expect(rov(signerManagerCore.getWithdrawalLiability())).toBe(total);
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(0n);
+  // `amount + max-fee` is locked by the sBTC withdrawal system; it still
+  // counts toward the contract's balance until the request is resolved.
+  expect(sbtcBalance(signerManagerCore.identifier)).toBe(total);
+  const request = rov(contracts.sbtcRegistry.getWithdrawalRequest(1n))!;
+  expect(request.amount).toBe(total - 100n);
+  expect(request.maxFee).toBe(100n);
+  expect(request.sender).toBe(signerManagerCore.identifier);
+  expectSolvent();
+});
+
+test('L1 payouts below max-fee plus dust are rejected up front', () => {
+  stake(alice, randomPayoutConfig({ maxFee: 100n, minClaim: 0n }));
+  // 700 * 85% = 595 <= 100 + 546.
+  const total = claimCycle(1n, 700n);
+  expect(total).toBeLessThanOrEqual(100n + DUST_LIMIT);
+  txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), alice);
+  expect(txErr(signerManagerV1.payout(alice), alice).value).toBe(
+    signerManagerCoreErrors.ERR_BELOW_DUST_LIMIT,
+  );
+  // The balance is untouched and still pending.
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(total);
+});
+
+test('sub-dust cycles accumulate in pending until one payout clears', () => {
+  stake(alice, randomPayoutConfig({ maxFee: 100n, minClaim: 0n }));
+  const first = claimCycle(1n, 700n);
+  txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), alice);
+  const second = claimCycle(2n, 700n);
+  expect(
+    txOk(signerManagerV1.claimStakerRewards(alice, 2n, null), alice).value,
+  ).toEqual({ earned: first + second, withdrawalRequest: 1n });
+  expectSolvent();
+});
+
+test('a rejected withdrawal is credited back and retried in one call', () => {
+  stake(alice, randomPayoutConfig({ maxFee: 100n, minClaim: 0n }));
+  const total = claimCycle(1n, 2000n);
+  txOk(signerManagerV1.claimStakerRewards(alice, 1n, null), bob);
+
+  // Still pending: nothing to reclaim yet.
+  expect(txErr(signerManagerV1.retryFailedWithdrawal(1n), bob).value).toBe(
+    signerManagerCoreErrors.ERR_WITHDRAWAL_NOT_REJECTED,
+  );
+  txOk(sbtcWithdrawal.rejectWithdrawalRequest(1n, 0n), SBTC_SIGNER);
+  expect(sbtcBalance(signerManagerCore.identifier)).toBe(total);
+
+  // Raise the fee budget, then retry: a new request with the new fee.
+  txOk(
+    signerManagerV1.setPayoutConfig({
+      l1Withdrawal: {
+        poxAddr: rov(signerManagerCore.getPayoutConfig(alice))!.l1Withdrawal!
+          .poxAddr,
+        maxFee: 300n,
+        minClaim: 0n,
+      },
+      sbtcRecipient: null,
+    }),
+    alice,
+  );
+  expect(txOk(signerManagerV1.retryFailedWithdrawal(1n), bob).value).toEqual({
+    amount: total,
+    withdrawalRequest: 2n,
+  });
+  expect(rov(signerManagerCore.getWithdrawalRequestStaker(1n))).toBeNull();
+  expect(rov(signerManagerCore.getWithdrawalRequestStaker(2n))).toBe(alice);
+  expect(rov(signerManagerCore.getWithdrawalLiability())).toBe(total);
+  expect(rov(contracts.sbtcRegistry.getWithdrawalRequest(2n))!.maxFee).toBe(
+    300n,
+  );
+  // The old id is gone, so the retry cannot be replayed.
+  expect(txErr(signerManagerV1.retryFailedWithdrawal(1n), bob).value).toBe(
+    signerManagerV1Errors.ERR_UNKNOWN_WITHDRAWAL_REQUEST,
+  );
+  expectSolvent();
+});
+
+test('a rejected withdrawal can be taken as sBTC by clearing the config', () => {
+  stake(alice, randomPayoutConfig({ maxFee: 100n, minClaim: 0n }));
+  const total = claimCycle(1n, 2000n);
+  txOk(signerManagerV1.claimStakerRewards(alice, 1n, null), bob);
+  txOk(sbtcWithdrawal.rejectWithdrawalRequest(1n, 0n), SBTC_SIGNER);
+
+  txOk(signerManagerV1.reclaimFailedWithdrawal(1n), bob);
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(total);
+  expect(rov(signerManagerCore.getWithdrawalLiability())).toBe(0n);
+
+  txOk(signerManagerV1.clearPayoutConfig(), alice);
+  const before = sbtcBalance(alice);
+  expect(txOk(signerManagerV1.payout(alice), bob).value).toEqual({
+    amount: total,
+    withdrawalRequest: null,
+  });
+  expect(sbtcBalance(alice)).toBe(before + total);
+  expectSolvent();
+});
+
+test('an accepted withdrawal is settled and its fee dust swept', () => {
+  stake(alice, randomPayoutConfig({ maxFee: 100n, minClaim: 0n }));
+  claimCycle(1n, 2000n);
+  txOk(signerManagerV1.claimStakerRewards(alice, 1n, null), bob);
+  acceptWithdrawal(1n, 30n);
+  const dust = 100n - 30n;
+  expect(sbtcBalance(signerManagerCore.identifier)).toBe(dust);
+
+  // Until settled, the live liability keeps the dust unsweepable.
+  expect(txErr(signerManagerV1.sweepFeeRefunds(deployer), deployer).value).toBe(
+    signerManagerCoreErrors.ERR_NO_REFUNDS,
+  );
+  expect(txErr(signerManagerV1.reclaimFailedWithdrawal(1n), bob).value).toBe(
+    signerManagerCoreErrors.ERR_WITHDRAWAL_NOT_REJECTED,
+  );
+  txOk(signerManagerV1.settleAcceptedWithdrawal(1n), bob);
+  expect(rov(signerManagerCore.getWithdrawalLiability())).toBe(0n);
+  expect(txOk(signerManagerV1.sweepFeeRefunds(deployer), deployer).value).toBe(
+    dust,
+  );
+  expect(sbtcBalance(signerManagerCore.identifier)).toBe(0n);
+});
+
+test('admins withdraw fees, bounded by what has been charged', () => {
+  stake(alice);
+  txOk(signerManagerV1.updateFees(1000n), deployer);
+  const gross = claimCycle(1n, 2000n);
+  const fee = (gross * 1000n) / BASIS_POINTS;
+  txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), alice);
+
+  expect(txErr(signerManagerV1.withdrawFees(fee, bob), alice).value).toBe(
+    signerManagerV1Errors.ERR_UNAUTHORIZED_ADMIN,
+  );
+  expect(
+    txErr(signerManagerV1.withdrawFees(fee + 1n, bob), deployer).value,
+  ).toBe(signerManagerCoreErrors.ERR_INSUFFICIENT_FEES);
+  const before = sbtcBalance(bob);
+  txOk(signerManagerV1.withdrawFees(fee, bob), deployer);
+  expect(sbtcBalance(bob)).toBe(before + fee);
+  expect(rov(signerManagerCore.getEarnedFees())).toBe(0n);
+  // The staker's net is still fully covered.
+  expect(sbtcBalance(signerManagerCore.identifier)).toBe(gross - fee);
+  expectSolvent();
+});
+
+test('only admins can update fees, and fees must be below 100%', () => {
+  expect(txErr(signerManagerV1.updateFees(100n), alice).value).toBe(
+    signerManagerV1Errors.ERR_UNAUTHORIZED_ADMIN,
+  );
+  expect(txErr(signerManagerV1.updateFees(10000n), deployer).value).toBe(
+    signerManagerV1Errors.ERR_INVALID_FEES_BIPS,
+  );
+  txOk(signerManagerV1.updateFees(9999n), deployer);
+  expect(rov(signerManagerV1.getFeesBips())).toBe(9999n);
+});
+
+test('core functions cannot be called around the module', () => {
+  stake(alice);
+  claimCycle(1n, 2000n);
+  txOk(signerManagerV1.settleStakerRewards(alice, 1n, null), alice);
+  const pending = rov(signerManagerCore.getPendingPayout(alice));
+  const calls: ContractCallTyped<any, Response<any, bigint>>[] = [
+    signerManagerCore.settleStakerRewards(alice, 1n, null),
+    signerManagerCore.chargeFee(alice, 1n),
+    signerManagerCore.payout(alice, pending),
+    signerManagerCore.withdrawFees(1n, alice),
+    signerManagerCore.sweepFeeRefunds(alice),
+    signerManagerCore.claimRewards([], 2n),
+  ];
+  for (const call of calls) {
+    expect(txErr(call, alice).value).toBe(
+      signerManagerCoreErrors.ERR_UNAUTHORIZED_MODULE,
+    );
+  }
+  expect(rov(signerManagerCore.getPendingPayout(alice))).toBe(pending);
+});


### PR DESCRIPTION
This PR implements a new upgradable signer manager, along with an initial version for this new upgradable architecture.

This new signer manager architecture uses two contracts:

- **core**: the immutable contract that holds state and acts as the interface to pox-5
- **module**: the upgradable contract that stakers and signers interact with for things like claiming rewards