### PR TITLE
refactor: address option-result and default clippy lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [alias]
 stacks-node = "run --package stacks-node --"
 fmt-stacks = "fmt -- --config group_imports=StdExternalCrate,imports_granularity=Module"
-clippy-stacks = "clippy -p stx-genesis -p libstackerdb -p stacks-signer -p pox-locking -p clarity-types -p clarity -p libsigner -p stacks-common -p stacks-codec -p stacks-transactions -p clarity-cli -p stacks-cli -p stacks-inspect -p stacks-profiler -p stacks-profiler-macros -p marf-squash --no-deps --tests --all-features -- -D warnings -Aclippy::unnecessary_lazy_evaluations"
+clippy-stacks = "clippy -p stx-genesis -p libstackerdb -p stacks-signer -p pox-locking -p clarity-types -p clarity -p libsigner -p stacks-common -p stacks-codec -p stacks-transactions -p clarity-cli -p stacks-cli -p stacks-inspect -p stacks-profiler -p stacks-profiler-macros -p marf-squash --no-deps --tests --all-features -- -D warnings"
 clippy-stackslib = "clippy -p stackslib --no-deps -- -Aclippy::all -Wclippy::indexing_slicing -Wclippy::nonminimal_bool -Wclippy::clone_on_copy"
 
 # Uncomment to improve performance slightly, at the cost of portability

--- a/clarity-types/src/types/mod.rs
+++ b/clarity-types/src/types/mod.rs
@@ -1106,7 +1106,7 @@ impl Value {
                     .map(|(value, _did_sanitize)| value)
             })
             .collect();
