### PR TITLE
refactor: use borrowed parameters and standard conversion traits

### DIFF
--- a/changelog.d/borrowed-parameters-and-traits.changed
+++ b/changelog.d/borrowed-parameters-and-traits.changed
@@ -1,0 +1,1 @@
+Accept slices and borrowed paths in Rust helper APIs and use standard conversion and formatting traits.

--- a/stacks-node/src/burnchains/rpc/bitcoin_rpc_client/test_utils.rs
+++ b/stacks-node/src/burnchains/rpc/bitcoin_rpc_client/test_utils.rs
@@ -15,6 +15,8 @@
 
 //! Test-only utilities for [`BitcoinRpcClient`]
 
+use std::fmt;
+
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 use stacks::burnchains::bitcoin::address::BitcoinAddress;
@@ -101,15 +103,28 @@ pub enum AddressType {
     Bech32m,
 }
 
-impl ToString for AddressType {
-    fn to_string(&self) -> String {
-        match self {
+impl fmt::Display for AddressType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
             AddressType::Legacy => "legacy",
             AddressType::P2shSegwit => "p2sh-segwit",
             AddressType::Bech32 => "bech32",
             AddressType::Bech32m => "bech32m",
-        }
-        .to_string()
+        })
+    }
+}
+
+/// Address formatting must preserve the strings accepted by Bitcoin Core RPC.
+#[test]
+fn test_address_type_rpc_strings() {
+    for (address_type, expected) in [
+        (AddressType::Legacy, "legacy"),
+        (AddressType::P2shSegwit, "p2sh-segwit"),
+        (AddressType::Bech32, "bech32"),
+        (AddressType::Bech32m, "bech32m"),
+    ] {
+        assert_eq!(address_type.to_string(), expected);
+        assert_eq!(format!("{address_type}"), expected);
     }
 }
 

