### PR TITLE
refactor: small collection of remaining clippy lint fixes

### DIFF
--- a/clarity/benches/sequence_ops.rs
+++ b/clarity/benches/sequence_ops.rs
@@ -85,6 +85,10 @@ fn make_utf8_string(n: usize) -> SequenceData {
 // ---------------------------------------------------------------------------
 
 /// Old behavior: drain(..).collect() + iter + to_value (clone) + SymbolicExpression wrap.
+#[expect(
+    clippy::drain_collect,
+    reason = "This benchmark compares drain-and-collect with mem::take."
+)]
 fn drain_and_clone(sequence_data: &mut SequenceData) {
     let result: Vec<_> = match sequence_data {
         SequenceData::Buffer(data) => data
@@ -281,9 +285,7 @@ fn new_try_retain_linear(
     sequence_data: SequenceData,
     predicate: &mut impl FnMut(Value) -> Result<bool, ()>,
 ) -> SequenceData {
-    sequence_data
-        .try_retain::<(), _>(|val| predicate(val))
-        .unwrap()
+    sequence_data.try_retain::<(), _>(predicate).unwrap()
 }
 
 fn bench_try_retain(c: &mut Criterion) {
@@ -305,7 +307,7 @@ fn bench_try_retain(c: &mut Criterion) {
                         counter = 0;
                         old_retain_quadratic(&mut seq, &mut |_sym| {
                             counter += 1;
-                            Ok(counter % 2 == 0)
+                            Ok(counter.is_multiple_of(2))
                         });
                         black_box(seq);
                     },
@@ -324,7 +326,7 @@ fn bench_try_retain(c: &mut Criterion) {
                         counter = 0;
                         let seq = new_try_retain_linear(seq, &mut |_sym| {
                             counter += 1;
-                            Ok(counter % 2 == 0)
+                            Ok(counter.is_multiple_of(2))
                         });
                         black_box(seq);
                     },

--- a/clarity/benches/variadic_concat.rs
+++ b/clarity/benches/variadic_concat.rs
@@ -36,6 +36,7 @@
 //!                                          variadic-is-cheaper property.
 
 use std::hint::black_box;
+use std::iter;
 
 use clarity::vm::contexts::{ContractContext, GlobalContext};
 use clarity::vm::costs::LimitedCostTracker;
@@ -100,7 +101,7 @@ fn buff_literal(bytes_per_arg: usize) -> String {
 /// `(concat <arg> <arg> ... <arg>)` with `n_args` copies of the same arg.
 fn make_variadic_concat_program(n_args: usize, bytes_per_arg: usize) -> String {
     let arg = buff_literal(bytes_per_arg);
-    let args: Vec<&str> = std::iter::repeat(arg.as_str()).take(n_args).collect();
+    let args: Vec<&str> = iter::repeat_n(arg.as_str(), n_args).collect();
     format!("(concat {})", args.join(" "))
 }
 

--- a/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -2909,7 +2909,7 @@ mod tests {
             config.burnchain.password = None;
             config.burnchain.peer_host = String::from("127.0.0.1");
             config.burnchain.peer_port = 8333;
-            config.node.working_dir = format!("/tmp/follower");
+            config.node.working_dir = "/tmp/follower".to_string();
             config
         }
     }

--- a/stacks-node/src/burnchains/rpc/bitcoin_rpc_client/tests.rs
+++ b/stacks-node/src/burnchains/rpc/bitcoin_rpc_client/tests.rs
@@ -749,7 +749,7 @@ fn test_send_raw_transaction_ok_with_custom_params() {
 
 #[test]
 fn test_get_descriptor_info_ok() {
-    let descriptor = format!("addr(bc1_address)");
+    let descriptor = "addr(bc1_address)".to_string();
     let expected_checksum = "mychecksum";
     let expected_descriptor = format!("{descriptor}#{expected_checksum}");
 

--- a/stacks-node/src/event_dispatcher.rs
+++ b/stacks-node/src/event_dispatcher.rs
@@ -86,20 +86,20 @@ lazy_static! {
 #[derive(Debug, thiserror::Error)]
 enum EventDispatcherError {
     #[error("Serialization error: {0}")]
-    SerializationError(#[from] serde_json::Error),
+    Serialization(#[from] serde_json::Error),
     #[error("HTTP error: {0}")]
-    HttpError(#[from] std::io::Error),
+    Http(#[from] std::io::Error),
     #[error("Database error: {0}")]
-    DbError(#[from] stacks::util_lib::db::Error),
+    Db(#[from] stacks::util_lib::db::Error),
     #[error("Channel receive error: {0}")]
-    RecvError(#[from] std::sync::mpsc::RecvError),
+    Recv(#[from] std::sync::mpsc::RecvError),
     #[error("Channel send error: {0}")]
-    SendError(String), // not capturing the underlying because it's a generic type
+    Send(String), // not capturing the underlying because it's a generic type
 }
 
 impl<T> From<std::sync::mpsc::SendError<T>> for EventDispatcherError {
     fn from(value: std::sync::mpsc::SendError<T>) -> Self {
-        EventDispatcherError::SendError(format!("{value}"))
+        EventDispatcherError::Send(format!("{value}"))
     }
 }
 

--- a/stacks-node/src/nakamoto_node/miner.rs
+++ b/stacks-node/src/nakamoto_node/miner.rs
@@ -777,7 +777,7 @@ impl BlockMinerThread {
                 if self.is_aborted() {
                     info!("Miner interrupted while mining in order to shut down");
                     self.globals
-                        .raise_initiative(format!("MiningFailure: aborted by node"));
+                        .raise_initiative("MiningFailure: aborted by node".to_string());
                     return Err(ChainstateError::MinerAborted.into());
                 }
 
@@ -800,7 +800,7 @@ impl BlockMinerThread {
                     if self.is_aborted() {
                         info!("Miner interrupted while mining in order to shut down");
                         self.globals
-                            .raise_initiative(format!("MiningFailure: aborted by node"));
+                            .raise_initiative("MiningFailure: aborted by node".to_string());
                         return Err(ChainstateError::MinerAborted.into());
                     }
 
@@ -1056,7 +1056,7 @@ impl BlockMinerThread {
             if self.is_aborted() {
                 info!("Miner interrupted while mining in order to shut down");
                 self.globals
-                    .raise_initiative(format!("MiningFailure: aborted by node"));
+                    .raise_initiative("MiningFailure: aborted by node".to_string());
                 return Err(ChainstateError::MinerAborted.into());
             }
 

--- a/stacks-node/src/nakamoto_node/relayer.rs
+++ b/stacks-node/src/nakamoto_node/relayer.rs
@@ -2330,7 +2330,6 @@ pub mod test {
     use std::io::Write;
     use std::path::Path;
     use std::time::Duration;
-    use std::u64;
 
     use rand::{thread_rng, Rng};
     use stacks::burnchains::Txid;

--- a/stacks-node/src/neon_node.rs
+++ b/stacks-node/src/neon_node.rs
@@ -3221,7 +3221,6 @@ impl RelayerThread {
                 parent_consensus_hash,
                 anchored_block: mined_block,
                 burn_hash: mined_burn_hash,
-                attempt: _,
                 ..
             } = last_mined_block_data;
 

--- a/stacks-node/src/tests/marf/marf_compress_dyn.rs
+++ b/stacks-node/src/tests/marf/marf_compress_dyn.rs
@@ -69,7 +69,7 @@ pub mod utils {
             .collect::<Vec<_>>();
         let initial_sender_addrs = initial_sender_sks
             .iter()
-            .map(|sk| tests::to_addr(sk))
+            .map(tests::to_addr)
             .collect::<Vec<_>>();
 
         // These 10 accounts will send to 25 accounts each, then those 260 accounts
@@ -253,7 +253,7 @@ pub mod utils {
             for (sender_sk, nonce) in senders.iter_mut() {
                 let sender_addr = tests::to_addr(sender_sk);
                 let fee = set_fee();
-                assert!(fee >= 180 && fee <= 2000);
+                assert!((180..=2000).contains(&fee));
                 let transfer_tx = make_stacks_transfer_serialized(
                     sender_sk, *nonce, fee, chain_id, &recipient, 1,
                 );

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -744,7 +744,7 @@ pub fn naka_neon_integration_conf(seed: Option<&[u8]>) -> (Config, StacksAddress
         burnchain.peer_host = Some("127.0.0.1".to_string());
     }
 
-    conf.burnchain.magic_bytes = MagicBytes::from([b'T', b'3'].as_ref());
+    conf.burnchain.magic_bytes = MagicBytes::from(b"T3".as_slice());
     conf.burnchain.poll_time_secs = 1;
     conf.node.pox_sync_sample_secs = 0;
 
@@ -6029,7 +6029,7 @@ fn check_block_heights() {
 
     let mut last_burn_block_height;
     let mut last_stacks_block_height = info.stacks_tip_height as u128;
-    let mut last_tenure_height = last_stacks_block_height as u128;
+    let mut last_tenure_height = last_stacks_block_height;
 
     let heights0_value = call_read_only(
         &naka_conf,
@@ -12302,7 +12302,7 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
         .collect::<Vec<_>>();
     let initial_sender_addrs = initial_sender_sks
         .iter()
-        .map(|sk| tests::to_addr(sk))
+        .map(tests::to_addr)
         .collect::<Vec<_>>();
 
     // These 10 accounts will send to 25 accounts each, then those 260 accounts
@@ -12508,7 +12508,7 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
         for (sender_sk, nonce) in senders.iter_mut() {
             let sender_addr = tests::to_addr(sender_sk);
             let fee = set_fee();
-            assert!(fee >= 180 && fee <= 2000);
+            assert!((180..=2000).contains(&fee));
             let transfer_tx = make_stacks_transfer_serialized(
                 sender_sk,
                 *nonce,
@@ -12646,7 +12646,7 @@ fn larger_mempool() {
         .collect::<Vec<_>>();
     let initial_sender_addrs = initial_sender_sks
         .iter()
-        .map(|sk| tests::to_addr(sk))
+        .map(tests::to_addr)
         .collect::<Vec<_>>();
 
     // These 10 accounts will send to 25 accounts each, then those 260 accounts
@@ -16318,8 +16318,7 @@ fn check_with_stacking_allowances_delegate_stx() {
 
     let mut sender_nonce = 0;
     let contract_name = "test-contract";
-    let contract = format!(
-        r#"
+    let contract = r#"
 (define-public (delegate-stx (amount uint) (allowed uint))
   (as-contract? ((with-stacking allowed))
     (unwrap! (contract-call? 'ST000000000000000000002AMW42H.pox-4 delegate-stx
@@ -16355,7 +16354,7 @@ fn check_with_stacking_allowances_delegate_stx() {
   )
 )
 "#
-    );
+    .to_string();
 
     let contract_tx = make_contract_publish(
         &sender_sk,
@@ -17328,8 +17327,7 @@ fn check_restrict_assets_rollback() {
 
     let mut sender_nonce = 0;
     let contract_name = "test-contract";
-    let contract = format!(
-        r#"
+    let contract = r#"
 (define-public (single-transfer
     (recipient principal)
     (amount uint)
@@ -17472,7 +17470,7 @@ fn check_restrict_assets_rollback() {
   )
 )
 "#
-    );
+    .to_string();
 
     let contract_tx = make_contract_publish(
         &sender_sk,
@@ -18048,8 +18046,7 @@ fn check_as_contract_rollback() {
     next_block_and_mine_commit(&mut btc_regtest_controller, 60, &naka_conf, &counters).unwrap();
 
     let mut sender_nonce = 0;
-    let contract = format!(
-        r#"
+    let contract = r#"
 (define-public (single-transfer
     (recipient principal)
     (amount uint)
@@ -18192,7 +18189,7 @@ fn check_as_contract_rollback() {
   )
 )
 "#
-    );
+    .to_string();
 
     let contract_tx = make_contract_publish(
         &sender_sk,

--- a/stacks-node/src/tests/neon_integrations.rs
+++ b/stacks-node/src/tests/neon_integrations.rs
@@ -1399,7 +1399,7 @@ fn confirm_unparsed_ongoing_ops() {
     bitcoin_regtest_controller::TEST_MAGIC_BYTES
         .lock()
         .unwrap()
-        .replace([b'Z', b'Z']);
+        .replace(*b"ZZ");
 
     // let's trigger another mining loop: this should create an invalid block commit.
     // this bitcoin block will contain the valid commit created before (so, a second stacks block)

--- a/stacks-node/src/tests/signer/mod.rs
+++ b/stacks-node/src/tests/signer/mod.rs
@@ -395,7 +395,7 @@ impl<Z: SpawnedSignerTrait> SignerTest<Z> {
             let duration = now.duration_since(created_at).unwrap();
             // Regtest doesn't like if the last block is > 2 hours old, so
             // don't use this snapshot.
-            if duration > Duration::from_secs(3600 * 1) {
+            if duration > Duration::from_secs(3600) {
                 // Bitcoin regtest node is too old, act like no snapshot exists
                 warn!("Bitcoin regtest node is too old, not restoring snapshot");
                 std::fs::remove_dir_all(snapshot_path.clone()).unwrap();
@@ -1229,7 +1229,7 @@ impl<Z: SpawnedSignerTrait> SignerTest<Z> {
     /// Chain information is captured before `f` is called, and then again after `f`
     /// to ensure that the block was mined.
     /// Note: this function does _not_ mine a BTC block.
-    fn wait_for_nakamoto_block(&self, timeout_secs: u64, f: impl FnOnce() -> ()) {
+    fn wait_for_nakamoto_block(&self, timeout_secs: u64, f: impl FnOnce()) {
         let blocks_before = self.running_nodes.counters.naka_mined_blocks.get();
         let info_before = self.get_peer_info();
 

--- a/stacks-node/src/tests/signer/multiversion.rs
+++ b/stacks-node/src/tests/signer/multiversion.rs
@@ -133,7 +133,7 @@ impl SpawnedSignerTrait for MultiverSpawnedSigner {
     type StopResult = ();
 
     fn new(c: stacks_signer::config::GlobalConfig) -> Self {
-        if c.endpoint.port() % 2 == 0 {
+        if c.endpoint.port().is_multiple_of(2) {
             debug!(
                 "Spawning current version signer for endpoint {}",
                 c.endpoint

--- a/stacks-node/src/tests/signer/v0/mod.rs
+++ b/stacks-node/src/tests/signer/v0/mod.rs
@@ -4905,7 +4905,7 @@ fn multiple_miners_with_nakamoto_blocks() {
     assert_eq!(peer_1_height, peer_2_height);
     assert_eq!(
         peer_1_height,
-        pre_nakamoto_peer_1_height + (btc_blocks_mined - 1) * (inter_blocks_per_tenure as u64 + 1)
+        pre_nakamoto_peer_1_height + (btc_blocks_mined - 1) * (inter_blocks_per_tenure + 1)
     );
     assert_eq!(btc_blocks_mined, miner_1_tenures + miner_2_tenures);
     miners.shutdown();
@@ -7312,7 +7312,7 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
         .collect::<Vec<_>>();
     let initial_sender_addrs = initial_sender_sks
         .iter()
-        .map(|sk| tests::to_addr(sk))
+        .map(tests::to_addr)
         .collect::<Vec<_>>();
 
     // These 10 accounts will send to 25 accounts each, then those 260 accounts
@@ -7493,7 +7493,7 @@ fn large_mempool_base(strategy: MemPoolWalkStrategy, set_fee: impl Fn() -> u64) 
         for (sender_sk, nonce) in senders.iter_mut() {
             let sender_addr = tests::to_addr(sender_sk);
             let fee = set_fee();
-            assert!(fee >= 180 && fee <= 2000);
+            assert!((180..=2000).contains(&fee));
             let transfer_tx =
                 make_stacks_transfer_serialized(sender_sk, *nonce, fee, chain_id, &recipient, 1);
             insert_tx_in_mempool(
@@ -7603,7 +7603,7 @@ fn larger_mempool() {
         .collect::<Vec<_>>();
     let initial_sender_addrs = initial_sender_sks
         .iter()
-        .map(|sk| tests::to_addr(sk))
+        .map(tests::to_addr)
         .collect::<Vec<_>>();
 
     // These 10 accounts will send to 25 accounts each, then those 260 accounts

--- a/stacks-node/src/tests/signer/v0/tenure_extend.rs
+++ b/stacks-node/src/tests/signer/v0/tenure_extend.rs
@@ -586,6 +586,7 @@ fn stx_transfers_dont_effect_idle_timeout() {
 
     let slot_id = 0_u32;
 
+    // This response predates global acceptance and reports an estimated idle time.
     let initial_acceptance = signer_test.get_latest_block_acceptance(slot_id);
     assert_eq!(initial_acceptance.signer_signature_hash, last_block_hash);
 
@@ -598,8 +599,6 @@ fn stx_transfers_dont_effect_idle_timeout() {
 
     let mut sender_nonce = 0;
 
-    // Note that this response was BEFORE the block was globally accepted. it will report a guestimated idle time
-    let initial_acceptance = initial_acceptance;
     let mut first_global_acceptance = None;
     for i in 0..num_txs {
         info!("---- Mining interim block {} ----", i + 1);

--- a/stackslib/src/burnchains/bitcoin/indexer.rs
+++ b/stackslib/src/burnchains/bitcoin/indexer.rs
@@ -3214,7 +3214,7 @@ mod test {
                         if block_height > 40320 {
                             break;
                         }
-                        if block_height >= 40319 && block_height <= 40320 {
+                        if (40319..=40320).contains(&block_height) {
                             test_debug!("insert bad header {}", block_height);
                             ret.push(bad_headers[(block_height - 40319) as usize].clone());
                             inserted_bad_header = true;
@@ -3377,7 +3377,7 @@ mod test {
                         if block_height > 40320 {
                             break;
                         }
-                        if block_height >= 40319 && block_height <= 40320 {
+                        if (40319..=40320).contains(&block_height) {
                             test_debug!("insert good header {}", block_height);
                             ret.push(good_headers[(block_height - 40319) as usize].clone());
                             inserted_good_header = true;

--- a/stackslib/src/burnchains/bitcoin/spv.rs
+++ b/stackslib/src/burnchains/bitcoin/spv.rs
@@ -859,7 +859,7 @@ impl SpvClient {
                 .inspect_err(|e| error!("Failed to insert block headers: {e:?}"))?;
 
             // check work
-            let interval_start = if insert_height % BLOCK_DIFFICULTY_CHUNK_SIZE == 0 {
+            let interval_start = if insert_height.is_multiple_of(BLOCK_DIFFICULTY_CHUNK_SIZE) {
                 insert_height / BLOCK_DIFFICULTY_CHUNK_SIZE
             } else {
                 insert_height / BLOCK_DIFFICULTY_CHUNK_SIZE + 1
@@ -1139,7 +1139,7 @@ impl SpvClient {
             }
         };
 
-        if current_header_height % BLOCK_DIFFICULTY_CHUNK_SIZE != 0
+        if !current_header_height.is_multiple_of(BLOCK_DIFFICULTY_CHUNK_SIZE)
             && self.network_id == BitcoinNetworkType::Testnet
         {
             // In Testnet mode, if the new block's timestamp is more than 2 * 60 * 10 minutes

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -604,14 +604,19 @@ impl PoxConstants {
 
     /// Is this the first block to be signed by the signer set in cycle N?
     /// This is the mod 0 block.
-    #[expect(
-        clippy::manual_is_multiple_of,
-        reason = "Remainder must still panic for a zero reward-cycle length."
-    )]
+    ///
+    /// # Panics
+    /// Panics if the reward-cycle length is zero.
     pub fn is_naka_signing_cycle_start(&self, first_block_height: u64, burn_height: u64) -> bool {
         let effective_height = burn_height - first_block_height;
+        let reward_cycle_length = u64::from(self.reward_cycle_length);
+
+        assert_ne!(
+            reward_cycle_length, 0,
+            "Reward-cycle length must be nonzero"
+        );
         // first block of the new reward cycle
-        (effective_height % u64::from(self.reward_cycle_length)) == 0
+        effective_height.is_multiple_of(reward_cycle_length)
     }
 
     /// return the first burn block which receives reward in `reward_cycle`.

--- a/stackslib/src/burnchains/mod.rs
+++ b/stackslib/src/burnchains/mod.rs
@@ -604,6 +604,10 @@ impl PoxConstants {
 
     /// Is this the first block to be signed by the signer set in cycle N?
     /// This is the mod 0 block.
+    #[expect(
+        clippy::manual_is_multiple_of,
+        reason = "Remainder must still panic for a zero reward-cycle length."
+    )]
     pub fn is_naka_signing_cycle_start(&self, first_block_height: u64, burn_height: u64) -> bool {
         let effective_height = burn_height - first_block_height;
         // first block of the new reward cycle

--- a/stackslib/src/burnchains/tests/burnchain.rs
+++ b/stackslib/src/burnchains/tests/burnchain.rs
@@ -38,6 +38,35 @@ use crate::chainstate::burn::{
 };
 use crate::chainstate::stacks::StacksPublicKey;
 
+/// Signer cycles begin at the offset's multiples of the reward-cycle length.
+#[test]
+fn test_naka_signing_cycle_start() {
+    let mut pox_constants = PoxConstants::test_default();
+    pox_constants.reward_cycle_length = 10;
+
+    for (height, expected) in [
+        (100, true),
+        (101, false),
+        (109, false),
+        (110, true),
+        (111, false),
+    ] {
+        assert_eq!(
+            pox_constants.is_naka_signing_cycle_start(100, height),
+            expected
+        );
+    }
+}
+
+/// A zero-length cycle must panic even at an effective height of zero.
+#[test]
+#[should_panic(expected = "Reward-cycle length must be nonzero")]
+fn test_naka_signing_cycle_start_zero_length() {
+    let mut pox_constants = PoxConstants::test_default();
+    pox_constants.reward_cycle_length = 0;
+    pox_constants.is_naka_signing_cycle_start(100, 100);
+}
+
 #[test]
 fn test_process_block_ops() {
     let first_burn_hash = BurnchainHeaderHash::from_hex(

--- a/stackslib/src/chainstate/burn/atc.rs
+++ b/stackslib/src/chainstate/burn/atc.rs
@@ -1428,7 +1428,7 @@ mod test {
             grid[101][j] = '_';
         }
 
-        println!("");
+        println!();
         for row in grid.iter() {
             let grid_str: String = row.clone().into_iter().collect();
             println!("|{}", &grid_str);

--- a/stackslib/src/chainstate/burn/db/sortdb.rs
+++ b/stackslib/src/chainstate/burn/db/sortdb.rs
@@ -310,7 +310,8 @@ impl FromRow<StackStxOp> for StackStxOp {
         let sender = StacksAddress::from_column(row, "sender_addr")?;
         let reward_addr = PoxAddress::from_column(row, "reward_addr")?;
         let stacked_ustx_str: String = row.get_unwrap("stacked_ustx");
-        let stacked_ustx = u128::from_str_radix(&stacked_ustx_str, 10)
+        let stacked_ustx = stacked_ustx_str
+            .parse::<u128>()
             .expect("CORRUPTION: bad u128 written to sortdb");
         let num_cycles = row.get_unwrap("num_cycles");
         let signing_key_str_opt: Option<String> = row.get("signer_key")?;
@@ -320,7 +321,8 @@ impl FromRow<StackStxOp> for StackStxOp {
         };
         let max_amount_str_opt: Option<String> = row.get("max_amount")?;
         let max_amount = match max_amount_str_opt {
-            Some(max_amount_str) => u128::from_str_radix(&max_amount_str, 10)
+            Some(max_amount_str) => max_amount_str
+                .parse::<u128>()
                 .map_err(|_| db_error::ParseError)
                 .ok(),
             None => None,
@@ -357,7 +359,8 @@ impl FromRow<DelegateStxOp> for DelegateStxOp {
             .expect("CORRUPTION: DB stored bad transition ops");
 
         let delegated_ustx_str: String = row.get_unwrap("delegated_ustx");
-        let delegated_ustx = u128::from_str_radix(&delegated_ustx_str, 10)
+        let delegated_ustx = delegated_ustx_str
+            .parse::<u128>()
             .expect("CORRUPTION: bad u128 written to sortdb");
         let until_burn_height = u64::from_column(row, "until_burn_height")?;
 
@@ -385,7 +388,8 @@ impl FromRow<TransferStxOp> for TransferStxOp {
         let sender = StacksAddress::from_column(row, "sender_addr")?;
         let recipient = StacksAddress::from_column(row, "recipient_addr")?;
         let transfered_ustx_str: String = row.get_unwrap("transfered_ustx");
-        let transfered_ustx = u128::from_str_radix(&transfered_ustx_str, 10)
+        let transfered_ustx = transfered_ustx_str
+            .parse::<u128>()
             .expect("CORRUPTION: bad u128 written to sortdb");
         let memo_hex: String = row.get_unwrap("memo");
         let memo = hex_bytes(&memo_hex).map_err(|_| db_error::Corruption)?;
@@ -6342,7 +6346,7 @@ impl SortitionHandleTx<'_> {
                             pox_payout_addrs = vec![wf.sbtc_address.clone()];
                             keys.push(db_keys::pox_reward_set_size().to_string());
                             values.push(db_keys::reward_set_size_to_string(1));
-                            keys.push(db_keys::pox_reward_set_entry(0 as u16));
+                            keys.push(db_keys::pox_reward_set_entry(0_u16));
                             values.push(wf.sbtc_address.to_db_string());
                             keys.push(db_keys::pox_reward_set_wf_activated().to_string());
                             values.push("1".to_string());

--- a/stackslib/src/chainstate/burn/distribution.rs
+++ b/stackslib/src/chainstate/burn/distribution.rs
@@ -294,7 +294,7 @@ impl BurnSamplePoint {
 
                 let mut sorted_burns = all_burns.clone();
                 sorted_burns.sort();
-                let median_burn = if window_size % 2 == 0 {
+                let median_burn = if window_size.is_multiple_of(2) {
                     (sorted_burns[(window_size / 2) as usize]
                         + sorted_burns[(window_size / 2 - 1) as usize])
                         / 2

--- a/stackslib/src/chainstate/burn/operations/stack_stx.rs
+++ b/stackslib/src/chainstate/burn/operations/stack_stx.rs
@@ -842,7 +842,7 @@ mod tests {
             auth_id: Some(0u32),
         };
         let op_bytes = {
-            let mut bytes = [b'T', b'3'].to_vec();
+            let mut bytes = b"T3".to_vec();
             op.consensus_serialize(&mut bytes)
                 .expect("Expected to be able to serialize op into bytes");
             bytes

--- a/stackslib/src/chainstate/coordinator/tests.rs
+++ b/stackslib/src/chainstate/coordinator/tests.rs
@@ -1253,7 +1253,7 @@ fn missed_block_commits_2_05() {
             let min_burn = 1;
             let median_burn = if expected_window_commits > expected_window_size / 2 {
                 10000
-            } else if expected_window_size % 2 == 0
+            } else if expected_window_size.is_multiple_of(2)
                 && expected_window_commits == expected_window_size / 2
             {
                 (10000 + 1) / 2
@@ -1586,7 +1586,7 @@ fn missed_block_commits_2_1() {
                 && last_bad_op_height + (MINING_COMMITMENT_WINDOW as u64) > tip.block_height;
             if have_bad_missed_commit {
                 // bad commit breaks the chain if its PoX outputs are invalid
-                if ix >= 24 && ix < 29 {
+                if (24..29).contains(&ix) {
                     expected_window_commits = (tip.block_height - last_bad_op_height + 1) as usize;
                 }
                 info!(
@@ -1603,7 +1603,7 @@ fn missed_block_commits_2_1() {
             let min_burn = 1;
             let median_burn = if expected_window_commits > expected_window_size / 2 {
                 10000
-            } else if expected_window_size % 2 == 0
+            } else if expected_window_size.is_multiple_of(2)
                 && expected_window_commits == expected_window_size / 2
             {
                 (10000 + 1) / 2
@@ -1942,7 +1942,7 @@ fn late_block_commits_2_1() {
             let min_burn = 1;
             let median_burn = if expected_window_commits > expected_window_size / 2 {
                 10000
-            } else if expected_window_size % 2 == 0
+            } else if expected_window_size.is_multiple_of(2)
                 && expected_window_commits == expected_window_size / 2
             {
                 (10000 + 1) / 2
@@ -3559,7 +3559,7 @@ fn test_delegate_stx_btc_ops() {
         //                          \ _ S30 -> S31 -> ...
         let parent = if ix == 0 {
             BlockHeaderHash([0; 32])
-        } else if ix >= 22 && ix <= 30 {
+        } else if (22..=30).contains(&ix) {
             stacks_blocks[20].1.header.block_hash()
         } else {
             stacks_blocks[ix - 1].1.header.block_hash()
@@ -3741,7 +3741,7 @@ fn test_delegate_stx_btc_ops() {
             // Want to ensure that a burnchain operation sent in a burn block
             // is picked up by stacks blocks on the same burnchain block
             // up to 6 stacks blocks in the future, even if the stacks blockchain is forking.
-            if ix >= 21 && ix <= 27 {
+            if (21..=27).contains(&ix) {
                 assert_eq!(
                     second_delegation_info,
                     Some((delegated_amt * 2, None)),
@@ -4372,7 +4372,7 @@ fn test_epoch_switch_pox_2_contract_instantiation() {
         // check that the expected stacks epoch ID is equal to the actual stacks epoch ID
         let expected_epoch = match burn_block_height {
             x if x < 4 => StacksEpochId::Epoch20,
-            x if x >= 4 && x < 8 => StacksEpochId::Epoch2_05,
+            x if (4..8).contains(&x) => StacksEpochId::Epoch2_05,
             x => StacksEpochId::Epoch21,
         };
         assert_eq!(
@@ -4393,7 +4393,7 @@ fn test_epoch_switch_pox_2_contract_instantiation() {
         // `StacksEpoch::unit_test_up_to(_, Epoch21)`.
         let expected_runtime = match burn_block_height {
             x if x < 4 => u64::MAX,
-            x if x >= 4 && x < 8 => 205205,
+            x if (4..8).contains(&x) => 205205,
             x => 210210,
         };
         assert_eq!(
@@ -4579,10 +4579,10 @@ fn test_epoch_switch_pox_3_contract_instantiation() {
         // check that the expected stacks epoch ID is equal to the actual stacks epoch ID
         let expected_epoch = match burn_block_height {
             x if x < 4 => StacksEpochId::Epoch20,
-            x if x >= 4 && x < 8 => StacksEpochId::Epoch2_05,
-            x if x >= 8 && x < 12 => StacksEpochId::Epoch21,
-            x if x >= 12 && x < 16 => StacksEpochId::Epoch22,
-            x if x >= 16 && x < 20 => StacksEpochId::Epoch23,
+            x if (4..8).contains(&x) => StacksEpochId::Epoch2_05,
+            x if (8..12).contains(&x) => StacksEpochId::Epoch21,
+            x if (12..16).contains(&x) => StacksEpochId::Epoch22,
+            x if (16..20).contains(&x) => StacksEpochId::Epoch23,
             _ => StacksEpochId::Epoch24,
         };
         assert_eq!(
@@ -4603,7 +4603,7 @@ fn test_epoch_switch_pox_3_contract_instantiation() {
         // `StacksEpoch::unit_test_up_to(_, Epoch24)`.
         let expected_runtime = match burn_block_height {
             x if x < 4 => u64::MAX,
-            x if x >= 4 && x < 8 => 205205,
+            x if (4..8).contains(&x) => 205205,
             x => 210210,
         };
         assert_eq!(

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -992,7 +992,9 @@ impl<
                 .burnchain
                 .block_height_to_reward_cycle(stacks_sn.block_height)
                 .ok_or_else(|| {
-                    ChainstateError::Expects(format!("burnchain block height has no reward cycle"))
+                    ChainstateError::Expects(
+                        "burnchain block height has no reward cycle".to_string(),
+                    )
                 })?;
 
             let last_processed_reward_cycle = {

--- a/stackslib/src/chainstate/nakamoto/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/mod.rs
@@ -1194,7 +1194,7 @@ impl NakamotoBlockHeader {
     pub fn compute_voting_weight_threshold(total_weight: u32) -> Result<u32, ChainstateError> {
         let threshold = NAKAMOTO_SIGNER_BLOCK_APPROVAL_THRESHOLD;
         let total_weight = u64::from(total_weight);
-        let ceil = if (total_weight * threshold) % 10 == 0 {
+        let ceil = if (total_weight * threshold).is_multiple_of(10) {
             0
         } else {
             1

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -3078,7 +3078,7 @@ fn valid_vote_transaction_malformed_transactions() {
         post_conditions: vec![],
         payload: TransactionPayload::ContractCall(TransactionContractCall {
             address: contract_addr.clone(),
-            contract_name: contract_name,
+            contract_name,
             function_name: ClarityName::from_literal(SIGNERS_VOTING_FUNCTION_NAME),
             function_args: valid_function_args,
         }),

--- a/stackslib/src/chainstate/stacks/boot/contract_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/contract_tests.rs
@@ -1060,7 +1060,7 @@ fn pox_2_lock_extend_units() {
         // check that entries exist for each cycle stacked
         for cycle in 0..20 {
             eprintln!("Cycle number = {}", cycle);
-            let empty_set = cycle < 1 || cycle >= 13;
+            let empty_set = !(1..13).contains(&cycle);
             let expected = if empty_set {
                 "(u0 u0)"
             } else {
@@ -1624,7 +1624,7 @@ fn pox_2_delegate_extend_units() {
         // for all other cycles, reward set should be empty
         for cycle in 0..20 {
             eprintln!("Cycle number = {}, MIN_THRESHOLD  = {}", cycle, MIN_THRESHOLD.deref());
-            let empty_set = cycle < 1 || cycle >= 12;
+            let empty_set = !(1..12).contains(&cycle);
             let expected = if empty_set {
                 "(u0 u0)".into()
             } else {

--- a/stackslib/src/chainstate/stacks/boot/mod.rs
+++ b/stackslib/src/chainstate/stacks/boot/mod.rs
@@ -5697,7 +5697,7 @@ pub mod test {
                             1,
                         );
                         block_txs.push(alice_stack);
-                    } else if tenure_id >= 2 && tenure_id <= 8 {
+                    } else if (2..=8).contains(&tenure_id) {
                         // try to spend tokens -- they should all fail with short-return
                         let alice_spend = make_bare_contract(
                             &alice,
@@ -5911,7 +5911,7 @@ pub mod test {
 
                 assert!(reward_cycle > cur_reward_cycle);
                 test_before_first_reward_cycle = true;
-            } else if tenure_id >= 2 && tenure_id <= 8 {
+            } else if (2..=8).contains(&tenure_id) {
                 // alice did _NOT_ spend
                 assert!(get_contract(
                     &mut peer,

--- a/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -830,7 +830,7 @@ fn test_simple_pox_lockup_transition_pox_2() {
 
     // our "tenure counter" is now at 0
     let tip = get_tip(peer.chain.sortdb.as_ref());
-    assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
+    assert_eq!(tip.block_height, (EMPTY_SORTITIONS as u64));
 
     // first tenure is empty
     peer.tenure_with_txs(&[], &mut coinbase_nonce);
@@ -1244,7 +1244,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
     let bob_lockup = make_pox_2_lockup(
         &bob,
         0,
-        1 * POX_THRESHOLD_STEPS_USTX,
+        POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
             key_to_stacks_addr(&bob).destruct().1,
@@ -2116,7 +2116,7 @@ fn test_lock_period_invariant_extend_transition() {
 
     // our "tenure counter" is now at 0
     let tip = get_tip(peer.chain.sortdb.as_ref());
-    assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
+    assert_eq!(tip.block_height, (EMPTY_SORTITIONS as u64));
 
     // first tenure is empty
     peer.tenure_with_txs(&[], &mut coinbase_nonce);
@@ -2368,7 +2368,7 @@ fn test_pox_extend_transition_pox_2() {
 
     // our "tenure counter" is now at 0
     let tip = get_tip(peer.chain.sortdb.as_ref());
-    assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
+    assert_eq!(tip.block_height, (EMPTY_SORTITIONS as u64));
 
     // first tenure is empty
     peer.tenure_with_txs(&[], &mut coinbase_nonce);
@@ -2754,7 +2754,7 @@ fn test_delegate_extend_transition_pox_2() {
         );
         assert_eq!(&(reward_addrs[0].0).hash160(), charlie_address.bytes());
         // 1 lockup was done between alice's first cycle and the start of v2 cycles
-        assert_eq!(reward_addrs[0].1, 1 * LOCKUP_AMT);
+        assert_eq!(reward_addrs[0].1, LOCKUP_AMT);
     };
 
     // these checks should pass after the start of V2 reward cycles
@@ -2793,7 +2793,7 @@ fn test_delegate_extend_transition_pox_2() {
 
     // our "tenure counter" is now at 0
     let tip = get_tip(peer.chain.sortdb.as_ref());
-    assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
+    assert_eq!(tip.block_height, (EMPTY_SORTITIONS as u64));
 
     // first tenure is empty
     peer.tenure_with_txs(&[], &mut coinbase_nonce);
@@ -3548,7 +3548,7 @@ fn test_pox_2_getters() {
     }}", &alice_address,
         &bob_address,
         &bob_address, &format!("{}.hello-world", &charlie_address), cur_reward_cycle + 1,
-        charlie_address.bytes(), cur_reward_cycle + 0, &charlie_address,
+        charlie_address.bytes(), cur_reward_cycle, &charlie_address,
         charlie_address.bytes(), cur_reward_cycle + 1, &charlie_address,
         charlie_address.bytes(), cur_reward_cycle + 2, &charlie_address,
         charlie_address.bytes(), cur_reward_cycle + 3, &charlie_address,

--- a/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_3_tests.rs
@@ -185,7 +185,7 @@ fn simple_pox_lockup_transition_pox_2() {
 
     // our "tenure counter" is now at 0
     let tip = get_tip(peer.chain.sortdb.as_ref());
-    assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
+    assert_eq!(tip.block_height, (EMPTY_SORTITIONS as u64));
 
     // first tenure is empty
     peer.tenure_with_txs(&[], &mut coinbase_nonce);
@@ -615,7 +615,7 @@ fn pox_auto_unlock(alice_first: bool) {
     let bob_lockup = make_pox_2_lockup(
         &bob,
         0,
-        1 * POX_THRESHOLD_STEPS_USTX,
+        POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
             key_to_stacks_addr(&bob).destruct().1,
@@ -778,7 +778,7 @@ fn pox_auto_unlock(alice_first: bool) {
     let bob_lockup = make_pox_3_lockup(
         &bob,
         1,
-        1 * POX_THRESHOLD_STEPS_USTX,
+        POX_THRESHOLD_STEPS_USTX,
         PoxAddress::from_legacy(
             AddressHashMode::SerializeP2PKH,
             key_to_stacks_addr(&bob).destruct().1,
@@ -2602,7 +2602,7 @@ fn delegate_extend_pox_3() {
 
     // our "tenure counter" is now at 0
     let tip = get_tip(peer.chain.sortdb.as_ref());
-    assert_eq!(tip.block_height, 0 + EMPTY_SORTITIONS as u64);
+    assert_eq!(tip.block_height, (EMPTY_SORTITIONS as u64));
 
     // first tenure is empty
     let mut latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
@@ -3189,7 +3189,7 @@ fn pox_3_getters() {
     }}", &alice_address,
         &bob_address,
         &bob_address, &format!("{}.hello-world", &charlie_address), first_v3_cycle + 1,
-        charlie_address.bytes(), first_v3_cycle + 0, &charlie_address,
+        charlie_address.bytes(), first_v3_cycle, &charlie_address,
         charlie_address.bytes(), first_v3_cycle + 1, &charlie_address,
         charlie_address.bytes(), first_v3_cycle + 2, &charlie_address,
         charlie_address.bytes(), first_v3_cycle + 3, &charlie_address,

--- a/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
+++ b/stackslib/src/chainstate/stacks/boot/pox_4_tests.rs
@@ -6808,9 +6808,9 @@ pub fn pox_4_scenario_test_setup<'a>(
         peer,
         peer_nonce,
         burn_block_height,
-        reward_cycle as u128,
-        next_reward_cycle as u128,
-        min_ustx as u128,
+        reward_cycle,
+        next_reward_cycle,
+        min_ustx,
         peer_config.clone(),
         None,
     )
@@ -9567,7 +9567,7 @@ fn missed_slots_no_unlock() {
     let alice_lockup =
         make_simple_pox_4_lock(&alice, &mut peer, 1024 * POX_THRESHOLD_STEPS_USTX, 6);
 
-    let bob_lockup = make_simple_pox_4_lock(&bob, &mut peer, 1 * POX_THRESHOLD_STEPS_USTX, 6);
+    let bob_lockup = make_simple_pox_4_lock(&bob, &mut peer, POX_THRESHOLD_STEPS_USTX, 6);
 
     let txs = [alice_lockup, bob_lockup];
     let mut latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
@@ -9815,7 +9815,7 @@ fn no_lockups_2_5() {
 
     let tip = get_tip(peer.chain.sortdb.as_ref());
 
-    let bob_lockup = make_simple_pox_4_lock(&bob, &mut peer, 1 * POX_THRESHOLD_STEPS_USTX, 6);
+    let bob_lockup = make_simple_pox_4_lock(&bob, &mut peer, POX_THRESHOLD_STEPS_USTX, 6);
 
     let txs = [bob_lockup];
     let mut latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -300,7 +300,7 @@ impl MemPoolRejection {
             Other(s) => ("ServerFailureOther", Some(json!({ "message": s }))),
         };
         let mut result = json!({
-            "txid": format!("{}", txid.to_hex()),
+            "txid": txid.to_hex(),
             "error": "transaction rejected",
             "reason": reason_code,
         });

--- a/stackslib/src/chainstate/stacks/index/file.rs
+++ b/stackslib/src/chainstate/stacks/index/file.rs
@@ -582,7 +582,7 @@ impl TrieFile {
             let block_hash: T = row.get_unwrap("block_hash");
             let offset_i64: i64 = row.get_unwrap("external_offset");
             let offset = offset_i64 as u64;
-            let start = TrieStorageConnection::<T>::root_ptr_disk() as u64;
+            let start = TrieStorageConnection::<T>::root_ptr_disk();
 
             self.seek(SeekFrom::Start(offset + start))?;
             let hash_buff = read_hash_bytes(self)?;

--- a/stackslib/src/chainstate/stacks/index/node.rs
+++ b/stackslib/src/chainstate/stacks/index/node.rs
@@ -1540,7 +1540,7 @@ impl TrieNodePatch {
         let ptr_diff = Self::make_ptr_diff(&old_node_ptr, old_node.ptrs(), new_node.ptrs());
         Self {
             ptr: old_node_ptr,
-            ptr_diff: ptr_diff,
+            ptr_diff,
         }
     }
 
@@ -1553,7 +1553,7 @@ impl TrieNodePatch {
         let ptr_diff = Self::make_ptr_diff(&old_node_ptr, old_node.ptrs(), new_node.ptrs());
         Self {
             ptr: old_node_ptr,
-            ptr_diff: ptr_diff,
+            ptr_diff,
         }
     }
 
@@ -1566,7 +1566,7 @@ impl TrieNodePatch {
         let ptr_diff = Self::make_ptr_diff(&old_node_ptr, old_node.ptrs(), new_node.ptrs());
         Self {
             ptr: old_node_ptr,
-            ptr_diff: ptr_diff,
+            ptr_diff,
         }
     }
 
@@ -1579,7 +1579,7 @@ impl TrieNodePatch {
         let ptr_diff = Self::make_ptr_diff(&old_node_ptr, old_node.ptrs(), new_node.ptrs());
         Self {
             ptr: old_node_ptr,
-            ptr_diff: ptr_diff,
+            ptr_diff,
         }
     }
 

--- a/stackslib/src/chainstate/stacks/index/squash.rs
+++ b/stackslib/src/chainstate/stacks/index/squash.rs
@@ -120,7 +120,7 @@ fn remap_child_ptrs(
     let node_count = store.len();
 
     for idx in 0..node_count {
-        if idx > 0 && idx as u64 % LOG_PROGRESS_NODE_INTERVAL == 0 {
+        if idx > 0 && (idx as u64).is_multiple_of(LOG_PROGRESS_NODE_INTERVAL) {
             info!(
                 "[{label}] Remap trie pointers: {idx}/{node_count} nodes in {}",
                 fmt_duration(remap_start.elapsed())
@@ -1053,7 +1053,7 @@ impl<T: MarfTrieId> MARF<T> {
 
                 nodes_collected += 1;
                 if last_log.elapsed().as_secs() >= LOG_PROGRESS_TIME_INTERVAL_SECS
-                    || nodes_collected % LOG_PROGRESS_NODE_INTERVAL == 0
+                    || nodes_collected.is_multiple_of(LOG_PROGRESS_NODE_INTERVAL)
                 {
                     info!(
                         "Trie DFS: {nodes_collected} nodes, stack depth {stack_depth}, {} elapsed",

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -1794,7 +1794,7 @@ impl StacksBlockBuilder {
     }
 
     /// Cut the next microblock.
-    pub fn mine_next_microblock<'a>(&mut self) -> Result<StacksMicroblock, Error> {
+    pub fn mine_next_microblock(&mut self) -> Result<StacksMicroblock, Error> {
         let txid_vecs: Vec<_> = self
             .micro_txs
             .iter()

--- a/stackslib/src/clarity_vm/database/ephemeral.rs
+++ b/stackslib/src/clarity_vm/database/ephemeral.rs
@@ -182,14 +182,14 @@ impl ClarityMarfStoreTransaction for EphemeralMarfStore<'_> {
 /// The tip can point to a block in the ephemeral RAM-backed MARF, or the on-disk MARF.
 #[derive(Debug, PartialEq, Clone)]
 enum EphemeralTip {
-    RAM(StacksBlockId),
+    Ram(StacksBlockId),
     Disk(StacksBlockId),
 }
 
 impl EphemeralTip {
     fn into_block_id(self) -> StacksBlockId {
         match self {
-            Self::RAM(tip) => tip,
+            Self::Ram(tip) => tip,
             Self::Disk(tip) => tip,
         }
     }
@@ -230,7 +230,7 @@ impl<'a> EphemeralMarfStore<'a> {
             .ok_or(Error::NotFoundError)?
             .clone();
         let ephemeral_marf_store = Self {
-            open_tip: EphemeralTip::RAM(ephemeral_tip),
+            open_tip: EphemeralTip::Ram(ephemeral_tip),
             base_tip: read_only_marf.get_chain_tip().clone(),
             base_tip_height,
             ephemeral_marf: ephemeral_marf_tx,
@@ -349,7 +349,7 @@ impl<'a> EphemeralMarfStore<'a> {
         MarfGetter: FnOnce(&mut ReadOnlyMarfStore, Key) -> Result<Option<V>, VmExecutionError>,
         Key: std::fmt::Debug + Copy,
     {
-        let value_opt = if let EphemeralTip::RAM(tip) = &self.open_tip {
+        let value_opt = if let EphemeralTip::Ram(tip) = &self.open_tip {
             // try the ephemeral MARF first
             tx_getter(&mut self.ephemeral_marf, tip, key)?
         } else {
@@ -385,8 +385,8 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
 
             // update ephemeral MARF open tip
             let old_tip =
-                mem::replace(&mut self.open_tip, EphemeralTip::RAM(bhh.clone())).into_block_id();
-            self.open_tip = EphemeralTip::RAM(bhh);
+                mem::replace(&mut self.open_tip, EphemeralTip::Ram(bhh.clone())).into_block_id();
+            self.open_tip = EphemeralTip::Ram(bhh);
             return Ok(old_tip);
         }
 
@@ -568,7 +568,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     /// Returns Some(block-id) if there is a block at the given height.
     /// Returns None otherwise.
     fn get_block_at_height(&mut self, height: u32) -> Option<StacksBlockId> {
-        let block_id_opt = if let EphemeralTip::RAM(tip) = &self.open_tip {
+        let block_id_opt = if let EphemeralTip::Ram(tip) = &self.open_tip {
             // careful -- the ephemeral MARF's height 0 corresponds to the base tip height
             if height > self.base_tip_height {
                 self.ephemeral_marf
@@ -602,7 +602,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     /// If the tip points to the ephemeral MARF, then use that MARF.
     /// Otherwise, use the disk-backed one.
     fn get_open_chain_tip(&mut self) -> StacksBlockId {
-        if let EphemeralTip::RAM(..) = &self.open_tip {
+        if let EphemeralTip::Ram(..) = &self.open_tip {
             return self
                 .ephemeral_marf
                 .get_open_chain_tip()
@@ -617,7 +617,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     /// If the tip points to the ephemeral MARF, then use that MARF.
     /// Otherwise, use the disk-backed one.
     fn get_open_chain_tip_height(&mut self) -> u32 {
-        if let EphemeralTip::RAM(..) = &self.open_tip {
+        if let EphemeralTip::Ram(..) = &self.open_tip {
             return self
                 .ephemeral_marf
                 .get_open_chain_tip_height()
@@ -633,7 +633,7 @@ impl ClarityBackingStore for EphemeralMarfStore<'_> {
     /// If the tip points to the ephemeral MARF, then use that MARF.
     /// Otherwise, use the disk-backed one.
     fn get_current_block_height(&mut self) -> u32 {
-        let height_opt = if let EphemeralTip::RAM(tip) = &self.open_tip {
+        let height_opt = if let EphemeralTip::Ram(tip) = &self.open_tip {
             match self.ephemeral_marf.get_block_height_of(tip, tip) {
                 Ok(Some(x)) => Some(x + self.base_tip_height + 1),
                 Ok(None) => {

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -4986,11 +4986,11 @@ mod tests {
     #[test]
     fn test_config_file() {
         assert_eq!(
-            format!("Invalid path: No such file or directory (os error 2)"),
+            "Invalid path: No such file or directory (os error 2)".to_string(),
             ConfigFile::from_path("some_path").unwrap_err()
         );
         assert_eq!(
-            format!("Invalid toml: unexpected character found: `/` at line 1 column 1"),
+            "Invalid toml: unexpected character found: `/` at line 1 column 1".to_string(),
             ConfigFile::from_str("//[node]").unwrap_err()
         );
         assert!(ConfigFile::from_str("").is_ok());
@@ -4999,7 +4999,7 @@ mod tests {
     #[test]
     fn test_config() {
         assert_eq!(
-            format!("node.seed should be a hex encoded string"),
+            "node.seed should be a hex encoded string".to_string(),
             Config::from_config_file(
                 ConfigFile::from_str(
                     r#"
@@ -5014,7 +5014,7 @@ mod tests {
         );
 
         assert_eq!(
-            format!("node.local_peer_seed should be a hex encoded string"),
+            "node.local_peer_seed should be a hex encoded string".to_string(),
             Config::from_config_file(
                 ConfigFile::from_str(
                     r#"

--- a/stackslib/src/core/mempool.rs
+++ b/stackslib/src/core/mempool.rs
@@ -862,7 +862,7 @@ const MEMPOOL_SCHEMA_7_TIME_ESTIMATES: &[&str] = &[
     "#,
 ];
 
-const MEMPOOL_SCHEMA_8_NONCE_SORTING: &'static [&'static str] = &[
+const MEMPOOL_SCHEMA_8_NONCE_SORTING: &[&str] = &[
     r#"
     -- Add table to track considered transactions
     CREATE TABLE IF NOT EXISTS considered_txs(

--- a/stackslib/src/core/nonce_cache.rs
+++ b/stackslib/src/core/nonce_cache.rs
@@ -259,8 +259,8 @@ mod tests {
             )
             .commit_block();
         let mut clarity_conn = clarity_instance.begin_block(
-            &StacksBlockId([0 as u8; 32]),
-            &StacksBlockId([1 as u8; 32]),
+            &StacksBlockId([0_u8; 32]),
+            &StacksBlockId([1_u8; 32]),
             &TEST_HEADER_DB,
             &TEST_BURN_STATE_DB,
         );

--- a/stackslib/src/core/test_util.rs
+++ b/stackslib/src/core/test_util.rs
@@ -658,7 +658,7 @@ pub fn make_big_read_count_contract(limit: ExecutionCost, proportion: u64) -> St
     let read_count = (limit.read_count * proportion) / 100;
 
     let read_lines = (0..read_count)
-        .map(|_| format!("(var-get my-var)"))
+        .map(|_| "(var-get my-var)".to_string())
         .collect::<Vec<_>>()
         .join("\n");
 

--- a/stackslib/src/cost_estimates/fee_rate_fuzzer.rs
+++ b/stackslib/src/cost_estimates/fee_rate_fuzzer.rs
@@ -30,7 +30,7 @@ impl<UnderlyingEstimator: FeeEstimator> FeeRateFuzzer<UnderlyingEstimator> {
         underlying: UnderlyingEstimator,
         uniform_fuzz_fraction: f64,
     ) -> FeeRateFuzzer<UnderlyingEstimator> {
-        assert!(0.0 <= uniform_fuzz_fraction && uniform_fuzz_fraction < 1.0);
+        assert!((0.0..1.0).contains(&uniform_fuzz_fraction));
         let rng_creator = Box::new(|| {
             let r: Box<dyn RngCore> = Box::new(thread_rng());
             r
@@ -49,7 +49,7 @@ impl<UnderlyingEstimator: FeeEstimator> FeeRateFuzzer<UnderlyingEstimator> {
         rng_creator: Box<dyn Fn() -> Box<dyn RngCore>>,
         uniform_fuzz_fraction: f64,
     ) -> FeeRateFuzzer<UnderlyingEstimator> {
-        assert!(0.0 <= uniform_fuzz_fraction && uniform_fuzz_fraction < 1.0);
+        assert!((0.0..1.0).contains(&uniform_fuzz_fraction));
         Self {
             underlying,
             rng_creator,

--- a/stackslib/src/cost_estimates/fee_scalar.rs
+++ b/stackslib/src/cost_estimates/fee_scalar.rs
@@ -166,7 +166,6 @@ impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
                             unlock_height: 1,
                         }
                         .serialize()
-                        .as_bytes()
                         .len() as u64;
                         self.metric.from_cost_and_len(
                             &ExecutionCost {

--- a/stackslib/src/net/api/getsigner.rs
+++ b/stackslib/src/net/api/getsigner.rs
@@ -90,7 +90,9 @@ impl HttpRequest for GetSignerRequestHandler {
         let signer_pubkey = Secp256k1PublicKey::from_hex(signer_pubkey_str.into())
             .map_err(|e| Error::DecodeError(format!("Failed to signer public key: {e}")))?;
 
-        let cycle_num = u64::from_str_radix(cycle_num_str.into(), 10)
+        let cycle_num = cycle_num_str
+            .as_str()
+            .parse::<u64>()
             .map_err(|e| Error::DecodeError(format!("Failed to parse cycle number: {e}")))?;
 
         self.signer_pubkey = Some(signer_pubkey);

--- a/stackslib/src/net/api/getstackers.rs
+++ b/stackslib/src/net/api/getstackers.rs
@@ -137,7 +137,9 @@ impl HttpRequest for GetStackersRequestHandler {
                 "Missing in request path: `cycle_num`".into(),
             ));
         };
-        let cycle_num = u64::from_str_radix(cycle_num_str.into(), 10)
+        let cycle_num = cycle_num_str
+            .as_str()
+            .parse::<u64>()
             .map_err(|e| Error::DecodeError(format!("Failed to parse cycle number: {e}")))?;
 
         self.cycle_number = Some(cycle_num);

--- a/stackslib/src/net/api/gettenureblocks.rs
+++ b/stackslib/src/net/api/gettenureblocks.rs
@@ -438,7 +438,7 @@ impl HttpChunkGenerator for RPCTenureStream {
         // end of blocks?
         if send_more.is_empty() {
             self.last_chunk = true;
-            return Ok(format!("]}}").into_bytes());
+            return Ok("]}".to_string().into_bytes());
         }
 
         if !self.first_block {

--- a/stackslib/src/net/asn.rs
+++ b/stackslib/src/net/asn.rs
@@ -180,7 +180,7 @@ impl ASEntry4 {
             ));
         }
         let mask = mask_opt.unwrap();
-        if mask < 8 || mask > 24 {
+        if !(8..=24).contains(&mask) {
             debug!("Invalid mask \"{}\"", mask);
             return Err(net_error::DeserializeError(format!(
                 "Invalid ASN mask {}",

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -44,7 +44,7 @@ use crate::net::db::LocalPeer;
 use crate::net::{Error as net_error, *};
 
 pub fn bitvec_len(bitlen: u16) -> u16 {
-    (bitlen / 8) + (if bitlen % 8 != 0 { 1 } else { 0 })
+    (bitlen / 8) + (if !bitlen.is_multiple_of(8) { 1 } else { 0 })
 }
 
 impl Preamble {

--- a/stackslib/src/net/db.rs
+++ b/stackslib/src/net/db.rs
@@ -130,7 +130,6 @@ impl LocalPeer {
         rng.fill_bytes(&mut my_nonce);
 
         let addr = addrbytes;
-        let port = port;
         let services = (ServiceFlags::RELAY as u16)
             | (ServiceFlags::RPC as u16)
             | (ServiceFlags::STACKERDB as u16);

--- a/stackslib/src/net/download/nakamoto/download_state_machine.rs
+++ b/stackslib/src/net/download/nakamoto/download_state_machine.rs
@@ -926,7 +926,7 @@ impl NakamotoDownloadStateMachine {
     /// additionally ensure that there are no in-flight confirmed tenure downloads.
     ///
     /// This method is static to facilitate testing.
-    pub(crate) fn need_unconfirmed_tenures<'a>(
+    pub(crate) fn need_unconfirmed_tenures(
         burnchain_height: u64,
         sort_tip: &BlockSnapshot,
         wanted_tenures: &[WantedTenure],

--- a/stackslib/src/net/http/error.rs
+++ b/stackslib/src/net/http/error.rs
@@ -30,7 +30,7 @@ pub fn try_parse_error_response(
     content_type: HttpContentType,
     body: &[u8],
 ) -> Result<HttpResponsePayload, Error> {
-    if status_code < 400 || status_code > 599 {
+    if !(400..=599).contains(&status_code) {
         return Err(Error::DecodeError(
             "Inavlid response: not an error".to_string(),
         ));

--- a/stackslib/src/net/http/request.rs
+++ b/stackslib/src/net/http/request.rs
@@ -255,7 +255,7 @@ impl StacksMessageCodec for HttpRequestPreamble {
         if let Some(ref c) = self.content_type {
             fd.write_all("Content-Type: ".as_bytes())
                 .map_err(CodecError::WriteError)?;
-            fd.write_all(c.to_string().as_str().as_bytes())
+            fd.write_all(c.to_string().as_bytes())
                 .map_err(CodecError::WriteError)?;
             fd.write_all("\r\n".as_bytes())
                 .map_err(CodecError::WriteError)?;
@@ -482,7 +482,7 @@ impl HttpRequestPayload {
             }
             Self::JSONBytes(ref val) => Ok(val.len() as u32),
             Self::Bytes(ref val) => Ok(val.len() as u32),
-            Self::Text(ref val) => Ok(val.as_str().as_bytes().len() as u32),
+            Self::Text(ref val) => Ok(val.as_str().len() as u32),
         }
     }
 

--- a/stackslib/src/net/http/response.rs
+++ b/stackslib/src/net/http/response.rs
@@ -652,7 +652,7 @@ impl HttpResponsePayload {
                 Some(value.len() as u32)
             }
             Self::Text(value) => {
-                if value.as_bytes().len() > (u32::MAX as usize) {
+                if value.len() > (u32::MAX as usize) {
                     return None;
                 }
                 Some(value.len() as u32)

--- a/stackslib/src/net/http/tests.rs
+++ b/stackslib/src/net/http/tests.rs
@@ -523,9 +523,7 @@ fn test_http_parse_host_header_value() {
 
 #[test]
 fn test_http_headers_too_big() {
-    let bad_header_value = std::iter::repeat("A")
-        .take(HTTP_PREAMBLE_MAX_ENCODED_SIZE as usize)
-        .collect::<String>();
+    let bad_header_value = "A".repeat(HTTP_PREAMBLE_MAX_ENCODED_SIZE as usize);
     let bad_request_preamble = format!(
         "GET /v2/neighbors HTTP/1.1\r\nHost: localhost:1234\r\nBad-Header: {}\r\n\r\n",
         &bad_header_value

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -1562,7 +1562,7 @@ impl ProtocolFamily for StacksHttp {
         if self.body_start.is_none() {
             for i in 0..=buf.len() {
                 let window = self.body_start_search_window(i, buf);
-                if window == [b'\r', b'\n', b'\r', b'\n'] {
+                if window == *b"\r\n\r\n" {
                     self.body_start = Some(self.num_preamble_bytes + i);
                 }
             }

--- a/stackslib/src/net/inv/epoch2x.rs
+++ b/stackslib/src/net/inv/epoch2x.rs
@@ -2326,9 +2326,7 @@ impl PeerNetwork {
 
                 // find peer with lowest block_reward_cycle
                 let lowest_block_reward_cycle = inv_state
-                    .block_stats
-                    .iter()
-                    .map(|(_nk, stats)| stats.block_reward_cycle)
+                    .block_stats.values().map(|stats| stats.block_reward_cycle)
                     .fold(local_rc, |min_block_reward_cycle, rc| cmp::min(rc, min_block_reward_cycle));
 
                 // hint to downloader as to where to begin scanning next time

--- a/stackslib/src/net/neighbors/mod.rs
+++ b/stackslib/src/net/neighbors/mod.rs
@@ -208,10 +208,9 @@ impl PeerNetwork {
     ///
     /// Returns the new neighbor walk on success.
     /// Returns None if we could not instantiate a walk for some reason.
-    #[expect(
-        clippy::manual_is_multiple_of,
-        reason = "Remainder must still panic if the configured walk interval wraps to zero."
-    )]
+    ///
+    /// # Panics
+    /// Panics if selecting an inbound/outbound strategy requires an overflowing walk interval.
     fn new_neighbor_walk(
         &mut self,
         ibd: bool,
@@ -245,7 +244,12 @@ impl PeerNetwork {
                 self,
                 ibd,
             )
-        } else if self.walk_attempts % (self.connection_opts.walk_inbound_ratio + 1) == 0 {
+        } else if self.walk_attempts.is_multiple_of(
+            self.connection_opts
+                .walk_inbound_ratio
+                .checked_add(1)
+                .expect("Inbound walk interval must not overflow"),
+        ) {
             // not IBD, or not walk_seed, or connected to an always-allowed peer, or no always-allowed.
             // Time to try an inbound neighbor
             debug!("{:?}: Instantiate walk to inbound neigbor", self.get_local_peer();
@@ -274,7 +278,12 @@ impl PeerNetwork {
             Ok(x) => Ok(x),
             Err(net_error::NotFoundError) => {
                 // initial strategy failed, so try the other strategy
-                if self.walk_attempts % (self.connection_opts.walk_inbound_ratio + 1) == 0 {
+                if self.walk_attempts.is_multiple_of(
+                    self.connection_opts
+                        .walk_inbound_ratio
+                        .checked_add(1)
+                        .expect("Inbound walk interval must not overflow"),
+                ) {
                     // tried inbound walk (it failed), so try outbound or pingback
                     self.new_outbound_or_pingback_walk()
                 } else {
@@ -477,5 +486,20 @@ impl PeerNetwork {
 
         self.walk = Some(walk);
         (done, walk_result_opt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::net::test::{TestPeer, TestPeerConfig};
+
+    /// An overflowing interval must panic instead of selecting a walk using a zero divisor.
+    #[test]
+    #[should_panic(expected = "Inbound walk interval must not overflow")]
+    fn test_neighbor_walk_interval_overflow() {
+        let config = TestPeerConfig::new(function_name!(), 0, 0);
+        let mut peer = TestPeer::new(config);
+        peer.network.connection_opts.walk_inbound_ratio = u64::MAX;
+        peer.network.new_neighbor_walk(false);
     }
 }

--- a/stackslib/src/net/neighbors/mod.rs
+++ b/stackslib/src/net/neighbors/mod.rs
@@ -208,6 +208,10 @@ impl PeerNetwork {
     ///
     /// Returns the new neighbor walk on success.
     /// Returns None if we could not instantiate a walk for some reason.
+    #[expect(
+        clippy::manual_is_multiple_of,
+        reason = "Remainder must still panic if the configured walk interval wraps to zero."
+    )]
     fn new_neighbor_walk(
         &mut self,
         ibd: bool,

--- a/stackslib/src/net/prune.rs
+++ b/stackslib/src/net/prune.rs
@@ -133,7 +133,7 @@ impl PeerNetwork {
 
         // flip a coin
         let mut rng = thread_rng();
-        if rng.next_u32() % 2 == 0 {
+        if rng.next_u32().is_multiple_of(2) {
             return Ordering::Less;
         } else {
             return Ordering::Greater;

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -1109,9 +1109,9 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             .map(|naddr| self.unpin_connected_replica(network, &naddr));
 
         if requested == 0 && self.comms.count_inflight() == 0 {
-            return Err(net_error::PeerNotConnected(format!(
-                "StackerDB getchunks_begin: no chunks to request"
-            )));
+            return Err(net_error::PeerNotConnected(
+                "StackerDB getchunks_begin: no chunks to request".to_string(),
+            ));
         }
 
         self.next_chunk_fetch_priority = cur_priority;

--- a/stackslib/src/net/stackerdb/tests/db.rs
+++ b/stackslib/src/net/stackerdb/tests/db.rs
@@ -283,13 +283,13 @@ fn test_stackerdb_prepare_clear_slots() {
                 slot_validation.signer,
                 StacksAddress::new(0x02, Hash160([0x02; 20])).unwrap()
             );
-        } else if slot_id >= 2 && slot_id < 2 + 3 {
+        } else if (2..2 + 3).contains(&slot_id) {
             // belongs to 0x03
             assert_eq!(
                 slot_validation.signer,
                 StacksAddress::new(0x03, Hash160([0x03; 20])).unwrap()
             );
-        } else if slot_id >= 2 + 3 && slot_id < 2 + 3 + 4 {
+        } else if (2 + 3..2 + 3 + 4).contains(&slot_id) {
             // belongs to 0x03
             assert_eq!(
                 slot_validation.signer,

--- a/stackslib/src/net/tests/convergence.rs
+++ b/stackslib/src/net/tests/convergence.rs
@@ -93,7 +93,7 @@ fn setup_peer_config(
 
     // even-number peers support stacker DBs.
     // odd-number peers do not
-    if i % 2 == 0 {
+    if i.is_multiple_of(2) {
         conf.services = (ServiceFlags::RELAY as u16)
             | (ServiceFlags::RPC as u16)
             | (ServiceFlags::STACKERDB as u16);

--- a/stackslib/src/util_lib/strings.rs
+++ b/stackslib/src/util_lib/strings.rs
@@ -60,18 +60,18 @@ impl StacksMessageCodec for UrlString {
     fn consensus_serialize<W: Write>(&self, fd: &mut W) -> Result<(), codec_error> {
         // UrlString can't be longer than vm::representations::MAX_STRING_LEN, which itself is
         // a u8, so we should be good here.
-        if self.as_bytes().len() > CLARITY_MAX_STRING_LENGTH as usize {
+        if self.as_str().len() > CLARITY_MAX_STRING_LENGTH as usize {
             return Err(codec_error::SerializeError(
                 "Failed to serialize URL string: too long".to_string(),
             ));
         }
 
         // must be a valid block URL, or empty string
-        if !self.as_bytes().is_empty() {
+        if !self.as_str().is_empty() {
             let _ = self.parse_to_block_url()?;
         }
 
-        write_next(fd, &(self.as_bytes().len() as u8))?;
+        write_next(fd, &(self.as_str().len() as u8))?;
         fd.write_all(self.as_bytes())
             .map_err(codec_error::WriteError)?;
         Ok(())


### PR DESCRIPTION
### Description

This PR addresses small Clippy lints across arithmetic checks, string construction, redundant syntax, private enum names, and benchmarks.

Explicit assertions and checked arithmetic preserve invalid-divisor panics. New tests cover signer-cycle boundaries, zero-length cycles, and overflowing neighbor-walk intervals.

### Applicable issues

None.

### Additional info (benefits, drawbacks, caveats)

Private enum renames change derived `Debug` output; `Display` messages remain unchanged. 
One scoped lint expectation remains because a benchmark deliberately measures `drain().collect()`.

### Checklist

- [x] Test coverage for new or modified code paths
- [x] Required documentation changes