-        let list_data = list_data_opt.ok_or_else(|| ClarityTypeError::ListTypeMismatch)?;
+        let list_data = list_data_opt.ok_or(ClarityTypeError::ListTypeMismatch)?;
         Ok(Value::Sequence(SequenceData::List(ListData {
             data: list_data,
             type_signature: type_sig,
@@ -1163,8 +1163,7 @@ impl Value {
                     // so from_str_radix only sees valid hex and never errors here.
                     let u = u32::from_str_radix(&scalar_value, 16)
                         .map_err(|_| ClarityTypeError::InvalidUtf8Encoding)?;
-                    let c =
-                        char::from_u32(u).ok_or_else(|| ClarityTypeError::InvalidUtf8Encoding)?;
+                    let c = char::from_u32(u).ok_or(ClarityTypeError::InvalidUtf8Encoding)?;
                     let mut encoded_char: Vec<u8> = vec![0; c.len_utf8()];
                     c.encode_utf8(&mut encoded_char[..]);
                     encoded_char
@@ -1478,7 +1477,7 @@ impl ListData {
         let max_len = self.type_signature.get_max_len() + other_seq.type_signature.get_max_len();
         for item in other_seq.data.into_iter() {
             let (item, _) = Value::sanitize_value(epoch, &entry_type, item)
-                .ok_or_else(|| ClarityTypeError::ListTypeMismatch)?;
+                .ok_or(ClarityTypeError::ListTypeMismatch)?;
             self.data.push(item);
         }
 

--- a/clarity-types/src/types/serialization.rs
+++ b/clarity-types/src/types/serialization.rs
@@ -424,14 +424,14 @@ impl TypeSignature {
                     .get_max_len()
                     .checked_mul(list_type.get_list_item_type().max_serialized_size()?)
                     .and_then(|x| x.checked_add(list_length_encode))
-                    .ok_or_else(|| ClarityTypeError::ValueTooLarge)?
+                    .ok_or(ClarityTypeError::ValueTooLarge)?
             }
             TypeSignature::SequenceType(SequenceSubtype::BufferType(buff_length)) => {
                 // u32 length as big-endian bytes
                 let buff_length_encode = 4;
                 u32::from(buff_length)
                     .checked_add(buff_length_encode)
-                    .ok_or_else(|| ClarityTypeError::ValueTooLarge)?
+                    .ok_or(ClarityTypeError::ValueTooLarge)?
             }
             TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::ASCII(
                 length,
@@ -441,7 +441,7 @@ impl TypeSignature {
                 // ascii is 1-byte per character
                 u32::from(length)
                     .checked_add(str_length_encode)
-                    .ok_or_else(|| ClarityTypeError::ValueTooLarge)?
+                    .ok_or(ClarityTypeError::ValueTooLarge)?
             }
             TypeSignature::SequenceType(SequenceSubtype::StringType(StringSubtype::UTF8(
                 length,
@@ -452,7 +452,7 @@ impl TypeSignature {
                 u32::from(length)
                     .checked_mul(4)
                     .and_then(|x| x.checked_add(str_length_encode))
-                    .ok_or_else(|| ClarityTypeError::ValueTooLarge)?
+                    .ok_or(ClarityTypeError::ValueTooLarge)?
             }
             TypeSignature::PrincipalType
             | TypeSignature::CallableType(_)
@@ -475,7 +475,7 @@ impl TypeSignature {
                         .checked_add(1) // length of key-name
                         .and_then(|x| x.checked_add(key.len() as u32)) // ClarityName is ascii-only, so 1 byte per length
                         .and_then(|x| x.checked_add(value_size))
-                        .ok_or_else(|| ClarityTypeError::ValueTooLarge)?;
+                        .ok_or(ClarityTypeError::ValueTooLarge)?;
                 }
                 total_size
             }
@@ -518,7 +518,7 @@ impl TypeSignature {
 
         max_output_size
             .checked_add(type_prefix_size)
-            .ok_or_else(|| ClarityTypeError::ValueTooLarge)
+            .ok_or(ClarityTypeError::ValueTooLarge)
     }
 }
 

--- a/clarity-types/src/types/signatures.rs
+++ b/clarity-types/src/types/signatures.rs
@@ -369,7 +369,7 @@ impl ListTypeData {
         };
         let would_be_size = list_data
             .inner_size()?
-            .ok_or_else(|| ClarityTypeError::ValueTooLarge)?;
+            .ok_or(ClarityTypeError::ValueTooLarge)?;
         if would_be_size > MAX_VALUE_SIZE {
             Err(ClarityTypeError::ValueTooLarge)
         } else {
@@ -758,7 +758,7 @@ impl TryFrom<BTreeMap<ClarityName, TypeSignature>> for TupleTypeSignature {
         let result = TupleTypeSignature { type_map };
         let would_be_size = result
             .inner_size()?
-            .ok_or_else(|| ClarityTypeError::ValueTooLarge)?;
+            .ok_or(ClarityTypeError::ValueTooLarge)?;
         if would_be_size > MAX_VALUE_SIZE {
             Err(ClarityTypeError::ValueTooLarge)
         } else {
@@ -1401,7 +1401,7 @@ impl TypeSignature {
 
     pub fn type_size(&self) -> Result<u32, ClarityTypeError> {
         self.inner_type_size()
-            .ok_or_else(|| ClarityTypeError::ValueTooLarge)
+            .ok_or(ClarityTypeError::ValueTooLarge)
     }
 
     /// Returns the size of the _type signature_

--- a/clarity/src/vm/analysis/errors.rs
+++ b/clarity/src/vm/analysis/errors.rs
@@ -1153,7 +1153,10 @@ pub fn get_arguments_at_least<T, const N: usize>(
     args: &[T],
 ) -> Result<(&[T; N], &[T]), CommonCheckErrorKind> {
     args.split_first_chunk::<N>()
-        .ok_or_else(|| CommonCheckErrorKind::RequiresAtLeastArguments(N, args.len()))
+        .ok_or(CommonCheckErrorKind::RequiresAtLeastArguments(
+            N,
+            args.len(),
+        ))
 }
 
 /// Renders a type union as `'a', 'b' or 'c'`. A `Display` adapter rather than

--- a/clarity/src/vm/analysis/type_checker/v2_1/natives/post_conditions.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/natives/post_conditions.rs
@@ -84,7 +84,7 @@ pub fn check_restrict_assets(
         last_return = Some(type_return);
     }
 
-    let ok_type = last_return.ok_or_else(|| StaticCheckErrorKind::CheckerImplementationFailure)?;
+    let ok_type = last_return.ok_or(StaticCheckErrorKind::CheckerImplementationFailure)?;
 
     Ok(TypeSignature::new_response(
         ok_type,
@@ -139,7 +139,7 @@ pub fn check_as_contract(
         last_return = Some(type_return);
     }
 
-    let ok_type = last_return.ok_or_else(|| StaticCheckErrorKind::CheckerImplementationFailure)?;
+    let ok_type = last_return.ok_or(StaticCheckErrorKind::CheckerImplementationFailure)?;
     Ok(TypeSignature::new_response(
         ok_type,
         TypeSignature::UIntType,

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1763,7 +1763,7 @@ impl ContractContext {
                 let owned = std::mem::replace(value, Value::none());
                 let (sanitized, _) =
                     Value::sanitize_value(epoch, &TypeSignature::type_of(&owned)?, owned)
-                        .ok_or_else(|| RuntimeCheckErrorKind::CouldNotDetermineType)?;
+                        .ok_or(RuntimeCheckErrorKind::CouldNotDetermineType)?;
                 *value = sanitized;
             }
         }

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -594,7 +594,7 @@ impl<'a> ClarityDatabase<'a> {
 
             let (sanitized_value, did_sanitize) =
                 Value::sanitize_value(epoch, &TypeSignature::type_of(&value)?, value)
-                    .ok_or_else(|| RuntimeCheckErrorKind::CouldNotDetermineType)?;
+                    .ok_or(RuntimeCheckErrorKind::CouldNotDetermineType)?;
             // if data needed to be sanitized *charge* for the unsanitized cost
             if did_sanitize {
                 pre_sanitized_size = Some(value_size);

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -246,7 +246,7 @@ pub fn special_contract_call(
     // sanitize contract-call outputs in epochs >= 2.4
     let result_type = TypeSignature::type_of(&result)?;
     let (result, _) = Value::sanitize_value(exec_state.epoch(), &result_type, result)
-        .ok_or_else(|| RuntimeCheckErrorKind::CouldNotDetermineType)?;
+        .ok_or(RuntimeCheckErrorKind::CouldNotDetermineType)?;
 
     // Ensure that the expected type from the trait spec admits
     // the type of the value returned by the dynamic dispatch.

--- a/clarity/src/vm/functions/sequences.rs
+++ b/clarity/src/vm/functions/sequences.rs
@@ -379,7 +379,7 @@ pub fn special_append(
             let next_entry_type =
                 TypeSignature::least_supertype(exec_state.epoch(), &entry_type, &element_type)?;
             let (element, _) = Value::sanitize_value(exec_state.epoch(), &next_entry_type, element)
-                .ok_or_else(|| RuntimeCheckErrorKind::ListTypesMustMatch)?;
+                .ok_or(RuntimeCheckErrorKind::ListTypesMustMatch)?;
 
             let next_type_signature = ListTypeData::new_list(next_entry_type, size + 1)?;
             data.push(element);

--- a/clarity/src/vm/mod.rs
+++ b/clarity/src/vm/mod.rs
@@ -214,7 +214,7 @@ fn lookup_variable<'a>(
         let value = value.clone_with_cost(exec_state)?;
         let (value, _) =
             Value::sanitize_value(exec_state.epoch(), &TypeSignature::type_of(&value)?, value)
-                .ok_or_else(|| RuntimeCheckErrorKind::CouldNotDetermineType)?;
+                .ok_or(RuntimeCheckErrorKind::CouldNotDetermineType)?;
         return Ok(ValueRef::Owned(value));
     }
     if let Some(callable_data) = context.lookup_callable_contract(name) {

--- a/stacks-node/src/nakamoto_node/relayer.rs
+++ b/stacks-node/src/nakamoto_node/relayer.rs
@@ -2016,9 +2016,9 @@ impl RelayerThread {
         };
         // reset timer so we can try again if for some reason a miner was already running (e.g. a
         // blockfound from earlier).
-        self.tenure_extend_time
-            .as_mut()
-            .map(|t| t.refresh(self.config.miner.tenure_extend_poll_timeout));
+        if let Some(t) = self.tenure_extend_time.as_mut() {
+            t.refresh(self.config.miner.tenure_extend_poll_timeout);
+        }
         // try to extend, but only if we aren't already running a thread for the current or newer
         // burnchain view
         let Ok(burn_tip) = SortitionDB::get_canonical_burn_chain_tip(self.sortdb.conn())

--- a/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/stacks-node/src/tests/nakamoto_integrations.rs
@@ -3259,8 +3259,8 @@ fn correct_burn_outs() {
     let new_blocks_with_reward_set: Vec<serde_json::Value> = test_observer::get_blocks()
         .into_iter()
         .filter(|block| {
-            block.get("reward_set").map_or(false, |v| !v.is_null())
-                && block.get("cycle_number").map_or(false, |v| !v.is_null())
+            block.get("reward_set").is_some_and(|v| !v.is_null())
+                && block.get("cycle_number").is_some_and(|v| !v.is_null())
         })
         .collect();
     info!(
@@ -8903,7 +8903,7 @@ fn check_block_info() {
             }
         }
         // if `signer_bitvec` is set on a block, then it's a nakamoto block
-        let is_nakamoto_block = block.get("signer_bitvec").map_or(false, |v| !v.is_null());
+        let is_nakamoto_block = block.get("signer_bitvec").is_some_and(|v| !v.is_null());
         let tenure_height = block.get("tenure_height").unwrap().as_u64().unwrap();
         let block_height = block.get("block_height").unwrap().as_u64().unwrap();
 

--- a/stacks-node/src/tests/signer/v0/capitulate_parent_tenure_view.rs
+++ b/stacks-node/src/tests/signer/v0/capitulate_parent_tenure_view.rs
@@ -857,9 +857,9 @@ fn minority_signers_capitulate_to_supermajority_consensus() {
                 continue;
             };
             if parent_tenure_last_block == &block_id_n_1 {
-                rejecting_signer_addrs.iter().find(|a| *a == address).map(|a| {
+                if let Some(a) = rejecting_signer_addrs.iter().find(|a| *a == address) {
                     found_updates_n_1.insert(a.clone());
-                });
+                }
             }
         }
         Ok(found_updates_n_1.len() == rejecting_signer_addrs.len())

--- a/stacks-node/src/tests/signer/v0/mod.rs
+++ b/stacks-node/src/tests/signer/v0/mod.rs
@@ -8102,7 +8102,7 @@ fn verify_mempool_caches() {
         let is_next_block = test_observer::get_blocks()
             .last()
             .and_then(|block| block["block_height"].as_u64())
-            .map_or(false, |h| h == block_height_before + 1);
+            .is_some_and(|h| h == block_height_before + 1);
 
         Ok(is_next_block)
     })

--- a/stackslib/src/burnchains/tests/mod.rs
+++ b/stackslib/src/burnchains/tests/mod.rs
@@ -222,10 +222,8 @@ impl TestMiner {
         match self.vrf_key_map.get(vrf_pubkey) {
             Some(prover_key) => {
                 let proof = VRF::prove(prover_key, last_sortition_hash.as_bytes())?;
-                let valid = match VRF::verify(vrf_pubkey, &proof, last_sortition_hash.as_bytes()) {
-                    Ok(v) => v,
-                    Err(e) => false,
-                };
+                let valid = VRF::verify(vrf_pubkey, &proof, last_sortition_hash.as_bytes())
+                    .unwrap_or_default();
                 assert!(valid);
                 Some(proof)
             }

--- a/stackslib/src/chainstate/coordinator/mod.rs
+++ b/stackslib/src/chainstate/coordinator/mod.rs
@@ -353,7 +353,7 @@ impl<T: BlockEventDispatcher> RewardSetProvider for OnChainRewardSetProvider<'_,
             cur_epoch,
         )?;
 
-        if is_nakamoto_reward_set && reward_set.signers().map_or(true, |s| s.is_empty()) {
+        if is_nakamoto_reward_set && reward_set.signers().is_none_or(|s| s.is_empty()) {
             error!("FATAL: Signer sets are empty in a reward set that will be used in nakamoto"; "reward_set" => ?reward_set);
             return Err(Error::PoXAnchorBlockRequired);
         }

--- a/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/mod.rs
@@ -220,7 +220,7 @@ impl<T: BlockEventDispatcher> OnChainRewardSetProvider<'_, T> {
         //  Non participation is fatal.
         if reward_set
             .rewarded_addresses()
-            .map_or(false, |addrs| addrs.is_empty())
+            .is_some_and(|addrs| addrs.is_empty())
         {
             // no one is stacking (V0 with empty rewarded_addresses)
             err_or_debug!(debug_log, "No PoX participation");

--- a/stackslib/src/chainstate/stacks/index/storage.rs
+++ b/stackslib/src/chainstate/stacks/index/storage.rs
@@ -18,7 +18,7 @@ use std::collections::{HashMap, VecDeque};
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
-use std::{fmt, fs, io};
+use std::{fmt, fs, io, mem};
 
 use rusqlite::{Connection, OpenFlags, Transaction};
 use sha2::Digest;
@@ -488,7 +488,7 @@ impl<T: MarfTrieId> TrieRAM<T> {
     ///
     /// Do not call directly; instead, use `with_reinstated_data()`.
     fn move_to(&mut self) -> TrieRAM<T> {
-        let moved_data = std::mem::replace(&mut self.data, vec![]);
+        let moved_data = mem::take(&mut self.data);
         TrieRAM {
             data: moved_data,
             block_header: self.block_header.clone(),

--- a/stackslib/src/chainstate/stacks/miner.rs
+++ b/stackslib/src/chainstate/stacks/miner.rs
@@ -1875,15 +1875,13 @@ impl StacksBlockBuilder {
                 &self.parent_header_hash,
             );
             let (parent_microblocks, _) =
-                match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
+                StacksChainState::load_descendant_staging_microblock_stream_with_poison(
                     chainstate.db(),
                     &parent_index_hash,
                     0,
                     u16::MAX,
-                )? {
-                    Some(x) => x,
-                    None => (vec![], None),
-                };
+                )?
+                .unwrap_or_default();
 
             debug!(
                 "Loaded {} microblocks made by {}/{}",

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -2538,18 +2538,16 @@ fn test_build_microblock_stream_forks() {
              ref parent_opt,
              ref parent_microblock_header_opt| {
                 let parent_tip = match parent_opt {
-                    None => StacksChainState::get_genesis_header_info(chainstate.db())
-                        .unwrap(),
+                    None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
                     Some(block) => {
                         let ic = sortdb.index_conn();
-                        let snapshot =
-                            SortitionDB::get_block_snapshot_for_winning_stacks_block(
-                                &ic,
-                                &tip.sortition_id,
-                                &block.block_hash(),
-                            )
-                            .unwrap()
-                            .unwrap(); // succeeds because we don't fork
+                        let snapshot = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                            &ic,
+                            &tip.sortition_id,
+                            &block.block_hash(),
+                        )
+                        .unwrap()
+                        .unwrap(); // succeeds because we don't fork
                         StacksChainState::get_anchored_block_header_info(
                             chainstate.db(),
                             &snapshot.consensus_hash,
@@ -2562,161 +2560,210 @@ fn test_build_microblock_stream_forks() {
 
                 let parent_header_hash = parent_tip.anchored_header.block_hash();
                 let parent_consensus_hash = parent_tip.consensus_hash.clone();
-                let parent_index_hash = StacksBlockHeader::make_index_block_hash(&parent_consensus_hash, &parent_header_hash);
+                let parent_index_hash = StacksBlockHeader::make_index_block_hash(
+                    &parent_consensus_hash,
+                    &parent_header_hash,
+                );
                 let parent_size = parent_tip.anchored_block_size;
 
-                let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+                let mut mempool =
+                    MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
-                let expected_parent_microblock_opt =
-                    if tenure_id > 0 {
-                        let parent_microblock_privkey = mblock_privks[tenure_id - 1].clone();
+                let expected_parent_microblock_opt = if tenure_id > 0 {
+                    let parent_microblock_privkey = mblock_privks[tenure_id - 1].clone();
 
-                        let parent_mblock_stream = {
-                            let parent_cost = StacksChainState::get_stacks_block_anchored_cost(chainstate.db(), &StacksBlockHeader::make_index_block_hash(&parent_consensus_hash, &parent_header_hash)).unwrap().unwrap();
+                    let parent_mblock_stream = {
+                        let parent_cost = StacksChainState::get_stacks_block_anchored_cost(
+                            chainstate.db(),
+                            &StacksBlockHeader::make_index_block_hash(
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                            ),
+                        )
+                        .unwrap()
+                        .unwrap();
 
-                            // produce the microblock stream for the parent, which this tenure's anchor
-                            // block will confirm.
-                            let sort_ic = sortdb.index_handle_at_tip();
+                        // produce the microblock stream for the parent, which this tenure's anchor
+                        // block will confirm.
+                        let sort_ic = sortdb.index_handle_at_tip();
 
-                            chainstate
-                                .reload_unconfirmed_state(&sort_ic, parent_index_hash.clone())
-                                .unwrap();
+                        chainstate
+                            .reload_unconfirmed_state(&sort_ic, parent_index_hash.clone())
+                            .unwrap();
 
-                            let mut microblock_builder = StacksMicroblockBuilder::new(parent_header_hash.clone(), parent_consensus_hash.clone(), chainstate, &sort_ic, BlockBuilderSettings::max_value()).unwrap();
+                        let mut microblock_builder = StacksMicroblockBuilder::new(
+                            parent_header_hash.clone(),
+                            parent_consensus_hash.clone(),
+                            chainstate,
+                            &sort_ic,
+                            BlockBuilderSettings::max_value(),
+                        )
+                        .unwrap();
 
-                            let mut microblocks = vec![];
-                            for i in 0..5 {
-                                let mblock_tx = make_user_contract_publish(
-                                    &privks[tenure_id - 1],
-                                    i,
-                                    0,
-                                    &format!("hello-world-{}-{}", i, thread_rng().gen::<u64>()),
-                                    &format!("(begin (print \"{}\"))", thread_rng().gen::<u64>())
-                                );
-                                let mblock_tx_len = {
-                                    let mut bytes = vec![];
-                                    mblock_tx.consensus_serialize(&mut bytes).unwrap();
-                                    bytes.len() as u64
-                                };
-
-                                let mblock = microblock_builder.mine_next_microblock_from_txs(vec![(mblock_tx, mblock_tx_len)], &parent_microblock_privkey).unwrap();
-                                microblocks.push(mblock);
-                            }
-                            microblocks
-                        };
-
-                        // make a fork at seq 2
-                        let mut forked_parent_microblock_stream = parent_mblock_stream.clone();
-                        for i in 2..forked_parent_microblock_stream.len() {
-                            let forked_mblock_tx = make_user_contract_publish(
+                        let mut microblocks = vec![];
+                        for i in 0..5 {
+                            let mblock_tx = make_user_contract_publish(
                                 &privks[tenure_id - 1],
-                                i as u64,
+                                i,
                                 0,
-                                &format!("hello-world-fork-{}-{}", i, thread_rng().gen::<u64>()),
-                                &format!("(begin (print \"fork-{}\"))", thread_rng().gen::<u64>())
+                                &format!("hello-world-{}-{}", i, thread_rng().gen::<u64>()),
+                                &format!("(begin (print \"{}\"))", thread_rng().gen::<u64>()),
                             );
+                            let mblock_tx_len = {
+                                let mut bytes = vec![];
+                                mblock_tx.consensus_serialize(&mut bytes).unwrap();
+                                bytes.len() as u64
+                            };
 
-                            forked_parent_microblock_stream[i].txs[0] = forked_mblock_tx;
-
-                            // re-calculate merkle root
-                            let txid_vecs: Vec<_> = forked_parent_microblock_stream[i].txs
-                                .iter()
-                                .map(|tx| tx.txid().as_bytes().to_vec())
-                                .collect();
-
-                            let merkle_tree = MerkleTree::<Sha512Trunc256Sum>::new(&txid_vecs);
-                            let tx_merkle_root = merkle_tree.root();
-
-                            forked_parent_microblock_stream[i].header.tx_merkle_root = tx_merkle_root;
-                            forked_parent_microblock_stream[i].header.prev_block = forked_parent_microblock_stream[i-1].block_hash();
-                            forked_parent_microblock_stream[i].header.sign(&parent_microblock_privkey).unwrap();
-
-                            test_debug!("parent of microblock {} is {}", &forked_parent_microblock_stream[i].block_hash(), &forked_parent_microblock_stream[i-1].block_hash());
+                            let mblock = microblock_builder
+                                .mine_next_microblock_from_txs(
+                                    vec![(mblock_tx, mblock_tx_len)],
+                                    &parent_microblock_privkey,
+                                )
+                                .unwrap();
+                            microblocks.push(mblock);
                         }
+                        microblocks
+                    };
 
-                        let mut tail = None;
+                    // make a fork at seq 2
+                    let mut forked_parent_microblock_stream = parent_mblock_stream.clone();
+                    for i in 2..forked_parent_microblock_stream.len() {
+                        let forked_mblock_tx = make_user_contract_publish(
+                            &privks[tenure_id - 1],
+                            i as u64,
+                            0,
+                            &format!("hello-world-fork-{}-{}", i, thread_rng().gen::<u64>()),
+                            &format!("(begin (print \"fork-{}\"))", thread_rng().gen::<u64>()),
+                        );
 
-                        // store two forks, which diverge at seq 2
-                        for mblock in parent_mblock_stream.into_iter() {
-                            if mblock.header.sequence < 2 {
-                                tail = Some((mblock.block_hash(), mblock.header.sequence));
-                            }
-                            let stored = chainstate.preprocess_streamed_microblock(&parent_consensus_hash, &parent_header_hash, &mblock).unwrap();
-                            assert!(stored);
+                        forked_parent_microblock_stream[i].txs[0] = forked_mblock_tx;
+
+                        // re-calculate merkle root
+                        let txid_vecs: Vec<_> = forked_parent_microblock_stream[i]
+                            .txs
+                            .iter()
+                            .map(|tx| tx.txid().as_bytes().to_vec())
+                            .collect();
+
+                        let merkle_tree = MerkleTree::<Sha512Trunc256Sum>::new(&txid_vecs);
+                        let tx_merkle_root = merkle_tree.root();
+
+                        forked_parent_microblock_stream[i].header.tx_merkle_root = tx_merkle_root;
+                        forked_parent_microblock_stream[i].header.prev_block =
+                            forked_parent_microblock_stream[i - 1].block_hash();
+                        forked_parent_microblock_stream[i]
+                            .header
+                            .sign(&parent_microblock_privkey)
+                            .unwrap();
+
+                        test_debug!(
+                            "parent of microblock {} is {}",
+                            &forked_parent_microblock_stream[i].block_hash(),
+                            &forked_parent_microblock_stream[i - 1].block_hash()
+                        );
+                    }
+
+                    let mut tail = None;
+
+                    // store two forks, which diverge at seq 2
+                    for mblock in parent_mblock_stream.into_iter() {
+                        if mblock.header.sequence < 2 {
+                            tail = Some((mblock.block_hash(), mblock.header.sequence));
                         }
-                        for mblock in forked_parent_microblock_stream[2..].iter() {
-                            let stored = chainstate.preprocess_streamed_microblock(&parent_consensus_hash, &parent_header_hash, mblock).unwrap();
-                            assert!(stored);
-                        }
+                        let stored = chainstate
+                            .preprocess_streamed_microblock(
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                                &mblock,
+                            )
+                            .unwrap();
+                        assert!(stored);
+                    }
+                    for mblock in forked_parent_microblock_stream[2..].iter() {
+                        let stored = chainstate
+                            .preprocess_streamed_microblock(
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                                mblock,
+                            )
+                            .unwrap();
+                        assert!(stored);
+                    }
 
-                        // find the poison-microblock at seq 2
-                        let (_, poison_opt) = match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
+                    // find the poison-microblock at seq 2
+                    let (_, poison_opt) =
+                        StacksChainState::load_descendant_staging_microblock_stream_with_poison(
                             chainstate.db(),
                             &parent_index_hash,
                             0,
-                            u16::MAX
-                        ).unwrap() {
-                            Some(x) => x,
-                            None => (vec![], None)
-                        };
+                            u16::MAX,
+                        )
+                        .unwrap()
+                        .unwrap_or_default();
 
-                        if let Some(poison_payload) = poison_opt {
-                            let mut tx_bytes = vec![];
-                            let poison_microblock_tx = make_user_poison_microblock(
-                                &privks[tenure_id - 1],
-                                2,
-                                0,
-                                poison_payload
-                            );
+                    if let Some(poison_payload) = poison_opt {
+                        let mut tx_bytes = vec![];
+                        let poison_microblock_tx = make_user_poison_microblock(
+                            &privks[tenure_id - 1],
+                            2,
+                            0,
+                            poison_payload,
+                        );
 
-                            poison_microblock_tx
-                                .consensus_serialize(&mut tx_bytes)
-                                .unwrap();
+                        poison_microblock_tx
+                            .consensus_serialize(&mut tx_bytes)
+                            .unwrap();
 
-                            mempool
-                                .submit_raw(
-                                    chainstate,
-                                    sortdb,
-                                    &parent_consensus_hash,
-                                    &parent_header_hash,
-                                    tx_bytes,
-                            &ExecutionCost::max_value(),
-                            &StacksEpochId::Epoch20,
-                                )
-                                .unwrap();
-                        }
-                        // the miner will load a microblock stream up to the first detected
-                        // fork (which is at sequence 2)
-                        tail
+                        mempool
+                            .submit_raw(
+                                chainstate,
+                                sortdb,
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                                tx_bytes,
+                                &ExecutionCost::max_value(),
+                                &StacksEpochId::Epoch20,
+                            )
+                            .unwrap();
                     }
-                    else {
-                        None
-                    };
+                    // the miner will load a microblock stream up to the first detected
+                    // fork (which is at sequence 2)
+                    tail
+                } else {
+                    None
+                };
 
                 let coinbase_tx = make_coinbase(miner, tenure_id);
 
-                let mblock_pubkey_hash = Hash160::from_node_public_key(&StacksPublicKey::from_private(&mblock_privks[tenure_id]));
+                let mblock_pubkey_hash = Hash160::from_node_public_key(
+                    &StacksPublicKey::from_private(&mblock_privks[tenure_id]),
+                );
 
-                let (anchored_block, block_size, block_execution_cost) = StacksBlockBuilder::build_anchored_block(
-                    chainstate,
-                    &sortdb.index_handle_at_tip(),
-                    &mut mempool,
-                    &parent_tip,
-                    tip.total_burn,
-                    vrf_proof,
-                    &mblock_pubkey_hash,
-                    &coinbase_tx,
-                    BlockBuilderSettings::max_value(),
-                    None,
-                    &burnchain,
-                )
-                .unwrap();
+                let (anchored_block, block_size, block_execution_cost) =
+                    StacksBlockBuilder::build_anchored_block(
+                        chainstate,
+                        &sortdb.index_handle_at_tip(),
+                        &mut mempool,
+                        &parent_tip,
+                        tip.total_burn,
+                        vrf_proof,
+                        &mblock_pubkey_hash,
+                        &coinbase_tx,
+                        BlockBuilderSettings::max_value(),
+                        None,
+                        &burnchain,
+                    )
+                    .unwrap();
 
                 // miner should have picked up the preprocessed microblocks, but only up to the
                 // fork.
                 if let Some((mblock_tail_hash, mblock_tail_seq)) = expected_parent_microblock_opt {
                     assert_eq!(anchored_block.header.parent_microblock, mblock_tail_hash);
-                    assert_eq!(anchored_block.header.parent_microblock_sequence, mblock_tail_seq);
+                    assert_eq!(
+                        anchored_block.header.parent_microblock_sequence,
+                        mblock_tail_seq
+                    );
                     assert_eq!(mblock_tail_seq, 1);
                 }
 
@@ -2728,7 +2775,11 @@ fn test_build_microblock_stream_forks() {
                             have_poison_microblock = true;
                         }
                     }
-                    assert!(have_poison_microblock, "Anchored block has no poison microblock: {:#?}", &anchored_block);
+                    assert!(
+                        have_poison_microblock,
+                        "Anchored block has no poison microblock: {:#?}",
+                        &anchored_block
+                    );
                 }
 
                 (anchored_block, vec![])
@@ -2977,15 +3028,12 @@ fn test_build_microblock_stream_forks_with_descendants() {
                         }
 
                         // find the poison-microblock at seq 2
-                        let (_, poison_opt) = match StacksChainState::load_descendant_staging_microblock_stream_with_poison(
+                        let (_, poison_opt) = StacksChainState::load_descendant_staging_microblock_stream_with_poison(
                             chainstate.db(),
                             &parent_index_hash,
                             0,
                             u16::MAX
-                        ).unwrap() {
-                            Some(x) => x,
-                            None => (vec![], None)
-                        };
+                        ).unwrap().unwrap_or_default();
 
                         if let Some(poison_payload) = poison_opt {
                             *discovered_poison_payload.borrow_mut() = Some(poison_payload.clone());

--- a/stackslib/src/chainstate/tests/mod.rs
+++ b/stackslib/src/chainstate/tests/mod.rs
@@ -787,7 +787,7 @@ impl<'a> TestChainstate<'a> {
         block.header.tx_merkle_root = compute_tx_merkle_root(&block.txs);
         block.header.state_index_root = self
             .compute_nakamoto_marf_root(block.header.timestamp, &block.txs)
-            .unwrap_or_else(|e| TrieHash::ZERO);
+            .unwrap_or(TrieHash::ZERO);
 
         self.miner.sign_nakamoto_block(&mut block);
         let signers = self.config.test_signers.clone().unwrap_or_default();

--- a/stackslib/src/clarity_vm/tests/analysis_costs.rs
+++ b/stackslib/src/clarity_vm/tests/analysis_costs.rs
@@ -253,7 +253,7 @@ fn epoch_21_test_all(use_mainnet: bool, version: ClarityVersion) {
     let baseline = test_tracked_costs("1", StacksEpochId::Epoch21, version, 0, &mut instance);
 
     for (ix, f) in NativeFunctions::ALL.iter().enumerate() {
-        if version < f.get_min_version() || f.get_max_version().map_or(false, |max| version > max) {
+        if version < f.get_min_version() || f.get_max_version().is_some_and(|max| version > max) {
             continue;
         }
 

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -805,7 +805,7 @@ impl Config {
         // Stacks 1.0 must start at 0
         if matched_epochs
             .first()
-            .ok_or_else(|| "Must configure at least 1 epoch")?
+            .ok_or("Must configure at least 1 epoch")?
             .1
             != 0
         {

--- a/stackslib/src/net/api/postblock_proposal.rs
+++ b/stackslib/src/net/api/postblock_proposal.rs
@@ -667,7 +667,7 @@ impl NakamotoBlockProposal {
                 TransactionPayload::TenureChange(tc) => Some(MinerTenureInfoCause::from(tc)),
                 _ => None,
             })
-            .unwrap_or_else(|| MinerTenureInfoCause::NoTenureChange);
+            .unwrap_or(MinerTenureInfoCause::NoTenureChange);
 
         let mut builder = NakamotoBlockBuilder::new(
             &parent_stacks_header,

--- a/stackslib/src/net/atlas/download.rs
+++ b/stackslib/src/net/atlas/download.rs
@@ -19,7 +19,7 @@ use std::collections::hash_map::Entry;
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
-use std::{cmp, fmt};
+use std::{cmp, fmt, mem};
 
 use clarity::vm::types::QualifiedContractIdentifier;
 use rand::{thread_rng, Rng};
@@ -320,7 +320,7 @@ impl AttachmentsDownloader {
 
         // we're draining the initial batch, so to avoid angering The Borrow Checker
         //  use mem replace to just take the whole vec.
-        let initial_batch = std::mem::replace(&mut self.initial_batch, vec![]);
+        let initial_batch = mem::take(&mut self.initial_batch);
 
         self.check_attachment_instances(
             atlas_db,

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -231,7 +231,7 @@ impl NeighborStats {
     }
 
     pub fn take_relayers(&mut self) -> HashMap<NeighborAddress, RelayStats> {
-        let ret = mem::replace(&mut self.relayed_messages, HashMap::new());
+        let ret = mem::take(&mut self.relayed_messages);
         ret
     }
 
@@ -447,10 +447,7 @@ impl Neighbor {
         let asn_opt =
             PeerDB::asn_lookup(conn, &handshake_data.addrbytes).map_err(net_error::DBError)?;
 
-        let asn = match asn_opt {
-            Some(a) => a,
-            None => 0,
-        };
+        let asn = asn_opt.unwrap_or_default();
 
         self.public_key = pubk;
         self.expire_block = handshake_data.expire_block_height;

--- a/stackslib/src/net/httpcore.rs
+++ b/stackslib/src/net/httpcore.rs
@@ -915,7 +915,7 @@ impl StacksHttpRecvStream {
         // did we get a message?
         if self.state.is_eof() {
             // reset
-            let message_data = mem::replace(&mut self.data, vec![]);
+            let message_data = mem::take(&mut self.data);
             let total_consumed = self.total_consumed;
 
             self.state = HttpChunkedTransferReaderState::new(self.state.max_size);

--- a/stackslib/src/net/neighbors/comms.rs
+++ b/stackslib/src/net/neighbors/comms.rs
@@ -592,7 +592,7 @@ impl NeighborComms for PeerNetworkComms {
     }
 
     fn clear_pinned_connections(&mut self) -> HashSet<usize> {
-        let events = mem::replace(&mut self.events, HashSet::new());
+        let events = mem::take(&mut self.events);
         events
     }
 
@@ -651,11 +651,11 @@ impl NeighborComms for PeerNetworkComms {
     }
 
     fn take_dead_neighbors(&mut self) -> HashSet<DropNeighbor> {
-        mem::replace(&mut self.dead_connections, HashSet::new())
+        mem::take(&mut self.dead_connections)
     }
 
     fn take_broken_neighbors(&mut self) -> HashSet<DropNeighbor> {
-        mem::replace(&mut self.broken_connections, HashSet::new())
+        mem::take(&mut self.broken_connections)
     }
 }
 

--- a/stackslib/src/net/neighbors/rpc.rs
+++ b/stackslib/src/net/neighbors/rpc.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{HashMap, HashSet};
+use std::mem;
 
 use stacks_common::types::net::PeerHost;
 
@@ -107,12 +108,12 @@ impl NeighborRPC {
 
     /// Extract the list of dead neighbors
     pub fn take_dead(&mut self) -> HashSet<DropNeighbor> {
-        std::mem::replace(&mut self.dead, HashSet::new())
+        mem::take(&mut self.dead)
     }
 
     /// Extract the list of broken neighbors
     pub fn take_broken(&mut self) -> HashSet<DropNeighbor> {
-        std::mem::replace(&mut self.broken, HashSet::new())
+        mem::take(&mut self.broken)
     }
 
     /// Collect all in-flight replies into a vec.

--- a/stackslib/src/net/neighbors/walk.rs
+++ b/stackslib/src/net/neighbors/walk.rs
@@ -1279,7 +1279,7 @@ impl<DB: NeighborWalkDB, NC: NeighborComms> NeighborWalk<DB, NC> {
     ) -> Result<bool, net_error> {
         assert!(self.state == NeighborWalkState::GetNeighborsNeighborsBegin);
 
-        let handshake_neighbor_addrs = mem::replace(&mut self.handshake_neighbor_addrs, vec![]);
+        let handshake_neighbor_addrs = mem::take(&mut self.handshake_neighbor_addrs);
         for naddr in handshake_neighbor_addrs.into_iter() {
             let nk = naddr.to_neighbor_key(network);
             if !network.is_registered(&nk) {
@@ -1591,7 +1591,7 @@ impl<DB: NeighborWalkDB, NC: NeighborComms> NeighborWalk<DB, NC> {
         // caller will have already populated the pending_pingback_handshakes hashmap
         assert!(self.state == NeighborWalkState::PingbackHandshakesBegin);
 
-        let network_pingbacks = mem::replace(&mut self.network_pingbacks, HashMap::new());
+        let network_pingbacks = mem::take(&mut self.network_pingbacks);
         let mut still_pending: HashMap<NeighborAddress, _> = HashMap::new();
 
         for (naddr, pingback) in network_pingbacks.into_iter() {

--- a/stackslib/src/net/p2p.rs
+++ b/stackslib/src/net/p2p.rs
@@ -2838,7 +2838,7 @@ impl PeerNetwork {
         let mut drained = vec![];
 
         // flush each outgoing conversation
-        let mut relay_handles = std::mem::replace(&mut self.relay_handles, HashMap::new());
+        let mut relay_handles = mem::take(&mut self.relay_handles);
         for (event_id, handle_list) in relay_handles.iter_mut() {
             if handle_list.is_empty() {
                 debug!("No handles for event {}", event_id);
@@ -4467,7 +4467,7 @@ impl PeerNetwork {
         sortdb: &SortitionDB,
         chainstate: &mut StacksChainState,
     ) -> Result<(), net_error> {
-        let stacker_db_configs = mem::replace(&mut self.stacker_db_configs, HashMap::new());
+        let stacker_db_configs = mem::take(&mut self.stacker_db_configs);
         self.stacker_db_configs = self.stackerdbs.create_or_reconfigure_stackerdbs(
             chainstate,
             sortdb,
@@ -4947,7 +4947,7 @@ impl PeerNetwork {
                     .iter()
                     .fold(0, |acc, (_, inbox)| acc + inbox.messages.len())
             );
-            let buffered_messages = mem::replace(&mut self.pending_messages, HashMap::new());
+            let buffered_messages = mem::take(&mut self.pending_messages);
             let unhandled = self.handle_unsolicited_sortition_messages(
                 sortdb,
                 chainstate,
@@ -4968,8 +4968,7 @@ impl PeerNetwork {
                     .iter()
                     .fold(0, |acc, (_, inbox)| acc + inbox.messages.len())
             );
-            let buffered_stacks_messages =
-                mem::replace(&mut self.pending_stacks_messages, HashMap::new());
+            let buffered_stacks_messages = mem::take(&mut self.pending_stacks_messages);
             let unhandled = self.handle_unsolicited_stacks_messages(
                 chainstate,
                 buffered_stacks_messages,

--- a/stackslib/src/net/relay.rs
+++ b/stackslib/src/net/relay.rs
@@ -2022,8 +2022,7 @@ impl Relayer {
     ) -> Result<(Vec<AcceptedNakamotoBlocks>, Vec<NeighborKey>), net_error> {
         // process downloaded Nakamoto blocks.
         // We treat them as singleton blocks fetched via zero relayers
-        let nakamoto_blocks =
-            std::mem::replace(&mut network_result.nakamoto_blocks, HashMap::new());
+        let nakamoto_blocks = mem::take(&mut network_result.nakamoto_blocks);
         let mut accepted_nakamoto_blocks_and_relayers =
             match Self::process_downloaded_nakamoto_blocks(
                 burnchain,
@@ -2912,7 +2911,7 @@ impl Relayer {
         // push events for HTTP-uploaded stacker DB chunks
         self.process_uploaded_stackerdb_chunks(
             &network_result.rc_consensus_hash,
-            mem::replace(&mut network_result.uploaded_stackerdb_chunks, vec![]),
+            mem::take(&mut network_result.uploaded_stackerdb_chunks),
             event_observer.map(|obs| obs.as_stackerdb_event_dispatcher()),
         );
 
@@ -2920,7 +2919,7 @@ impl Relayer {
         self.process_stacker_db_chunks(
             &network_result.rc_consensus_hash,
             &network_result.stacker_db_configs,
-            mem::replace(&mut network_result.stacker_db_sync_results, vec![]),
+            mem::take(&mut network_result.stacker_db_sync_results),
             event_observer.map(|obs| obs.as_stackerdb_event_dispatcher()),
         )?;
 
@@ -2928,7 +2927,7 @@ impl Relayer {
         self.process_pushed_stacker_db_chunks(
             &network_result.rc_consensus_hash,
             &network_result.stacker_db_configs,
-            mem::replace(&mut network_result.pushed_stackerdb_chunks, vec![]),
+            mem::take(&mut network_result.pushed_stackerdb_chunks),
             event_observer.map(|obs| obs.as_stackerdb_event_dispatcher()),
         )?;
 

--- a/stackslib/src/net/stackerdb/sync.rs
+++ b/stackslib/src/net/stackerdb/sync.rs
@@ -181,25 +181,25 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             &self.smart_contract_id, config
         );
         let mut chunks = vec![];
-        let downloaded_chunks = mem::replace(&mut self.downloaded_chunks, HashMap::new());
+        let downloaded_chunks = mem::take(&mut self.downloaded_chunks);
         for (naddr, data) in downloaded_chunks.into_iter() {
             for chunk in data {
                 chunks.push((StackerDBChunkOrigin::Poll(naddr.clone()), chunk));
             }
         }
 
-        let chunk_invs = mem::replace(&mut self.chunk_invs, HashMap::new());
+        let chunk_invs = mem::take(&mut self.chunk_invs);
         let result = StackerDBSyncResult {
             contract_id: self.smart_contract_id.clone(),
             chunk_invs,
             chunks_to_store: chunks,
-            stale: std::mem::replace(&mut self.stale_neighbors, HashSet::new()),
+            stale: mem::take(&mut self.stale_neighbors),
             num_connections: self.num_connections,
             num_attempted_connections: self.num_attempted_connections,
         };
 
         // keep all connected replicas, and replenish from config hints and the DB as needed
-        let connected_replicas = mem::replace(&mut self.connected_replicas, HashSet::new());
+        let connected_replicas = mem::take(&mut self.connected_replicas);
         let next_connected_replicas =
             if let Ok(new_replicas) = self.find_new_replicas(connected_replicas, network, config) {
                 new_replicas
@@ -736,7 +736,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
             return Err(net_error::NoSuchNeighbor);
         }
 
-        let naddrs = mem::replace(&mut self.replicas, HashSet::new());
+        let naddrs = mem::take(&mut self.replicas);
         for naddr in naddrs.into_iter() {
             if self.comms.is_neighbor_connecting(network, &naddr) {
                 debug!(
@@ -906,7 +906,7 @@ impl<NC: NeighborComms> StackerDBSync<NC> {
     /// StackerDBGetChunksInv
     /// Always succeeds; does not block.
     pub fn getchunksinv_begin(&mut self, network: &mut PeerNetwork) {
-        let naddrs = mem::replace(&mut self.connected_replicas, HashSet::new());
+        let naddrs = mem::take(&mut self.connected_replicas);
         let mut already_sent = vec![];
         debug!(
             "{:?}: {}: getchunksinv_begin: Send StackerDBGetChunksInv to {} replicas",

--- a/stackslib/src/net/tests/mod.rs
+++ b/stackslib/src/net/tests/mod.rs
@@ -23,6 +23,7 @@ pub mod neighbors;
 pub mod relay;
 
 use std::collections::{HashMap, HashSet};
+use std::mem;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use clarity::types::{EpochList, StacksEpochId};
@@ -698,8 +699,7 @@ impl NakamotoBootPlan {
                         .map(|(block, _, _)| block)
                         .collect();
 
-                    let malleablized_blocks =
-                        std::mem::replace(&mut peer.chain.malleablized_blocks, vec![]);
+                    let malleablized_blocks = mem::take(&mut peer.chain.malleablized_blocks);
                     for mblk in malleablized_blocks.iter() {
                         malleablized_block_ids.insert(mblk.block_id());
                     }
@@ -816,8 +816,7 @@ impl NakamotoBootPlan {
                         .map(|(block, _, _)| block)
                         .collect();
 
-                    let malleablized_blocks =
-                        std::mem::replace(&mut peer.chain.malleablized_blocks, vec![]);
+                    let malleablized_blocks = mem::take(&mut peer.chain.malleablized_blocks);
                     for mblk in malleablized_blocks.iter() {
                         malleablized_block_ids.insert(mblk.block_id());
                     }


### PR DESCRIPTION
### Description

This PR replaces verbose Option and Result handling with idiomatic combinators and uses `mem::take` for default-value replacements. It also removes the `unnecessary_lazy_evaluations` exception from the shared Clippy alias.

### Applicable issues

None.

### Additional info (benefits, drawbacks, caveats)

Existing return values, error propagation, and side effects are preserved.

### Checklist

- [x] Test coverage for new or modified code paths