--- a/stacks-node/src/event_dispatcher/db.rs
+++ b/stacks-node/src/event_dispatcher/db.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt::Debug;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -39,12 +39,12 @@ pub struct EventDispatcherDbConnection {
 }
 
 impl EventDispatcherDbConnection {
-    pub fn new_without_init(db_path: &PathBuf) -> Result<EventDispatcherDbConnection, db_error> {
+    pub fn new_without_init(db_path: &Path) -> Result<EventDispatcherDbConnection, db_error> {
         let connection = Connection::open(db_path.to_str().unwrap())?;
         Ok(EventDispatcherDbConnection { connection })
     }
 
-    pub fn new(db_path: &PathBuf) -> Result<EventDispatcherDbConnection, db_error> {
+    pub fn new(db_path: &Path) -> Result<EventDispatcherDbConnection, db_error> {
         let connection = Connection::open(db_path.to_str().unwrap())?;
         connection.execute(
             "CREATE TABLE IF NOT EXISTS pending_payloads (

--- a/stacks-node/src/nakamoto_node/miner.rs
+++ b/stacks-node/src/nakamoto_node/miner.rs
@@ -256,12 +256,12 @@ impl std::fmt::Display for MinerReason {
     }
 }
 
-impl Into<MiningReason> for MinerReason {
-    fn into(self) -> MiningReason {
-        match self {
-            Self::BlockFound { .. } => MiningReason::BlockFound,
-            Self::Extended { .. } => MiningReason::Extended,
-            Self::ReadCountExtend { .. } => MiningReason::ReadCountExtend,
+impl From<MinerReason> for MiningReason {
+    fn from(reason: MinerReason) -> Self {
+        match reason {
+            MinerReason::BlockFound { .. } => MiningReason::BlockFound,
+            MinerReason::Extended { .. } => MiningReason::Extended,
+            MinerReason::ReadCountExtend { .. } => MiningReason::ReadCountExtend,
         }
     }
 }

--- a/stackslib/src/burnchains/db.rs
+++ b/stackslib/src/burnchains/db.rs
@@ -140,7 +140,7 @@ impl FromRow<BlockCommitMetadata> for BlockCommitMetadata {
 /// - make sure there are no vtxindex duplicates
 pub(crate) fn apply_blockstack_txs_safety_checks(
     block_height: u64,
-    blockstack_txs: &mut Vec<BlockstackOperationType>,
+    blockstack_txs: &mut [BlockstackOperationType],
 ) {
     test_debug!(
         "Apply safety checks on {} txs at burnchain height {}",

--- a/stackslib/src/chainstate/burn/distribution.rs
+++ b/stackslib/src/chainstate/burn/distribution.rs
@@ -275,7 +275,7 @@ impl BurnSamplePoint {
 
         // now, commits_with_priors has the burn amounts for each
         //   linked commitment, we can now generate the burn sample points.
-        let mut burn_sample = commits_with_priors
+        let mut burn_sample: Vec<BurnSamplePoint> = commits_with_priors
             .into_iter()
             .map(|mut linked_commits| {
                 let all_burns: Vec<_> = linked_commits
@@ -378,7 +378,7 @@ impl BurnSamplePoint {
 
     /// Calculate the ranges between 0 and 2**256 - 1 over which each point in the burn sample
     /// applies, so we can later select which block to use.
-    fn make_sortition_ranges(burn_sample: &mut Vec<BurnSamplePoint>) {
+    fn make_sortition_ranges(burn_sample: &mut [BurnSamplePoint]) {
         if burn_sample.is_empty() {
             // empty sample
             return;

--- a/stackslib/src/chainstate/nakamoto/signer_set.rs
+++ b/stackslib/src/chainstate/nakamoto/signer_set.rs
@@ -568,7 +568,7 @@ impl NakamotoSigners {
     fn update_signers(
         clarity: &mut ClarityTransactionConnection,
         reward_cycle: u64,
-        signers: &Vec<NakamotoSignerEntry>,
+        signers: &[NakamotoSignerEntry],
         signers_contract: &QualifiedContractIdentifier,
         has_participation: bool,
         coinbase_height: u64,

--- a/stackslib/src/chainstate/stacks/index/test/marf_regression.rs
+++ b/stackslib/src/chainstate/stacks/index/test/marf_regression.rs
@@ -39,7 +39,7 @@ mod utils {
     /// Returns the root hash at the final block.
     pub fn run_test_with_string_keys(
         test_name: &str,
-        data: &Vec<Vec<(String, MARFValue)>>,
+        data: &[Vec<(String, MARFValue)>],
         marf_opts: &MARFOpenOpts,
         batch_size: usize,
     ) -> TrieHash {
@@ -74,7 +74,7 @@ mod utils {
     /// Returns the root hash at the final block.
     pub fn run_test_with_triehash_keys(
         test_name: &str,
-        data: &Vec<Vec<(TrieHash, MARFValue)>>,
+        data: &[Vec<(TrieHash, MARFValue)>],
         marf_opts: &MARFOpenOpts,
     ) -> TrieHash {
         run_test_with_batch_common(
@@ -102,7 +102,7 @@ mod utils {
     /// benchmarks reads/writes, and returns the final root hash.
     fn run_test_with_batch_common<K, FInsert, FPath>(
         test_name: &str,
-        data: &Vec<Vec<(K, MARFValue)>>,
+        data: &[Vec<(K, MARFValue)>],
         marf_opts: &MARFOpenOpts,
         batch_size: usize,
         mut insert_fn: FInsert,

--- a/stackslib/src/net/api/blocksimulate.rs
+++ b/stackslib/src/net/api/blocksimulate.rs
@@ -267,8 +267,8 @@ impl StacksHttpRequest {
     pub fn new_block_simulate(
         host: PeerHost,
         block_id: &StacksBlockId,
-        transactions: &Vec<StacksTransaction>,
-        mint: &Vec<RPCNakamotoBlockSimulateMint>,
+        transactions: &[StacksTransaction],
+        mint: &[RPCNakamotoBlockSimulateMint],
     ) -> StacksHttpRequest {
         let transactions_hex = transactions
             .iter()
@@ -276,7 +276,7 @@ impl StacksHttpRequest {
             .collect();
 
         let block_simulate_body = RPCNakamotoBlockSimulateBody {
-            mint: mint.clone(),
+            mint: mint.to_owned(),
             transactions_hex,
         };
 
@@ -296,8 +296,8 @@ impl StacksHttpRequest {
         host: PeerHost,
         block_id: &StacksBlockId,
         profiler: bool,
-        transactions: &Vec<StacksTransaction>,
-        mint: &Vec<RPCNakamotoBlockSimulateMint>,
+        transactions: &[StacksTransaction],
+        mint: &[RPCNakamotoBlockSimulateMint],
     ) -> StacksHttpRequest {
         let transactions_hex = transactions
             .iter()
@@ -305,7 +305,7 @@ impl StacksHttpRequest {
             .collect();
 
         let block_simulate_body = RPCNakamotoBlockSimulateBody {
-            mint: mint.clone(),
+            mint: mint.to_owned(),
             transactions_hex,
         };
         StacksHttpRequest::new_for_peer(

--- a/stackslib/src/net/api/tests/blocksimulate.rs
+++ b/stackslib/src/net/api/tests/blocksimulate.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::slice;
 
 use clarity::types::chainstate::StacksPrivateKey;
 use clarity::vm::types::PrincipalData;
@@ -42,12 +43,8 @@ fn test_try_parse_request() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 33333);
     let mut http = StacksHttp::new(addr.clone(), &ConnectionOptions::default());
 
-    let mut request = StacksHttpRequest::new_block_simulate(
-        addr.into(),
-        &StacksBlockId([0x01; 32]),
-        &vec![],
-        &vec![],
-    );
+    let mut request =
+        StacksHttpRequest::new_block_simulate(addr.into(), &StacksBlockId([0x01; 32]), &[], &[]);
 
     // add the authorization header
     request.add_header("authorization".into(), "password".into());
@@ -89,8 +86,8 @@ fn test_try_parse_request_with_profiler() {
         addr.into(),
         &StacksBlockId([0x01; 32]),
         true,
-        &vec![],
-        &vec![],
+        &[],
+        &[],
     );
 
     // add the authorization header
@@ -179,8 +176,8 @@ fn test_try_make_response() {
     let mut request = StacksHttpRequest::new_block_simulate(
         addr.clone().into(),
         &rpc_test.canonical_tip,
-        &vec![deploy_tx1.clone(), deploy_tx2.clone()],
-        &vec![blocksimulate::RPCNakamotoBlockSimulateMint {
+        &[deploy_tx1.clone(), deploy_tx2.clone()],
+        &[blocksimulate::RPCNakamotoBlockSimulateMint {
             principal: PrincipalData::from(&private_key),
             amount: 3000,
         }],
@@ -193,8 +190,8 @@ fn test_try_make_response() {
     let mut request = StacksHttpRequest::new_block_simulate(
         addr.clone().into(),
         &StacksBlockId([0x01; 32]),
-        &vec![],
-        &vec![],
+        &[],
+        &[],
     );
     // add the authorization header
     request.add_header("authorization".into(), "password".into());
@@ -204,8 +201,8 @@ fn test_try_make_response() {
     let request = StacksHttpRequest::new_block_simulate(
         addr.clone().into(),
         &StacksBlockId([0x00; 32]),
-        &vec![],
-        &vec![],
+        &[],
+        &[],
     );
     requests.push(request);
 
@@ -356,8 +353,8 @@ fn simulate_block_with_pc_failure() {
     let mut request = StacksHttpRequest::new_block_simulate(
         addr.clone().into(),
         &rpc_test.canonical_tip,
-        &vec![contract_call],
-        &vec![],
+        &[contract_call],
+        &[],
     );
     request.add_header("authorization".into(), "password".into());
     requests.push(request);
@@ -436,8 +433,8 @@ fn test_try_make_response_with_unsuccessful_transaction() {
     let mut request = StacksHttpRequest::new_block_simulate(
         addr.clone().into(),
         &rpc_test.canonical_tip,
-        &vec![deploy_tx.clone()],
-        &vec![blocksimulate::RPCNakamotoBlockSimulateMint {
+        slice::from_ref(&deploy_tx),
+        &[blocksimulate::RPCNakamotoBlockSimulateMint {
             principal: PrincipalData::from(&private_key),
             amount: 3000,
         }],

--- a/stackslib/src/net/connection.rs
+++ b/stackslib/src/net/connection.rs
@@ -1994,7 +1994,7 @@ mod test {
             pipes.push(pipe);
         }
 
-        fn flush_all(pipes: &mut Vec<ReplyHandleP2P>) {
+        fn flush_all(pipes: &mut [ReplyHandleP2P]) {
             for ref mut p in pipes.iter_mut() {
                 let _ = p.try_flush();
             }

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -3544,7 +3544,7 @@ pub mod test {
         }
 
         pub fn set_ops_consensus_hash(
-            blockstack_ops: &mut Vec<BlockstackOperationType>,
+            blockstack_ops: &mut [BlockstackOperationType],
             ch: &ConsensusHash,
         ) {
             for op in blockstack_ops.iter_mut() {
@@ -3555,7 +3555,7 @@ pub mod test {
         }
 
         pub fn set_ops_burn_header_hash(
-            blockstack_ops: &mut Vec<BlockstackOperationType>,
+            blockstack_ops: &mut [BlockstackOperationType],
             bhh: &BurnchainHeaderHash,
         ) {
             for op in blockstack_ops.iter_mut() {

--- a/stackslib/src/net/tests/convergence.rs
+++ b/stackslib/src/net/tests/convergence.rs
@@ -252,7 +252,7 @@ fn test_walk_ring_15_org_biased() {
 }
 
 fn test_walk_ring_ex(
-    peer_configs: &mut Vec<TestPeerConfig>,
+    peer_configs: &mut [TestPeerConfig],
     test_pingback: bool,
 ) -> Vec<TestPeer<'_>> {
     // arrange neighbors into a "ring" topology, where
@@ -308,11 +308,11 @@ fn test_walk_ring_ex(
     peers
 }
 
-fn test_walk_ring(peer_configs: &mut Vec<TestPeerConfig>) -> Vec<TestPeer<'_>> {
+fn test_walk_ring(peer_configs: &mut [TestPeerConfig]) -> Vec<TestPeer<'_>> {
     test_walk_ring_ex(peer_configs, false)
 }
 
-fn test_walk_ring_pingback(peer_configs: &mut Vec<TestPeerConfig>) -> Vec<TestPeer<'_>> {
+fn test_walk_ring_pingback(peer_configs: &mut [TestPeerConfig]) -> Vec<TestPeer<'_>> {
     test_walk_ring_ex(peer_configs, true)
 }
 
@@ -458,16 +458,16 @@ fn test_walk_line_15_pingback() {
     })
 }
 
-fn test_walk_line(peer_configs: &mut Vec<TestPeerConfig>) -> Vec<TestPeer<'_>> {
+fn test_walk_line(peer_configs: &mut [TestPeerConfig]) -> Vec<TestPeer<'_>> {
     test_walk_line_ex(peer_configs, false)
 }
 
-fn test_walk_line_pingback(peer_configs: &mut Vec<TestPeerConfig>) -> Vec<TestPeer<'_>> {
+fn test_walk_line_pingback(peer_configs: &mut [TestPeerConfig]) -> Vec<TestPeer<'_>> {
     test_walk_line_ex(peer_configs, true)
 }
 
 fn test_walk_line_ex(
-    peer_configs: &mut Vec<TestPeerConfig>,
+    peer_configs: &mut [TestPeerConfig],
     pingback_test: bool,
 ) -> Vec<TestPeer<'_>> {
     // arrange neighbors into a "line" topology.
@@ -667,16 +667,16 @@ fn test_walk_star_15_org_biased() {
     })
 }
 
-fn test_walk_star(peer_configs: &mut Vec<TestPeerConfig>) -> Vec<TestPeer<'_>> {
+fn test_walk_star(peer_configs: &mut [TestPeerConfig]) -> Vec<TestPeer<'_>> {
     test_walk_star_ex(peer_configs, false)
 }
 
-fn test_walk_star_pingback(peer_configs: &mut Vec<TestPeerConfig>) -> Vec<TestPeer<'_>> {
+fn test_walk_star_pingback(peer_configs: &mut [TestPeerConfig]) -> Vec<TestPeer<'_>> {
     test_walk_star_ex(peer_configs, true)
 }
 
 fn test_walk_star_ex(
-    peer_configs: &mut Vec<TestPeerConfig>,
+    peer_configs: &mut [TestPeerConfig],
     pingback_test: bool,
 ) -> Vec<TestPeer<'_>> {
     // arrange neighbors into a "star" topology.
@@ -729,7 +729,7 @@ fn test_walk_star_ex(
     peers
 }
 
-fn test_walk_inbound_line(peer_configs: &mut Vec<TestPeerConfig>) -> Vec<TestPeer<'_>> {
+fn test_walk_inbound_line(peer_configs: &mut [TestPeerConfig]) -> Vec<TestPeer<'_>> {
     // arrange neighbors into a two-tiered "line" topology, where even-numbered neighbors are
     // "NAT'ed" but connected to both the predecessor and successor odd neighbors.  Odd
     // numbered neighbors are not connected to anyone.  The first and last even-numbered

--- a/stackslib/src/util_lib/signed_structured_data.rs
+++ b/stackslib/src/util_lib/signed_structured_data.rs
@@ -137,10 +137,10 @@ pub mod pox4 {
         structured_data_message_hash(data_tuple, domain_tuple)
     }
 
-    impl Into<Pox4SignatureTopic> for &'static str {
+    impl From<&'static str> for Pox4SignatureTopic {
         #[cfg_attr(test, mutants::skip)]
-        fn into(self) -> Pox4SignatureTopic {
-            match self {
+        fn from(topic: &'static str) -> Self {
+            match topic {
                 "stack-stx" => Pox4SignatureTopic::StackStx,
                 "agg-commit" => Pox4SignatureTopic::AggregationCommit,
                 "stack-extend" => Pox4SignatureTopic::StackExtend,


### PR DESCRIPTION
### Description

This PR updates helper APIs to accept slices and borrowed paths, replaces explicit `Into` implementations with `From`, and implements `Display` instead of `ToString` for `AddressType`. Callers are updated, and a new test covers address-type formatting.

### Applicable issues

None.

### Additional info (benefits, drawbacks, caveats)

Some Rust helper signatures change. Conversion behavior and formatted values remain unchanged; existing `.into()` calls continue to work through the standard blanket implementation.

### Checklist

- [x] Test coverage for new or modified code paths
- [x] Changelog fragment(s) or "no changelog" label added
- [x] Required documentation changes