### PR TITLE
refactor: simplify assertions and default-based fixtures (test-code only)

### DIFF
--- a/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -3093,15 +3093,13 @@ mod tests {
         let btc_controller = BitcoinRegtestController::new(config.clone(), None);
 
         let reviewed = btc_controller.to_epoch_aware_pubkey(StacksEpochId::Epoch20, &pubkey);
-        assert_eq!(
-            false,
-            reviewed.compressed(),
+        assert!(
+            !reviewed.compressed(),
             "Segwit disabled with Epoch < 2.1: not compressed"
         );
         let reviewed = btc_controller.to_epoch_aware_pubkey(StacksEpochId::Epoch21, &pubkey);
-        assert_eq!(
-            false,
-            reviewed.compressed(),
+        assert!(
+            !reviewed.compressed(),
             "Segwit disabled with Epoch >= 2.1: not compressed"
         );
 
@@ -3109,14 +3107,12 @@ mod tests {
         let btc_controller = BitcoinRegtestController::new(config.clone(), None);
 
         let reviewed = btc_controller.to_epoch_aware_pubkey(StacksEpochId::Epoch20, &pubkey);
-        assert_eq!(
-            false,
-            reviewed.compressed(),
+        assert!(
+            !reviewed.compressed(),
             "Segwit enabled with Epoch < 2.1: not compressed"
         );
         let reviewed = btc_controller.to_epoch_aware_pubkey(StacksEpochId::Epoch21, &pubkey);
-        assert_eq!(
-            true,
+        assert!(
             reviewed.compressed(),
             "Segwit enabled with Epoch >= 2.1: compressed"
         );
@@ -3183,8 +3179,8 @@ mod tests {
 
         let btc_controller = BitcoinRegtestController::with_burnchain(config, None, None, None);
 
+        // Accessing the RPC client must not panic for a miner.
         let _ = btc_controller.get_rpc_client();
-        assert!(true, "Invoking any Bitcoin RPC related method should work.");
     }
 
     #[test]
@@ -3223,8 +3219,8 @@ mod tests {
 
         let btc_controller = BitcoinRegtestController::new_dummy(config);
 
+        // Accessing the RPC client must not panic for a miner.
         let _ = btc_controller.get_rpc_client();
-        assert!(true, "Invoking any Bitcoin RPC related method should work.");
     }
 
     #[test]

--- a/stacks-node/src/event_dispatcher/tests.rs
+++ b/stacks-node/src/event_dispatcher/tests.rs
@@ -514,8 +514,8 @@ fn test_new_event_observer() {
     // Verify fields
     assert_eq!(observer.endpoint, endpoint);
     assert_eq!(observer.timeout, timeout);
-    assert_eq!(observer.disable_retries, false);
-    assert_eq!(observer.disable_contract_interface, false);
+    assert!(!observer.disable_retries);
+    assert!(!observer.disable_contract_interface);
 }
 
 #[test]

--- a/stacks-node/src/nakamoto_node/miner.rs
+++ b/stacks-node/src/nakamoto_node/miner.rs
@@ -2357,9 +2357,8 @@ fn should_read_count_extend_units() {
         runtime: 1000,
     };
 
-    assert_eq!(
-        miner.should_read_count_extend(&()).unwrap(),
-        false,
+    assert!(
+        !miner.should_read_count_extend(&()).unwrap(),
         "When read_count is below the configured threshold, we shouldn't try to extend"
     );
 
@@ -2379,9 +2378,8 @@ fn should_read_count_extend_units() {
         runtime: 1000,
     };
 
-    assert_eq!(
+    assert!(
         miner.should_read_count_extend(&()).unwrap(),
-        true,
         "When read_count is at the configured threshhold, we should try to extend"
     );
 }

--- a/stacks-node/src/tests/bitcoin/rpc_integrations.rs
+++ b/stacks-node/src/tests/bitcoin/rpc_integrations.rs
@@ -24,6 +24,8 @@
 //! CI uses this mechanism to automate checks across
 //! the relevant set of Bitcoin Core versions.
 
+use std::assert_matches;
+
 use pinny::tag;
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, LegacyBitcoinAddressType};
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
@@ -225,15 +227,11 @@ fn test_wallet_creation_fails_if_already_exists() {
         .create_wallet("mywallet1", Some(false))
         .expect_err("mywallet1 creation should fail now!");
 
-    match &err {
-        BitcoinRpcClientError::Rpc(RpcError::NetworkIO(_)) => {
-            assert!(true, "Bitcoind v25 returns HTTP 500)");
-        }
-        BitcoinRpcClientError::Rpc(RpcError::Service(_)) => {
-            assert!(true, "Bitcoind v26+ returns HTTP 200");
-        }
-        _ => panic!("Expected Network or Service error, got {err:?}"),
-    }
+    // Bitcoind v25 returns HTTP 500; v26+ returns HTTP 200. Both are accepted.
+    assert_matches!(
+        err,
+        BitcoinRpcClientError::Rpc(RpcError::NetworkIO(_) | RpcError::Service(_))
+    );
 }
 
 #[tag(ci_skip)]

--- a/stacks-node/src/tests/mem_abort.rs
+++ b/stacks-node/src/tests/mem_abort.rs
@@ -237,8 +237,10 @@ fn test_analysis_limit_fine_but_execution_limit_too_low() {
 #[test]
 fn test_read_only_call_max_mem_bytes_threaded_into_http() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let mut conn_opts = ConnectionOptions::default();
-    conn_opts.read_only_call_max_mem_bytes = 12345;
+    let conn_opts = ConnectionOptions {
+        read_only_call_max_mem_bytes: 12345,
+        ..Default::default()
+    };
 
     let http = StacksHttp::new(addr, &conn_opts);
     assert_eq!(http.read_only_call_max_mem_bytes, 12345);
@@ -269,8 +271,10 @@ fn try_parse_call_read(
     read_only_call_max_mem_bytes: u64,
 ) -> Result<(), String> {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
-    let mut conn_opts = ConnectionOptions::default();
-    conn_opts.read_only_call_max_mem_bytes = read_only_call_max_mem_bytes;
+    let conn_opts = ConnectionOptions {
+        read_only_call_max_mem_bytes,
+        ..Default::default()
+    };
     let mut http = StacksHttp::new(addr, &conn_opts);
     let request = new_call_read_request(addr, arguments);
     let mut bytes = vec![];

--- a/stacks-node/src/tests/pox_5_integrations.rs
+++ b/stacks-node/src/tests/pox_5_integrations.rs
@@ -2329,8 +2329,7 @@ fn check_pox_5_register_for_bond_l1_lockup_lifecycle() {
     let interloper_result =
         bondholder_rpc.send_raw_transaction(&interloper_sweep_tx, Some(0.0), Some(1_000_000));
     let interloper_err = interloper_result
-        .err()
-        .expect("interloper sweep must be rejected: the script's OP_CHECKSIG should fail");
+        .expect_err("interloper sweep must be rejected: the script's OP_CHECKSIG should fail");
     info!(
         "Interloper sweep rejected as expected (no valid signature for staker_unlock_pk): \
          {interloper_err:?}"
@@ -3196,8 +3195,7 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
     let res_both_wrong =
         bondholder_rpc.send_raw_transaction(&tx_both_wrong, Some(0.0), Some(1_000_000));
     let err_both_wrong = res_both_wrong
-        .err()
-        .expect("both-wrong-sigs early-exit sweep must be rejected by the script's CHECKSIGs");
+        .expect_err("both-wrong-sigs early-exit sweep must be rejected by the script's CHECKSIGs");
     info!("Both-wrong-sigs early-exit sweep rejected as expected: {err_both_wrong:?}");
 
     // (b) Owner sig correct, early sig from a random key (correct preimage).
@@ -3208,9 +3206,9 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
     );
     let res_no_early =
         bondholder_rpc.send_raw_transaction(&tx_no_early, Some(0.0), Some(1_000_000));
-    let err_no_early = res_no_early
-        .err()
-        .expect("missing-early-sig sweep must be rejected: early-unlock CHECKSIG fails OP_VERIFY");
+    let err_no_early = res_no_early.expect_err(
+        "missing-early-sig sweep must be rejected: early-unlock CHECKSIG fails OP_VERIFY",
+    );
     info!(
         "Owner-only early-exit sweep rejected (early-unlock CHECKSIG fails the shared OP_VERIFY): \
          {err_no_early:?}"
@@ -3225,8 +3223,7 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
     let res_no_owner =
         bondholder_rpc.send_raw_transaction(&tx_no_owner, Some(0.0), Some(1_000_000));
     let err_no_owner = res_no_owner
-        .err()
-        .expect("missing-owner-sig sweep must be rejected by the closing OP_CHECKSIG");
+        .expect_err("missing-owner-sig sweep must be rejected by the closing OP_CHECKSIG");
     info!(
         "Early-only early-exit sweep rejected (closing CHECKSIG on the owner sig fails): \
          {err_no_owner:?}"
@@ -3242,8 +3239,7 @@ fn check_pox_5_register_for_bond_l1_early_unlock_lifecycle() {
     let res_wrong_preimage =
         bondholder_rpc.send_raw_transaction(&tx_wrong_preimage, Some(0.0), Some(1_000_000));
     let err_wrong_preimage = res_wrong_preimage
-        .err()
-        .expect("wrong-preimage sweep must be rejected by OP_SHA256 <H> OP_EQUALVERIFY");
+        .expect_err("wrong-preimage sweep must be rejected by OP_SHA256 <H> OP_EQUALVERIFY");
     info!(
         "Wrong-preimage early-exit sweep rejected (sha256(preimage) != H fails OP_EQUALVERIFY): \
          {err_wrong_preimage:?}"

--- a/stacks-node/src/tests/signer/commands/block_wait.rs
+++ b/stacks-node/src/tests/signer/commands/block_wait.rs
@@ -103,7 +103,9 @@ impl Command<SignerTestState, SignerTestContext> for ChainExpectNakaBlock {
 
                 let miner_block =
                     wait_for_block_pushed_by_miner_key(30, expected_height, &miner_pk)
-                        .expect(&format!("Failed to get block {}", expected_height));
+                        .unwrap_or_else(|error| {
+                            panic!("Failed to get block {expected_height}: {error:?}")
+                        });
 
                 let mined_block_height = miner_block.header.chain_length;
 
@@ -124,12 +126,13 @@ impl Command<SignerTestState, SignerTestContext> for ChainExpectNakaBlock {
                 let expected_height = state.last_stacks_block_height.unwrap() + 1;
 
                 let miner_block =
-                    wait_for_block_pushed_by_miner_key(30, expected_height, &miner_pk).expect(
-                        &format!(
-                            "Failed to get block for miner {} - Strategy: {:?}",
-                            self.miner_index, self.height_strategy
-                        ),
-                    );
+                    wait_for_block_pushed_by_miner_key(30, expected_height, &miner_pk)
+                        .unwrap_or_else(|error| {
+                            panic!(
+                                "Failed to get block for miner {} - Strategy: {:?}: {error:?}",
+                                self.miner_index, self.height_strategy
+                            )
+                        });
 
                 let mined_block_height = miner_block.header.chain_length;
 
@@ -346,11 +349,13 @@ impl Command<SignerTestState, SignerTestContext> for ChainExpectStacksTenureChan
             self.miner_index
         );
 
-        let block =
-            wait_for_block_pushed_by_miner_key(30, expected_height, &miner_pk).expect(&format!(
-                "Failed to get tenure change block for miner {} at height {expected_height}",
-                self.miner_index
-            ));
+        let block = wait_for_block_pushed_by_miner_key(30, expected_height, &miner_pk)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "Failed to get tenure change block for miner {} at height {expected_height}: {error:?}",
+                    self.miner_index,
+                )
+            });
 
         // Verify this is a tenure change block
         let is_tenure_change_block_found = block.tx_count() == 2

--- a/stacks-node/src/tests/signer/v0/reorg.rs
+++ b/stacks-node/src/tests/signer/v0/reorg.rs
@@ -4876,8 +4876,8 @@ fn miner_rejection_by_contract_call_execution_time_expired() {
 
     miners.wait_for_test_observer_blocks(60);
 
-    assert_eq!(last_block_contains_txid(&tx1), true);
-    assert_eq!(last_block_contains_txid(&contract_call_txid), false);
+    assert!(last_block_contains_txid(&tx1));
+    assert!(!last_block_contains_txid(&contract_call_txid));
 
     info!("------------------------- Miner 1 Mines a Nakamoto Block N+2 -------------------------");
 
@@ -4887,7 +4887,7 @@ fn miner_rejection_by_contract_call_execution_time_expired() {
 
     miners.wait_for_test_observer_blocks(60);
 
-    assert_eq!(last_block_contains_txid(&tx2), true);
+    assert!(last_block_contains_txid(&tx2));
 
     verify_sortition_winner(&sortdb, &miner_pkh_1);
 
@@ -4915,7 +4915,7 @@ fn miner_rejection_by_contract_call_execution_time_expired() {
 
     miners.wait_for_test_observer_blocks(60);
 
-    assert_eq!(last_block_contains_txid(&contract_call_txid), true);
+    assert!(last_block_contains_txid(&contract_call_txid));
 
     verify_sortition_winner(&sortdb, &miner_pkh_2);
 
@@ -5000,7 +5000,7 @@ fn miner_rejection_by_contract_publish_execution_time_expired() {
         .send_and_mine_contract_publish(sender_nonce + 1, "dummy-contract", dummy_contract_src, 60)
         .expect_err("Expected an error while publishing contract in a new block");
 
-    assert_eq!(last_block_contains_txid(&tx1), true);
+    assert!(last_block_contains_txid(&tx1));
 
     verify_sortition_winner(&sortdb, &miner_pkh_1);
 

--- a/stackslib/src/burnchains/bitcoin/address.rs
+++ b/stackslib/src/burnchains/bitcoin/address.rs
@@ -1120,8 +1120,8 @@ mod tests {
         assert_eq!(addr_str, addr.to_bech32(), "to bench32 check");
         assert_eq!(addr_str, addr.to_string(), "to string check");
         assert_eq!(Variant::Bech32, addr.bech32_variant(), "variant check");
-        assert_eq!(true, addr.is_p2wpkh(), "type check");
-        assert_eq!(false, addr.is_mainnet(), "mainnet check");
+        assert!(addr.is_p2wpkh(), "type check");
+        assert!(!addr.is_mainnet(), "mainnet check");
         assert_eq!(SEGWIT_REGTEST_HRP, addr.hrp(), "hrp check");
         assert_eq!(BitcoinNetworkType::Regtest, addr.network(), "network check");
     }
@@ -1134,8 +1134,8 @@ mod tests {
         assert_eq!(addr_str, addr.to_bech32(), "to bench32 check");
         assert_eq!(addr_str, addr.to_string(), "to string check");
         assert_eq!(Variant::Bech32, addr.bech32_variant(), "variant check");
-        assert_eq!(true, addr.is_p2wsh(), "type check");
-        assert_eq!(false, addr.is_mainnet(), "mainnet check");
+        assert!(addr.is_p2wsh(), "type check");
+        assert!(!addr.is_mainnet(), "mainnet check");
         assert_eq!(SEGWIT_REGTEST_HRP, addr.hrp(), "hrp check");
         assert_eq!(BitcoinNetworkType::Regtest, addr.network(), "network check");
     }
@@ -1148,8 +1148,8 @@ mod tests {
         assert_eq!(addr_str, addr.to_bech32(), "to bench32 check");
         assert_eq!(addr_str, addr.to_string(), "to string check");
         assert_eq!(Variant::Bech32m, addr.bech32_variant(), "variant check");
-        assert_eq!(false, addr.is_mainnet(), "mainnet check");
-        assert_eq!(true, addr.is_p2tr(), "type check");
+        assert!(!addr.is_mainnet(), "mainnet check");
+        assert!(addr.is_p2tr(), "type check");
         assert_eq!(SEGWIT_REGTEST_HRP, addr.hrp(), "hrp check");
         assert_eq!(BitcoinNetworkType::Regtest, addr.network(), "network check");
     }

--- a/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
+++ b/stackslib/src/chainstate/nakamoto/coordinator/tests.rs
@@ -2009,7 +2009,7 @@ fn transactions_indexing() {
     let (tracked_block, burn_height, ..) =
         peer.single_block_tenure(&private_key, |_| {}, |_| {}, |_| false);
 
-    assert_eq!(peer.try_process_block(&tracked_block).unwrap(), true);
+    assert!(peer.try_process_block(&tracked_block).unwrap());
 
     let tracked_block_id = tracked_block.block_id();
 
@@ -2074,7 +2074,7 @@ fn transactions_not_indexing() {
     let (untracked_block, burn_height, ..) =
         peer.single_block_tenure(&private_key, |_| {}, |_| {}, |_| false);
 
-    assert_eq!(peer.try_process_block(&untracked_block).unwrap(), true);
+    assert!(peer.try_process_block(&untracked_block).unwrap());
 
     let untracked_block_id = untracked_block.block_id();
 
@@ -2082,11 +2082,10 @@ fn transactions_not_indexing() {
 
     // ensure untracked transactions are not recorded
     for tx in untracked_block.txs {
-        assert_eq!(
+        assert!(
             NakamotoChainState::get_tx_info_from_txid(&chainstate.index_conn(), &tx.txid(),)
                 .unwrap()
-                .is_none(),
-            true
+                .is_none()
         );
     }
 }

--- a/stackslib/src/chainstate/stacks/tests/block_construction.rs
+++ b/stackslib/src/chainstate/stacks/tests/block_construction.rs
@@ -5084,8 +5084,10 @@ fn mempool_walk_test_next_nonce_with_highest_fee_rate_strategy() {
 
     // Visit transactions using the `NextNonceWithHighestFeeRate` strategy. Keep a record of the order of visits so we can compare
     // at the end.
-    let mut mempool_settings = MemPoolWalkSettings::default();
-    mempool_settings.strategy = MemPoolWalkStrategy::NextNonceWithHighestFeeRate;
+    let mempool_settings = MemPoolWalkSettings {
+        strategy: MemPoolWalkStrategy::NextNonceWithHighestFeeRate,
+        ..Default::default()
+    };
     let mut considered_txs = vec![];
     let deadline = get_epoch_time_ms() + 30000;
     chainstate.with_read_only_clarity_tx(

--- a/stackslib/src/config/mod.rs
+++ b/stackslib/src/config/mod.rs
@@ -5558,11 +5558,8 @@ mod tests {
                 "#,
         );
 
-        assert_eq!(
-            true, config.node.marf_defer_hashing,
-            "default defer hashing"
-        );
-        assert_eq!(true, config.node.marf_compress, "default compress");
+        assert!(config.node.marf_defer_hashing, "default defer hashing");
+        assert!(config.node.marf_compress, "default compress");
 
         let cfg_opts = config.node.get_marf_opts();
         assert_eq!(
@@ -5570,13 +5567,10 @@ mod tests {
             cfg_opts.hash_calculation_mode,
             "default defer hashing opt"
         );
-        assert_eq!(true, cfg_opts.compress, "default compress opt");
-        assert_eq!(
-            false, cfg_opts.external_blobs,
-            "internal default blob setting"
-        );
-        assert_eq!(
-            false, cfg_opts.force_db_migrate,
+        assert!(cfg_opts.compress, "default compress opt");
+        assert!(!cfg_opts.external_blobs, "internal default blob setting");
+        assert!(
+            !cfg_opts.force_db_migrate,
             "internal default migrate setting"
         );
 
@@ -5590,11 +5584,8 @@ mod tests {
                 "#,
         );
 
-        assert_eq!(
-            false, config.node.marf_defer_hashing,
-            "configured defer hashing"
-        );
-        assert_eq!(false, config.node.marf_compress, "configured compress");
+        assert!(!config.node.marf_defer_hashing, "configured defer hashing");
+        assert!(!config.node.marf_compress, "configured compress");
 
         let cfg_opts = config.node.get_marf_opts();
         assert_eq!(
@@ -5602,13 +5593,10 @@ mod tests {
             cfg_opts.hash_calculation_mode,
             "configured hash opt"
         );
-        assert_eq!(false, cfg_opts.compress, "configured compress opt");
-        assert_eq!(
-            false, cfg_opts.external_blobs,
-            "internal default blob setting"
-        );
-        assert_eq!(
-            false, cfg_opts.force_db_migrate,
+        assert!(!cfg_opts.compress, "configured compress opt");
+        assert!(!cfg_opts.external_blobs, "internal default blob setting");
+        assert!(
+            !cfg_opts.force_db_migrate,
             "internal default migrate setting"
         );
     }

--- a/stackslib/src/core/tests/mod.rs
+++ b/stackslib/src/core/tests/mod.rs
@@ -2801,8 +2801,10 @@ fn large_mempool() {
     }
     mempool_tx.commit().unwrap();
 
-    let mut mempool_settings = MemPoolWalkSettings::default();
-    mempool_settings.strategy = MemPoolWalkStrategy::NextNonceWithHighestFeeRate;
+    let mempool_settings = MemPoolWalkSettings {
+        strategy: MemPoolWalkStrategy::NextNonceWithHighestFeeRate,
+        ..Default::default()
+    };
     let mut tx_events = Vec::new();
 
     println!("Iterating mempool");

--- a/stackslib/src/net/api/tests/blockreplay.rs
+++ b/stackslib/src/net/api/tests/blockreplay.rs
@@ -72,7 +72,7 @@ fn test_try_parse_request() {
     let (preamble, contents) = parsed_request.destruct();
 
     assert_eq!(&preamble, request.preamble());
-    assert_eq!(handler.profiler, false);
+    assert!(!handler.profiler);
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn test_try_parse_request_with_profiler() {
 
     let (preamble, contents) = parsed_request.destruct();
 
-    assert_eq!(handler.profiler, true);
+    assert!(handler.profiler);
 }
 
 #[test]

--- a/stackslib/src/net/api/tests/blocksimulate.rs
+++ b/stackslib/src/net/api/tests/blocksimulate.rs
@@ -77,7 +77,7 @@ fn test_try_parse_request() {
     let (preamble, contents) = parsed_request.destruct();
 
     assert_eq!(&preamble, request.preamble());
-    assert_eq!(handler.profiler, false);
+    assert!(!handler.profiler);
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn test_try_parse_request_with_profiler() {
 
     let (preamble, contents) = parsed_request.destruct();
 
-    assert_eq!(handler.profiler, true);
+    assert!(handler.profiler);
 }
 
 #[test]

--- a/stackslib/src/net/chat.rs
+++ b/stackslib/src/net/chat.rs
@@ -6925,8 +6925,10 @@ mod test {
 
     #[test]
     fn test_validate_block_push() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.max_block_push_bandwidth = 100;
+        let conn_opts = ConnectionOptions {
+            max_block_push_bandwidth: 100,
+            ..Default::default()
+        };
 
         let socketaddr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 8081);
 
@@ -7052,8 +7054,10 @@ mod test {
 
     #[test]
     fn test_validate_transaction_push() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.max_transaction_push_bandwidth = 100;
+        let conn_opts = ConnectionOptions {
+            max_transaction_push_bandwidth: 100,
+            ..Default::default()
+        };
 
         let socketaddr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 8081);
 
@@ -7179,8 +7183,10 @@ mod test {
 
     #[test]
     fn test_validate_microblocks_push() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.max_microblocks_push_bandwidth = 100;
+        let conn_opts = ConnectionOptions {
+            max_microblocks_push_bandwidth: 100,
+            ..Default::default()
+        };
 
         let socketaddr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 8081);
 
@@ -7306,8 +7312,10 @@ mod test {
 
     #[test]
     fn test_validate_stackerdb_push() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.max_stackerdb_push_bandwidth = 100;
+        let conn_opts = ConnectionOptions {
+            max_stackerdb_push_bandwidth: 100,
+            ..Default::default()
+        };
 
         let socketaddr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 8081);
 

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -1944,9 +1944,11 @@ mod test {
 
     #[test]
     fn test_connection_ping_relay_producer_consumer() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.inbox_maxlen = 5000;
-        conn_opts.outbox_maxlen = 5000;
+        let conn_opts = ConnectionOptions {
+            inbox_maxlen: 5000,
+            outbox_maxlen: 5000,
+            ..Default::default()
+        };
 
         let conn = ConnectionP2P::new(StacksP2P::new(), &conn_opts, None);
 
@@ -1955,9 +1957,11 @@ mod test {
 
     #[test]
     fn test_connection_ping_request_producer_consumer() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.inbox_maxlen = 5000;
-        conn_opts.outbox_maxlen = 5000;
+        let conn_opts = ConnectionOptions {
+            inbox_maxlen: 5000,
+            outbox_maxlen: 5000,
+            ..Default::default()
+        };
 
         let conn = ConnectionP2P::new(StacksP2P::new(), &conn_opts, None);
 
@@ -1966,9 +1970,11 @@ mod test {
 
     #[test]
     fn connection_relay_send() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.inbox_maxlen = 5;
-        conn_opts.outbox_maxlen = 5;
+        let conn_opts = ConnectionOptions {
+            inbox_maxlen: 5,
+            outbox_maxlen: 5,
+            ..Default::default()
+        };
 
         let mut conn = ConnectionP2P::new(StacksP2P::new(), &conn_opts, None);
 
@@ -2129,9 +2135,11 @@ mod test {
             out_degree: 0,
         };
 
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.inbox_maxlen = 5;
-        conn_opts.outbox_maxlen = 5;
+        let conn_opts = ConnectionOptions {
+            inbox_maxlen: 5,
+            outbox_maxlen: 5,
+            ..Default::default()
+        };
 
         let mut conn = ConnectionP2P::new(StacksP2P::new(), &conn_opts, Some(neighbor.public_key));
 
@@ -2227,9 +2235,11 @@ mod test {
                 out_degree: 0,
             };
 
-            let mut conn_opts = ConnectionOptions::default();
-            conn_opts.inbox_maxlen = 5;
-            conn_opts.outbox_maxlen = 5;
+            let conn_opts = ConnectionOptions {
+                inbox_maxlen: 5,
+                outbox_maxlen: 5,
+                ..Default::default()
+            };
 
             let mut conn =
                 ConnectionP2P::new(StacksP2P::new(), &conn_opts, Some(neighbor.public_key));
@@ -2342,9 +2352,11 @@ mod test {
             out_degree: 0,
         };
 
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.inbox_maxlen = 5;
-        conn_opts.outbox_maxlen = 5;
+        let conn_opts = ConnectionOptions {
+            inbox_maxlen: 5,
+            outbox_maxlen: 5,
+            ..Default::default()
+        };
 
         let mut conn = ConnectionP2P::new(StacksP2P::new(), &conn_opts, Some(neighbor.public_key));
 

--- a/stackslib/src/net/server.rs
+++ b/stackslib/src/net/server.rs
@@ -975,9 +975,11 @@ mod test {
     #[test]
     #[ignore]
     fn test_http_too_many_clients() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.num_clients = 1;
-        conn_opts.max_http_clients = 1;
+        let conn_opts = ConnectionOptions {
+            num_clients: 1,
+            max_http_clients: 1,
+            ..Default::default()
+        };
 
         let have_success = RefCell::new(false);
         let have_error = RefCell::new(false);
@@ -1031,8 +1033,11 @@ mod test {
     #[test]
     #[ignore]
     fn test_http_slow_client() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.timeout = 3; // kill a connection after 3 seconds of idling
+        let conn_opts = ConnectionOptions {
+            // kill a connection after 3 seconds of idling
+            timeout: 3,
+            ..Default::default()
+        };
 
         test_http_server(
             function_name!(),
@@ -1193,9 +1198,11 @@ mod test {
 
     #[test]
     fn test_http_no_connecting_event_id_leak() {
-        let mut conn_opts = ConnectionOptions::default();
-        conn_opts.timeout = 10;
-        conn_opts.connect_timeout = 10;
+        let conn_opts = ConnectionOptions {
+            timeout: 10,
+            connect_timeout: 10,
+            ..Default::default()
+        };
 
         let num_events = test_http_server(
             function_name!(),


### PR DESCRIPTION
### Description

This PR simplifies boolean and error assertions, replaces redundant constant assertions, and initializes test fixtures directly instead of assigning fields after `Default::default()`. Failure messages retain their underlying error details.

### Applicable issues

None.

### Additional info (benefits, drawbacks, caveats)

Existing test operations, fixture values, and meaningful assertions are preserved. No tests are removed or newly ignored.

### Checklist

- [x] Test coverage for new or modified code paths